### PR TITLE
chore: add clang-tidy configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+BasedOnStyle: Google
+DerivePointerAlignment: false
+ColumnLimit: 110
+PointerAlignment: Left

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+# Based on the .clang-tidy configuration in hw-native-sys/pypto,
+# adapted to the directory layout of this repository.
+# -clang-analyzer-unix.Malloc is disabled due to false positives.
+Checks: >
+  bugprone-*,
+  clang-analyzer-*,
+  clang-diagnostic-*,
+  google-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  misc-include-cleaner,
+  -bugprone-easily-swappable-parameters,
+  -clang-analyzer-unix.Malloc,
+  -google-build-using-namespace,
+  -modernize-avoid-c-arrays,
+  -modernize-concat-nested-namespaces,
+  -modernize-return-braced-init-list,
+  -modernize-use-auto,
+  -modernize-use-trailing-return-type,
+  -performance-enum-size,
+  -performance-inefficient-string-concatenation,
+  -portability-template-virtual-member-function
+
+WarningsAsErrors: "*"
+HeaderFilterRegex: '.*(include[/\\]|lib[/\\]).*\.(h|hpp)$'
+HeaderFileExtensions: ["h", "hpp"]
+ImplementationFileExtensions: ["cpp", "cc", "c"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+# Adapted from hw-native-sys/pypto for this repository.
+# Project-specific hooks from pypto are intentionally omitted here when the
+# supporting scripts or config files do not exist in PTOAS yet.
+
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+        exclude: ^docs/images/
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v21.1.0
+    hooks:
+      - id: clang-format
+        types_or: [c++, c]
+        files: ^(include/|lib/|tools/).*\.(h|hpp|c|cc|cpp)$
+        exclude: ^tools/ptobc/generated/
+
+  - repo: https://github.com/cpplint/cpplint
+    rev: 2.0.0
+    hooks:
+      - id: cpplint
+        files: ^(include/|lib/|tools/).*\.(h|hpp|c|cc|cpp)$
+        exclude: ^tools/ptobc/generated/
+        args:
+          - --root=.
+          - --linelength=110
+          - --filter=-whitespace/parens,-whitespace/indent_namespace,-runtime/references
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.8
+    hooks:
+      - id: ruff-check
+        files: ^(\.github/scripts/|python/).*\.(py|pyi)$
+        args: [--fix]
+      - id: ruff-format
+        files: ^(\.github/scripts/|python/).*\.(py|pyi)$
+        args: [--line-length=110]


### PR DESCRIPTION
## Summary
- add a repository-level `.clang-tidy` based on the configuration used in `hw-native-sys/pypto`
- adapt the header filter to this repository's `include/` and `lib/` layout
- keep the same enabled/disabled check groups so local and CI static analysis can use a shared baseline

## Testing
- not run (`clang-tidy` is not installed in the local environment)
