### PR TITLE
Update PTO IR manual pipe frontend notes

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -7791,13 +7791,36 @@ generated IR. The detailed design document is:
   - `1`: C2V
   - `2`: V2C
   - `3`: both directions at frontend level
+- `id` is a compile-time integer attribute used to bind
+  `pto.aic_initialize_pipe` / `pto.aiv_initialize_pipe` with the matching
+  `pto.tpush_*` / `pto.tpop_*` / `pto.tfree_*` ops in the same function.
 - `slot_size` is expressed in bytes and uses the pre-split logical tile size.
+- `nosplit` is an optional compile-time boolean attribute on
+  `pto.aic_initialize_pipe` / `pto.aiv_initialize_pipe`.
 - `split` is a compile-time attribute, not a runtime SSA operand.
 - `split = 0/1/2` corresponds to `TILE_NO_SPLIT`, `TILE_UP_DOWN`, and
   `TILE_LEFT_RIGHT`.
 - `pto.tpop_from_aic` and `pto.tpop_from_aiv` are result-valued frontend ops.
-- A single function currently models at most one logical C2V pipe and one
-  logical V2C pipe.
+- A single logical pipe cannot mix `split = 0` with `split = 1` / `2`.
+  `nosplit = true` requires all bound data-transfer ops to use `split = 0`;
+  `nosplit = false` requires all bound data-transfer ops to use `split = 1`
+  or `split = 2`.
+- Multiple logical pipes are allowed in one function.
+- A frontend logical pipe is uniquely identified by `function + id + direction`.
+- When `dir_mask = 1` or `2`, one `id` denotes one single-direction logical
+  pipe.
+- When `dir_mask = 3`, one `id` denotes one DIR_BOTH physical pipe covering
+  both logical directions.
+
+`nosplit` platform restrictions:
+
+- On A5, `nosplit` supports a `1C:1V` pipe communication mode. The vector side
+  may execute the pipe sequence on a single vector core.
+- On A2/A3, `nosplit` follows the hardware `1C:2V` synchronization
+  configuration. The two vector cores must run the same code for the same
+  logical pipe, and the `tpush` / `tpop` / `tfree` sequence for that pipe must
+  be identical in order on both vector cores. They do not need to reach each
+  operation at the same time; only the relative order must remain consistent.
 
 ##### `pto.reserve_buffer` - Reserve Local Consumer FIFO Buffer
 
@@ -7840,7 +7863,8 @@ When the address is already fixed in the input IR:
 
 **Constraints & Verification:**
 
-- At most one `pto.reserve_buffer` is expected in one function
+- Multiple `pto.reserve_buffer` ops are allowed in one function, but `name`
+  must be unique within that function
 - `location` must be a supported local address space
 - Op-level verification requires:
   - `auto = false` must provide `base`
@@ -7876,7 +7900,8 @@ function's reserved buffer declaration.
 
 **Constraints & Verification:**
 
-- At most one `pto.import_reserved_buffer` is expected in one function
+- Multiple `pto.import_reserved_buffer` ops are allowed in one function, but
+  the `(name, peer_func)` pair must be unique within that function
 - `peer_func` must contain a matching `pto.reserve_buffer`
 - The imported address is resolved by `pto-resolve-reserved-buffers`
   - from the peer `reserve_buffer.base` filled by `PlanMemory` when the active
@@ -7892,21 +7917,24 @@ function's reserved buffer declaration.
 
 ```mlir
 // A2/A3 (with GM slot buffer):
-pto.aic_initialize_pipe {dir_mask = 1, slot_size = 1024}
+pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
   (gm_slot_buffer = %gm_buf : !pto.ptr<f32>,
    c2v_consumer_buf = %c2v_import : i32,
    v2c_consumer_buf = %c0_i32 : i32)
 
 // A5 (without GM slot buffer):
-pto.aic_initialize_pipe {dir_mask = 1, slot_size = 1024}
+pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
   (c2v_consumer_buf = %c2v_import : i32,
    v2c_consumer_buf = %c0_i32 : i32)
 ```
 
 **Arguments:**
 
+- `id`: compile-time pipe identifier, unique among frontend initialize ops in
+  the same function
 - `dir_mask`: communication direction encoding
 - `slot_size`: logical slot size in bytes
+- `nosplit`: optional compile-time boolean controlling no-split pipe mode
 - `gm_slot_buffer`: optional GM pointer (`!pto.ptr<T>`), required on A2/A3, omitted on A5
 - `c2v_consumer_buf`: C2V consumer local base address
 - `v2c_consumer_buf`: V2C consumer local base address
@@ -7916,7 +7944,12 @@ pto.aic_initialize_pipe {dir_mask = 1, slot_size = 1024}
 **Constraints & Verification:**
 
 - Must appear in Cube kernels
-- At most one `pto.aic_initialize_pipe` is expected in one Cube function
+- Multiple `pto.aic_initialize_pipe` ops are allowed in one Cube function, but
+  `id` must be unique among frontend initialize ops in that function
+- If `nosplit = true`, all frontend data-transfer ops bound to the same logical
+  pipe must use `split = 0`
+- If `nosplit = false`, all frontend data-transfer ops bound to the same
+  logical pipe must use `split = 1` or `split = 2`
 
 ##### `pto.aiv_initialize_pipe` - Frontend Vector Pipe Initialization
 
@@ -7926,13 +7959,13 @@ pto.aic_initialize_pipe {dir_mask = 1, slot_size = 1024}
 
 ```mlir
 // A2/A3 (with GM slot buffer):
-pto.aiv_initialize_pipe {dir_mask = 1, slot_size = 1024}
+pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
   (gm_slot_buffer = %gm_buf : !pto.ptr<f32>,
    c2v_consumer_buf = %c2v_local : i32,
    v2c_consumer_buf = %c0_i32 : i32)
 
 // A5 (without GM slot buffer):
-pto.aiv_initialize_pipe {dir_mask = 1, slot_size = 1024}
+pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
   (c2v_consumer_buf = %c2v_local : i32,
    v2c_consumer_buf = %c0_i32 : i32)
 ```
@@ -7945,7 +7978,12 @@ pto.aiv_initialize_pipe {dir_mask = 1, slot_size = 1024}
 **Constraints & Verification:**
 
 - Must appear in Vector kernels
-- At most one `pto.aiv_initialize_pipe` is expected in one Vector function
+- Multiple `pto.aiv_initialize_pipe` ops are allowed in one Vector function,
+  but `id` must be unique among frontend initialize ops in that function
+- If `nosplit = true`, all frontend data-transfer ops bound to the same logical
+  pipe must use `split = 0`
+- If `nosplit = false`, all frontend data-transfer ops bound to the same
+  logical pipe must use `split = 1` or `split = 2`
 
 ##### `pto.tpush_to_aiv` - Frontend C2V Producer Push
 
@@ -7954,12 +7992,13 @@ pto.aiv_initialize_pipe {dir_mask = 1, slot_size = 1024}
 **Syntax:**
 
 ```mlir
-pto.tpush_to_aiv(%tile : !pto.tile_buf<...>) {split = 1}
+pto.tpush_to_aiv(%tile : !pto.tile_buf<...>) {id = 0, split = 1}
 ```
 
 **Arguments:**
 
 - one tile operand
+- compile-time `id` attribute
 - compile-time `split` attribute
 
 **Results:** None.
@@ -7968,6 +8007,8 @@ pto.tpush_to_aiv(%tile : !pto.tile_buf<...>) {split = 1}
 
 - Must appear in Cube kernels
 - Represents the producer side of a C2V transfer
+- `id` must match exactly one frontend initialize_pipe op in the same function
+  with `dir_mask = 1` or `dir_mask = 3`
 
 ##### `pto.tpush_to_aic` - Frontend V2C Producer Push
 
@@ -7976,12 +8017,13 @@ pto.tpush_to_aiv(%tile : !pto.tile_buf<...>) {split = 1}
 **Syntax:**
 
 ```mlir
-pto.tpush_to_aic(%tile : !pto.tile_buf<...>) {split = 1}
+pto.tpush_to_aic(%tile : !pto.tile_buf<...>) {id = 0, split = 1}
 ```
 
 **Arguments:**
 
 - one tile operand
+- compile-time `id` attribute
 - compile-time `split` attribute
 
 **Results:** None.
@@ -7990,6 +8032,8 @@ pto.tpush_to_aic(%tile : !pto.tile_buf<...>) {split = 1}
 
 - Must appear in Vector kernels
 - Represents the producer side of a V2C transfer
+- `id` must match exactly one frontend initialize_pipe op in the same function
+  with `dir_mask = 2` or `dir_mask = 3`
 
 ##### `pto.tpop_from_aic` - Frontend C2V Consumer Pop
 
@@ -7998,10 +8042,10 @@ pto.tpush_to_aic(%tile : !pto.tile_buf<...>) {split = 1}
 **Syntax:**
 
 ```mlir
-%tile = pto.tpop_from_aic {split = 1} -> !pto.tile_buf<...>
+%tile = pto.tpop_from_aic {id = 0, split = 1} -> !pto.tile_buf<...>
 ```
 
-**Arguments:** compile-time `split` attribute.
+**Arguments:** compile-time `id` and `split` attributes.
 
 **Results:** one `!pto.tile_buf<...>` result tile.
 
@@ -8009,6 +8053,8 @@ pto.tpush_to_aic(%tile : !pto.tile_buf<...>) {split = 1}
 
 - Must appear in Vector kernels
 - Represents the consumer side of a C2V transfer
+- `id` must match exactly one frontend initialize_pipe op in the same function
+  with `dir_mask = 1` or `dir_mask = 3`
 
 ##### `pto.tpop_from_aiv` - Frontend V2C Consumer Pop
 
@@ -8017,10 +8063,10 @@ pto.tpush_to_aic(%tile : !pto.tile_buf<...>) {split = 1}
 **Syntax:**
 
 ```mlir
-%tile = pto.tpop_from_aiv {split = 1} -> !pto.tile_buf<...>
+%tile = pto.tpop_from_aiv {id = 0, split = 1} -> !pto.tile_buf<...>
 ```
 
-**Arguments:** compile-time `split` attribute.
+**Arguments:** compile-time `id` and `split` attributes.
 
 **Results:** one `!pto.tile_buf<...>` result tile.
 
@@ -8028,6 +8074,8 @@ pto.tpush_to_aic(%tile : !pto.tile_buf<...>) {split = 1}
 
 - Must appear in Cube kernels
 - Represents the consumer side of a V2C transfer
+- `id` must match exactly one frontend initialize_pipe op in the same function
+  with `dir_mask = 2` or `dir_mask = 3`
 
 ##### `pto.tfree_from_aic` - Frontend C2V Consumer Free
 
@@ -8036,10 +8084,10 @@ pto.tpush_to_aic(%tile : !pto.tile_buf<...>) {split = 1}
 **Syntax:**
 
 ```mlir
-pto.tfree_from_aic {split = 1}
+pto.tfree_from_aic {id = 0, split = 1}
 ```
 
-**Arguments:** compile-time `split` attribute.
+**Arguments:** compile-time `id` and `split` attributes.
 
 **Results:** None.
 
@@ -8047,6 +8095,8 @@ pto.tfree_from_aic {split = 1}
 
 - Must appear in Vector kernels
 - Represents the consumer free side of a C2V transfer
+- `id` must match exactly one frontend initialize_pipe op in the same function
+  with `dir_mask = 1` or `dir_mask = 3`
 
 ##### `pto.tfree_from_aiv` - Frontend V2C Consumer Free
 
@@ -8055,10 +8105,10 @@ pto.tfree_from_aic {split = 1}
 **Syntax:**
 
 ```mlir
-pto.tfree_from_aiv {split = 1}
+pto.tfree_from_aiv {id = 0, split = 1}
 ```
 
-**Arguments:** compile-time `split` attribute.
+**Arguments:** compile-time `id` and `split` attributes.
 
 **Results:** None.
 
@@ -8066,6 +8116,8 @@ pto.tfree_from_aiv {split = 1}
 
 - Must appear in Cube kernels
 - Represents the consumer free side of a V2C transfer
+- `id` must match exactly one frontend initialize_pipe op in the same function
+  with `dir_mask = 2` or `dir_mask = 3`
 
 ---
 


### PR DESCRIPTION
## What changed

This updates the frontend pipe communication section in `docs/PTO_IR_manual.md` to match the newer frontend pipe model and the pipe-related design updates.

## Why

The IR manual still described the older single-pipe frontend model and did not clearly document the current `nosplit` constraints across A5 and A2/A3.

## Details

- document compile-time `id` binding between `initialize_pipe` and frontend `tpush` / `tpop` / `tfree` ops
- clarify that multiple logical pipes are allowed in one function
- update `reserve_buffer` and `import_reserved_buffer` constraints to reflect multi-buffer usage with unique keys
- add frontend op matching rules for `dir_mask`
- clarify `nosplit` behavior and limitations:
  - A5 supports `1C:1V`
  - A2/A3 requires the two vector cores to execute the same pipe operation sequence in the same order for the same logical pipe

## Impact

Frontend and framework users can now rely on the IR manual for the current pipe model instead of the older single-pipe description.

## Validation

- reviewed the corresponding frontend pipe design notes from PR #509
- cross-checked the updated wording against the current IR/test usage in the repository
- no automated tests were run because this is a documentation-only change