### PR TITLE
fix: force left tile blayout by target arch in parser

### DIFF
--- a/include/PTO/IR/PTO.h
+++ b/include/PTO/IR/PTO.h
@@ -77,6 +77,24 @@ AddressSpaceAttr getPTOAddressSpaceAttr(Type type);
 /// Return true if type is a ptr/memref in GM address space (or default).
 bool isScalarPtrOrMemRef(Type type);
 
+enum class PTOParserTargetArch {
+  Unspecified,
+  A3,
+  A5,
+};
+
+void setPTOParserTargetArch(PTOParserTargetArch arch);
+PTOParserTargetArch getPTOParserTargetArch();
+
+class ScopedPTOParserTargetArch {
+public:
+  explicit ScopedPTOParserTargetArch(PTOParserTargetArch arch);
+  ~ScopedPTOParserTargetArch();
+
+private:
+  PTOParserTargetArch previousArch;
+};
+
 
 /// Function attribute that marks an explicit PTO kernel entry.
 inline constexpr llvm::StringLiteral kPTOEntryAttrName = "pto.entry";

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3021,9 +3021,9 @@ mlir::LogicalResult mlir::pto::TExtractOp::verify() {
       if (!hasMatExtractSourceLayoutA5(srcTb, *dstSpace))
         return emitOpError("expects A5 textract src to use a supported mat blayout/slayout combination");
       if (*dstSpace == pto::AddressSpace::LEFT) {
-        if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
+        if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor) ||
             dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))
-          return emitOpError("expects A5 left dst to use row_major blayout and row_major slayout");
+          return emitOpError("expects A5 left dst to use col_major blayout and row_major slayout");
       } else if (*dstSpace == pto::AddressSpace::RIGHT) {
         if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
             dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor))

--- a/lib/PTO/IR/PTOTypeDefs.cpp
+++ b/lib/PTO/IR/PTOTypeDefs.cpp
@@ -5,6 +5,29 @@
 using namespace mlir;
 using namespace mlir::pto;
 
+namespace {
+thread_local PTOParserTargetArch currentParserTargetArch =
+    PTOParserTargetArch::Unspecified;
+}
+
+void mlir::pto::setPTOParserTargetArch(PTOParserTargetArch arch) {
+  currentParserTargetArch = arch;
+}
+
+PTOParserTargetArch mlir::pto::getPTOParserTargetArch() {
+  return currentParserTargetArch;
+}
+
+mlir::pto::ScopedPTOParserTargetArch::ScopedPTOParserTargetArch(
+    PTOParserTargetArch arch)
+    : previousArch(getPTOParserTargetArch()) {
+  setPTOParserTargetArch(arch);
+}
+
+mlir::pto::ScopedPTOParserTargetArch::~ScopedPTOParserTargetArch() {
+  setPTOParserTargetArch(previousArch);
+}
+
 static SmallVector<int64_t, 4> canonicalizeTileBufValidShape(ArrayRef<int64_t> validShape) {
   SmallVector<int64_t, 4> canonical;
   canonical.reserve(validShape.size());
@@ -211,7 +234,21 @@ Type TileBufType::parse(AsmParser &parser) {
     return Type();
   }
 
-  auto blAttr = BLayoutAttr::get(ctx, bl.value());
+  BLayout effectiveBLayout = bl.value();
+  if (memorySpace.value() == AddressSpace::LEFT) {
+    switch (getPTOParserTargetArch()) {
+    case PTOParserTargetArch::A3:
+      effectiveBLayout = BLayout::RowMajor;
+      break;
+    case PTOParserTargetArch::A5:
+      effectiveBLayout = BLayout::ColMajor;
+      break;
+    case PTOParserTargetArch::Unspecified:
+      break;
+    }
+  }
+
+  auto blAttr = BLayoutAttr::get(ctx, effectiveBLayout);
   auto slAttr = SLayoutAttr::get(ctx, sl.value());
   auto fractalAttr =
       IntegerAttr::get(IntegerType::get(ctx, 32), fractal);

--- a/test/basic/left_blayout_parser_a3.pto
+++ b/test/basic/left_blayout_parser_a3.pto
@@ -1,0 +1,13 @@
+// RUN: ptoas --pto-arch a3 %s | FileCheck %s
+
+module {
+  func.func @left_blayout_parser_a3() {
+    %c0 = arith.constant 0 : index
+    %src = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.textract ins(%src, %c0, %c0 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>, index, index) outs(%dst : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: left_blayout_parser_a3

--- a/test/basic/left_blayout_parser_a5.pto
+++ b/test/basic/left_blayout_parser_a5.pto
@@ -2,10 +2,10 @@
 
 module {
   func.func @left_blayout_parser_a5() {
-    %lhs = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>
-    %rhs = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>
-    %dst = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.tmatmul ins(%lhs, %rhs : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+    %c0 = arith.constant 0 : index
+    %src = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>
+    pto.textract ins(%src, %c0, %c0 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>, index, index) outs(%dst : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>)
     return
   }
 }

--- a/test/basic/left_blayout_parser_a5.pto
+++ b/test/basic/left_blayout_parser_a5.pto
@@ -1,0 +1,13 @@
+// RUN: ptoas --pto-arch a5 %s | FileCheck %s
+
+module {
+  func.func @left_blayout_parser_a5() {
+    %lhs = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>
+    %rhs = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tmatmul ins(%lhs, %rhs : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+    return
+  }
+}
+
+// CHECK: left_blayout_parser_a5

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -757,6 +757,15 @@ int main(int argc, char **argv) {
   context.getOrLoadDialect<affine::AffineDialect>();
   context.getOrLoadDialect<mlir::LLVM::LLVMDialect>();
 
+  std::string arch = ptoTargetArch;
+  for (char &c : arch)
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  if (arch != "a3" && arch != "a5") {
+    llvm::errs() << "Error: invalid --pto-arch='" << ptoTargetArch
+                 << "'. Expected 'a3' or 'a5'.\n";
+    return 1;
+  }
+
   OwningOpRef<ModuleOp> module;
   llvm::StringRef buf = (*fileOrErr)->getBuffer();
   const bool isPTOBC = (buf.size() >= 6 && std::memcmp(buf.data(), "PTOBC\0", 6) == 0);
@@ -782,6 +791,9 @@ int main(int argc, char **argv) {
     // Parse textual MLIR (.pto).
     llvm::SourceMgr sourceMgr;
     sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), llvm::SMLoc());
+    pto::ScopedPTOParserTargetArch scopedParserArch(
+        arch == "a5" ? pto::PTOParserTargetArch::A5
+                     : pto::PTOParserTargetArch::A3);
     module = parseSourceFile<ModuleOp>(sourceMgr, &context);
     if (!module) {
       llvm::errs() << "Error: Failed to parse MLIR.\n";
@@ -880,14 +892,6 @@ int main(int argc, char **argv) {
   // pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOVFloopGatherPass());
 
   pm.addPass(createCSEPass());
-  std::string arch = ptoTargetArch;
-  for (char &c : arch)
-    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-  if (arch != "a3" && arch != "a5") {
-    llvm::errs() << "Error: invalid --pto-arch='" << ptoTargetArch
-                 << "'. Expected 'a3' or 'a5'.\n";
-    return 1;
-  }
   module->getOperation()->setAttr("pto.target_arch",
                                   mlir::StringAttr::get(&context, arch));
   if (arch == "a3") {


### PR DESCRIPTION
Apply the target arch before textual PTO parsing so loc=left tile buffers normalize to row-major on A3 and col-major on A5. Add regression cases to cover both parser paths.

Made-with: Cursor