### PR TITLE
Preserve alloc valid shape before set_validshape

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -10397,28 +10397,10 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
     };
 
     if (op.getSource().getDefiningOp<pto::DeclareTileMemRefOp>()) {
-      auto hasFollowingSetValidShape = [&]() {
-        for (Operation *user : op->getUsers()) {
-          auto setValidShape = dyn_cast<pto::SetValidShapeOp>(user);
-          if (!setValidShape)
-            continue;
-          if (setValidShape.getSource() != op.getResult())
-            continue;
-          return true;
-        }
-        return false;
-      };
-
       FailureOr<TileBuildSpec> tileSpec = buildTileSpec();
       if (failed(tileSpec))
         return failure();
-      TileBuildSpec declSpec = *tileSpec;
-      if (op->hasAttr(kForceDynamicValidShapeAttrName) &&
-          hasFollowingSetValidShape()) {
-        declSpec.useConstructor = false;
-        declSpec.constructorArgs.clear();
-      }
-      rewriter.replaceOp(op, buildTileValue(declSpec));
+      rewriter.replaceOp(op, buildTileValue(*tileSpec));
       return success();
     }
 
@@ -10549,22 +10531,10 @@ struct PTOAllocTileToEmitC
     if (!convertedTy)
       convertedTy = emitc::OpaqueType::get(ctx, *tileTypeString);
 
-    auto hasFollowingSetValidShape = [&]() {
-      for (Operation *user : op->getUsers()) {
-        auto setValidShape = dyn_cast<pto::SetValidShapeOp>(user);
-        if (setValidShape && setValidShape.getSource() == op.getResult())
-          return true;
-      }
-      return false;
-    };
-
-    bool suppressDynamicConstructor =
-        op->hasAttr(kForceDynamicValidShapeAttrName) &&
-        hasFollowingSetValidShape();
     auto validShape = tileTy.getValidShape();
     bool hasDynamicValidDim =
         llvm::any_of(validShape, [](int64_t dim) { return dim < 0; });
-    bool useConstructor = hasDynamicValidDim && !suppressDynamicConstructor;
+    bool useConstructor = hasDynamicValidDim;
 
     SmallVector<Value> constructorArgs;
     if (useConstructor) {
@@ -10774,16 +10744,6 @@ struct PTOMaterializeTileToEmitC
     bool isSubview = viewSemantics && viewSemantics.getValue() == "subview";
     bool sourceIsDeclaredTile =
         op.getSource().getDefiningOp<pto::DeclareTileMemRefOp>();
-    bool declaredTileHasFollowingSetValidShape = false;
-    if (sourceIsDeclaredTile) {
-      for (Operation *user : op->getUsers()) {
-        auto setValidShape = dyn_cast<pto::SetValidShapeOp>(user);
-        if (setValidShape && setValidShape.getSource() == op.getResult()) {
-          declaredTileHasFollowingSetValidShape = true;
-          break;
-        }
-      }
-    }
 
     auto createTileValue = [&]() -> Value {
       SmallVector<Value, 2> constructorArgs;
@@ -10813,9 +10773,7 @@ struct PTOMaterializeTileToEmitC
         return renderTileTemplateDim(shape[dimIdx], elemTy, blayout, dimIdx);
       };
 
-      if (sourceIsDeclaredTile && declaredTileHasFollowingSetValidShape) {
-        useConstructor = false;
-      } else if (forceDynamicValid) {
+      if (forceDynamicValid) {
         useConstructor = true;
         constructorArgs.push_back(makeCtorDimValue(
             maybeScaleDynamicValid(adaptor.getValidRow(), 0), fallbackDim(0)));

--- a/test/lit/pto/issue660_trowexpandmul_set_validshape_preserves_alloc_valid.pto
+++ b/test/lit/pto/issue660_trowexpandmul_set_validshape_preserves_alloc_valid.pto
@@ -1,0 +1,47 @@
+// RUN: ptoas --pto-arch=a3 %s | FileCheck %s
+
+module {
+  func.func @issue660_trowexpandmul_then_set_validshape() {
+    %c16 = arith.constant 16 : index
+    %c256 = arith.constant 256 : index
+    %src0 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=16, v_col=256,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile valid_row = %c16 valid_col = %c256
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %padded = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=16, v_col=256,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=3>
+    pto.trowexpandmul
+      ins(%src0, %src1
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=16, v_col=256,
+                          blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+            !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1,
+                          blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=?, v_col=?,
+                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.set_validshape %dst, %c16, %c16
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tfillpad
+      ins(%dst
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=?, v_col=?,
+                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%padded
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=16, v_col=256,
+                          blayout=row_major, slayout=none_box, fractal=512, pad=3>)
+    return
+  }
+}
+
+// CHECK-DAG: const int32_t [[ROW:v[0-9]+]] = 16;
+// CHECK-DAG: const int32_t [[FULL_COL:v[0-9]+]] = 256;
+// CHECK: Tile<TileType::Vec, float, 16, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[DST:v[0-9]+]] = Tile<TileType::Vec, float, 16, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>([[ROW]], [[FULL_COL]]);
+// CHECK: TROWEXPANDMUL([[DST]],
+// CHECK: [[DST]].SetValidShape([[ROW]], [[ROW]]);
+// CHECK: TFILLPAD({{v[0-9]+}}, [[DST]]);

--- a/test/lit/pto/set_validshape_if.pto
+++ b/test/lit/pto/set_validshape_if.pto
@@ -31,7 +31,8 @@ module {
   }
 }
 
-// CHECK: Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[TILE:v[0-9]+]];
+// CHECK-DAG: const int32_t [[C32:v[0-9]+]] = 32;
+// CHECK: Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[TILE:v[0-9]+]] = Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>([[C32]], [[C32]]);
 // CHECK: TASSIGN([[TILE]],
 // CHECK: if (
 // CHECK: [[TILE]].SetValidShape([[ROW1:v[0-9]+]], [[COL1:v[0-9]+]])

--- a/test/lit/pto/set_validshape_local_lowering.pto
+++ b/test/lit/pto/set_validshape_local_lowering.pto
@@ -15,6 +15,7 @@ module {
   }
 }
 
-// CHECK: Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[TILE:v[0-9]+]];
+// CHECK-DAG: const int32_t [[C32:v[0-9]+]] = 32;
+// CHECK: Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[TILE:v[0-9]+]] = Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>([[C32]], [[C32]]);
 // CHECK: TASSIGN([[TILE]], [[ADDR:v[0-9]+]]);
 // CHECK: [[TILE]].SetValidShape([[ROW:v[0-9]+]], [[COL:v[0-9]+]])

--- a/test/lit/pto/tpush_tpop_dynamic_validshape_a5.pto
+++ b/test/lit/pto/tpush_tpop_dynamic_validshape_a5.pto
@@ -48,12 +48,12 @@ module {
 
 // A5-LABEL: AICORE void cube_kernel(
 // A5: auto {{v[0-9]+}} = TPipe<0, Direction::DIR_BOTH, 1024, 4, 2, false>(
-// A5: Tile<TileType::Mat, float, 16, 64, BLayout::ColMajor, -1, -1, SLayout::RowMajor, 512, PadValue::Null, CompactMode::Null> [[CUBE_TILE:v[0-9]+]];
+// A5: Tile<TileType::Mat, float, 16, 64, BLayout::ColMajor, -1, -1, SLayout::RowMajor, 512, PadValue::Null, CompactMode::Null> [[CUBE_TILE:v[0-9]+]] = Tile<TileType::Mat, float, 16, 64, BLayout::ColMajor, -1, -1, SLayout::RowMajor, 512, PadValue::Null, CompactMode::Null>({{v[0-9]+}}, {{v[0-9]+}});
 // A5: [[CUBE_TILE]].SetValidShape({{v[0-9]+}}, {{v[0-9]+}});
 // A5: TPOP<TPipe<0, Direction::DIR_BOTH, 1024, 4, 2, false>, Tile<TileType::Mat, float, 16, 64, BLayout::ColMajor, -1, -1, SLayout::RowMajor, 512, PadValue::Null, CompactMode::Null>, TileSplitAxis::TILE_LEFT_RIGHT>({{v[0-9]+}}, [[CUBE_TILE]]);
 
 // A5-LABEL: AICORE void vector_kernel(
 // A5: auto {{v[0-9]+}} = TPipe<0, Direction::DIR_BOTH, 1024, 4, 2, false>(
-// A5: Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[VEC_TILE:v[0-9]+]];
+// A5: Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[VEC_TILE:v[0-9]+]] = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>({{v[0-9]+}}, {{v[0-9]+}});
 // A5: [[VEC_TILE]].SetValidShape({{v[0-9]+}}, {{v[0-9]+}});
 // A5: TPOP<TPipe<0, Direction::DIR_BOTH, 1024, 4, 2, false>, Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>, TileSplitAxis::TILE_LEFT_RIGHT>({{v[0-9]+}}, [[VEC_TILE]]);


### PR DESCRIPTION
## Summary
- preserve original dynamic valid-shape operands when lowering alloc/bind/materialized tiles to EmitC constructors
- keep later set_validshape calls as metadata updates instead of letting them suppress tile construction
- add a regression for trowexpandmul -> set_validshape -> tfillpad from issue #660

## Tests
- cmake --build /mnt/c/Users/rdp/Documents/ptoas/build-codex-debug --target ptoas
- /home/rdp/llvm-workspace/llvm-project/build-shared/bin/llvm-lit -v build-codex-debug/test/lit --filter issue660|set_validshape_(local|if)
