### PR TITLE
fix(ptobc): support tstore_fp in v0 encoding

### DIFF
--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -162,7 +162,7 @@ inline constexpr OpInfo kOpTable[] = {
   {0x1063, "pto.tsort32", 0, 0x00, 0x02, 0, 0, 0, 0x00},
   {0x1064, "pto.tsqrt", 0, 0x00, 0x00, 2, 0, 0, 0x00},
   {0x1065, "pto.tstore", 0, 0x00, 0x02, 0, 0, 0, 0x00},
-  {0x1066, "pto.tstore.fp", 0, 0x00, 0x00, 3, 0, 0, 0x00},
+  {0x1066, "pto.tstore_fp", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x1067, "pto.tsub", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x1068, "pto.tsubc", 0, 0x00, 0x00, 4, 0, 0, 0x00},
   {0x1069, "pto.tsubs", 0, 0x00, 0x00, 3, 0, 0, 0x00},
@@ -356,7 +356,7 @@ inline std::optional<uint16_t> lookupOpcodeByName(llvm::StringRef name) {
     .Case("pto.tsort32", 0x1063)
     .Case("pto.tsqrt", 0x1064)
     .Case("pto.tstore", 0x1065)
-    .Case("pto.tstore.fp", 0x1066)
+    .Case("pto.tstore_fp", 0x1066)
     .Case("pto.tsub", 0x1067)
     .Case("pto.tsubc", 0x1068)
     .Case("pto.tsubs", 0x1069)
@@ -535,7 +535,7 @@ inline std::optional<OpcodeAndVariant> lookupOpcodeAndVariantByFullName(llvm::St
     .Case("pto.tsort32", OpcodeAndVariant{0x1063, 0, 0})
     .Case("pto.tsqrt", OpcodeAndVariant{0x1064, 0, 0})
     .Case("pto.tstore", OpcodeAndVariant{0x1065, 0, 0})
-    .Case("pto.tstore.fp", OpcodeAndVariant{0x1066, 0, 0})
+    .Case("pto.tstore_fp", OpcodeAndVariant{0x1066, 0, 0})
     .Case("pto.tsub", OpcodeAndVariant{0x1067, 0, 0})
     .Case("pto.tsubc", OpcodeAndVariant{0x1068, 0, 0})
     .Case("pto.tsubs", OpcodeAndVariant{0x1069, 0, 0})

--- a/tools/ptobc/testdata/tstore_fp_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/tstore_fp_v0_roundtrip.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module {
+  func.func @tstore_fp_v0(%dst: !pto.ptr<i8>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %dst_tv = pto.make_tensor_view %dst, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<32x32xi8>
+    %dst_part = pto.partition_view %dst_tv, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<32x32xi8> -> !pto.partition_tensor_view<32x32xi8>
+    %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=32, v_row=1, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    %fp_tile = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tstore_fp ins(%acc_tile, %fp_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=32, v_row=1, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>, !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_part : !pto.partition_tensor_view<32x32xi8>)
+    return
+  }
+}

--- a/tools/ptobc/tests/CMakeLists.txt
+++ b/tools/ptobc/tests/CMakeLists.txt
@@ -84,3 +84,10 @@ add_test(NAME ptobc_tconcat_set_validshape_v0_encode
     TESTDATA_DIR=${PTObc_TESTDATA_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/tconcat_set_validshape_v0_encode.sh
 )
+
+add_test(NAME ptobc_tstore_fp_v0_encode
+  COMMAND ${CMAKE_COMMAND} -E env
+    PTOBC_BIN=$<TARGET_FILE:ptobc>
+    TESTDATA_DIR=${PTObc_TESTDATA_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/tstore_fp_v0_encode.sh
+)

--- a/tools/ptobc/tests/tstore_fp_v0_encode.sh
+++ b/tools/ptobc/tests/tstore_fp_v0_encode.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+PTOBC_BIN=${PTOBC_BIN:-}
+if [[ -z "${PTOBC_BIN}" ]]; then
+  echo "error: PTOBC_BIN not set" >&2
+  exit 2
+fi
+
+TESTDATA_DIR=${TESTDATA_DIR:-}
+if [[ -z "${TESTDATA_DIR}" ]]; then
+  echo "error: TESTDATA_DIR not set" >&2
+  exit 2
+fi
+
+IN="${TESTDATA_DIR}/tstore_fp_v0_roundtrip.pto"
+OUT_DIR=${OUT_DIR:-"${PWD}/ptobc_tstore_fp_out"}
+mkdir -p "${OUT_DIR}"
+
+BC="${OUT_DIR}/tstore_fp_v0_roundtrip.ptobc"
+ROUNDTRIP="${OUT_DIR}/tstore_fp_v0_roundtrip.roundtrip.pto"
+
+"${PTOBC_BIN}" encode "${IN}" -o "${BC}"
+"${PTOBC_BIN}" decode "${BC}" -o "${ROUNDTRIP}"
+
+grep -F "pto.tstore_fp ins(" "${ROUNDTRIP}" >/dev/null
+grep -F "!pto.partition_tensor_view<32x32xi8>" "${ROUNDTRIP}" >/dev/null


### PR DESCRIPTION
## Summary
- fix the PTO-BC v0 opcode table entry for `pto.tstore_fp`
- add a minimal `tstore_fp` roundtrip test case
- cover the regression in `ctest`

## Root cause
`tools/ptobc/generated/ptobc_opcodes_v0.h` registered opcode `0x1066` under `pto.tstore.fp`, but the real op mnemonic is `pto.tstore_fp`. As a result, `ptobc encode` could not find `pto.tstore_fp` in the v0 table and rejected the IR.

## Validation
- `ctest --test-dir build-issue20 -R 'ptobc_tstore_fp_v0_encode|ptobc_opcode_coverage_check' --output-on-failure`
- manual repro before fix: `ptobc encode` on a minimal `tstore_fp` IR failed with `op is not in v0 opcode table`
- manual repro after fix: encode + decode roundtrip succeeds for the same IR
