### PR TITLE
test: add scope3 TPushTPop precision reproducer

### DIFF
--- a/test/basic/tpush_tpop_scope3_precision_a5.pto
+++ b/test/basic/tpush_tpop_scope3_precision_a5.pto
@@ -1,0 +1,110 @@
+// RUN: ptoas --pto-arch=a5 --pto-level=level3 %s 2>&1 | FileCheck %s --check-prefix=A5
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @scope3_incore_0_incore_0_aic(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<bf16>, %arg2: !pto.ptr<f32>, %arg3: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c16384 = arith.constant 16384 : i64
+    %c0i = arith.constant 0 : i64
+    %c16 = arith.constant 16 : index
+    %c128 = arith.constant 128 : index
+    %c64 = arith.constant 64 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %attn_out_view = pto.make_tensor_view %arg0, shape = [%c16, %c128], strides = [%c128, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xf32>
+    %hidden_states_view = pto.make_tensor_view %arg1, shape = [%c16, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %resid_out_view = pto.make_tensor_view %arg2, shape = [%c16, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xf32>
+    %wo_view = pto.make_tensor_view %arg3, shape = [%c128, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %v2c_buf = pto.reserve_buffer {name = "scope3_incore_0_incore_0_v2c_slot_buffer", size = 16384, location = #pto.address_space<mat>, auto = false, base = 0} -> i32
+    %c2v_buf_import = pto.import_reserved_buffer {name = "scope3_incore_0_incore_0_c2v_slot_buffer", peer_func = @scope3_incore_0_incore_0_aiv} -> i32
+    pto.aic_initialize_pipe {dir_mask = 3, slot_size = 4096} (c2v_consumer_buf = %c2v_buf_import : i32, v2c_consumer_buf = %v2c_buf : i32)
+
+    %w_tile = pto.alloc_tile addr = %c16384 : !pto.tile_buf<loc=mat, dtype=bf16, rows=128, cols=64, v_row=128, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %wo_pview = pto.partition_view %wo_view, offsets = [%c0, %c0], sizes = [%c128, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<128x64xbf16>
+    pto.tload ins(%wo_pview : !pto.partition_tensor_view<128x64xbf16>) outs(%w_tile : !pto.tile_buf<loc=mat, dtype=bf16, rows=128, cols=64, v_row=128, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+
+    %a_tile_mat = pto.tpop_from_aiv {split = 1} -> !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %a_tile_left = pto.alloc_tile addr = %c0i : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tmov ins(%a_tile_mat : !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%a_tile_left : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    pto.tfree_from_aiv {split = 1}
+
+    %w_tile_right = pto.alloc_tile addr = %c0i : !pto.tile_buf<loc=right, dtype=bf16, rows=128, cols=64, v_row=128, v_col=64, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+    pto.tmov ins(%w_tile : !pto.tile_buf<loc=mat, dtype=bf16, rows=128, cols=64, v_row=128, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%w_tile_right : !pto.tile_buf<loc=right, dtype=bf16, rows=128, cols=64, v_row=128, v_col=64, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+
+    %out_tile = pto.alloc_tile addr = %c0i : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tmatmul ins(%a_tile_left, %w_tile_right : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=bf16, rows=128, cols=64, v_row=128, v_col=64, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%out_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+    pto.tpush_to_aiv(%out_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 1}
+    return
+  }
+
+  func.func @scope3_incore_0_incore_0_aiv(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<bf16>, %arg2: !pto.ptr<f32>, %arg3: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c16384 = arith.constant 16384 : i64
+    %c18432 = arith.constant 18432 : i64
+    %c22528 = arith.constant 22528 : i64
+    %c24576 = arith.constant 24576 : i64
+    %c28672 = arith.constant 28672 : i64
+    %c30720 = arith.constant 30720 : i64
+    %c16 = arith.constant 16 : index
+    %c128 = arith.constant 128 : index
+    %c64 = arith.constant 64 : index
+    %c8 = arith.constant 8 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %c8_i64 = arith.constant 8 : i64
+    %attn_out_view = pto.make_tensor_view %arg0, shape = [%c16, %c128], strides = [%c128, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xf32>
+    %hidden_states_view = pto.make_tensor_view %arg1, shape = [%c16, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %resid_out_view = pto.make_tensor_view %arg2, shape = [%c16, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xf32>
+    %wo_view = pto.make_tensor_view %arg3, shape = [%c128, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %subblock_idx = pto.get_subblock_idx
+    %v2c_buf_import = pto.import_reserved_buffer {name = "scope3_incore_0_incore_0_v2c_slot_buffer", peer_func = @scope3_incore_0_incore_0_aic} -> i32
+    %c2v_buf = pto.reserve_buffer {name = "scope3_incore_0_incore_0_c2v_slot_buffer", size = 16384, location = #pto.address_space<vec>, auto = false, base = 0} -> i32
+    pto.aiv_initialize_pipe {dir_mask = 3, slot_size = 4096} (c2v_consumer_buf = %c2v_buf : i32, v2c_consumer_buf = %v2c_buf_import : i32)
+
+    %row_offset_i64 = arith.muli %subblock_idx, %c8_i64 : i64
+    %row_offset = arith.index_cast %row_offset_i64 : i64 to index
+
+    %attn_tile_f32 = pto.alloc_tile addr = %c18432 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %attn_pview = pto.partition_view %attn_out_view, offsets = [%row_offset, %c0], sizes = [%c8, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<8x128xf32>
+    pto.tload ins(%attn_pview : !pto.partition_tensor_view<8x128xf32>) outs(%attn_tile_f32 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %attn_tile_bf16 = pto.alloc_tile addr = %c22528 : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcvt ins(%attn_tile_f32{rmode = #pto<round_mode ROUND>} : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%attn_tile_bf16 : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %attn_tile_nz = pto.alloc_tile addr = %c24576 : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=128, v_row=8, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tmov ins(%attn_tile_bf16 : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%attn_tile_nz : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=128, v_row=8, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    pto.tpush_to_aic(%attn_tile_nz : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=128, v_row=8, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>) {split = 1}
+
+    %cube_out = pto.tpop_from_aic {split = 1} -> !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %hidden_tile_bf16 = pto.alloc_tile addr = %c30720 : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %hidden_pview = pto.partition_view %hidden_states_view, offsets = [%row_offset, %c0], sizes = [%c8, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<8x64xbf16>
+    pto.tload ins(%hidden_pview : !pto.partition_tensor_view<8x64xbf16>) outs(%hidden_tile_bf16 : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %hidden_tile = pto.alloc_tile addr = %c28672 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcvt ins(%hidden_tile_bf16{rmode = #pto<round_mode ROUND>} : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%hidden_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %final_tile = pto.alloc_tile addr = %c16384 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%cube_out, %hidden_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%final_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tfree_from_aic {split = 1}
+
+    %resid_pview = pto.partition_view %resid_out_view, offsets = [%row_offset, %c0], sizes = [%c8, %c64] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<8x64xf32>
+    pto.tstore ins(%final_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%resid_pview : !pto.partition_tensor_view<8x64xf32>)
+    return
+  }
+}
+
+// A5-LABEL: AICORE void scope3_incore_0_incore_0_aic(
+// A5: auto {{v[0-9]+}} = TPipe<0, Direction::DIR_BOTH, 4096, 4>(
+// A5: Tile<TileType::Mat, bfloat16_t, 16, 128, BLayout::ColMajor, 16, 128, SLayout::RowMajor, 512, PadValue::Null> {{v[0-9]+}};
+// A5: TPOP<TPipe<0, Direction::DIR_BOTH, 4096, 4>, Tile<TileType::Mat, bfloat16_t, 16, 128, BLayout::ColMajor, 16, 128, SLayout::RowMajor, 512, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(
+// A5: Tile<TileType::Left, bfloat16_t, 16, 128, BLayout::ColMajor, 16, 128, SLayout::RowMajor, 512, PadValue::Null> {{v[0-9]+}};
+// A5: Tile<TileType::Right, bfloat16_t, 128, 64, BLayout::RowMajor, 128, 64, SLayout::ColMajor, 512, PadValue::Null> {{v[0-9]+}};
+// A5: TMATMUL(
+// A5: TPUSH<TPipe<0, Direction::DIR_BOTH, 4096, 4>, Tile<TileType::Acc, float, 16, 64, BLayout::ColMajor, 16, 64, SLayout::RowMajor, 1024, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(
+
+// A5-LABEL: AICORE void scope3_incore_0_incore_0_aiv(
+// A5: Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, 8, 128, SLayout::NoneBox, 512, PadValue::Null> {{v[0-9]+}};
+// A5: TCVT(
+// A5: Tile<TileType::Vec, bfloat16_t, 8, 128, BLayout::ColMajor, 8, 128, SLayout::RowMajor, 512, PadValue::Null> {{v[0-9]+}};
+// A5: TPUSH<TPipe<0, Direction::DIR_BOTH, 4096, 4>, Tile<TileType::Vec, bfloat16_t, 8, 128, BLayout::ColMajor, 8, 128, SLayout::RowMajor, 512, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(
+// A5: TPOP<TPipe<0, Direction::DIR_BOTH, 4096, 4>, Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 8, 64, SLayout::NoneBox, 512, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(
+// A5: TADD(
+// A5: TSTORE(

--- a/test/samples/TPushTPop/test7/kernel.cpp
+++ b/test/samples/TPushTPop/test7/kernel.cpp
@@ -1,0 +1,117 @@
+#include "pto/pto-inst.hpp"
+using namespace pto;
+
+enum class PTOAutoSyncTailMode : int {
+  kBarrierAll = 0,
+  kSetWaitMte3ToSEvent0 = 1,
+};
+
+static AICORE inline void ptoas_auto_sync_tail(
+    PTOAutoSyncTailMode mode = PTOAutoSyncTailMode::kBarrierAll) {
+  switch (mode) {
+  case PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0:
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    break;
+  case PTOAutoSyncTailMode::kBarrierAll:
+  default:
+    pipe_barrier(PIPE_ALL);
+    break;
+  }
+}
+
+AICORE void scope3_incore_0_incore_0_aic(__gm__ float* v1, __gm__ bfloat16_t* v2, __gm__ float* v3, __gm__ bfloat16_t* v4) {
+  unsigned v5 = 0;
+  __gm__ void * v6 = nullptr;
+  const int32_t v7 = 1;
+  const int32_t v8 = 64;
+  const int64_t v9 = 0;
+  const int64_t v10 = 16384;
+  const int32_t v11 = 0;
+  using T = float;
+
+  #if defined(__DAV_CUBE__)
+  auto v12 = TPipe<0, Direction::DIR_BOTH, 4096, 4>(v6, v11, v11);
+  Tile<TileType::Mat, bfloat16_t, 128, 64, BLayout::ColMajor, 128, 64, SLayout::RowMajor, 512, PadValue::Null> v13;
+  TASSIGN(v13, v10);
+  pto::Shape<1, 1, 1, 128, 64> v14 = pto::Shape<1, 1, 1, 128, 64>();
+  pto::Stride<8192, 8192, 8192, 64, 1> v15 = pto::Stride<8192, 8192, 8192, 64, 1>();
+  GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 128, 64>, pto::Stride<8192, 8192, 8192, 64, 1>, pto::Layout::ND> v16 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 128, 64>, pto::Stride<8192, 8192, 8192, 64, 1>, pto::Layout::ND>(v4 + (v5 + v5 * (unsigned) v8 + v5 * (unsigned) v7), v14, v15);
+  TLOAD(v13, v16);
+  Tile<TileType::Mat, bfloat16_t, 16, 128, BLayout::ColMajor, 16, 128, SLayout::RowMajor, 512, PadValue::Null> v17;
+  TPOP<TPipe<0, Direction::DIR_BOTH, 4096, 4>, Tile<TileType::Mat, bfloat16_t, 16, 128, BLayout::ColMajor, 16, 128, SLayout::RowMajor, 512, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(v12, v17);
+  Tile<TileType::Left, bfloat16_t, 16, 128, BLayout::ColMajor, 16, 128, SLayout::RowMajor, 512, PadValue::Null> v18;
+  TASSIGN(v18, v9);
+  TMOV(v18, v17);
+  TFREE<TPipe<0, Direction::DIR_BOTH, 4096, 4>, TileSplitAxis::TILE_UP_DOWN>(v12);
+  Tile<TileType::Right, bfloat16_t, 128, 64, BLayout::RowMajor, 128, 64, SLayout::ColMajor, 512, PadValue::Null> v19;
+  TASSIGN(v19, v9);
+  TMOV(v19, v13);
+  Tile<TileType::Acc, float, 16, 64, BLayout::ColMajor, 16, 64, SLayout::RowMajor, 1024, PadValue::Null> v20;
+  TASSIGN(v20, v9);
+  TMATMUL(v20, v18, v19);
+  TPUSH<TPipe<0, Direction::DIR_BOTH, 4096, 4>, Tile<TileType::Acc, float, 16, 64, BLayout::ColMajor, 16, 64, SLayout::RowMajor, 1024, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(v12, v20);
+  #endif // __DAV_CUBE__
+
+  return;
+}
+
+AICORE void scope3_incore_0_incore_0_aiv(__gm__ float* v1, __gm__ bfloat16_t* v2, __gm__ float* v3, __gm__ bfloat16_t* v4) {
+  RoundMode v5 = RoundMode::CAST_ROUND;
+  unsigned v6 = 0;
+  __gm__ void * v7 = nullptr;
+  const int64_t v8 = 8;
+  const int32_t v9 = 1;
+  const int32_t v10 = 64;
+  const int32_t v11 = 128;
+  const int64_t v12 = 30720;
+  const int64_t v13 = 28672;
+  const int64_t v14 = 24576;
+  const int64_t v15 = 22528;
+  const int64_t v16 = 18432;
+  const int64_t v17 = 16384;
+  const int32_t v18 = 0;
+  using T = float;
+
+  #if defined(__DAV_VEC__)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+  int64_t v19 = get_subblockid();
+  auto v20 = TPipe<0, Direction::DIR_BOTH, 4096, 4>(v7, v18, v18);
+  int32_t v21 = (int32_t) ((int64_t) (uint64_t) ((int64_t) v19) * (uint64_t) v8);
+  Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, 8, 128, SLayout::NoneBox, 512, PadValue::Null> v22;
+  TASSIGN(v22, v16);
+  pto::Shape<1, 1, 1, 8, 128> v23 = pto::Shape<1, 1, 1, 8, 128>();
+  pto::Stride<1024, 1024, 1024, 128, 1> v24 = pto::Stride<1024, 1024, 1024, 128, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 8, 128>, pto::Stride<1024, 1024, 1024, 128, 1>, pto::Layout::ND> v25 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 128>, pto::Stride<1024, 1024, 1024, 128, 1>, pto::Layout::ND>(v1 + (v6 + (unsigned) v21 * (unsigned) v11 + v6 * (unsigned) v9), v23, v24);
+  TLOAD(v22, v25);
+  Tile<TileType::Vec, bfloat16_t, 8, 128, BLayout::RowMajor, 8, 128, SLayout::NoneBox, 512, PadValue::Null> v26;
+  TASSIGN(v26, v15);
+  TCVT(v26, v22, v5);
+  Tile<TileType::Vec, bfloat16_t, 8, 128, BLayout::ColMajor, 8, 128, SLayout::RowMajor, 512, PadValue::Null> v27;
+  TASSIGN(v27, v14);
+  TMOV(v27, v26);
+  TPUSH<TPipe<0, Direction::DIR_BOTH, 4096, 4>, Tile<TileType::Vec, bfloat16_t, 8, 128, BLayout::ColMajor, 8, 128, SLayout::RowMajor, 512, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(v20, v27);
+  Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 8, 64, SLayout::NoneBox, 512, PadValue::Null> v28;
+  TPOP<TPipe<0, Direction::DIR_BOTH, 4096, 4>, Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 8, 64, SLayout::NoneBox, 512, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(v20, v28);
+  Tile<TileType::Vec, bfloat16_t, 8, 64, BLayout::RowMajor, 8, 64, SLayout::NoneBox, 512, PadValue::Null> v29;
+  TASSIGN(v29, v12);
+  pto::Shape<1, 1, 1, 8, 64> v30 = pto::Shape<1, 1, 1, 8, 64>();
+  pto::Stride<512, 512, 512, 64, 1> v31 = pto::Stride<512, 512, 512, 64, 1>();
+  GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 8, 64>, pto::Stride<512, 512, 512, 64, 1>, pto::Layout::ND> v32 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 8, 64>, pto::Stride<512, 512, 512, 64, 1>, pto::Layout::ND>(v2 + (v6 + (unsigned) v21 * (unsigned) v10 + v6 * (unsigned) v9), v30, v31);
+  TLOAD(v29, v32);
+  Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 8, 64, SLayout::NoneBox, 512, PadValue::Null> v33;
+  TASSIGN(v33, v13);
+  TCVT(v33, v29, v5);
+  Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 8, 64, SLayout::NoneBox, 512, PadValue::Null> v34;
+  TASSIGN(v34, v17);
+  TADD(v34, v28, v33);
+  TFREE<TPipe<0, Direction::DIR_BOTH, 4096, 4>, TileSplitAxis::TILE_UP_DOWN>(v20);
+  pto::Shape<1, 1, 1, 8, 64> v35 = pto::Shape<1, 1, 1, 8, 64>();
+  pto::Stride<512, 512, 512, 64, 1> v36 = pto::Stride<512, 512, 512, 64, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 8, 64>, pto::Stride<512, 512, 512, 64, 1>, pto::Layout::ND> v37 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 64>, pto::Stride<512, 512, 512, 64, 1>, pto::Layout::ND>(v3 + (v6 + (unsigned) v21 * (unsigned) v10 + v6 * (unsigned) v9), v35, v36);
+  TSTORE(v37, v34);
+  #endif // __DAV_VEC__
+
+  return;
+}

--- a/test/samples/TPushTPop/test7/kernel.cpp
+++ b/test/samples/TPushTPop/test7/kernel.cpp
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
 #include "pto/pto-inst.hpp"
 using namespace pto;
 

--- a/test/samples/TPushTPop/test7/kernel.cpp
+++ b/test/samples/TPushTPop/test7/kernel.cpp
@@ -38,21 +38,30 @@ AICORE void scope3_incore_0_incore_0_aic(__gm__ float* v1, __gm__ bfloat16_t* v2
   pto::Stride<8192, 8192, 8192, 64, 1> v15 = pto::Stride<8192, 8192, 8192, 64, 1>();
   GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 128, 64>, pto::Stride<8192, 8192, 8192, 64, 1>, pto::Layout::ND> v16 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 128, 64>, pto::Stride<8192, 8192, 8192, 64, 1>, pto::Layout::ND>(v4 + (v5 + v5 * (unsigned) v8 + v5 * (unsigned) v7), v14, v15);
   TLOAD(v13, v16);
+  set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
   Tile<TileType::Mat, bfloat16_t, 16, 128, BLayout::ColMajor, 16, 128, SLayout::RowMajor, 512, PadValue::Null> v17;
   TPOP<TPipe<0, Direction::DIR_BOTH, 4096, 4>, Tile<TileType::Mat, bfloat16_t, 16, 128, BLayout::ColMajor, 16, 128, SLayout::RowMajor, 512, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(v12, v17);
+  set_flag(PIPE_S, PIPE_MTE1, EVENT_ID0);
   Tile<TileType::Left, bfloat16_t, 16, 128, BLayout::ColMajor, 16, 128, SLayout::RowMajor, 512, PadValue::Null> v18;
   TASSIGN(v18, v9);
+  wait_flag(PIPE_S, PIPE_MTE1, EVENT_ID0);
   TMOV(v18, v17);
   TFREE<TPipe<0, Direction::DIR_BOTH, 4096, 4>, TileSplitAxis::TILE_UP_DOWN>(v12);
   Tile<TileType::Right, bfloat16_t, 128, 64, BLayout::RowMajor, 128, 64, SLayout::ColMajor, 512, PadValue::Null> v19;
   TASSIGN(v19, v9);
+  wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
   TMOV(v19, v13);
+  set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
   Tile<TileType::Acc, float, 16, 64, BLayout::ColMajor, 16, 64, SLayout::RowMajor, 1024, PadValue::Null> v20;
   TASSIGN(v20, v9);
+  wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
   TMATMUL(v20, v18, v19);
+  set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+  wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
   TPUSH<TPipe<0, Direction::DIR_BOTH, 4096, 4>, Tile<TileType::Acc, float, 16, 64, BLayout::ColMajor, 16, 64, SLayout::RowMajor, 1024, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(v12, v20);
   #endif // __DAV_CUBE__
 
+  ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
   return;
 }
 
@@ -85,33 +94,44 @@ AICORE void scope3_incore_0_incore_0_aiv(__gm__ float* v1, __gm__ bfloat16_t* v2
   pto::Stride<1024, 1024, 1024, 128, 1> v24 = pto::Stride<1024, 1024, 1024, 128, 1>();
   GlobalTensor<float, pto::Shape<1, 1, 1, 8, 128>, pto::Stride<1024, 1024, 1024, 128, 1>, pto::Layout::ND> v25 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 128>, pto::Stride<1024, 1024, 1024, 128, 1>, pto::Layout::ND>(v1 + (v6 + (unsigned) v21 * (unsigned) v11 + v6 * (unsigned) v9), v23, v24);
   TLOAD(v22, v25);
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
   Tile<TileType::Vec, bfloat16_t, 8, 128, BLayout::RowMajor, 8, 128, SLayout::NoneBox, 512, PadValue::Null> v26;
   TASSIGN(v26, v15);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
   TCVT(v26, v22, v5);
   Tile<TileType::Vec, bfloat16_t, 8, 128, BLayout::ColMajor, 8, 128, SLayout::RowMajor, 512, PadValue::Null> v27;
   TASSIGN(v27, v14);
   TMOV(v27, v26);
+  set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
   TPUSH<TPipe<0, Direction::DIR_BOTH, 4096, 4>, Tile<TileType::Vec, bfloat16_t, 8, 128, BLayout::ColMajor, 8, 128, SLayout::RowMajor, 512, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(v20, v27);
   Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 8, 64, SLayout::NoneBox, 512, PadValue::Null> v28;
   TPOP<TPipe<0, Direction::DIR_BOTH, 4096, 4>, Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 8, 64, SLayout::NoneBox, 512, PadValue::Null>, TileSplitAxis::TILE_UP_DOWN>(v20, v28);
+  set_flag(PIPE_S, PIPE_V, EVENT_ID0);
   Tile<TileType::Vec, bfloat16_t, 8, 64, BLayout::RowMajor, 8, 64, SLayout::NoneBox, 512, PadValue::Null> v29;
   TASSIGN(v29, v12);
   pto::Shape<1, 1, 1, 8, 64> v30 = pto::Shape<1, 1, 1, 8, 64>();
   pto::Stride<512, 512, 512, 64, 1> v31 = pto::Stride<512, 512, 512, 64, 1>();
   GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 8, 64>, pto::Stride<512, 512, 512, 64, 1>, pto::Layout::ND> v32 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 8, 64>, pto::Stride<512, 512, 512, 64, 1>, pto::Layout::ND>(v2 + (v6 + (unsigned) v21 * (unsigned) v10 + v6 * (unsigned) v9), v30, v31);
   TLOAD(v29, v32);
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
   Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 8, 64, SLayout::NoneBox, 512, PadValue::Null> v33;
   TASSIGN(v33, v13);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
   TCVT(v33, v29, v5);
   Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 8, 64, SLayout::NoneBox, 512, PadValue::Null> v34;
   TASSIGN(v34, v17);
+  wait_flag(PIPE_S, PIPE_V, EVENT_ID0);
   TADD(v34, v28, v33);
+  set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
   TFREE<TPipe<0, Direction::DIR_BOTH, 4096, 4>, TileSplitAxis::TILE_UP_DOWN>(v20);
   pto::Shape<1, 1, 1, 8, 64> v35 = pto::Shape<1, 1, 1, 8, 64>();
   pto::Stride<512, 512, 512, 64, 1> v36 = pto::Stride<512, 512, 512, 64, 1>();
   GlobalTensor<float, pto::Shape<1, 1, 1, 8, 64>, pto::Stride<512, 512, 512, 64, 1>, pto::Layout::ND> v37 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 64>, pto::Stride<512, 512, 512, 64, 1>, pto::Layout::ND>(v3 + (v6 + (unsigned) v21 * (unsigned) v10 + v6 * (unsigned) v9), v35, v36);
+  wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
   TSTORE(v37, v34);
   #endif // __DAV_VEC__
 
+  ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
   return;
 }

--- a/test/samples/TPushTPop/test7/launch.cpp
+++ b/test/samples/TPushTPop/test7/launch.cpp
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
 // ---------------------------------------------------------------------------
 // PTOAS compatibility layer
 // ---------------------------------------------------------------------------

--- a/test/samples/TPushTPop/test7/launch.cpp
+++ b/test/samples/TPushTPop/test7/launch.cpp
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------
+// PTOAS compatibility layer
+// ---------------------------------------------------------------------------
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct {
+  unsigned char v;
+} hifloat8_t;
+typedef struct {
+  unsigned char v;
+} float8_e4m3_t;
+typedef struct {
+  unsigned char v;
+} float8_e5m2_t;
+typedef struct {
+  unsigned char v;
+} float8_e8m0_t;
+typedef struct {
+  unsigned char v;
+} float4_e1m2x2_t;
+typedef struct {
+  unsigned char v;
+} float4_e2m1x2_t;
+#endif
+
+#include <cstdint>
+
+#include "kernel.cpp"
+
+__global__ AICORE void scope3_incore_0_incore_0_kernel(
+    __gm__ float *attn_out, __gm__ bfloat16_t *hidden_states,
+    __gm__ float *resid_out, __gm__ bfloat16_t *wo) {
+  scope3_incore_0_incore_0_aic(attn_out, hidden_states, resid_out, wo);
+  scope3_incore_0_incore_0_aiv(attn_out, hidden_states, resid_out, wo);
+}
+
+void LaunchScope3Incore0Incore0(float *attn_out, uint16_t *hidden_states,
+                                float *resid_out, uint16_t *wo,
+                                void *stream) {
+  scope3_incore_0_incore_0_kernel<<<1, nullptr, stream>>>(
+      (__gm__ float *)attn_out, (__gm__ bfloat16_t *)hidden_states,
+      (__gm__ float *)resid_out, (__gm__ bfloat16_t *)wo);
+}

--- a/test/samples/TPushTPop/test7/main.cpp
+++ b/test/samples/TPushTPop/test7/main.cpp
@@ -1,0 +1,181 @@
+#include "acl/acl.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+void LaunchScope3Incore0Incore0(float *attn_out, uint16_t *hidden_states,
+                                float *resid_out, uint16_t *wo, void *stream);
+
+#define ACL_CHECK(expr)                                                        \
+  do {                                                                         \
+    aclError _ret = (expr);                                                    \
+    if (_ret != ACL_SUCCESS) {                                                 \
+      std::fprintf(stderr, "[ACL ERROR] %s failed: %d (%s:%d)\n", #expr,       \
+                   (int)_ret, __FILE__, __LINE__);                             \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+static uint16_t floatToBf16Bits(float value) {
+  uint32_t bits = 0;
+  std::memcpy(&bits, &value, sizeof(bits));
+  const uint32_t lsb = (bits >> 16) & 1u;
+  bits += 0x7FFFu + lsb;
+  return static_cast<uint16_t>(bits >> 16);
+}
+
+static float bf16BitsToFloat(uint16_t bits) {
+  uint32_t value = static_cast<uint32_t>(bits) << 16;
+  float result = 0.0f;
+  std::memcpy(&result, &value, sizeof(result));
+  return result;
+}
+
+static float attnValue(int row, int col) {
+  return static_cast<float>(row * 10 + col);
+}
+
+static float hiddenValue(int row, int col) {
+  return static_cast<float>((row % 4) * 3 - (col % 5));
+}
+
+static void printMatrix(const char *title, const std::vector<float> &data,
+                        int rows, int cols) {
+  std::printf("%s\n", title);
+  for (int row = 0; row < rows; ++row) {
+    std::printf("row %02d:", row);
+    for (int col = 0; col < cols; ++col)
+      std::printf(" %7.1f", data[static_cast<size_t>(row) * cols + col]);
+    std::printf("\n");
+  }
+}
+
+int main() {
+  constexpr int Rows = 16;
+  constexpr int KCols = 128;
+  constexpr int OutCols = 64;
+  constexpr int InitValue = -777;
+  constexpr float Atol = 1e-3f;
+  constexpr float Rtol = 1e-3f;
+
+  constexpr size_t attnElems = static_cast<size_t>(Rows) * KCols;
+  constexpr size_t hiddenElems = static_cast<size_t>(Rows) * OutCols;
+  constexpr size_t outElems = static_cast<size_t>(Rows) * OutCols;
+  constexpr size_t weightElems = static_cast<size_t>(KCols) * OutCols;
+
+  constexpr size_t attnBytes = attnElems * sizeof(float);
+  constexpr size_t hiddenBytes = hiddenElems * sizeof(uint16_t);
+  constexpr size_t outBytes = outElems * sizeof(float);
+  constexpr size_t weightBytes = weightElems * sizeof(uint16_t);
+
+  std::vector<float> hostAttn(attnElems, 0.0f);
+  std::vector<float> hostAttnRounded(attnElems, 0.0f);
+  std::vector<uint16_t> hostHidden(hiddenElems, 0);
+  std::vector<float> hostHiddenF32(hiddenElems, 0.0f);
+  std::vector<uint16_t> hostWeight(weightElems, 0);
+  std::vector<float> hostOut(outElems, static_cast<float>(InitValue));
+  std::vector<float> hostGolden(outElems, 0.0f);
+
+  for (int row = 0; row < Rows; ++row) {
+    for (int col = 0; col < KCols; ++col) {
+      const size_t idx = static_cast<size_t>(row) * KCols + col;
+      hostAttn[idx] = attnValue(row, col);
+      hostAttnRounded[idx] = bf16BitsToFloat(floatToBf16Bits(hostAttn[idx]));
+    }
+  }
+
+  for (int row = 0; row < Rows; ++row) {
+    for (int col = 0; col < OutCols; ++col) {
+      const size_t idx = static_cast<size_t>(row) * OutCols + col;
+      hostHidden[idx] = floatToBf16Bits(hiddenValue(row, col));
+      hostHiddenF32[idx] = bf16BitsToFloat(hostHidden[idx]);
+      hostGolden[idx] =
+          hostAttnRounded[static_cast<size_t>(row) * KCols + col] +
+          hostHiddenF32[idx];
+    }
+  }
+
+  for (int row = 0; row < KCols; ++row) {
+    for (int col = 0; col < OutCols; ++col) {
+      const size_t idx = static_cast<size_t>(row) * OutCols + col;
+      hostWeight[idx] = floatToBf16Bits(row == col ? 1.0f : 0.0f);
+    }
+  }
+
+  ACL_CHECK(aclInit(nullptr));
+  ACL_CHECK(aclrtSetDevice(0));
+
+  aclrtStream stream = nullptr;
+  ACL_CHECK(aclrtCreateStream(&stream));
+
+  float *devAttn = nullptr;
+  uint16_t *devHidden = nullptr;
+  float *devOut = nullptr;
+  uint16_t *devWeight = nullptr;
+
+  ACL_CHECK(aclrtMalloc(reinterpret_cast<void **>(&devAttn), attnBytes,
+                        ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc(reinterpret_cast<void **>(&devHidden), hiddenBytes,
+                        ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc(reinterpret_cast<void **>(&devOut), outBytes,
+                        ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc(reinterpret_cast<void **>(&devWeight), weightBytes,
+                        ACL_MEM_MALLOC_HUGE_FIRST));
+
+  ACL_CHECK(aclrtMemcpy(devAttn, attnBytes, hostAttn.data(), attnBytes,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(devHidden, hiddenBytes, hostHidden.data(), hiddenBytes,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(devOut, outBytes, hostOut.data(), outBytes,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(devWeight, weightBytes, hostWeight.data(), weightBytes,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+
+  LaunchScope3Incore0Incore0(devAttn, devHidden, devOut, devWeight, stream);
+
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(hostOut.data(), outBytes, devOut, outBytes,
+                        ACL_MEMCPY_DEVICE_TO_HOST));
+
+  printMatrix("device output:", hostOut, Rows, OutCols);
+  printMatrix("golden output:", hostGolden, Rows, OutCols);
+
+  int mismatchCount = 0;
+  for (int row = 0; row < Rows; ++row) {
+    for (int col = 0; col < OutCols; ++col) {
+      const size_t idx = static_cast<size_t>(row) * OutCols + col;
+      const float got = hostOut[idx];
+      const float expect = hostGolden[idx];
+      const float diff = std::fabs(got - expect);
+      const float limit = Atol + Rtol * std::fabs(expect);
+      if (diff > limit) {
+        if (mismatchCount < 16) {
+          std::fprintf(stderr,
+                       "Mismatch at (%d, %d): got %.6f, expect %.6f, diff %.6f, "
+                       "limit %.6f\n",
+                       row, col, got, expect, diff, limit);
+        }
+        ++mismatchCount;
+      }
+    }
+  }
+
+  if (mismatchCount == 0) {
+    std::puts("scope3_incore_0_incore_0 test7 passed.");
+  } else {
+    std::fprintf(stderr, "Found %d mismatches.\n", mismatchCount);
+  }
+
+  aclrtFree(devWeight);
+  aclrtFree(devOut);
+  aclrtFree(devHidden);
+  aclrtFree(devAttn);
+  aclrtDestroyStream(stream);
+  aclrtResetDevice(0);
+  aclFinalize();
+  return mismatchCount == 0 ? 0 : 1;
+}

--- a/test/samples/TPushTPop/test7/main.cpp
+++ b/test/samples/TPushTPop/test7/main.cpp
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
 #include "acl/acl.h"
 
 #include <cmath>

--- a/test/samples/TPushTPop/test7/scope3_incore_0_incore_0.pto
+++ b/test/samples/TPushTPop/test7/scope3_incore_0_incore_0.pto
@@ -1,0 +1,91 @@
+module attributes {pto.target_arch = "a5"} {
+  func.func @scope3_incore_0_incore_0_aic(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<bf16>, %arg2: !pto.ptr<f32>, %arg3: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c16384 = arith.constant 16384 : i64
+    %c0i = arith.constant 0 : i64
+    %c16 = arith.constant 16 : index
+    %c128 = arith.constant 128 : index
+    %c64 = arith.constant 64 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %attn_out_view = pto.make_tensor_view %arg0, shape = [%c16, %c128], strides = [%c128, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xf32>
+    %hidden_states_view = pto.make_tensor_view %arg1, shape = [%c16, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %resid_out_view = pto.make_tensor_view %arg2, shape = [%c16, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xf32>
+    %wo_view = pto.make_tensor_view %arg3, shape = [%c128, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %v2c_buf = pto.reserve_buffer {name = "scope3_incore_0_incore_0_v2c_slot_buffer", size = 16384, location = #pto.address_space<mat>, auto = false, base = 0} -> i32
+    %c2v_buf_import = pto.import_reserved_buffer {name = "scope3_incore_0_incore_0_c2v_slot_buffer", peer_func = @scope3_incore_0_incore_0_aiv} -> i32
+    pto.aic_initialize_pipe {dir_mask = 3, slot_size = 4096} (c2v_consumer_buf = %c2v_buf_import : i32, v2c_consumer_buf = %v2c_buf : i32)
+
+    %w_tile = pto.alloc_tile addr = %c16384 : !pto.tile_buf<loc=mat, dtype=bf16, rows=128, cols=64, v_row=128, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %wo_pview = pto.partition_view %wo_view, offsets = [%c0, %c0], sizes = [%c128, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<128x64xbf16>
+    pto.tload ins(%wo_pview : !pto.partition_tensor_view<128x64xbf16>) outs(%w_tile : !pto.tile_buf<loc=mat, dtype=bf16, rows=128, cols=64, v_row=128, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+
+    %a_tile_mat = pto.tpop_from_aiv {split = 1} -> !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %a_tile_left = pto.alloc_tile addr = %c0i : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tmov ins(%a_tile_mat : !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%a_tile_left : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    pto.tfree_from_aiv {split = 1}
+
+    %w_tile_right = pto.alloc_tile addr = %c0i : !pto.tile_buf<loc=right, dtype=bf16, rows=128, cols=64, v_row=128, v_col=64, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+    pto.tmov ins(%w_tile : !pto.tile_buf<loc=mat, dtype=bf16, rows=128, cols=64, v_row=128, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%w_tile_right : !pto.tile_buf<loc=right, dtype=bf16, rows=128, cols=64, v_row=128, v_col=64, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+
+    %out_tile = pto.alloc_tile addr = %c0i : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tmatmul ins(%a_tile_left, %w_tile_right : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=bf16, rows=128, cols=64, v_row=128, v_col=64, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%out_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+    pto.tpush_to_aiv(%out_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 1}
+    return
+  }
+
+  func.func @scope3_incore_0_incore_0_aiv(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<bf16>, %arg2: !pto.ptr<f32>, %arg3: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c16384 = arith.constant 16384 : i64
+    %c18432 = arith.constant 18432 : i64
+    %c22528 = arith.constant 22528 : i64
+    %c24576 = arith.constant 24576 : i64
+    %c28672 = arith.constant 28672 : i64
+    %c30720 = arith.constant 30720 : i64
+    %c16 = arith.constant 16 : index
+    %c128 = arith.constant 128 : index
+    %c64 = arith.constant 64 : index
+    %c8 = arith.constant 8 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %c8_i64 = arith.constant 8 : i64
+    %attn_out_view = pto.make_tensor_view %arg0, shape = [%c16, %c128], strides = [%c128, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xf32>
+    %hidden_states_view = pto.make_tensor_view %arg1, shape = [%c16, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %resid_out_view = pto.make_tensor_view %arg2, shape = [%c16, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xf32>
+    %wo_view = pto.make_tensor_view %arg3, shape = [%c128, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %subblock_idx = pto.get_subblock_idx
+    %v2c_buf_import = pto.import_reserved_buffer {name = "scope3_incore_0_incore_0_v2c_slot_buffer", peer_func = @scope3_incore_0_incore_0_aic} -> i32
+    %c2v_buf = pto.reserve_buffer {name = "scope3_incore_0_incore_0_c2v_slot_buffer", size = 16384, location = #pto.address_space<vec>, auto = false, base = 0} -> i32
+    pto.aiv_initialize_pipe {dir_mask = 3, slot_size = 4096} (c2v_consumer_buf = %c2v_buf : i32, v2c_consumer_buf = %v2c_buf_import : i32)
+
+    %row_offset_i64 = arith.muli %subblock_idx, %c8_i64 : i64
+    %row_offset = arith.index_cast %row_offset_i64 : i64 to index
+
+    %attn_tile_f32 = pto.alloc_tile addr = %c18432 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %attn_pview = pto.partition_view %attn_out_view, offsets = [%row_offset, %c0], sizes = [%c8, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<8x128xf32>
+    pto.tload ins(%attn_pview : !pto.partition_tensor_view<8x128xf32>) outs(%attn_tile_f32 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %attn_tile_bf16 = pto.alloc_tile addr = %c22528 : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcvt ins(%attn_tile_f32{rmode = #pto<round_mode ROUND>} : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%attn_tile_bf16 : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %attn_tile_nz = pto.alloc_tile addr = %c24576 : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=128, v_row=8, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tmov ins(%attn_tile_bf16 : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%attn_tile_nz : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=128, v_row=8, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    pto.tpush_to_aic(%attn_tile_nz : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=128, v_row=8, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>) {split = 1}
+
+    %cube_out = pto.tpop_from_aic {split = 1} -> !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %hidden_tile_bf16 = pto.alloc_tile addr = %c30720 : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %hidden_pview = pto.partition_view %hidden_states_view, offsets = [%row_offset, %c0], sizes = [%c8, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<8x64xbf16>
+    pto.tload ins(%hidden_pview : !pto.partition_tensor_view<8x64xbf16>) outs(%hidden_tile_bf16 : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %hidden_tile = pto.alloc_tile addr = %c28672 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcvt ins(%hidden_tile_bf16{rmode = #pto<round_mode ROUND>} : !pto.tile_buf<loc=vec, dtype=bf16, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%hidden_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %final_tile = pto.alloc_tile addr = %c16384 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%cube_out, %hidden_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%final_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tfree_from_aic {split = 1}
+
+    %resid_pview = pto.partition_view %resid_out_view, offsets = [%row_offset, %c0], sizes = [%c8, %c64] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<8x64xf32>
+    pto.tstore ins(%final_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%resid_pview : !pto.partition_tensor_view<8x64xf32>)
+    return
+  }
+}

--- a/test/samples/TPushTPop/test7/tensor.h
+++ b/test/samples/TPushTPop/test7/tensor.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+struct TensorBuffer {
+  void *addr;
+};
+
+struct Tensor {
+  TensorBuffer buffer;
+  int64_t start_offset;
+};

--- a/test/samples/TPushTPop/test7/tensor.h
+++ b/test/samples/TPushTPop/test7/tensor.h
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
 #pragma once
 
 #include <cstdint>


### PR DESCRIPTION
## Summary
- add `test/samples/TPushTPop/test7` as a scope3 single-window TPush/TPop precision reproducer
- add `test/basic/tpush_tpop_scope3_precision_a5.pto` as a lightweight A5 compile reproducer for slash-command testing

## Context
- testcase source: https://github.com/KurrinQu/PTOAS/tree/tpush-tpop-test6-scope3-20260402/test/samples/TPushTPop/test7
- upstream repo: https://github.com/hw-native-sys/PTOAS/

## Validation
- `git diff --check`
- local end-to-end FileCheck was not completed because the available WSL `ptoas` binary was from a divergent workspace
