### PR TITLE
feat: support local_slot_num on legacy pipe init

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -7844,6 +7844,10 @@ generated IR. The detailed design document is:
   `pto.aic_initialize_pipe` / `pto.aiv_initialize_pipe` with the matching
   `pto.tpush_*` / `pto.tpop_*` / `pto.tfree_*` ops in the same function.
 - `slot_size` is expressed in bytes and uses the pre-split logical tile size.
+- `local_slot_num` is an optional compile-time integer attribute on
+  `pto.aic_initialize_pipe` / `pto.aiv_initialize_pipe`.
+  On A2/A3 it overrides the default consumer-side local FIFO slot count used
+  when lowering to `pto.initialize_l2g2l_pipe`.
 - `nosplit` is an optional compile-time boolean attribute on
   `pto.aic_initialize_pipe` / `pto.aiv_initialize_pipe`.
 - `split` is a compile-time attribute, not a runtime SSA operand.
@@ -7969,7 +7973,7 @@ function's reserved buffer declaration.
 
 ```mlir
 // A2/A3 (with GM slot buffer):
-pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
+pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, local_slot_num = 1}
   (gm_slot_buffer = %gm_buf : !pto.ptr<f32>,
    c2v_consumer_buf = %c2v_import : i32,
    v2c_consumer_buf = %c0_i32 : i32)
@@ -7986,6 +7990,8 @@ pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
   the same function
 - `dir_mask`: communication direction encoding
 - `slot_size`: logical slot size in bytes
+- `local_slot_num`: optional A2/A3-only local FIFO slot count override for the
+  lowered `pto.initialize_l2g2l_pipe`
 - `nosplit`: optional compile-time boolean controlling no-split pipe mode
 - `gm_slot_buffer`: optional GM pointer (`!pto.ptr<T>`), required on A2/A3, omitted on A5
 - `c2v_consumer_buf`: C2V consumer local base address
@@ -7998,6 +8004,9 @@ pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
 - Must appear in Cube kernels
 - Multiple `pto.aic_initialize_pipe` ops are allowed in one Cube function, but
   `id` must be unique among frontend initialize ops in that function
+- If `local_slot_num` is present, it must be greater than `0` and no greater
+  than the legacy slot count implied by `dir_mask`
+  (`8` for `dir_mask = 1/2`, `4` for `dir_mask = 3`)
 - The lowered pipes for one function must fit within 16 hardware flag ids in
   total
 - If `nosplit = true`, all frontend data-transfer ops bound to the same logical
@@ -8013,7 +8022,7 @@ pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
 
 ```mlir
 // A2/A3 (with GM slot buffer):
-pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
+pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, local_slot_num = 1}
   (gm_slot_buffer = %gm_buf : !pto.ptr<f32>,
    c2v_consumer_buf = %c2v_local : i32,
    v2c_consumer_buf = %c0_i32 : i32)

--- a/docs/designs/ptoas-tpush-tpop-design.md
+++ b/docs/designs/ptoas-tpush-tpop-design.md
@@ -47,7 +47,7 @@
 #### 语法
 
 ```mlir
-pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
+pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024, local_slot_num = 1}
   (gm_slot_buffer = %gm_buf : !pto.ptr<f32>,
    c2v_consumer_buf = %c2v_consumer_buf : i32,
    v2c_consumer_buf = %v2c_consumer_buf : i32)
@@ -60,6 +60,7 @@ pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
 | `ID` | 编译期整数常量 | 前端逻辑 pipe 标识，要求 `>= 0` |
 | `DIR_MASK` | 编译期整数常量 | `1`、`2` 或 `3` |
 | `SLOT_SIZE` | 编译期整数常量 | 单 slot 字节数，定义为切分前完整 tile 字节数 |
+| `LOCAL_SLOT_NUM` | 编译期整数常量或空值 | 可选，仅影响 A2/A3 lowering 后 consumer 侧 local slot buffer 槽数 |
 | `GM_SLOT_BUFFER` | `!pto.ptr<T>` 或空值 | A2/A3 路径使用的 GM 指针，A5 路径为空 |
 | `C2V_CONSUMER_BUF` | `i32` | C2V 方向 consumer 的 local slot buffer 基址 |
 | `V2C_CONSUMER_BUF` | `i32` | V2C 方向 consumer 的 local slot buffer 基址 |
@@ -73,7 +74,7 @@ pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
 #### 语法
 
 ```mlir
-pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
+pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024, local_slot_num = 1}
   (gm_slot_buffer = %gm_buf : !pto.ptr<f32>,
    c2v_consumer_buf = %c2v_consumer_buf : i32,
    v2c_consumer_buf = %v2c_consumer_buf : i32)
@@ -350,7 +351,8 @@ DIR_BOTH 示例：
 #### 可选属性
 
 - `local_slot_num`
-  - 仅 `initialize_l2g2l_pipe` 承载
+  - 可直接由 `initialize_l2g2l_pipe` 承载，也可由 legacy 前端
+    `pto.aic_initialize_pipe` / `pto.aiv_initialize_pipe` 提供并在 A2/A3 lowering 时转发
   - 表示 GM 路径下 consumer 侧 local slot buffer 的槽数
   - 仅在通过 GM 传递时对底层 `TPipe` 模板参数有意义，不改变 GM FIFO 的 `slot_num`
   - 缺省值等于该内部 pipe 的 `slot_num`
@@ -447,6 +449,8 @@ pto.tfree(%pipe) { split = 0 }
 #### A2/A3
 
 - `pto.aic_initialize_pipe` 和 `pto.aiv_initialize_pipe` lower 为 `pto.initialize_l2g2l_pipe`
+- 若前端提供了 `local_slot_num`，则直接转发到 lowered
+  `pto.initialize_l2g2l_pipe`
 - 若前端未提供更具体信息，lowering 默认补上 `local_slot_num = slot_num`
 
 #### A5
@@ -457,14 +461,16 @@ pto.tfree(%pipe) { split = 0 }
 
 - 只生成一条内部 pipe
 - `slot_num = 8`
-- 对 `initialize_l2g2l_pipe`，`local_slot_num = 8`
+- 对 `initialize_l2g2l_pipe`，默认 `local_slot_num = 8`
+- 若前端显式提供 `local_slot_num`，则使用显式值
 
 ### 6.3 `DIR_MASK=3`
 
 前端一个 init op 生成**单条** DIR_BOTH 内部 pipe：
 
 - `%pipe`：`dir_mask = 3`，`slot_num = 4`
-- 若 lowering 为 `initialize_l2g2l_pipe`，`local_slot_num = 4`
+- 若 lowering 为 `initialize_l2g2l_pipe`，默认 `local_slot_num = 4`
+- 若前端显式提供 `local_slot_num`，则使用显式值
 
 地址选择规则：
 
@@ -756,7 +762,9 @@ pass 在模块级按两步执行：
 - `slot_size > 0`
 - `slot_num` 只允许 `8` 或 `4`
 - `DIR_MASK=1/2` 时，`slot_num` 必须与单向/双向 lowering 规则一致
-- `local_slot_num` 若出现，只允许出现在 `pto.initialize_l2g2l_pipe` 上，且必须大于 `0` 且不大于 `slot_num`
+- `local_slot_num` 若出现，可出现在 `pto.initialize_l2g2l_pipe` 或 legacy 前端
+  `pto.aic_initialize_pipe` / `pto.aiv_initialize_pipe` 上，且必须大于 `0`
+  且不大于其对应 lowering 规则下的 `slot_num`
 - `flag_base` 若出现，必须满足基本合法性；是否已填写以及具体分配值由 flag 分配保证
 - `pto.initialize_l2g2l_pipe` 必须提供 `gm_addr` 和 `local_addr`
 - `pto.initialize_l2l_pipe` 必须提供 `local_addr`
@@ -805,7 +813,7 @@ EmitC 将以下内部 init op 映射到底层 `TPipe`：
 - `dir_mask`
 - `slot_size`
 - `slot_num`
-- `local_slot_num`（仅 `initialize_l2g2l_pipe`）
+- `local_slot_num`
 - `flag_base`
 - `gm_addr`（仅 `initialize_l2g2l_pipe`）
 - `local_addr`

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1367,6 +1367,7 @@ def AicInitializePipeOp : PTO_Op<"aic_initialize_pipe"> {
       DefaultValuedOptionalAttr<I32Attr, "0">:$id,
       I8Attr:$dir_mask,
       I32Attr:$slot_size,
+      OptionalAttr<I32Attr>:$local_slot_num,
       OptionalAttr<BoolAttr>:$nosplit,
       Optional<PtrType>:$gm_slot_buffer,
       I32:$c2v_consumer_buf,
@@ -1375,20 +1376,7 @@ def AicInitializePipeOp : PTO_Op<"aic_initialize_pipe"> {
 
   let results = (outs);
   let hasVerifier = 1;
-
-  let assemblyFormat = [{
-    `{` (`id` `=` $id^ `,`)?
-        `dir_mask` `=` $dir_mask `,`
-        `slot_size` `=` $slot_size
-        (`,` `nosplit` `=` $nosplit^)?
-        `}`
-    `(`
-      (`gm_slot_buffer` `=` $gm_slot_buffer^ `:` type($gm_slot_buffer) `,`)?
-      `c2v_consumer_buf` `=` $c2v_consumer_buf `:` type($c2v_consumer_buf) `,`
-      `v2c_consumer_buf` `=` $v2c_consumer_buf `:` type($v2c_consumer_buf)
-    `)`
-    attr-dict
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 def AivInitializePipeOp : PTO_Op<"aiv_initialize_pipe"> {
@@ -1398,6 +1386,7 @@ def AivInitializePipeOp : PTO_Op<"aiv_initialize_pipe"> {
       DefaultValuedOptionalAttr<I32Attr, "0">:$id,
       I8Attr:$dir_mask,
       I32Attr:$slot_size,
+      OptionalAttr<I32Attr>:$local_slot_num,
       OptionalAttr<BoolAttr>:$nosplit,
       Optional<PtrType>:$gm_slot_buffer,
       I32:$c2v_consumer_buf,
@@ -1406,20 +1395,7 @@ def AivInitializePipeOp : PTO_Op<"aiv_initialize_pipe"> {
 
   let results = (outs);
   let hasVerifier = 1;
-
-  let assemblyFormat = [{
-    `{` (`id` `=` $id^ `,`)?
-        `dir_mask` `=` $dir_mask `,`
-        `slot_size` `=` $slot_size
-        (`,` `nosplit` `=` $nosplit^)?
-        `}`
-    `(`
-      (`gm_slot_buffer` `=` $gm_slot_buffer^ `:` type($gm_slot_buffer) `,`)?
-      `c2v_consumer_buf` `=` $c2v_consumer_buf `:` type($c2v_consumer_buf) `,`
-      `v2c_consumer_buf` `=` $v2c_consumer_buf `:` type($v2c_consumer_buf)
-    `)`
-    attr-dict
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 def TPushToAivOp : PTO_TOp<"tpush_to_aiv"> {

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -10013,6 +10013,158 @@ static LogicalResult verifyFrontendKernelKind(Operation *op,
   return success();
 }
 
+static ParseResult parseFrontendInitializePipeOp(OpAsmParser &parser,
+                                                 OperationState &result) {
+  NamedAttrList attrs;
+  bool sawId = false;
+  bool sawDirMask = false;
+  bool sawSlotSize = false;
+  bool sawLocalSlotNum = false;
+  bool sawNoSplit = false;
+
+  if (parser.parseLBrace())
+    return failure();
+
+  while (failed(parser.parseOptionalRBrace())) {
+    StringRef keyword;
+    if (parser.parseKeyword(&keyword) || parser.parseEqual())
+      return failure();
+
+    if (keyword == "id") {
+      if (sawId)
+        return parser.emitError(parser.getCurrentLocation(),
+                                "duplicate 'id' clause");
+      IntegerAttr idAttr;
+      if (parser.parseAttribute(idAttr, parser.getBuilder().getI32Type(), "id",
+                                attrs))
+        return failure();
+      sawId = true;
+    } else if (keyword == "dir_mask") {
+      if (sawDirMask)
+        return parser.emitError(parser.getCurrentLocation(),
+                                "duplicate 'dir_mask' clause");
+      IntegerAttr dirMaskAttr;
+      if (parser.parseAttribute(dirMaskAttr, parser.getBuilder().getI8Type(),
+                                "dir_mask", attrs))
+        return failure();
+      sawDirMask = true;
+    } else if (keyword == "slot_size") {
+      if (sawSlotSize)
+        return parser.emitError(parser.getCurrentLocation(),
+                                "duplicate 'slot_size' clause");
+      IntegerAttr slotSizeAttr;
+      if (parser.parseAttribute(slotSizeAttr, parser.getBuilder().getI32Type(),
+                                "slot_size", attrs))
+        return failure();
+      sawSlotSize = true;
+    } else if (keyword == "local_slot_num") {
+      if (sawLocalSlotNum)
+        return parser.emitError(parser.getCurrentLocation(),
+                                "duplicate 'local_slot_num' clause");
+      IntegerAttr localSlotNumAttr;
+      if (parser.parseAttribute(localSlotNumAttr, parser.getBuilder().getI32Type(),
+                                "local_slot_num", attrs))
+        return failure();
+      sawLocalSlotNum = true;
+    } else if (keyword == "nosplit") {
+      if (sawNoSplit)
+        return parser.emitError(parser.getCurrentLocation(),
+                                "duplicate 'nosplit' clause");
+      BoolAttr noSplitAttr;
+      if (parser.parseAttribute(noSplitAttr, "nosplit", attrs))
+        return failure();
+      sawNoSplit = true;
+    } else {
+      return parser.emitError(parser.getCurrentLocation())
+             << "unexpected keyword '" << keyword << "'";
+    }
+
+    if (succeeded(parser.parseOptionalRBrace()))
+      break;
+    if (parser.parseComma())
+      return failure();
+  }
+
+  if (!sawDirMask)
+    return parser.emitError(parser.getNameLoc(), "expected 'dir_mask' clause");
+  if (!sawSlotSize)
+    return parser.emitError(parser.getNameLoc(), "expected 'slot_size' clause");
+  if (!sawId)
+    attrs.set("id", parser.getBuilder().getI32IntegerAttr(0));
+
+  OpAsmParser::UnresolvedOperand gmSlotBuffer;
+  OpAsmParser::UnresolvedOperand c2vConsumerBuf;
+  OpAsmParser::UnresolvedOperand v2cConsumerBuf;
+  Type gmSlotBufferTy;
+  Type c2vConsumerBufTy;
+  Type v2cConsumerBufTy;
+  bool hasGmSlotBuffer = false;
+
+  if (parser.parseLParen())
+    return failure();
+  if (succeeded(parser.parseOptionalKeyword("gm_slot_buffer"))) {
+    if (parser.parseEqual() || parser.parseOperand(gmSlotBuffer) ||
+        parser.parseColonType(gmSlotBufferTy) || parser.parseComma())
+      return failure();
+    hasGmSlotBuffer = true;
+  }
+  if (parser.parseKeyword("c2v_consumer_buf") || parser.parseEqual() ||
+      parser.parseOperand(c2vConsumerBuf) ||
+      parser.parseColonType(c2vConsumerBufTy) || parser.parseComma() ||
+      parser.parseKeyword("v2c_consumer_buf") || parser.parseEqual() ||
+      parser.parseOperand(v2cConsumerBuf) ||
+      parser.parseColonType(v2cConsumerBufTy) || parser.parseRParen())
+    return failure();
+
+  if (parser.parseOptionalAttrDict(attrs))
+    return failure();
+
+  result.addAttributes(attrs);
+  if (hasGmSlotBuffer &&
+      parser.resolveOperand(gmSlotBuffer, gmSlotBufferTy, result.operands))
+    return failure();
+  if (parser.resolveOperand(c2vConsumerBuf, c2vConsumerBufTy, result.operands) ||
+      parser.resolveOperand(v2cConsumerBuf, v2cConsumerBufTy, result.operands))
+    return failure();
+  return success();
+}
+
+template <typename InitOpT>
+static void printFrontendInitializePipeOp(InitOpT op, OpAsmPrinter &p) {
+  p << " {";
+  bool needsComma = false;
+  auto printClause = [&](StringRef keyword, auto value) {
+    if (needsComma)
+      p << ", ";
+    p << keyword << " = " << value;
+    needsComma = true;
+  };
+
+  if (op.getId() != 0)
+    printClause("id", op.getId());
+  printClause("dir_mask", static_cast<int32_t>(op.getDirMask()));
+  printClause("slot_size", op.getSlotSize());
+  if (auto localSlotNumAttr = op.getLocalSlotNumAttr())
+    printClause("local_slot_num", localSlotNumAttr.getInt());
+  if (auto noSplitAttr = op.getNosplitAttr())
+    printClause("nosplit", noSplitAttr.getValue() ? "true" : "false");
+  p << "}";
+
+  p << "(";
+  if (op.getGmSlotBuffer()) {
+    p << "gm_slot_buffer = " << op.getGmSlotBuffer() << " : "
+      << op.getGmSlotBuffer().getType() << ", ";
+  }
+  p << "c2v_consumer_buf = " << op.getC2vConsumerBuf() << " : "
+    << op.getC2vConsumerBuf().getType() << ", ";
+  p << "v2c_consumer_buf = " << op.getV2cConsumerBuf() << " : "
+    << op.getV2cConsumerBuf().getType() << ")";
+  p.printOptionalAttrDict(
+      op->getAttrs(),
+      /*elidedAttrs=*/{"id", "dir_mask", "slot_size", "local_slot_num",
+                       "nosplit"});
+}
+
 template <typename InitOpT>
 static LogicalResult verifyFrontendInitCommon(InitOpT op,
                                               FunctionKernelKind expected,
@@ -10048,8 +10200,37 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
     return op.emitOpError("expects 'dir_mask' to be 1, 2, or 3");
   if (op.getSlotSize() <= 0)
     return op.emitOpError("expects 'slot_size' to be greater than 0");
+  if (auto localSlotNumAttr = op.getLocalSlotNumAttr()) {
+    int32_t localSlotNum = localSlotNumAttr.getInt();
+    if (localSlotNum <= 0)
+      return op.emitOpError("expects 'local_slot_num' to be greater than 0");
+    int32_t loweredSlotNum = dirMask == 3 ? 4 : 8;
+    if (localSlotNum > loweredSlotNum) {
+      return op.emitOpError()
+             << "expects 'local_slot_num' to be less than or equal to "
+             << loweredSlotNum << " for dir_mask = " << static_cast<int>(dirMask);
+    }
+  }
 
   return success();
+}
+
+ParseResult AicInitializePipeOp::parse(OpAsmParser &parser,
+                                       OperationState &result) {
+  return parseFrontendInitializePipeOp(parser, result);
+}
+
+void AicInitializePipeOp::print(OpAsmPrinter &p) {
+  printFrontendInitializePipeOp(*this, p);
+}
+
+ParseResult AivInitializePipeOp::parse(OpAsmParser &parser,
+                                       OperationState &result) {
+  return parseFrontendInitializePipeOp(parser, result);
+}
+
+void AivInitializePipeOp::print(OpAsmPrinter &p) {
+  printFrontendInitializePipeOp(*this, p);
 }
 
 static ReserveBufferOp findReserveBufferByName(func::FuncOp funcOp,

--- a/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
+++ b/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
@@ -70,7 +70,9 @@ static FailureOr<Value> createFrontendPipe(InitOpT initOp, IRRewriter &rewriter,
   if (failed(requireFrontendGmSlotBuffer(initOp)))
     return failure();
 
-  auto localSlotNumAttr = rewriter.getI32IntegerAttr(slotNum);
+  IntegerAttr localSlotNumAttr = initOp.getLocalSlotNumAttr();
+  if (!localSlotNumAttr)
+    localSlotNumAttr = rewriter.getI32IntegerAttr(slotNum);
   auto pipe = rewriter.create<InitializeL2G2LPipeOp>(
       loc, pipeTy, dirAttr, slotSizeAttr, slotNumAttr, localSlotNumAttr,
       IntegerAttr{}, noSplitAttr, initOp.getGmSlotBuffer(), localAddr,

--- a/test/lit/pto/tpush_tpop_frontend_local_slot_num_a3.pto
+++ b/test/lit/pto/tpush_tpop_frontend_local_slot_num_a3.pto
@@ -1,0 +1,49 @@
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+
+module {
+  func.func @cube_kernel(%gm_slot_buffer: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0_i32 = arith.constant 0 : i32
+    %v2c_local = pto.reserve_buffer {
+      name = "v2c_fifo",
+      size = 4096,
+      location = #pto.address_space<mat>,
+      auto = true
+    } -> i32
+    pto.aic_initialize_pipe {id = 0, dir_mask = 2, slot_size = 1024, local_slot_num = 1}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %c0_i32 : i32,
+       v2c_consumer_buf = %v2c_local : i32)
+
+    %recv_tile = pto.tpop_from_aiv {id = 0, split = 0}
+      -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tfree_from_aiv {id = 0, split = 0}
+    return
+  }
+
+  func.func @vector_kernel(%gm_slot_buffer: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i32 = arith.constant 0 : i32
+    %v2c_import = pto.import_reserved_buffer {
+      name = "v2c_fifo",
+      peer_func = @cube_kernel
+    } -> i32
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 2, slot_size = 1024, local_slot_num = 1}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %c0_i32 : i32,
+       v2c_consumer_buf = %v2c_import : i32)
+
+    %vec_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tpush_to_aic(%vec_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0, split = 0}
+    return
+  }
+}
+
+// A3-LABEL: AICORE void cube_kernel(__gm__ float*
+// A3: auto {{v[0-9]+}} = TPipe<0, Direction::DIR_V2C, 1024, 8, 1, true>(
+// A3: TPOP<TPipe<0, Direction::DIR_V2C, 1024, 8, 1, true>
+// A3: TFREE<TPipe<0, Direction::DIR_V2C, 1024, 8, 1, true>, TileSplitAxis::TILE_NO_SPLIT>(
+
+// A3-LABEL: AICORE void vector_kernel(__gm__ float*
+// A3: auto {{v[0-9]+}} = TPipe<0, Direction::DIR_V2C, 1024, 8, 1, true>(
+// A3: TPUSH<TPipe<0, Direction::DIR_V2C, 1024, 8, 1, true>

--- a/test/lit/pto/tpush_tpop_frontend_local_slot_num_invalid.pto
+++ b/test/lit/pto/tpush_tpop_frontend_local_slot_num_invalid.pto
@@ -1,0 +1,15 @@
+// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @cube_kernel(%gm_slot_buffer: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0_i32 = arith.constant 0 : i32
+    pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024, local_slot_num = 5}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %c0_i32 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    return
+  }
+}
+
+// CHECK: error: 'pto.aic_initialize_pipe' op expects 'local_slot_num' to be less than or equal to 4 for dir_mask = 3


### PR DESCRIPTION
## Summary
- add optional `local_slot_num` to legacy `pto.aic_initialize_pipe` and `pto.aiv_initialize_pipe`
- forward explicit `local_slot_num` to lowered `pto.initialize_l2g2l_pipe` on A2/A3, while keeping the old default behavior when absent
- document the new frontend attribute and add positive/negative lit coverage

## Validation
- `./build-local-slot/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/tpush_tpop_frontend_local_slot_num_a3.pto 2>&1 | /Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/FileCheck test/lit/pto/tpush_tpop_frontend_local_slot_num_a3.pto --check-prefix=A3`
- `./build-local-slot/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/tpush_tpop_frontend_local_slot_num_invalid.pto 2>&1 | /Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/FileCheck test/lit/pto/tpush_tpop_frontend_local_slot_num_invalid.pto`
- `./build-local-slot/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/tpush_tpop_frontend_lowering_a3.pto 2>&1 | /Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/FileCheck test/lit/pto/tpush_tpop_frontend_lowering_a3.pto --check-prefix=A3`
- `./build-local-slot/tools/ptoas/ptoas --pto-arch=a3 --enable-insert-sync test/lit/pto/issue481_addptr_gm_slot_buffer.pto 2>&1 | /Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/FileCheck test/lit/pto/issue481_addptr_gm_slot_buffer.pto`
