### PR TITLE
Fix A5 tmov treshape valid shape

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -370,6 +370,30 @@ def SetValidShapeOp : PTO_Op<"set_validshape", [
   }];
 }
 
+def GetValidShapeOp : PTO_Op<"get_validshape", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  ]> {
+  let summary = "Read runtime valid row/col metadata from a tile";
+  let description = [{
+    Reads the current runtime valid_row/valid_col metadata from a tile_buf
+    handle. This op observes prior set_validshape updates and returns the
+    current values as index-typed SSA values.
+  }];
+
+  let arguments = (ins
+    TileBufOrMemRef:$source
+  );
+
+  let results = (outs
+    Index:$valid_row,
+    Index:$valid_col
+  );
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = "$source attr-dict `:` qualified(type($source))";
+}
+
 // ============================================================================
 // SSA TileBuf Config Ops (aliasing views)
 // ============================================================================

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -7778,6 +7778,22 @@ mlir::LogicalResult mlir::pto::SetValidShapeOp::verify() {
   return success();
 }
 
+mlir::LogicalResult mlir::pto::GetValidShapeOp::verify() {
+  if (auto srcTy = llvm::dyn_cast<TileBufType>(getSource().getType())) {
+    if (srcTy.getRank() != 2)
+      return emitOpError("expects rank-2 tile_buf source");
+    if (srcTy.getValidShape().size() != 2)
+      return emitOpError("expects source validShape to be rank-2");
+    return success();
+  }
+  if (auto srcTy = llvm::dyn_cast<MemRefType>(getSource().getType())) {
+    if (srcTy.getRank() != 2)
+      return emitOpError("expects rank-2 memref source after tile lowering");
+    return success();
+  }
+  return emitOpError("expects tile_buf source (or lowered memref source)");
+}
+
 
 mlir::LogicalResult mlir::pto::TReshapeOp::verify() {
   if (shouldBypassDecodedMemrefVerifier(getOperation()))
@@ -10266,6 +10282,12 @@ void TSetValOp::getEffects(
 void SetValidShapeOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_WRITE(getSourceMutable());
+}
+
+// GET_VALIDSHAPE: read runtime valid row/col metadata from source tile.
+void GetValidShapeOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
+  PTO_ADD_READ(getSourceMutable());
 }
 
 // Elementwise + reductions: mostly PIPE_V tilebuf ops

--- a/lib/PTO/Transforms/PTOA5NormalizeTMovPass.cpp
+++ b/lib/PTO/Transforms/PTOA5NormalizeTMovPass.cpp
@@ -109,6 +109,17 @@ buildRowMajorReinterpretType(MLIRContext *ctx, pto::TileBufType srcType) {
                                srcType.getMemorySpace(), swappedValid, newCfg);
 }
 
+static void setSwappedDynamicValidShapeIfNeeded(
+    IRRewriter &rewriter, Location loc, Value sourceTile, Value reshapedTile,
+    pto::TileBufType reshapedType) {
+  if (!reshapedType.hasDynamicValid())
+    return;
+
+  auto validShape = rewriter.create<pto::GetValidShapeOp>(loc, sourceTile);
+  rewriter.create<pto::SetValidShapeOp>(
+      loc, reshapedTile, validShape.getValidCol(), validShape.getValidRow());
+}
+
 struct PTOA5NormalizeTMovPass
     : public mlir::pto::impl::PTOA5NormalizeTMovBase<PTOA5NormalizeTMovPass> {
   void runOnOperation() override {
@@ -144,6 +155,10 @@ struct PTOA5NormalizeTMovPass
           rewriter.create<pto::TReshapeOp>(op.getLoc(), *srcRowTy, op.getSrc());
       auto dstRow =
           rewriter.create<pto::TReshapeOp>(op.getLoc(), *dstRowTy, op.getDst());
+      setSwappedDynamicValidShapeIfNeeded(
+          rewriter, op.getLoc(), op.getSrc(), srcRow.getResult(), *srcRowTy);
+      setSwappedDynamicValidShapeIfNeeded(
+          rewriter, op.getLoc(), op.getDst(), dstRow.getResult(), *dstRowTy);
       SmallVector<Value, kTMovOperandReserveSize> newOperands(
           op->operand_begin(), op->operand_end());
       if (newOperands.size() < kTileRank2D) {

--- a/lib/PTO/Transforms/PTOMaterializeTileHandles.cpp
+++ b/lib/PTO/Transforms/PTOMaterializeTileHandles.cpp
@@ -31,6 +31,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 
 #include <memory>
 #include <optional>
@@ -92,6 +93,8 @@ static bool shouldMaterializeOperand(Operation *owner) {
 
   StringRef name = owner->getName().getStringRef();
   if (name == "pto.set_validshape")
+    return true;
+  if (name == "pto.get_validshape")
     return true;
   if (name == "pto.build_async_session")
     return true;
@@ -764,9 +767,15 @@ static void updateResultTypesAfterMaterializingOperand(Operation *op,
   }
 }
 
+static bool isTileViewSemantics(StringAttr viewSemantics) {
+  return viewSemantics && (viewSemantics.getValue() == "treshape" ||
+                           viewSemantics.getValue() == "bitcast");
+}
+
 static Value materializeAnchorResult(Operation *anchor, Value anchoredValue,
                                      OpBuilder &builder, MLIRContext *ctx,
                                      DenseMap<Value, Value> &tileHandles,
+                                     const DenseSet<Value> &mustMaterialize,
                                      bool &failedMaterialization) {
   auto memTy = dyn_cast<MemRefType>(anchoredValue.getType());
   if (!memTy || !isLocalTileMemRef(memTy))
@@ -782,10 +791,9 @@ static Value materializeAnchorResult(Operation *anchor, Value anchoredValue,
   TileHandleMetadata meta = getTileHandleMetadata(anchoredValue, ctx);
   auto viewSemantics = dyn_cast_or_null<StringAttr>(
       getAttr(meta.attrs, "pto.view_semantics"));
-  bool isTileView =
-      viewSemantics && (viewSemantics.getValue() == "treshape" ||
-                        viewSemantics.getValue() == "bitcast");
-  if (usesToRewrite.empty() && !isTileView)
+  bool isTileView = isTileViewSemantics(viewSemantics);
+  if (usesToRewrite.empty() && !isTileView &&
+      !mustMaterialize.contains(anchoredValue))
     return Value();
 
   for (OpOperand *use : usesToRewrite)
@@ -843,6 +851,7 @@ struct PTOMaterializeTileHandlesPass
 
     OpBuilder builder(ctx);
     DenseMap<Value, Value> tileHandles;
+    DenseSet<Value> mustMaterialize;
     bool failedMaterialization = false;
 
     SmallVector<Operation *, 32> anchors;
@@ -851,12 +860,25 @@ struct PTOMaterializeTileHandlesPass
         return;
       anchors.push_back(op);
     });
+    for (Operation *anchor : anchors) {
+      if (anchor->getNumResults() != 1)
+        continue;
+      Value anchoredValue = anchor->getResult(0);
+      if (!isLocalTileMemRef(anchoredValue.getType()))
+        continue;
+      TileHandleMetadata meta = getTileHandleMetadata(anchoredValue, ctx);
+      auto viewSemantics = dyn_cast_or_null<StringAttr>(
+          getAttr(meta.attrs, "pto.view_semantics"));
+      if (isTileViewSemantics(viewSemantics) && meta.source)
+        mustMaterialize.insert(meta.source);
+    }
 
     for (Operation *anchor : anchors) {
       if (anchor->getNumResults() != 1)
         continue;
       materializeAnchorResult(anchor, anchor->getResult(0), builder, ctx,
-                              tileHandles, failedMaterialization);
+                              tileHandles, mustMaterialize,
+                              failedMaterialization);
     }
 
     if (failedMaterialization) {

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -426,6 +426,12 @@ void MemLivenessAnalysis::RecursionIR(Region *region, Liveness live) {
       // alias/result buffer.
       UpdateOpGenInfo(curOpInfo, ValueRange{op->getOperand(0)});
       OpKillHandle(curOpInfo, live, op->getBlock());
+    } else if (auto getValidShapeOp = dyn_cast<pto::GetValidShapeOp>(op)) {
+      (void)getValidShapeOp;
+      // Metadata-only read from an existing tile handle. It touches the source
+      // buffer for liveness, but the scalar row/col results are not buffers.
+      UpdateOpGenInfo(curOpInfo, ValueRange{op->getOperand(0)});
+      OpKillHandle(curOpInfo, live, op->getBlock());
     } else if (auto storeOp = dyn_cast<memref::StoreOp>(op)) {
       UpdateStoreOpInfo(curOpInfo, storeOp.getMemRef(), live);
     } else if (auto ptoDpsOp = dyn_cast<pto::PTO_DpsInitOpInterface>(op)) {

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5509,6 +5509,53 @@ struct PTOSetValidShapeToEmitC : public OpConversionPattern<pto::SetValidShapeOp
   }
 };
 
+struct PTOGetValidShapeToEmitC
+    : public OpConversionPattern<pto::GetValidShapeOp> {
+  using OpConversionPattern<pto::GetValidShapeOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(pto::GetValidShapeOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    auto peelAllCasts = [](Value v) {
+      while (auto castOp = v.getDefiningOp<UnrealizedConversionCastOp>())
+        v = castOp.getOperand(0);
+      if (auto castOp = v.getDefiningOp<emitc::CastOp>())
+        v = castOp.getOperand();
+      return v;
+    };
+    auto isTileLike = [](Value v) -> bool {
+      auto ot = dyn_cast<emitc::OpaqueType>(v.getType());
+      if (!ot)
+        return false;
+      StringRef s = ot.getValue();
+      return s.contains("Tile<") || s.contains("ConvTile<");
+    };
+
+    Value src = peelAllCasts(peelUnrealized(adaptor.getSource()));
+    if (!isTileLike(src))
+      return rewriter.notifyMatchFailure(
+          op, "get_validshape source must lower to a tile-like value");
+
+    auto resultTy = getTypeConverter()->convertType(rewriter.getIndexType());
+    if (!resultTy)
+      return failure();
+
+    Value row = rewriter
+                    .create<emitc::CallOpaqueOp>(
+                        op.getLoc(), resultTy,
+                        "PTOAS__TILE_GET_VALID_ROW", ArrayAttr{},
+                        ArrayAttr{}, ValueRange{src})
+                    .getResult(0);
+    Value col = rewriter
+                    .create<emitc::CallOpaqueOp>(
+                        op.getLoc(), resultTy,
+                        "PTOAS__TILE_GET_VALID_COL", ArrayAttr{},
+                        ArrayAttr{}, ValueRange{src})
+                    .getResult(0);
+    rewriter.replaceOp(op, ValueRange{row, col});
+    return success();
+  }
+};
+
 struct PTOTAssignToEmitC : public OpConversionPattern<pto::TAssignOp> {
   using OpConversionPattern<pto::TAssignOp>::OpConversionPattern;
 
@@ -10535,9 +10582,10 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
       return TileBuildSpec{tileTypeStr, useConstructor, constructorArgs};
     };
 
-    auto buildTileValue = [&](const TileBuildSpec &spec) -> Value {
+    auto buildTileValue = [&](const TileBuildSpec &spec,
+                              bool forceDeclaration = false) -> Value {
       auto tileType = emitc::OpaqueType::get(ctx, spec.tileTypeStr);
-      if (spec.useConstructor) {
+      if (spec.useConstructor && !forceDeclaration) {
         return rewriter
             .create<emitc::CallOpaqueOp>(loc, tileType, spec.tileTypeStr,
                                          ArrayAttr{}, ArrayAttr{},
@@ -10619,7 +10667,7 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
       FailureOr<TileBuildSpec> tileSpec = buildTileSpec();
       if (failed(tileSpec))
         return failure();
-      Value dstTile = buildTileValue(*tileSpec);
+      Value dstTile = buildTileValue(*tileSpec, /*forceDeclaration=*/true);
 
       rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "TRESHAPE",
                                            ArrayAttr{}, ArrayAttr{},
@@ -11859,7 +11907,7 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<SubviewToEmitCPattern>(typeConverter, ctx);
   patterns.add<PointerCastConversion>(typeConverter, ctx);
   patterns.add<PTOSetValToSETVAL, PTOGetValToGETVAL, PTOSetValidShapeToEmitC,
-               PTOTAssignToEmitC, PTOLoadScalarToEmitC,
+               PTOGetValidShapeToEmitC, PTOTAssignToEmitC, PTOLoadScalarToEmitC,
                PTOStoreScalarToEmitC>(typeConverter, ctx);
   patterns.add<PTOTAxpyToEmitC, PTOHistogramToEmitC, PTOGetScaleAddrToEmitC>(
       typeConverter, ctx);

--- a/test/lit/pto/get_validshape_emitc.pto
+++ b/test/lit/pto/get_validshape_emitc.pto
@@ -1,0 +1,28 @@
+// RUN: ptoas --pto-level=level3 --pto-arch=a5 %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @get_validshape_emitc() {
+    %c8 = arith.constant 8 : index
+    %c16 = arith.constant 16 : index
+    %c0_i64 = arith.constant 0 : i64
+
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c8 valid_col = %c16
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %valid_row, %valid_col = pto.get_validshape %tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.set_validshape %tile, %valid_row, %valid_col
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void get_validshape_emitc()
+// CHECK: Tile<TileType::Vec, float, 16, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[TILE:v[0-9]+]] = Tile
+// CHECK: int32_t [[ROW:v[0-9]+]] = [[TILE]].GetValidRow();
+// CHECK-NEXT: int32_t [[COL:v[0-9]+]] = [[TILE]].GetValidCol();
+// CHECK-NEXT: [[TILE]].SetValidShape([[ROW]], [[COL]]);

--- a/test/lit/pto/issue686_a5_tmov_treshape_dynamic_valid_shape.pto
+++ b/test/lit/pto/issue686_a5_tmov_treshape_dynamic_valid_shape.pto
@@ -1,0 +1,41 @@
+// RUN: ptoas --pto-level=level3 --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @a5_tmov_treshape_dynamic_valid_shape() {
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c192_i64 = arith.constant 192 : i64
+    %c18048_i64 = arith.constant 18048 : i64
+
+    %src = pto.alloc_tile addr = %c192_i64 valid_row = %c16 valid_col = %c1
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=?, v_col=?,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile addr = %c18048_i64 valid_row = %c16 valid_col = %c1
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=?, v_col=?,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tmov
+      ins(%src
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=?, v_col=?,
+                          blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=?, v_col=?,
+                          blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+
+    return
+  }
+}
+
+// CHECK: Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[SRC_ORIG:v[0-9]+]] = Tile
+// CHECK: Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[DST_ORIG:v[0-9]+]] = Tile
+// CHECK: Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[SRC:v[0-9]+]];
+// CHECK-NEXT: TRESHAPE([[SRC]], [[SRC_ORIG]]);
+// CHECK: Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[DST:v[0-9]+]];
+// CHECK-NEXT: TRESHAPE([[DST]], [[DST_ORIG]]);
+// CHECK: int32_t [[SRC_ROW:v[0-9]+]] = [[SRC_ORIG]].GetValidRow();
+// CHECK-NEXT: int32_t [[SRC_COL:v[0-9]+]] = [[SRC_ORIG]].GetValidCol();
+// CHECK-NEXT: [[SRC]].SetValidShape([[SRC_COL]], [[SRC_ROW]]);
+// CHECK-NEXT: int32_t [[DST_ROW:v[0-9]+]] = [[DST_ORIG]].GetValidRow();
+// CHECK-NEXT: int32_t [[DST_COL:v[0-9]+]] = [[DST_ORIG]].GetValidCol();
+// CHECK-NEXT: [[DST]].SetValidShape([[DST_COL]], [[DST_ROW]]);
+// CHECK-NEXT: TMOV([[DST]], [[SRC]]);

--- a/test/lit/pto/issue686_a5_tmov_treshape_dynamic_valid_shape_level2.pto
+++ b/test/lit/pto/issue686_a5_tmov_treshape_dynamic_valid_shape_level2.pto
@@ -1,0 +1,40 @@
+// RUN: ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @a5_tmov_treshape_dynamic_valid_shape_level2() {
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+
+    %src = pto.alloc_tile valid_row = %c16 valid_col = %c1
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=?, v_col=?,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile valid_row = %c16 valid_col = %c1
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=?, v_col=?,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tmov
+      ins(%src
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=?, v_col=?,
+                          blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=?, v_col=?,
+                          blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void a5_tmov_treshape_dynamic_valid_shape_level2()
+// CHECK: Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[SRC_ORIG:v[0-9]+]]
+// CHECK: Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[DST_ORIG:v[0-9]+]]
+// CHECK: Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[SRC:v[0-9]+]];
+// CHECK-NEXT: TRESHAPE([[SRC]], [[SRC_ORIG]]);
+// CHECK: Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[DST:v[0-9]+]];
+// CHECK-NEXT: TRESHAPE([[DST]], [[DST_ORIG]]);
+// CHECK: int32_t [[SRC_ROW:v[0-9]+]] = [[SRC_ORIG]].GetValidRow();
+// CHECK-NEXT: int32_t [[SRC_COL:v[0-9]+]] = [[SRC_ORIG]].GetValidCol();
+// CHECK-NEXT: [[SRC]].SetValidShape([[SRC_COL]], [[SRC_ROW]]);
+// CHECK-NEXT: int32_t [[DST_ROW:v[0-9]+]] = [[DST_ORIG]].GetValidRow();
+// CHECK-NEXT: int32_t [[DST_COL:v[0-9]+]] = [[DST_ORIG]].GetValidCol();
+// CHECK-NEXT: [[DST]].SetValidShape([[DST_COL]], [[DST_ROW]]);
+// CHECK-NEXT: TMOV([[DST]], [[SRC]]);

--- a/test/lit/pto/issue686_a5_tmov_treshape_square_dynamic_valid_shape.pto
+++ b/test/lit/pto/issue686_a5_tmov_treshape_square_dynamic_valid_shape.pto
@@ -1,0 +1,39 @@
+// RUN: ptoas --pto-level=level3 --pto-arch=a5 \
+// RUN:   --mlir-print-ir-after=pto-view-to-memref %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @a5_tmov_treshape_square_dynamic_valid_shape() {
+    %c8 = arith.constant 8 : index
+    %c16 = arith.constant 16 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+
+    %src = pto.alloc_tile addr = %c0_i64 valid_row = %c8 valid_col = %c16
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile addr = %c1024_i64 valid_row = %c8 valid_col = %c16
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tmov
+      ins(%src
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                          blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                          blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+
+    return
+  }
+}
+
+// CHECK-DAG: [[PART:%[A-Za-z0-9_]+]] = arith.constant 8 : index
+// CHECK-DAG: [[FULL:%[A-Za-z0-9_]+]] = arith.constant 16 : index
+// CHECK: [[SRC_BASE:%[0-9]+]] = pto.bind_tile {{.*}}, [[PART]], [[FULL]] {{.*}}blayout=#pto.blayout<col_major>
+// CHECK: [[DST_BASE:%[0-9]+]] = pto.bind_tile {{.*}}, [[PART]], [[FULL]] {{.*}}blayout=#pto.blayout<col_major>
+// CHECK: [[SRC:%[0-9]+]] = pto.bind_tile [[SRC_BASE]], [[PART]], [[FULL]] {{.*}}blayout=#pto.blayout<row_major>{{.*}}pto.view_semantics = "treshape"
+// CHECK: [[DST:%[0-9]+]] = pto.bind_tile [[DST_BASE]], [[PART]], [[FULL]] {{.*}}blayout=#pto.blayout<row_major>{{.*}}pto.view_semantics = "treshape"
+// CHECK: [[SRC_ROW:%[A-Za-z0-9_]+]], [[SRC_COL:%[A-Za-z0-9_]+]] = pto.get_validshape [[SRC_BASE]]
+// CHECK-NEXT: pto.set_validshape [[SRC]], [[SRC_COL]], [[SRC_ROW]]
+// CHECK-NEXT: [[DST_ROW:%[A-Za-z0-9_]+]], [[DST_COL:%[A-Za-z0-9_]+]] = pto.get_validshape [[DST_BASE]]
+// CHECK-NEXT: pto.set_validshape [[DST]], [[DST_COL]], [[DST_ROW]]

--- a/test/lit/pto/treshape_explicit_dynamic_valid_shape_preserved.pto
+++ b/test/lit/pto/treshape_explicit_dynamic_valid_shape_preserved.pto
@@ -1,0 +1,38 @@
+// RUN: ptoas --pto-level=level3 --pto-arch=a5 \
+// RUN:   --mlir-print-ir-after=pto-view-to-memref %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @treshape_explicit_dynamic_valid_shape_preserved() {
+    %c8 = arith.constant 8 : index
+    %c16 = arith.constant 16 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+
+    %src = pto.alloc_tile addr = %c0_i64 valid_row = %c8 valid_col = %c16
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %dst = pto.treshape %src
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+     -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+
+    %out = pto.alloc_tile addr = %c1024_i64 valid_row = %c8 valid_col = %c16
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    pto.tmov
+      ins(%dst
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                          blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%out
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=?, v_col=?,
+                          blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+
+    return
+  }
+}
+
+// CHECK-DAG: [[PART:%[A-Za-z0-9_]+]] = arith.constant 8 : index
+// CHECK-DAG: [[FULL:%[A-Za-z0-9_]+]] = arith.constant 16 : index
+// CHECK: pto.bind_tile {{.*}}, [[PART]], [[FULL]] {{.*}}blayout=#pto.blayout<col_major>{{.*}}pto.view_semantics = "treshape"

--- a/test/lit/pto/treshape_static_valid_shape_emitc.pto
+++ b/test/lit/pto/treshape_static_valid_shape_emitc.pto
@@ -1,0 +1,41 @@
+// RUN: ptoas --pto-level=level3 --pto-arch=a5 %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @treshape_static_valid_shape_emitc() {
+    %c0_i64 = arith.constant 0 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+
+    %src = pto.alloc_tile addr = %c0_i64
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+
+    %reshaped = pto.treshape %src
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+     -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %out = pto.alloc_tile addr = %c1024_i64
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tmov
+      ins(%reshaped
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16,
+                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%out
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16,
+                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void treshape_static_valid_shape_emitc()
+// CHECK: Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, 16, 1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[SRC:v[0-9]+]];
+// CHECK: TASSIGN([[SRC]],
+// CHECK: Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, 1, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[RESHAPED:v[0-9]+]];
+// CHECK-NEXT: TRESHAPE([[RESHAPED]], [[SRC]]);
+// CHECK-NOT: SetValidShape
+// CHECK-NOT: TRESHAPE
+// CHECK: TMOV({{v[0-9]+}}, [[RESHAPED]]);

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -292,6 +292,8 @@ static bool parseAutoSyncTailHint(llvm::StringRef hintStr, std::string &normaliz
 //   PTOAS__TILE_GET_VALUE(src, offset)      -> src.GetValue(offset)
 //   PTOAS__TILE_DATA(obj)                   -> obj.data()
 //   PTOAS__TILE_SET_VALIDSHAPE(obj, r, c)   -> obj.SetValidShape(r, c)
+//   PTOAS__TILE_GET_VALID_ROW(obj)          -> obj.GetValidRow()
+//   PTOAS__TILE_GET_VALID_COL(obj)          -> obj.GetValidCol()
 //   PTOAS__PTR_LOAD(ptr, offset)            -> ptr[offset]
 //   PTOAS__PTR_STORE(ptr, offset, val)      -> ptr[offset] = val
 //   PTOAS__EVENTID_ARRAY_LOAD(arr, idx)     -> arr[idx]
@@ -448,6 +450,8 @@ static void rewriteTileGetSetValueMarkers(std::string &cpp) {
       {"PTOAS__TILE_GET_VALUE", "GetValue", 2},
       {"PTOAS__TILE_DATA", "data", 1},
       {"PTOAS__TILE_SET_VALIDSHAPE", "SetValidShape", 3},
+      {"PTOAS__TILE_GET_VALID_ROW", "GetValidRow", 1},
+      {"PTOAS__TILE_GET_VALID_COL", "GetValidCol", 1},
   };
   rewriteMarkerCallsToMembers(cpp, kTileMarkerRewrites);
 }


### PR DESCRIPTION
## Summary
- add `pto.get_validshape` to read runtime tile valid_row/valid_col metadata, with EmitC lowering to `tile.GetValidRow()` / `tile.GetValidCol()`
- normalize risky A5 vec-to-vec col_major TMOV by emitting row-major treshape in the producer pass
- set auto-inserted treshape valid shape from runtime `get_validshape`, swapping col/row without compile-time valid-dim lookup
- preserve treshape alias semantics through tile-handle materialization so generated code declares the row-major tile, calls TRESHAPE, then SetValidShape
- preserve user-authored explicit treshape valid-shape semantics and cover dynamic, square, handwritten static-valid, and get_validshape cases

## Testing
- `ninja -C build-wsl-pr567-verify tools/ptoas/ptoas`
- `python3 /usr/lib/llvm-18/build/utils/lit/lit.py -a build-wsl-pr567-verify/test/lit/pto/get_validshape_emitc.pto build-wsl-pr567-verify/test/lit/pto/issue686_a5_tmov_treshape_dynamic_valid_shape.pto build-wsl-pr567-verify/test/lit/pto/issue686_a5_tmov_treshape_square_dynamic_valid_shape.pto build-wsl-pr567-verify/test/lit/pto/treshape_explicit_dynamic_valid_shape_preserved.pto build-wsl-pr567-verify/test/lit/pto/treshape_static_valid_shape_emitc.pto`
- `ptoas/FileCheck` for `issue660_trowexpandmul_set_validshape_preserves_alloc_valid.pto`
- `ptoas/FileCheck` for `tpush_tpop_dynamic_validshape_default_a5.pto --check-prefix=A5`
- `git diff --check`
