### PR TITLE
emitc: render scalar constants as const locals

### DIFF
--- a/test/basic/kernel_kind_vector_scf_while_emitc.pto
+++ b/test/basic/kernel_kind_vector_scf_while_emitc.pto
@@ -61,6 +61,16 @@ module {
 }
 
 // CHECK: AICORE void vector_while_kernel()
+// CHECK: const int64_t {{v[0-9]+}} = 0;
+// CHECK: const int32_t {{v[0-9]+}} = 32;
+// CHECK: const float {{v[0-9]+}} = 10.0f;
+// CHECK: const float {{v[0-9]+}} = 1.0f;
+// CHECK: const bool {{v[0-9]+}} = false;
+// CHECK: const bool {{v[0-9]+}} = true;
+// CHECK: const int32_t {{v[0-9]+}} = 4;
+// CHECK: const int32_t {{v[0-9]+}} = 2;
+// CHECK: const int32_t {{v[0-9]+}} = 1;
+// CHECK: const int32_t {{v[0-9]+}} = 0;
 // CHECK: using T = float;
 // CHECK: #if defined(__DAV_VEC__)
 // CHECK: set_mask_norm();

--- a/test/basic/tpush_tpop_emitc.pto
+++ b/test/basic/tpush_tpop_emitc.pto
@@ -1,0 +1,52 @@
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+
+module {
+  func.func @cube_push_gm(%gm_slot_buffer: memref<256xf32, #pto.address_space<gm>>,
+                          %c2v_consumer_buf: i32) attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %pipe = pto.initialize_l2g2l_pipe {
+      dir_mask = 1,
+      slot_size = 1024,
+      slot_num = 8,
+      local_slot_num = 8,
+      flag_base = 0
+    }(%gm_slot_buffer : memref<256xf32, #pto.address_space<gm>>, %c2v_consumer_buf : i32) -> !pto.pipe
+    %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tpush(%acc_tile, %pipe : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>, !pto.pipe) {split = 0}
+    return
+  }
+
+  func.func @vector_pop_gm(%gm_slot_buffer: memref<256xf32, #pto.address_space<gm>>,
+                           %c2v_consumer_buf: i32) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %pipe = pto.initialize_l2g2l_pipe {
+      dir_mask = 1,
+      slot_size = 1024,
+      slot_num = 8,
+      local_slot_num = 8,
+      flag_base = 0
+    }(%gm_slot_buffer : memref<256xf32, #pto.address_space<gm>>, %c2v_consumer_buf : i32) -> !pto.pipe
+    %fifo_tile = pto.declare_tile -> !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tpop(%fifo_tile, %pipe : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.pipe) {split = 1}
+    pto.tfree(%pipe : !pto.pipe) {split = 2}
+    return
+  }
+}
+
+// A3-LABEL: AICORE void cube_push_gm(
+// A3: const int32_t {{v[0-9]+}} = 0;
+// A3: const int32_t {{v[0-9]+}} = 16;
+// A3: const int64_t {{v[0-9]+}} = 0;
+// A3: #if defined(__DAV_CUBE__)
+// A3: auto {{v[0-9]+}} = TPipe<0, Direction::DIR_C2V, 1024, 8, 8>(
+// A3: TPUSH<TPipe<0, Direction::DIR_C2V, 1024, 8, 8>, Tile<TileType::Acc, float, 16, 16, BLayout::ColMajor, 16, 16, SLayout::RowMajor, 1024, PadValue::Null>, TileSplitAxis::TILE_NO_SPLIT>(
+// A3: #endif // __DAV_CUBE__
+
+// A3-LABEL: AICORE void vector_pop_gm(
+// A3: const int32_t {{v[0-9]+}} = 0;
+// A3: #if defined(__DAV_VEC__)
+// A3: set_mask_norm();
+// A3: set_vector_mask(-1, -1);
+// A3: auto {{v[0-9]+}} = TPipe<0, Direction::DIR_C2V, 1024, 8, 8>(
+// A3: Tile<TileType::Vec, float, 8, 16, BLayout::RowMajor, 8, 16, SLayout::NoneBox, 512, PadValue::Null> {{v[0-9]+}};
+// A3: TPOP<TPipe<0, Direction::DIR_C2V, 1024, 8, 8>, Tile<TileType::Vec, float, 8, 16, BLayout::RowMajor, 8, 16, SLayout::NoneBox, 512, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(
+// A3: TFREE<TPipe<0, Direction::DIR_C2V, 1024, 8, 8>, TileSplitAxis::TILE_LEFT_RIGHT>(
+// A3: #endif // __DAV_VEC__

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -1,12 +1,9 @@
-// Copyright (c) 2026 Huawei Technologies Co., Ltd.
-// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
-// CANN Open Software License Agreement Version 2.0 (the "License").
-// Please refer to the License for details. You may not use this file except in compliance with the License.
-// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
-// See LICENSE in the root of the software repository for the full text of the License.
-
 //===- ptoas.cpp -------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
 //===----------------------------------------------------------------------===//
 
 #include "PTO/IR/PTO.h"
@@ -37,11 +34,14 @@
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/EmitC/Transforms/Passes.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Regex.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/ADT/StringMap.h"
 #include <string>
 
 using namespace mlir;
@@ -275,9 +275,10 @@ static bool rewriteMarkerCallToMember(std::string &cpp, llvm::StringRef marker,
                                       unsigned expectedNumArgs) {
   size_t searchPos = 0;
   bool changed = false;
-  for (size_t markerPos = cpp.find(marker.str(), searchPos);
-       markerPos != std::string::npos;
-       markerPos = cpp.find(marker.str(), searchPos)) {
+  while (true) {
+    size_t markerPos = cpp.find(marker.str(), searchPos);
+    if (markerPos == std::string::npos)
+      break;
 
     size_t lparenPos = markerPos + marker.size();
     if (lparenPos >= cpp.size() || cpp[lparenPos] != '(') {
@@ -450,9 +451,10 @@ static bool rewriteMarkerCallToSubscript(std::string &cpp, llvm::StringRef marke
                                          bool isStore) {
   size_t searchPos = 0;
   bool changed = false;
-  for (size_t markerPos = cpp.find(marker.str(), searchPos);
-       markerPos != std::string::npos;
-       markerPos = cpp.find(marker.str(), searchPos)) {
+  while (true) {
+    size_t markerPos = cpp.find(marker.str(), searchPos);
+    if (markerPos == std::string::npos)
+      break;
 
     size_t lparenPos = markerPos + marker.size();
     if (lparenPos >= cpp.size() || cpp[lparenPos] != '(') {
@@ -544,9 +546,10 @@ static void rewriteEventIdArrayMarkers(std::string &cpp) {
 static bool rewriteAddPtrTraceMarkers(std::string &cpp, bool showTrace) {
   size_t searchPos = 0;
   bool changed = false;
-  for (size_t markerPos = cpp.find("PTOAS__ADDPTR_TRACE", searchPos);
-       markerPos != std::string::npos;
-       markerPos = cpp.find("PTOAS__ADDPTR_TRACE", searchPos)) {
+  while (true) {
+    size_t markerPos = cpp.find("PTOAS__ADDPTR_TRACE", searchPos);
+    if (markerPos == std::string::npos)
+      break;
 
     size_t lparenPos = markerPos + (sizeof("PTOAS__ADDPTR_TRACE") - 1);
     if (lparenPos >= cpp.size() || cpp[lparenPos] != '(') {
@@ -630,10 +633,14 @@ static void rewriteHoistedGlobalTensorDecls(std::string &cpp) {
   // declarations to the top of the function and emits assignments later. This
   // requires the C++ type to be default-constructible.
   //
-  // `GlobalTensor<...>` from pto-isa does not have a default constructor, so a
-  // hoisted declaration without an initializer would fail to compile.
+  // `GlobalTensor<...>` from pto-isa does NOT have a default constructor, so a
+  // hoisted declaration like:
+  //   GlobalTensor<...> v42;
   // fails to compile. Initialize those hoisted temporaries with a null pointer
-  // so they stay constructible until the later assignment overwrites them.
+  // so they are constructible:
+  //   GlobalTensor<...> v42(nullptr);
+  //
+  // We keep the assignment later; the null-initialized value is never used.
   std::string out;
   out.reserve(cpp.size() + 64);
 
@@ -684,6 +691,232 @@ static void rewriteHoistedGlobalTensorDecls(std::string &cpp) {
   cpp.swap(out);
 }
 
+namespace {
+struct ConstantDeclCandidate {
+  size_t declLine = 0;
+  std::string indent;
+  std::string type;
+  bool hasInitializer = false;
+  std::string initializer;
+  size_t assignmentCount = 0;
+  size_t assignmentLine = 0;
+  std::string assignmentRhs;
+};
+} // namespace
+
+static bool isGeneratedValueName(llvm::StringRef name) {
+  if (!name.consume_front("v") || name.empty())
+    return false;
+  return llvm::all_of(name, [](char c) { return std::isdigit(c); });
+}
+
+static bool isConstFoldableScalarType(llvm::StringRef type) {
+  type = type.trim();
+  if (type.starts_with("const ") || type.starts_with("constexpr "))
+    return false;
+  return llvm::StringSwitch<bool>(type)
+      .Cases("bool", "float", "double", "half", "bfloat16_t", true)
+      .Cases("int8_t", "uint8_t", "int16_t", "uint16_t", true)
+      .Cases("int32_t", "uint32_t", "int64_t", "uint64_t", true)
+      .Default(false);
+}
+
+static bool isLiteralInitializer(llvm::StringRef rhs) {
+  rhs = rhs.trim();
+  if (rhs.empty())
+    return false;
+  if (rhs == "true" || rhs == "false" || rhs == "nullptr")
+    return true;
+
+  static const llvm::Regex kIntLiteral(
+      R"(^[+-]?(0[xX][0-9A-Fa-f]+|[0-9]+)[uUlL]*$)");
+  static const llvm::Regex kFloatLiteral(
+      R"(^[+-]?(([0-9]+\.[0-9]*|\.[0-9]+|[0-9]+)([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)[fF]?$)");
+  static const llvm::Regex kHexFloatLiteral(
+      R"(^[+-]?0[xX]([0-9A-Fa-f]+\.[0-9A-Fa-f]*|[0-9A-Fa-f]+|\.[0-9A-Fa-f]+)[pP][+-]?[0-9]+[fF]?$)");
+  static const llvm::Regex kSpecialFloatLiteral(
+      R"(^[+-]?(nan|inf)[fF]?$)");
+
+  return kIntLiteral.match(rhs) || kFloatLiteral.match(rhs) ||
+         kHexFloatLiteral.match(rhs) || kSpecialFloatLiteral.match(rhs);
+}
+
+static std::string normalizeConstInitializer(llvm::StringRef type,
+                                             llvm::StringRef rhs) {
+  type = type.trim();
+  rhs = rhs.trim();
+  if (type == "bool") {
+    if (rhs == "0" || rhs == "false")
+      return "false";
+    if (rhs == "1" || rhs == "-1" || rhs == "true")
+      return "true";
+  }
+  return rhs.str();
+}
+
+static bool parseConstantDeclarationLine(llvm::StringRef line,
+                                         ConstantDeclCandidate &candidate,
+                                         std::string &valueName) {
+  llvm::StringRef trimmed = line.trim();
+  if (trimmed.empty() || trimmed.starts_with("#") || trimmed.starts_with("//") ||
+      !trimmed.ends_with(";"))
+    return false;
+
+  llvm::StringRef body = trimmed.drop_back().rtrim();
+  if (body.starts_with("return") || body.starts_with("goto ") ||
+      body.starts_with("if ") || body.starts_with("if(") ||
+      body.starts_with("switch ") || body.starts_with("switch(") ||
+      body.starts_with("for ") || body.starts_with("for(") ||
+      body.starts_with("while ") || body.starts_with("while(") ||
+      body.starts_with("case ") || body == "default")
+    return false;
+
+  llvm::StringRef lhs = body;
+  llvm::StringRef rhs;
+  if (size_t eqPos = body.find('='); eqPos != llvm::StringRef::npos) {
+    lhs = body.take_front(eqPos).rtrim();
+    rhs = body.drop_front(eqPos + 1).trim();
+  }
+
+  size_t lastWs = lhs.find_last_of(" \t");
+  if (lastWs == llvm::StringRef::npos)
+    return false;
+
+  llvm::StringRef type = lhs.take_front(lastWs).rtrim();
+  llvm::StringRef name = lhs.drop_front(lastWs + 1).trim();
+  if (!isGeneratedValueName(name) || !isConstFoldableScalarType(type))
+    return false;
+
+  size_t indentLen = line.find_first_not_of(" \t");
+  if (indentLen == llvm::StringRef::npos)
+    indentLen = 0;
+  candidate.indent = line.take_front(indentLen).str();
+  candidate.type = type.str();
+  valueName = name.str();
+
+  if (!rhs.empty()) {
+    if (!isLiteralInitializer(rhs))
+      return false;
+    candidate.hasInitializer = true;
+    candidate.initializer = normalizeConstInitializer(type, rhs);
+  }
+
+  return true;
+}
+
+static bool parseGeneratedValueAssignment(llvm::StringRef line,
+                                          llvm::StringRef &valueName,
+                                          llvm::StringRef &rhs) {
+  llvm::StringRef trimmed = line.trim();
+  if (trimmed.empty() || trimmed.starts_with("#") || trimmed.starts_with("//") ||
+      !trimmed.ends_with(";"))
+    return false;
+
+  llvm::StringRef body = trimmed.drop_back().rtrim();
+  size_t eqPos = body.find('=');
+  if (eqPos == llvm::StringRef::npos)
+    return false;
+
+  llvm::StringRef lhs = body.take_front(eqPos).rtrim();
+  rhs = body.drop_front(eqPos + 1).trim();
+  if (!isGeneratedValueName(lhs))
+    return false;
+  valueName = lhs;
+  return true;
+}
+
+static void rewriteScalarConstantDecls(std::string &cpp) {
+  llvm::SmallVector<std::string, 0> lines;
+  llvm::StringRef ref(cpp);
+  while (true) {
+    auto split = ref.split('\n');
+    lines.push_back(split.first.str());
+    if (split.second.empty())
+      break;
+    ref = split.second;
+  }
+
+  llvm::SmallVector<bool, 0> eraseLine(lines.size(), false);
+  auto rewriteSegment = [&](size_t beginLine, size_t endLine) {
+    llvm::StringMap<ConstantDeclCandidate> candidates;
+
+    for (size_t i = beginLine; i <= endLine; ++i) {
+      ConstantDeclCandidate candidate;
+      std::string valueName;
+      if (parseConstantDeclarationLine(lines[i], candidate, valueName)) {
+        candidate.declLine = i;
+        candidates[valueName] = std::move(candidate);
+        continue;
+      }
+
+      llvm::StringRef assignedName;
+      llvm::StringRef rhs;
+      if (!parseGeneratedValueAssignment(lines[i], assignedName, rhs))
+        continue;
+
+      auto it = candidates.find(assignedName);
+      if (it == candidates.end())
+        continue;
+
+      ConstantDeclCandidate &info = it->second;
+      ++info.assignmentCount;
+      info.assignmentLine = i;
+      info.assignmentRhs = rhs.str();
+    }
+
+    for (auto &entry : candidates) {
+      llvm::StringRef valueName = entry.getKey();
+      ConstantDeclCandidate &info = entry.getValue();
+
+      std::string initializer;
+      if (info.hasInitializer) {
+        if (info.assignmentCount != 0)
+          continue;
+        initializer = info.initializer;
+      } else {
+        if (info.assignmentCount != 1)
+          continue;
+        if (!isLiteralInitializer(info.assignmentRhs))
+          continue;
+        initializer = normalizeConstInitializer(
+            info.type, llvm::StringRef(info.assignmentRhs));
+        eraseLine[info.assignmentLine] = true;
+      }
+
+      lines[info.declLine] = (info.indent + "const " + info.type + " " +
+                              valueName.str() + " = " + initializer + ";");
+    }
+  };
+
+  int braceDepth = 0;
+  size_t segmentStart = 0;
+  for (size_t i = 0; i < lines.size(); ++i) {
+    int depthBefore = braceDepth;
+    for (char c : lines[i]) {
+      if (c == '{')
+        ++braceDepth;
+      else if (c == '}')
+        --braceDepth;
+    }
+
+    if (depthBefore == 0 && braceDepth > 0)
+      segmentStart = i;
+    if (depthBefore > 0 && braceDepth == 0)
+      rewriteSegment(segmentStart, i);
+  }
+
+  std::string out;
+  out.reserve(cpp.size());
+  for (size_t i = 0; i < lines.size(); ++i) {
+    if (eraseLine[i])
+      continue;
+    out.append(lines[i]);
+    if (i + 1 != lines.size())
+      out.push_back('\n');
+  }
+  cpp.swap(out);
+}
+
 int main(int argc, char **argv) {
   DialectRegistry registry;
   registry.insert<mlir::func::FuncDialect>();
@@ -696,8 +929,10 @@ int main(int argc, char **argv) {
   registry.insert<mlir::scf::SCFDialect>();
 
   registry.insert<mlir::pto::PTODialect>();
+  //mlir::registerAllDialects(registry);
   arith::registerBufferizableOpInterfaceExternalModels(registry);
   tensor::registerBufferizableOpInterfaceExternalModels(registry);
+  //func::registerBufferizableOpInterfaceExternalModels(registry);
   pto::registerBufferizableOpInterfaceExternalModels(registry);
 
   registry.insert<emitc::EmitCDialect>();
@@ -849,6 +1084,7 @@ int main(int argc, char **argv) {
   if (!disableInferLayout)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createInferPTOLayoutPass());
   pm.addPass(pto::createPTOViewToMemrefPass());
+  //pm.addPass(createInferPTOMemScopePass());
 
   if (effectiveLevel != PTOBuildLevel::Level3) {
     PlanMemoryOptions planMemoryOption;
@@ -915,6 +1151,7 @@ int main(int argc, char **argv) {
   rewritePtrScalarMarkers(cppOutput);
   rewriteEventIdArrayMarkers(cppOutput);
   rewriteAddPtrTraceMarkers(cppOutput, emitAddPtrTrace);
+  rewriteScalarConstantDecls(cppOutput);
   rewriteHoistedGlobalTensorDecls(cppOutput);
   outputFile.os() << cppOutput;
 


### PR DESCRIPTION
## Summary
- rewrite emitted scalar temporaries backed by literal values into `const <type> v = <literal>;`
- handle both single-block functions and hoisted declarations in multi-block EmitC output
- extend EmitC regression coverage for the hoisted `scf.while` case and the existing `tpush_tpop` sample

## Why
This keeps the generated C++ closer to constant-style declarations such as `const int v = 1` without changing the lowering pipeline itself.

## Validation
- `build/tools/ptoas/ptoas test/basic/kernel_kind_vector_scf_while_emitc.pto 2>&1 | /home/gpt/llvm-project/out-of-tree-ptoas/llvm-project/llvm/build-shared/bin/FileCheck test/basic/kernel_kind_vector_scf_while_emitc.pto`
- `build/tools/ptoas/ptoas --pto-arch=a3 test/basic/tpush_tpop_emitc.pto 2>&1 | /home/gpt/llvm-project/out-of-tree-ptoas/llvm-project/llvm/build-shared/bin/FileCheck test/basic/tpush_tpop_emitc.pto --check-prefix=A3`

## Note
- `test/basic/tpush_tpop_emitc.pto` is not present on the current `main` branch, so this focused PR carries it as a new file with the added checks from the current workspace state.