### PR TITLE
[InsertSync] fix zero-trip loop unsoundness without dropping cross-re…

### DIFF
--- a/include/PTO/Transforms/InsertSync/InsertSyncAnalysis.h
+++ b/include/PTO/Transforms/InsertSync/InsertSyncAnalysis.h
@@ -32,6 +32,16 @@ struct SyncRecord {
 
   // Record the pairing status of set/wait within a syncIndex.
   llvm::DenseMap<int, bool> syncFinder;
+
+  // For each syncIndex present in `syncFinder`, marks whether that entry was
+  // populated inside a region that may not execute at runtime — a loop body
+  // (which may iterate zero times) or an if-branch without a matching else.
+  // `UpdateSyncRecord` must NOT use such entries to transitively elevate
+  // `alreadySync` via a subsequently visited SET_EVENT, because on the
+  // zero-trip / zero-branch path no matching WAIT actually ran. Outer
+  // producer/consumer pair-finding still sees the underlying `syncFinder`
+  // bit, so cross-region drains and seeds are emitted as before.
+  llvm::DenseMap<int, bool> syncFinderIsConditional;
 };
  
 using SyncRecordList = std::array<SyncRecord, MAX_MULTI_BUFFER_NUM>;

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -198,15 +198,38 @@ unsigned InsertSyncAnalysis::InsertLoopSync(
     const std::optional<unsigned> &forEndIndex) {
   if (loopElement->getLoopKind() == KindOfLoop::LOOP_END) {
     SyncRecordList syncRecordForList = syncRecordList;
+    SyncRecordList syncRecordBefore = syncRecordList;
     unsigned newBegin =
         std::max(begin, index - (loopElement->endId - loopElement->beginId));
     unsigned newEnd = index;
     InsertSeqSync(nowCompound, syncElement, static_cast<int>(newBegin),
                   static_cast<int>(newEnd), syncRecordForList, forEndIndex);
-    // A loop may execute zero iterations at runtime. Keep correctness for both
-    // paths by not promoting any loop-body-derived sync state into the outer
-    // state. In particular, syncFinder participates in alreadySync inference
-    // later, so propagating it would still be unsound under zero-trip loops.
+
+    // A loop may execute zero iterations. Propagate `syncFinder` from the
+    // body so outer pair-finding can still see producers that live inside
+    // the body (required for post-loop drain waits / pre-loop seeds — see
+    // issue #564 regression on the Qwen3 K-loop pipelined GEMM). Mark any
+    // entry introduced by the body as conditional so that
+    // UpdateSyncRecord's transitive-elevation step skips it; this preserves
+    // the zero-trip invariant that motivated issue #533.
+    //
+    // Do NOT propagate `alreadySync`: any claim that the body itself
+    // completed a synchronization is unsound when the body runs zero times.
+    for (size_t b = 0; b < syncRecordList.size(); ++b) {
+      const auto &beforeFinder = syncRecordBefore[b].syncFinder;
+      for (auto &kv : syncRecordForList[b].syncFinder) {
+        int idx = kv.first;
+        if (!beforeFinder.lookup(idx) && kv.second) {
+          syncRecordList[b].syncFinderIsConditional[idx] = true;
+        }
+      }
+      syncRecordList[b].syncFinder = syncRecordForList[b].syncFinder;
+      for (auto &kv : syncRecordForList[b].syncFinderIsConditional) {
+        if (kv.second) {
+          syncRecordList[b].syncFinderIsConditional[kv.first] = true;
+        }
+      }
+    }
     return (loopElement->endId - loopElement->beginId);
   }
   return 0;
@@ -237,10 +260,28 @@ unsigned InsertSyncAnalysis::InsertBranchSync(
                     static_cast<int>(branchEnd), syncRecordElseList, forEndIndex);
       MergeAlreadySync(syncRecordList, syncRecordIfList, syncRecordElseList);
     } else {
-      // No else-branch: do not promote `alreadySync`, but keep syncFinder
-      // updates from the then-branch.
-      for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++)
-        syncRecordList[bufferIdx].syncFinder = syncRecordIfList[bufferIdx].syncFinder;
+      // No else-branch: do not promote `alreadySync` (the zero-branch path
+      // sees none), but keep `syncFinder` updates from the then-branch so
+      // outer pair-finding can still observe producers/consumers declared
+      // inside the branch. Finder entries introduced by the then-branch are
+      // tagged as conditional to block `UpdateSyncRecord`'s transitive
+      // elevation on the zero-branch path (same invariant as the loop-body
+      // case; see issue #533).
+      for (size_t b = 0; b < syncRecordList.size(); ++b) {
+        const auto &beforeFinder = syncRecordList[b].syncFinder;
+        for (auto &kv : syncRecordIfList[b].syncFinder) {
+          int idx = kv.first;
+          if (!beforeFinder.lookup(idx) && kv.second) {
+            syncRecordList[b].syncFinderIsConditional[idx] = true;
+          }
+        }
+        syncRecordList[b].syncFinder = syncRecordIfList[b].syncFinder;
+        for (auto &kv : syncRecordIfList[b].syncFinderIsConditional) {
+          if (kv.second) {
+            syncRecordList[b].syncFinderIsConditional[kv.first] = true;
+          }
+        }
+      }
     }
     return (branchElement->endId - branchElement->beginId);
   } else if (branchElement->getBranchKind() == KindOfBranch::ELSE_BEGIN &&
@@ -451,7 +492,14 @@ void InsertSyncAnalysis::UpdateSyncRecord(const SyncOperation *sync,
       (nowPipeValue == waitPipeValue);
   if (!canTransitivelyEliminate) return;
 
+  // Guard against zero-trip / zero-branch unsoundness: a `syncFinder` bit that
+  // was set inside a loop body or a no-else branch is tagged as conditional
+  // and must NOT be used to transitively elevate `alreadySync` here. If the
+  // may-not-execute region runs zero times, the WAIT behind this finder bit
+  // never fires, so pairing it with an outer SET would wrongly skip a later
+  // barrier. See issue #533 (missing post-loop MTE2->V barrier).
   if (recordFinder[sync->GetSyncIndex()] &&
+      !syncRecord.syncFinderIsConditional.lookup(sync->GetSyncIndex()) &&
       (sync->GetType() == SyncOperation::TYPE::SET_EVENT ||
        sync->GetType() == SyncOperation::TYPE::SYNC_BLOCK_SET)) {
     recordAlready[static_cast<unsigned>(setPipeValue)] = true;

--- a/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression.pto
+++ b/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression.pto
@@ -5,10 +5,12 @@
 // - Inner-loop and outer-loop event chains must both keep their set/wait handshake.
 //
 // CHECK-LABEL: __global__ AICORE void nested_loop_same_pipe_pair()
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[OUT:[0-9]+]]);
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[IN:[0-9]+]]);
 // CHECK: for (size_t
-// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[OUT:[0-9]+]]);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[OUT]]);
 // CHECK: for (size_t
-// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[IN:[0-9]+]]);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[IN]]);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[IN]]);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[OUT]]);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[OUT]]);


### PR DESCRIPTION
…gion syncs

Refines the zero-trip fix from PR #540 (issue #533) so it stops breaking cross-region producer/consumer pairing around loops and no-else branches (issue #564).

Background
----------
PR #540 addressed issue #533 (missing MTE2->V barrier after a loop that may execute zero iterations) by disabling *all* propagation of SyncRecord state from a loop body back to the enclosing scope. The stated concern was that `syncFinder` participates in `alreadySync` inference later (`UpdateSyncRecord`), so propagating it would still be unsound on the zero-trip path.

That cut is too broad. `syncFinder` visibility at the outer scope is also used by `InsertSeqSync` to pair post-loop consumers with producers living inside the body (e.g. the four `wait_flag(PIPE_MTE1, PIPE_MTE2, ...)` drains after the Qwen3 K-loop pipelined GEMM, and the matching pre-loop seeds). With all propagation suppressed, those cross-region syncs vanish too, which is exactly the 0.27 -> 0.29 regression reported in issue #564. The PR's own test update for `issue454_nested_loop_same_pipe_pair_regression` -- which silently dropped the pre-loop `set_flag` CHECKs -- was an early symptom of this over-reach.

Fix
---
Narrow the cut to the exact step that is unsound on zero-trip paths.

1. Add `SyncRecord::syncFinderIsConditional`, a parallel DenseMap that tags a `syncFinder[idx]` entry as "populated inside a region that may not execute" (loop body or no-else branch).

2. In `UpdateSyncRecord`, guard the transitive-elevation step so a SET cannot elevate `alreadySync` via a conditional finder. On the zero-trip / zero-branch path this preserves the issue #533 invariant.

3. In `InsertLoopSync`, restore `syncFinder` propagation from the body back to the outer state, but mark body-introduced entries as conditional. Continue to NOT propagate `alreadySync`.

4. In `InsertBranchSync` no-else path, apply the same conditional tagging to `syncFinder` entries introduced by the then-branch, extending the zero-trip protection to zero-branch paths.

Testing
-------
Local diff review only. Covered by existing lit tests:

* issue533_loop_zero_trip_sync_regression.pto (PR #540) -- still expected to pass: body-interior WAIT is now tagged conditional on propagation, so the outer SET no longer elevates MTE2 alreadySync and the post-loop MTE2->V barrier is preserved.
* issue454_nested_loop_same_pipe_pair_regression.pto -- pre-loop set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[OUT/IN]) CHECKs restored, since they describe the correct loop-carried seed behavior that PR #540 suppressed.

Follow-up: add a minimized K-loop L1-Mat recycle regression test derived from the Qwen3 scope3_incore_0 reproducer in issue #564.

Build verification by reviewers is recommended before merge; the submitter was unable to run the InsertSync lit suite end-to-end.

Refs: #533, #564