### PR TITLE
fix(ptobc): add v0 support for internal pipe ops

### DIFF
--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -199,6 +199,12 @@ inline constexpr OpInfo kOpTable[] = {
   {0x1088, "pto.set_validshape", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x1089, "pto.tconcat", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x108A, "pto.trowprod", 0, 0x00, 0x00, 3, 0, 0, 0x00},
+  {0x108B, "pto.initialize_l2g2l_pipe", 0, 0x01, 0x02, 0, 1, 0, 0x00},
+  {0x108C, "pto.initialize_l2l_pipe", 0, 0x01, 0x02, 0, 1, 0, 0x00},
+  {0x108D, "pto.tpush", 0, 0x00, 0x00, 2, 0, 0, 0x00},
+  {0x108E, "pto.declare_tile", 0, 0x01, 0x00, 0, 1, 0, 0x00},
+  {0x108F, "pto.tpop", 0, 0x00, 0x00, 2, 0, 0, 0x00},
+  {0x1090, "pto.tfree", 0, 0x00, 0x00, 1, 0, 0, 0x00},
   {0x2000, "arith.addi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2001, "arith.ceildivsi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2002, "arith.cmpi", 0, 0x01, 0x00, 2, 1, 0, 0x01},
@@ -388,6 +394,12 @@ inline std::optional<uint16_t> lookupOpcodeByName(llvm::StringRef name) {
     .Case("pto.set_validshape", 0x1088)
     .Case("pto.tconcat", 0x1089)
     .Case("pto.trowprod", 0x108A)
+    .Case("pto.initialize_l2g2l_pipe", 0x108B)
+    .Case("pto.initialize_l2l_pipe", 0x108C)
+    .Case("pto.tpush", 0x108D)
+    .Case("pto.declare_tile", 0x108E)
+    .Case("pto.tpop", 0x108F)
+    .Case("pto.tfree", 0x1090)
     .Case("scf.for", 0x4000)
     .Case("scf.if", 0x4001)
     .Case("scf.yield", 0x4002)
@@ -562,6 +574,12 @@ inline std::optional<OpcodeAndVariant> lookupOpcodeAndVariantByFullName(llvm::St
     .Case("pto.set_validshape", OpcodeAndVariant{0x1088, 0, 0})
     .Case("pto.tconcat", OpcodeAndVariant{0x1089, 0, 0})
     .Case("pto.trowprod", OpcodeAndVariant{0x108A, 0, 0})
+    .Case("pto.initialize_l2g2l_pipe", OpcodeAndVariant{0x108B, 0, 0})
+    .Case("pto.initialize_l2l_pipe", OpcodeAndVariant{0x108C, 0, 0})
+    .Case("pto.tpush", OpcodeAndVariant{0x108D, 0, 0})
+    .Case("pto.declare_tile", OpcodeAndVariant{0x108E, 0, 0})
+    .Case("pto.tpop", OpcodeAndVariant{0x108F, 0, 0})
+    .Case("pto.tfree", OpcodeAndVariant{0x1090, 0, 0})
     .Case("scf.for", OpcodeAndVariant{0x4000, 0, 0})
     .Case("scf.if", OpcodeAndVariant{0x4001, 0, 0})
     .Case("scf.yield", OpcodeAndVariant{0x4002, 0, 0})

--- a/tools/ptobc/testdata/internal_pipe_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/internal_pipe_v0_roundtrip.pto
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module {
+  func.func @internal_l2l_pipe() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %local_addr = pto.reserve_buffer {
+      name = "l2l_local",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+    %peer_local_addr = pto.reserve_buffer {
+      name = "l2l_peer",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+    %pipe = pto.initialize_l2l_pipe {
+      dir_mask = 3,
+      slot_size = 1024,
+      slot_num = 4,
+      flag_base = 2,
+      nosplit = true
+    }(%local_addr : i32, %peer_local_addr : i32) -> !pto.pipe
+
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tpush(%src, %pipe : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.pipe) {split = 0}
+    %dst = pto.declare_tile -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tpop(%dst, %pipe : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.pipe) {split = 0}
+    pto.tfree(%pipe : !pto.pipe) {split = 0}
+    return
+  }
+
+  func.func @internal_l2g2l_pipe(%gm_addr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %local_addr = pto.reserve_buffer {
+      name = "l2g2l_local",
+      size = 4096,
+      location = #pto.address_space<mat>,
+      auto = true
+    } -> i32
+    %peer_local_addr = pto.reserve_buffer {
+      name = "l2g2l_peer",
+      size = 4096,
+      location = #pto.address_space<mat>,
+      auto = true
+    } -> i32
+    %pipe = pto.initialize_l2g2l_pipe {
+      dir_mask = 3,
+      slot_size = 1024,
+      slot_num = 4,
+      local_slot_num = 2,
+      flag_base = 6,
+      nosplit = false
+    }(%gm_addr : !pto.ptr<f32>, %local_addr : i32, %peer_local_addr : i32) -> !pto.pipe
+
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tpush(%src, %pipe : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.pipe) {split = 1}
+    %dst = pto.declare_tile -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tpop(%dst, %pipe : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.pipe) {split = 1}
+    pto.tfree(%pipe : !pto.pipe) {split = 1}
+    return
+  }
+}

--- a/tools/ptobc/tests/CMakeLists.txt
+++ b/tools/ptobc/tests/CMakeLists.txt
@@ -71,6 +71,13 @@ add_test(NAME ptobc_frontend_pipe_v0_encode
     ${CMAKE_CURRENT_LIST_DIR}/frontend_pipe_v0_encode.sh
 )
 
+add_test(NAME ptobc_internal_pipe_v0_encode
+  COMMAND ${CMAKE_COMMAND} -E env
+    PTOBC_BIN=$<TARGET_FILE:ptobc>
+    TESTDATA_DIR=${PTObc_TESTDATA_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/internal_pipe_v0_encode.sh
+)
+
 add_test(NAME ptobc_tconcat_set_validshape_v0_encode
   COMMAND ${CMAKE_COMMAND} -E env
     PTOBC_BIN=$<TARGET_FILE:ptobc>

--- a/tools/ptobc/tests/internal_pipe_v0_encode.sh
+++ b/tools/ptobc/tests/internal_pipe_v0_encode.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+PTOBC_BIN=${PTOBC_BIN:-}
+if [[ -z "${PTOBC_BIN}" ]]; then
+  echo "error: PTOBC_BIN not set" >&2
+  exit 2
+fi
+
+TESTDATA_DIR=${TESTDATA_DIR:-}
+if [[ -z "${TESTDATA_DIR}" ]]; then
+  echo "error: TESTDATA_DIR not set" >&2
+  exit 2
+fi
+
+IN="${TESTDATA_DIR}/internal_pipe_v0_roundtrip.pto"
+OUT_DIR=${OUT_DIR:-"${PWD}/ptobc_internal_pipe_out"}
+mkdir -p "${OUT_DIR}"
+
+BC="${OUT_DIR}/internal_pipe_v0_roundtrip.ptobc"
+ROUNDTRIP="${OUT_DIR}/internal_pipe_v0_roundtrip.roundtrip.pto"
+
+"${PTOBC_BIN}" encode "${IN}" -o "${BC}"
+"${PTOBC_BIN}" decode "${BC}" -o "${ROUNDTRIP}"
+
+grep -F "pto.initialize_l2l_pipe" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.initialize_l2g2l_pipe" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.declare_tile" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.tpush(" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.tpop(" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.tfree(" "${ROUNDTRIP}" >/dev/null


### PR DESCRIPTION
## Summary
- add PTOBC v0 opcode entries for internal pipe ops used by unified TPUSH/TPOP IR
- cover `initialize_l2g2l_pipe`, `initialize_l2l_pipe`, `declare_tile`, `tpush`, `tpop`, and `tfree`
- add an internal pipe roundtrip test and keep the existing frontend pipe roundtrip test green

## Testing
- `ctest --test-dir /Users/laoda/pto/PTOAS-_ptobc-pipe-ops/build-ptobc-pipe -R ptobc_frontend_pipe_v0_encode --output-on-failure`
- `ctest --test-dir /Users/laoda/pto/PTOAS-_ptobc-pipe-ops/build-ptobc-pipe -R ptobc_internal_pipe_v0_encode --output-on-failure`

## Notes
- full `ptobc_*` still has unrelated pre-existing failures in this worktree: `ptobc_stage9_e2e`, `ptobc_to_ptoas_smoke`, `ptobc_recent_ops_v0_encode`