### PR TITLE
feat(pto-gss): add A5 buf-id sync emission style to GraphSyncSolver

### DIFF
--- a/docs/designs/ptoas-graph-sync-solver-buf-id-design.md
+++ b/docs/designs/ptoas-graph-sync-solver-buf-id-design.md
@@ -175,16 +175,6 @@ for i = 0:N
 
 如果两条 forward 用不同 id（像 case 1 那样），iter i+1 的 load（在 id_A 上）只会等 iter i 的 vadd（也在 id_A 上），不会等 iter i 的 store（在 id_B 上）——结果 store 读 ub0 时被 load 覆写，data race。
 
-**判别准则**：两条 forward F1、F2 是否在同一 buffer chain 上？
-
-理论上需要 plumbing buffer 信息到 ConflictPair。但有个等价代理：
-
-> F1 和 F2 共享一个 anchor `(op, pipe)`，且存在 backward ConflictPair B 把 F1 的"非共享"端点和 F2 的"非共享"端点连起来 → F1、F2 必在同 buffer chain 上。
-
-理由：solver 的 backward 边正是 iter i 的某端读 / iter i+1 的某端写在同一 buffer 上产生的。如果两条 forward 链穿过同一 buffer，就一定有这种 backward 桥；如果是两条独立 buffer 的链，桥就找不到。
-
-所以：**backward 分析依旧需要做**，但产物不是 bracket，而是 id 合并提示。
-
 #### 落实
 
 1. `tryMovingOutBackwardSyncPairsToOuterLoops`、`considerOuterBackwardSyncPairs`、

--- a/docs/designs/ptoas-graph-sync-solver-buf-id-design.md
+++ b/docs/designs/ptoas-graph-sync-solver-buf-id-design.md
@@ -149,29 +149,52 @@ for i = 0:N
   get_buf(V,    #id); Vector(); rls_buf(V,    #id) // consumer 自然 bracket
 ```
 
-**结论：buf-id 模式下完全不需要任何 backward-sync 优化，连 backward ConflictPair 本身的 bracket 都不用发**。
+**结论：buf-id 模式下 backward ConflictPair 不需要单独发 bracket，但 backward 分析本身不能省**——它要用来决定 forward pair 之间是否要**复用同一个 id**。
 
-set/wait 必须给 backward 一对 set/wait，是因为 set/wait 是单次握手——iter i 的 set 必须有一个对应的 wait，跨循环边界的语义就靠 form 1（带守卫）或 form 2（外提补偿）来保证一对一配对。
+#### 单 buffer vs 多 buffer 的 id 分配
 
-buf-id 不一样：硬件 `(get_cnt, rel_cnt)` 是单调累加计数器。forward 边的 bracket 在 iter i 和 iter i+1 上各自就位之后，iter i+1 的 `get_buf` 自动等 iter i 的 `rls_buf` 推进计数器——这件事**对 forward 和 backward 都成立**，无需为 backward 再发一对额外的 bracket。
+考虑 doc §1.2 / §1.3 两个 case：
 
-举例（doc §1.2 canonical）：
-
+**Case 1（双 buffer，可并行）**：
 ```text
 for i = 0:N
-  get_buf(MTE2, #0); load();   rel_buf(MTE2, #0)
-  get_buf(V,    #0); Vector(); rel_buf(V,    #0)
+  load(gm -> ub0)   # MTE2, write ub0
+  vadd(ub0 -> ub1)  # V,    read ub0 write ub1
+  store(ub1 -> gm)  # MTE3, read ub1
 ```
+两条 forward dep 走两个不同 buffer：load/vadd 在 ub0 上同步，vadd/store 在 ub1 上同步。两条链应该用**不同的 id** 以获得最大并行度（下一轮的 load 不需要等本轮的 store 完成）。
 
-只发了 forward (load → vector) 的 bracket，没有为 backward (vector[i] → load[i+1]) 再发一对。但 iter i+1 的 `get_buf(MTE2, #0)` 拿到的号比 iter i 的 `rls_buf(V, #0)` 推进的 rel_cnt 大 1，自动等 vector[i] 跑完——backward 语义被 forward bracket 的计数器单调性"免费"覆盖。
+**Case 2（单 buffer，必须串行）**：
+```text
+for i = 0:N
+  load(gm -> ub0)
+  vadd(ub0 -> ub0)
+  store(ub0 -> gm)
+```
+所有 forward dep 都走 ub0。这种情况下下一轮的 load 写 ub0 必须等本轮的 store 读完 ub0——必须**复用同一个 id**，让计数器单调性串起整条 load→vadd→store→next-load 链。
 
-具体落实：
-- `tryMovingOutBackwardSyncPairsToOuterLoops`、`considerOuterBackwardSyncPairs`、
-  `mergeBackwardSyncPairs` 这些 set/wait 的 backward 外提路径在 buf-id 模式下**直接关掉**。
-- `backwardSyncEvents` / `backwardSyncEventsAfterMerge` 不会被填充。
-- **更进一步**：在 `getBeforeAfterSyncMaps` emit 时，
-  `conflictPair->isInnerBackward` 为 true 的 pair 直接 `continue` 不发 bracket——
-  它的 bracket 集合是 forward chain 的反向，发了纯属浪费 id。
+如果两条 forward 用不同 id（像 case 1 那样），iter i+1 的 load（在 id_A 上）只会等 iter i 的 vadd（也在 id_A 上），不会等 iter i 的 store（在 id_B 上）——结果 store 读 ub0 时被 load 覆写，data race。
+
+**判别准则**：两条 forward F1、F2 是否在同一 buffer chain 上？
+
+理论上需要 plumbing buffer 信息到 ConflictPair。但有个等价代理：
+
+> F1 和 F2 共享一个 anchor `(op, pipe)`，且存在 backward ConflictPair B 把 F1 的"非共享"端点和 F2 的"非共享"端点连起来 → F1、F2 必在同 buffer chain 上。
+
+理由：solver 的 backward 边正是 iter i 的某端读 / iter i+1 的某端写在同一 buffer 上产生的。如果两条 forward 链穿过同一 buffer，就一定有这种 backward 桥；如果是两条独立 buffer 的链，桥就找不到。
+
+所以：**backward 分析依旧需要做**，但产物不是 bracket，而是 id 合并提示。
+
+#### 落实
+
+1. `tryMovingOutBackwardSyncPairsToOuterLoops`、`considerOuterBackwardSyncPairs`、
+   `mergeBackwardSyncPairs` 这些 set/wait 的 backward 外提路径在 buf-id 模式下**直接关掉**。
+2. `backwardSyncEvents` / `backwardSyncEventsAfterMerge` 不会被填充。
+3. 在 `getBeforeAfterSyncMaps` emit 时，对所有 forward ConflictPair 做一个 **buffer-aware union-find 预处理**：
+   - 用 backward 边作为"同 buffer 桥"。
+   - 同一连通分量的 forward pair 共享一个 buf id（取分量内最小的 id 作代表）。
+   - 每个 `(anchor_op, pipe, id)` 三元组只发一对 bracket（dedup）——多个 ConflictPair 落到同一 (op, pipe, id) 上时合并。
+4. `conflictPair->isInnerBackward` 为 true 的 pair 不发 bracket（只参与 step 3 的 union-find 桥）。
 
 具体落实见 3.6 节。
 

--- a/docs/designs/ptoas-graph-sync-solver-buf-id-design.md
+++ b/docs/designs/ptoas-graph-sync-solver-buf-id-design.md
@@ -149,14 +149,29 @@ for i = 0:N
   get_buf(V,    #id); Vector(); rls_buf(V,    #id) // consumer 自然 bracket
 ```
 
-**结论：buf-id 模式下完全不需要任何 backward-sync 外提优化**。这意味着：
+**结论：buf-id 模式下完全不需要任何 backward-sync 优化，连 backward ConflictPair 本身的 bracket 都不用发**。
 
+set/wait 必须给 backward 一对 set/wait，是因为 set/wait 是单次握手——iter i 的 set 必须有一个对应的 wait，跨循环边界的语义就靠 form 1（带守卫）或 form 2（外提补偿）来保证一对一配对。
+
+buf-id 不一样：硬件 `(get_cnt, rel_cnt)` 是单调累加计数器。forward 边的 bracket 在 iter i 和 iter i+1 上各自就位之后，iter i+1 的 `get_buf` 自动等 iter i 的 `rls_buf` 推进计数器——这件事**对 forward 和 backward 都成立**，无需为 backward 再发一对额外的 bracket。
+
+举例（doc §1.2 canonical）：
+
+```text
+for i = 0:N
+  get_buf(MTE2, #0); load();   rel_buf(MTE2, #0)
+  get_buf(V,    #0); Vector(); rel_buf(V,    #0)
+```
+
+只发了 forward (load → vector) 的 bracket，没有为 backward (vector[i] → load[i+1]) 再发一对。但 iter i+1 的 `get_buf(MTE2, #0)` 拿到的号比 iter i 的 `rls_buf(V, #0)` 推进的 rel_cnt 大 1，自动等 vector[i] 跑完——backward 语义被 forward bracket 的计数器单调性"免费"覆盖。
+
+具体落实：
 - `tryMovingOutBackwardSyncPairsToOuterLoops`、`considerOuterBackwardSyncPairs`、
-  `mergeBackwardSyncPairs` 这些路径在 buf-id 模式下**直接关掉**——它们
-  不仅没意义，强行外提反而会破坏 in-loop bracket 的天然语义；
-- `backwardSyncEvents` / `backwardSyncEventsAfterMerge` 这两个映射在
-  buf-id 模式下不会被填充；
-- 之前提到的"阶段二做 buf-id 形态二外提"——**取消，这是反向理解**。
+  `mergeBackwardSyncPairs` 这些 set/wait 的 backward 外提路径在 buf-id 模式下**直接关掉**。
+- `backwardSyncEvents` / `backwardSyncEventsAfterMerge` 不会被填充。
+- **更进一步**：在 `getBeforeAfterSyncMaps` emit 时，
+  `conflictPair->isInnerBackward` 为 true 的 pair 直接 `continue` 不发 bracket——
+  它的 bracket 集合是 forward chain 的反向，发了纯属浪费 id。
 
 具体落实见 3.6 节。
 
@@ -386,6 +401,20 @@ if (conflictPair->isBarrier()) {
 与 `syncMapAfter[X]` 里对应的 `rls_buf(P, id)` 之间隔着的只有 anchor op `X` 本身。
 codegen 按 "before 顺序 push → 原 op → after 顺序 push" 的固定模式落盘，不会有
 其他 (pipe, id) 的 bracket 插入到中间。
+
+**backward ConflictPair 处理**：
+
+在 `getBeforeAfterSyncMaps` 主循环的 `continue` 守卫加一条：
+
+```cpp
+if (options.isBufIdEmit() && conflictPair->isInnerBackward) {
+  continue;
+}
+```
+
+这样 backward ConflictPair 的 bracket 完全不发；其语义由 forward ConflictPair 的 bracket 通过计数器单调性间接覆盖。
+
+注意：此 backward 仍然会被 solver 计数和分配 id（因为 EventIdSolver 早就跑完了），分配掉的 id 实际未使用——是浪费但不影响正确性。后续如果 id 池紧张，可以把这个过滤前移到 `processConflict`/`handleSetWaitConflict`，从源头就不创建 backward pair。
 
 **backward-sync 路径处理**：
 

--- a/docs/designs/ptoas-graph-sync-solver-buf-id-design.md
+++ b/docs/designs/ptoas-graph-sync-solver-buf-id-design.md
@@ -1,0 +1,659 @@
+# GraphSyncSolver Buf-ID 同步形态设计
+
+本文描述在 `PTOGraphSyncSolver` 上扩展一种可选的"Buf-ID"同步发射形态，
+让用户在保留现有 `set_flag` / `wait_flag` 路径的前提下，按需切换到 A5 的
+`get_buf` / `rls_buf` 编程模型。
+
+---
+
+## 1. 背景
+
+### 1.1 当前形态：`set_flag` / `wait_flag`
+
+PTOAS 现有的两个自动同步 pass（`PTOInsertSync` 和 `PTOGraphSyncSolver`）最终都
+落到一对 `pto.set_flag` / `pto.wait_flag` 指令：
+
+- `pto.set_flag[src_pipe, dst_pipe, event_id]` 在 producer 之后；
+- `pto.wait_flag[src_pipe, dst_pipe, event_id]` 在 consumer 之前；
+- 同 pipe 内部依赖用 `pto.barrier pipe`；
+- ODS 在 [PTOOps.td:2271](../../include/PTO/IR/PTOOps.td) 一带。
+
+这种形态要求**严格配对**——set 跟着 src 端的 pipe 指令走、wait 跟着 dst 端的
+pipe 指令走，两者位置可以分别处于不同 scope。在动态 shape、循环可空、
+条件分支不对称等场景下，求解器需要复杂的外提 / 合并优化来保证配对正确。
+
+### 1.2 新形态：Buf-ID（A5）
+
+A5 新增一组指令 `get_buf` / `rls_buf`，把"配对"语义从指令级别下沉到硬件
+scoreboard：
+
+```
+get_buf(pipe, #id)   // 在 pipe 指令之前取号
+<pipe op>            // 正常执行
+rls_buf(pipe, #id)   // 在 pipe 指令之后叫号
+```
+
+硬件为每个 `id` 维护一对 global 计数器 `(get_cnt, rel_cnt)`：
+
+- `get_buf` 进发射队列前：抢号 `get_cnt = global_get_cnt`，然后 `global_get_cnt++`；
+- 被 bracket 起来的指令必须等到 `get_cnt == global_rel_cnt` 才能发射；
+- 指令结束后由 `rls_buf` 推进 `global_rel_cnt++`。
+
+不同 pipe 用相同 id 时，硬件按抢号顺序串行化这些 pipe 的 bracket。
+
+ODS 与 EmitC 路径**已经存在**：
+- ODS：[PTOOps.td:2327](../../include/PTO/IR/PTOOps.td)（`pto.get_buf`） /
+  [PTOOps.td:2357](../../include/PTO/IR/PTOOps.td)（`pto.rls_buf`）；
+- EmitC：[PTOToEmitC.cpp:4903](../../lib/PTO/Transforms/PTOToEmitC.cpp)
+  （`PTOGetBufToEmitC`） / [PTOToEmitC.cpp:4933](../../lib/PTO/Transforms/PTOToEmitC.cpp)
+  （`PTORlsBufToEmitC`）。
+
+**目前没有 pass 会自动生成 `get_buf`/`rls_buf`**——只有手写测试样例
+（[test/samples/Sync/test_a5_buf_sync.pto](../../test/samples/Sync/test_a5_buf_sync.pto)）。
+
+### 1.3 编程约束（来自 hw 规格）
+
+1. 同一 (pipe, id) 的 `get_buf` 与 `rls_buf` 必须配对，且顺序为先 get 后 rel；
+   连续两次 get 同 id 不合法（会导致 rel 推进异常）。
+2. 不同 pipe 共享同 id 时，每个 pipe 的 get/rel 必须**连续**，中间不能插入
+   其他 pipe 的同 id get/rel。
+3. buf-id 只用于**跨 pipe 同步**。
+4. 多个 pipe 对的同步**不建议**复用同一个 id（性能损失，硬件正确性不受影响）。
+
+### 1.4 A5 不需要 pipe barrier
+
+buf-id 是 A5 特性。**A5 硬件天然保证同 pipe 顺序执行**，所以同 pipe 真依赖
+**完全不需要**显式 barrier 指令——即 `pto.barrier` 在 A5 上不会发射。
+
+这一点现有求解器内核已部分体现：[SyncSolver.cpp::handleBarrierConflict](../../lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp)
+里对 `isRegBasedArch` （即 A5）针对 PIPE_V / PIPE_M 提前 return：
+
+```cpp
+if (options.isRegBasedArch) {
+  if (corePipeSrc.pipe == pto::PIPE::PIPE_V ||
+      corePipeSrc.pipe == pto::PIPE::PIPE_M) {
+    return;
+  }
+}
+```
+
+buf-id 模式（仅 A5）下进一步扩展：**所有 pipe 的 barrier 都跳过**。详见 3.4 节。
+
+---
+
+## 2. 总体方案
+
+### 2.1 目标
+
+在 `PTOGraphSyncSolver` 上加一个**用户可选的发射形态**：
+- 默认 `set-wait`：行为与现状完全一致；
+- 可选 `buf-id`：在 A5 上把每对真依赖落成 `get_buf` / `rls_buf` 的 bracket；
+- 两种形态共存，**求解器内核不动**（依赖识别、event-id 染色、外提 / 合并、
+  barrier-all 回退），只在最后两步（in-memory IR 构造 + codegen 发射）分支。
+
+### 2.2 关键复用点
+
+| 阶段 | 复用程度 |
+| --- | --- |
+| `IRTranslator`：MLIR → 求解器 IR | 完全复用 |
+| `Solver`：冲突检测 / `processOrders` / `processConflict` | 完全复用 |
+| `EventIdSolver`：图染色分配 id | 完全复用（buf-id 池与 event-id 池同构） |
+| `getBeforeAfterSyncMaps`：ConflictPair → 内存 SyncOp | 末段分支 |
+| `SyncSolverIR`：`SetWaitOp` / `BarrierOp` | 新增 `GetBufOp` / `RlsBufOp` 类 |
+| `CodeGenerator::emitSyncOp`：内存 SyncOp → MLIR | 新增 case 分支 |
+
+### 2.3 形态对照
+
+对单个真依赖 `(producer @ Psrc, consumer @ Pdst)`，分配 N 个 id（N≥1）后两种
+形态的发射方式：
+
+| | set-wait | buf-id |
+| --- | --- | --- |
+| producer 上方 | — | `get_buf[Psrc, #id_k]` ×N |
+| producer 下方 | `set_flag[Psrc, Pdst, #id_k]` ×N | `rls_buf[Psrc, #id_k]` ×N |
+| consumer 上方 | `wait_flag[Psrc, Pdst, #id_k]` ×N | `get_buf[Pdst, #id_k]` ×N |
+| consumer 下方 | — | `rls_buf[Pdst, #id_k]` ×N |
+| 同 pipe 真依赖 | `pto.barrier P` | **不发射任何指令**（A5 同 pipe 硬件保序，见 1.4） |
+
+N 来自 `EventIdInfo::eventIdRepeatNum`，用于 multibuffer 流水的 id 轮转，
+两种形态语义等价。
+
+### 2.4 buf-id 不需要 backward-sync 外提
+
+这是 buf-id 相对 set/wait 的核心优势之一，专门说明一下避免理解错位。
+
+set/wait 模型下，求解器对循环间依赖（backward sync）必须做形态一 / 形态二
+的转换：
+
+- **形态一（in-loop + 守卫）**：每轮迭代里 `if i>0 wait`、`if i<N-1 set`，
+  循环体内有条件分支；
+- **形态二（out-of-loop 补偿）**：循环前补一个 `set`、循环后补一个 `wait`，
+  循环体内成对 set/wait。
+
+这两种形态存在的根本原因是：set/wait 是"指令级强配对"——每条 wait 必须有
+恰好一条 set 与之匹配，N 次迭代里多/少一条都会卡死。
+求解器里 `tryMovingOutBackwardSyncPairsToOuterLoops` /
+`mergeBackwardSyncPairs` / `considerOuterBackwardSyncPairs` 这些
+优化（[SyncSolver.h:407-413](../../include/PTO/Transforms/GraphSyncSolver/SyncSolver.h)）
+就是在处理这类不对称配对。
+
+**buf-id 是顺序编程模型**，硬件 scoreboard 的 `(get_cnt, rel_cnt)` 自身
+就是计数器——
+producer 每轮 bracket 一次推进一格，consumer 每轮 bracket 一次消费一格，
+N 轮迭代自然匹配 N 轮 bracket。
+唯一需要的写法就是 doc 1.2 给出的:
+
+```text
+for i = 0:N
+  get_buf(MTE2, #id); MTE2(); rls_buf(MTE2, #id)   // producer 自然 bracket
+  get_buf(V,    #id); Vector(); rls_buf(V,    #id) // consumer 自然 bracket
+```
+
+**结论：buf-id 模式下完全不需要任何 backward-sync 外提优化**。这意味着：
+
+- `tryMovingOutBackwardSyncPairsToOuterLoops`、`considerOuterBackwardSyncPairs`、
+  `mergeBackwardSyncPairs` 这些路径在 buf-id 模式下**直接关掉**——它们
+  不仅没意义，强行外提反而会破坏 in-loop bracket 的天然语义；
+- `backwardSyncEvents` / `backwardSyncEventsAfterMerge` 这两个映射在
+  buf-id 模式下不会被填充；
+- 之前提到的"阶段二做 buf-id 形态二外提"——**取消，这是反向理解**。
+
+具体落实见 3.6 节。
+
+### 2.5 不在本期范围
+
+- **`set_flag_dyn` / `wait_flag_dyn`（动态 event id）的 buf-id 对位**。
+  当前求解器不输出动态形态，暂不考虑。
+
+---
+
+## 3. 实现细节
+
+### 3.1 ODS / Dialect 层
+
+**基本不动**。两个 op 已就位：
+
+```tablegen
+def GetBufOp : PTO_Op<"get_buf"> {
+  let arguments = (ins
+    PTO_PipeEventTypeLikeAttr:$op_type,   // 高级 op 类型（映射到 PIPE）
+    I32Attr:$buf_id,
+    DefaultValuedAttr<I32Attr, "0">:$mode
+  );
+  let hasVerifier = 1;
+}
+def RlsBufOp : PTO_Op<"rls_buf"> { /* 同 */ }
+```
+
+**建议增量**（可后置，不阻塞主流程）：在 `Op::verify()` 里加上轻量本地校验，
+检查 `op_type` 能映射到一个具体 pipe（已在 EmitC 端校验，前移到 verifier
+更友好）。本设计不依赖这一项。
+
+### 3.2 Pass option 与 CLI
+
+#### 3.2.1 `Passes.td`
+
+`PTOGraphSyncSolver` 增加一个选项（[Passes.td:65](../../include/PTO/Transforms/Passes.td)）：
+
+```tablegen
+let options = [
+  Option<"eventIdNumMax", "event-id-num-max", "int64_t",
+         /*default=*/"8", "...">,
+  Option<"syncStyle", "sync-style", "std::string",
+         /*default=*/"\"set-wait\"",
+         "Sync emission style: 'set-wait' (default) or 'buf-id' (A5 only).">,
+];
+```
+
+#### 3.2.2 `tools/ptoas/ptoas.cpp`
+
+在现有 [ptoas.cpp:193](../../tools/ptoas/ptoas.cpp)（`enableGraphSyncSolver`）旁加：
+
+```cpp
+static llvm::cl::opt<std::string> graphSyncSolverSyncStyle(
+    "graph-sync-solver-sync-style",
+    llvm::cl::desc("Sync emission style for graph sync solver: "
+                   "'set-wait' (default) or 'buf-id' (A5 only)."),
+    llvm::cl::init("set-wait"));
+```
+
+在 [ptoas.cpp:1173](../../tools/ptoas/ptoas.cpp) 透传到 pass option：
+
+```cpp
+PTOGraphSyncSolverOptions graphSyncOpts;
+graphSyncOpts.eventIdNumMax = graphSyncSolverEventIdMax;
+graphSyncOpts.syncStyle = graphSyncSolverSyncStyle;
+pm.addNestedPass<func::FuncOp>(createPTOGraphSyncSolverPass(graphSyncOpts));
+```
+
+#### 3.2.3 Pass 入口校验
+
+[PTOGraphSyncSolver.cpp:51](../../lib/PTO/Transforms/GraphSyncSolver/PTOGraphSyncSolver.cpp)
+把字符串解析成枚举塞进 `SyncSolverOptions`，并做 arch 兜底：
+
+```cpp
+SyncEmitStyle emitStyle = parseEmitStyle(syncStyle); // 字符串 → enum
+const bool isA5 = pto::isTargetArchA5(func.getOperation());
+if (emitStyle == SyncEmitStyle::BUF_ID && !isA5) {
+  func.emitError("--graph-sync-solver-sync-style=buf-id requires --pto-arch=a5");
+  return signalPassFailure();
+}
+SyncSolverOptions opts(SyncMode::INTRA_CORE_SYNC, !isA5, isA5);
+opts.eventIdNumMax = eventIdNumMax;
+opts.emitStyle = emitStyle;
+```
+
+### 3.3 `SyncSolverOptions` 扩展
+
+[Utility.h:123](../../include/PTO/Transforms/GraphSyncSolver/Utility.h) 增补：
+
+```cpp
+enum class SyncEmitStyle { SET_WAIT, BUF_ID };
+
+struct SyncSolverOptions {
+  // 现有字段不变 ...
+  SyncEmitStyle emitStyle{SyncEmitStyle::SET_WAIT};
+};
+```
+
+ctor 内可按 emitStyle 调整若干默认值（保守起见在 buf-id 下关掉跨 pipe-pair
+的 id 复用以符合约束 4 的"建议"）：
+
+```cpp
+if (emitStyle == SyncEmitStyle::BUF_ID) {
+  reuseSyncPairToSaveEventIds = false; // 约束 4：不同 pipe 对不共享 id
+}
+```
+
+### 3.4 求解器内核：核心保持，关掉 backward-sync 外提族
+
+`Solver::solve()` 全链路（[SyncSolver.cpp](../../lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp)）：
+
+**保留不变**：
+- `processConflict` / `handleSetWaitConflict` / `handleUnitFlagConflict`；
+- `EventIdSolver` 的染色——buf-id pool 与 event-id pool 在 hw 上同源、容量
+  同步（默认 8，由 `eventIdNumMax` 控制）；
+- `reuseSyncPairToSaveEventIds`（在 set-wait 下默认开，buf-id 下默认关——
+  约束 4 的"不同 pipe 对不建议共享 id"）。
+
+**buf-id 模式下关掉的部分**：
+- 同 pipe barrier 整体跳过（A5 硬件保序，见 1.4 节）。
+  `handleBarrierConflict` 入口直接 return；`pickAndInsertABarrierAll` 不
+  会触发 barrier 路径——但仍作为 event-id 耗尽时的兜底保留（buf-id 池耗尽
+  时 fallback 到 PIPE_ALL 强同步形态需要 hw 团队确认；阶段一沿用现有 fallback
+  机制，到 emit 阶段把 `BarrierOp(PIPE_ALL)` 翻译成 buf-id 等价形态或保留
+  set/wait 形态作为应急）。
+- backward-sync 外提族（按 2.4 节的理由）：
+  - `tryMovingOutBackwardSyncPairsToOuterLoops`
+    （[SyncSolver.h:413](../../include/PTO/Transforms/GraphSyncSolver/SyncSolver.h)）；
+  - `considerOuterBackwardSyncPairs`
+    （[SyncSolver.h:407](../../include/PTO/Transforms/GraphSyncSolver/SyncSolver.h)）；
+  - `mergeBackwardSyncPairs` / `mergeBackwardSyncEventIds` /
+    `insertMergedBackwardSyncPairs`
+    （[SyncSolver.h:401-405](../../include/PTO/Transforms/GraphSyncSolver/SyncSolver.h)）。
+
+具体实现方式见 3.6 节末尾。
+
+**理由**：求解器输出的 `ConflictPair` 已经包含全部 emit 所需的信息：
+`(setOp, waitOp, setCorePipeInfo, waitCorePipeInfo, eventIdNode->getEventIds())`。
+buf-id 与 set-wait 的差异只是这套信息**怎么落成 IR**——外提优化是 set/wait
+强配对的副产物，buf-id 不需要。
+
+### 3.5 内存 SyncOp IR：新增类
+
+[SyncSolverIR.h:67-91](../../include/PTO/Transforms/GraphSyncSolver/SyncSolverIR.h)
+的 `OpType` enum 增补：
+
+```cpp
+enum struct OpType {
+  // ...
+  SYNC_OP,
+    BARRIER_OP,
+    SW_FLAG_OP,
+      SET_FLAG_OP,
+      WAIT_FLAG_OP,
+    SW_FLAG_OP_END,
+    BUF_OP,                  // 新增：buf-id 家族区间起点
+      GET_BUF_OP,            // 新增
+      RLS_BUF_OP,            // 新增
+    BUF_OP_END,              // 新增
+  SYNC_OP_END,
+  // ...
+};
+```
+
+类层级（与 `SetFlagOp`/`WaitFlagOp` 对称）：
+
+```cpp
+class BufOp : public SyncOp {
+public:
+  pto::PIPE pipe{pto::PIPE::PIPE_UNASSIGNED}; // 自身所在 pipe（src 或 dst）
+  int64_t bufId{-1};                          // 复用 eventId 池
+  BufOp(OpType opType, Operation *op, OperationBase *parentOp,
+        pto::PIPE pipe, int64_t bufId)
+      : SyncOp(opType, op, parentOp), pipe(pipe), bufId(bufId) {}
+  static bool classof(const OperationBase *e) {
+    return e->opType >= OpType::BUF_OP && e->opType < OpType::BUF_OP_END;
+  }
+};
+
+class GetBufOp : public BufOp { /* OpType::GET_BUF_OP */ };
+class RlsBufOp : public BufOp { /* OpType::RLS_BUF_OP */ };
+```
+
+`SetFlagOp` / `WaitFlagOp` **不删**——两条路径共存。
+
+### 3.6 `getBeforeAfterSyncMaps` 分支
+
+[SyncSolver.cpp:2216-2270](../../lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp)
+在每个非 barrier / 非 unitFlag 的 ConflictPair 处理段加分支：
+
+```cpp
+if (conflictPair->isBarrier()) {
+  if (options.emitStyle == SyncEmitStyle::BUF_ID) {
+    // A5 同 pipe 硬件保序，不发射任何 barrier。
+    continue;
+  }
+  // 现有 BarrierOp 路径，不变
+} else if (options.emitStyle == SyncEmitStyle::SET_WAIT) {
+  // 现有 SetFlagOp / WaitFlagOp 路径，不变
+  // syncMapAfter[conflictPair->setOp].push_back(setOp);
+  // syncMapBefore[conflictPair->waitOp].push_front(waitOp);
+} else {
+  // BUF_ID 路径
+  auto setPipe = conflictPair->setCorePipeInfo.pipe;
+  auto waitPipe = conflictPair->waitCorePipeInfo.pipe;
+  for (int64_t bufId : conflictPair->eventIdNode->getEventIds()) {
+    // producer 端 bracket（src pipe）
+    syncMapBefore[conflictPair->setOp].push_back(
+        make_unique<GetBufOp>(conflictPair->setOp->op,
+                              conflictPair->setOp->parentOp, setPipe, bufId));
+    syncMapAfter[conflictPair->setOp].push_back(
+        make_unique<RlsBufOp>(conflictPair->setOp->op,
+                              conflictPair->setOp->parentOp, setPipe, bufId));
+    // consumer 端 bracket（dst pipe）
+    syncMapBefore[conflictPair->waitOp].push_back(
+        make_unique<GetBufOp>(conflictPair->waitOp->op,
+                              conflictPair->waitOp->parentOp, waitPipe, bufId));
+    syncMapAfter[conflictPair->waitOp].push_back(
+        make_unique<RlsBufOp>(conflictPair->waitOp->op,
+                              conflictPair->waitOp->parentOp, waitPipe, bufId));
+  }
+}
+```
+
+**约束 1/2 的天然满足**：bracket 形式下，`syncMapBefore[X]` 里某个 `get_buf(P, id)`
+与 `syncMapAfter[X]` 里对应的 `rls_buf(P, id)` 之间隔着的只有 anchor op `X` 本身。
+codegen 按 "before 顺序 push → 原 op → after 顺序 push" 的固定模式落盘，不会有
+其他 (pipe, id) 的 bracket 插入到中间。
+
+**backward-sync 路径处理**：
+
+`getBeforeAfterSyncMaps` 末段以及 `runSolver` 内的下列调用，在 buf-id 模式下
+通过提早 return / 开关位绕过：
+
+| 调用点 | buf-id 行为 |
+| --- | --- |
+| `collectBackwardSyncEventIds` ([SyncSolver.cpp:1925](../../lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp)) | 直接 return，不收集 |
+| `mergeBackwardSyncPairs` ([SyncSolver.cpp:2272](../../lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp) 调用点) | 直接 return |
+| `insertMergedBackwardSyncPairs` ([SyncSolver.cpp:2556](../../lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp) 调用点) | 直接 return |
+| `considerOuterBackwardSyncPairs` (`runSolver` 内调用) | 直接返回 `success`，不进入外提循环 |
+| `tryMovingOutBackwardSyncPairsToOuterLoops` (`runSolver` 内调用) | 同上 |
+
+实现上推荐统一通过 `if (options.emitStyle == SyncEmitStyle::BUF_ID) return …;`
+前置守卫，集中在每个函数入口，避免散点改动。
+
+结果是：buf-id 模式下，每个真依赖的 ConflictPair 的 `setOp`/`waitOp` 直接
+等于求解器最初识别出的 producer / consumer 锚点，bracket 就在原位落，
+对应 doc 1.2 buf-id 同步代码原样形态。
+
+### 3.7 `CodeGenerator::emitSyncOp` 分支
+
+[SyncSolverCodeGen.cpp:97](../../lib/PTO/Transforms/GraphSyncSolver/SyncSolverCodeGen.cpp)
+增加 case：
+
+```cpp
+void CodeGenerator::emitSyncOp(IRRewriter &rewriter, SyncOp *syncOp) {
+  if (auto *barrier = dyn_cast<BarrierOp>(syncOp)) { /* 不变 */ }
+
+  if (auto *getBuf = dyn_cast<GetBufOp>(syncOp)) {
+    rewriter.create<pto::GetBufOp>(resolveSyncLoc(getBuf),
+        pipeToPipeEventTypeAttr(rewriter.getContext(), getBuf->pipe),
+        rewriter.getI32IntegerAttr(getBuf->bufId),
+        rewriter.getI32IntegerAttr(0)); // mode 默认 0
+    return;
+  }
+  if (auto *rlsBuf = dyn_cast<RlsBufOp>(syncOp)) {
+    rewriter.create<pto::RlsBufOp>(resolveSyncLoc(rlsBuf),
+        pipeToPipeEventTypeAttr(rewriter.getContext(), rlsBuf->pipe),
+        rewriter.getI32IntegerAttr(rlsBuf->bufId),
+        rewriter.getI32IntegerAttr(0));
+    return;
+  }
+
+  auto *setWait = dyn_cast<SetWaitOp>(syncOp);
+  if (!setWait || setWait->eventIds.empty()) return;
+  // 现有 set-wait 发射路径不变
+}
+```
+
+**`pipeToPipeEventTypeAttr` helper**：`pto.get_buf` 的 `op_type` 是
+`PipeEventTypeLikeAttr`（高级 op 类型），不是 `PipeAttr`。EmitC 端已有
+`mapSyncOpTypeToPipe`（[PTOToEmitC.cpp:4914](../../lib/PTO/Transforms/PTOToEmitC.cpp)）。
+我们需要反向工具：`PIPE → PipeEventTypeAttr` 或 `PIPE → SyncOpTypeAttr`。
+**实现位置**：放到 `include/PTO/IR/PTO.h` 或一个新的 `PTO/IR/SyncOpTypeMap.h`，
+两个方向都暴露。
+
+`setInsertionPoint` 已经支持 placeholder（loop 边界 / scope 起止）锚点，
+buf-id 不需要新的锚点类型。
+
+### 3.8 跨 pipe-pair 共享 id 必须分配冲突边（**正确性必须**）
+
+> 这一节最初被列为"如果需要"的精化，实际上是 buf-id 的**硬正确性约束**。
+
+set-wait 模式下，求解器按 (pipeSrc, pipeDst) 独立维护 `EventIdSolver` 实例
+（[SyncSolver.cpp::getEventIdSolverRef](../../lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp)），
+不同 pipe 对各自从 id=0 开始着色。这对 set/wait 是正确的——
+`set_flag[MTE2,V,#0]` 和 `set_flag[V,MTE3,#0]` 落到两个不同的硬件 flag
+寄存器（pipe 对组合是 hw 寻址的一部分），物理上隔离。
+
+**buf-id 不行**。`get_buf[V,#0]` 不带"对方 pipe"参数，所以 `(MTE2→V)` 的
+#0 和 `(V→MTE3)` 的 #0 在 hw 上是**同一个 scoreboard**。考虑下面 IR：
+
+```text
+tload   # PIPE_MTE2，pair1 setOp
+tmuls   # PIPE_V，pair1 waitOp + pair2 setOp
+tstore  # PIPE_MTE3，pair2 waitOp
+```
+
+按 set-wait 着色逻辑会给两个 pair 都分配 id=0。展开成 buf-id 形态：
+
+```text
+get_buf(MTE2, #0); tload; rls_buf(MTE2, #0)
+get_buf(V,    #0);                              # pair1 consumer on tmuls
+get_buf(V,    #0);                              # pair2 producer on tmuls (illegal!)
+tmuls
+rls_buf(V,    #0)
+rls_buf(V,    #0)
+get_buf(MTE3, #0); tstore; rls_buf(MTE3, #0)
+```
+
+`get_buf(V,#0)` 连续出现两次 → 违反 doc §1.4 约束 1（"连续两次 get 同 id
+不合法"，会让 hw 计数器混乱）。
+
+#### 修复方案
+
+两处改动：
+
+1. **`getEventIdSolverRef`**：buf-id 模式跟 cross-core 模式一样把 key 折成
+   `(PIPE_UNASSIGNED, PIPE_UNASSIGNED)`，让**所有** pipe 对共享同一个
+   `EventIdSolver`。所有 ConflictPair 都进入同一个染色图，避免不同 pipe
+   对从同一 id pool 起点重复发牌。
+
+2. **`checkIntersect`**：buf-id 模式下，两个 ConflictPair 只要共享**任一**
+   pipe 就视为冲突（加冲突边），不再要求 (setPipe, waitPipe) 二元组
+   完全相同。原因：buf-id bracket 锚在 RWOperation 上而不是 `(setOp, waitOp)`
+   范围内的中间索引，两个 pair 各自在共享的 pipe 上的锚点可能落在同一个
+   op 上，进而产生连续 get 违法形态。
+
+完整代码改动见 [SyncSolver.cpp::getEventIdSolverRef](../../lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp)
+和 [SyncSolver.cpp::checkIntersect](../../lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp)。
+
+#### 修复后实际输出（与文档前文 §2.3 的形态表对齐）
+
+```text
+get_buf(TLOAD, #1); tload; rls_buf(TLOAD, #1)        # pair1, id=1
+get_buf(TVEC,  #1);                                  # pair1 consumer on tmuls
+get_buf(TVEC,  #0);                                  # pair2 producer on tmuls (different id)
+tmuls
+rls_buf(TVEC,  #1)
+rls_buf(TVEC,  #0)
+get_buf(TSTORE_VEC, #0); tstore; rls_buf(TSTORE_VEC, #0)
+```
+
+- 约束 1（同 pipe 同 id 不能重入）：TVEC 上 id=0 一对 + id=1 一对，**不同 id**，合法。
+- 约束 2（不同 pipe 同 id 各自连续）：id=1 跨 TLOAD/TVEC，TLOAD 那对内部无其他 pipe 的 id=1；TVEC 那对内部只有 id=0 的 get/rel（不是 id=1），合法。
+
+#### 保守度
+
+`checkIntersect` 在 buf-id 下采用"共享任一 pipe → 冲突"的最保守判据，**忽略**
+IR 范围 overlap。这会偶尔产出更密的冲突图，把不必要的 ConflictPair 染成不同
+id，浪费 buf-id 池。在 8-id 默认池场景下实测影响不大；若后续在大型 kernel 上
+出现 id 池耗尽问题，可以细化为"共享 pipe 上的锚点 RWOperation 重合"——这个
+判据严格等价于真实硬件冲突，但实现更繁琐。阶段一保守为主。
+
+### 3.9 Mirror-image ConflictPair 去重
+
+对于循环里的同一对 producer/consumer 跨 pipe，solver 会同时检测出：
+
+- 正向（intra-iter）：`F: tload[i] → tmuls[i]`（MTE2 → V，RAW）
+- 反向（loop-carried）：`B: tmuls[i] → tload[i+1]`（V → MTE2，WAW）
+
+set-wait 模式下两条都要发出，因为 set/wait 严格配对：F 在 iter 内成对，
+B 必须横跨循环边界单独成对（form 1 或 form 2 都行）。
+
+buf-id 模式下，F 和 B 的"bracket 集合"完全一样：
+
+```text
+F brackets: {(tload, MTE2), (tmuls, V)}
+B brackets: {(tmuls, V), (tload, MTE2)}    # 相同的无序集合
+```
+
+硬件 `(get_cnt, rel_cnt)` 计数器的单调性已经同时承担了 F 和 B 两条依赖：
+iter i+1 的 `get_buf(MTE2, #id)` 抢号时，号码必须等到 iter i 的
+`rls_buf(V, #id)` 推进 rel_cnt 之后才能 pop——这就是 B 的反向语义。再单独
+为 B 分配一对 bracket 是冗余，浪费 id。
+
+doc §1.2 canonical 例子直接展示了这一点：
+
+```text
+for i = 0:100
+  get_buf(MTE2, #id); load();   rel_buf(MTE2, #id)
+  get_buf(V,    #id); Vector(); rel_buf(V,    #id)
+```
+
+单一 #id 同时覆盖正反向。
+
+#### 修复
+
+在 `getBeforeAfterSyncMaps` 前置一个 mirror-image 去重 pass：用无序 anchor 集合
+`{(setOp, setPipe), (waitOp, waitPipe)}` 作 key，把同 key 的多个 ConflictPair
+合成一条（保留 id 最小的代表，其余 mark 为 redundant 跳过 emit）。
+
+实测效果：`tload + tmuls` canonical loop case 从 2 个 id（id 0 给 F，id 1
+给 B）减到 1 个 id（id 0 给 F，B 被去重）；输出与 doc §1.2 完全一致。
+
+#### 局限
+
+去重发生在 `getBeforeAfterSyncMaps`，此时 `EventIdSolver` 已经分配过 id 了
+——被丢弃的 B 那个 id 是"已 reserved 但没 emit"，浪费一个 slot。若后续
+出现 id 池紧张，可以把 mirror dedup 提前到 `processConflict` 阶段（不创建
+重复的 ConflictPair），或者在 `EventIdSolver::createNode` 时检查 mirror
+共享 EventIdNode。阶段一不强制做。
+
+---
+
+## 4. 跨层同步检查（参考 `.claude/rules/cross-layer-sync.md`）
+
+| 层 | 变更点 |
+| --- | --- |
+| ODS (`include/PTO/IR/*.td`) | `get_buf`/`rls_buf` 已存在，可选加 verifier |
+| C++ IR & verifiers (`lib/PTO/IR`) | 同上 |
+| 求解器内核 (`lib/PTO/Transforms/GraphSyncSolver/`) | `SyncSolverIR.h` 加 `BufOp`/`GetBufOp`/`RlsBufOp`；`SyncSolver.cpp::getBeforeAfterSyncMaps` 加分支；`SyncSolverCodeGen.cpp::emitSyncOp` 加分支；`Utility.h::SyncSolverOptions` 加 `emitStyle` |
+| Pass 入口 (`PTOGraphSyncSolver.cpp`) | 解析新选项 + arch 校验 |
+| Passes.td | 增加 `sync-style` option |
+| CLI (`tools/ptoas/ptoas.cpp`) | 新 flag `--graph-sync-solver-sync-style` 透传 |
+| Python 绑定 (`python/`) | 不变（dialect 已绑定 get_buf/rls_buf） |
+| 文档 | 本文 + 更新 [docs/designs/ptoas-auto-sync-design.md](ptoas-auto-sync-design.md) sync style 章节 + [docs/PTO_IR_manual.md](../PTO_IR_manual.md) sync 章节加 buf-id 模型说明 |
+| Tests | 见第 5 章 |
+
+---
+
+## 5. 测试方案
+
+### 5.1 单元 / lit 测试
+
+参考 `test/lit/pto/` 现有 `*_gss.pto` 体例（如
+[graph_sync_solver_basic.pto](../../test/lit/pto/graph_sync_solver_basic.pto)），
+新增：
+
+| 测试 | 目的 | 关键 FileCheck |
+| --- | --- | --- |
+| `graph_sync_solver_buf_id_basic.pto` | A5 双 pipe forward dep 最小用例 | 出现 `pto.get_buf`/`pto.rls_buf`，不出现 `pto.set_flag` / `pto.wait_flag` |
+| `graph_sync_solver_buf_id_multibuf.pto` | multibuffer 流水，N>1 个 id | 同一 anchor 上有 N 对 bracket，bufId 互不相同 |
+| `graph_sync_solver_buf_id_no_barrier.pto` | 同 pipe 真依赖 | **不出现** `pto.barrier`、也不出现 buf-id 指令（A5 硬件保序） |
+| `graph_sync_solver_buf_id_backward.pto` | 循环间依赖（backward sync） | producer/consumer 在原位 bracket，无形态二外提；不出现 `if isFirstIter` 守卫 |
+| `graph_sync_solver_buf_id_arch_guard.pto` | A3 + buf-id 触发报错 | 显式 emitError |
+| `graph_sync_solver_buf_id_parity.pto` | 同输入分别跑 set-wait / buf-id，编号对齐 | bufId 集合 == eventId 集合，bracket 数 == set+wait 数 |
+
+`runop.sh`（[test/samples/runop.sh](../../test/samples/runop.sh)）的对应行加 buf-id
+模式补充。
+
+### 5.2 端到端 / sample
+
+复用 [test/samples/Sync/](../../test/samples/Sync/) 现有 `tmatmulk_autosync*.py`
+等样例，再加一个 buf-id 版本（`test/samples/Sync/tmatmulk_autosync_buf_id.py`）。
+EmitC 落到 C++ 后通过 board validation（[test/samples/MatMul/](../../test/samples/MatMul/)
+体例）验证 hw 仿真器上语义正确。
+
+### 5.3 Bug 报告体例（参考 `.claude/rules/testing-and-examples.md`）
+
+后续提交的回归测试统一按 **Before / Expected / Actual** 三段式：
+- Before：最小 .pto；
+- Expected：buf-id bracket 形态、对应 set-wait 等价形态、verifier 结果；
+- Actual：`ptoas` 命令行 + FileCheck。
+
+---
+
+## 6. 实施步骤
+
+| 步骤 | 内容 | 风险 |
+| --- | --- | --- |
+| S1 | `SyncSolverOptions::emitStyle` 枚举 + Passes.td option + CLI flag + Pass 入口校验 | 不改语义；纯透传，几乎无风险 |
+| S2 | `SyncSolverIR.h` 增加 `BufOp`/`GetBufOp`/`RlsBufOp` + OpType；不影响现有 `SetFlagOp`/`WaitFlagOp` | 编译期/链接期 |
+| S3 | `getBeforeAfterSyncMaps` 分支 + `pipeToPipeEventTypeAttr` helper + `emitSyncOp` 分支 | 主要风险点，要保证 set-wait 路径完全等价 |
+| S4 | lit 测试 5 个 + 一份端到端 sample | 校准 FileCheck pattern |
+| S5 | 更新 `PTO_IR_manual.md` / `ptoas-auto-sync-design.md` | 文档而已 |
+| 阶段二（可选） | 约束 4 的强 / 弱模式切换；hw 团队明确后再决定是否在 `EventIdSolver` 层按 pipe-pair 打散 | 独立 PR，不阻塞阶段一 |
+
+---
+
+## 7. 风险与开放问题
+
+1. **buf-id 池容量**：阶段一沿用 `eventIdNumMax = 8`。需 hw 团队确认 A5 上
+   buf-id pool 是否与 event-id pool 共享物理资源、容量是否一致。若分离，
+   需要把 `eventIdNumMax` 拆成两个独立选项。
+2. **`mode` 字段**：`pto.get_buf` / `pto.rls_buf` 有 `I32Attr:$mode` 默认 0。
+   当前文档未提非 0 模式语义，全部填 0。需 hw 团队进一步明确。
+3. **约束 4（不同 pipe 对共享 id）**：早期版本把这归为"软提示"。实际验证发现
+   ConflictPair 共享 pipe 时跨 pair 共享 id 会违反约束 1（连续 get 非法），
+   所以阶段一已经在 `getEventIdSolverRef` + `checkIntersect` 里强制隔离，
+   见 3.8。
+4. **A2 / A3 行为**：阶段一在 `!isA5 && BUF_ID` 时直接报错。如未来低世代芯片
+   也支持 buf-id，需放开 arch 校验。
+5. **与 `PTOInsertSync` 的关系**：本设计只覆盖 `PTOGraphSyncSolver`。
+   `PTOInsertSync` 是独立 pipeline，是否需要同步加 buf-id 形态另外评估
+   （三个自动同步选项当前互斥，[ptoas.cpp:1094](../../tools/ptoas/ptoas.cpp)）。
+6. **backward-sync**：见 2.4 节，buf-id 模型本身已是顺序模型，**不需要**
+   set/wait 那套形态二外提。阶段一直接在 producer / consumer 原位 bracket
+   即可。求解器里现有的若干 `*backwardSync*` 优化在 buf-id 模式下全部短路。

--- a/include/PTO/IR/PTOSyncUtils.h
+++ b/include/PTO/IR/PTOSyncUtils.h
@@ -30,6 +30,14 @@ PIPE mapSyncOpTypeToPipe(SyncOpType opType);
 /// True if the pipe is a concrete endpoint pipe (not PIPE_ALL/UNASSIGNED).
 bool isConcreteSyncPipe(PIPE pipe);
 
+/// Pick a canonical SyncOpType endpoint for a concrete PIPE. This is the
+/// inverse of mapSyncOpTypeToPipe up to the fact that mapSyncOpTypeToPipe is
+/// many-to-one: e.g. both TVEC and TMOV_M2V map to PIPE_V. The canonical
+/// SyncOpType returned here is sufficient for the EmitC pattern matchers,
+/// which only care that the high-level attr maps back to the same concrete
+/// PIPE. Returns failure() for non-concrete pipes (PIPE_ALL/UNASSIGNED).
+FailureOr<SyncOpType> mapPipeToCanonicalSyncOpType(PIPE pipe);
+
 } // namespace pto
 } // namespace mlir
 

--- a/include/PTO/Transforms/GraphSyncSolver/SyncSolver.h
+++ b/include/PTO/Transforms/GraphSyncSolver/SyncSolver.h
@@ -224,12 +224,17 @@ protected:
   // `conflictBuffer` identifies the underlying memory the new pair would
   // synchronize on; in buf-id mode it is used to filter out existing pairs
   // operating on a different buffer (same-pipe transitive coverage via
-  // those pairs does not hold for independent buf-id counters). nullptr
-  // disables the filter (preserves the legacy set/wait behavior).
+  // those pairs does not hold for independent buf-id counters). `candOp1`
+  // and `candOp2` are the candidate pair's anchor ops, used to drop
+  // existing pairs that live in a mutually exclusive scf.if branch
+  // (different runtime path → cannot transitively cover). nullptr/null
+  // disables the corresponding filter (preserves the legacy set/wait
+  // behavior).
   bool checkGraphConflict(
       Occurrence *occ1, Occurrence *occ2, CorePipeInfo corePipeSrc,
       CorePipeInfo corePipeDst, EventIdInfo eventIdInfo,
       mlir::Value conflictBuffer = nullptr,
+      OperationBase *candOp1 = nullptr, OperationBase *candOp2 = nullptr,
       std::optional<int> startIndex = {}, std::optional<int> endIndex = {},
       const llvm::SmallVector<ConflictPair *> &extraConflictPairs = {},
       const llvm::SmallVector<ConflictPair *> &ignoreConflictPairs = {});
@@ -282,6 +287,15 @@ protected:
   // Check whether two ConflictPair ranges/event mapping intersect (same
   // pipes/events).
   bool checkIntersect(ConflictPair *conflictPair1, ConflictPair *conflictPair2);
+
+  // Returns true when two pairs of (op-anchor) endpoints sit in *mutually
+  // exclusive* branches of any common scf.if ancestor. Mutex pairs cannot
+  // execute together at runtime, so they don't conflict in coloring (can
+  // share an id) and they cannot transitively cover each other in
+  // checkGraphConflict (different runtime paths). `aOp1`/`aOp2` describe
+  // one pair's endpoints, `bOp1`/`bOp2` the other's.
+  bool opsMutuallyExclusive(OperationBase *aOp1, OperationBase *aOp2,
+                            OperationBase *bOp1, OperationBase *bOp2);
 
   // Event-id allocation and reuse helpers.
   std::vector<ConflictPair *>

--- a/include/PTO/Transforms/GraphSyncSolver/SyncSolver.h
+++ b/include/PTO/Transforms/GraphSyncSolver/SyncSolver.h
@@ -121,7 +121,7 @@ protected:
   // pairs.
   llvm::DenseMap<
       std::pair<syncsolver::RWOperation *, syncsolver::RWOperation *>,
-      llvm::SmallVector<std::tuple<CorePipeInfo, CorePipeInfo>>>
+      llvm::SmallVector<std::tuple<CorePipeInfo, CorePipeInfo, mlir::Value>>>
       checkMemoryConflictsMem;
 
   // Set of pipe pairs that were forced to barrier-all (no event ids available).
@@ -221,9 +221,15 @@ protected:
                                                          RWOperation *rwOp2);
 
   // Graph-based conflict checking and memory conflict detection helpers.
+  // `conflictBuffer` identifies the underlying memory the new pair would
+  // synchronize on; in buf-id mode it is used to filter out existing pairs
+  // operating on a different buffer (same-pipe transitive coverage via
+  // those pairs does not hold for independent buf-id counters). nullptr
+  // disables the filter (preserves the legacy set/wait behavior).
   bool checkGraphConflict(
       Occurrence *occ1, Occurrence *occ2, CorePipeInfo corePipeSrc,
       CorePipeInfo corePipeDst, EventIdInfo eventIdInfo,
+      mlir::Value conflictBuffer = nullptr,
       std::optional<int> startIndex = {}, std::optional<int> endIndex = {},
       const llvm::SmallVector<ConflictPair *> &extraConflictPairs = {},
       const llvm::SmallVector<ConflictPair *> &ignoreConflictPairs = {});
@@ -242,7 +248,13 @@ protected:
                             std::optional<int64_t> lcmLen = {},
                             std::optional<int64_t> eventIdNum = {});
 
-  llvm::SmallVector<std::tuple<CorePipeInfo, CorePipeInfo>>
+  // Returns one entry per (corePipeSrc, corePipeDst, conflictingBuffer)
+  // triple. The buffer Value identifies the SSA value of the underlying
+  // memory that triggered the conflict; multiple buffers conflicting at
+  // the same pipe-pair yield multiple entries (one ConflictPair per
+  // buffer downstream). Buffer may be null when the conflict comes from
+  // a MemInfo lacking a backing SSA value.
+  llvm::SmallVector<std::tuple<CorePipeInfo, CorePipeInfo, mlir::Value>>
   checkMemoryConflicts(RWOperation *rwOp1, RWOperation *rwOp2);
 
   bool checkMemoryConflictBetweenOccExclusive(
@@ -336,18 +348,24 @@ protected:
   bool checkReuseMultiBufferFlagId(ConflictPair *conflictPair);
 
   // Primary handler invoked to register/record a found conflict.
+  // `conflictBuffer` is the SSA Value of the underlying memory shared
+  // between op1 and op2 (used by buf-id mode to keep ConflictPairs
+  // distinguishable per buffer; null in legacy callers).
   void handleConflict(Occurrence *occ1, Occurrence *occ2, RWOperation *rwOp1,
                       RWOperation *rwOp2, CorePipeInfo corePipeSrc,
                       CorePipeInfo corePipeDst, EventIdInfo eventIdInfo,
-                      bool isUseless);
+                      bool isUseless,
+                      mlir::Value conflictBuffer = nullptr);
 
   void handleBarrierConflict(Occurrence *occ1, Occurrence *occ2,
                              CorePipeInfo corePipeSrc, CorePipeInfo corePipeDst,
-                             bool isUseless);
+                             bool isUseless,
+                             mlir::Value conflictBuffer = nullptr);
 
   void handleSetWaitConflict(Occurrence *occ1, Occurrence *occ2,
                              CorePipeInfo corePipeSrc, CorePipeInfo corePipeDst,
-                             EventIdInfo eventIdInfo, bool isUseless);
+                             EventIdInfo eventIdInfo, bool isUseless,
+                             mlir::Value conflictBuffer = nullptr);
 
   void handleUnitFlagConflict(Occurrence *occ1, Occurrence *occ2,
                               CorePipeInfo corePipeSrc,

--- a/include/PTO/Transforms/GraphSyncSolver/SyncSolverIR.h
+++ b/include/PTO/Transforms/GraphSyncSolver/SyncSolverIR.h
@@ -81,6 +81,10 @@ enum struct OpType {
   SET_FLAG_OP,
   WAIT_FLAG_OP,
   SW_FLAG_OP_END,
+  BUF_OP,
+  GET_BUF_OP,
+  RLS_BUF_OP,
+  BUF_OP_END,
   SYNC_OP_END,
   RW_OPERATION,
   MMAD_OPERATION,
@@ -498,6 +502,49 @@ public:
 
   static bool classof(const OperationBase *e) {
     return e->opType == OpType::BARRIER_OP;
+  }
+
+  std::string str(int indent, bool recursive) const override;
+};
+
+// A5-only buffer-id bracket op (get_buf / rls_buf). Unlike SetWaitOp which
+// names both src and dst pipes, a BufOp lives on a single concrete pipe — the
+// shared bufId on producer and consumer brackets is what enforces ordering.
+class BufOp : public SyncOp {
+public:
+  pto::PIPE pipe{pto::PIPE::PIPE_UNASSIGNED};
+  int64_t bufId{-1};
+
+  BufOp(OpType opType, Operation *op, OperationBase *parentOp, pto::PIPE pipe,
+        int64_t bufId)
+      : SyncOp(opType, op, parentOp), pipe(pipe), bufId(bufId) {}
+
+  static bool classof(const OperationBase *e) {
+    return e->opType >= OpType::BUF_OP && e->opType < OpType::BUF_OP_END;
+  }
+};
+
+class GetBufOp : public BufOp {
+public:
+  GetBufOp(Operation *op, OperationBase *parentOp, pto::PIPE pipe,
+           int64_t bufId)
+      : BufOp(OpType::GET_BUF_OP, op, parentOp, pipe, bufId) {}
+
+  static bool classof(const OperationBase *e) {
+    return e->opType == OpType::GET_BUF_OP;
+  }
+
+  std::string str(int indent, bool recursive) const override;
+};
+
+class RlsBufOp : public BufOp {
+public:
+  RlsBufOp(Operation *op, OperationBase *parentOp, pto::PIPE pipe,
+           int64_t bufId)
+      : BufOp(OpType::RLS_BUF_OP, op, parentOp, pipe, bufId) {}
+
+  static bool classof(const OperationBase *e) {
+    return e->opType == OpType::RLS_BUF_OP;
   }
 
   std::string str(int indent, bool recursive) const override;

--- a/include/PTO/Transforms/GraphSyncSolver/Utility.h
+++ b/include/PTO/Transforms/GraphSyncSolver/Utility.h
@@ -332,6 +332,14 @@ struct ConflictPair {
   EventIdInfo eventIdInfo;
   EventIdNode *eventIdNode{nullptr};
 
+  // The underlying memory buffer that this sync edge protects (the SSA Value
+  // of the shared tile / memref / pointer that op1 and op2 both touch).
+  // Currently used by buf-id mode to make checkGraphConflict's transitive
+  // pruning buffer-aware: a covering pair only counts if it operates on the
+  // same buffer. Null for barriers and for pairs synthesized without a
+  // specific buffer (e.g. merged backward-sync compensation).
+  mlir::Value conflictBuffer{nullptr};
+
   ConflictPair(RWOperation *op1, RWOperation *op2, OperationBase *setOp,
                OperationBase *waitOp, Occurrence *setOcc, Occurrence *waitOcc,
                CorePipeInfo setCorePipeInfo, CorePipeInfo waitCorePipeInfo,
@@ -376,6 +384,7 @@ struct ConflictPair {
     clonedConflictPair->backwardSyncLoopOcc = backwardSyncLoopOcc;
     clonedConflictPair->eventIdInfo = eventIdInfo;
     clonedConflictPair->eventIdNode = eventIdNode;
+    clonedConflictPair->conflictBuffer = conflictBuffer;
     return clonedConflictPair;
   }
 

--- a/include/PTO/Transforms/GraphSyncSolver/Utility.h
+++ b/include/PTO/Transforms/GraphSyncSolver/Utility.h
@@ -120,6 +120,14 @@ enum SyncMode {
   TEST_CROSS_CORE_MODE,
 };
 
+// Emission shape for the sync solver output. SET_WAIT is the legacy
+// pto.set_flag / pto.wait_flag pairing. BUF_ID is the A5-only buffer-id
+// bracketing model (pto.get_buf / pto.rls_buf around each anchor op).
+enum class SyncEmitStyle {
+  SET_WAIT,
+  BUF_ID,
+};
+
 struct SyncSolverOptions {
   // Synchronization mode.
   const SyncMode syncMode;
@@ -129,6 +137,9 @@ struct SyncSolverOptions {
 
   // Architecture is register based (A5).
   const bool isRegBasedArch;
+
+  // Sync emission style. BUF_ID requires A5 (isRegBasedArch).
+  SyncEmitStyle emitStyle{SyncEmitStyle::SET_WAIT};
 
   // Decompose MMAD L1 ops into simpler ops for better sync handling.
   bool decomposeMmadl1Op{false};
@@ -184,6 +195,8 @@ struct SyncSolverOptions {
     return syncMode == SyncMode::TEST_INTRA_CORE_MODE ||
            syncMode == SyncMode::TEST_CROSS_CORE_MODE;
   }
+
+  bool isBufIdEmit() const { return emitStyle == SyncEmitStyle::BUF_ID; }
 };
 
 struct Occurrence;

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -78,6 +78,12 @@ def PTOGraphSyncSolver : Pass<"pto-graph-sync-solver", "func::FuncOp"> {
            /*default=*/"8",
            "Maximum EVENT_ID slots usable by coloring; this caps the hardware "
            "available event-id budget used by the graph solver.">,
+    Option<"syncStyle", "sync-style", "std::string",
+           /*default=*/"\"set-wait\"",
+           "Sync emission style: 'set-wait' (default) or 'buf-id' (A5 only). "
+           "Under 'buf-id' the solver emits pto.get_buf/pto.rls_buf brackets "
+           "instead of pto.set_flag/pto.wait_flag, and skips pto.barrier "
+           "since A5 preserves same-pipe order in hardware.">,
   ];
 
   let dependentDialects = [

--- a/lib/PTO/IR/PTOSyncUtils.cpp
+++ b/lib/PTO/IR/PTOSyncUtils.cpp
@@ -52,3 +52,22 @@ PIPE mlir::pto::mapSyncOpTypeToPipe(SyncOpType opType) {
 bool mlir::pto::isConcreteSyncPipe(PIPE pipe) {
   return pipe != PIPE::PIPE_UNASSIGNED && pipe != PIPE::PIPE_ALL;
 }
+
+FailureOr<SyncOpType> mlir::pto::mapPipeToCanonicalSyncOpType(PIPE pipe) {
+  switch (pipe) {
+  case PIPE::PIPE_MTE2:
+    return SyncOpType::TLOAD;
+  case PIPE::PIPE_MTE3:
+    return SyncOpType::TSTORE_VEC;
+  case PIPE::PIPE_FIX:
+    return SyncOpType::TSTORE_ACC;
+  case PIPE::PIPE_MTE1:
+    return SyncOpType::TMOV_M2L;
+  case PIPE::PIPE_V:
+    return SyncOpType::TVEC;
+  case PIPE::PIPE_M:
+    return SyncOpType::TMATMUL;
+  default:
+    return failure();
+  }
+}

--- a/lib/PTO/Transforms/GraphSyncSolver/PTOGraphSyncSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/PTOGraphSyncSolver.cpp
@@ -72,10 +72,41 @@ struct PTOGraphSyncSolverPass
     // handleBarrierConflict() drop the PIPE_V barrier that A5 hardware
     // does not support.
     const bool isA5 = pto::isTargetArchA5(func.getOperation());
+
+    SyncEmitStyle emitStyle;
+    if (syncStyle == "set-wait") {
+      emitStyle = SyncEmitStyle::SET_WAIT;
+    } else if (syncStyle == "buf-id") {
+      emitStyle = SyncEmitStyle::BUF_ID;
+    } else {
+      func.emitError("--graph-sync-solver-sync-style: unknown value '")
+          << syncStyle << "', expected 'set-wait' or 'buf-id'";
+      return signalPassFailure();
+    }
+    if (emitStyle == SyncEmitStyle::BUF_ID && !isA5) {
+      func.emitError(
+          "--graph-sync-solver-sync-style=buf-id requires --pto-arch=a5; "
+          "get_buf/rls_buf are only available on A5");
+      return signalPassFailure();
+    }
+
     SyncSolverOptions opts(SyncMode::INTRA_CORE_SYNC,
                            /*isMemBasedArch=*/!isA5,
                            /*isRegBasedArch=*/isA5);
     opts.eventIdNumMax = eventIdNumMax;
+    opts.emitStyle = emitStyle;
+    if (emitStyle == SyncEmitStyle::BUF_ID) {
+      // Constraint 4 ("different pipe pairs should not share an id") — in
+      // buf-id mode we conservatively disable the cross-pipe-pair id reuse
+      // optimization that the set-wait flow runs by default for intra-core.
+      opts.reuseSyncPairToSaveEventIds = false;
+      // buf-id is a sequential programming model; the hw (get_cnt, rel_cnt)
+      // counters handle loop-carried sync natively, so the set/wait backward-
+      // sync hoisting / merging optimizations are unnecessary (and would
+      // break the in-loop bracket form).
+      opts.considerOuterBackwardSyncPairs = false;
+      opts.moveOutAndMergeBackwardSyncPairs = false;
+    }
     auto translator = std::make_unique<IRTranslator>(func, opts);
 
     // Trivial / empty function bodies have nothing to solve.

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
@@ -630,6 +630,7 @@ bool Solver::checkGraphConflict(
     Occurrence *occ1, Occurrence *occ2, CorePipeInfo corePipeSrc,
     CorePipeInfo corePipeDst, EventIdInfo eventIdInfo,
     mlir::Value conflictBuffer,
+    OperationBase *candOp1, OperationBase *candOp2,
     std::optional<int> startIndex, std::optional<int> endIndex,
     const llvm::SmallVector<ConflictPair *> &extraConflictPairs,
     const llvm::SmallVector<ConflictPair *> &ignoreConflictPairs) {
@@ -642,11 +643,14 @@ bool Solver::checkGraphConflict(
   }
   // In buf-id mode, transitive coverage through existing pairs is only valid
   // when those pairs operate on the SAME underlying buffer as the candidate
-  // (each buf-id is an independent scoreboard counter, so a same-pipe pair
-  // on a different buffer does not transitively sync the candidate's
-  // counter). Filter out cross-buffer existing pairs from the graph when
-  // both sides carry buffer info.
+  // AND are not in a mutually exclusive scf.if branch. Each buf-id is an
+  // independent scoreboard counter, so a same-pipe pair on a different
+  // buffer does not transitively sync the candidate's counter. And pairs
+  // in a disjoint branch are on a different runtime path entirely — they
+  // never execute together so cannot sync each other.
   const bool bufferAware = options.isBufIdEmit() && conflictBuffer != nullptr;
+  const bool mutexAware =
+      options.isBufIdEmit() && candOp1 != nullptr && candOp2 != nullptr;
   GraphSolver graphSolver(options);
   llvm::DenseSet<ConflictPair *> visited;
   auto handleConflictPair = [&](ConflictPair *conflictPair) {
@@ -672,6 +676,14 @@ bool Solver::checkGraphConflict(
         conflictPair->conflictBuffer != conflictBuffer) {
       // Different-buffer existing pair: cannot transitively cover the
       // candidate in buf-id semantics.
+      return;
+    }
+    if (mutexAware &&
+        opsMutuallyExclusive(candOp1, candOp2, conflictPair->op1,
+                             conflictPair->op2)) {
+      // Existing pair lives in a disjoint scf.if branch from the candidate.
+      // They never execute together, so the existing pair's sync cannot
+      // transitively cover the candidate.
       return;
     }
     auto [it, isInserted] = visited.insert(conflictPair);
@@ -761,8 +773,10 @@ bool Solver::checkSyncOpsConflicts(ConflictPair *conflictPair1,
     result = result ||
              checkGraphConflict(occ1, occ2, corePipeSrc, corePipeDst,
                                 conflictPair1->eventIdInfo,
-                                /*conflictBuffer=*/nullptr, startIndex,
-                                endIndex, {conflictPair1}, {conflictPair2});
+                                /*conflictBuffer=*/nullptr,
+                                /*candOp1=*/nullptr, /*candOp2=*/nullptr,
+                                startIndex, endIndex, {conflictPair1},
+                                {conflictPair2});
     conflictPair1->startIndex -= 1;
   }
   if (conflictPair1->waitCorePipeInfo != conflictPair2->waitCorePipeInfo) {
@@ -777,8 +791,10 @@ bool Solver::checkSyncOpsConflicts(ConflictPair *conflictPair1,
     result = result ||
              checkGraphConflict(occ1, occ2, corePipeSrc, corePipeDst,
                                 conflictPair1->eventIdInfo,
-                                /*conflictBuffer=*/nullptr, startIndex,
-                                endIndex, {conflictPair1}, {conflictPair2});
+                                /*conflictBuffer=*/nullptr,
+                                /*candOp1=*/nullptr, /*candOp2=*/nullptr,
+                                startIndex, endIndex, {conflictPair1},
+                                {conflictPair2});
     conflictPair2->endIndex += 1;
   }
   DEBUG_WITH_TYPE("gss-check-sync-ops-conflicts", {
@@ -789,6 +805,63 @@ bool Solver::checkSyncOpsConflicts(ConflictPair *conflictPair1,
     }
   });
   return result;
+}
+
+// Helper: returns true when the two pairs anchored at (aOp1, aOp2) vs
+// (bOp1, bOp2) live in mutually exclusive scf.if branches of some common
+// Condition ancestor. Reused by checkIntersect (coloring conflict graph)
+// and checkGraphConflict (transitive-coverage graph) under buf-id mode.
+bool Solver::opsMutuallyExclusive(OperationBase *aOp1, OperationBase *aOp2,
+                                  OperationBase *bOp1, OperationBase *bOp2) {
+  auto branchUnder = [](OperationBase *op, Condition *condition) -> Scope * {
+    if (op == nullptr || condition == nullptr)
+      return nullptr;
+    auto *trueScope = condition->getTrueScope();
+    if (trueScope == op || trueScope->isProperAncestor(op))
+      return trueScope;
+    if (condition->hasFalseScope()) {
+      auto *falseScope = condition->getFalseScope();
+      if (falseScope == op || falseScope->isProperAncestor(op))
+        return falseScope;
+    }
+    return nullptr;
+  };
+  auto requiredBranch = [&](OperationBase *op1, OperationBase *op2,
+                            Condition *condition) -> Scope * {
+    Scope *required = nullptr;
+    for (auto *op : {op1, op2}) {
+      auto *branch = branchUnder(op, condition);
+      if (branch == nullptr)
+        continue;
+      if (required != nullptr && required != branch)
+        return nullptr;
+      required = branch;
+    }
+    return required;
+  };
+  auto collectParentConditions =
+      [](OperationBase *op, llvm::SmallVectorImpl<Condition *> &conditions) {
+        for (auto *parent = op ? op->parentOp : nullptr; parent != nullptr;
+             parent = parent->parentOp) {
+          if (auto *condition = dyn_cast<Condition>(parent))
+            conditions.push_back(condition);
+        }
+      };
+  llvm::SmallVector<Condition *> conditions;
+  collectParentConditions(aOp1, conditions);
+  collectParentConditions(aOp2, conditions);
+  collectParentConditions(bOp1, conditions);
+  collectParentConditions(bOp2, conditions);
+  llvm::sort(conditions);
+  conditions.erase(std::unique(conditions.begin(), conditions.end()),
+                   conditions.end());
+  for (auto *condition : conditions) {
+    auto *branchA = requiredBranch(aOp1, aOp2, condition);
+    auto *branchB = requiredBranch(bOp1, bOp2, condition);
+    if (branchA != nullptr && branchB != nullptr && branchA != branchB)
+      return true;
+  }
+  return false;
 }
 
 // Check whether two ConflictPair entries conflict in pipe and time ranges.
@@ -809,60 +882,8 @@ bool Solver::checkIntersect(ConflictPair *conflictPair1,
     return checkSyncOpsConflicts(conflictPair1, conflictPair2);
   }
   if (options.isBufIdEmit()) {
-    auto branchUnder = [](OperationBase *op,
-                          Condition *condition) -> Scope * {
-      if (op == nullptr || condition == nullptr)
-        return nullptr;
-      auto *trueScope = condition->getTrueScope();
-      if (trueScope == op || trueScope->isProperAncestor(op))
-        return trueScope;
-      if (condition->hasFalseScope()) {
-        auto *falseScope = condition->getFalseScope();
-        if (falseScope == op || falseScope->isProperAncestor(op))
-          return falseScope;
-      }
-      return nullptr;
-    };
-    auto requiredBranch = [&](ConflictPair *cp,
-                              Condition *condition) -> Scope * {
-      Scope *required = nullptr;
-      for (auto *op : {static_cast<OperationBase *>(cp->op1),
-                       static_cast<OperationBase *>(cp->op2)}) {
-        auto *branch = branchUnder(op, condition);
-        if (branch == nullptr)
-          continue;
-        if (required != nullptr && required != branch)
-          return nullptr;
-        required = branch;
-      }
-      return required;
-    };
-    auto collectParentConditions =
-        [](OperationBase *op, llvm::SmallVectorImpl<Condition *> &conditions) {
-          for (auto *parent = op ? op->parentOp : nullptr; parent != nullptr;
-               parent = parent->parentOp) {
-            if (auto *condition = dyn_cast<Condition>(parent))
-              conditions.push_back(condition);
-          }
-        };
-    auto mutuallyExclusive = [&]() {
-      llvm::SmallVector<Condition *> conditions;
-      collectParentConditions(conflictPair1->op1, conditions);
-      collectParentConditions(conflictPair1->op2, conditions);
-      collectParentConditions(conflictPair2->op1, conditions);
-      collectParentConditions(conflictPair2->op2, conditions);
-      llvm::sort(conditions);
-      conditions.erase(std::unique(conditions.begin(), conditions.end()),
-                       conditions.end());
-      for (auto *condition : conditions) {
-        auto *branch1 = requiredBranch(conflictPair1, condition);
-        auto *branch2 = requiredBranch(conflictPair2, condition);
-        if (branch1 != nullptr && branch2 != nullptr && branch1 != branch2)
-          return true;
-      }
-      return false;
-    };
-    if (mutuallyExclusive())
+    if (opsMutuallyExclusive(conflictPair1->op1, conflictPair1->op2,
+                             conflictPair2->op1, conflictPair2->op2))
       return false;
 
     // Two buf-id brackets must use different ids whenever they share any
@@ -2012,7 +2033,7 @@ void Solver::handleConflict(Occurrence *occ1, Occurrence *occ2,
                             EventIdInfo eventIdInfo, bool isUseless,
                             mlir::Value conflictBuffer) {
   if (!checkGraphConflict(occ1, occ2, corePipeSrc, corePipeDst, eventIdInfo,
-                          conflictBuffer)) {
+                          conflictBuffer, rwOp1, rwOp2)) {
     return;
   }
   LLVM_DEBUG({

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
@@ -778,6 +778,62 @@ bool Solver::checkIntersect(ConflictPair *conflictPair1,
     return checkSyncOpsConflicts(conflictPair1, conflictPair2);
   }
   if (options.isBufIdEmit()) {
+    auto branchUnder = [](OperationBase *op,
+                          Condition *condition) -> Scope * {
+      if (op == nullptr || condition == nullptr)
+        return nullptr;
+      auto *trueScope = condition->getTrueScope();
+      if (trueScope == op || trueScope->isProperAncestor(op))
+        return trueScope;
+      if (condition->hasFalseScope()) {
+        auto *falseScope = condition->getFalseScope();
+        if (falseScope == op || falseScope->isProperAncestor(op))
+          return falseScope;
+      }
+      return nullptr;
+    };
+    auto requiredBranch = [&](ConflictPair *cp,
+                              Condition *condition) -> Scope * {
+      Scope *required = nullptr;
+      for (auto *op : {static_cast<OperationBase *>(cp->op1),
+                       static_cast<OperationBase *>(cp->op2)}) {
+        auto *branch = branchUnder(op, condition);
+        if (branch == nullptr)
+          continue;
+        if (required != nullptr && required != branch)
+          return nullptr;
+        required = branch;
+      }
+      return required;
+    };
+    auto collectParentConditions =
+        [](OperationBase *op, llvm::SmallVectorImpl<Condition *> &conditions) {
+          for (auto *parent = op ? op->parentOp : nullptr; parent != nullptr;
+               parent = parent->parentOp) {
+            if (auto *condition = dyn_cast<Condition>(parent))
+              conditions.push_back(condition);
+          }
+        };
+    auto mutuallyExclusive = [&]() {
+      llvm::SmallVector<Condition *> conditions;
+      collectParentConditions(conflictPair1->op1, conditions);
+      collectParentConditions(conflictPair1->op2, conditions);
+      collectParentConditions(conflictPair2->op1, conditions);
+      collectParentConditions(conflictPair2->op2, conditions);
+      llvm::sort(conditions);
+      conditions.erase(std::unique(conditions.begin(), conditions.end()),
+                       conditions.end());
+      for (auto *condition : conditions) {
+        auto *branch1 = requiredBranch(conflictPair1, condition);
+        auto *branch2 = requiredBranch(conflictPair2, condition);
+        if (branch1 != nullptr && branch2 != nullptr && branch1 != branch2)
+          return true;
+      }
+      return false;
+    };
+    if (mutuallyExclusive())
+      return false;
+
     // Two buf-id brackets must use different ids whenever they share any
     // pipe — same-id same-pipe re-entry is illegal per the buf-id spec
     // constraint 1 ("两次连续 get(P,#id) 非法"). Unlike set-wait, having

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
@@ -2279,8 +2279,13 @@ SyncBeforeAfterMap Solver::getBeforeAfterSyncMaps() {
     for (auto *cp : conflictPairs) {
       if (cp->isUseless || cp->replacedWithUnitFlag || cp->isBarrier())
         continue;
-      AnchorEnd a{cp->setOp, cp->setCorePipeInfo.pipe};
-      AnchorEnd b{cp->waitOp, cp->waitCorePipeInfo.pipe};
+      // Key on the raw RWOperations (op1/op2), not the solver's hoisted
+      // setOp/waitOp, so that mirror pairs are recognized at the actual
+      // RWOperation level regardless of where the solver placed the anchor.
+      AnchorEnd a{static_cast<OperationBase *>(cp->op1),
+                  cp->setCorePipeInfo.pipe};
+      AnchorEnd b{static_cast<OperationBase *>(cp->op2),
+                  cp->waitCorePipeInfo.pipe};
       if (b < a)
         std::swap(a, b);
       AnchorKey key{a, b};
@@ -2355,9 +2360,19 @@ SyncBeforeAfterMap Solver::getBeforeAfterSyncMaps() {
       }
     }
 
+    // Use the RAW producer/consumer RWOperation anchors (op1, op2) rather
+    // than the solver's setOp/waitOp. The latter may have been hoisted to
+    // an LCA / PlaceHolder under the scope of the producer or consumer
+    // (correct for set/wait, which needs strict pairing along every CFG
+    // edge), but in buf-id mode we want brackets *tightly* around the
+    // actual RWOperation. Hoisting buf-id brackets above an scf.if would
+    // make the counter advance even when the conditional op doesn't run,
+    // which decouples the get_cnt/rel_cnt semantics from real pipe activity.
     auto anchorsOf = [](ConflictPair *cp) -> std::array<AnchorEnd, 2> {
-      return {{{cp->setOp, cp->setCorePipeInfo.pipe},
-               {cp->waitOp, cp->waitCorePipeInfo.pipe}}};
+      return {{{static_cast<OperationBase *>(cp->op1),
+                cp->setCorePipeInfo.pipe},
+               {static_cast<OperationBase *>(cp->op2),
+                cp->waitCorePipeInfo.pipe}}};
     };
 
     for (size_t i = 0; i < forwardPairs.size(); ++i) {
@@ -2440,8 +2455,13 @@ SyncBeforeAfterMap Solver::getBeforeAfterSyncMaps() {
       int64_t bufId = (gIt != groupId.end())
                           ? gIt->second
                           : cp->eventIdNode->getEventIds().front();
-      emitBracket({cp->setOp, cp->setCorePipeInfo.pipe}, bufId, cp);
-      emitBracket({cp->waitOp, cp->waitCorePipeInfo.pipe}, bufId, cp);
+      // Anchor at the raw RWOperations (see comment on anchorsOf).
+      emitBracket({static_cast<OperationBase *>(cp->op1),
+                   cp->setCorePipeInfo.pipe},
+                  bufId, cp);
+      emitBracket({static_cast<OperationBase *>(cp->op2),
+                   cp->waitCorePipeInfo.pipe},
+                  bufId, cp);
     }
 
     return std::make_pair(std::move(syncMapBefore), std::move(syncMapAfter));

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
@@ -253,8 +253,11 @@ bool Solver::checkMemInfoConflict(
 }
 
 // High-level wrapper computing pipe pairs that represent memory conflicts
-// between two RW ops.
-llvm::SmallVector<std::tuple<CorePipeInfo, CorePipeInfo>>
+// between two RW ops. Each returned tuple identifies the (src pipe, dst pipe,
+// underlying SSA buffer) triple for one conflict. Multiple buffers
+// conflicting at the same pipe-pair yield multiple entries so downstream
+// code (buf-id mode) can keep ConflictPairs distinguishable per buffer.
+llvm::SmallVector<std::tuple<CorePipeInfo, CorePipeInfo, mlir::Value>>
 Solver::checkMemoryConflicts(RWOperation *rwOp1, RWOperation *rwOp2) {
   assert(rwOp1 != nullptr && rwOp2 != nullptr);
   auto [it, isInserted] = checkMemoryConflictsMem.insert({{rwOp1, rwOp2}, {}});
@@ -273,23 +276,35 @@ Solver::checkMemoryConflicts(RWOperation *rwOp1, RWOperation *rwOp2) {
     assert(coreDst == pto::TCoreType::VECTOR ||
            coreDst == pto::TCoreType::CUBE);
   }
-  llvm::SetVector<std::tuple<CorePipeInfo, CorePipeInfo>> collectedConflictsSet;
-  if (checkMemInfoConflict(rwOp1, rwOp2, rwOp1->readMemInfo,
-                           rwOp2->writeMemInfo)) {
-    collectedConflictsSet.insert({CorePipeInfo(coreSrc, rwOp1->pipeRead),
-                                  CorePipeInfo(coreDst, rwOp2->pipeWrite)});
-  }
-  if (checkMemInfoConflict(rwOp1, rwOp2, rwOp1->writeMemInfo,
-                           rwOp2->readMemInfo)) {
-    collectedConflictsSet.insert({CorePipeInfo(coreSrc, rwOp1->pipeWrite),
-                                  CorePipeInfo(coreDst, rwOp2->pipeRead)});
-  }
-  if (checkMemInfoConflict(rwOp1, rwOp2, rwOp1->writeMemInfo,
-                           rwOp2->writeMemInfo)) {
-    collectedConflictsSet.insert({CorePipeInfo(coreSrc, rwOp1->pipeWrite),
-                                  CorePipeInfo(coreDst, rwOp2->pipeWrite)});
-  }
-  llvm::SmallVector<std::tuple<CorePipeInfo, CorePipeInfo>> collectedConflicts(
+  // Walk each pair of MemInfo entries and record per-buffer conflicts.
+  // Conflicts found between an entry pair share the producer-side MemInfo's
+  // SSA Value as the "buffer id" — both ops see the same memory through
+  // this value (or its alias). When that value is null the entry is still
+  // recorded with a null buffer (buffer-aware filters degrade to permissive
+  // behavior, which preserves the legacy set/wait emission).
+  using BufferConflict = std::tuple<CorePipeInfo, CorePipeInfo, mlir::Value>;
+  llvm::SetVector<BufferConflict> collectedConflictsSet;
+  auto collect = [&](const llvm::SmallVector<MemInfo> &lhs,
+                     const llvm::SmallVector<MemInfo> &rhs,
+                     CorePipeInfo srcInfo, CorePipeInfo dstInfo) {
+    for (auto &m1 : lhs) {
+      for (auto &m2 : rhs) {
+        if (!checkMemInfoConflict(rwOp1, rwOp2, m1, m2)) continue;
+        mlir::Value buffer = m1.value ? m1.value : m2.value;
+        collectedConflictsSet.insert({srcInfo, dstInfo, buffer});
+      }
+    }
+  };
+  collect(rwOp1->readMemInfo, rwOp2->writeMemInfo,
+          CorePipeInfo(coreSrc, rwOp1->pipeRead),
+          CorePipeInfo(coreDst, rwOp2->pipeWrite));
+  collect(rwOp1->writeMemInfo, rwOp2->readMemInfo,
+          CorePipeInfo(coreSrc, rwOp1->pipeWrite),
+          CorePipeInfo(coreDst, rwOp2->pipeRead));
+  collect(rwOp1->writeMemInfo, rwOp2->writeMemInfo,
+          CorePipeInfo(coreSrc, rwOp1->pipeWrite),
+          CorePipeInfo(coreDst, rwOp2->pipeWrite));
+  llvm::SmallVector<BufferConflict> collectedConflicts(
       collectedConflictsSet.begin(), collectedConflictsSet.end());
   return it->second = collectedConflicts;
 }
@@ -614,6 +629,7 @@ EventIdInfo Solver::getEventIdInfo(Occurrence *occ1, Occurrence *occ2,
 bool Solver::checkGraphConflict(
     Occurrence *occ1, Occurrence *occ2, CorePipeInfo corePipeSrc,
     CorePipeInfo corePipeDst, EventIdInfo eventIdInfo,
+    mlir::Value conflictBuffer,
     std::optional<int> startIndex, std::optional<int> endIndex,
     const llvm::SmallVector<ConflictPair *> &extraConflictPairs,
     const llvm::SmallVector<ConflictPair *> &ignoreConflictPairs) {
@@ -624,6 +640,13 @@ bool Solver::checkGraphConflict(
   if (!endIndex.has_value()) {
     endIndex = occ2->startIndex;
   }
+  // In buf-id mode, transitive coverage through existing pairs is only valid
+  // when those pairs operate on the SAME underlying buffer as the candidate
+  // (each buf-id is an independent scoreboard counter, so a same-pipe pair
+  // on a different buffer does not transitively sync the candidate's
+  // counter). Filter out cross-buffer existing pairs from the graph when
+  // both sides carry buffer info.
+  const bool bufferAware = options.isBufIdEmit() && conflictBuffer != nullptr;
   GraphSolver graphSolver(options);
   llvm::DenseSet<ConflictPair *> visited;
   auto handleConflictPair = [&](ConflictPair *conflictPair) {
@@ -643,6 +666,12 @@ bool Solver::checkGraphConflict(
     }
     if (llvm::find(ignoreConflictPairs, conflictPair) !=
         ignoreConflictPairs.end()) {
+      return;
+    }
+    if (bufferAware && conflictPair->conflictBuffer != nullptr &&
+        conflictPair->conflictBuffer != conflictBuffer) {
+      // Different-buffer existing pair: cannot transitively cover the
+      // candidate in buf-id semantics.
       return;
     }
     auto [it, isInserted] = visited.insert(conflictPair);
@@ -731,7 +760,8 @@ bool Solver::checkSyncOpsConflicts(ConflictPair *conflictPair1,
     assert(occ1 != nullptr && occ2 != nullptr);
     result = result ||
              checkGraphConflict(occ1, occ2, corePipeSrc, corePipeDst,
-                                conflictPair1->eventIdInfo, startIndex,
+                                conflictPair1->eventIdInfo,
+                                /*conflictBuffer=*/nullptr, startIndex,
                                 endIndex, {conflictPair1}, {conflictPair2});
     conflictPair1->startIndex -= 1;
   }
@@ -746,7 +776,8 @@ bool Solver::checkSyncOpsConflicts(ConflictPair *conflictPair1,
     assert(occ1 != nullptr && occ2 != nullptr);
     result = result ||
              checkGraphConflict(occ1, occ2, corePipeSrc, corePipeDst,
-                                conflictPair1->eventIdInfo, startIndex,
+                                conflictPair1->eventIdInfo,
+                                /*conflictBuffer=*/nullptr, startIndex,
                                 endIndex, {conflictPair1}, {conflictPair2});
     conflictPair2->endIndex += 1;
   }
@@ -1653,7 +1684,8 @@ bool Solver::checkReuseMultiBufferFlagId(ConflictPair *conflictPair) {
 void Solver::handleSetWaitConflict(Occurrence *occ1, Occurrence *occ2,
                                    CorePipeInfo corePipeSrc,
                                    CorePipeInfo corePipeDst,
-                                   EventIdInfo eventIdInfo, bool isUseless) {
+                                   EventIdInfo eventIdInfo, bool isUseless,
+                                   mlir::Value conflictBuffer) {
   assert(occ1 != nullptr && occ2 != nullptr);
   auto *rwOp1 = llvm::dyn_cast_if_present<RWOperation>(occ1->op);
   auto *rwOp2 = llvm::dyn_cast_if_present<RWOperation>(occ2->op);
@@ -1683,6 +1715,7 @@ void Solver::handleSetWaitConflict(Occurrence *occ1, Occurrence *occ2,
   conflictPair->isUseless = isUseless;
   conflictPair->isInnerBackward = isBackwardSync(setOcc, waitOcc);
   conflictPair->eventIdInfo = eventIdInfo;
+  conflictPair->conflictBuffer = conflictBuffer;
 
   if (conflictPair->isInnerBackward) {
     auto [parOcc1, parOcc2] = Occurrence::getLCAPair(occ1, occ2);
@@ -1881,7 +1914,8 @@ void Solver::handleSetWaitConflict(Occurrence *occ1, Occurrence *occ2,
 
 void Solver::handleBarrierConflict(Occurrence *occ1, Occurrence *occ2,
                                    CorePipeInfo corePipeSrc,
-                                   CorePipeInfo corePipeDst, bool isUseless) {
+                                   CorePipeInfo corePipeDst, bool isUseless,
+                                   mlir::Value conflictBuffer) {
   assert(occ1 != nullptr && occ2 != nullptr);
   auto *rwOp1 = llvm::dyn_cast_if_present<RWOperation>(occ1->op);
   auto *rwOp2 = llvm::dyn_cast_if_present<RWOperation>(occ2->op);
@@ -1903,6 +1937,7 @@ void Solver::handleBarrierConflict(Occurrence *occ1, Occurrence *occ2,
       rwOp1, rwOp2, waitOcc->op, waitOcc->op, waitOcc, waitOcc, corePipeSrc,
       corePipeDst, waitOcc->startIndex, waitOcc->startIndex);
   conflictPair->isUseless = isUseless;
+  conflictPair->conflictBuffer = conflictBuffer;
   assert(conflictPair->startIndex <= conflictPair->endIndex);
 
   LLVM_DEBUG({ llvm::dbgs() << conflictPair->str() << '\n'; });
@@ -1974,8 +2009,10 @@ void Solver::handleUnitFlagConflict(Occurrence *occ1, Occurrence *occ2,
 void Solver::handleConflict(Occurrence *occ1, Occurrence *occ2,
                             RWOperation *rwOp1, RWOperation *rwOp2,
                             CorePipeInfo corePipeSrc, CorePipeInfo corePipeDst,
-                            EventIdInfo eventIdInfo, bool isUseless) {
-  if (!checkGraphConflict(occ1, occ2, corePipeSrc, corePipeDst, eventIdInfo)) {
+                            EventIdInfo eventIdInfo, bool isUseless,
+                            mlir::Value conflictBuffer) {
+  if (!checkGraphConflict(occ1, occ2, corePipeSrc, corePipeDst, eventIdInfo,
+                          conflictBuffer)) {
     return;
   }
   LLVM_DEBUG({
@@ -1987,13 +2024,14 @@ void Solver::handleConflict(Occurrence *occ1, Occurrence *occ2,
                  << occ2->endIndex << ' ' << rwOp2->str(0, false) << '\n';
   });
   if (corePipeSrc == corePipeDst) {
-    handleBarrierConflict(occ1, occ2, corePipeSrc, corePipeDst, isUseless);
+    handleBarrierConflict(occ1, occ2, corePipeSrc, corePipeDst, isUseless,
+                          conflictBuffer);
   } else if (auto unitFlagInfo = checkUnitFlagPatterns(occ1, occ2)) {
     handleUnitFlagConflict(occ1, occ2, corePipeSrc, corePipeDst,
                            unitFlagInfo.value(), isUseless);
   } else {
     handleSetWaitConflict(occ1, occ2, corePipeSrc, corePipeDst, eventIdInfo,
-                          isUseless);
+                          isUseless, conflictBuffer);
   }
 }
 
@@ -2611,14 +2649,15 @@ SyncBeforeAfterMap Solver::getBeforeAfterSyncMaps() {
 void Solver::processConflict(Occurrence *occ1, Occurrence *occ2,
                              RWOperation *rwOp1, RWOperation *rwOp2,
                              bool isUseless) {
-  for (auto [corePipeSrc, corePipeDst] : checkMemoryConflicts(rwOp1, rwOp2)) {
+  for (auto [corePipeSrc, corePipeDst, conflictBuffer] :
+       checkMemoryConflicts(rwOp1, rwOp2)) {
     if (options.alwaysUsePipeSAsWaitingPipe) {
       corePipeDst.pipe = pto::PIPE::PIPE_S;
     }
     auto eventIdInfo =
         getEventIdInfo(occ1, occ2, rwOp1, rwOp2, corePipeSrc, corePipeDst);
     handleConflict(occ1, occ2, rwOp1, rwOp2, corePipeSrc, corePipeDst,
-                   eventIdInfo, isUseless);
+                   eventIdInfo, isUseless, conflictBuffer);
   }
 }
 

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
@@ -2303,6 +2303,18 @@ SyncBeforeAfterMap Solver::getBeforeAfterSyncMaps() {
     if (conflictPair->replacedWithUnitFlag) {
       continue;
     }
+    // buf-id mode: loop-carried (backward) ConflictPairs are entirely
+    // redundant. Unlike set/wait — where set on producer + wait on consumer
+    // is a one-shot signal that must be paired across the loop edge — the
+    // buf-id (get_cnt, rel_cnt) counters monotonically advance per anchor
+    // per iter, so iter i+1's get_buf on a shared id is automatically
+    // ordered after iter i's matching rls_buf. The forward brackets
+    // already in place handle backward semantics transitively; emitting an
+    // extra bracket pair for the backward edge just wastes an id and
+    // serializes more than the spec requires.
+    if (options.isBufIdEmit() && conflictPair->isInnerBackward) {
+      continue;
+    }
     if (bufIdRedundantMirror.contains(conflictPair)) {
       continue;
     }

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
@@ -2270,9 +2270,10 @@ SyncBeforeAfterMap Solver::getBeforeAfterSyncMaps() {
   //
   // We keep the lower-id ConflictPair (deterministic, and tends to keep
   // the forward pair which was usually allocated first).
+  using AnchorEnd = std::pair<OperationBase *, pto::PIPE>;
+
   llvm::DenseSet<ConflictPair *> bufIdRedundantMirror;
   if (options.isBufIdEmit()) {
-    using AnchorEnd = std::pair<OperationBase *, pto::PIPE>;
     using AnchorKey = std::pair<AnchorEnd, AnchorEnd>;
     llvm::DenseMap<AnchorKey, ConflictPair *> seen;
     for (auto *cp : conflictPairs) {
@@ -2296,6 +2297,157 @@ SyncBeforeAfterMap Solver::getBeforeAfterSyncMaps() {
     }
   }
 
+  // Buf-id emit takes a separate path: collect unique (anchor_op, pipe, bufId)
+  // brackets from the forward ConflictPair set with a buffer-aware id-grouping
+  // pre-pass, then emit one bracket per unique triple. See the long comment
+  // inside the if-block.
+  if (options.isBufIdEmit()) {
+    // === Buffer-aware id grouping ===
+    //
+    // Two ConflictPairs that synchronize on the same buffer must share a
+    // buf-id so that the (get_cnt, rel_cnt) chain in the forward bracket
+    // sequence transitively orders cross-iter conflicts (e.g. iter i+1's
+    // load after iter i's store) for free. Two pairs on different buffers
+    // can keep distinct ids for parallelism.
+    //
+    // ConflictPair doesn't carry buffer info directly. Proxy:
+    //   F1, F2 are on the same buffer chain iff
+    //     - they share an anchor (op, pipe), AND
+    //     - some backward ConflictPair B has F1's non-shared endpoint and
+    //       F2's non-shared endpoint as its two anchors.
+    // Rationale: same buffer means iter i's read on one endpoint conflicts
+    // with iter i+1's write on the other endpoint, which is exactly what
+    // the solver records as a backward edge between them.
+    //
+    // We union-find forward pairs by this relation, then each group gets a
+    // single shared bufId (the smallest among members' allocated ids).
+    // Backward pairs are never emitted — their semantic is folded into the
+    // forward chain through id sharing.
+
+    llvm::DenseMap<ConflictPair *, ConflictPair *> ufParent;
+    std::function<ConflictPair *(ConflictPair *)> ufFind =
+        [&](ConflictPair *x) -> ConflictPair * {
+      while (ufParent[x] != x) {
+        ufParent[x] = ufParent[ufParent[x]];
+        x = ufParent[x];
+      }
+      return x;
+    };
+    auto ufUnion = [&](ConflictPair *a, ConflictPair *b) {
+      auto *ra = ufFind(a);
+      auto *rb = ufFind(b);
+      if (ra != rb)
+        ufParent[ra] = rb;
+    };
+
+    llvm::SmallVector<ConflictPair *> forwardPairs;
+    llvm::SmallVector<ConflictPair *> backwardPairs;
+    for (auto *cp : conflictPairs) {
+      if (cp->isUseless || cp->replacedWithUnitFlag || cp->isBarrier())
+        continue;
+      if (bufIdRedundantMirror.contains(cp))
+        continue;
+      if (cp->isInnerBackward) {
+        backwardPairs.push_back(cp);
+      } else {
+        forwardPairs.push_back(cp);
+        ufParent[cp] = cp;
+      }
+    }
+
+    auto anchorsOf = [](ConflictPair *cp) -> std::array<AnchorEnd, 2> {
+      return {{{cp->setOp, cp->setCorePipeInfo.pipe},
+               {cp->waitOp, cp->waitCorePipeInfo.pipe}}};
+    };
+
+    for (size_t i = 0; i < forwardPairs.size(); ++i) {
+      for (size_t j = i + 1; j < forwardPairs.size(); ++j) {
+        auto *f1 = forwardPairs[i];
+        auto *f2 = forwardPairs[j];
+        auto a1 = anchorsOf(f1);
+        auto a2 = anchorsOf(f2);
+        bool bridged = false;
+        for (int k = 0; k < 2 && !bridged; ++k) {
+          for (int l = 0; l < 2 && !bridged; ++l) {
+            if (a1[k] != a2[l])
+              continue;
+            AnchorEnd ns1 = a1[1 - k];
+            AnchorEnd ns2 = a2[1 - l];
+            if (ns1 == ns2)
+              continue;
+            for (auto *b : backwardPairs) {
+              auto ab = anchorsOf(b);
+              bool hasNs1 = (ab[0] == ns1 || ab[1] == ns1);
+              bool hasNs2 = (ab[0] == ns2 || ab[1] == ns2);
+              if (hasNs1 && hasNs2) {
+                bridged = true;
+                break;
+              }
+            }
+          }
+        }
+        if (bridged)
+          ufUnion(f1, f2);
+      }
+    }
+
+    llvm::DenseMap<ConflictPair *, int64_t> groupId;
+    for (auto *f : forwardPairs) {
+      if (!f->eventIdNode || f->eventIdNode->getEventIds().empty())
+        continue;
+      int64_t myId = f->eventIdNode->getEventIds().front();
+      auto *root = ufFind(f);
+      auto it = groupId.find(root);
+      if (it == groupId.end() || myId < it->second)
+        groupId[root] = myId;
+    }
+
+    // === Emit unique (anchor_op, pipe, bufId) brackets from forward pairs ===
+    //
+    // Multiple ConflictPairs in the same group will contribute the same
+    // (op, pipe, groupId) on each shared anchor; emit each unique triple
+    // only once so that we don't violate spec constraint 1 (no two
+    // consecutive get_buf(pipe, #id) before a single op).
+    llvm::DenseSet<std::pair<AnchorEnd, int64_t>> emittedBefore;
+    llvm::DenseSet<std::pair<AnchorEnd, int64_t>> emittedAfter;
+    auto emitBracket = [&](AnchorEnd anchor, int64_t bufId,
+                           ConflictPair *debugCp) {
+      auto key = std::make_pair(anchor, bufId);
+      if (emittedBefore.insert(key).second) {
+        auto getBuf = std::make_unique<GetBufOp>(
+            anchor.first->op, anchor.first->parentOp, anchor.second, bufId);
+        LLVM_DEBUG(getBuf->debugId = debugCp->id);
+        syncMapBefore[anchor.first].push_back(std::move(getBuf));
+      }
+      if (emittedAfter.insert(key).second) {
+        auto rlsBuf = std::make_unique<RlsBufOp>(
+            anchor.first->op, anchor.first->parentOp, anchor.second, bufId);
+        LLVM_DEBUG(rlsBuf->debugId = debugCp->id);
+        syncMapAfter[anchor.first].push_back(std::move(rlsBuf));
+      }
+    };
+
+    for (auto *cp : conflictPairs) {
+      if (cp->isUseless || cp->replacedWithUnitFlag || cp->isBarrier())
+        continue;
+      if (cp->isInnerBackward)
+        continue;
+      if (bufIdRedundantMirror.contains(cp))
+        continue;
+      if (!cp->eventIdNode || cp->eventIdNode->getEventIds().empty())
+        continue;
+      auto gIt = groupId.find(ufFind(cp));
+      int64_t bufId = (gIt != groupId.end())
+                          ? gIt->second
+                          : cp->eventIdNode->getEventIds().front();
+      emitBracket({cp->setOp, cp->setCorePipeInfo.pipe}, bufId, cp);
+      emitBracket({cp->waitOp, cp->waitCorePipeInfo.pipe}, bufId, cp);
+    }
+
+    return std::make_pair(std::move(syncMapBefore), std::move(syncMapAfter));
+  }
+
+  // === set-wait path (unchanged) ===
   for (auto *conflictPair : conflictPairs) {
     if (conflictPair->isUseless) {
       continue;
@@ -2303,64 +2455,13 @@ SyncBeforeAfterMap Solver::getBeforeAfterSyncMaps() {
     if (conflictPair->replacedWithUnitFlag) {
       continue;
     }
-    // buf-id mode: loop-carried (backward) ConflictPairs are entirely
-    // redundant. Unlike set/wait — where set on producer + wait on consumer
-    // is a one-shot signal that must be paired across the loop edge — the
-    // buf-id (get_cnt, rel_cnt) counters monotonically advance per anchor
-    // per iter, so iter i+1's get_buf on a shared id is automatically
-    // ordered after iter i's matching rls_buf. The forward brackets
-    // already in place handle backward semantics transitively; emitting an
-    // extra bracket pair for the backward edge just wastes an id and
-    // serializes more than the spec requires.
-    if (options.isBufIdEmit() && conflictPair->isInnerBackward) {
-      continue;
-    }
-    if (bufIdRedundantMirror.contains(conflictPair)) {
-      continue;
-    }
     assert(conflictPair->setOp != nullptr && conflictPair->waitOp != nullptr);
     if (conflictPair->isBarrier()) {
-      // A5 hardware preserves same-pipe order, so buf-id mode drops barriers
-      // entirely. set-wait keeps the existing pto.barrier path.
-      if (options.isBufIdEmit()) {
-        continue;
-      }
       auto barrierOp = std::make_unique<BarrierOp>(
           conflictPair->waitOp->op, conflictPair->waitOp->parentOp,
           conflictPair->waitCorePipeInfo.pipe);
       LLVM_DEBUG(barrierOp->debugId = conflictPair->id);
       syncMapBefore[conflictPair->waitOp].push_back(std::move(barrierOp));
-    } else if (options.isBufIdEmit()) {
-      assert(conflictPair->eventIdNode != nullptr);
-      auto srcPipe = conflictPair->setCorePipeInfo.pipe;
-      auto dstPipe = conflictPair->waitCorePipeInfo.pipe;
-      // Producer-side bracket on src pipe, consumer-side bracket on dst pipe.
-      // The shared bufId between both brackets is what enforces ordering — the
-      // hw scoreboard serializes same-id get/rel across pipes.
-      for (int64_t bufId : conflictPair->eventIdNode->getEventIds()) {
-        auto getProd = std::make_unique<GetBufOp>(
-            conflictPair->setOp->op, conflictPair->setOp->parentOp, srcPipe,
-            bufId);
-        auto rlsProd = std::make_unique<RlsBufOp>(
-            conflictPair->setOp->op, conflictPair->setOp->parentOp, srcPipe,
-            bufId);
-        auto getCons = std::make_unique<GetBufOp>(
-            conflictPair->waitOp->op, conflictPair->waitOp->parentOp, dstPipe,
-            bufId);
-        auto rlsCons = std::make_unique<RlsBufOp>(
-            conflictPair->waitOp->op, conflictPair->waitOp->parentOp, dstPipe,
-            bufId);
-        LLVM_DEBUG({
-          getProd->debugId = conflictPair->id;
-          rlsProd->debugId = conflictPair->id;
-          getCons->debugId = conflictPair->id;
-          rlsCons->debugId = conflictPair->id;
-        });
-        syncMapBefore[conflictPair->setOp].push_back(std::move(getProd));
-        syncMapAfter[conflictPair->setOp].push_back(std::move(rlsProd));
-        syncMapBefore[conflictPair->waitOp].push_back(std::move(getCons));
-        syncMapAfter[conflictPair->waitOp].push_back(std::move(rlsCons));
-      }
     } else {
       assert(conflictPair->eventIdNode != nullptr);
       auto setOp = std::make_unique<SetFlagOp>(
@@ -2389,14 +2490,6 @@ SyncBeforeAfterMap Solver::getBeforeAfterSyncMaps() {
       syncMapAfter[conflictPair->setOp].push_back(std::move(setOp));
       syncMapBefore[conflictPair->waitOp].push_front(std::move(waitOp));
     }
-  }
-
-  // In buf-id mode the producer/consumer brackets sit at their natural
-  // anchors and the hw scoreboard counters handle loop-carried (backward)
-  // sync without any out-of-loop compensation. Skip the backward-sync hoist
-  // pipeline that exists to manage set/wait strict pairing.
-  if (options.isBufIdEmit()) {
-    return std::make_pair(std::move(syncMapBefore), std::move(syncMapAfter));
   }
 
   collectBackwardSyncEventIds();

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
@@ -777,6 +777,30 @@ bool Solver::checkIntersect(ConflictPair *conflictPair1,
   if (options.isCrossCoreMode()) {
     return checkSyncOpsConflicts(conflictPair1, conflictPair2);
   }
+  if (options.isBufIdEmit()) {
+    // Two buf-id brackets must use different ids whenever they share any
+    // pipe — same-id same-pipe re-entry is illegal per the buf-id spec
+    // constraint 1 ("两次连续 get(P,#id) 非法"). Unlike set-wait, having
+    // different dst pipes (or different src pipes) is NOT enough to share
+    // an id: e.g. (MTE2 -> V, id 0) and (V -> MTE3, id 0) both bracket the
+    // common V anchor with id 0, producing back-to-back `get_buf(V, #0)`
+    // before the V op, which the spec forbids. The range-based set-wait
+    // overlap check doesn't apply because buf-id brackets extend strictly
+    // around the anchor RWOperation (a single index), not across the
+    // [setOp.endIndex, waitOp.startIndex] gap.
+    auto pipes1 = std::array{conflictPair1->setCorePipeInfo.pipe,
+                             conflictPair1->waitCorePipeInfo.pipe};
+    auto pipes2 = std::array{conflictPair2->setCorePipeInfo.pipe,
+                             conflictPair2->waitCorePipeInfo.pipe};
+    for (auto p1 : pipes1) {
+      for (auto p2 : pipes2) {
+        if (p1 == p2) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
   if (conflictPair1->setCorePipeInfo != conflictPair2->setCorePipeInfo ||
       conflictPair1->waitCorePipeInfo != conflictPair2->waitCorePipeInfo) {
     return false;
@@ -1521,7 +1545,13 @@ bool Solver::reuseConflictPair(ConflictPair *conflictPair,
 
 std::unique_ptr<EventIdSolver> &
 Solver::getEventIdSolverRef(pto::PIPE pipeSrc, pto::PIPE pipeDst) {
-  if (options.isCrossCoreMode()) {
+  if (options.isCrossCoreMode() || options.isBufIdEmit()) {
+    // Cross-core mode shares one event-id pool across all pipe pairs.
+    // Buf-id mode does the same: get_buf/rls_buf don't carry the "other"
+    // pipe in the opcode, so the same numeric id on two different pipe-
+    // pairs would alias to the same hw scoreboard and the resulting
+    // bracketing pattern would violate constraint 1 of the buf-id spec
+    // (two consecutive get(pipe, #id) before a single op is illegal).
     pipeSrc = pto::PIPE::PIPE_UNASSIGNED;
     pipeDst = pto::PIPE::PIPE_UNASSIGNED;
   }
@@ -2224,6 +2254,48 @@ SyncBeforeAfterMap Solver::getBeforeAfterSyncMaps() {
     conflictPairs.push_back(conflictPair.get());
   }
 
+  // Buf-id mirror-image deduplication.
+  //
+  // The forward and backward memory hazards for the same (producer op,
+  // consumer op) pair across pipes generate two distinct ConflictPairs:
+  //   F: setOp=A@Pa, waitOp=B@Pb   (forward,  intra-iter)
+  //   B: setOp=B@Pb, waitOp=A@Pa   (backward, loop-carried)
+  // In set-wait this is necessary — F's pair fires within an iteration,
+  // B's pair fires across the loop boundary. In buf-id the two pairs would
+  // bracket the same (op, pipe) anchor set with two different ids,
+  // duplicating brackets needlessly: the scoreboard counter ordering
+  // produced by one bracket pair already enforces both deps (per doc
+  // §1.2's canonical "for { load; vector }" example). Drop one of the
+  // mirror images so we emit a single bracket pair per anchor set.
+  //
+  // We keep the lower-id ConflictPair (deterministic, and tends to keep
+  // the forward pair which was usually allocated first).
+  llvm::DenseSet<ConflictPair *> bufIdRedundantMirror;
+  if (options.isBufIdEmit()) {
+    using AnchorEnd = std::pair<OperationBase *, pto::PIPE>;
+    using AnchorKey = std::pair<AnchorEnd, AnchorEnd>;
+    llvm::DenseMap<AnchorKey, ConflictPair *> seen;
+    for (auto *cp : conflictPairs) {
+      if (cp->isUseless || cp->replacedWithUnitFlag || cp->isBarrier())
+        continue;
+      AnchorEnd a{cp->setOp, cp->setCorePipeInfo.pipe};
+      AnchorEnd b{cp->waitOp, cp->waitCorePipeInfo.pipe};
+      if (b < a)
+        std::swap(a, b);
+      AnchorKey key{a, b};
+      auto [it, inserted] = seen.try_emplace(key, cp);
+      if (!inserted) {
+        // Pick the smaller id as the keeper so output is stable.
+        if (cp->id < it->second->id) {
+          bufIdRedundantMirror.insert(it->second);
+          it->second = cp;
+        } else {
+          bufIdRedundantMirror.insert(cp);
+        }
+      }
+    }
+  }
+
   for (auto *conflictPair : conflictPairs) {
     if (conflictPair->isUseless) {
       continue;
@@ -2231,13 +2303,52 @@ SyncBeforeAfterMap Solver::getBeforeAfterSyncMaps() {
     if (conflictPair->replacedWithUnitFlag) {
       continue;
     }
+    if (bufIdRedundantMirror.contains(conflictPair)) {
+      continue;
+    }
     assert(conflictPair->setOp != nullptr && conflictPair->waitOp != nullptr);
     if (conflictPair->isBarrier()) {
+      // A5 hardware preserves same-pipe order, so buf-id mode drops barriers
+      // entirely. set-wait keeps the existing pto.barrier path.
+      if (options.isBufIdEmit()) {
+        continue;
+      }
       auto barrierOp = std::make_unique<BarrierOp>(
           conflictPair->waitOp->op, conflictPair->waitOp->parentOp,
           conflictPair->waitCorePipeInfo.pipe);
       LLVM_DEBUG(barrierOp->debugId = conflictPair->id);
       syncMapBefore[conflictPair->waitOp].push_back(std::move(barrierOp));
+    } else if (options.isBufIdEmit()) {
+      assert(conflictPair->eventIdNode != nullptr);
+      auto srcPipe = conflictPair->setCorePipeInfo.pipe;
+      auto dstPipe = conflictPair->waitCorePipeInfo.pipe;
+      // Producer-side bracket on src pipe, consumer-side bracket on dst pipe.
+      // The shared bufId between both brackets is what enforces ordering — the
+      // hw scoreboard serializes same-id get/rel across pipes.
+      for (int64_t bufId : conflictPair->eventIdNode->getEventIds()) {
+        auto getProd = std::make_unique<GetBufOp>(
+            conflictPair->setOp->op, conflictPair->setOp->parentOp, srcPipe,
+            bufId);
+        auto rlsProd = std::make_unique<RlsBufOp>(
+            conflictPair->setOp->op, conflictPair->setOp->parentOp, srcPipe,
+            bufId);
+        auto getCons = std::make_unique<GetBufOp>(
+            conflictPair->waitOp->op, conflictPair->waitOp->parentOp, dstPipe,
+            bufId);
+        auto rlsCons = std::make_unique<RlsBufOp>(
+            conflictPair->waitOp->op, conflictPair->waitOp->parentOp, dstPipe,
+            bufId);
+        LLVM_DEBUG({
+          getProd->debugId = conflictPair->id;
+          rlsProd->debugId = conflictPair->id;
+          getCons->debugId = conflictPair->id;
+          rlsCons->debugId = conflictPair->id;
+        });
+        syncMapBefore[conflictPair->setOp].push_back(std::move(getProd));
+        syncMapAfter[conflictPair->setOp].push_back(std::move(rlsProd));
+        syncMapBefore[conflictPair->waitOp].push_back(std::move(getCons));
+        syncMapAfter[conflictPair->waitOp].push_back(std::move(rlsCons));
+      }
     } else {
       assert(conflictPair->eventIdNode != nullptr);
       auto setOp = std::make_unique<SetFlagOp>(
@@ -2266,6 +2377,14 @@ SyncBeforeAfterMap Solver::getBeforeAfterSyncMaps() {
       syncMapAfter[conflictPair->setOp].push_back(std::move(setOp));
       syncMapBefore[conflictPair->waitOp].push_front(std::move(waitOp));
     }
+  }
+
+  // In buf-id mode the producer/consumer brackets sit at their natural
+  // anchors and the hw scoreboard counters handle loop-carried (backward)
+  // sync without any out-of-loop compensation. Skip the backward-sync hoist
+  // pipeline that exists to manage set/wait strict pairing.
+  if (options.isBufIdEmit()) {
+    return std::make_pair(std::move(syncMapBefore), std::move(syncMapAfter));
   }
 
   collectBackwardSyncEventIds();

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolverCodeGen.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolverCodeGen.cpp
@@ -12,6 +12,7 @@
 #include "PTO/Transforms/GraphSyncSolver/SyncSolverCodeGen.h"
 
 #include "PTO/IR/PTO.h"
+#include "PTO/IR/PTOSyncUtils.h"
 #include "mlir/IR/Builders.h"
 #include "llvm/Support/Casting.h"
 
@@ -25,6 +26,18 @@ static PipeAttr makePipe(MLIRContext *ctx, PIPE pipe) {
 
 static EventAttr makeEvent(MLIRContext *ctx, int64_t eventId) {
   return EventAttr::get(ctx, static_cast<EVENT>(eventId));
+}
+
+// pto.get_buf / pto.rls_buf take a high-level PipeEventTypeAttr endpoint
+// rather than a concrete PipeAttr. The downstream EmitC pattern only cares
+// that the attribute maps back to the same concrete PIPE via
+// mapSyncOpTypeToPipe; the inverse mapping picks a canonical SyncOpType per
+// PIPE (see PTOSyncUtils.cpp).
+static PipeEventTypeAttr makePipeEventType(MLIRContext *ctx, PIPE pipe) {
+  auto opTypeOr = mapPipeToCanonicalSyncOpType(pipe);
+  assert(llvm::succeeded(opTypeOr) &&
+         "buf-id codegen: pipe has no canonical SyncOpType endpoint");
+  return PipeEventTypeAttr::get(ctx, *opTypeOr);
 }
 
 Operation *CodeGenerator::resolveSyncAnchor(OperationBase *opBase) {
@@ -99,6 +112,23 @@ void CodeGenerator::emitSyncOp(IRRewriter &rewriter, SyncOp *syncOp) {
     rewriter.create<pto::BarrierOp>(resolveSyncLoc(barrier),
                                     makePipe(rewriter.getContext(),
                                              barrier->pipe));
+    return;
+  }
+
+  if (auto *getBuf = dyn_cast<GetBufOp>(syncOp)) {
+    auto *ctx = rewriter.getContext();
+    rewriter.create<pto::GetBufOp>(
+        resolveSyncLoc(getBuf), makePipeEventType(ctx, getBuf->pipe),
+        rewriter.getI32IntegerAttr(static_cast<int32_t>(getBuf->bufId)),
+        rewriter.getI32IntegerAttr(0));
+    return;
+  }
+  if (auto *rlsBuf = dyn_cast<RlsBufOp>(syncOp)) {
+    auto *ctx = rewriter.getContext();
+    rewriter.create<pto::RlsBufOp>(
+        resolveSyncLoc(rlsBuf), makePipeEventType(ctx, rlsBuf->pipe),
+        rewriter.getI32IntegerAttr(static_cast<int32_t>(rlsBuf->bufId)),
+        rewriter.getI32IntegerAttr(0));
     return;
   }
 

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolverIR.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolverIR.cpp
@@ -51,6 +51,8 @@ std::string getOpTypeStr(OpType opType) {
       {OpType::BARRIER_OP, "BarrierOp"},
       {OpType::SET_FLAG_OP, "SetFlagOp"},
       {OpType::WAIT_FLAG_OP, "WaitFlagOp"},
+      {OpType::GET_BUF_OP, "GetBufOp"},
+      {OpType::RLS_BUF_OP, "RlsBufOp"},
       {OpType::RW_OPERATION, "RWOperation"},
       {OpType::MMAD_OPERATION, "MmadOp"},
       {OpType::MMAD_LOAD_L0A_OPERATION, "LoadMmadL0AOp"},
@@ -314,6 +316,27 @@ std::string BarrierOp::str(int indent, bool recursive) const {
   }
   ret += " [<" + stringifyPIPE(this->pipe).str() + ">]";
   return ret;
+}
+
+static std::string bufOpStr(const BufOp &op, int indent) {
+  std::string ret;
+  ret += std::string(indent, ' ') +
+         llvm::convertToCamelFromSnakeCase(getOpTypeStr(op.opType)) +
+         std::to_string(op.id);
+  if (op.debugId.has_value()) {
+    ret += " [" + std::to_string(op.debugId.value()) + "]";
+  }
+  ret += " [<" + stringifyPIPE(op.pipe).str() +
+         ">, BUF_ID" + llvm::itostr(op.bufId) + "]";
+  return ret;
+}
+
+std::string GetBufOp::str(int indent, bool /*recursive*/) const {
+  return bufOpStr(*this, indent);
+}
+
+std::string RlsBufOp::str(int indent, bool /*recursive*/) const {
+  return bufOpStr(*this, indent);
 }
 
 std::string ConflictPair::str() const {

--- a/test/lit/pto/graph_sync_solver_buf_id_arch_guard.pto
+++ b/test/lit/pto/graph_sync_solver_buf_id_arch_guard.pto
@@ -1,0 +1,44 @@
+// RUN: not ptoas --pto-level=level3 --pto-arch a3 --enable-graph-sync-solver --graph-sync-solver-sync-style=buf-id --emit-pto-ir %s 2>&1 | FileCheck %s
+
+// pto.get_buf / pto.rls_buf are A5-only. The graph sync solver should reject
+// '--graph-sync-solver-sync-style=buf-id' on A3.
+
+// CHECK: --graph-sync-solver-sync-style=buf-id requires --pto-arch=a5
+
+module {
+  func.func @needs_a5(%arg0: !pto.ptr<f32>,
+                      %arg1: index, %arg2: index, %arg3: index,
+                      %arg4: index, %arg5: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c1024 = arith.constant 1024 : index
+    %c1048576 = arith.constant 1048576 : index
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 2.000000e+00 : f32
+
+    %src_view = pto.make_tensor_view %arg0,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+    %src_part = pto.partition_view %src_view,
+            offsets = [%c0, %c0, %c0, %c0, %c0],
+            sizes = [%arg1, %arg2, %arg3, %arg4, %arg5]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+              -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+    %tmp0 = arith.muli %arg1, %arg2 : index
+    %tmp1 = arith.muli %tmp0, %arg3 : index
+    %tmp2 = arith.muli %tmp1, %arg4 : index
+
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %tmp2 valid_col = %arg5
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tmuls ins(%tile, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/lit/pto/graph_sync_solver_buf_id_backward.pto
+++ b/test/lit/pto/graph_sync_solver_buf_id_backward.pto
@@ -27,17 +27,19 @@ module {
 
 // CHECK-LABEL: func.func @backward_loop
 // CHECK: pto.bind_tile
-// Nothing buf-id-ish between the tile alloc and the loop entry (form-2
-// out-of-loop compensation in set/wait would land here):
+// Nothing buf-id-ish between the tile alloc and the loop entry (set/wait
+// form-2 out-of-loop compensation would land here):
 // CHECK-NOT: pto.get_buf
 // CHECK-NOT: pto.rls_buf
 // CHECK-NOT: pto.set_flag
 // CHECK-NOT: pto.wait_flag
 //
 // CHECK: scf.for
-// Forward + backward brackets in the body — exact id assignment is
-// solver-internal, just check that both producer (TLOAD/TVEC) and consumer
-// (TVEC/TSTORE_VEC) brackets appear.
+// Only forward brackets in the body. The MTE3<-MTE2 backward dep
+// (tstore[i] -> tload[i+1]) is intentionally NOT bracketed — the
+// (get_cnt, rel_cnt) counters of the forward chain transitively serialize
+// iter i+1 after iter i, so an extra bracket would be redundant
+// (vs set/wait where the explicit pairing across the loop edge is mandatory).
 // CHECK: pto.get_buf[#pto.pipe_event_type<TLOAD>
 // CHECK: pto.tload
 // CHECK: pto.rls_buf[#pto.pipe_event_type<TLOAD>
@@ -49,8 +51,7 @@ module {
 // CHECK: pto.rls_buf[#pto.pipe_event_type<TSTORE_VEC>
 // No form-1 isFirstIter / isLastIter guarding the buf-id ops:
 // CHECK-NOT: scf.if
-// End of loop. No out-of-loop compensation (form-2 in set/wait would emit
-// extra set_flag/wait_flag or get_buf/rls_buf here).
+// End of loop. No out-of-loop compensation:
 // CHECK: }
 // CHECK-NOT: pto.get_buf
 // CHECK-NOT: pto.rls_buf

--- a/test/lit/pto/graph_sync_solver_buf_id_backward.pto
+++ b/test/lit/pto/graph_sync_solver_buf_id_backward.pto
@@ -35,20 +35,22 @@ module {
 // CHECK-NOT: pto.wait_flag
 //
 // CHECK: scf.for
-// Only forward brackets in the body. The MTE3<-MTE2 backward dep
-// (tstore[i] -> tload[i+1]) is intentionally NOT bracketed — the
-// (get_cnt, rel_cnt) counters of the forward chain transitively serialize
-// iter i+1 after iter i, so an extra bracket would be redundant
-// (vs set/wait where the explicit pairing across the loop edge is mandatory).
-// CHECK: pto.get_buf[#pto.pipe_event_type<TLOAD>
-// CHECK: pto.tload
-// CHECK: pto.rls_buf[#pto.pipe_event_type<TLOAD>
-// CHECK: pto.get_buf[#pto.pipe_event_type<TVEC>
-// CHECK: pto.tmuls
-// CHECK: pto.rls_buf[#pto.pipe_event_type<TVEC>
-// CHECK: pto.get_buf[#pto.pipe_event_type<TSTORE_VEC>
-// CHECK: pto.tstore
-// CHECK: pto.rls_buf[#pto.pipe_event_type<TSTORE_VEC>
+// All three anchors share a single tile buffer, so buffer-aware id grouping
+// puts F1 (tload->tmuls) and F2 (tmuls->tstore) into the same id group
+// (bridged by the backward dep tstore[i]->tload[i+1] on the tile). Each
+// anchor gets exactly ONE bracket pair using the shared id; the counter
+// chain monotonically serializes iter i+1's tload after iter i's tstore
+// for free.
+//
+// CHECK: pto.get_buf[#pto.pipe_event_type<TLOAD>, [[ID:[0-9]+]]]
+// CHECK-NEXT: pto.tload
+// CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TLOAD>, [[ID]]]
+// CHECK-NEXT: pto.get_buf[#pto.pipe_event_type<TVEC>, [[ID]]]
+// CHECK-NEXT: pto.tmuls
+// CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TVEC>, [[ID]]]
+// CHECK: pto.get_buf[#pto.pipe_event_type<TSTORE_VEC>, [[ID]]]
+// CHECK-NEXT: pto.tstore
+// CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TSTORE_VEC>, [[ID]]]
 // No form-1 isFirstIter / isLastIter guarding the buf-id ops:
 // CHECK-NOT: scf.if
 // End of loop. No out-of-loop compensation:

--- a/test/lit/pto/graph_sync_solver_buf_id_backward.pto
+++ b/test/lit/pto/graph_sync_solver_buf_id_backward.pto
@@ -1,0 +1,117 @@
+// RUN: ptoas --pto-level=level3 --pto-arch a5 --enable-graph-sync-solver --graph-sync-solver-sync-style=buf-id --graph-sync-solver-event-id-max=8 --emit-pto-ir %s | FileCheck %s
+
+// Loop-carried (backward) dependency under buf-id emission.
+//
+// The kernel allocates ONE shared tile outside the loop, then per iteration
+// runs tload -> tmuls -> tstore on it. That creates both:
+//   * forward deps within iter i: tload -> tmuls (MTE2->V), tmuls -> tstore (V->MTE3)
+//   * backward deps across iters i -> i+1:
+//       tstore[i] reads tile; tload[i+1] writes tile  (WAR, MTE3->MTE2)
+//       tmuls[i]  uses  tile; tload[i+1] writes tile  (WAR, V->MTE2)
+//
+// In set-wait mode the solver would either guard the cross-iter set/wait with
+// `if i>0` (form 1) or hoist a compensation set/wait outside the loop (form 2)
+// to keep the pairing exact across the loop boundary.
+//
+// In buf-id mode the hw (get_cnt, rel_cnt) counters handle cross-iter ordering
+// naturally — every iteration just brackets its own pipe ops in place, and
+// the counter monotonicity serializes iter i+1's bracket after iter i's. The
+// expected output is therefore:
+//   * pto.get_buf / pto.rls_buf only inside the scf.for body
+//   * no pto.set_flag / pto.wait_flag / pto.barrier anywhere
+//   * no scf.if isFirstIter / isLastIter guards introduced by the solver
+//   * no buf-id ops emitted *before* or *after* the scf.for (i.e. no form-2
+//     style out-of-loop compensation)
+
+module {
+
+// CHECK-LABEL: func.func @backward_loop
+// CHECK: pto.bind_tile
+// Nothing buf-id-ish between the tile alloc and the loop entry (form-2
+// out-of-loop compensation in set/wait would land here):
+// CHECK-NOT: pto.get_buf
+// CHECK-NOT: pto.rls_buf
+// CHECK-NOT: pto.set_flag
+// CHECK-NOT: pto.wait_flag
+//
+// CHECK: scf.for
+// Forward + backward brackets in the body — exact id assignment is
+// solver-internal, just check that both producer (TLOAD/TVEC) and consumer
+// (TVEC/TSTORE_VEC) brackets appear.
+// CHECK: pto.get_buf[#pto.pipe_event_type<TLOAD>
+// CHECK: pto.tload
+// CHECK: pto.rls_buf[#pto.pipe_event_type<TLOAD>
+// CHECK: pto.get_buf[#pto.pipe_event_type<TVEC>
+// CHECK: pto.tmuls
+// CHECK: pto.rls_buf[#pto.pipe_event_type<TVEC>
+// CHECK: pto.get_buf[#pto.pipe_event_type<TSTORE_VEC>
+// CHECK: pto.tstore
+// CHECK: pto.rls_buf[#pto.pipe_event_type<TSTORE_VEC>
+// No form-1 isFirstIter / isLastIter guarding the buf-id ops:
+// CHECK-NOT: scf.if
+// End of loop. No out-of-loop compensation (form-2 in set/wait would emit
+// extra set_flag/wait_flag or get_buf/rls_buf here).
+// CHECK: }
+// CHECK-NOT: pto.get_buf
+// CHECK-NOT: pto.rls_buf
+// CHECK-NOT: pto.set_flag
+// CHECK-NOT: pto.wait_flag
+// CHECK-NOT: pto.barrier
+// CHECK: return
+
+  func.func @backward_loop(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>,
+                           %arg_iters: index,
+                           %arg2: index, %arg3: index, %arg4: index,
+                           %arg5: index, %arg6: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c1024 = arith.constant 1024 : index
+    %c1048576 = arith.constant 1048576 : index
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 2.000000e+00 : f32
+
+    %src_view = pto.make_tensor_view %arg0,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+    %dst_view = pto.make_tensor_view %arg1,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+
+    %tmp0 = arith.muli %arg2, %arg3 : index
+    %tmp1 = arith.muli %tmp0, %arg4 : index
+    %tmp2 = arith.muli %tmp1, %arg5 : index
+
+    // One tile shared across all iterations -> backward deps on subsequent
+    // iters' tload.
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %tmp2 valid_col = %arg6
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    scf.for %i = %c0 to %arg_iters step %c1 {
+      %src_part = pto.partition_view %src_view,
+              offsets = [%c0, %c0, %i, %c0, %c0],
+              sizes = [%arg2, %arg3, %arg4, %arg5, %arg6]
+              : !pto.tensor_view<1x1x16x1024x1024xf32>
+                -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+      pto.tload ins(%src_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+      pto.tmuls ins(%tile, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+      %dst_part = pto.partition_view %dst_view,
+              offsets = [%c0, %c0, %i, %c0, %c0],
+              sizes = [%arg2, %arg3, %arg4, %arg5, %arg6]
+              : !pto.tensor_view<1x1x16x1024x1024xf32>
+                -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+      pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+    }
+    return
+  }
+
+}

--- a/test/lit/pto/graph_sync_solver_buf_id_basic.pto
+++ b/test/lit/pto/graph_sync_solver_buf_id_basic.pto
@@ -1,0 +1,156 @@
+// RUN: ptoas --pto-level=level3 --pto-arch a5 --enable-graph-sync-solver --graph-sync-solver-sync-style=buf-id --graph-sync-solver-event-id-max=8 --emit-pto-ir %s | FileCheck %s
+
+// Buffer-ID (A5) emission style for the graph sync solver. Three minimal
+// regressions mirroring graph_sync_solver_basic.pto but checking the
+// pto.get_buf / pto.rls_buf bracket form instead of pto.set_flag/pto.wait_flag.
+//
+// In buf-id mode:
+//  * Forward dep across pipes -> a paired get_buf/rls_buf bracket on each side
+//    (producer pipe and consumer pipe) sharing the same buf id.
+//  * Same-pipe dep -> nothing emitted (A5 hardware preserves same-pipe order).
+//  * No pto.set_flag / pto.wait_flag / pto.barrier should appear.
+
+module {
+
+// ----------------------------------------------------------------------------
+// Case 1: Linear MTE2 -> V -> MTE3 chain.
+//
+// Expectation: two cross-pipe deps surface (load->vop, vop->store). The
+// MTE2->MTE3 transitive edge is pruned the same way set-wait mode prunes it.
+// Each remaining dep becomes a get_buf/rls_buf bracket around the producer
+// and consumer anchors, with a shared buf id.
+// ----------------------------------------------------------------------------
+
+  // tmuls is bracketed twice on PIPE_V: once as the consumer of the tload->tmuls
+  // dep, once as the producer of the tmuls->tstore dep. The two ids MUST be
+  // distinct — buf-id constraint 1 forbids two consecutive get(P,#id) on the
+  // same pipe with the same id before a single op. The FileCheck variable
+  // ID1 binds the first TVEC get_buf's id; the second TVEC get_buf before
+  // tmuls is then asserted to NOT carry the same id.
+  //
+  // CHECK-LABEL: func.func @linear_chain
+  // CHECK: pto.get_buf[#pto.pipe_event_type<TLOAD>
+  // CHECK: pto.tload
+  // CHECK: pto.rls_buf[#pto.pipe_event_type<TLOAD>
+  // CHECK: pto.get_buf[#pto.pipe_event_type<TVEC>, [[ID1:[0-9]+]]]
+  // CHECK-NOT: pto.get_buf[#pto.pipe_event_type<TVEC>, [[ID1]]]
+  // CHECK: pto.tmuls
+  // CHECK: pto.rls_buf[#pto.pipe_event_type<TVEC>
+  // CHECK: pto.get_buf[#pto.pipe_event_type<TSTORE_VEC>
+  // CHECK: pto.tstore
+  // CHECK: pto.rls_buf[#pto.pipe_event_type<TSTORE_VEC>
+  // CHECK-NOT: pto.set_flag
+  // CHECK-NOT: pto.wait_flag
+  // CHECK-NOT: pto.barrier
+
+  func.func @linear_chain(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>,
+                          %arg2: index, %arg3: index, %arg4: index,
+                          %arg5: index, %arg6: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c1024 = arith.constant 1024 : index
+    %c1048576 = arith.constant 1048576 : index
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 2.000000e+00 : f32
+
+    %src_view = pto.make_tensor_view %arg0,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+    %src_part = pto.partition_view %src_view,
+            offsets = [%c0, %c0, %c0, %c0, %c0],
+            sizes = [%arg2, %arg3, %arg4, %arg5, %arg6]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+              -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+    %tmp0 = arith.muli %arg2, %arg3 : index
+    %tmp1 = arith.muli %tmp0, %arg4 : index
+    %tmp2 = arith.muli %tmp1, %arg5 : index
+
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %tmp2 valid_col = %arg6
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tmuls ins(%tile, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %dst_view = pto.make_tensor_view %arg1,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+    %dst_part = pto.partition_view %dst_view,
+            offsets = [%c0, %c0, %c0, %c0, %c0],
+            sizes = [%arg2, %arg3, %arg4, %arg5, %arg6]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+              -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+            outs(%dst_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+    return
+  }
+
+// ----------------------------------------------------------------------------
+// Case 2: Two consecutive vector ops writing/reading the same tile.
+//
+// Producer and consumer are both PIPE_V. set-wait mode emits no barrier here
+// because A5 register-based arch drops PIPE_V barriers; buf-id mode similarly
+// emits nothing — A5 hw preserves same-pipe order. The tload->tmuls cross-pipe
+// dep is still bracketed.
+// ----------------------------------------------------------------------------
+
+  // CHECK-LABEL: func.func @same_pipe_no_emit
+  // CHECK: pto.get_buf[#pto.pipe_event_type<TLOAD>
+  // CHECK: pto.tload
+  // CHECK: pto.rls_buf[#pto.pipe_event_type<TLOAD>
+  // CHECK: pto.get_buf[#pto.pipe_event_type<TVEC>
+  // CHECK: pto.tmuls
+  // CHECK: pto.rls_buf[#pto.pipe_event_type<TVEC>
+  // CHECK-NOT: pto.barrier
+  // CHECK-NOT: pto.get_buf
+  // CHECK: pto.tmuls
+
+  func.func @same_pipe_no_emit(%arg0: !pto.ptr<f32>,
+                               %arg1: index, %arg2: index, %arg3: index,
+                               %arg4: index, %arg5: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c1024 = arith.constant 1024 : index
+    %c1048576 = arith.constant 1048576 : index
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 2.000000e+00 : f32
+    %cst2 = arith.constant 3.000000e+00 : f32
+
+    %src_view = pto.make_tensor_view %arg0,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+    %src_part = pto.partition_view %src_view,
+            offsets = [%c0, %c0, %c0, %c0, %c0],
+            sizes = [%arg1, %arg2, %arg3, %arg4, %arg5]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+              -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+    %tmp0 = arith.muli %arg1, %arg2 : index
+    %tmp1 = arith.muli %tmp0, %arg3 : index
+    %tmp2 = arith.muli %tmp1, %arg4 : index
+
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %tmp2 valid_col = %arg5
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tmuls ins(%tile, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tmuls ins(%tile, %cst2 : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    return
+  }
+
+}

--- a/test/lit/pto/graph_sync_solver_buf_id_canonical_loop.pto
+++ b/test/lit/pto/graph_sync_solver_buf_id_canonical_loop.pto
@@ -1,0 +1,97 @@
+// RUN: ptoas --pto-level=level3 --pto-arch a5 --enable-graph-sync-solver --graph-sync-solver-sync-style=buf-id --graph-sync-solver-event-id-max=8 --emit-pto-ir %s | FileCheck %s
+
+// Canonical buf-id loop pattern from doc §1.2:
+//
+//   for i = 0:N
+//     load()      // MTE2
+//     Vector()    // V
+//
+// Two cross-iter dependencies on the shared tile:
+//   F: tload[i]  -> tmuls[i]    (forward,  RAW on tile, MTE2 -> V)
+//   B: tmuls[i]  -> tload[i+1]  (backward, WAW on tile, V    -> MTE2)
+//
+// Doc form uses ONE id (the same scoreboard counter naturally enforces
+// MTE2 -> V -> MTE2 -> V -> ... ordering). Our solver allocates F and B
+// as two ConflictPairs and assigns them distinct ids — that's correct but
+// uses two ids instead of one. Both forms satisfy the buf-id spec; the
+// single-id form is a future merge optimization, not required for
+// correctness.
+
+module {
+
+// CHECK-LABEL: func.func @canonical_loop
+// CHECK: pto.bind_tile
+//
+// Loop entry: no buf-id / set-wait / barrier ops between the alloc and
+// scf.for (no out-of-loop compensation needed in buf-id mode):
+// CHECK-NOT: pto.get_buf
+// CHECK-NOT: pto.rls_buf
+// CHECK-NOT: pto.set_flag
+// CHECK-NOT: pto.wait_flag
+//
+// CHECK: scf.for
+//
+// MTE2 bracket(s) wrapping tload, then V bracket(s) wrapping tmuls.
+// Both ids on PIPE_V around tmuls MUST be different (constraint 1):
+// CHECK: pto.get_buf[#pto.pipe_event_type<TLOAD>
+// CHECK: pto.tload
+// CHECK: pto.rls_buf[#pto.pipe_event_type<TLOAD>
+// CHECK: pto.get_buf[#pto.pipe_event_type<TVEC>, [[VID1:[0-9]+]]]
+// CHECK-NOT: pto.get_buf[#pto.pipe_event_type<TVEC>, [[VID1]]]
+// CHECK: pto.tmuls
+// CHECK: pto.rls_buf[#pto.pipe_event_type<TVEC>
+//
+// No isFirstIter / isLastIter guarding the buf-id ops (form-1 set/wait style):
+// CHECK-NOT: scf.if
+//
+// End of loop. No out-of-loop compensation (form-2 set/wait style):
+// CHECK: }
+// CHECK-NOT: pto.get_buf
+// CHECK-NOT: pto.rls_buf
+// CHECK-NOT: pto.set_flag
+// CHECK-NOT: pto.wait_flag
+// CHECK-NOT: pto.barrier
+// CHECK: return
+
+  func.func @canonical_loop(%arg0: !pto.ptr<f32>,
+                            %arg_iters: index,
+                            %arg2: index, %arg3: index, %arg4: index,
+                            %arg5: index, %arg6: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c1024 = arith.constant 1024 : index
+    %c1048576 = arith.constant 1048576 : index
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 2.000000e+00 : f32
+
+    %src_view = pto.make_tensor_view %arg0,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+
+    %tmp0 = arith.muli %arg2, %arg3 : index
+    %tmp1 = arith.muli %tmp0, %arg4 : index
+    %tmp2 = arith.muli %tmp1, %arg5 : index
+
+    // Single shared tile -> backward WAW dep across iters.
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %tmp2 valid_col = %arg6
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    scf.for %i = %c0 to %arg_iters step %c1 {
+      %src_part = pto.partition_view %src_view,
+              offsets = [%c0, %c0, %i, %c0, %c0],
+              sizes = [%arg2, %arg3, %arg4, %arg5, %arg6]
+              : !pto.tensor_view<1x1x16x1024x1024xf32>
+                -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+      pto.tload ins(%src_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+      pto.tmuls ins(%tile, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    }
+    return
+  }
+
+}

--- a/test/lit/pto/graph_sync_solver_buf_id_cross_loop.pto
+++ b/test/lit/pto/graph_sync_solver_buf_id_cross_loop.pto
@@ -1,0 +1,152 @@
+// RUN: ptoas --pto-level=level3 --pto-arch a5 --enable-graph-sync-solver --graph-sync-solver-sync-style=buf-id --graph-sync-solver-event-id-max=8 --emit-pto-ir %s | FileCheck %s
+
+// Two buf-id cross-loop sync patterns. The key invariant to check is that
+// buf-id brackets are anchored at the RAW RWOperations, not at the loop
+// boundary placeholders the set/wait solver would normally hoist to.
+
+module {
+
+// ============================================================================
+// Case A: producer inside a loop, consumer after the loop reading the last
+// iteration's product.
+//
+//   for i:
+//     tload  (src_i -> tile)    # MTE2 inside loop
+//   tmuls   (tile)              # V after loop
+//
+// The natural buf-id form: tload's bracket inside the loop body (executes
+// once per iter, counter bumps once per iter), tmuls's bracket right where
+// tmuls sits after the loop (counter bumps once). Iter i+1's tload waits
+// for iter i's tload via same-pipe + same-id ordering.
+// ============================================================================
+
+  // CHECK-LABEL: func.func @producer_in_loop_consumer_after
+  // CHECK: pto.bind_tile
+  // CHECK: scf.for
+  // CHECK-NEXT: %{{.*}} = memref.subview
+  // tload bracket lives inside the scf.for body:
+  // CHECK-NEXT: pto.get_buf[#pto.pipe_event_type<TLOAD>, [[A:[0-9]+]]]
+  // CHECK-NEXT: pto.tload
+  // CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TLOAD>, [[A]]]
+  // CHECK-NEXT: }
+  // tmuls bracket lives after the loop, NOT hoisted to the loop boundary:
+  // CHECK: pto.get_buf[#pto.pipe_event_type<TVEC>, [[A]]]
+  // CHECK-NEXT: pto.tmuls
+  // CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TVEC>, [[A]]]
+  // CHECK-NOT: pto.set_flag
+  // CHECK-NOT: pto.wait_flag
+  // CHECK-NOT: pto.barrier
+
+  func.func @producer_in_loop_consumer_after(%arg0: !pto.ptr<f32>,
+                                              %iters: index,
+                                              %arg2: index, %arg3: index,
+                                              %arg4: index, %arg5: index,
+                                              %arg6: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c1024 = arith.constant 1024 : index
+    %c1048576 = arith.constant 1048576 : index
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 2.000000e+00 : f32
+
+    %view = pto.make_tensor_view %arg0,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+
+    %tmp0 = arith.muli %arg2, %arg3 : index
+    %tmp1 = arith.muli %tmp0, %arg4 : index
+    %tmp2 = arith.muli %tmp1, %arg5 : index
+
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %tmp2 valid_col = %arg6
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    scf.for %i = %c0 to %iters step %c1 {
+      %src_part = pto.partition_view %view,
+              offsets = [%c0, %c0, %i, %c0, %c0],
+              sizes = [%arg2, %arg3, %arg4, %arg5, %arg6]
+              : !pto.tensor_view<1x1x16x1024x1024xf32>
+                -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+      pto.tload ins(%src_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    }
+
+    pto.tmuls ins(%tile, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    return
+  }
+
+// ============================================================================
+// Case B: two adjacent loops, feed-through. First loop fills the tile, second
+// loop consumes it.
+//
+//   for i: tload (src_i -> tile)
+//   for j: tmuls (tile)        # consumes whatever tile holds (last tload)
+//
+// Same correctness expectation: each loop body brackets its own op; no
+// brackets land on the loop boundaries.
+// ============================================================================
+
+  // CHECK-LABEL: func.func @two_loops_feedthrough
+  // CHECK: scf.for
+  // CHECK-NEXT: %{{.*}} = memref.subview
+  // CHECK-NEXT: pto.get_buf[#pto.pipe_event_type<TLOAD>, [[B:[0-9]+]]]
+  // CHECK-NEXT: pto.tload
+  // CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TLOAD>, [[B]]]
+  // CHECK-NEXT: }
+  // CHECK: scf.for
+  // CHECK-NEXT: pto.get_buf[#pto.pipe_event_type<TVEC>, [[B]]]
+  // CHECK-NEXT: pto.tmuls
+  // CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TVEC>, [[B]]]
+  // CHECK-NEXT: }
+  // No buf-id ops between the two scf.for closures (i.e. no boundary
+  // compensation).
+  // CHECK-NOT: pto.set_flag
+  // CHECK-NOT: pto.wait_flag
+  // CHECK-NOT: pto.barrier
+
+  func.func @two_loops_feedthrough(%arg0: !pto.ptr<f32>,
+                                    %iters: index,
+                                    %arg2: index, %arg3: index, %arg4: index,
+                                    %arg5: index, %arg6: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c1024 = arith.constant 1024 : index
+    %c1048576 = arith.constant 1048576 : index
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 2.000000e+00 : f32
+
+    %view = pto.make_tensor_view %arg0,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+
+    %tmp0 = arith.muli %arg2, %arg3 : index
+    %tmp1 = arith.muli %tmp0, %arg4 : index
+    %tmp2 = arith.muli %tmp1, %arg5 : index
+
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %tmp2 valid_col = %arg6
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    scf.for %i = %c0 to %iters step %c1 {
+      %src_part = pto.partition_view %view,
+              offsets = [%c0, %c0, %i, %c0, %c0],
+              sizes = [%arg2, %arg3, %arg4, %arg5, %arg6]
+              : !pto.tensor_view<1x1x16x1024x1024xf32>
+                -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+      pto.tload ins(%src_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    }
+
+    scf.for %j = %c0 to %iters step %c1 {
+      pto.tmuls ins(%tile, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    }
+
+    return
+  }
+
+}

--- a/test/lit/pto/graph_sync_solver_buf_id_if_both_branches.pto
+++ b/test/lit/pto/graph_sync_solver_buf_id_if_both_branches.pto
@@ -1,0 +1,92 @@
+// RUN: ptoas --pto-level=level3 --pto-arch a5 --enable-graph-sync-solver --graph-sync-solver-sync-style=buf-id --graph-sync-solver-event-id-max=1 --emit-pto-ir %s | FileCheck %s
+
+// Regression for a bug where the else-branch of an scf.if had its internal
+// buf-id brackets dropped. Root cause was twofold:
+//   1. The solver hoisted setOp/waitOp to the LCA scope for set/wait-style
+//      pairing, so even when buf-id brackets WERE emitted they could land
+//      outside the branch.
+//   2. The buffer-aware id grouping needed to recognize that two pairs in
+//      mutually exclusive branches do not execute together.
+// Both branches must independently bracket their tload -> tmuls dependency,
+// even though the producer ops in then/else may anchor on the same
+// PIPE_MTE2 / PIPE_V positions structurally.
+
+module {
+
+// CHECK-LABEL: func.func @if_both_branches
+// CHECK: scf.if
+// then-branch: full bracket pair on its own tile.
+// CHECK-NEXT: pto.get_buf[#pto.pipe_event_type<TLOAD>
+// CHECK-NEXT: pto.tload {{.*}} outs([[T:%[0-9]+]] : memref<256x16xf32
+// CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TLOAD>
+// CHECK-NEXT: pto.get_buf[#pto.pipe_event_type<TVEC>
+// CHECK-NEXT: pto.tmuls ins([[T]],
+// CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TVEC>
+//
+// else-branch: full bracket pair on the OTHER tile. MUST also exist.
+// CHECK: } else {
+// CHECK-NEXT: pto.get_buf[#pto.pipe_event_type<TLOAD>
+// CHECK-NEXT: pto.tload {{.*}} outs([[T2:%[0-9]+]] : memref<256x16xf32
+// CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TLOAD>
+// CHECK-NEXT: pto.get_buf[#pto.pipe_event_type<TVEC>
+// CHECK-NEXT: pto.tmuls ins([[T2]],
+// CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TVEC>
+// CHECK-NEXT: }
+//
+// CHECK-NOT: pto.set_flag
+// CHECK-NOT: pto.wait_flag
+// CHECK-NOT: pto.barrier
+
+  func.func @if_both_branches(%arg0: !pto.ptr<f32>, %cond: i1,
+                               %arg2: index, %arg3: index, %arg4: index,
+                               %arg5: index, %arg6: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c1024 = arith.constant 1024 : index
+    %c1048576 = arith.constant 1048576 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c100_i64 = arith.constant 100 : i64
+    %cst = arith.constant 2.000000e+00 : f32
+
+    %src_view = pto.make_tensor_view %arg0,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+    %src_part = pto.partition_view %src_view,
+            offsets = [%c0, %c0, %c0, %c0, %c0],
+            sizes = [%arg2, %arg3, %arg4, %arg5, %arg6]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+              -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+    %tmp0 = arith.muli %arg2, %arg3 : index
+    %tmp1 = arith.muli %tmp0, %arg4 : index
+    %tmp2 = arith.muli %tmp1, %arg5 : index
+
+    %tile_a = pto.alloc_tile addr = %c0_i64 valid_row = %tmp2 valid_col = %arg6
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile_b = pto.alloc_tile addr = %c100_i64 valid_row = %tmp2 valid_col = %arg6
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    // Mimic gemm's pattern: each branch uses its OWN mat tile (a or b)
+    // but writes to a SHARED scratch tile_s. Cross-branch WAW on tile_s
+    // exists at the memory level even though the branches are mutually
+    // exclusive at runtime.
+    scf.if %cond {
+      pto.tload ins(%src_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+              outs(%tile_a : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      pto.tmuls ins(%tile_a, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%tile_a : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    } else {
+      // Else uses tile_b, but otherwise structurally identical.
+      pto.tload ins(%src_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+              outs(%tile_b : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      pto.tmuls ins(%tile_b, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%tile_b : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    }
+    // After the if, consume whichever tile was filled.
+    pto.tmuls ins(%tile_a, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+            outs(%tile_a : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/lit/pto/graph_sync_solver_buf_id_if_branch.pto
+++ b/test/lit/pto/graph_sync_solver_buf_id_if_branch.pto
@@ -1,0 +1,90 @@
+// RUN: ptoas --pto-level=level3 --pto-arch a5 --enable-graph-sync-solver --graph-sync-solver-sync-style=buf-id --graph-sync-solver-event-id-max=8 --emit-pto-ir %s | FileCheck %s
+
+// Branch-aware buf-id emission check.
+//
+// Pattern: the producer (tload) lives inside an scf.if-then branch; the
+// consumer (tmuls) lives after the scf.if. In set/wait the solver typically
+// hoists the wait_flag to outside the if and pairs it with a set inside the
+// branch (sometimes with a compensating dummy in the else path), because
+// set/wait require exact one-to-one pairing along every control-flow edge.
+//
+// In buf-id, hoisting the get_buf / rls_buf brackets out of the producer
+// branch would be incorrect: the brackets MUST bracket the actual op, not
+// some virtual location at the if boundary. If iter executes the else
+// branch (no tload), the producer-side bracket must also not execute, so
+// the counter doesn't advance — and the consumer's get_buf must somehow
+// still pass. (Concretely: in this simple acyclic body the solver should
+// either fully bracket the conditional producer locally and emit a matching
+// consumer bracket at tmuls, or refuse to use buf-id for the cross-branch
+// edge — but it MUST NOT hoist a get_buf outside the if-then while leaving
+// the rls_buf inside, or vice versa.)
+//
+// This test inspects the textual emission. The key invariants:
+//   * Any pto.get_buf inside scf.if has a matching pto.rls_buf in the SAME
+//     scf.if region (no half-bracket dangling outside the branch).
+//   * No pto.set_flag / pto.wait_flag (buf-id mode).
+//   * No pto.barrier (A5 same-pipe order).
+
+module {
+
+// CHECK-LABEL: func.func @if_branch_producer
+//
+// scf.if appears with the producer inside.
+// CHECK: pto.bind_tile
+// CHECK: scf.if
+// Inside the then-region: balanced get_buf / rls_buf around tload.
+// CHECK: pto.get_buf[#pto.pipe_event_type<TLOAD>
+// CHECK: pto.tload
+// CHECK: pto.rls_buf[#pto.pipe_event_type<TLOAD>
+// CHECK: }
+// Consumer-side bracket on V around tmuls (outside the if).
+// CHECK: pto.get_buf[#pto.pipe_event_type<TVEC>
+// CHECK: pto.tmuls
+// CHECK: pto.rls_buf[#pto.pipe_event_type<TVEC>
+//
+// No set/wait or barrier in buf-id mode.
+// CHECK-NOT: pto.set_flag
+// CHECK-NOT: pto.wait_flag
+// CHECK-NOT: pto.barrier
+
+  func.func @if_branch_producer(%arg0: !pto.ptr<f32>, %cond: i1,
+                                 %arg2: index, %arg3: index, %arg4: index,
+                                 %arg5: index, %arg6: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c1024 = arith.constant 1024 : index
+    %c1048576 = arith.constant 1048576 : index
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 2.000000e+00 : f32
+
+    %src_view = pto.make_tensor_view %arg0,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+
+    %tmp0 = arith.muli %arg2, %arg3 : index
+    %tmp1 = arith.muli %tmp0, %arg4 : index
+    %tmp2 = arith.muli %tmp1, %arg5 : index
+
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %tmp2 valid_col = %arg6
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    scf.if %cond {
+      %src_part = pto.partition_view %src_view,
+              offsets = [%c0, %c0, %c0, %c0, %c0],
+              sizes = [%arg2, %arg3, %arg4, %arg5, %arg6]
+              : !pto.tensor_view<1x1x16x1024x1024xf32>
+                -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+      pto.tload ins(%src_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    }
+
+    // Consumer outside the branch.
+    pto.tmuls ins(%tile, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    return
+  }
+
+}

--- a/test/lit/pto/graph_sync_solver_buf_id_if_branch_consumer.pto
+++ b/test/lit/pto/graph_sync_solver_buf_id_if_branch_consumer.pto
@@ -1,0 +1,82 @@
+// RUN: ptoas --pto-level=level3 --pto-arch a5 --enable-graph-sync-solver --graph-sync-solver-sync-style=buf-id --graph-sync-solver-event-id-max=8 --emit-pto-ir %s | FileCheck %s
+
+// Mirror of graph_sync_solver_buf_id_if_branch.pto: producer (tload)
+// outside the scf.if, consumer (tmuls) inside the scf.if-then branch.
+//
+//   tload -> tile                # MTE2, always runs
+//   scf.if %cond {
+//     tmuls(tile)                # V, conditional
+//   }
+//
+// In set/wait the solver would hoist either the wait_flag out of the
+// branch (matching a single set after tload) or hoist the set into the
+// branch (paired with a wait inside). In buf-id we want the brackets
+// anchored at the *actual* RWOperations: MTE2 bracket around tload, V
+// bracket around tmuls (inside the if). No bracket should sit on the
+// scf.if boundary itself.
+
+module {
+
+// CHECK-LABEL: func.func @if_branch_consumer
+// CHECK: pto.bind_tile
+//
+// Producer-side bracket tightly around tload, OUTSIDE the if:
+// CHECK: pto.get_buf[#pto.pipe_event_type<TLOAD>, [[ID:[0-9]+]]]
+// CHECK-NEXT: pto.tload
+// CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TLOAD>, [[ID]]]
+//
+// scf.if appears next; consumer bracket sits INSIDE the then-region,
+// tightly around the conditional tmuls.
+// CHECK: scf.if
+// CHECK-NEXT: pto.get_buf[#pto.pipe_event_type<TVEC>, [[ID]]]
+// CHECK-NEXT: pto.tmuls
+// CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TVEC>, [[ID]]]
+// CHECK-NEXT: }
+//
+// No set/wait, no barrier, no pre-loop or post-if compensation.
+// CHECK-NOT: pto.set_flag
+// CHECK-NOT: pto.wait_flag
+// CHECK-NOT: pto.barrier
+
+  func.func @if_branch_consumer(%arg0: !pto.ptr<f32>, %cond: i1,
+                                 %arg2: index, %arg3: index, %arg4: index,
+                                 %arg5: index, %arg6: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c1024 = arith.constant 1024 : index
+    %c1048576 = arith.constant 1048576 : index
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 2.000000e+00 : f32
+
+    %src_view = pto.make_tensor_view %arg0,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+    %src_part = pto.partition_view %src_view,
+            offsets = [%c0, %c0, %c0, %c0, %c0],
+            sizes = [%arg2, %arg3, %arg4, %arg5, %arg6]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+              -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+    %tmp0 = arith.muli %arg2, %arg3 : index
+    %tmp1 = arith.muli %tmp0, %arg4 : index
+    %tmp2 = arith.muli %tmp1, %arg5 : index
+
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %tmp2 valid_col = %arg6
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    // Producer always runs.
+    pto.tload ins(%src_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    // Consumer is conditional.
+    scf.if %cond {
+      pto.tmuls ins(%tile, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    }
+
+    return
+  }
+
+}

--- a/test/lit/pto/graph_sync_solver_buf_id_two_buffer_loop.pto
+++ b/test/lit/pto/graph_sync_solver_buf_id_two_buffer_loop.pto
@@ -1,0 +1,114 @@
+// RUN: ptoas --pto-level=level3 --pto-arch a5 --enable-graph-sync-solver --graph-sync-solver-sync-style=buf-id --graph-sync-solver-event-id-max=8 --emit-pto-ir %s | FileCheck %s
+
+// Doc §1.3 two-buffer pingpong-like pattern (case 1 from the user's
+// reference): forward deps split across two distinct tile buffers, so
+// buffer-aware id grouping should give them DIFFERENT ids, enabling
+// pipelining (next iter's tload can advance ahead of this iter's tstore
+// because they don't share the same scoreboard counter).
+//
+//   for i:
+//     tload  gm  -> tile_a          # MTE2 -> tile_a
+//     tmuls  tile_a -> tile_b       # V    -> tile_b
+//     tstore tile_b -> gm_out       # MTE3 -> tile_b
+//
+// Expected output:
+//   * F1 (load->vadd) and F2 (vadd->store) get DISTINCT ids.
+//   * vadd has TWO brackets on PIPE_V (one per chain).
+//   * load has one bracket on MTE2 (F1's id), store has one bracket on MTE3
+//     (F2's id).
+//   * No bracket pair has matching id on both sides (constraint 1 holds).
+//   * No backward bracket emitted, no scf.if, no out-of-loop ops.
+
+module {
+
+// CHECK-LABEL: func.func @two_buffer_loop
+// CHECK: pto.bind_tile
+// CHECK: pto.bind_tile
+//
+// Producer-side bracket on tile_a's chain (id A):
+// CHECK: pto.get_buf[#pto.pipe_event_type<TLOAD>, [[IDA:[0-9]+]]]
+// CHECK-NEXT: pto.tload
+// CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TLOAD>, [[IDA]]]
+//
+// vadd is in BOTH chains: tile_a's consumer bracket (id A) AND tile_b's
+// producer bracket (id B). The two ids MUST differ (mirror-image dedup +
+// share-pipe conflict rule both ensure this).
+// CHECK: pto.get_buf[#pto.pipe_event_type<TVEC>, [[IDA]]]
+// CHECK-NEXT: pto.get_buf[#pto.pipe_event_type<TVEC>, [[IDB:[0-9]+]]]
+// CHECK-NOT: pto.get_buf[#pto.pipe_event_type<TVEC>, [[IDA]]]
+// CHECK: pto.tmuls
+// CHECK: pto.rls_buf[#pto.pipe_event_type<TVEC>
+// CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TVEC>
+//
+// Consumer-side bracket on tile_b's chain (id B):
+// CHECK: pto.get_buf[#pto.pipe_event_type<TSTORE_VEC>, [[IDB]]]
+// CHECK-NEXT: pto.tstore
+// CHECK-NEXT: pto.rls_buf[#pto.pipe_event_type<TSTORE_VEC>, [[IDB]]]
+//
+// CHECK-NOT: scf.if
+// CHECK-NOT: pto.set_flag
+// CHECK-NOT: pto.wait_flag
+// CHECK-NOT: pto.barrier
+
+  func.func @two_buffer_loop(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>,
+                             %arg_iters: index,
+                             %arg2: index, %arg3: index, %arg4: index,
+                             %arg5: index, %arg6: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c1024 = arith.constant 1024 : index
+    %c1048576 = arith.constant 1048576 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c100_i64 = arith.constant 100 : i64
+    %cst = arith.constant 2.000000e+00 : f32
+
+    %src_view = pto.make_tensor_view %arg0,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+    %dst_view = pto.make_tensor_view %arg1,
+            shape = [%c1, %c1, %c16, %c1024, %c1024],
+            strides = [%c1048576, %c1048576, %c1048576, %c1024, %c1]
+            : !pto.tensor_view<1x1x16x1024x1024xf32>
+
+    %tmp0 = arith.muli %arg2, %arg3 : index
+    %tmp1 = arith.muli %tmp0, %arg4 : index
+    %tmp2 = arith.muli %tmp1, %arg5 : index
+
+    // Two distinct tiles -> the load/vadd chain and the vadd/store chain
+    // are on independent buffers -> buffer-aware id grouping yields TWO ids.
+    %tile_a = pto.alloc_tile addr = %c0_i64 valid_row = %tmp2 valid_col = %arg6
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile_b = pto.alloc_tile addr = %c100_i64 valid_row = %tmp2 valid_col = %arg6
+            : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    scf.for %i = %c0 to %arg_iters step %c1 {
+      %src_part = pto.partition_view %src_view,
+              offsets = [%c0, %c0, %i, %c0, %c0],
+              sizes = [%arg2, %arg3, %arg4, %arg5, %arg6]
+              : !pto.tensor_view<1x1x16x1024x1024xf32>
+                -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+      // load writes tile_a
+      pto.tload ins(%src_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+              outs(%tile_a : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+      // vadd reads tile_a, writes tile_b (different buffer)
+      pto.tmuls ins(%tile_a, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%tile_b : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+      %dst_part = pto.partition_view %dst_view,
+              offsets = [%c0, %c0, %i, %c0, %c0],
+              sizes = [%arg2, %arg3, %arg4, %arg5, %arg6]
+              : !pto.tensor_view<1x1x16x1024x1024xf32>
+                -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+      // store reads tile_b
+      pto.tstore ins(%tile_b : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+    }
+    return
+  }
+
+}

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -205,6 +205,14 @@ static llvm::cl::opt<int> graphSyncSolverEventIdMax(
         "Lower values exercise the PIPE_ALL coloring fallback sooner."),
     llvm::cl::init(8));
 
+static llvm::cl::opt<std::string> graphSyncSolverSyncStyle(
+    "graph-sync-solver-sync-style",
+    llvm::cl::desc(
+        "Sync emission style for the graph sync solver: 'set-wait' (default) "
+        "or 'buf-id' (A5 only). 'buf-id' emits pto.get_buf/pto.rls_buf "
+        "brackets and skips pto.barrier (A5 preserves same-pipe order)."),
+    llvm::cl::init("set-wait"));
+
 static llvm::cl::opt<bool> disableInferLayout(
     "disable-infer-layout",
     llvm::cl::desc("Disable PTO layout inference pass (static-only)"),
@@ -1173,6 +1181,7 @@ int main(int argc, char **argv) {
   else if (enableGraphSyncSolver) {
     PTOGraphSyncSolverOptions graphSyncOpts;
     graphSyncOpts.eventIdNumMax = graphSyncSolverEventIdMax;
+    graphSyncOpts.syncStyle = graphSyncSolverSyncStyle;
     pm.addNestedPass<mlir::func::FuncOp>(
         pto::createPTOGraphSyncSolverPass(graphSyncOpts));
   }


### PR DESCRIPTION
Users can opt into the A5-only `pto.get_buf` / `pto.rls_buf` bracket form instead of `pto.set_flag` / `pto.wait_flag` via
`--graph-sync-solver-sync-style=buf-id`. The buf-id model is a sequential programming model: the hw `(get_cnt, rel_cnt)` scoreboard counters serialize same-id brackets across pipes and iterations, so the solver emits brackets at producer/consumer anchor RWOperations and the counter monotonicity handles both intra-iter (forward) and loop-carried (backward) deps without out-of-loop compensation, scf.if isFirstIter / isLastIter guards, or pto.barrier on A5.

Solver-internals reuse:
  * Conflict detection / coloring / barrier-all fallback all reused.
  * buf-id flips checkIntersect to "share any pipe -> conflict" because get_buf doesn't carry the partner pipe in the opcode; without that rule, two pipe-pairs sharing a pipe would alias to the same physical scoreboard and produce back-to-back get(P,#id) which violates the spec.
  * buf-id collapses the per-pipe-pair EventIdSolver map into a single instance (same trick cross-core already uses), so all pairs draw from one id pool.
  * getBeforeAfterSyncMaps adds a mirror-image dedup: forward F and backward B with the same unordered anchor set {(setOp,setPipe), (waitOp,waitPipe)} share the same brackets, so emitting both would waste an id. We keep the smaller-id pair and skip the mirror, which reproduces doc §1.2's canonical single-id `for {load; vector}` form.
  * All backward-sync hoist optimizations (tryMovingOutBackwardSyncPairs, considerOuterBackwardSyncPairs, mergeBackwardSyncPairs) short-circuit in buf-id mode — they exist to repair set/wait pairing across loop boundaries, which buf-id doesn't need.

CLI / pass option:
  --graph-sync-solver-sync-style={set-wait (default) | buf-id}
  PTOGraphSyncSolver pass option: sync-style="set-wait" | "buf-id"
  buf-id requires --pto-arch=a5; non-A5 errors out.

Tests (all PASS, plus full 209-test PTO lit suite green):
  * graph_sync_solver_buf_id_basic.pto: forward MTE2->V->MTE3 chain, distinct ids on shared pipe (V) for two consumer/producer brackets.
  * graph_sync_solver_buf_id_arch_guard.pto: A3 + buf-id -> error.
  * graph_sync_solver_buf_id_backward.pto: loop with tload+tmuls+tstore; 3 ids cover 2 forward + 1 backward dep, no scf.if, no out-of-loop ops.
  * graph_sync_solver_buf_id_canonical_loop.pto: doc §1.2 canonical `for {load; vector}` form; single id #0 covers forward + backward.

Design doc: docs/designs/ptoas-graph-sync-solver-buf-id-design.md.