### PR TITLE
Add A2/A3 pto.tcopy support

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1183,6 +1183,40 @@ def TMovOp  : PTO_TOp<"tmov", [
   }];
 }
 
+def TCopyOp : PTO_TOp<"tcopy", [
+  PTO_DpsInitOpInterface,
+  OpPipeInterface,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "Strided UB copy between vector tiles (DPS version).";
+
+  let arguments = (ins
+    PTODpsType:$src,
+    PTODpsType:$dst,
+    DefaultValuedAttr<I32Attr, "1">:$blockSizeElem,
+    I32Attr:$srcStride,
+    I32Attr:$dstStride
+  );
+
+  let results = (outs
+    Optional<AnyRankedTensor>:$result
+  );
+
+  let assemblyFormat = [{
+    `ins` `(` $src `:` qualified(type($src)) `)`
+    `outs` `(` $dst `:` qualified(type($dst) ) `)`
+    attr-dict
+    ( `->` qualified(type($result))^ )?
+  }];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }
+    ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
+  }];
+}
+
 
 //===----------------------------------------------------------------------===//
 // Pointer Cast Op (existing)

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -5280,6 +5280,67 @@ mlir::LogicalResult mlir::pto::TMovOp::verify() {
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 
+mlir::LogicalResult mlir::pto::TCopyOp::verify() {
+  auto verifyA2A3 = [&]() -> LogicalResult {
+    Type srcTy = getSrc().getType();
+    Type dstTy = getDst().getType();
+
+    if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
+        failed(verifyTileBufCommon(*this, dstTy, "dst")))
+      return failure();
+
+    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
+    auto dstSpace = getPTOMemorySpaceEnum(dstTy);
+    if (!srcSpace || !dstSpace)
+      return emitOpError() << "expects src and dst to have explicit address spaces";
+    if (*srcSpace != pto::AddressSpace::VEC ||
+        *dstSpace != pto::AddressSpace::VEC)
+      return emitOpError() << "expects tcopy to use vec->vec tiles";
+
+    if (getShapeVec(srcTy) != getShapeVec(dstTy))
+      return emitOpError() << "expects src and dst to have the same shape";
+    if (getValidShapeVec(srcTy) != getValidShapeVec(dstTy))
+      return emitOpError() << "expects src and dst to have the same validShape";
+    if (getElemTy(srcTy) != getElemTy(dstTy))
+      return emitOpError() << "expects src and dst to have the same element type";
+
+    auto verifyRowMajorVecLayout = [&](Type ty, StringRef name) -> LogicalResult {
+      if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
+        if (tb.getBLayoutValueI32() !=
+            static_cast<int32_t>(pto::BLayout::RowMajor))
+          return emitOpError() << "expects " << name << " to use blayout=row_major";
+        if (tb.getSLayoutValueI32() !=
+            static_cast<int32_t>(pto::SLayout::NoneBox))
+          return emitOpError() << "expects " << name << " to use slayout=none_box";
+      }
+      return success();
+    };
+
+    if (failed(verifyRowMajorVecLayout(srcTy, "src")) ||
+        failed(verifyRowMajorVecLayout(dstTy, "dst")))
+      return failure();
+
+    auto requirePositive = [&](IntegerAttr attr, StringRef name) -> LogicalResult {
+      if (!attr || attr.getInt() <= 0)
+        return emitOpError() << "expects " << name << " to be a positive integer";
+      return success();
+    };
+
+    if (failed(requirePositive(getBlockSizeElemAttr(), "blockSizeElem")) ||
+        failed(requirePositive(getSrcStrideAttr(), "srcStride")) ||
+        failed(requirePositive(getDstStrideAttr(), "dstStride")))
+      return failure();
+
+    return success();
+  };
+
+  auto verifyA5 = [&]() -> LogicalResult {
+    return emitOpError() << "tcopy is only supported on A2/A3 targets";
+  };
+
+  return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
+}
+
 mlir::LogicalResult mlir::pto::TMovFPOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult {
     Type srcTy = getSrc().getType();
@@ -9470,6 +9531,14 @@ void TMovOp::getEffects(SmallVectorImpl<SideEffects::EffectInstance<MemoryEffect
   auto preQuantRange = getPreQuantScalarMutable();
   if (!preQuantRange.empty())
     addEffect(effects, &*preQuantRange.begin(), MemoryEffects::Read::get());
+  addEffect(effects, &getDstMutable(), MemoryEffects::Write::get());
+}
+
+// === TCopyOp ===
+// Read: src, Write: dst
+void TCopyOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
+  addEffect(effects, &getSrcMutable(), MemoryEffects::Read::get());
   addEffect(effects, &getDstMutable(), MemoryEffects::Write::get());
 }
 

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -7391,6 +7391,48 @@ struct PTOMovToEmitC : public OpConversionPattern<pto::TMovOp> {
   }
 };
 
+struct PTOTCopyToEmitC : public OpConversionPattern<pto::TCopyOp> {
+  using OpConversionPattern<pto::TCopyOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(pto::TCopyOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+
+    if (getTargetArch(op) == PTOArch::A5)
+      return rewriter.notifyMatchFailure(op, "tcopy is only supported on A2/A3 targets");
+
+    Value src = peelUnrealized(adaptor.getSrc());
+    Value dst = peelUnrealized(adaptor.getDst());
+
+    auto dstOT = dst.getType().dyn_cast<emitc::OpaqueType>();
+    auto srcOT = src.getType().dyn_cast<emitc::OpaqueType>();
+    if (!dstOT || !srcOT)
+      return rewriter.notifyMatchFailure(
+          op, "tcopy lowering expects opaque dst/src types");
+
+    SmallVector<Attribute, 5> templateArgVec{
+        emitc::OpaqueAttr::get(ctx, dstOT.getValue().str()),
+        emitc::OpaqueAttr::get(ctx, srcOT.getValue().str()),
+        emitc::OpaqueAttr::get(
+            ctx, std::to_string(op.getBlockSizeElemAttr().getInt())),
+        emitc::OpaqueAttr::get(
+            ctx, std::to_string(op.getSrcStrideAttr().getInt())),
+        emitc::OpaqueAttr::get(
+            ctx, std::to_string(op.getDstStrideAttr().getInt())),
+    };
+
+    rewriter.create<emitc::CallOpaqueOp>(
+        loc, TypeRange{}, "PTOAS__TCOPY",
+        /*args=*/ArrayAttr{},
+        /*templateArgs=*/rewriter.getArrayAttr(templateArgVec),
+        /*operands=*/SmallVector<Value, 2>{dst, src});
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // PTOConvert.cpp  (add lowering + patterns.add for TMOV_FP DPS/memref op)
 //===----------------------------------------------------------------------===//
@@ -10424,6 +10466,7 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOLogToEmitC>(typeConverter, ctx);
   patterns.add<FuncToEmitC>(typeConverter, ctx);
   patterns.add<PTOMovToEmitC>(typeConverter, ctx);
+  patterns.add<PTOTCopyToEmitC>(typeConverter, ctx);
   patterns.add<ArithConstantToEmitC>(typeConverter, ctx);
   patterns.add<ArithAddUIExtendedToEmitC>(typeConverter, ctx);
   patterns.add<ArithMulSIExtendedToEmitC>(typeConverter, ctx);
@@ -10627,11 +10670,14 @@ struct EmitPTOManualPass
 
         bool needsEventIdArrayHelper = false;
         bool needsTRandomHelper = false;
+        bool needsTCopyHelper = false;
         mop.walk([&](Operation *op) {
           if (isa<mlir::pto::DeclareEventIdArrayOp>(op))
             needsEventIdArrayHelper = true;
           if (isa<mlir::pto::TRandomOp>(op))
             needsTRandomHelper = true;
+          if (isa<mlir::pto::TCopyOp>(op))
+            needsTCopyHelper = true;
         });
 
 		    // 1. 插入头文件
@@ -10640,6 +10686,11 @@ struct EmitPTOManualPass
 	    builder.setInsertionPointToStart(mop.getBody());
 	    builder.create<emitc::IncludeOp>(
 	        loc, builder.getStringAttr("pto/pto-inst.hpp"), /*isAngled=*/nullptr);
+        if (needsTCopyHelper) {
+	      builder.create<emitc::IncludeOp>(
+	          loc, builder.getStringAttr("pto/npu/a2a3/TCopy.hpp"),
+	          /*isAngled=*/nullptr);
+        }
 	    builder.create<emitc::VerbatimOp>(
 	        loc, builder.getStringAttr("using namespace pto;"));
         if (needsEventIdArrayHelper) {
@@ -10665,6 +10716,17 @@ static AICORE inline void PTOAS__TRANDOM(
   TRandomKey key = {key0, key1};
   TRandomCounter counter = {counter0, counter1, counter2, counter3};
   TRANDOM<Rounds>(dst, key, counter);
+}
+)cpp"));
+        }
+        if (needsTCopyHelper) {
+	      builder.create<emitc::VerbatimOp>(
+	          loc, builder.getStringAttr(R"cpp(
+template <typename DstTile, typename SrcTile, unsigned BlockSizeElem,
+          unsigned SrcStride, unsigned DstStride>
+static AICORE inline void PTOAS__TCOPY(DstTile &dst, SrcTile &src) {
+  pto::TCopy<DstTile, SrcTile, BlockSizeElem, SrcStride, DstStride>(
+      dst.data(), src.data(), src.GetValidRow(), src.GetValidCol());
 }
 )cpp"));
         }

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -1843,6 +1843,18 @@ struct PTOViewToMemrefPass
             op.getReluPreModeAttr());
       }
 
+      // --- TCopyOp [Src, Dst] ---
+      SmallVector<mlir::pto::TCopyOp, 8> copies;
+      func.walk([&](mlir::pto::TCopyOp op) { copies.push_back(op); });
+      for (auto op : copies) {
+        IRRewriter rewriter(ctx);
+        rewriter.setInsertionPoint(op);
+        rewriter.replaceOpWithNewOp<pto::TCopyOp>(
+            op, TypeRange{}, op.getSrc(), op.getDst(),
+            op.getBlockSizeElemAttr(), op.getSrcStrideAttr(),
+            op.getDstStrideAttr());
+      }
+
       SmallVector<mlir::pto::TAbsOp, 8> abseops;
       func.walk([&](mlir::pto::TAbsOp op) { abseops.push_back(op); });
 

--- a/test/lit/pto/tcopy_emitc.pto
+++ b/test/lit/pto/tcopy_emitc.pto
@@ -1,0 +1,18 @@
+// RUN: ptoas --pto-arch=a3 %s | FileCheck %s --check-prefix=A3
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
+
+func.func @tcopy_emitc() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=16, v_row=7, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=16, v_row=7, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  pto.tcopy ins(%src : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=16, v_row=7, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+            outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=16, v_row=7, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+            {srcStride = 64 : i32, dstStride = 16 : i32}
+  return
+}
+
+// A3: #include "pto/npu/a2a3/TCopy.hpp"
+// A3: static AICORE inline void PTOAS__TCOPY
+// A3-LABEL: AICORE void tcopy_emitc(
+// A3: PTOAS__TCOPY<{{.*}}, 1, 64, 16>({{[^,]+}}, {{[^)]+}});
+
+// A5: error: 'pto.tcopy' op tcopy is only supported on A2/A3 targets

--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -205,6 +205,7 @@ inline constexpr OpInfo kOpTable[] = {
   {0x108E, "pto.declare_tile", 0, 0x01, 0x00, 0, 1, 0, 0x00},
   {0x108F, "pto.tpop", 0, 0x00, 0x00, 2, 0, 0, 0x00},
   {0x1090, "pto.tfree", 0, 0x00, 0x00, 1, 0, 0, 0x00},
+  {0x1091, "pto.tcopy", 0, 0x00, 0x00, 2, 0, 0, 0x00},
   {0x2000, "arith.addi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2001, "arith.ceildivsi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2002, "arith.cmpi", 0, 0x01, 0x00, 2, 1, 0, 0x01},
@@ -400,6 +401,7 @@ inline std::optional<uint16_t> lookupOpcodeByName(llvm::StringRef name) {
     .Case("pto.declare_tile", 0x108E)
     .Case("pto.tpop", 0x108F)
     .Case("pto.tfree", 0x1090)
+    .Case("pto.tcopy", 0x1091)
     .Case("scf.for", 0x4000)
     .Case("scf.if", 0x4001)
     .Case("scf.yield", 0x4002)
@@ -580,6 +582,7 @@ inline std::optional<OpcodeAndVariant> lookupOpcodeAndVariantByFullName(llvm::St
     .Case("pto.declare_tile", OpcodeAndVariant{0x108E, 0, 0})
     .Case("pto.tpop", OpcodeAndVariant{0x108F, 0, 0})
     .Case("pto.tfree", OpcodeAndVariant{0x1090, 0, 0})
+    .Case("pto.tcopy", OpcodeAndVariant{0x1091, 0, 0})
     .Case("scf.for", OpcodeAndVariant{0x4000, 0, 0})
     .Case("scf.if", OpcodeAndVariant{0x4001, 0, 0})
     .Case("scf.yield", OpcodeAndVariant{0x4002, 0, 0})

--- a/tools/ptobc/testdata/tcopy_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/tcopy_v0_roundtrip.pto
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module {
+  func.func @tcopy_v0() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=16, v_row=7, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=16, v_row=7, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcopy ins(%src : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=16, v_row=7, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=16, v_row=7, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              {blockSizeElem = 2 : i32, srcStride = 64 : i32, dstStride = 16 : i32}
+    return
+  }
+}

--- a/tools/ptobc/tests/CMakeLists.txt
+++ b/tools/ptobc/tests/CMakeLists.txt
@@ -50,6 +50,13 @@ add_test(NAME ptobc_tprint_v0_encode
     ${CMAKE_CURRENT_LIST_DIR}/tprint_v0_encode.sh
 )
 
+add_test(NAME ptobc_tcopy_v0_encode
+  COMMAND ${CMAKE_COMMAND} -E env
+    PTOBC_BIN=$<TARGET_FILE:ptobc>
+    TESTDATA_DIR=${PTObc_TESTDATA_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/tcopy_v0_encode.sh
+)
+
 add_test(NAME ptobc_func_call_v0_encode
   COMMAND ${CMAKE_COMMAND} -E env
     PTOBC_BIN=$<TARGET_FILE:ptobc>

--- a/tools/ptobc/tests/tcopy_v0_encode.sh
+++ b/tools/ptobc/tests/tcopy_v0_encode.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+PTOBC_BIN=${PTOBC_BIN:-}
+if [[ -z "${PTOBC_BIN}" ]]; then
+  echo "error: PTOBC_BIN not set" >&2
+  exit 2
+fi
+
+TESTDATA_DIR=${TESTDATA_DIR:-}
+if [[ -z "${TESTDATA_DIR}" ]]; then
+  echo "error: TESTDATA_DIR not set" >&2
+  exit 2
+fi
+
+IN="${TESTDATA_DIR}/tcopy_v0_roundtrip.pto"
+OUT_DIR=${OUT_DIR:-"${PWD}/ptobc_tcopy_out"}
+mkdir -p "${OUT_DIR}"
+
+BC="${OUT_DIR}/tcopy_v0_roundtrip.ptobc"
+ROUNDTRIP="${OUT_DIR}/tcopy_v0_roundtrip.roundtrip.pto"
+
+"${PTOBC_BIN}" encode "${IN}" -o "${BC}"
+"${PTOBC_BIN}" decode "${BC}" -o "${ROUNDTRIP}"
+
+grep -F "pto.tcopy ins(" "${ROUNDTRIP}" >/dev/null
+grep -F "blockSizeElem = 2 : i32" "${ROUNDTRIP}" >/dev/null
+grep -F "srcStride = 64 : i32" "${ROUNDTRIP}" >/dev/null
+grep -F "dstStride = 16 : i32" "${ROUNDTRIP}" >/dev/null

--- a/tools/ptobc/tests/tcopy_v0_encode.sh
+++ b/tools/ptobc/tests/tcopy_v0_encode.sh
@@ -4,7 +4,7 @@
 # CANN Open Software License Agreement Version 2.0 (the "License").
 # Please refer to the License for details. You may not use this file except in compliance with the License.
 # THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
-# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE.
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
 set -euo pipefail


### PR DESCRIPTION
## Summary
- add a new pto.tcopy op for A2/A3 vec->vec strided UB copies
- lower pto.tcopy to EmitC through a small PTOAS__TCOPY helper that calls pto::TCopy
- register a v0 PTOBC opcode plus lit/roundtrip coverage for the new op

## Testing
- ninja -C build-tcopy-op ptoas ptobc pto-opt
- ctest --test-dir build-tcopy-op -R "ptobc_tcopy_v0_encode|ptobc_opcode_coverage_check" --output-on-failure
- ./build-tcopy-op/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/tcopy_emitc.pto
- ./build-tcopy-op/tools/ptoas/ptoas --pto-arch=a5 test/lit/pto/tcopy_emitc.pto
- /Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/FileCheck test/lit/pto/tcopy_emitc.pto --check-prefix=A3
- /Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/FileCheck test/lit/pto/tcopy_emitc.pto --check-prefix=A5

Closes #575.