### PR TITLE
feat(pto): support C++ stack-local arrays via !pto.local_array

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -168,6 +168,43 @@ dimension counts FP4 pairs stored per byte, not logical scalar FP4 elements.
 
 ---
 
+### 2.6 `!pto.local_array<D1 x D2 x ... x Dk x T>`
+
+A **C++ stack-local statically-shaped array**. Lowers to a plain `T a[D1][D2]...;`
+declaration in the emitted C++ — the array's address is decided by the host C++
+compiler, not by PTO memory planning.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| shape (`D1..Dk`) | static positive `int64` per dim, `k ≥ 1` | Static dimensions; `?` is **not** allowed |
+| `T` | scalar `int` / `float` family | Element type; aggregates / nested `local_array` are not allowed |
+
+**Constraints (enforced by the type verifier):**
+- rank ≥ 1
+- every `Di > 0` (no dynamic shape, no zero-sized dims)
+- `T` is a scalar integer or float
+
+**Disjoint from tile-buf world.** Values of `!pto.local_array<...>` never
+participate in `pto.pointer_cast`, `pto-plan-memory`, or
+`AllocToPointerCast` rewrites — these passes match on `memref` / tile-buf
+types and simply do not see this type.
+
+**Syntax:**
+```mlir
+!pto.local_array<16xi32>      // int32_t a[16];
+!pto.local_array<4x8xf32>     // float   m[4][8];
+```
+
+**Associated ops** (see Section 4 — mirrors the `eventid_array` triad):
+- `pto.declare_local_array` — declare
+- `pto.local_array_get`     — `a[i0][i1]...` rvalue
+- `pto.local_array_set`     — `a[i0][i1]... = v;`
+
+The number of indices on `get` / `set` must equal the array's rank
+(verifier-checked).
+
+---
+
 ## 3. Enums & Attributes
 
 ### 3.1 AddressSpace
@@ -9287,6 +9324,94 @@ pto.comm.treduce(%dst, %acc, recv(%ping, %pong), group(%g0, %g1, %g2) :
 
 ---
 
+### 4.22 Stack-Local Array Operations
+
+Minimum support for **C++ stack-local statically-shaped arrays of scalars** —
+suitable for small auxiliary buffers in host scalar code. Disjoint from the
+tile-buf world: these values do not participate in PTO memory planning or
+`pto.pointer_cast`, and their underlying address is decided by the host C++
+compiler. Naming and asm style mirror the `eventid_array` triad.
+
+Operates on the [`!pto.local_array<...>`](#26-ptolocal_arrayd1-x-d2-x--x-dk-x-t) type. See Section 2.6 for type-level constraints.
+
+##### `pto.declare_local_array` - Declare a Stack-Local Array
+
+**Summary:** Declare a statically-shaped scalar array on the C++ stack.
+
+**Semantics:** Lowers to `T a[D1][D2]...;` in the emitted C++.
+
+**Arguments:** None.
+
+**Results:** `!pto.local_array<D1 x D2 x ... x T>`
+
+**Basic Example:**
+
+```mlir
+%a = pto.declare_local_array -> !pto.local_array<16xi32>     // int32_t a[16];
+%m = pto.declare_local_array -> !pto.local_array<4x8xf32>    // float   m[4][8];
+```
+
+---
+
+##### `pto.local_array_get` - Read One Element by Index
+
+**Summary:** Read a single element by full-rank indexing.
+
+**Semantics:** `result = a[i0][i1]...[iN-1]` (rvalue).
+
+**Arguments:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `array` | `!pto.local_array<D1 x ... x Dk x T>` | The local array |
+| `indices` | variadic `Index` | Exactly `k` indices, one per dim |
+
+**Results:** Scalar matching the array's element type.
+
+**Constraints & Verification:**
+
+- Number of indices must equal the array's rank (verifier error otherwise).
+- Result type must equal the array's element type.
+
+**Basic Example:**
+
+```mlir
+%v = pto.local_array_get %m[%i, %j]
+   : !pto.local_array<4x8xf32> -> f32                      // v = m[i][j];
+```
+
+---
+
+##### `pto.local_array_set` - Write One Element by Index
+
+**Summary:** Write a scalar into one element by full-rank indexing.
+
+**Semantics:** `a[i0][i1]...[iN-1] = value;`
+
+**Arguments:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `array` | `!pto.local_array<D1 x ... x Dk x T>` | The local array |
+| `indices` | variadic `Index` | Exactly `k` indices, one per dim |
+| `value` | `ScalarType` | Scalar value to write |
+
+**Results:** None.
+
+**Constraints & Verification:**
+
+- Number of indices must equal the array's rank.
+- `value` type must equal the array's element type.
+
+**Basic Example:**
+
+```mlir
+pto.local_array_set %m[%i, %j], %v
+   : !pto.local_array<4x8xf32>, f32                        // m[i][j] = v;
+```
+
+---
+
 ## 5. Operation Summary Table
 
 | Category | Count | Pipeline |
@@ -9309,5 +9434,6 @@ pto.comm.treduce(%dst, %acc, recv(%ping, %pong), group(%g0, %g1, %g2) :
 | CV-Related | 2 | - |
 | Runtime Intrinsics | 4 | - (Pure) |
 | Debug | 3 | - |
+| Stack-Local Array | 3 | - (Scalar / Host) |
 
-**Total: 107 operations**
+**Total: 110 operations**

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2086,6 +2086,75 @@ def EventIdArraySetOp : PTO_Op<"eventid_array_set"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Stack-local array (minimum set)
+//===----------------------------------------------------------------------===//
+//
+// Mirrors the `eventid_array` triad (declare / get / set) for a generic
+// statically-shaped scalar stack array. Disjoint from the tile-buf / scratch
+// memory world: the array's address is decided by the host C++ compiler at
+// codegen time, never by PTO memory planning or `pto.pointer_cast`.
+
+def DeclareLocalArrayOp : PTO_Op<"declare_local_array"> {
+  let summary = "Declare a stack-local statically-shaped array";
+  let description = [{
+    Lowers to a plain C++ stack variable like `T a[d1][d2]...;`. The element
+    type is restricted to scalars (integer / float); no nested aggregates.
+
+    This op does not participate in PTO memory planning. The resulting array's
+    address is determined by the host C++ compiler.
+  }];
+
+  let results = (outs LocalArrayType:$array);
+
+  let assemblyFormat = [{
+    attr-dict `->` qualified(type($array))
+  }];
+}
+
+def LocalArrayGetOp : PTO_Op<"local_array_get"> {
+  let summary = "Read one element from a stack-local array";
+  let description = [{
+    Lowers to `a[i0][i1]...[iN-1]` (an rvalue) in the emitted C++. The number
+    of indices must equal the array's rank.
+  }];
+
+  let arguments = (ins
+    LocalArrayType:$array,
+    Variadic<Index>:$indices
+  );
+  let results = (outs ScalarType:$result);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $array `[` $indices `]` attr-dict
+      `:` qualified(type($array)) `->` type($result)
+  }];
+}
+
+def LocalArraySetOp : PTO_Op<"local_array_set"> {
+  let summary = "Write one element into a stack-local array";
+  let description = [{
+    Lowers to `a[i0][i1]...[iN-1] = v;` in the emitted C++. The number of
+    indices must equal the array's rank.
+  }];
+
+  let arguments = (ins
+    LocalArrayType:$array,
+    Variadic<Index>:$indices,
+    ScalarType:$value
+  );
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $array `[` $indices `]` `,` $value attr-dict
+      `:` qualified(type($array)) `,` type($value)
+  }];
+}
+
 def DeclareTileMemRefOp : PTO_Op<"declare_tile_memref"> {
   let summary = "Internal memref placeholder for a tile whose address is assigned later";
   let description = [{

--- a/include/PTO/IR/PTOTypeDefs.td
+++ b/include/PTO/IR/PTOTypeDefs.td
@@ -230,6 +230,33 @@ def EventIdArrayType : TypeDef<PTO_Dialect, "EventIdArray"> {
   let assemblyFormat = "`<` $size `>`";
 }
 
+// ---- !pto.local_array<D1 x D2 x ... x Dk x T> ----
+// Statically-shaped C++ stack-local array. Lowers to a plain `T a[D1][D2]...;`
+// declaration in the emitted C++. Element type is restricted to scalars
+// (integer / float). This type does NOT participate in PTO memory planning
+// or pto.pointer_cast lowering — the underlying address is decided by the
+// host C++ compiler, not by PTOAS.
+def LocalArrayType : TypeDef<PTO_Dialect, "LocalArray"> {
+  let mnemonic = "local_array";
+  let summary = "C++ stack-local statically-sized array";
+  let parameters = (ins
+    ArrayRefParameter<"int64_t">:$shape,
+    "mlir::Type":$elementType
+  );
+
+  let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    int64_t getRank() const { return getShape().size(); }
+    int64_t getNumElements() const {
+      int64_t num = 1;
+      for (int64_t d : getShape()) num *= d;
+      return num;
+    }
+  }];
+}
+
 def PipeType : TypeDef<PTO_Dialect, "Pipe"> {
   let mnemonic = "pipe";
   let summary = "Opaque pipe handle type for TPUSH/TPOP communication";

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -1787,6 +1787,37 @@ LogicalResult mlir::pto::AddPtrOp::verify() {
   return success();
 }
 
+LogicalResult mlir::pto::LocalArrayGetOp::verify() {
+  auto arrayTy = getArray().getType();
+  int64_t rank = arrayTy.getRank();
+  int64_t numIdx = static_cast<int64_t>(getIndices().size());
+  if (numIdx != rank)
+    return emitOpError() << "expects " << rank
+                         << " indices for !pto.local_array of rank " << rank
+                         << ", got " << numIdx;
+  if (getResult().getType() != arrayTy.getElementType())
+    return emitOpError()
+           << "result type " << getResult().getType()
+           << " does not match array element type "
+           << arrayTy.getElementType();
+  return success();
+}
+
+LogicalResult mlir::pto::LocalArraySetOp::verify() {
+  auto arrayTy = getArray().getType();
+  int64_t rank = arrayTy.getRank();
+  int64_t numIdx = static_cast<int64_t>(getIndices().size());
+  if (numIdx != rank)
+    return emitOpError() << "expects " << rank
+                         << " indices for !pto.local_array of rank " << rank
+                         << ", got " << numIdx;
+  if (getValue().getType() != arrayTy.getElementType())
+    return emitOpError() << "value type " << getValue().getType()
+                         << " does not match array element type "
+                         << arrayTy.getElementType();
+  return success();
+}
+
 
 
 
@@ -9228,6 +9259,43 @@ Type TileType::parse(AsmParser &parser) {
 
 void TileType::print(AsmPrinter &printer) const {
   printShapeAndElem(printer, getShape(), getElementType());
+}
+
+// ---- LocalArrayType ----
+// Asm form: !pto.local_array<D1 x D2 x ... x Dk x T>
+// Static shape only (no '?'). Element type must be a scalar; this is enforced
+// by the type verifier below.
+Type LocalArrayType::parse(AsmParser &parser) {
+  SmallVector<int64_t, 4> shape;
+  Type elemTy;
+  if (failed(parseShapeAndElem(parser, shape, elemTy, /*allowDynamic=*/false)))
+    return Type();
+  return LocalArrayType::getChecked(
+      [&]() { return parser.emitError(parser.getNameLoc()); },
+      parser.getContext(), shape, elemTy);
+}
+
+void LocalArrayType::print(AsmPrinter &printer) const {
+  printShapeAndElem(printer, getShape(), getElementType());
+}
+
+LogicalResult LocalArrayType::verify(
+    llvm::function_ref<InFlightDiagnostic()> emitError,
+    llvm::ArrayRef<int64_t> shape, Type elementType) {
+  if (shape.empty())
+    return emitError() << "'!pto.local_array' requires at least one dimension";
+  for (auto [i, d] : llvm::enumerate(shape)) {
+    if (d <= 0)
+      return emitError()
+             << "'!pto.local_array' dimension " << i
+             << " must be a positive static size, got " << d;
+  }
+  if (!elementType.isIntOrFloat())
+    return emitError()
+           << "'!pto.local_array' element type must be a scalar integer or "
+              "float, got "
+           << elementType;
+  return success();
 }
 
 // =============================================================================

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6301,7 +6301,9 @@ struct PTODeclareLocalArrayToEmitC
 
 // pto.local_array_get %a[%i0, %i1, ...] -> rvalue.
 // Lowers to a single emitc.subscript with the full index pack; the C++ emitter
-// prints it as `a[i0][i1]...`.
+// prints it as `a[i0][i1]...`. The adaptor already exposes target-typed values
+// (the type converter has remapped !pto.local_array -> !emitc.array and
+// index/integer indices), so they're forwarded directly to the builder.
 struct PTOLocalArrayGetToEmitC
     : public OpConversionPattern<mlir::pto::LocalArrayGetOp> {
   using OpConversionPattern<
@@ -6310,27 +6312,22 @@ struct PTOLocalArrayGetToEmitC
   LogicalResult matchAndRewrite(mlir::pto::LocalArrayGetOp op,
                                 OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
-    Value array = peelUnrealized(adaptor.getArray());
-    SmallVector<Value> indices;
-    indices.reserve(adaptor.getIndices().size());
-    for (Value idx : adaptor.getIndices())
-      indices.push_back(peelUnrealized(idx));
-
     Type resultTy =
         getTypeConverter()->convertType(op.getResult().getType());
     if (!resultTy)
       return rewriter.notifyMatchFailure(
           op, "failed to map local_array element type");
 
-    auto sub = rewriter.create<emitc::SubscriptOp>(op.getLoc(), resultTy,
-                                                   array, indices);
+    auto sub = rewriter.create<emitc::SubscriptOp>(
+        op.getLoc(), resultTy, adaptor.getArray(), adaptor.getIndices());
     rewriter.replaceOp(op, sub.getResult());
     return success();
   }
 };
 
 // pto.local_array_set %a[%i0, %i1, ...], %v -> emitc.assign to subscript slot.
-// The C++ emitter prints this as `a[i0][i1]... = v;`.
+// The C++ emitter prints this as `a[i0][i1]... = v;`. As above, adaptor values
+// are already target-typed; pass them through directly.
 struct PTOLocalArraySetToEmitC
     : public OpConversionPattern<mlir::pto::LocalArraySetOp> {
   using OpConversionPattern<
@@ -6339,21 +6336,13 @@ struct PTOLocalArraySetToEmitC
   LogicalResult matchAndRewrite(mlir::pto::LocalArraySetOp op,
                                 OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
-    Value array = peelUnrealized(adaptor.getArray());
-    Value value = peelUnrealized(adaptor.getValue());
-    SmallVector<Value> indices;
-    indices.reserve(adaptor.getIndices().size());
-    for (Value idx : adaptor.getIndices())
-      indices.push_back(peelUnrealized(idx));
-
-    Type elemTy = getTypeConverter()->convertType(value.getType());
-    if (!elemTy)
-      return rewriter.notifyMatchFailure(
-          op, "failed to map local_array value type");
+    Value value = adaptor.getValue();
+    Type elemTy = value.getType();
 
     Value slot = rewriter
-                     .create<emitc::SubscriptOp>(op.getLoc(), elemTy, array,
-                                                 indices)
+                     .create<emitc::SubscriptOp>(op.getLoc(), elemTy,
+                                                 adaptor.getArray(),
+                                                 adaptor.getIndices())
                      .getResult();
     rewriter.create<emitc::AssignOp>(op.getLoc(), slot, value);
     rewriter.eraseOp(op);

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -454,6 +454,15 @@ public:
       return emitc::OpaqueType::get(Ctx, tok);
     });
 
+    // !pto.local_array<D1 x D2 x ... x T> -> !emitc.array<D1 x D2 x ... x T>.
+    // Variables of this type render as `T a[D1][D2]...;` in the emitted C++.
+    addConversion([this](pto::LocalArrayType type) -> std::optional<Type> {
+      Type convertedElem = convertType(type.getElementType());
+      if (!convertedElem)
+        return std::nullopt;
+      return emitc::ArrayType::get(type.getShape(), convertedElem);
+    });
+
     addConversion([Ctx](pto::AsyncSessionType type) -> Type {
       (void)type;
       return emitc::OpaqueType::get(Ctx, "pto::comm::AsyncSession");
@@ -6264,6 +6273,94 @@ struct PTOEventIdArraySetToEmitC
   }
 };
 
+// pto.declare_local_array -> emitc.variable of !emitc.array<...>.
+// Renders as `T a[D1][D2]...;` in the emitted C++.
+struct PTODeclareLocalArrayToEmitC
+    : public OpConversionPattern<mlir::pto::DeclareLocalArrayOp> {
+  using OpConversionPattern<
+      mlir::pto::DeclareLocalArrayOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::DeclareLocalArrayOp op,
+                                OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    Type arrayTy = getTypeConverter()->convertType(op.getArray().getType());
+    if (!arrayTy)
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to map !pto.local_array type");
+
+    auto var = rewriter
+                   .create<emitc::VariableOp>(
+                       op.getLoc(), arrayTy,
+                       emitc::OpaqueAttr::get(rewriter.getContext(), ""))
+                   .getResult();
+    rewriter.replaceOp(op, var);
+    return success();
+  }
+};
+
+// pto.local_array_get %a[%i0, %i1, ...] -> rvalue.
+// Lowers to a single emitc.subscript with the full index pack; the C++ emitter
+// prints it as `a[i0][i1]...`.
+struct PTOLocalArrayGetToEmitC
+    : public OpConversionPattern<mlir::pto::LocalArrayGetOp> {
+  using OpConversionPattern<
+      mlir::pto::LocalArrayGetOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::LocalArrayGetOp op,
+                                OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    Value array = peelUnrealized(adaptor.getArray());
+    SmallVector<Value> indices;
+    indices.reserve(adaptor.getIndices().size());
+    for (Value idx : adaptor.getIndices())
+      indices.push_back(peelUnrealized(idx));
+
+    Type resultTy =
+        getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultTy)
+      return rewriter.notifyMatchFailure(
+          op, "failed to map local_array element type");
+
+    auto sub = rewriter.create<emitc::SubscriptOp>(op.getLoc(), resultTy,
+                                                   array, indices);
+    rewriter.replaceOp(op, sub.getResult());
+    return success();
+  }
+};
+
+// pto.local_array_set %a[%i0, %i1, ...], %v -> emitc.assign to subscript slot.
+// The C++ emitter prints this as `a[i0][i1]... = v;`.
+struct PTOLocalArraySetToEmitC
+    : public OpConversionPattern<mlir::pto::LocalArraySetOp> {
+  using OpConversionPattern<
+      mlir::pto::LocalArraySetOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::LocalArraySetOp op,
+                                OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    Value array = peelUnrealized(adaptor.getArray());
+    Value value = peelUnrealized(adaptor.getValue());
+    SmallVector<Value> indices;
+    indices.reserve(adaptor.getIndices().size());
+    for (Value idx : adaptor.getIndices())
+      indices.push_back(peelUnrealized(idx));
+
+    Type elemTy = getTypeConverter()->convertType(value.getType());
+    if (!elemTy)
+      return rewriter.notifyMatchFailure(
+          op, "failed to map local_array value type");
+
+    Value slot = rewriter
+                     .create<emitc::SubscriptOp>(op.getLoc(), elemTy, array,
+                                                 indices)
+                     .getResult();
+    rewriter.create<emitc::AssignOp>(op.getLoc(), slot, value);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 static std::optional<int64_t> getStaticIndexLikeValue(Value value) {
   if (!value)
     return std::nullopt;
@@ -11827,6 +11924,9 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTODeclareEventIdArrayToEmitC>(typeConverter, ctx);
   patterns.add<PTOEventIdArrayGetToEmitC>(typeConverter, ctx);
   patterns.add<PTOEventIdArraySetToEmitC>(typeConverter, ctx);
+  patterns.add<PTODeclareLocalArrayToEmitC>(typeConverter, ctx);
+  patterns.add<PTOLocalArrayGetToEmitC>(typeConverter, ctx);
+  patterns.add<PTOLocalArraySetToEmitC>(typeConverter, ctx);
   patterns.add<PTOTReshapeToEmitC>(typeConverter, ctx);
   patterns.add<PTOBitcastToEmitC>(typeConverter, ctx);
   patterns.add<PTOTAllocToEmitC>(typeConverter, ctx, targetArch);

--- a/test/lit/pto/local_array_1d_emitc.pto
+++ b/test/lit/pto/local_array_1d_emitc.pto
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas %s 2>&1 | FileCheck %s
+
+// Stack-local 1D array: declare, set by dynamic index, get by another dynamic
+// index, set the read-back. Expected: lowers to `int32_t a[16];` plus
+// `a[i] = v;` / `a[i] = a[j];` in the emitted C++.
+
+module {
+  func.func @local_array_1d(%i : index, %j : index, %v : i32) {
+    %a = pto.declare_local_array -> !pto.local_array<16xi32>
+    pto.local_array_set %a[%i], %v : !pto.local_array<16xi32>, i32
+    %r = pto.local_array_get %a[%j] : !pto.local_array<16xi32> -> i32
+    pto.local_array_set %a[%i], %r : !pto.local_array<16xi32>, i32
+    return
+  }
+}
+
+// CHECK-LABEL: local_array_1d
+// CHECK: int32_t [[A:v[0-9]+]][16];
+// CHECK: [[A]][{{v[0-9]+}}] = {{v[0-9]+}};
+// CHECK: [[A]][{{v[0-9]+}}] = [[A]][{{v[0-9]+}}];

--- a/test/lit/pto/local_array_2d_emitc.pto
+++ b/test/lit/pto/local_array_2d_emitc.pto
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas %s 2>&1 | FileCheck %s
+
+// Stack-local 2D array: declare, set at (i, j), get at (j, i), set the
+// read-back to (i, j). Expected: lowers to `float m[8][8];` plus chained
+// `m[i][j] = v;` / `m[i][j] = m[j][i];` in the emitted C++.
+
+module {
+  func.func @local_array_2d(%i : index, %j : index, %v : f32) {
+    %m = pto.declare_local_array -> !pto.local_array<8x8xf32>
+    pto.local_array_set %m[%i, %j], %v : !pto.local_array<8x8xf32>, f32
+    %r = pto.local_array_get %m[%j, %i] : !pto.local_array<8x8xf32> -> f32
+    pto.local_array_set %m[%i, %j], %r : !pto.local_array<8x8xf32>, f32
+    return
+  }
+}
+
+// CHECK-LABEL: local_array_2d
+// CHECK: float [[M:v[0-9]+]][8][8];
+// CHECK: [[M]][{{v[0-9]+}}][{{v[0-9]+}}] = {{v[0-9]+}};
+// CHECK: [[M]][{{v[0-9]+}}][{{v[0-9]+}}] = [[M]][{{v[0-9]+}}][{{v[0-9]+}}];

--- a/test/lit/pto/local_array_get_rvalue_emitc.pto
+++ b/test/lit/pto/local_array_get_rvalue_emitc.pto
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas %s 2>&1 | FileCheck %s
+
+// Verify that pto.local_array_get behaves as a real scalar rvalue: its result
+// flows into arith ops without an explicit load. The expected C++ shape is
+// `t = a[j] + 1; a[i] = t;` (or any expression-folded equivalent).
+
+module {
+  func.func @local_array_get_rvalue(%i : index, %j : index) {
+    %a = pto.declare_local_array -> !pto.local_array<16xi32>
+    %c1 = arith.constant 1 : i32
+    %r = pto.local_array_get %a[%j] : !pto.local_array<16xi32> -> i32
+    %s = arith.addi %r, %c1 : i32
+    pto.local_array_set %a[%i], %s : !pto.local_array<16xi32>, i32
+    return
+  }
+}
+
+// CHECK-LABEL: local_array_get_rvalue
+// CHECK: int32_t [[A:v[0-9]+]][16];
+// `a[i] = ...a[j]... + ...;` — confirms the get result flows through arith as
+// a scalar rvalue. The exact cast/paren shape comes from arith.addi's signless
+// overflow-aware lowering; we only pin the subscript-rvalue flow here.
+// CHECK: [[A]][{{v[0-9]+}}] = {{.*}}[[A]][{{v[0-9]+}}]{{.*}};


### PR DESCRIPTION
Add a minimum support set for expressing and accessing C++ stack-local statically-shaped scalar arrays, mirroring the eventid_array triad in naming and asm style:

- !pto.local_array<D1 x D2 x ... x T> type with static positive dims and scalar element type, verified at type construction time.
- pto.declare_local_array : declaration; lowers to T a[D1][D2]...;
- pto.local_array_get : indexed read; lowers to a[i0][i1]... rvalue
- pto.local_array_set : indexed write; lowers to a[...] = v;

Ops verify that the number of indices equals the array's rank and that the read/write element type matches the array. They lower to EmitC via emitc::ArrayType + emitc::SubscriptOp + emitc::AssignOp, so the C++ emitter produces plain stack-array declarations and subscript syntax.

These ops are intentionally disjoint from the tile-buf / scratch memory world: they never participate in PlanMemory or AllocToPointerCast, and the underlying address is decided by the host C++ compiler.

Cross-layer notes:
- Python op bindings are auto-generated via the existing -gen-python-op- bindings flow; no manual binding needed (matches eventid_array).
- PTOBC requires no changes (generic dialect serialization path).
- Docs added under PTO_IR_manual.md §2.6 and §4.22.