### PR TITLE
[codex] add claude skill files

### DIFF
--- a/.claude/skill/camodel_isa_verification_skill.md
+++ b/.claude/skill/camodel_isa_verification_skill.md
@@ -1,0 +1,406 @@
+# CA Model ISA Verification Skill
+
+> How to create ST test cases, run them on the CA model (cycle-accurate simulator), and analyze instruction logs for latency and correctness verification.
+
+---
+
+## Overview
+
+This skill covers the complete workflow for verifying PTO-ISA instructions using the CANN simulator (CA model):
+
+1. **Create/Select an ST test case**
+2. **Build and run on NPU SIM**
+3. **Locate and interpret instruction logs**
+4. **Extract latency data**
+5. **Verify hex correctness via UB dumps**
+
+---
+
+## Prerequisites
+
+### Environment Setup
+
+```bash
+cd ~/pto-isa
+source /usr/local/Ascend/cann/set_env.sh
+```
+
+### Build Fix (CANN 9.0.0)
+
+If using CANN 9.0.0-alpha.1, ensure the namespace fix is applied:
+
+```bash
+# Check if fix is applied
+grep '__cce_simd::RoundRType' ~/pto-isa/include/pto/npu/a5/TCvt.hpp
+
+# If not, apply:
+# Change "using ::RoundRType;" to "using __cce_simd::RoundRType;" etc.
+```
+
+---
+
+## Step 1: Create/Select a Test Case
+
+### Existing Test Structure
+
+Tests are located in `~/pto-isa/tests/st/` with naming convention `t<operation>`:
+
+```
+tests/st/
+├── tadd/           # Vector add
+├── tmul/           # Vector multiply
+├── tload/          # Load operations
+├── tgather/        # Gather operations
+├── tcvt/           # Type conversions
+└── ...
+```
+
+### Test File Structure
+
+Each test directory contains:
+
+```
+tests/st/tadd/
+├── CMakeLists.txt
+├── test_tadd.cpp   # Google Test cases
+└── inc/
+    └── test_tadd.hpp  # Test parameters & configs
+```
+
+### Creating a New Test Case
+
+1. **Copy an existing similar test:**
+   ```bash
+   cp -r tests/st/tadd tests/st/tnewop
+   ```
+
+2. **Modify the test source** (`test_tnewop.cpp`):
+   ```cpp
+   #include "gtest/gtest.h"
+   #include "pto/npu/a5/TNewOp.hpp"  // Your new operation header
+   
+   class TNEWOPTest : public ::testing::Test {
+   protected:
+       void SetUp() override {
+           // Initialize input buffers, parameters
+       }
+       void TearDown() override {
+           // Cleanup
+       }
+   };
+   
+   TEST_F(TNEWOPTest, case_float_64x64) {
+       // Setup input data
+       // Call the operation
+       // Verify output matches expected
+   }
+   ```
+
+3. **Update CMakeLists.txt:**
+   ```cmake
+   set(TEST_NAME tnewop)
+   # Add sources, includes, link libraries
+   ```
+
+---
+
+## Step 2: Run Test on CA Model
+
+### Command Syntax
+
+```bash
+# Run full test suite:
+python3 tests/script/run_st.py -r sim -v a5 -t <testcase>
+
+# Run specific test case:
+python3 tests/script/run_st.py -r sim -v a5 -t <testcase> -g "<TestSuite>.<case_name>"
+```
+
+### Examples
+
+```bash
+# Full tadd suite
+python3 tests/script/run_st.py -r sim -v a5 -t tadd
+
+# Specific tadd case
+python3 tests/script/run_st.py -r sim -v a5 -t tadd -g "TADDTest.case_float_64x64_64x64_64x64_64x64"
+
+# Multiple tests with output capture
+python3 tests/script/run_st.py -r sim -v a5 -t tmul 2>&1 | tee logs/tmul.log
+```
+
+### SOC Versions
+
+| SOC Version | Description |
+|-------------|-------------|
+| `a5` | Ascend 910 (A5 architecture) |
+| `Ascend910_9599` | Full chip model |
+
+### Run Mode Options
+
+| Mode | Description |
+|------|-------------|
+| `sim` | Run on cycle-accurate simulator (CA model) |
+| `npu` | Run on real NPU hardware |
+| `cpu` | Run on CPU simulator |
+
+---
+
+## Step 3: Locate Output Logs
+
+### Output Directory Structure
+
+After running a test, logs are generated in:
+
+```
+build/tests/st/<testcase>/
+└── core0.veccore0.instr_log.dump        # Main instruction trace
+└── core0.veccore0.instr_popped_log.dump # Instruction pipeline log
+└── core0.veccore0.ub.rd_log.dump        # UB read log (hex dumps)
+└── core0.veccore0.ub.wr_log.dump        # UB write log (hex dumps)
+```
+
+### Copying Logs for Analysis
+
+```bash
+mkdir -p ~/npu_skills/pto-isa/verification/logs/<test_name>
+cp build/tests/st/<testcase>/core0.veccore0.*.dump \
+   ~/npu_skills/pto-isa/verification/logs/<test_name>/
+```
+
+---
+
+## Step 4: Parse Instruction Logs for Latency
+
+### Log Format
+
+The `instr_log.dump` file contains cycle-by-cycle instruction execution:
+
+```
+[info] [CYCLE] (PC: 0x...) PIPE : (Binary: 0x...) (ID: NNNNNN) INSTR_NAME params
+```
+
+### Key Fields
+
+| Field | Description |
+|-------|-------------|
+| `[CYCLE]` | Clock cycle when instruction issued/completed (10-digit) |
+| `PC` | Program counter address |
+| `Binary` | Instruction hex encoding |
+| `ID` | Instruction sequence number |
+| `PIPE` | Execution pipe: SCALAR, MTE2, RVECLD, RVECEX, RVECST |
+| `INSTR_NAME` | Instruction mnemonic |
+
+### Example Log Lines
+
+```
+[info] [00002664] (PC: 0x13b3b714) RVECLD   : (Binary: 0x00180008) (ID: 000112) RV_VLD  Vd[0], Sn[6]=0x0, ...
+[info] [00002669] (PC: 0x13b3b720) RVECEX   : (Binary: 0x80082780) (ID: 000115) RV_VADD Dtype: F32  Vd[0], Vn[0], Vm[1], ...
+[info] [00002676] (PC: 0x13b3b724) RVECST   : (Binary: 0x40280000) (ID: 000116) RV_VST  Vn[0], ...
+```
+
+### Calculating Latency
+
+**Latency = (Store complete cycle) - (Load issue cycle)**
+
+For the example above:
+- VLD issued at cycle 2664
+- VADD issued at cycle 2669 (depends on VLD)
+- VST issued at cycle 2676 (depends on VADD)
+
+**VLD latency** = 2669 - 2664 = 5 cycles (+ pipeline dependency)
+**VADD latency** = 2676 - 2669 = 7 cycles
+
+### Instruction Mapping Table
+
+| PTO Op | A5 Vector Instruction | Pipe | Typical Latency |
+|--------|----------------------|------|-----------------|
+| TLOAD | MOV_SRC_TO_DST_ALIGNv2 (MTE2 DMA) | MTE2 | Variable |
+| VLD | RV_VLD (NORM) | RVECLD | 9 cycles |
+| VST | RV_VST (NORM_B32) | RVECST | 9 cycles |
+| VADD | RV_VADD | RVECEX | 7 cycles |
+| VMUL | RV_VMUL | RVECEX | 7 cycles |
+| VGATHER2 | RV_VGATHER2 | RVECLD | 28 cycles |
+| VLD UNPK_B16 | RV_VLD (dist=UNPK_B16) | RVECLD | 9 cycles |
+| VLD PK_B32 | RV_VLD (dist=PK_B32) | RVECLD | 9 cycles |
+
+### Parsing Script
+
+```bash
+#!/bin/bash
+# Extract latency pairs from instruction log
+
+LOG=$1
+echo "=== Latency Analysis: $LOG ==="
+
+# Find VLD->VADD pairs
+grep -E "RV_VLD|RV_VADD|RV_VST" $LOG | head -20
+
+# Parse cycle numbers
+grep "RV_VLD" $LOG | head -5 | while read line; do
+  CYCLE=$(echo $line | sed 's/.*\[\([0-9]*\)\].*/\1/')
+  ID=$(echo $line | sed 's/.*ID: \([0-9]*\).*/\1/')
+  echo "VLD ID:$ID at cycle:$CYCLE"
+done
+```
+
+---
+
+## Step 5: Verify Hex Correctness via UB Dumps
+
+### UB Write Log Format
+
+The `ub.wr_log.dump` shows memory writes:
+
+```
+[info] [CYCLE] INSTR_NAME, pc: 0x..., id: NNN
+[info] Address XXXXXXXX = [HHHHHHHH]  Address ...
+```
+
+### Example UB Dump
+
+```
+[info] [0000002027] MOV_SRC_TO_DST_ALIGNv2, pc: 0x13b3a084, id: 33
+[info] Address 00000000 = [40c00000]  Address 00000004 = [40400000]  ...
+       Address 00000010 = [40a00000]  Address 00000014 = [40400000]  ...
+```
+
+### Interpreting Hex Values
+
+| Hex | Float32 | Description |
+|-----|---------|-------------|
+| `3f800000` | 1.0 | |
+| `40000000` | 2.0 | |
+| `40400000` | 3.0 | |
+| `40800000` | 4.0 | |
+| `40a00000` | 5.0 | |
+| `40c00000` | 6.0 | |
+| `40e00000` | 7.0 | |
+| `41000000` | 8.0 | |
+| `41100000` | 9.0 | |
+
+### Verification Steps
+
+1. **Compare UB write addresses** with expected output buffer location
+2. **Decode hex to float** and compare with expected values
+3. **Check for padding patterns** (e.g., `0x00000000` for zero-pad)
+
+### Python Verification Script
+
+```python
+import struct
+
+def hex_to_float(hex_str):
+    """Convert hex string to float32"""
+    return struct.unpack('!f', bytes.fromhex(hex_str))[0]
+
+def verify_ub_dump(log_path, expected_values, start_addr=0):
+    """Verify UB dump matches expected float values"""
+    with open(log_path) as f:
+        for line in f:
+            if 'Address' in line:
+                # Parse: Address XXXXXXXX = [HHHHHHHH]
+                parts = line.split('Address')
+                for part in parts[1:]:
+                    if '=' in part:
+                        addr_hex, val_hex = part.split('=')
+                        addr = int(addr_hex.strip(), 16)
+                        val = hex_to_float(val_hex.strip().strip('[]'))
+                        
+                        idx = (addr - start_addr) // 4
+                        if idx < len(expected_values):
+                            if abs(val - expected_values[idx]) > 1e-5:
+                                print(f"MISMATCH at addr {addr:08x}: got {val}, expected {expected_values[idx]}")
+                            else:
+                                print(f"OK addr {addr:08x}: {val}")
+
+# Example usage
+expected = [6.0, 3.0, 9.0, 4.0, 5.0, 3.0, 9.0, 7.0]  # First 8 values
+verify_ub_dump('core0.veccore0.ub.wr_log.dump', expected)
+```
+
+---
+
+## Step 6: Correlate Instruction ID to Name
+
+### Finding Instruction by ID
+
+Each instruction has a unique ID assigned during compilation. To find an instruction:
+
+```bash
+# Search for specific instruction ID
+grep "ID: 000115" core0.veccore0.instr_log.dump
+```
+
+Output:
+```
+[info] [00002669] (PC: 0x13b3b720) RVECEX   : (Binary: 0x80082780) (ID: 000115) RV_VADD Dtype: F32  Vd[0], Vn[0], Vm[1], Pg[1],
+```
+
+### Decoding Binary to Instruction
+
+The `Binary: 0xXXXXXXXX` field is the raw instruction encoding. Use the A5 ISA reference to decode:
+
+| Bits | Field |
+|------|-------|
+| 31:26 | Opcode |
+| 25:21 | Dest register |
+| 20:16 | Src1 register |
+| 15:11 | Src2 register |
+| 10:0 | Modifiers/Immediate |
+
+---
+
+## Quick Reference
+
+### Common Test Commands
+
+```bash
+# Build and run single test
+python3 tests/script/run_st.py -r sim -v a5 -t tadd
+
+# Run with debug output
+python3 tests/script/run_st.py -r sim -v a5 -t tadd --debug
+
+# List available tests
+ls tests/st/
+
+# Check test result
+grep -E "PASS|FAIL" build/tests/st/tadd/*.log
+```
+
+### Verified Latencies (A5)
+
+| Instruction | Latency (cycles) | Notes |
+|-------------|-----------------|-------|
+| VLD NORM | 9 | Normal vector load |
+| VLD UNPK_B16 | 9 | Unpack 16-bit |
+| VLD PK_B32 | 9 | Pack 32-bit |
+| VST NORM_B32 | 9 | Normal vector store |
+| VADD F32 | 7 | FP32 add |
+| VMUL F32 | 7 | FP32 multiply |
+| VGATHER2 B32 | 28 | Indexed gather |
+
+### Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "NOT SUPPORT TASK TYPE 3" warning | Ignore - normal simulator message |
+| Test hangs | Check timeout, may need longer for large tiles |
+| "namespace" errors | Apply TCvt.hpp fix (see Prerequisites) |
+| No output logs | Check build directory, ensure `-r sim` mode |
+
+---
+
+## References
+
+- PTO-ISA repo: `~/pto-isa/`
+- A5 ISA reference: `~/pto-isa/docs/`
+- Test scripts: `~/pto-isa/tests/script/`
+- Verification reports: `~/npu_skills/pto-isa/verification/reports/`
+
+---
+
+*Created: 2026-03-25*
+*Author: AI Assistant*
+*Version: 1.0*

--- a/.claude/skill/msprof_op_sim_insight_skill.md
+++ b/.claude/skill/msprof_op_sim_insight_skill.md
@@ -1,0 +1,213 @@
+---
+name: msprof-op-simulator-insight
+description: Use when you need to compile a PTOAS-generated kernel source in this repo with a host runner that launches the kernel, run `msprof op simulator` on A3 `dav_2201`, and export MindStudio Insight visualization files such as `trace.json` and `visualize_data.bin`. Supports arbitrary generated kernel source files, resolves mangled kernel symbols for arbitrary kernel entry names, and uses direct WSL commands.
+---
+
+# Msprof Op Simulator Insight
+
+Use this skill from WSL and run commands from the repo root. Execute the build, collect, and export commands directly.
+
+## When to use
+
+- You need the full `build -> collect -> export` workflow for `msprof op simulator`.
+- You need MindStudio Insight files like `trace.json` and `visualize_data.bin`, not just raw `*.dump`.
+- You want the exact exported kernel symbol instead of guessing the mangled name by hand.
+
+## Workflow
+
+1. Run from WSL after `source /usr/local/Ascend/cann/set_env.sh`.
+2. Run the commands from the repo root when possible so source paths can stay relative.
+3. Prefer a Linux-local run directory under `~/...`; do not run the produced binary from `/mnt/...`.
+4. Build a host runner executable that launches your kernel and points at the generated source.
+5. Locate the resulting application binary and shared library that contain the kernel symbol.
+6. Resolve the real mangled kernel symbol from that shared library.
+7. Collect raw data with `msprof op simulator`.
+8. Export from `.../device0/tmp_dump` to generate Insight files.
+
+## Important details
+
+- `msprof op simulator` collection does not create `trace.json` by itself. You must run the export step.
+- `--export` must target `.../device0/tmp_dump`, not the top-level `out/` directory.
+- `msprof op simulator --kernel-name` must match the exact exported mangled symbol. Passing only the bare kernel base name is often not enough and may be filtered.
+- If multiple exported symbols demangle to the same base name, choose the one whose full demangled signature matches the kernel entry you intend to profile, or set `KERNEL_SYMBOL` manually.
+- `RUN_ROOT` is just the working directory for one profiling session. It is where build artifacts, raw collect output, logs, and exported Insight files are stored.
+- `APPLICATION` is the host runner executable you actually built. `msprof` does not generate this path for you.
+- `APPLICATION` does not have to be named `msprof_native_a3`. Any executable is fine as long as it initializes runtime, launches the target kernel, and can run under the simulator.
+- Large generated kernels can take a long time on `dav_2201`; use a generous `--timeout-minutes`.
+- Exported files usually include:
+  - `simulator/trace.json`
+  - `simulator/visualize_data.bin`
+  - `simulator/core*.*/trace.json`
+  - `simulator/core*.*/core*_instr_exe_*.csv`
+- If export warns that `tmp_dump` lacks `pc_start_addr.txt`, copy it from `.../device0/<kernel>/0/dump/pc_start_addr.txt` into `tmp_dump` first.
+
+## Full Run Template
+
+Run this from the repo root and adjust `SOURCE_CPP`, `KERNEL_BASE_NAME`, `RUN_ROOT`, and the runner build variables as needed:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+source /usr/local/Ascend/cann/set_env.sh
+
+SOURCE_CPP=./your-kernel.cpp
+KERNEL_BASE_NAME=your_kernel_base_name
+SOC_VERSION=dav_2201
+TIMEOUT_MINUTES=120
+RUN_TAG="${KERNEL_BASE_NAME}_$(date +%Y%m%d_%H%M%S)"
+RUN_ROOT=~/msprof-op-simulator-runs/"$RUN_TAG"
+RUNNER_CMAKE_DIR=./path-to-runner-project
+RUNNER_TARGET=your_runner_target
+APPLICATION_RELATIVE_PATH="bin/$RUNNER_TARGET"
+KERNEL_LIB_RELATIVE_PATH="lib/your_kernel_library.so"
+
+BUILD_DIR="$RUN_ROOT/build"
+COLLECT_DIR="$RUN_ROOT/msprof_run_$(date +%Y%m%d_%H%M%S)"
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0-beta.1}"
+SIM_LIB_DIR="$ASCEND_HOME_PATH/x86_64-linux/simulator/$SOC_VERSION/lib"
+BASE_LD_LIBRARY_PATH="$ASCEND_HOME_PATH/lib64:$ASCEND_HOME_PATH/devlib:$ASCEND_HOME_PATH/x86_64-linux/devlib:$SIM_LIB_DIR:${LD_LIBRARY_PATH:-}"
+
+mkdir -p "$RUN_ROOT"
+
+cmake -G Ninja \
+  -S "$RUNNER_CMAKE_DIR" \
+  -B "$BUILD_DIR" \
+  -DNATIVE_CPP="$(realpath "$SOURCE_CPP")"
+
+cmake --build "$BUILD_DIR" --target "$RUNNER_TARGET" -v
+
+APPLICATION="$BUILD_DIR/$APPLICATION_RELATIVE_PATH"
+KERNEL_LIB="$BUILD_DIR/$KERNEL_LIB_RELATIVE_PATH"
+
+if [[ ! -x "$APPLICATION" ]]; then
+  echo "Missing application binary: $APPLICATION" >&2
+  exit 1
+fi
+
+if [[ ! -f "$KERNEL_LIB" ]]; then
+  echo "Missing kernel library: $KERNEL_LIB" >&2
+  exit 1
+fi
+
+KERNEL_SYMBOL="$(
+  nm -D "$KERNEL_LIB" | awk '/ [TW] / {print $3}' | while read -r candidate; do
+    demangled="$(c++filt "$candidate" 2>/dev/null || true)"
+    if [[ "$demangled" == "$KERNEL_BASE_NAME("* ]]; then
+      printf '%s\n' "$candidate"
+    fi
+  done | head -n 1
+)"
+
+if [[ -z "$KERNEL_SYMBOL" ]]; then
+  echo "Failed to resolve mangled kernel symbol for $KERNEL_BASE_NAME" >&2
+  exit 1
+fi
+
+echo "Resolved kernel symbol: $KERNEL_SYMBOL"
+
+export LD_LIBRARY_PATH="$(dirname "$KERNEL_LIB"):$BASE_LD_LIBRARY_PATH"
+
+msprof op simulator \
+  --application="$APPLICATION" \
+  --kernel-name="$KERNEL_SYMBOL" \
+  --launch-count=1 \
+  --soc-version="$SOC_VERSION" \
+  --timeout="$TIMEOUT_MINUTES" \
+  --output="$COLLECT_DIR/out" \
+  2>&1 | tee "$COLLECT_DIR/msprof_collect.log"
+```
+
+This creates a directory layout like:
+
+```text
+~/msprof-op-simulator-runs/<run-tag>/
+  build/
+    <application-relative-path>
+    <kernel-lib-relative-path>
+  msprof_run_<timestamp>/
+    msprof_collect.log
+    out/
+```
+
+The important alignment is:
+
+- `RUNNER_TARGET` is the build target you ask CMake to compile.
+- `APPLICATION_RELATIVE_PATH` is where that target's executable lands under `BUILD_DIR`.
+- `KERNEL_LIB_RELATIVE_PATH` is the shared library under `BUILD_DIR` that exports the kernel symbol.
+
+If your runner is not built by CMake, replace the `cmake ...` lines with your actual build command, then set:
+
+```bash
+APPLICATION=/absolute/or/build-relative/path/to/your_runner
+KERNEL_LIB=/absolute/or/build-relative/path/to/your_kernel_library.so
+```
+
+before running `nm` and `msprof`.
+
+If the first-match resolution is too loose for your kernel, inspect all candidates first:
+
+```bash
+nm -D "$KERNEL_LIB" | awk '/ [TW] / {print $3}' | while read -r candidate; do
+  demangled="$(c++filt "$candidate" 2>/dev/null || true)"
+  if [[ "$demangled" == "$KERNEL_BASE_NAME("* ]]; then
+    printf '%s  # %s\n' "$candidate" "$demangled"
+  fi
+done
+```
+
+Then set:
+
+```bash
+KERNEL_SYMBOL=<exact_mangled_symbol>
+```
+
+and use that symbol directly in the collect command.
+
+## Export Existing Collect Data
+
+Use this when you already have raw `msprof op simulator` output and only need Insight files:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+source /usr/local/Ascend/cann/set_env.sh
+
+RUN_ROOT=~/msprof-op-simulator-runs/<run-tag>
+COLLECT_ROOT="$RUN_ROOT/msprof_run_<timestamp>/out"
+EXPORT_ROOT="$RUN_ROOT/insight_export_$(date +%Y%m%d_%H%M%S)"
+
+if [[ -d "$COLLECT_ROOT/device0/tmp_dump" ]]; then
+  TMP_DUMP_DIR="$COLLECT_ROOT/device0/tmp_dump"
+else
+  OPPROF_DIR="$(find "$COLLECT_ROOT" -maxdepth 1 -mindepth 1 -type d -name 'OPPROF_*' | sort | tail -n 1)"
+  TMP_DUMP_DIR="$OPPROF_DIR/device0/tmp_dump"
+fi
+
+DEVICE0_DIR="$(dirname "$TMP_DUMP_DIR")"
+PC_START_FILE="$(find "$DEVICE0_DIR" -path '*/dump/pc_start_addr.txt' | sort | head -n 1 || true)"
+if [[ -n "$PC_START_FILE" && -f "$PC_START_FILE" ]]; then
+  cp -f "$PC_START_FILE" "$TMP_DUMP_DIR/pc_start_addr.txt"
+fi
+
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0-beta.1}"
+SIM_LIB_DIR="$ASCEND_HOME_PATH/x86_64-linux/simulator/dav_2201/lib"
+export LD_LIBRARY_PATH="$ASCEND_HOME_PATH/lib64:$ASCEND_HOME_PATH/devlib:$ASCEND_HOME_PATH/x86_64-linux/devlib:$SIM_LIB_DIR:${LD_LIBRARY_PATH:-}"
+
+mkdir -p "$EXPORT_ROOT"
+
+msprof op simulator \
+  --export="$TMP_DUMP_DIR" \
+  --output="$EXPORT_ROOT" \
+  2>&1 | tee "$EXPORT_ROOT/msprof_export.log"
+
+find "$EXPORT_ROOT" \
+  \( -path '*/simulator/trace.json' -o -path '*/simulator/visualize_data.bin' \) \
+  | sort
+```
+
+## Quick Checks
+
+- Confirm collect produced an `OPPROF_*` directory under `out/`.
+- Confirm export produced:
+  - `simulator/trace.json`
+  - `simulator/visualize_data.bin`
+- If export fails with `Failed to get any available dump file to parse`, the `--export` path is wrong. Point it to `tmp_dump`.
+- If export warns about missing `debug_line`, that only means there is no source-level call stack. The trace can still be valid.


### PR DESCRIPTION
## Summary
- add `.claude/skill/msprof_op_sim_insight_skill.md`
- add `.claude/skill/camodel_isa_verification_skill.md`
- copy both files from the provided source skill directory into this repo

## Why
These skill documents need to live under `.claude/skill` in this repository so they are available alongside the existing Claude project guidance.

## Validation
- verified the destination files match the provided source files locally
- reviewed the staged diff to confirm the PR only adds the two new markdown files
- no build or runtime tests were run because this change only adds documentation/skill files
