### PR TITLE
[codex] Fix partition_view IR parser compatibility

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -163,7 +163,10 @@ def MakeTensorViewOp : PTO_Op<"make_tensor_view", [AttrSizedOperandSegments]> {
 // =============================================================================
 // PartitionViewOp
 // =============================================================================
-def PartitionViewOp : PTO_Op<"partition_view", [AttrSizedOperandSegments]> {
+def PartitionViewOp : PTO_Op<"partition_view", [
+    AttrSizedOperandSegments,
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
+  ]> {
   let summary = "Partition a tensor view into a smaller logical view (logical slicing).";
   let description = [{
     Captures a specific calculation region from a large view.
@@ -183,11 +186,7 @@ def PartitionViewOp : PTO_Op<"partition_view", [AttrSizedOperandSegments]> {
   let results = (outs PartitionTensorViewType:$result); // 输出: 逻辑切片
 
   let hasVerifier = 1;
-
-  let assemblyFormat = [{
-    $source `,` `offsets` `=` `[` $offsets `]` `,` `sizes` `=` `[` $sizes `]`
-    attr-dict `:` qualified(type($source)) `->` qualified(type($result))
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 // Helper: tensor_view or memref (after lowering tensor_view to memref).

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -163,10 +163,7 @@ def MakeTensorViewOp : PTO_Op<"make_tensor_view", [AttrSizedOperandSegments]> {
 // =============================================================================
 // PartitionViewOp
 // =============================================================================
-def PartitionViewOp : PTO_Op<"partition_view", [
-    AttrSizedOperandSegments,
-    DeclareOpInterfaceMethods<InferTypeOpInterface>
-  ]> {
+def PartitionViewOp : PTO_Op<"partition_view", [AttrSizedOperandSegments]> {
   let summary = "Partition a tensor view into a smaller logical view (logical slicing).";
   let description = [{
     Captures a specific calculation region from a large view.

--- a/include/PTO/IR/PTOTypeDefs.td
+++ b/include/PTO/IR/PTOTypeDefs.td
@@ -88,6 +88,15 @@ def PartitionTensorViewType : TypeDef<PTO_Dialect, "PartitionTensorView"> {
 
   let hasCustomAssemblyFormat = 1;
 
+  // Convenience builders: explicit shape, or rank -> all dynamic ("?")
+  let builders = [
+    TypeBuilder<(ins "int64_t":$rank,
+                     "Type":$elementType), [{
+      SmallVector<int64_t, 4> shp(rank, mlir::ShapedType::kDynamic);
+      return Base::get($_ctxt, shp, elementType);
+    }]>
+  ];
+
   let extraClassDeclaration = [{
     int64_t getRank() const { return getShape().size(); }
     int64_t getDimSize(unsigned idx) const { return getShape()[idx]; }

--- a/lib/Bindings/Python/PTOModule.cpp
+++ b/lib/Bindings/Python/PTOModule.cpp
@@ -36,6 +36,17 @@ static std::vector<int64_t> toInt64Vector(const py::sequence &seq) {
   return out;
 }
 
+static std::vector<int64_t> toShapeVectorOrDynamicRank(py::object shapeOrRank) {
+  if (py::isinstance<py::int_>(shapeOrRank)) {
+    auto rank = shapeOrRank.cast<int64_t>();
+    if (rank < 0)
+      throw py::value_error("rank must be non-negative");
+    return std::vector<int64_t>(static_cast<size_t>(rank),
+                                mlir::ShapedType::kDynamic);
+  }
+  return toInt64Vector(shapeOrRank.cast<py::sequence>());
+}
+
 static py::list shapeToPyList(const int64_t *data, intptr_t n) {
   py::list lst;
   for (intptr_t i = 0; i < n; ++i)
@@ -627,13 +638,7 @@ static void bindPTOModule(pybind11::module &m) {
         .def_classmethod(
             "get",
             [](py::object cls, py::object shape_or_rank, MlirType elementType, MlirContext context) -> py::object {
-                std::vector<int64_t> shp;
-                if (py::isinstance<py::int_>(shape_or_rank)) {
-                    auto rank = shape_or_rank.cast<int64_t>();
-                    shp.assign(static_cast<size_t>(rank), mlir::ShapedType::kDynamic);
-                } else {
-                    shp = toInt64Vector(shape_or_rank.cast<py::sequence>());
-                }
+                std::vector<int64_t> shp = toShapeVectorOrDynamicRank(shape_or_rank);
                 MlirType t = mlirPTOTensorViewTypeGet(
                     context, (intptr_t)shp.size(), shp.data(), elementType);
                 return cls.attr("__call__")(t);
@@ -663,15 +668,15 @@ static void bindPTOModule(pybind11::module &m) {
         [](MlirType t) -> bool { return mlirPTOTypeIsAPartitionTensorViewType(t); })
     .def_classmethod(
         "get",
-        [](py::object cls, py::sequence shape, MlirType elementType, MlirContext context) -> py::object {
-        auto shp = toInt64Vector(shape);
+        [](py::object cls, py::object shape_or_rank, MlirType elementType, MlirContext context) -> py::object {
+        std::vector<int64_t> shp = toShapeVectorOrDynamicRank(shape_or_rank);
         MlirType t = mlirPTOPartitionTensorViewTypeGet(context,
                                             (intptr_t)shp.size(),
                                             shp.data(),
                                             elementType);
         return cls.attr("__call__")(t);
         },
-        py::arg("cls"), py::arg("shape"), py::arg("element_type"),
+        py::arg("cls"), py::arg("shape_or_rank"), py::arg("element_type"),
         py::arg("context") = py::none())
     .def_property_readonly(
         "rank",

--- a/lib/Bindings/Python/PTOModule.cpp
+++ b/lib/Bindings/Python/PTOModule.cpp
@@ -47,6 +47,15 @@ static std::vector<int64_t> toShapeVectorOrDynamicRank(py::object shapeOrRank) {
   return toInt64Vector(shapeOrRank.cast<py::sequence>());
 }
 
+static MlirContext inferContextFromElementType(MlirContext context,
+                                               MlirType elementType) {
+  if (!mlirContextIsNull(context))
+    return context;
+  if (mlirTypeIsNull(elementType))
+    throw py::value_error("context is required when element_type is null");
+  return mlirTypeGetContext(elementType);
+}
+
 static py::list shapeToPyList(const int64_t *data, intptr_t n) {
   py::list lst;
   for (intptr_t i = 0; i < n; ++i)
@@ -639,6 +648,7 @@ static void bindPTOModule(pybind11::module &m) {
             "get",
             [](py::object cls, py::object shape_or_rank, MlirType elementType, MlirContext context) -> py::object {
                 std::vector<int64_t> shp = toShapeVectorOrDynamicRank(shape_or_rank);
+                context = inferContextFromElementType(context, elementType);
                 MlirType t = mlirPTOTensorViewTypeGet(
                     context, (intptr_t)shp.size(), shp.data(), elementType);
                 return cls.attr("__call__")(t);
@@ -670,6 +680,7 @@ static void bindPTOModule(pybind11::module &m) {
         "get",
         [](py::object cls, py::object shape_or_rank, MlirType elementType, MlirContext context) -> py::object {
         std::vector<int64_t> shp = toShapeVectorOrDynamicRank(shape_or_rank);
+        context = inferContextFromElementType(context, elementType);
         MlirType t = mlirPTOPartitionTensorViewTypeGet(context,
                                             (intptr_t)shp.size(),
                                             shp.data(),

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -880,6 +880,148 @@ static std::optional<int64_t> getConstIndexValue(Value v) {
   return std::nullopt;
 }
 
+static FailureOr<mlir::pto::PartitionTensorViewType>
+inferPartitionViewResultTypeFromSizes(mlir::pto::TensorViewType sourceType,
+                                      ValueRange sizes) {
+  if (!sourceType)
+    return failure();
+
+  if ((int64_t)sizes.size() != sourceType.getRank())
+    return failure();
+
+  SmallVector<int64_t, 4> shape;
+  shape.reserve(sizes.size());
+  for (Value size : sizes) {
+    auto constSize = getConstIndexValue(size);
+    if (constSize && *constSize >= 0)
+      shape.push_back(*constSize);
+    else
+      shape.push_back(ShapedType::kDynamic);
+  }
+
+  return mlir::pto::PartitionTensorViewType::get(
+      sourceType.getContext(), shape, sourceType.getElementType());
+}
+
+ParseResult mlir::pto::PartitionViewOp::parse(OpAsmParser &parser,
+                                              OperationState &result) {
+  OpAsmParser::UnresolvedOperand source;
+  SmallVector<OpAsmParser::UnresolvedOperand, 4> offsets;
+  SmallVector<OpAsmParser::UnresolvedOperand, 4> sizes;
+  Type sourceTy;
+  Type resultTy;
+  bool hasExplicitResultTy = false;
+
+  if (parser.parseOperand(source) || parser.parseComma() ||
+      parser.parseKeyword("offsets") || parser.parseEqual() ||
+      parser.parseLSquare() || parser.parseOperandList(offsets) ||
+      parser.parseRSquare() || parser.parseComma() ||
+      parser.parseKeyword("sizes") || parser.parseEqual() ||
+      parser.parseLSquare() || parser.parseOperandList(sizes) ||
+      parser.parseRSquare() || parser.parseOptionalAttrDict(result.attributes) ||
+      parser.parseColonType(sourceTy))
+    return failure();
+
+  if (succeeded(parser.parseOptionalArrow())) {
+    if (parser.parseType(resultTy))
+      return failure();
+    hasExplicitResultTy = true;
+  }
+
+  if (parser.resolveOperand(source, sourceTy, result.operands))
+    return failure();
+
+  Type indexTy = parser.getBuilder().getIndexType();
+  if (parser.resolveOperands(offsets, indexTy, result.operands) ||
+      parser.resolveOperands(sizes, indexTy, result.operands))
+    return failure();
+
+  auto &properties = result.getOrAddProperties<PartitionViewOp::Properties>();
+  llvm::copy(ArrayRef<int32_t>(
+                 {1, static_cast<int32_t>(offsets.size()),
+                  static_cast<int32_t>(sizes.size())}),
+             properties.operandSegmentSizes.begin());
+
+  if (hasExplicitResultTy) {
+    result.addTypes(resultTy);
+    return success();
+  }
+
+  SmallVector<Type> inferredReturnTypes;
+  DictionaryAttr attrs = result.attributes.getDictionary(parser.getContext());
+  if (failed(PartitionViewOp::inferReturnTypes(
+          parser.getContext(), std::nullopt, result.operands, attrs,
+          result.getRawProperties(),
+          RegionRange(), inferredReturnTypes))) {
+    return parser.emitError(parser.getCurrentLocation(),
+                            "failed to infer pto.partition_view result type");
+  }
+
+  result.addTypes(inferredReturnTypes);
+  return success();
+}
+
+void mlir::pto::PartitionViewOp::print(OpAsmPrinter &printer) {
+  printer << " " << getSource() << ", offsets = [";
+  printer.printOperands(getOffsets());
+  printer << "], sizes = [";
+  printer.printOperands(getSizes());
+  printer << "]";
+  printer.printOptionalAttrDict((*this)->getAttrs(),
+                                /*elidedAttrs=*/{"operandSegmentSizes"});
+  printer << " : " << getSource().getType();
+
+  auto inferredResultType = inferPartitionViewResultTypeFromSizes(
+      dyn_cast<mlir::pto::TensorViewType>(getSource().getType()), getSizes());
+  if (succeeded(inferredResultType) && *inferredResultType == getResult().getType())
+    return;
+
+  printer << " -> " << getResult().getType();
+}
+
+LogicalResult mlir::pto::PartitionViewOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
+    SmallVectorImpl<Type> &inferredReturnTypes) {
+  if (operands.empty())
+    return failure();
+
+  auto sourceType = dyn_cast<mlir::pto::TensorViewType>(operands.front().getType());
+  if (!sourceType)
+    return failure();
+
+  DenseI32ArrayAttr segmentSizes;
+  if (attributes)
+    segmentSizes = attributes.getAs<DenseI32ArrayAttr>("operandSegmentSizes");
+  ArrayRef<int32_t> segments;
+  if (properties) {
+    const auto *prop = properties.as<PartitionViewOp::Properties *>();
+    if (prop)
+      segments = prop->operandSegmentSizes;
+  }
+  if (segments.empty() && segmentSizes)
+    segments = segmentSizes.asArrayRef();
+  if (segments.empty())
+    return failure();
+
+  if (segments.size() != 3 || segments[0] != 1 || segments[1] < 0 ||
+      segments[2] < 0)
+    return failure();
+
+  size_t sizeStart = static_cast<size_t>(segments[0] + segments[1]);
+  size_t sizeCount = static_cast<size_t>(segments[2]);
+  if (sizeStart + sizeCount > operands.size())
+    return failure();
+
+  auto inferredResultType = inferPartitionViewResultTypeFromSizes(
+      sourceType, operands.slice(sizeStart, sizeCount));
+  if (failed(inferredResultType))
+    return failure();
+
+  inferredReturnTypes.push_back(*inferredResultType);
+  return success();
+}
+
 static std::optional<int64_t> getConstantIntegerValueEx(
     Value v, bool includeIndexAndIntOpsInConstFold) {
   if (includeIndexAndIntOpsInConstFold) {

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -947,17 +947,17 @@ ParseResult mlir::pto::PartitionViewOp::parse(OpAsmParser &parser,
     return success();
   }
 
-  SmallVector<Type> inferredReturnTypes;
-  DictionaryAttr attrs = result.attributes.getDictionary(parser.getContext());
-  if (failed(PartitionViewOp::inferReturnTypes(
-          parser.getContext(), std::nullopt, result.operands, attrs,
-          result.getRawProperties(),
-          RegionRange(), inferredReturnTypes))) {
+  ValueRange allOperands(result.operands);
+  ValueRange sizeOperands =
+      allOperands.slice(1 + offsets.size(), sizes.size());
+  auto inferredResultType = inferPartitionViewResultTypeFromSizes(
+      dyn_cast<mlir::pto::TensorViewType>(sourceTy), sizeOperands);
+  if (failed(inferredResultType)) {
     return parser.emitError(parser.getCurrentLocation(),
                             "failed to infer pto.partition_view result type");
   }
 
-  result.addTypes(inferredReturnTypes);
+  result.addTypes(*inferredResultType);
   return success();
 }
 
@@ -977,49 +977,6 @@ void mlir::pto::PartitionViewOp::print(OpAsmPrinter &printer) {
     return;
 
   printer << " -> " << getResult().getType();
-}
-
-LogicalResult mlir::pto::PartitionViewOp::inferReturnTypes(
-    MLIRContext *context, std::optional<Location> location, ValueRange operands,
-    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
-    SmallVectorImpl<Type> &inferredReturnTypes) {
-  if (operands.empty())
-    return failure();
-
-  auto sourceType = dyn_cast<mlir::pto::TensorViewType>(operands.front().getType());
-  if (!sourceType)
-    return failure();
-
-  DenseI32ArrayAttr segmentSizes;
-  if (attributes)
-    segmentSizes = attributes.getAs<DenseI32ArrayAttr>("operandSegmentSizes");
-  ArrayRef<int32_t> segments;
-  if (properties) {
-    const auto *prop = properties.as<PartitionViewOp::Properties *>();
-    if (prop)
-      segments = prop->operandSegmentSizes;
-  }
-  if (segments.empty() && segmentSizes)
-    segments = segmentSizes.asArrayRef();
-  if (segments.empty())
-    return failure();
-
-  if (segments.size() != 3 || segments[0] != 1 || segments[1] < 0 ||
-      segments[2] < 0)
-    return failure();
-
-  size_t sizeStart = static_cast<size_t>(segments[0] + segments[1]);
-  size_t sizeCount = static_cast<size_t>(segments[2]);
-  if (sizeStart + sizeCount > operands.size())
-    return failure();
-
-  auto inferredResultType = inferPartitionViewResultTypeFromSizes(
-      sourceType, operands.slice(sizeStart, sizeCount));
-  if (failed(inferredResultType))
-    return failure();
-
-  inferredReturnTypes.push_back(*inferredResultType);
-  return success();
 }
 
 static std::optional<int64_t> getConstantIntegerValueEx(

--- a/python/pto/dialects/pto.py
+++ b/python/pto/dialects/pto.py
@@ -583,6 +583,100 @@ class TileConfig:
     fractalMxSize = 32
 
 
+_PARTITION_VIEW_UNSET = object()
+_GeneratedPartitionViewOp = PartitionViewOp
+
+
+class PartitionViewOp(_GeneratedPartitionViewOp):
+    """Compatibility wrapper for inferred-result partition_view builders."""
+
+    def __init__(
+        self,
+        *args,
+        result=_PARTITION_VIEW_UNSET,
+        source=_PARTITION_VIEW_UNSET,
+        offsets=_PARTITION_VIEW_UNSET,
+        sizes=_PARTITION_VIEW_UNSET,
+        loc=None,
+        ip=None,
+    ):
+        if result is not _PARTITION_VIEW_UNSET:
+            if source is _PARTITION_VIEW_UNSET:
+                if not args:
+                    raise TypeError("missing required argument: source")
+                source, *args = args
+            self._init_explicit(result, source, offsets, sizes, args, loc, ip)
+            return
+
+        if source is not _PARTITION_VIEW_UNSET:
+            self._init_inferred(source, offsets, sizes, args, loc, ip)
+            return
+
+        if len(args) == 4 and offsets is _PARTITION_VIEW_UNSET and sizes is _PARTITION_VIEW_UNSET:
+            result, source, offsets, sizes = args
+            self._init_explicit(result, source, offsets, sizes, (), loc, ip)
+            return
+
+        if len(args) == 2 and offsets is not _PARTITION_VIEW_UNSET and sizes is not _PARTITION_VIEW_UNSET:
+            result, source = args
+            self._init_explicit(result, source, offsets, sizes, (), loc, ip)
+            return
+
+        kwargs = {}
+        if offsets is not _PARTITION_VIEW_UNSET:
+            kwargs["offsets"] = offsets
+        if sizes is not _PARTITION_VIEW_UNSET:
+            kwargs["sizes"] = sizes
+        super().__init__(*args, **kwargs, loc=loc, ip=ip)
+
+    def _init_inferred(self, source, offsets, sizes, args, loc, ip):
+        if offsets is _PARTITION_VIEW_UNSET:
+            if not args:
+                raise TypeError("missing required argument: offsets")
+            offsets, *args = args
+        if sizes is _PARTITION_VIEW_UNSET:
+            if not args:
+                raise TypeError("missing required argument: sizes")
+            sizes, *args = args
+        if args:
+            raise TypeError(f"too many positional arguments: {len(args)}")
+        super().__init__(source=source, offsets=offsets, sizes=sizes, loc=loc, ip=ip)
+
+    def _init_explicit(self, result, source, offsets, sizes, args, loc, ip):
+        if offsets is _PARTITION_VIEW_UNSET:
+            if not args:
+                raise TypeError("missing required argument: offsets")
+            offsets, *args = args
+        if sizes is _PARTITION_VIEW_UNSET:
+            if not args:
+                raise TypeError("missing required argument: sizes")
+            sizes, *args = args
+        if args:
+            raise TypeError(f"too many positional arguments: {len(args)}")
+        operands = [
+            _pto_ops_gen._get_op_result_or_value(source),
+            _pto_ops_gen._get_op_results_or_values(offsets),
+            _pto_ops_gen._get_op_results_or_values(sizes),
+        ]
+        op = self.build_generic(
+            attributes={},
+            results=[result],
+            operands=operands,
+            successors=None,
+            regions=None,
+            loc=loc,
+            ip=ip,
+        )
+        _ods_ir.OpView.__init__(self, op)
+
+
+def partition_view(*args, **kwargs) -> _ods_ir.Value:
+    return PartitionViewOp(*args, **kwargs).result
+
+
+PartitionView = PartitionViewOp
+
+
 # -----------------------------------------------------------------------------
 # Op aliases without "Op" suffix (user-facing)
 # -----------------------------------------------------------------------------

--- a/python/pto/dialects/pto.py
+++ b/python/pto/dialects/pto.py
@@ -640,7 +640,10 @@ class PartitionViewOp(_GeneratedPartitionViewOp):
             sizes, *args = args
         if args:
             raise TypeError(f"too many positional arguments: {len(args)}")
-        super().__init__(source=source, offsets=offsets, sizes=sizes, loc=loc, ip=ip)
+        source_value = _pto_ops_gen._get_op_result_or_value(source)
+        source_type = source_value.type
+        result = PartitionTensorViewType.get(source_type.rank, source_type.element_type)
+        self._init_explicit(result, source_value, offsets, sizes, (), loc, ip)
 
     def _init_explicit(self, result, source, offsets, sizes, args, loc, ip):
         if offsets is _PARTITION_VIEW_UNSET:

--- a/test/lit/pto/issue31_partition_view_parser_compat.pto
+++ b/test/lit/pto/issue31_partition_view_parser_compat.pto
@@ -1,0 +1,54 @@
+// RUN: ptoas --mlir-print-ir-before=pto-view-to-memref %s 2>&1 | FileCheck %s
+
+module {
+  func.func @new_format_static(%src: !pto.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+
+    %tv = pto.make_tensor_view %src, shape = [%c16, %c32], strides = [%c32, %c1]
+          : !pto.tensor_view<?x?xf32>
+    %sv = pto.partition_view %tv, offsets = [%c0, %c0], sizes = [%c16, %c32]
+          : !pto.tensor_view<?x?xf32>
+
+    %tile = pto.alloc_tile
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tload ins(%sv : !pto.partition_tensor_view<16x32xf32>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @old_format_static(%src: !pto.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+
+    %tv = pto.make_tensor_view %src, shape = [%c16, %c32], strides = [%c32, %c1]
+          : !pto.tensor_view<?x?xf32>
+    %sv = pto.partition_view %tv, offsets = [%c0, %c0], sizes = [%c16, %c32]
+          : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x32xf32>
+    return
+  }
+
+  func.func @old_format_dynamic(%src: !pto.ptr<f32>, %m: index, %n: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+
+    %tv = pto.make_tensor_view %src, shape = [%c64, %c64], strides = [%c64, %c1]
+          : !pto.tensor_view<?x?xf32>
+    %sv = pto.partition_view %tv, offsets = [%c0, %c0], sizes = [%m, %n]
+          : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<?x?xf32>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @new_format_static
+// CHECK: %[[SV0:.*]] = pto.partition_view %{{.*}}, offsets = [%{{.*}}, %{{.*}}], sizes = [%{{.*}}, %{{.*}}] : !pto.tensor_view<?x?xf32>{{$}}
+// CHECK: pto.tload ins(%[[SV0]] : !pto.partition_tensor_view<16x32xf32>)
+// CHECK-LABEL: func.func @old_format_static
+// CHECK: %[[SV1:.*]] = pto.partition_view %{{.*}}, offsets = [%{{.*}}, %{{.*}}], sizes = [%{{.*}}, %{{.*}}] : !pto.tensor_view<?x?xf32>{{$}}
+// CHECK-LABEL: func.func @old_format_dynamic
+// CHECK: %[[SV2:.*]] = pto.partition_view %{{.*}}, offsets = [%{{.*}}, %{{.*}}], sizes = [%{{.*}}, %{{.*}}] : !pto.tensor_view<?x?xf32>{{$}}


### PR DESCRIPTION
## Summary

- Add a custom `pto.partition_view` parser/printer so the result `!pto.partition_tensor_view<...>` can be inferred from `sizes=[...]` and omitted from the IR.
- Preserve compatibility with the old explicit-result format using `-> !pto.partition_tensor_view<...>`.
- Add rank-based construction support for `PartitionTensorViewType.get(rank, element_type, context)` in Python bindings.
- Add a regression test covering new-format parsing plus old-format static and dynamic result types.

Fixes #31.

## Validation

- `ninja tools/ptoas/ptoas`
- `ptoas --mlir-print-ir-before=pto-view-to-memref test/lit/pto/issue31_partition_view_parser_compat.pto | FileCheck test/lit/pto/issue31_partition_view_parser_compat.pto`
- `ptoas test/lit/pto/infer_layout_ambiguous_minor2d_user_dn.pto`
- `ninja _pto`
- Python smoke test for `PartitionTensorViewType.get(2, f32, ctx)` and negative rank validation
- `git diff --cached --check` in the PR worktree