### PR TITLE
[codex] Lower vector array idioms to PTO local arrays

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -7504,6 +7504,29 @@ pto.tsetval ins(%off, %val : index, f16) outs(%dst : !pto.tile_buf<loc=vec, dtyp
 
 ---
 
+#### Fixed Local Arrays From MLIR Vector
+
+PTOAS accepts a narrow front-end idiom for fixed-size local scalar arrays:
+one-dimensional, fixed-length MLIR `vector<NxT>` values with scalar
+`vector.from_elements`, `vector.insert`, and `vector.extract`. The
+`pto-lower-vector-local-array` pass lowers this idiom to PTO local-array helper
+ops:
+
+```mlir
+%arr0 = vector.from_elements %a, %b, %c, %d : vector<4xi32>
+%arr1 = vector.insert %x, %arr0[%idx] : i32 into vector<4xi32>
+%y = vector.extract %arr1[%idx] : i32 from vector<4xi32>
+```
+
+The generated C++ uses `PTOAS_LocalArray<T, N>` plus helper calls that preserve
+MLIR vector value semantics: `vector.insert` returns a new local-array value
+rather than mutating the old one in place. This path is intended for scalar
+bookkeeping arrays; tile data access should continue to use `pto.tgetval` /
+`pto.tsetval`, and global pointer element access should use `pto.load_scalar` /
+`pto.store_scalar`.
+
+---
+
 ### 4.15 MX Quantized Operations
 
 ##### `pto.tget_scale_addr` - Bind Scaling Tile View

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2086,6 +2086,57 @@ def EventIdArraySetOp : PTO_Op<"eventid_array_set"> {
   }];
 }
 
+def LocalArrayFromElementsOp : PTO_Op<"local_array_from_elements", [Pure]> {
+  let summary = "Build a fixed-size local scalar array from element values";
+
+  let arguments = (ins
+    Variadic<ScalarType>:$elements
+  );
+  let results = (outs LocalArrayType:$array);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $elements attr-dict `:` type($elements) `->` qualified(type($array))
+  }];
+}
+
+def LocalArrayInsertOp : PTO_Op<"local_array_insert", [Pure]> {
+  let summary = "Return a local scalar array with one updated element";
+
+  let arguments = (ins
+    ScalarType:$value,
+    LocalArrayType:$array,
+    Index:$index
+  );
+  let results = (outs LocalArrayType:$result);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $value `,` $array `[` $index `]`
+    attr-dict `:` qualified(type($array)) `,` type($value) `->`
+    qualified(type($result))
+  }];
+}
+
+def LocalArrayExtractOp : PTO_Op<"local_array_extract", [Pure]> {
+  let summary = "Read one element from a fixed-size local scalar array";
+
+  let arguments = (ins
+    LocalArrayType:$array,
+    Index:$index
+  );
+  let results = (outs ScalarType:$value);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $array `[` $index `]` attr-dict `:` qualified(type($array)) `->`
+    type($value)
+  }];
+}
+
 def DeclareTileMemRefOp : PTO_Op<"declare_tile_memref"> {
   let summary = "Internal memref placeholder for a tile whose address is assigned later";
   let description = [{

--- a/include/PTO/IR/PTOTypeDefs.td
+++ b/include/PTO/IR/PTOTypeDefs.td
@@ -230,6 +230,16 @@ def EventIdArrayType : TypeDef<PTO_Dialect, "EventIdArray"> {
   let assemblyFormat = "`<` $size `>`";
 }
 
+def LocalArrayType : TypeDef<PTO_Dialect, "LocalArray"> {
+  let mnemonic = "local_array";
+  let summary = "Fixed-size local scalar array helper";
+  let parameters = (ins
+    "int64_t":$size,
+    "mlir::Type":$elementType
+  );
+  let assemblyFormat = "`<` $size `x` $elementType `>`";
+}
+
 def PipeType : TypeDef<PTO_Dialect, "Pipe"> {
   let mnemonic = "pipe";
   let summary = "Opaque pipe handle type for TPUSH/TPOP communication";

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -70,6 +70,7 @@ std::unique_ptr<Pass> createPTOViewToMemrefPass();
 std::unique_ptr<Pass> createPTOMaterializeTileHandlesPass();
 std::unique_ptr<Pass> createInferPTOLayoutPass();
 std::unique_ptr<Pass> createPTOA5NormalizeTMovPass();
+std::unique_ptr<Pass> createPTOLowerVectorLocalArrayPass();
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -96,6 +96,22 @@ def ConvertToPTOOp : Pass<"convert-to-pto-op"> {
   ];
 }
 
+def PTOLowerVectorLocalArray : Pass<"pto-lower-vector-local-array", "ModuleOp"> {
+  let summary = "Lower one-dimensional MLIR vector array idioms to PTO local arrays";
+  let description = [{
+    Converts fixed-size one-dimensional `vector` values used with
+    `vector.from_elements`, `vector.insert`, and `vector.extract` into
+    `pto.local_array_*` helper operations. The lowering preserves vector SSA
+    value semantics by making insert return a new local-array value.
+  }];
+  let constructor = "mlir::pto::createPTOLowerVectorLocalArrayPass()";
+  let dependentDialects = [
+    "mlir::pto::PTODialect",
+    "mlir::arith::ArithDialect",
+    "mlir::vector::VectorDialect"
+  ];
+}
+
 def InferPTOLayout : Pass<"pto-infer-layout", "func::FuncOp"> {
   let summary = "Infer GlobalTensor layout (ND/DN/NZ) for make_tensor_view";
   let description = [{

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -5898,6 +5898,38 @@ LogicalResult StoreScalarOp::verify() {
   return success();
 }
 
+// ---- LocalArrayFromElementsOp ----
+LogicalResult LocalArrayFromElementsOp::verify() {
+  auto arrayTy = getArray().getType();
+  if (static_cast<int64_t>(getElements().size()) != arrayTy.getSize())
+    return emitOpError("expects number of elements to match local_array size");
+
+  Type elemTy = arrayTy.getElementType();
+  for (Value element : getElements()) {
+    if (element.getType() != elemTy)
+      return emitOpError("expects every element type to match local_array element type");
+  }
+  return success();
+}
+
+// ---- LocalArrayInsertOp ----
+LogicalResult LocalArrayInsertOp::verify() {
+  auto arrayTy = getArray().getType();
+  if (getResult().getType() != arrayTy)
+    return emitOpError("expects result type to match input local_array type");
+  if (getValue().getType() != arrayTy.getElementType())
+    return emitOpError("expects inserted value type to match local_array element type");
+  return success();
+}
+
+// ---- LocalArrayExtractOp ----
+LogicalResult LocalArrayExtractOp::verify() {
+  auto arrayTy = getArray().getType();
+  if (getValue().getType() != arrayTy.getElementType())
+    return emitOpError("expects result type to match local_array element type");
+  return success();
+}
+
 // ---- GetBufOp / RlsBufOp ----
 static LogicalResult verifyBufSyncOp(Operation *op, Attribute opTypeAttr,
                                      IntegerAttr bufIdAttr, IntegerAttr modeAttr) {

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -25,6 +25,7 @@ add_mlir_dialect_library(PTOTransforms
   PTORemoveRedundantBarrier.cpp
   InferPTOLayout.cpp
   PTOA5NormalizeTMovPass.cpp
+  PTOLowerVectorLocalArrayPass.cpp
   PTOMaterializeTileHandles.cpp
   BufferizableOpInterfaceImpl.cpp
   ConvertToPTOOp.cpp
@@ -73,6 +74,7 @@ add_mlir_dialect_library(PTOTransforms
   MLIRTransformUtils
   MLIRTransforms
   MLIRTensorDialect
+  MLIRVectorDialect
   MLIRSCFToEmitC
   MLIRSCFDialect
 )

--- a/lib/PTO/Transforms/PTOLowerVectorLocalArrayPass.cpp
+++ b/lib/PTO/Transforms/PTOLowerVectorLocalArrayPass.cpp
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- PTOLowerVectorLocalArrayPass.cpp ----------------------------------===//
+
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOLOWERVECTORLOCALARRAY
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+static bool isSupportedLocalArrayElementType(Type type) {
+  return isa<IntegerType, FloatType>(type);
+}
+
+static bool isSupportedVectorArrayType(Type type) {
+  auto vectorType = dyn_cast<VectorType>(type);
+  return vectorType && vectorType.getRank() == 1 && !vectorType.isScalable() &&
+         vectorType.getDimSize(0) > 0 &&
+         isSupportedLocalArrayElementType(vectorType.getElementType());
+}
+
+static pto::LocalArrayType getLocalArrayType(VectorType vectorType) {
+  return pto::LocalArrayType::get(vectorType.getContext(),
+                                  vectorType.getDimSize(0),
+                                  vectorType.getElementType());
+}
+
+static FailureOr<Value>
+materializeSingleVectorIndex(Location loc, ArrayRef<int64_t> staticPosition,
+                             ValueRange dynamicPosition,
+                             PatternRewriter &rewriter) {
+  if (staticPosition.size() != 1)
+    return failure();
+
+  int64_t staticIndex = staticPosition.front();
+  if (staticIndex == ShapedType::kDynamic) {
+    if (dynamicPosition.size() != 1)
+      return failure();
+    return dynamicPosition.front();
+  }
+
+  if (!dynamicPosition.empty() || staticIndex < 0)
+    return failure();
+  return rewriter.create<arith::ConstantIndexOp>(loc, staticIndex).getResult();
+}
+
+struct ArithVectorConstantLowering
+    : public OpConversionPattern<arith::ConstantOp> {
+  using OpConversionPattern<arith::ConstantOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(arith::ConstantOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    auto vectorType = dyn_cast<VectorType>(op.getType());
+    if (!vectorType || !isSupportedVectorArrayType(vectorType))
+      return failure();
+
+    auto elementsAttr = dyn_cast<DenseElementsAttr>(op.getValue());
+    if (!elementsAttr)
+      return rewriter.notifyMatchFailure(
+          op, "expected dense vector constant for local_array lowering");
+
+    Type elemType = vectorType.getElementType();
+    SmallVector<Value> elements;
+    elements.reserve(vectorType.getDimSize(0));
+    for (Attribute attr : elementsAttr.getValues<Attribute>()) {
+      auto typedAttr = dyn_cast<TypedAttr>(attr);
+      if (!typedAttr)
+        return rewriter.notifyMatchFailure(
+            op, "expected typed scalar attributes in dense vector constant");
+      elements.push_back(
+          rewriter.create<arith::ConstantOp>(op.getLoc(), elemType, typedAttr));
+    }
+
+    rewriter.replaceOpWithNewOp<pto::LocalArrayFromElementsOp>(
+        op, getLocalArrayType(vectorType), elements);
+    return success();
+  }
+};
+
+struct VectorFromElementsLowering
+    : public OpConversionPattern<vector::FromElementsOp> {
+  using OpConversionPattern<vector::FromElementsOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(vector::FromElementsOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto vectorType = dyn_cast<VectorType>(op.getType());
+    if (!vectorType || !isSupportedVectorArrayType(vectorType))
+      return failure();
+
+    rewriter.replaceOpWithNewOp<pto::LocalArrayFromElementsOp>(
+        op, getLocalArrayType(vectorType), adaptor.getElements());
+    return success();
+  }
+};
+
+struct VectorInsertLowering : public OpConversionPattern<vector::InsertOp> {
+  using OpConversionPattern<vector::InsertOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(vector::InsertOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto vectorType = dyn_cast<VectorType>(op.getDest().getType());
+    if (!vectorType || !isSupportedVectorArrayType(vectorType))
+      return failure();
+    if (op.getSource().getType() != vectorType.getElementType())
+      return rewriter.notifyMatchFailure(
+          op, "only scalar element inserts are supported");
+
+    FailureOr<Value> index = materializeSingleVectorIndex(
+        op.getLoc(), op.getStaticPosition(), op.getDynamicPosition(),
+        rewriter);
+    if (failed(index))
+      return rewriter.notifyMatchFailure(
+          op, "only one-dimensional vector.insert is supported");
+
+    rewriter.replaceOpWithNewOp<pto::LocalArrayInsertOp>(
+        op, getLocalArrayType(vectorType), adaptor.getSource(),
+        adaptor.getDest(), *index);
+    return success();
+  }
+};
+
+struct VectorExtractLowering : public OpConversionPattern<vector::ExtractOp> {
+  using OpConversionPattern<vector::ExtractOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(vector::ExtractOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto vectorType = dyn_cast<VectorType>(op.getVector().getType());
+    if (!vectorType || !isSupportedVectorArrayType(vectorType))
+      return failure();
+    if (op.getResult().getType() != vectorType.getElementType())
+      return rewriter.notifyMatchFailure(
+          op, "only scalar element extracts are supported");
+
+    FailureOr<Value> index = materializeSingleVectorIndex(
+        op.getLoc(), op.getStaticPosition(), op.getDynamicPosition(),
+        rewriter);
+    if (failed(index))
+      return rewriter.notifyMatchFailure(
+          op, "only one-dimensional vector.extract is supported");
+
+    rewriter.replaceOpWithNewOp<pto::LocalArrayExtractOp>(
+        op, vectorType.getElementType(), adaptor.getVector(), *index);
+    return success();
+  }
+};
+
+struct PTOLowerVectorLocalArrayPass
+    : public pto::impl::PTOLowerVectorLocalArrayBase<
+          PTOLowerVectorLocalArrayPass> {
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+
+    TypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) { return type; });
+    typeConverter.addConversion([](VectorType vectorType) -> Type {
+      if (!isSupportedVectorArrayType(vectorType))
+        return Type{};
+      return getLocalArrayType(vectorType);
+    });
+
+    RewritePatternSet patterns(ctx);
+    patterns.add<ArithVectorConstantLowering, VectorFromElementsLowering,
+                 VectorInsertLowering, VectorExtractLowering>(typeConverter,
+                                                              ctx);
+
+    ConversionTarget target(*ctx);
+    target.addLegalDialect<arith::ArithDialect, pto::PTODialect>();
+    target.addLegalDialect<func::FuncDialect>();
+    target.addIllegalDialect<vector::VectorDialect>();
+    target.addDynamicallyLegalOp<arith::ConstantOp>([](arith::ConstantOp op) {
+      return !isSupportedVectorArrayType(op.getType());
+    });
+    target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOLowerVectorLocalArrayPass() {
+  return std::make_unique<PTOLowerVectorLocalArrayPass>();
+}

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 
 #include "mlir/IR/AffineExpr.h"
@@ -451,6 +452,13 @@ public:
 
     addConversion([Ctx](pto::EventIdArrayType type) -> Type {
       std::string tok = "PTOAS_EventIdArray<" + std::to_string(type.getSize()) + ">";
+      return emitc::OpaqueType::get(Ctx, tok);
+    });
+
+    addConversion([Ctx](pto::LocalArrayType type) -> Type {
+      std::string tok = "PTOAS_LocalArray<" +
+                        getEmitCScalarTypeToken(type.getElementType()) + ", " +
+                        std::to_string(type.getSize()) + ">";
       return emitc::OpaqueType::get(Ctx, tok);
     });
 
@@ -6264,6 +6272,79 @@ struct PTOEventIdArraySetToEmitC
   }
 };
 
+static ArrayAttr getLocalArrayTemplateArgs(PatternRewriter &rewriter,
+                                           pto::LocalArrayType arrayTy) {
+  MLIRContext *ctx = rewriter.getContext();
+  return rewriter.getArrayAttr({
+      emitc::OpaqueAttr::get(ctx,
+                             getEmitCScalarTypeToken(arrayTy.getElementType())),
+      emitc::OpaqueAttr::get(ctx, std::to_string(arrayTy.getSize())),
+  });
+}
+
+struct PTOLocalArrayFromElementsToEmitC
+    : public OpConversionPattern<mlir::pto::LocalArrayFromElementsOp> {
+  using OpConversionPattern<
+      mlir::pto::LocalArrayFromElementsOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::LocalArrayFromElementsOp op,
+                                OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    auto arrayTy = op.getArray().getType();
+    Type resultTy = getTypeConverter()->convertType(arrayTy);
+    if (!resultTy)
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to map local_array result type");
+
+    auto call = rewriter.create<emitc::CallOpaqueOp>(
+        op.getLoc(), TypeRange{resultTy}, "PTOAS__LOCAL_ARRAY_MAKE",
+        ArrayAttr{}, getLocalArrayTemplateArgs(rewriter, arrayTy),
+        adaptor.getElements());
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+};
+
+struct PTOLocalArrayInsertToEmitC
+    : public OpConversionPattern<mlir::pto::LocalArrayInsertOp> {
+  using OpConversionPattern<mlir::pto::LocalArrayInsertOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::LocalArrayInsertOp op,
+                                OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    Type resultTy = getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultTy)
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to map local_array insert result type");
+
+    auto call = rewriter.create<emitc::CallOpaqueOp>(
+        op.getLoc(), TypeRange{resultTy}, "PTOAS__LOCAL_ARRAY_INSERT",
+        ArrayAttr{}, ArrayAttr{},
+        ValueRange{adaptor.getArray(), adaptor.getIndex(), adaptor.getValue()});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+};
+
+struct PTOLocalArrayExtractToEmitC
+    : public OpConversionPattern<mlir::pto::LocalArrayExtractOp> {
+  using OpConversionPattern<mlir::pto::LocalArrayExtractOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::LocalArrayExtractOp op,
+                                OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    Type resultTy = getTypeConverter()->convertType(op.getValue().getType());
+    if (!resultTy)
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to map local_array extract result type");
+
+    auto load = rewriter.create<emitc::SubscriptOp>(
+        op.getLoc(), resultTy, adaptor.getArray(), adaptor.getIndex());
+    rewriter.replaceOp(op, load.getResult());
+    return success();
+  }
+};
+
 static std::optional<int64_t> getStaticIndexLikeValue(Value value) {
   if (!value)
     return std::nullopt;
@@ -11827,6 +11908,9 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTODeclareEventIdArrayToEmitC>(typeConverter, ctx);
   patterns.add<PTOEventIdArrayGetToEmitC>(typeConverter, ctx);
   patterns.add<PTOEventIdArraySetToEmitC>(typeConverter, ctx);
+  patterns.add<PTOLocalArrayFromElementsToEmitC>(typeConverter, ctx);
+  patterns.add<PTOLocalArrayInsertToEmitC>(typeConverter, ctx);
+  patterns.add<PTOLocalArrayExtractToEmitC>(typeConverter, ctx);
   patterns.add<PTOTReshapeToEmitC>(typeConverter, ctx);
   patterns.add<PTOBitcastToEmitC>(typeConverter, ctx);
   patterns.add<PTOTAllocToEmitC>(typeConverter, ctx, targetArch);
@@ -11886,7 +11970,8 @@ struct EmitPTOManualPass
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<emitc::EmitCDialect, func::FuncDialect, arith::ArithDialect,
                     memref::MemRefDialect, affine::AffineDialect,
-                    mlir::cf::ControlFlowDialect, mlir::pto::PTODialect>();
+                    vector::VectorDialect, mlir::cf::ControlFlowDialect,
+                    mlir::pto::PTODialect>();
   }
 
   void runOnOperation() override {
@@ -11916,12 +12001,17 @@ struct EmitPTOManualPass
     }
 
         bool needsEventIdArrayHelper = false;
+        bool needsLocalArrayHelper = false;
         bool needsTRandomHelper = false;
         bool needsGlobalTensorDataHelper = false;
         bool needsCommInclude = false;
         mop.walk([&](Operation *op) {
           if (isa<mlir::pto::DeclareEventIdArrayOp>(op))
             needsEventIdArrayHelper = true;
+          if (isa<mlir::pto::LocalArrayFromElementsOp,
+                  mlir::pto::LocalArrayInsertOp,
+                  mlir::pto::LocalArrayExtractOp>(op))
+            needsLocalArrayHelper = true;
           if (isa<mlir::pto::TRandomOp>(op))
             needsTRandomHelper = true;
           if (isa<mlir::pto::PartitionViewOp>(op))
@@ -11975,6 +12065,39 @@ struct PTOAS_EventIdArray {
   AICORE inline int32_t &operator[](int32_t idx) { return data[idx]; }
   AICORE inline const int32_t &operator[](int32_t idx) const { return data[idx]; }
 };
+)cpp"));
+        }
+        if (needsLocalArrayHelper) {
+	      builder.create<emitc::VerbatimOp>(
+	          loc, builder.getStringAttr(R"cpp(
+template <typename T, int N>
+struct PTOAS_LocalArray {
+  static_assert(N > 0, "PTOAS_LocalArray requires a positive static size");
+  T data[N] = {};
+
+  AICORE inline T &operator[](int32_t idx) { return data[idx]; }
+  AICORE inline const T &operator[](int32_t idx) const { return data[idx]; }
+};
+
+template <typename T, int N, typename... Args>
+static AICORE inline PTOAS_LocalArray<T, N> PTOAS__LOCAL_ARRAY_MAKE(
+    Args... args) {
+  static_assert(sizeof...(Args) == N,
+                "PTOAS__LOCAL_ARRAY_MAKE expects exactly N elements");
+  PTOAS_LocalArray<T, N> out;
+  T init[N] = {static_cast<T>(args)...};
+  for (int32_t i = 0; i < N; ++i) {
+    out.data[i] = init[i];
+  }
+  return out;
+}
+
+template <typename Array, typename Value>
+static AICORE inline Array PTOAS__LOCAL_ARRAY_INSERT(
+    Array array, int32_t idx, Value value) {
+  array[idx] = value;
+  return array;
+}
 )cpp"));
         }
         if (needsTRandomHelper) {
@@ -12124,6 +12247,7 @@ static AICORE inline void ptoas_auto_sync_tail(
     target.addIllegalDialect<pto::PTODialect>();
     target.addIllegalDialect<arith::ArithDialect>();
     target.addIllegalDialect<mlir::scf::SCFDialect>(); 
+    target.addIllegalDialect<vector::VectorDialect>();
     
     // If we introduced CFG branches (e.g. from scf.while), make sure they are
     // updated to use legalized operand types.

--- a/test/lit/pto/vector_local_array_emitc.pto
+++ b/test/lit/pto/vector_local_array_emitc.pto
@@ -1,0 +1,25 @@
+// RUN: ptoas %s 2>&1 | FileCheck %s
+
+module {
+  func.func @vector_local_array(%value: i32, %idx: index) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : i32
+    %c3 = arith.constant 3 : i32
+    %arr0 = vector.from_elements %c0, %c1, %c2, %c3 : vector<4xi32>
+    %arr1 = vector.insert %value, %arr0[%idx] : i32 into vector<4xi32>
+    %loaded = vector.extract %arr1[%idx] : i32 from vector<4xi32>
+    %eid = arith.index_cast %loaded : i32 to index
+    pto.set_flag_dyn [#pto.pipe<PIPE_MTE2>, #pto.pipe<PIPE_MTE3>, %eid]
+    return
+  }
+}
+
+// CHECK: struct PTOAS_LocalArray
+// CHECK: PTOAS__LOCAL_ARRAY_MAKE
+// CHECK: PTOAS__LOCAL_ARRAY_INSERT
+// CHECK-LABEL: __global__ AICORE void vector_local_array
+// CHECK: PTOAS_LocalArray<int32_t, 4> {{v[0-9]+}} = PTOAS__LOCAL_ARRAY_MAKE<int32_t, 4>
+// CHECK: PTOAS_LocalArray<int32_t, 4> {{v[0-9]+}} = PTOAS__LOCAL_ARRAY_INSERT
+// CHECK: event_t {{v[0-9]+}} = (event_t) {{v[0-9]+}}[{{v[0-9]+}}]
+// CHECK: set_flag(PIPE_MTE2, PIPE_MTE3

--- a/tools/ptoas/CMakeLists.txt
+++ b/tools/ptoas/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(pto-opt PRIVATE
   MLIRAffineDialect
   MLIRArithDialect
   MLIRTensorDialect
+  MLIRVectorDialect
   MLIRControlFlowDialect
   MLIRBufferizationDialect
   MLIRFuncDialect

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Target/Cpp/CppEmitter.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
@@ -926,6 +927,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::bufferization::BufferizationDialect>();
   registry.insert<mlir::scf::SCFDialect>();
+  registry.insert<mlir::vector::VectorDialect>();
 
   registry.insert<mlir::pto::PTODialect>();
   arith::registerBufferizableOpInterfaceExternalModels(registry);
@@ -1147,6 +1149,7 @@ int main(int argc, char **argv) {
   //pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOVerifyTFreePass());
   pm.addPass(pto::createPTOInferValidatePipeInitPass());
   pm.addNestedPass<mlir::func::FuncOp>(pto::createLoweringSyncToPipePass());
+  pm.addPass(pto::createPTOLowerVectorLocalArrayPass());
   
   if (!disableInferLayout)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createInferPTOLayoutPass());


### PR DESCRIPTION
## Summary
- register MLIR VectorDialect in ptoas and add a pass that lowers one-dimensional fixed-size vector array idioms to PTO local arrays
- add PTO local_array type/ops plus EmitC helper lowering to PTOAS_LocalArray<T, N>
- cover vector.from_elements/insert/extract with a lit test and document the supported frontend idiom

## Testing
- ninja -C build-codex-debug tools/ptoas/ptoas -j2
- build-codex-debug/tools/ptoas/ptoas test/lit/pto/vector_local_array_emitc.pto 2>&1 | /home/rdp/llvm-workspace/llvm-project/build-shared/bin/FileCheck test/lit/pto/vector_local_array_emitc.pto