### PR TITLE
meta: add issue templates and AI rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,22 @@
+# AI Assistant Rules for PTOAS
+
+This directory contains project-specific rules for AI-assisted development.
+
+## Scope
+
+When you change any user-visible behavior, keep these layers synchronized:
+
+1. **ODS / Dialect definitions**: `include/PTO/IR/*.td`
+2. **C++ implementation & verifiers**: `lib/PTO/IR`, `lib/PTO/Transforms`
+3. **CLI / tool behavior**: `tools/ptoas`
+4. **Python bindings / samples** (if affected): `python/`, `test/samples`
+5. **Docs**: `README.md`, `docs/`, `PTO_OPS_SPEC.md`
+6. **Tests**: `test/`
+
+## Rules
+
+See `.claude/rules/` for specific guidance:
+
+- `cross-layer-sync.md`
+- `testing-and-examples.md`
+

--- a/.claude/rules/cross-layer-sync.md
+++ b/.claude/rules/cross-layer-sync.md
@@ -1,0 +1,50 @@
+# Cross-Layer Synchronization (PTOAS)
+
+## Overview
+
+PTOAS changes often span multiple layers. **All relevant layers must be updated together** when changing public APIs or semantics.
+
+## Layers to keep in sync
+
+1. **ODS / Dialect** (`include/PTO/IR/*.td`)
+   - Op definitions, assembly formats, traits/interfaces, verifiers (decls)
+2. **C++ IR & verifiers** (`lib/PTO/IR`)
+   - `Op::verify()` logic and semantic constraints
+3. **Lowering / transforms** (`lib/PTO/Transforms`)
+   - Type conversions, legality, conversion patterns
+   - Any new op attribute/operand must be handled through lowering
+4. **CLI tool** (`tools/ptoas/ptoas.cpp`)
+   - Flag parsing, validation gating (`--pto-level`, `--pto-arch`, etc.)
+5. **Python bindings** (`python/`)
+   - Op bindings generation inputs (TableGen wrapper `.td`), python API, samples
+6. **Docs & specs** (`README.md`, `PTO_OPS_SPEC.md`, `docs/`)
+7. **Tests** (`test/`)
+
+## Typical examples
+
+### Adding/changing an op operand
+
+- Update ODS (`*.td`): operand definition + assembly format
+- Update C++ verifier (`Op::verify`) if constraints change
+- Update lowering patterns (PTO → memref / EmitC) to consume/forward the operand
+- Update python bindings if the op is exposed and used from Python
+- Add or adjust a regression test
+- Update docs/spec if user-visible
+
+### Adding a CLI flag that changes lowering/codegen
+
+- Implement flag parsing in `tools/ptoas/ptoas.cpp`
+- Thread the flag into pass options or pass construction (avoid hidden global mutable state)
+- Update docs and add a test demonstrating behavior
+
+## Checklist
+
+Before finishing a change:
+
+- [ ] ODS matches actual operands/attrs and prints/parses correctly
+- [ ] C++ verifier errors are actionable
+- [ ] Lowering/codegen handles all new cases (including view ops like `memref.subview`)
+- [ ] Python side still builds/imports (if impacted)
+- [ ] Docs/specs updated
+- [ ] Tests cover regression
+

--- a/.claude/rules/testing-and-examples.md
+++ b/.claude/rules/testing-and-examples.md
@@ -1,0 +1,24 @@
+# Testing and Examples Policy (PTOAS)
+
+## Core Principle
+
+Prefer **regression tests** over ad-hoc scripts. Keep examples user-facing.
+
+## Where tests belong
+
+- **IR / lowering / codegen tests**: `test/`
+- **Python sample-based tests**: `test/samples/` (when the project already uses this flow)
+
+## What to include in bug reports / tests
+
+For pass bugs, prefer the **Before / Expected / Actual** pattern:
+
+- Minimal input IR (or Python that prints IR)
+- The exact `ptoas` invocation
+- Expected property (verifier success, type preservation, addr propagation, emitted C++ compiles, etc.)
+
+## Avoid
+
+- Temporary scripts committed outside `test/` or `test/samples/`
+- Large, non-minimized reproductions when a smaller IR can isolate the issue
+

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,123 @@
+name: Bug Report
+description: Report a general bug in PTOAS
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please provide enough info for us to reproduce and fix it.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part is affected?
+      options:
+        - PTO Dialect / ODS (include/PTO/IR)
+        - Verifier / IR semantics (lib/PTO/IR)
+        - Passes / Transforms (lib/PTO/Transforms)
+        - EmitC / Codegen (lib/PTO/Transforms/PTOToEmitC.cpp)
+        - CLI / Tooling (tools/ptoas)
+        - Python bindings (python/)
+        - Tests (test/)
+        - Build / CMake / Packaging
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Clear description of the bug
+      placeholder: e.g. "ptoas crashes when lowering pto.bind_tile after memref.subview"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction (minimal)
+      description: |
+        Provide either:
+        - A minimal `.pto` / MLIR snippet, or
+        - A Python script that prints MLIR, plus the `ptoas` command you run.
+      placeholder: |
+        ```mlir
+        // Paste minimal MLIR here
+        ```
+        ```bash
+        # Command you ran
+        ./build/tools/ptoas/ptoas input.pto -o out.cpp
+        ```
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: e.g. "ptoas should emit valid C++ without type errors"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior / error logs
+      placeholder: |
+        ```text
+        Paste the error message / stack trace / bad output here
+        ```
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: commit
+    attributes:
+      label: Git commit
+      description: Run `git rev-parse HEAD` to get the exact commit id
+      placeholder: e.g. f04cde8a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
+    validations:
+      required: true
+
+  - type: dropdown
+    id: host_platform
+    attributes:
+      label: Host platform
+      options:
+        - Linux (x86_64)
+        - Linux (aarch64)
+        - macOS (arm64)
+        - macOS (x86_64)
+        - Other
+    validations:
+      required: false
+
+  - type: dropdown
+    id: arch
+    attributes:
+      label: Target Ascend arch (if relevant)
+      options:
+        - N/A
+        - a3
+        - a5
+    validations:
+      required: false
+
+  - type: dropdown
+    id: pto_level
+    attributes:
+      label: PTOAS build level (if relevant)
+      options:
+        - N/A
+        - level1
+        - level2
+        - level3
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/zhangstevenunity/PTOAS/discussions
+    about: Please use Discussions for questions, ideas, and general discussion
+

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,38 @@
+name: Documentation Issue
+description: Report missing, incorrect, or unclear documentation
+title: "[Docs] "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve PTOAS documentation!
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Documentation location
+      description: Which file/section needs improvement?
+      placeholder: e.g. "README.md section 5. CLI usage", "docs/..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: What's wrong or missing?
+      placeholder: |
+        - Incorrect command
+        - Outdated flag behavior
+        - Missing example
+        - Unclear description
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for PTOAS
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please describe the feature and the user-facing behavior clearly.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: e.g. "Add --emit-addptr-trace to annotate generated C++"
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation / use case
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_behavior
+    attributes:
+      label: Proposed API / behavior
+      placeholder: |
+        - CLI flags:
+        - IR changes:
+        - Backward compatibility considerations:
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/new_operation.yml
+++ b/.github/ISSUE_TEMPLATE/new_operation.yml
@@ -1,0 +1,78 @@
+name: New Operation Request
+description: Propose a new PTO Dialect op / semantic extension
+title: "[New Op] "
+labels: ["enhancement", "new-operation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a new op! Please describe semantics precisely so we can implement it consistently across ODS, verifiers, lowering, codegen, and Python bindings (if any).
+
+  - type: textarea
+    id: proposed_name
+    attributes:
+      label: Proposed op name & signature
+      description: Prefer ODS-like or MLIR assembly-like form.
+      placeholder: |
+        - ODS: `pto.my_new_op` (operands...) -> (results...)
+        - MLIR:
+        ```mlir
+        %y = pto.my_new_op %x, %k {attr = ...} : (...) -> (...)
+        ```
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: semantics
+    attributes:
+      label: Semantics (what does it do?)
+      description: Include shape rules, constraints, and edge cases.
+      placeholder: |
+        - Inputs:
+        - Outputs:
+        - Valid shapes/dtypes:
+        - Side effects / memory effects:
+        - Failure modes / verifier rules:
+    validations:
+      required: true
+
+  - type: textarea
+    id: lowering
+    attributes:
+      label: Lowering/codegen expectations
+      description: How should this lower (e.g. to memref/emitc), and any arch/level specifics.
+      placeholder: |
+        - Lowering path: PTO -> memref -> EmitC
+        - Arch differences: a3 vs a5
+        - Level gating: level1/2/3 differences
+    validations:
+      required: false
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example IR usage
+      placeholder: |
+        ```mlir
+        // Example module showing the op in context
+        ```
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation / use case
+    validations:
+      required: true
+
+  - type: input
+    id: commit
+    attributes:
+      label: Git commit (optional)
+      description: If proposing against a specific revision, provide `git rev-parse HEAD`
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/pass_bug.yml
+++ b/.github/ISSUE_TEMPLATE/pass_bug.yml
@@ -1,0 +1,112 @@
+name: IR Pass / Transform Bug
+description: Report a bug in a PTOAS pass or lowering
+title: "[Pass Bug] "
+labels: ["bug", "ir-pass"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a pass bug! Please provide a **minimal Before IR** and what you expected after the pass/pipeline.
+        If this is about `ptoas` end-to-end behavior, include the full `ptoas` command line.
+
+  - type: input
+    id: pass_name
+    attributes:
+      label: Pass / pipeline name
+      description: Exact pass name (e.g. `pto-view-to-memref`) or pipeline stage (e.g. `EmitC lowering`)
+      placeholder: e.g. pto-view-to-memref, plan-memory, pto-insert-sync, emit-pto-manual
+    validations:
+      required: true
+
+  - type: input
+    id: command
+    attributes:
+      label: Command line
+      description: The exact command you ran (include relevant flags like `--pto-level`, `--pto-arch`, `--enable-insert-sync`)
+      placeholder: e.g. ./build/tools/ptoas/ptoas input.pto --pto-level=level3 --pto-arch=a3 -o out.cpp
+    validations:
+      required: true
+
+  - type: textarea
+    id: before_ir
+    attributes:
+      label: Before IR (input)
+      description: |
+        Minimal IR that reproduces the bug.
+        Prefer MLIR text. If you generate IR from Python, paste the printed module.
+      placeholder: |
+        ```mlir
+        // Minimal IR here
+        ```
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior / expected IR (after)
+      description: What you expected the pass to produce (or what property should hold).
+      placeholder: |
+        - Expected: no verifier error, types preserved, correct addr propagation
+        - Or paste expected IR:
+        ```mlir
+        // Expected IR here (optional)
+        ```
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual IR or error
+      description: What actually happened (transformed IR or error logs)
+      placeholder: |
+        ```text
+        Paste output IR / error message here
+        ```
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: commit
+    attributes:
+      label: Git commit
+      description: Run `git rev-parse HEAD`
+      placeholder: e.g. f04cde8a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
+    validations:
+      required: true
+
+  - type: dropdown
+    id: arch
+    attributes:
+      label: Target Ascend arch (if relevant)
+      options:
+        - N/A
+        - a3
+        - a5
+    validations:
+      required: false
+
+  - type: dropdown
+    id: pto_level
+    attributes:
+      label: PTOAS build level (if relevant)
+      options:
+        - N/A
+        - level1
+        - level2
+        - level3
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Anything else that helps (hardware, whether remote validation is involved, etc.)
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/performance_issue.yml
+++ b/.github/ISSUE_TEMPLATE/performance_issue.yml
@@ -1,0 +1,72 @@
+name: Performance Issue
+description: Report a performance regression or optimization opportunity in PTOAS
+title: "[Performance] "
+labels: ["performance"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a performance issue! Please provide a **reproducible** input and measurement.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: e.g. "pto-view-to-memref takes 5x longer after PR ###"
+    validations:
+      required: true
+
+  - type: input
+    id: command
+    attributes:
+      label: Command line
+      placeholder: e.g. time ./build/tools/ptoas/ptoas input.pto -o out.cpp
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro_input
+    attributes:
+      label: Reproduction input
+      description: Minimal `.pto` / MLIR, or attach a file and describe it.
+      placeholder: |
+        ```mlir
+        // minimal IR
+        ```
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected performance
+      placeholder: e.g. "Should finish in <200ms (previously ~120ms)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual performance
+      placeholder: e.g. "Now ~900ms on the same machine"
+    validations:
+      required: true
+
+  - type: textarea
+    id: profiling
+    attributes:
+      label: Profiling data (optional)
+      description: Flamegraph, `perf` output, timing breakdown, etc.
+    validations:
+      required: false
+
+  - type: input
+    id: commit
+    attributes:
+      label: Git commit
+      description: Run `git rev-parse HEAD`
+      placeholder: e.g. f04cde8a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
+    validations:
+      required: true
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,12 @@
+# AI Instructions for PTOAS
+
+All AI instructions for the PTOAS project are centralized in the `.claude/` directory.
+
+Please refer to:
+
+- **`.claude/CLAUDE.md`** - Main AI assistant rules and entry point
+- **`.claude/rules/`** - Development principles and conventions
+
+When changing public-facing behavior (dialect ops, passes, CLI flags, codegen),
+ensure cross-layer consistency (ODS/IR verifiers, lowering/codegen, Python bindings, docs, tests).
+


### PR DESCRIPTION
Add GitHub issue templates for bugs/pass regressions/perf/new ops and a minimal .claude rules entrypoint to keep cross-layer changes synchronized.