### PR TITLE
fix: preserve kernel_kind until EmitC lowering

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -2441,6 +2441,22 @@ static void inferTileMNK(func::FuncOp f, int &M, int &N, int &K) {
   }
 }
 
+static std::optional<StringRef> getKernelKindMacro(func::FuncOp funcOp) {
+  auto kernelKindAttr =
+      funcOp->getAttrOfType<FunctionKernelKindAttr>(FunctionKernelKindAttr::name);
+  if (!kernelKindAttr)
+    return std::nullopt;
+
+  switch (kernelKindAttr.getKernelKind()) {
+  case FunctionKernelKind::Cube:
+    return StringRef("__DAV_CUBE__");
+  case FunctionKernelKind::Vector:
+    return StringRef("__DAV_VEC__");
+  }
+
+  llvm_unreachable("unexpected kernel kind");
+}
+
 struct FuncToEmitC : public OpConversionPattern<func::FuncOp> {
   using OpConversionPattern<func::FuncOp>::OpConversionPattern;
 
@@ -2500,11 +2516,31 @@ struct FuncToEmitC : public OpConversionPattern<func::FuncOp> {
                                            *getTypeConverter(), &entryConv)))
       return failure();
 
-    // [Compatibility patch] Preserve existing snippets that rely on `T`.
+    std::optional<StringRef> kernelKindMacro = getKernelKindMacro(op);
+
+    // Preserve the existing function prologue shape. `kernel_kind` functions are
+    // emitted with the same macro guard/reset sequence that used to come from
+    // early pto.section wrapping, but only after SCF pre-lowering has finished.
     {
       Block &entryBlock = emitcFunc.getBody().front();
       rewriter.setInsertionPointToStart(&entryBlock);
       rewriter.create<emitc::VerbatimOp>(op.getLoc(), "using T = float;");
+      if (kernelKindMacro) {
+        std::string startMacro = "\n#if defined(" + kernelKindMacro->str() + ")";
+        rewriter.create<emitc::VerbatimOp>(op.getLoc(), startMacro);
+        if (*kernelKindMacro == "__DAV_VEC__") {
+          rewriter.create<emitc::VerbatimOp>(op.getLoc(), "set_mask_norm();");
+          rewriter.create<emitc::VerbatimOp>(op.getLoc(),
+                                             "set_vector_mask(-1, -1);");
+        }
+      }
+    }
+
+    if (kernelKindMacro) {
+      Block &lastBlock = emitcFunc.getBody().back();
+      rewriter.setInsertionPoint(lastBlock.getTerminator());
+      std::string endMacro = "#endif // " + kernelKindMacro->str() + "\n";
+      rewriter.create<emitc::VerbatimOp>(op.getLoc(), endMacro);
     }
 
     rewriter.eraseOp(op);

--- a/lib/PTO/Transforms/PTOVerifyTFreePass.cpp
+++ b/lib/PTO/Transforms/PTOVerifyTFreePass.cpp
@@ -96,6 +96,14 @@ static LogicalResult verifyNoTileUsesAfterTFree(TPopOp tpopOp,
   return success();
 }
 
+static bool isInsideSectionOrAttributedKernel(TPopOp tpopOp, func::FuncOp funcOp) {
+  if (tpopOp->getParentOfType<SectionCubeOp>() ||
+      tpopOp->getParentOfType<SectionVectorOp>())
+    return true;
+  return funcOp &&
+         funcOp->hasAttr(FunctionKernelKindAttr::name);
+}
+
 struct PTOVerifyTFreePass
     : public mlir::pto::impl::PTOVerifyTFreeBase<PTOVerifyTFreePass> {
   void runOnOperation() override {
@@ -105,8 +113,7 @@ struct PTOVerifyTFreePass
     funcOp.walk([&](TPopOp op) { tpops.push_back(op); });
 
     for (TPopOp tpopOp : tpops) {
-      if (!tpopOp->getParentOfType<SectionCubeOp>() &&
-          !tpopOp->getParentOfType<SectionVectorOp>())
+      if (!isInsideSectionOrAttributedKernel(tpopOp, funcOp))
         continue;
 
       TFreeOp existingTFree = findMatchingTFree(tpopOp);

--- a/test/basic/kernel_kind_vector_scf_while_emitc.pto
+++ b/test/basic/kernel_kind_vector_scf_while_emitc.pto
@@ -1,0 +1,76 @@
+// RUN: ptoas %s | FileCheck %s
+
+module {
+  func.func @vector_while_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    %c32 = arith.constant 32 : index
+    %true = arith.constant true
+    %false = arith.constant false
+    %one = arith.constant 1.0 : f32
+    %ten = arith.constant 10.0 : f32
+
+    %tile = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %final:2 = scf.while (%i = %c0, %alive = %true) : (index, i1) -> (index, i1) {
+      %lt = arith.cmpi slt, %i, %c4 : index
+      %go = arith.andi %lt, %alive : i1
+      scf.condition(%go) %i, %alive : index, i1
+    } do {
+    ^bb0(%i2: index, %alive2: i1):
+      pto.tadds ins(%tile, %one
+        : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                        blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+          f32)
+        outs(%tile
+        : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                        blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      %break_now = arith.cmpi eq, %i2, %c2 : index
+      %next_i = arith.addi %i2, %c1 : index
+      %yield:2 = scf.if %break_now -> (index, i1) {
+        scf.yield %next_i, %false : index, i1
+      } else {
+        pto.tadds ins(%tile, %ten
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                          blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+            f32)
+          outs(%tile
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+        scf.yield %next_i, %true : index, i1
+      }
+      scf.yield %yield#0, %yield#1 : index, i1
+    }
+
+    %stopped = arith.xori %final#1, %true : i1
+    scf.if %stopped {
+      pto.tadds ins(%tile, %one
+        : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                        blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+          f32)
+        outs(%tile
+        : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                        blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    }
+    return
+  }
+}
+
+// CHECK: AICORE void vector_while_kernel()
+// CHECK: using T = float;
+// CHECK: #if defined(__DAV_VEC__)
+// CHECK: set_mask_norm();
+// CHECK: set_vector_mask(-1, -1);
+// CHECK: goto [[HEADER:label[0-9]+]];
+// CHECK: [[HEADER]]:
+// CHECK: if ({{.*}}) {
+// CHECK: goto [[BODY:label[0-9]+]];
+// CHECK: goto [[EXIT:label[0-9]+]];
+// CHECK: [[BODY]]:
+// CHECK: goto [[HEADER]];
+// CHECK: [[EXIT]]:
+// CHECK: #endif // __DAV_VEC__

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -873,8 +873,6 @@ int main(int argc, char **argv) {
   // pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOInsertLoadStoreForMixCVPass());
   pm.addNestedPass<mlir::func::FuncOp>(
       pto::createPTOLowerFrontendPipeOpsPass());
-  pm.addNestedPass<mlir::func::FuncOp>(
-      pto::createPTOWrapFunctionsInSectionsPass());
   pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOVerifyTFreePass());
   pm.addNestedPass<mlir::func::FuncOp>(pto::createLoweringSyncToPipePass());
   


### PR DESCRIPTION
Delay kernel_kind section materialization so vector kernels with scf.while can be lowered before EmitC, while keeping the existing cube/vector macro emission and tfree verification behavior.

Made-with: Cursor