### PR TITLE
Add tile layout verification

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3021,8 +3021,6 @@ static LogicalResult verifyTileBufCommon(Operation *op, Type ty, StringRef name)
     if (isPTOLowPrecisionType(elemTy))
       return op->emitOpError() << name << ": dtype " << elemTy
                                << " is not supported by this op yet";
-    if (failed(verifyTileBufLayoutConstraints(op, tb, name)))
-      return failure();
   } else if (auto mr = dyn_cast<MemRefType>(ty)) {
     if (mr.getRank() != 2)
       return op->emitOpError() << "expects " << name << " to be a rank-2 memref";

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -1326,6 +1326,129 @@ static unsigned getElemByteSize(Type ty) {
   return getPTOStorageElemByteSize(ty);
 }
 
+static LogicalResult verifyTileBufLayoutConstraints(Operation *op,
+                                                    pto::TileBufType tb,
+                                                    StringRef name) {
+  auto shape = tb.getShape();
+  if (shape.size() != 2)
+    return op->emitOpError() << "expects " << name << " to be rank-2";
+
+  int64_t rows = shape[0];
+  int64_t cols = shape[1];
+  if (rows != ShapedType::kDynamic && rows <= 0)
+    return op->emitOpError() << "expects " << name << " rows to be positive";
+  if (cols != ShapedType::kDynamic && cols <= 0)
+    return op->emitOpError() << "expects " << name << " cols to be positive";
+
+  unsigned elemBytes = getElemByteSize(tb.getElementType());
+  if (elemBytes == 0)
+    return op->emitOpError() << "expects " << name
+                             << " element type to have a byte size";
+
+  auto cfg = tb.getConfigAttr();
+  if (!cfg)
+    cfg = TileBufConfigAttr::getDefault(tb.getContext());
+  auto readBLayout = [](Attribute attr, int32_t &out) -> bool {
+    if (auto layout = dyn_cast_or_null<BLayoutAttr>(attr)) {
+      out = static_cast<int32_t>(layout.getValue());
+      return true;
+    }
+    if (auto value = dyn_cast_or_null<IntegerAttr>(attr)) {
+      out = static_cast<int32_t>(value.getInt());
+      return true;
+    }
+    return false;
+  };
+  auto readSLayout = [](Attribute attr, int32_t &out) -> bool {
+    if (auto layout = dyn_cast_or_null<SLayoutAttr>(attr)) {
+      out = static_cast<int32_t>(layout.getValue());
+      return true;
+    }
+    if (auto value = dyn_cast_or_null<IntegerAttr>(attr)) {
+      out = static_cast<int32_t>(value.getInt());
+      return true;
+    }
+    return false;
+  };
+  int32_t blayout = 0;
+  int32_t slayout = 0;
+  if (!readBLayout(cfg.getBLayout(), blayout) ||
+      !readSLayout(cfg.getSLayout(), slayout))
+    return op->emitOpError() << "expects " << name
+                             << " to have concrete tile layout attributes";
+  constexpr int64_t kAlignedBytes = 32;
+
+  auto checkByteAlignment = [&](int64_t dim, StringRef layoutName,
+                                StringRef byteExpr) -> LogicalResult {
+    if (dim == ShapedType::kDynamic)
+      return success();
+    int64_t bytes = dim * static_cast<int64_t>(elemBytes);
+    if (bytes % kAlignedBytes == 0)
+      return success();
+    return op->emitOpError()
+           << "expects " << name << " " << layoutName
+           << " none_box tile " << byteExpr
+           << " to be 32-byte aligned, but got " << bytes << " bytes";
+  };
+
+  if (slayout == static_cast<int32_t>(SLayout::NoneBox)) {
+    if (blayout == static_cast<int32_t>(BLayout::RowMajor))
+      return checkByteAlignment(cols, "row-major",
+                                "row byte size (cols * sizeof(dtype))");
+    return checkByteAlignment(rows, "col-major",
+                              "column byte size (rows * sizeof(dtype))");
+  }
+
+  int64_t innerRows = 0;
+  int64_t innerCols = 0;
+  int32_t fractal = static_cast<int32_t>(cfg.getSFractalSize().getInt());
+  switch (fractal) {
+  case 1024:
+    innerRows = 16;
+    innerCols = 16;
+    break;
+  case 32:
+    innerRows = 16;
+    innerCols = 2;
+    break;
+  case 512:
+    if (kAlignedBytes % elemBytes != 0)
+      return op->emitOpError() << "expects " << name
+                               << " element byte size to divide 32 for boxed "
+                                  "fractal-512 tile layout";
+    if (slayout == static_cast<int32_t>(SLayout::RowMajor)) {
+      innerRows = 16;
+      innerCols = kAlignedBytes / static_cast<int64_t>(elemBytes);
+    } else if (slayout == static_cast<int32_t>(SLayout::ColMajor)) {
+      innerRows = kAlignedBytes / static_cast<int64_t>(elemBytes);
+      innerCols = 16;
+    }
+    break;
+  default:
+    break;
+  }
+  if (innerRows <= 0 || innerCols <= 0)
+    return op->emitOpError() << "expects " << name
+                             << " to use a supported boxed tile layout";
+
+  auto loc = getPTOMemorySpaceEnum(tb);
+  bool allowUnalignedRows =
+      (loc && *loc == pto::AddressSpace::VEC) || fractal == 32 || rows == 1;
+  if (!allowUnalignedRows && rows != ShapedType::kDynamic &&
+      rows % innerRows != 0)
+    return op->emitOpError()
+           << "expects " << name
+           << " boxed tile rows to be a multiple of innerRows (" << innerRows
+           << "), but got " << rows;
+  if (cols != ShapedType::kDynamic && cols % innerCols != 0)
+    return op->emitOpError()
+           << "expects " << name
+           << " boxed tile cols to be a multiple of innerCols (" << innerCols
+           << "), but got " << cols;
+
+  return success();
+}
+
 [[maybe_unused]] static bool isSupportedLoadStoreElemTypeA2A3(Type ty) {
   if (ty.isF16() || ty.isBF16() || ty.isF32())
     return true;
@@ -1981,6 +2104,9 @@ LogicalResult AllocTileOp::verify() {
     return emitOpError() << "result dtype " << elemTy
                          << " is not supported by pto.alloc_tile yet";
 
+  if (failed(verifyTileBufLayoutConstraints(*this, ty, "result")))
+    return failure();
+
   // op 上有没有传 operands
   bool hasVR = getValidRow() != nullptr;
   bool hasVC = getValidCol() != nullptr;
@@ -2020,6 +2146,8 @@ LogicalResult MaterializeTileOp::verify() {
     return emitOpError("source memref must be rank-2 to materialize a tile handle");
   if (resultTy.getRank() != 2)
     return emitOpError("result tile_buf must be rank-2");
+  if (failed(verifyTileBufLayoutConstraints(*this, resultTy, "result")))
+    return failure();
 
   auto viewSemantics = (*this)->getAttrOfType<StringAttr>("pto.view_semantics");
   bool isSubview = viewSemantics && viewSemantics.getValue() == "subview";
@@ -2893,6 +3021,8 @@ static LogicalResult verifyTileBufCommon(Operation *op, Type ty, StringRef name)
     if (isPTOLowPrecisionType(elemTy))
       return op->emitOpError() << name << ": dtype " << elemTy
                                << " is not supported by this op yet";
+    if (failed(verifyTileBufLayoutConstraints(op, tb, name)))
+      return failure();
   } else if (auto mr = dyn_cast<MemRefType>(ty)) {
     if (mr.getRank() != 2)
       return op->emitOpError() << "expects " << name << " to be a rank-2 memref";

--- a/test/lit/pto/infer_layout_ambiguous_minor2d_user_dn.pto
+++ b/test/lit/pto/infer_layout_ambiguous_minor2d_user_dn.pto
@@ -10,9 +10,9 @@ module {
     // User-specified DN should be accepted and preserved.
     %tv = pto.make_tensor_view %src, shape = [%c1, %c16], strides = [%c1, %c1] {layout = #pto.layout<dn>} : !pto.tensor_view<?x?xf16>
     %sv = pto.partition_view %tv, offsets = [%c0, %c0], sizes = [%c1, %c16] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<1x16xf16>
-    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=16, v_row=1, v_col=16, blayout=col_major, slayout=none_box, fractal=512, pad=1>
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=1, v_col=16, blayout=col_major, slayout=none_box, fractal=512, pad=1>
     pto.tload ins(%sv : !pto.partition_tensor_view<1x16xf16>)
-              outs(%tile : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=16, v_row=1, v_col=16, blayout=col_major, slayout=none_box, fractal=512, pad=1>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=1, v_col=16, blayout=col_major, slayout=none_box, fractal=512, pad=1>)
     return
   }
 }

--- a/test/lit/pto/issue226_remove_redundant_pipe_pair.pto
+++ b/test/lit/pto/issue226_remove_redundant_pipe_pair.pto
@@ -15,15 +15,20 @@
 
 module {
   func.func @remove_redundant_pipe_pair(
-      %arg0: memref<64x1xf16, strided<[1, 1]>, #pto.address_space<vec>>) {
+      %arg0: !pto.ptr<f16>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c2 = arith.constant 2 : index
-    %c64 = arith.constant 64 : index
-    %vbuf0 = pto.bind_tile %arg0, %c64, %c1
-      {config = #pto.tile_buf_config<blayout=1 : i32, slayout=2 : i32, s_fractal_size=512, pad=0 : i32>}
-      : memref<64x1xf16, strided<[1, 1]>, #pto.address_space<vec>>
-     -> memref<64x1xf16, strided<[1, 1], offset: ?>, #pto.address_space<vec>>
+    %c32 = arith.constant 32 : index
+    %c1024 = arith.constant 1024 : index
+    %src_view = pto.make_tensor_view %arg0,
+      shape = [%c1, %c1, %c1, %c32, %c32],
+      strides = [%c1024, %c1024, %c1024, %c32, %c1]
+      : !pto.tensor_view<1x1x1x32x32xf16>
+    %src_part = pto.partition_view %src_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c32, %c32]
+      : !pto.tensor_view<1x1x1x32x32xf16> -> !pto.partition_tensor_view<1x1x1x32x32xf16>
 
     pto.section.cube {
       %mat_a = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
@@ -33,7 +38,7 @@ module {
       %acc = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
 
       scf.for %i = %c0 to %c2 step %c1 {
-        pto.tload ins(%vbuf0 : memref<64x1xf16, strided<[1, 1], offset: ?>, #pto.address_space<vec>>)
+        pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x32x32xf16>)
             outs(%mat_a : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
         pto.tmov ins(%mat_a : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
             outs(%left : !pto.tile_buf<loc=left, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>)

--- a/test/lit/pto/issue522_expanddiv_a5_int_types.pto
+++ b/test/lit/pto/issue522_expanddiv_a5_int_types.pto
@@ -8,10 +8,10 @@ module {
     %dst_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tcolexpanddiv ins(%src0_col, %src1_col : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_col : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
-    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
-    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
 

--- a/test/lit/pto/issue522_expanddiv_a5_int_types.pto
+++ b/test/lit/pto/issue522_expanddiv_a5_int_types.pto
@@ -8,10 +8,10 @@ module {
     %dst_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tcolexpanddiv ins(%src0_col, %src1_col : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_col : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
-    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
-    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
 

--- a/test/lit/pto/issue522_expanddiv_a5_int_types_gss.pto
+++ b/test/lit/pto/issue522_expanddiv_a5_int_types_gss.pto
@@ -8,10 +8,10 @@ module {
     %dst_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tcolexpanddiv ins(%src0_col, %src1_col : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_col : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
-    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
-    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
 

--- a/test/lit/pto/issue522_expanddiv_a5_int_types_gss.pto
+++ b/test/lit/pto/issue522_expanddiv_a5_int_types_gss.pto
@@ -8,10 +8,10 @@ module {
     %dst_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tcolexpanddiv ins(%src0_col, %src1_col : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_col : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
-    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
-    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
 

--- a/test/lit/pto/issue531_tprelu_vec_overflow_a5.pto
+++ b/test/lit/pto/issue531_tprelu_vec_overflow_a5.pto
@@ -16,13 +16,13 @@
 
 module {
   func.func @TPRELU_OVERFLOW() {
-    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.tprelu ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-               outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tprelu ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
 }

--- a/test/lit/pto/issue531_tprelu_vec_overflow_a5.pto
+++ b/test/lit/pto/issue531_tprelu_vec_overflow_a5.pto
@@ -16,13 +16,13 @@
 
 module {
   func.func @TPRELU_OVERFLOW() {
-    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.tprelu ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-               outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=224, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tprelu ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
 }

--- a/test/lit/pto/issue558_trowargmax_vec_overflow_a5.pto
+++ b/test/lit/pto/issue558_trowargmax_vec_overflow_a5.pto
@@ -48,7 +48,7 @@ module {
       : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %dst = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=1, v_row=2, v_col=1,
+      : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=8, v_row=2, v_col=1,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x2x16381xf32>)
@@ -58,9 +58,9 @@ module {
                                             blayout=row_major, slayout=none_box, fractal=512, pad=0>,
                                 !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
                                             blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-                    outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=1, v_row=2, v_col=1,
+                    outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=8, v_row=2, v_col=1,
                                              blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=1, v_row=2, v_col=1,
+    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=8, v_row=2, v_col=1,
                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
                outs(%dst_part : !pto.partition_tensor_view<1x1x1x2x1xui32>)
     return

--- a/test/lit/pto/issue558_trowargmin_vec_overflow_a5.pto
+++ b/test/lit/pto/issue558_trowargmin_vec_overflow_a5.pto
@@ -48,7 +48,7 @@ module {
       : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %dst = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=1, v_row=2, v_col=1,
+      : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=8, v_row=2, v_col=1,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x2x16381xf32>)
@@ -58,9 +58,9 @@ module {
                                             blayout=row_major, slayout=none_box, fractal=512, pad=0>,
                                 !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16384, v_row=2, v_col=16381,
                                             blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-                    outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=1, v_row=2, v_col=1,
+                    outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=8, v_row=2, v_col=1,
                                              blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=1, v_row=2, v_col=1,
+    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=2, cols=8, v_row=2, v_col=1,
                                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
                outs(%dst_part : !pto.partition_tensor_view<1x1x1x2x1xui32>)
     return

--- a/test/lit/pto/subview_validshape_guard.pto
+++ b/test/lit/pto/subview_validshape_guard.pto
@@ -2,75 +2,78 @@
 
 module {
   func.func @subview_validshape_noncompact_default(
-      %dst: memref<2x2xf32, #pto.address_space<gm>>) {
+      %dst: memref<2x8xf32, #pto.address_space<gm>>) {
     %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
 
-    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=4, v_row=4, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %s = pto.subview %tile[%c2, %c2] sizes [2, 2] :
-      !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=4, v_row=4, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-      -> !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=2, v_row=2, v_col=2, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=16, v_row=4, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %s = pto.subview %tile[%c2, %c8] sizes [2, 8] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=16, v_row=4, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=8, v_row=2, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.tstore ins(%s : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=2, v_row=2, v_col=2, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-              outs(%dst : memref<2x2xf32, #pto.address_space<gm>>)
+    pto.tstore ins(%s : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=8, v_row=2, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst : memref<2x8xf32, #pto.address_space<gm>>)
     return
   }
 
   func.func @subview_validshape_compact_default(
-      %dst: memref<2x4xf32, #pto.address_space<gm>>) {
+      %dst: memref<2x8xf32, #pto.address_space<gm>>) {
     %c0 = arith.constant 0 : index
     %c2 = arith.constant 2 : index
 
-    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=4, v_row=4, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %s = pto.subview %tile[%c2, %c0] sizes [2, 4] :
-      !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=4, v_row=4, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-      -> !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=4, v_row=2, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=8, v_row=4, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %s = pto.subview %tile[%c2, %c0] sizes [2, 8] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=8, v_row=4, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=8, v_row=2, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.tstore ins(%s : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=4, v_row=2, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-              outs(%dst : memref<2x4xf32, #pto.address_space<gm>>)
+    pto.tstore ins(%s : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=8, v_row=2, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst : memref<2x8xf32, #pto.address_space<gm>>)
     return
   }
 
   func.func @subview_validshape_explicit_override(
-      %dst: memref<2x2xf32, #pto.address_space<gm>>) {
+      %dst: memref<2x8xf32, #pto.address_space<gm>>) {
     %c1 = arith.constant 1 : index
     %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
 
-    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=4, v_row=3, v_col=3, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %s = pto.subview %tile[%c2, %c2] sizes [2, 2] valid [%c1, %c1] :
-      !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=4, v_row=3, v_col=3, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-      -> !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=2, v_row=1, v_col=1, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=16, v_row=3, v_col=15, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %s = pto.subview %tile[%c2, %c8] sizes [2, 8] valid [%c1, %c1] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=16, v_row=3, v_col=15, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=8, v_row=1, v_col=1, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.tstore ins(%s : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=2, v_row=1, v_col=1, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-              outs(%dst : memref<2x2xf32, #pto.address_space<gm>>)
+    pto.tstore ins(%s : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=8, v_row=1, v_col=1, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst : memref<2x8xf32, #pto.address_space<gm>>)
     return
   }
 
   func.func @subview_validshape_explicit_dynamic(
       %vr: index, %vc: index,
-      %dst: memref<2x2xf32, #pto.address_space<gm>>) {
+      %dst: memref<2x8xf32, #pto.address_space<gm>>) {
     %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
 
-    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=4, v_row=4, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %s = pto.subview %tile[%c2, %c2] sizes [2, 2] valid [%vr, %vc] :
-      !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=4, v_row=4, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-      -> !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=2, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=16, v_row=4, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %s = pto.subview %tile[%c2, %c8] sizes [2, 8] valid [%vr, %vc] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=16, v_row=4, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=8, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.tstore ins(%s : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=2, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-              outs(%dst : memref<2x2xf32, #pto.address_space<gm>>)
+    pto.tstore ins(%s : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=8, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst : memref<2x8xf32, #pto.address_space<gm>>)
     return
   }
 }
 
-// Default non-compact subview keeps parent physical shape (4x4) but valid defaults
-// to subview shape (2x2), not clipped from parent valid shape.
-// CHECK: Tile<TileType::Vec, float, 4, 4, BLayout::RowMajor, 2, 2, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
-// CHECK-NOT: Tile<TileType::Vec, float, 4, 4, BLayout::RowMajor, 1, 1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
+// Default non-compact subview keeps parent physical shape (4x16) but valid
+// defaults to subview shape (2x8), not clipped from parent valid shape.
+// CHECK: Tile<TileType::Vec, float, 4, 16, BLayout::RowMajor, 2, 8, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
+// CHECK-NOT: Tile<TileType::Vec, float, 4, 16, BLayout::RowMajor, 1, 1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
 
-// Default row-major full-col subview can use the compact child physical shape (2x4).
-// CHECK: Tile<TileType::Vec, float, 2, 4, BLayout::RowMajor, 2, 4, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
+// Default row-major full-col subview can use the compact child physical shape (2x8).
+// CHECK: Tile<TileType::Vec, float, 2, 8, BLayout::RowMajor, 2, 8, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
 
 // Explicit valid override takes effect.
-// CHECK: Tile<TileType::Vec, float, 4, 4, BLayout::RowMajor, 1, 1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
+// CHECK: Tile<TileType::Vec, float, 4, 16, BLayout::RowMajor, 1, 1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
 
 // Dynamic explicit valid keeps dynamic valid dims at lowering.
-// CHECK: Tile<TileType::Vec, float, 4, 4, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
+// CHECK: Tile<TileType::Vec, float, 4, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>

--- a/test/lit/pto/subview_validshape_partial_parent_requires_explicit.pto
+++ b/test/lit/pto/subview_validshape_partial_parent_requires_explicit.pto
@@ -2,17 +2,18 @@
 
 module {
   func.func @subview_implicit_valid_partial_parent_allowed(
-      %dst: memref<2x2xf32, #pto.address_space<gm>>) {
+      %dst: memref<2x8xf32, #pto.address_space<gm>>) {
     %c2 = arith.constant 2 : index
-    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=4, v_row=3, v_col=3, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %s = pto.subview %tile[%c2, %c2] sizes [2, 2] :
-      !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=4, v_row=3, v_col=3, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-      -> !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=2, v_row=2, v_col=2, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tstore ins(%s : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=2, v_row=2, v_col=2, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-              outs(%dst : memref<2x2xf32, #pto.address_space<gm>>)
+    %c8 = arith.constant 8 : index
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=16, v_row=3, v_col=15, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %s = pto.subview %tile[%c2, %c8] sizes [2, 8] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=16, v_row=3, v_col=15, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=8, v_row=2, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tstore ins(%s : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=8, v_row=2, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst : memref<2x8xf32, #pto.address_space<gm>>)
     return
   }
 }
 
-// CHECK: Tile<TileType::Vec, float, 4, 4, BLayout::RowMajor, 2, 2, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
+// CHECK: Tile<TileType::Vec, float, 4, 16, BLayout::RowMajor, 2, 8, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
 // CHECK-NOT: error:

--- a/test/lit/pto/tconcatidx.pto
+++ b/test/lit/pto/tconcatidx.pto
@@ -145,10 +145,10 @@ module {
       : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %idx0 = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=1, v_row=8, v_col=1,
+      : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=8, v_row=8, v_col=1,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %idx1 = pto.alloc_tile
-      : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=1, v_row=8, v_col=1,
+      : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=8, v_row=8, v_col=1,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %dst = pto.alloc_tile
       : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
@@ -161,10 +161,10 @@ module {
               outs(%src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
                                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.tload ins(%idx0_part : !pto.partition_tensor_view<1x1x1x8x1xi32>)
-              outs(%idx0 : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=1, v_row=8, v_col=1,
+              outs(%idx0 : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=8, v_row=8, v_col=1,
                                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.tload ins(%idx1_part : !pto.partition_tensor_view<1x1x1x8x1xi32>)
-              outs(%idx1 : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=1, v_row=8, v_col=1,
+              outs(%idx1 : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=8, v_row=8, v_col=1,
                                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.tload ins(%dst_part : !pto.partition_tensor_view<1x1x1x8x64xf32>)
               outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
@@ -174,9 +174,9 @@ module {
                     blayout=row_major, slayout=none_box, fractal=512, pad=0>,
       !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
                     blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-      !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=1, v_row=8, v_col=1,
+      !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=8, v_row=8, v_col=1,
                     blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-      !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=1, v_row=8, v_col=1,
+      !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=8, v_row=8, v_col=1,
                     blayout=row_major, slayout=none_box, fractal=512, pad=0>)
       outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
                                 blayout=row_major, slayout=none_box, fractal=512, pad=0>)

--- a/test/lit/pto/thistogram_emitc.pto
+++ b/test/lit/pto/thistogram_emitc.pto
@@ -2,15 +2,15 @@
 
 module {
   func.func @thistogram_emitc() {
-    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %idx = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=8, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
-    %dst0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %dst1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=8, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
-                   outs(%dst0 : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=8, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
-                   outs(%dst1 : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {isMSB = false}
+    pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst0 : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst1 : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {isMSB = false}
     return
   }
 }

--- a/test/lit/pto/thistogram_verify_invalid_a3.pto
+++ b/test/lit/pto/thistogram_verify_invalid_a3.pto
@@ -1,12 +1,12 @@
 // RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
 
 func.func @thistogram_verify_invalid_a3() {
-  %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-  %idx = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=8, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
-  %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %idx = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-  pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=8, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
-                 outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                 outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
   return
 }
 

--- a/test/lit/pto/tile_layout_verify_boxed_invalid.pto
+++ b/test/lit/pto/tile_layout_verify_boxed_invalid.pto
@@ -1,0 +1,10 @@
+// RUN: not ptoas %s 2>&1 | FileCheck %s
+
+module {
+  func.func @bad_boxed_layout() {
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=8, cols=8, v_row=8, v_col=8, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    return
+  }
+}
+
+// CHECK: error: 'pto.alloc_tile' op expects result boxed tile rows to be a multiple of innerRows (16), but got 8

--- a/test/lit/pto/tile_layout_verify_col_major_nonebox_invalid.pto
+++ b/test/lit/pto/tile_layout_verify_col_major_nonebox_invalid.pto
@@ -1,0 +1,10 @@
+// RUN: not ptoas %s 2>&1 | FileCheck %s
+
+module {
+  func.func @bad_col_major_nonebox() {
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=2, v_row=7, v_col=2, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    return
+  }
+}
+
+// CHECK: error: 'pto.alloc_tile' op expects result col-major none_box tile column byte size (rows * sizeof(dtype)) to be 32-byte aligned, but got 28 bytes

--- a/test/lit/pto/tile_layout_verify_row_major_nonebox_invalid.pto
+++ b/test/lit/pto/tile_layout_verify_row_major_nonebox_invalid.pto
@@ -1,0 +1,10 @@
+// RUN: not ptoas %s 2>&1 | FileCheck %s
+
+module {
+  func.func @bad_row_major_nonebox() {
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=7, v_row=2, v_col=7, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    return
+  }
+}
+
+// CHECK: error: 'pto.alloc_tile' op expects result row-major none_box tile row byte size (cols * sizeof(dtype)) to be 32-byte aligned, but got 28 bytes

--- a/test/lit/pto/tquant.pto
+++ b/test/lit/pto/tquant.pto
@@ -3,28 +3,28 @@
 
 module attributes {"pto.device-spec" = "Ascend910B3"} {
   func.func @tquant_sym() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-    %src = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-    %fp  = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-    %dst = memref.alloc() : memref<16x16xi8, #pto.address_space<vec>>
+    %src = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
+    %fp  = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
+    %dst = memref.alloc() : memref<16x32xi8, #pto.address_space<vec>>
 
-    pto.tquant ins(%src, %fp : memref<16x16xf32, #pto.address_space<vec>>,
-                               memref<16x16xf32, #pto.address_space<vec>>)
-               outs(%dst : memref<16x16xi8, #pto.address_space<vec>>)
+    pto.tquant ins(%src, %fp : memref<16x32xf32, #pto.address_space<vec>>,
+                               memref<16x32xf32, #pto.address_space<vec>>)
+               outs(%dst : memref<16x32xi8, #pto.address_space<vec>>)
                {quant_type = #pto<quant_type INT8_SYM>}
 
     return
   }
 
   func.func @tquant_asym() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-    %src    = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-    %fp     = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-    %offset = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-    %dst    = memref.alloc() : memref<16x16xui8, #pto.address_space<vec>>
+    %src    = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
+    %fp     = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
+    %offset = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
+    %dst    = memref.alloc() : memref<16x32xui8, #pto.address_space<vec>>
 
-    pto.tquant ins(%src, %fp, %offset : memref<16x16xf32, #pto.address_space<vec>>,
-                                        memref<16x16xf32, #pto.address_space<vec>>,
-                                        memref<16x16xf32, #pto.address_space<vec>>)
-               outs(%dst : memref<16x16xui8, #pto.address_space<vec>>)
+    pto.tquant ins(%src, %fp, %offset : memref<16x32xf32, #pto.address_space<vec>>,
+                                        memref<16x32xf32, #pto.address_space<vec>>,
+                                        memref<16x32xf32, #pto.address_space<vec>>)
+               outs(%dst : memref<16x32xui8, #pto.address_space<vec>>)
                {quant_type = #pto<quant_type INT8_ASYM>}
 
     return

--- a/test/lit/pto/tquant.pto
+++ b/test/lit/pto/tquant.pto
@@ -3,28 +3,28 @@
 
 module attributes {"pto.device-spec" = "Ascend910B3"} {
   func.func @tquant_sym() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-    %src = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-    %fp  = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-    %dst = memref.alloc() : memref<16x32xi8, #pto.address_space<vec>>
+    %src = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+    %fp  = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+    %dst = memref.alloc() : memref<16x16xi8, #pto.address_space<vec>>
 
-    pto.tquant ins(%src, %fp : memref<16x32xf32, #pto.address_space<vec>>,
-                               memref<16x32xf32, #pto.address_space<vec>>)
-               outs(%dst : memref<16x32xi8, #pto.address_space<vec>>)
+    pto.tquant ins(%src, %fp : memref<16x16xf32, #pto.address_space<vec>>,
+                               memref<16x16xf32, #pto.address_space<vec>>)
+               outs(%dst : memref<16x16xi8, #pto.address_space<vec>>)
                {quant_type = #pto<quant_type INT8_SYM>}
 
     return
   }
 
   func.func @tquant_asym() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-    %src    = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-    %fp     = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-    %offset = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-    %dst    = memref.alloc() : memref<16x32xui8, #pto.address_space<vec>>
+    %src    = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+    %fp     = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+    %offset = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+    %dst    = memref.alloc() : memref<16x16xui8, #pto.address_space<vec>>
 
-    pto.tquant ins(%src, %fp, %offset : memref<16x32xf32, #pto.address_space<vec>>,
-                                        memref<16x32xf32, #pto.address_space<vec>>,
-                                        memref<16x32xf32, #pto.address_space<vec>>)
-               outs(%dst : memref<16x32xui8, #pto.address_space<vec>>)
+    pto.tquant ins(%src, %fp, %offset : memref<16x16xf32, #pto.address_space<vec>>,
+                                        memref<16x16xf32, #pto.address_space<vec>>,
+                                        memref<16x16xf32, #pto.address_space<vec>>)
+               outs(%dst : memref<16x16xui8, #pto.address_space<vec>>)
                {quant_type = #pto<quant_type INT8_ASYM>}
 
     return

--- a/test/lit/pto/tquant_verify_invalid_int8_asym_wrong_dst.pto
+++ b/test/lit/pto/tquant_verify_invalid_int8_asym_wrong_dst.pto
@@ -13,15 +13,15 @@
 // CHECK: AICORE void tquant_asym_wrong_dst()
 
 func.func @tquant_asym_wrong_dst() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-  %src = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-  %fp = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-  %offset = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-  %dst = memref.alloc() : memref<16x32xi8, #pto.address_space<vec>>
+  %src = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %fp = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %offset = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %dst = memref.alloc() : memref<16x16xi8, #pto.address_space<vec>>
 
-  pto.tquant ins(%src, %fp, %offset : memref<16x32xf32, #pto.address_space<vec>>,
-                                      memref<16x32xf32, #pto.address_space<vec>>,
-                                      memref<16x32xf32, #pto.address_space<vec>>)
-             outs(%dst : memref<16x32xi8, #pto.address_space<vec>>)
+  pto.tquant ins(%src, %fp, %offset : memref<16x16xf32, #pto.address_space<vec>>,
+                                      memref<16x16xf32, #pto.address_space<vec>>,
+                                      memref<16x16xf32, #pto.address_space<vec>>)
+             outs(%dst : memref<16x16xi8, #pto.address_space<vec>>)
              {quant_type = #pto<quant_type INT8_ASYM>}
 
   return

--- a/test/lit/pto/tquant_verify_invalid_int8_asym_wrong_dst.pto
+++ b/test/lit/pto/tquant_verify_invalid_int8_asym_wrong_dst.pto
@@ -13,15 +13,15 @@
 // CHECK: AICORE void tquant_asym_wrong_dst()
 
 func.func @tquant_asym_wrong_dst() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-  %src = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-  %fp = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-  %offset = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-  %dst = memref.alloc() : memref<16x16xi8, #pto.address_space<vec>>
+  %src = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
+  %fp = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
+  %offset = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
+  %dst = memref.alloc() : memref<16x32xi8, #pto.address_space<vec>>
 
-  pto.tquant ins(%src, %fp, %offset : memref<16x16xf32, #pto.address_space<vec>>,
-                                      memref<16x16xf32, #pto.address_space<vec>>,
-                                      memref<16x16xf32, #pto.address_space<vec>>)
-             outs(%dst : memref<16x16xi8, #pto.address_space<vec>>)
+  pto.tquant ins(%src, %fp, %offset : memref<16x32xf32, #pto.address_space<vec>>,
+                                      memref<16x32xf32, #pto.address_space<vec>>,
+                                      memref<16x32xf32, #pto.address_space<vec>>)
+             outs(%dst : memref<16x32xi8, #pto.address_space<vec>>)
              {quant_type = #pto<quant_type INT8_ASYM>}
 
   return

--- a/test/lit/pto/tquant_verify_invalid_int8_sym_wrong_dst.pto
+++ b/test/lit/pto/tquant_verify_invalid_int8_sym_wrong_dst.pto
@@ -13,13 +13,13 @@
 // CHECK: AICORE void tquant_sym_wrong_dst()
 
 func.func @tquant_sym_wrong_dst() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-  %src = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-  %fp = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-  %dst = memref.alloc() : memref<16x32xui8, #pto.address_space<vec>>
+  %src = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %fp = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %dst = memref.alloc() : memref<16x16xui8, #pto.address_space<vec>>
 
-  pto.tquant ins(%src, %fp : memref<16x32xf32, #pto.address_space<vec>>,
-                             memref<16x32xf32, #pto.address_space<vec>>)
-             outs(%dst : memref<16x32xui8, #pto.address_space<vec>>)
+  pto.tquant ins(%src, %fp : memref<16x16xf32, #pto.address_space<vec>>,
+                             memref<16x16xf32, #pto.address_space<vec>>)
+             outs(%dst : memref<16x16xui8, #pto.address_space<vec>>)
              {quant_type = #pto<quant_type INT8_SYM>}
 
   return

--- a/test/lit/pto/tquant_verify_invalid_int8_sym_wrong_dst.pto
+++ b/test/lit/pto/tquant_verify_invalid_int8_sym_wrong_dst.pto
@@ -13,13 +13,13 @@
 // CHECK: AICORE void tquant_sym_wrong_dst()
 
 func.func @tquant_sym_wrong_dst() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-  %src = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-  %fp = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-  %dst = memref.alloc() : memref<16x16xui8, #pto.address_space<vec>>
+  %src = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
+  %fp = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
+  %dst = memref.alloc() : memref<16x32xui8, #pto.address_space<vec>>
 
-  pto.tquant ins(%src, %fp : memref<16x16xf32, #pto.address_space<vec>>,
-                             memref<16x16xf32, #pto.address_space<vec>>)
-             outs(%dst : memref<16x16xui8, #pto.address_space<vec>>)
+  pto.tquant ins(%src, %fp : memref<16x32xf32, #pto.address_space<vec>>,
+                             memref<16x32xf32, #pto.address_space<vec>>)
+             outs(%dst : memref<16x32xui8, #pto.address_space<vec>>)
              {quant_type = #pto<quant_type INT8_SYM>}
 
   return


### PR DESCRIPTION
## Summary
- add PTO tile layout verification matching ISA 32-byte none_box alignment and boxed inner-shape constraints
- wire the verifier into alloc_tile, materialize_tile, and common tile operand/result checks
- add negative tile layout lit coverage and update existing lit shapes to remain valid under the new verifier

## Validation
- cmake --build build-codex-ci --target ptoas -j2
- llvm-lit -v on the 19 affected PTO lit tests
- llvm-lit -q build-codex-ci/test/lit/pto (2 unrelated graph-sync FileCheck failures remain)