### PR TITLE
ci: stop building wheels on pull requests

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags-ignore:
       - '**'
-  pull_request:
   workflow_dispatch:
   release:
     types: [published]

--- a/.github/workflows/build_wheel_mac.yml
+++ b/.github/workflows/build_wheel_mac.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags-ignore:
       - '**'
-  pull_request:
   workflow_dispatch:
   release:
     types: [published]


### PR DESCRIPTION
Remove pull_request trigger from wheel build workflows to avoid running heavy wheel builds on PRs.
