### PR TITLE
Fix zero-loop sync propagation

### DIFF
--- a/include/PTO/Transforms/InsertSync/InsertSyncAnalysis.h
+++ b/include/PTO/Transforms/InsertSync/InsertSyncAnalysis.h
@@ -32,6 +32,13 @@ struct SyncRecord {
 
   // Record the pairing status of set/wait within a syncIndex.
   llvm::DenseMap<int, bool> syncFinder;
+
+  // Marks syncFinder entries that came from a region that may not execute
+  // (for example, a zero-trip loop body or an if-without-else then branch).
+  // Such entries are still visible for outer set/wait pair discovery, but they
+  // must not transitively promote alreadySync: on the skipped path the wait did
+  // not run.
+  llvm::DenseMap<int, bool> syncFinderIsConditional;
 };
  
 using SyncRecordList = std::array<SyncRecord, MAX_MULTI_BUFFER_NUM>;
@@ -159,7 +166,7 @@ private:
                             const CompoundInstanceElement *frontCompound,
                             bool isBackwardDep) const;
  
-  /// 获取依赖对涉及的 Event ID 数量 (用于 Multi-Buffer 分析)
+  /// 获取依赖对憉及的 Event ID 数量 (用于 Multi-Buffer 分析)
   int GetEventIdNum(const DepBaseMemInfoPairVec &depBaseMemInfosVec);
  
   /// 辅助函数：获取所有涉及的 Buffer (用于 LCA 计算，虽然现在简化了，保留接口)

--- a/include/PTO/Transforms/InsertSync/SyncCommon.h
+++ b/include/PTO/Transforms/InsertSync/SyncCommon.h
@@ -270,12 +270,14 @@ class LoopInstanceElement : public InstanceElement {
 public:
   unsigned beginId;
   unsigned endId;
+  bool mayZeroTrip{true};
  
 public:
   LoopInstanceElement(unsigned index, unsigned beginId, unsigned endId,
-                      KindOfLoop loopKind = KindOfLoop::LOOP_BEGIN)
+                      KindOfLoop loopKind = KindOfLoop::LOOP_BEGIN,
+                      bool mayZeroTripLoop = true)
       : InstanceElement(KindTy::LOOP, index), beginId(beginId), endId(endId),
-        kLoopKind(loopKind) {}
+        mayZeroTrip(mayZeroTripLoop), kLoopKind(loopKind) {}
  
   ~LoopInstanceElement() override = default;
   std::unique_ptr<InstanceElement> CloneFor(KindOfLoop loopKind) const;
@@ -360,7 +362,7 @@ public:
   static bool classof(const InstanceElement *e);
   UNIT_FLAG getUnitFlagMode() const;
   
-  // PTO 暂时简化，去掉复杂的 UnitFlag 条件生成逻辑，或者稍后在 CPP 中适配
+  // PTO 暂时简化，去掉复杂的 UnitFlag 条件生成逻辑，或者稍后在 CPP 中退配
   std::optional<mlir::Value> getUnitFlagCond(Location loc, OpBuilder &rewriter);
 };
  

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -36,6 +36,55 @@ static bool isValidPipeIndex(PipelineType pipe) {
   return static_cast<unsigned>(pipe) < kPipeStateSize;
 }
 
+static bool hasUnconditionalFinder(const SyncRecord &record, int syncIndex) {
+  return record.syncFinder.lookup(syncIndex) &&
+         !record.syncFinderIsConditional.lookup(syncIndex);
+}
+
+static bool isFinderWaitAtRegionEntry(int syncIndex,
+                                      const SyncOperations &syncOperations,
+                                      unsigned regionBegin) {
+  if (syncIndex < 0 ||
+      static_cast<size_t>(syncIndex) >= syncOperations.size()) {
+    return false;
+  }
+
+  const auto &syncGroup = syncOperations[static_cast<size_t>(syncIndex)];
+  if (syncGroup.size() < 2 || !syncGroup[1]) {
+    return false;
+  }
+
+  const SyncOperation *wait = syncGroup[1].get();
+  return wait->isSyncWaitType() && wait->GetSyncIRIndex() == regionBegin;
+}
+
+static void propagateFinderFromMaySkipRegion(SyncRecord &target,
+                                             const SyncRecord &before,
+                                             const SyncRecord &after,
+                                             const SyncOperations &syncOperations,
+                                             unsigned regionBegin) {
+  llvm::DenseMap<int, bool> conditionalFinder;
+
+  for (const auto &entry : after.syncFinderIsConditional) {
+    int syncIndex = entry.first;
+    if (entry.second && after.syncFinder.lookup(syncIndex) &&
+        !hasUnconditionalFinder(before, syncIndex)) {
+      conditionalFinder[syncIndex] = true;
+    }
+  }
+
+  for (const auto &entry : after.syncFinder) {
+    int syncIndex = entry.first;
+    if (entry.second && !before.syncFinder.lookup(syncIndex) &&
+        !isFinderWaitAtRegionEntry(syncIndex, syncOperations, regionBegin)) {
+      conditionalFinder[syncIndex] = true;
+    }
+  }
+
+  target.syncFinder = after.syncFinder;
+  target.syncFinderIsConditional = std::move(conditionalFinder);
+}
+
 // ==============================================================================
 // 1. Entry Point
 // ==============================================================================
@@ -198,18 +247,29 @@ unsigned InsertSyncAnalysis::InsertLoopSync(
     const std::optional<unsigned> &forEndIndex) {
   if (loopElement->getLoopKind() == KindOfLoop::LOOP_END) {
     SyncRecordList syncRecordForList = syncRecordList;
+    SyncRecordList syncRecordBefore = syncRecordList;
     unsigned newBegin =
         std::max(begin, index - (loopElement->endId - loopElement->beginId));
     unsigned newEnd = index;
     InsertSeqSync(nowCompound, syncElement, static_cast<int>(newBegin),
                   static_cast<int>(newEnd), syncRecordForList, forEndIndex);
-    // A loop may execute zero iterations at runtime. Keep correctness for both
-    // paths by not promoting alreadySync from the loop-body traversal into the
-    // outer state. We only carry syncFinder updates, matching no-else branch
-    // behavior in InsertBranchSync.
-    for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++)
-      syncRecordList[bufferIdx].syncFinder =
-          syncRecordForList[bufferIdx].syncFinder;
+    for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
+      if (loopElement->mayZeroTrip) {
+        // A may-skip loop needs both paths to remain valid: keep finder
+        // updates visible for outer pair-finding, but tag body-introduced bits
+        // as conditional so they cannot claim that a body wait ran.
+        propagateFinderFromMaySkipRegion(syncRecordList[bufferIdx],
+                                         syncRecordBefore[bufferIdx],
+                                         syncRecordForList[bufferIdx],
+                                         syncOperations_,
+                                         loopElement->beginId);
+      } else {
+        syncRecordList[bufferIdx].syncFinder =
+            syncRecordForList[bufferIdx].syncFinder;
+        syncRecordList[bufferIdx].syncFinderIsConditional =
+            syncRecordForList[bufferIdx].syncFinderIsConditional;
+      }
+    }
     return (loopElement->endId - loopElement->beginId);
   }
   return 0;
@@ -240,10 +300,15 @@ unsigned InsertSyncAnalysis::InsertBranchSync(
                     static_cast<int>(branchEnd), syncRecordElseList, forEndIndex);
       MergeAlreadySync(syncRecordList, syncRecordIfList, syncRecordElseList);
     } else {
-      // No else-branch: do not promote `alreadySync`, but keep syncFinder
-      // updates from the then-branch.
+      // No else-branch: do not promote `alreadySync`, but keep finder updates
+      // visible for outer pair-finding. Finder bits introduced by the then
+      // branch are conditional because the branch may be skipped.
       for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++)
-        syncRecordList[bufferIdx].syncFinder = syncRecordIfList[bufferIdx].syncFinder;
+        propagateFinderFromMaySkipRegion(syncRecordList[bufferIdx],
+                                         syncRecordList[bufferIdx],
+                                         syncRecordIfList[bufferIdx],
+                                         syncOperations_,
+                                         branchElement->beginId);
     }
     return (branchElement->endId - branchElement->beginId);
   } else if (branchElement->getBranchKind() == KindOfBranch::ELSE_BEGIN &&
@@ -455,6 +520,7 @@ void InsertSyncAnalysis::UpdateSyncRecord(const SyncOperation *sync,
   if (!canTransitivelyEliminate) return;
 
   if (recordFinder[sync->GetSyncIndex()] &&
+      !syncRecord.syncFinderIsConditional.lookup(sync->GetSyncIndex()) &&
       (sync->GetType() == SyncOperation::TYPE::SET_EVENT ||
        sync->GetType() == SyncOperation::TYPE::SYNC_BLOCK_SET)) {
     recordAlready[static_cast<unsigned>(setPipeValue)] = true;

--- a/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
@@ -27,7 +27,17 @@
  
 using namespace mlir;
 using namespace mlir::pto;
- 
+
+static bool forOpMayZeroTrip(scf::ForOp forOp) {
+  llvm::APInt lowerBound;
+  llvm::APInt upperBound;
+  if (!matchPattern(forOp.getLowerBound(), m_ConstantInt(&lowerBound)) ||
+      !matchPattern(forOp.getUpperBound(), m_ConstantInt(&upperBound))) {
+    return true;
+  }
+  return !lowerBound.slt(upperBound);
+}
+
 // [辅助函数] 尝试从 Operation 中计算相对于 Source 的字节偏移量和新大小
 // 返回值: pair<offsetInBytes, sizeInBytes>
 // 如果无法计算静态值，返回 {-1, -1} 表示这是动态的
@@ -422,6 +432,7 @@ pto::PipelineType PTOIRTranslator::getOpPipeline(Operation *op) {
 void PTOIRTranslator::UpdateForOpInfo(scf::ForOp forOp) {
   auto forBeginElement = std::make_unique<LoopInstanceElement>(index, index, index);
   forBeginElement->elementOp = forOp.getOperation();
+  forBeginElement->mayZeroTrip = forOpMayZeroTrip(forOp);
   syncIR_.emplace_back(std::move(forBeginElement));
   
   std::unique_ptr<InstanceElement> &forElement = syncIR_[index];

--- a/lib/PTO/Transforms/InsertSync/SyncCommon.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCommon.cpp
@@ -171,7 +171,8 @@ LoopInstanceElement::CloneFor(KindOfLoop loopKind) const {
   checkCondition(this->beginId != this->endId,
                  "LoopInstanceElement clone failed.");
   auto res =
-      std::make_unique<LoopInstanceElement>(index, beginId, endId, loopKind);
+      std::make_unique<LoopInstanceElement>(index, beginId, endId, loopKind,
+                                            mayZeroTrip);
   res->elementOp = elementOp;
   return res;
 }

--- a/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression.pto
+++ b/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression.pto
@@ -5,10 +5,12 @@
 // - Inner-loop and outer-loop event chains must both keep their set/wait handshake.
 //
 // CHECK-LABEL: __global__ AICORE void nested_loop_same_pipe_pair()
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[OUT:[0-9]+]]);
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[IN:[0-9]+]]);
 // CHECK: for (size_t
-// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[OUT:[0-9]+]]);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[OUT]]);
 // CHECK: for (size_t
-// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[IN:[0-9]+]]);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[IN]]);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[IN]]);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[OUT]]);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[OUT]]);


### PR DESCRIPTION
## Summary
- distinguish may-zero-trip loops from definitely-entered loops
- keep conditional finder propagation for may-skip regions only
- restore transitive alreadySync guard for conditional finders
- update regression coverage for nested loop same-pipe pairing

## Test
- issue533_loop_zero_trip_sync_regression
- issue564_k_loop_mte1_mte2_wait_regression
- issue454_nested_loop_same_pipe_pair_regression
- issue428_cube_sync_regression