### PR TITLE
Add PTO pointer cast op

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -337,6 +337,83 @@ NOTE: These third-party ops are supported only to the extent required by PTOAS f
 
 ### 4.1 Pointer & View Operations
 
+##### `pto.ptrtoint` - Convert Pointer to Byte Address
+
+**Summary:** Converts a global pointer to an `i64` byte address.
+
+**Semantics:**
+
+```
+result = reinterpret_cast<i64>(ptr)
+```
+
+If the source is produced by `pto.addptr`, the addptr offset is materialized as an explicit byte offset:
+
+```
+pto.ptrtoint(pto.addptr %p, %idx) == pto.ptrtoint(%p) + idx * sizeof(elementType)
+```
+
+**Arguments:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `ptr` | `!pto.ptr<elementType>` | Source global pointer |
+
+**Results:** `i64`
+
+**Lowering Notes:**
+
+- PTO view lowering accepts either PTO pointer form or the lowered rank-1 GM memref form.
+- `pto.addptr` sources are folded into explicit byte-address arithmetic before EmitC lowering.
+- EmitC lowering emits a C++ `reinterpret_cast<int64_t>`.
+
+##### `pto.inttoptr` - Convert Byte Address to Pointer
+
+**Summary:** Converts an `i64` byte address to a global pointer of the requested element type.
+
+**Semantics:**
+
+```
+result = reinterpret_cast<result-element-type *>(addr)
+```
+
+This op is an escape hatch for explicit byte-address arithmetic and
+cross-element-type pointer reinterpretation.
+
+To limit provenance loss from integer-derived pointers, the result is
+restricted to scalar memory access: every direct use must be the pointer operand
+of `pto.load_scalar` or `pto.store_scalar`. The result cannot feed
+`pto.addptr`, `pto.make_tensor_view`, returns, or other general pointer users.
+Use the offset operand on `pto.load_scalar` / `pto.store_scalar` for element
+offsets from an `inttoptr` pointer.
+
+The result element type must be representable by EmitC scalar pointer lowering:
+floating-point element types (`f16`, `bf16`, `f32`, `f64`), 8/16/32/64-bit
+integer element types, and PTO low-precision floating-point element types are
+accepted. Non-scalar element types such as `index` are rejected by the verifier.
+
+**Arguments:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `addr` | `i64` | Source byte address |
+
+**Results:** `!pto.ptr<resultElementType>`
+
+**Lowering Notes:**
+
+- PTO view lowering rewrites the result to an equivalent rank-1 GM memref form.
+- EmitC lowering emits a C++ `reinterpret_cast<__gm__ T*>`.
+
+**Basic Example:**
+
+```mlir
+%p64_off = pto.addptr %p64, %idx : !pto.ptr<ui64> -> !pto.ptr<ui64>
+%addr = pto.ptrtoint %p64_off : !pto.ptr<ui64> -> i64
+%p32 = pto.inttoptr %addr : i64 -> !pto.ptr<ui32>
+%val = pto.load_scalar %p32[%c0] : !pto.ptr<ui32> -> ui32
+```
+
 ##### `pto.addptr` - Add Element Offset to Pointer
 
 **Summary:** Computes a new pointer by adding an element offset to the base pointer.
@@ -400,6 +477,9 @@ This operation defines the physical "base" and stride rules for global memory. I
   - `ptr` must be `!pto.ptr<...>` and its element type must match the result element type
   - `shape` and `strides` operand counts must match the tensor_view rank
   - If `layout` is provided with static shapes/strides, it must be consistent with inferred layout
+- `pto.inttoptr` results cannot feed `pto.make_tensor_view`. Tensor views must
+  be constructed from a source pointer that already carries the desired element
+  type.
 
 **Notes:**
 

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -105,6 +105,54 @@ def AddPtrOp : PTO_Op<"addptr", [
   }];
 }
 
+def PtrToIntOp : PTO_Op<"ptrtoint", [Pure]> {
+  let summary = "Convert a global pointer to a byte address";
+  let description = [{
+    Converts a global pointer value to an i64 byte address. If the source
+    pointer is produced by `pto.addptr`, lowering materializes the addptr
+    offset as an explicit byte offset before converting to EmitC.
+  }];
+
+  let arguments = (ins
+    PtrOrMemRef:$ptr
+  );
+
+  let results = (outs
+    I64:$result
+  );
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $ptr attr-dict `:` type($ptr) `->` type($result)
+  }];
+}
+
+def IntToPtrOp : PTO_Op<"inttoptr", [Pure]> {
+  let summary = "Convert an i64 byte address to a global pointer";
+  let description = [{
+    Converts an i64 byte address to a global pointer of the requested element
+    type. This is an escape hatch for explicit byte-address arithmetic and
+    cross-element-type pointer reinterpretation. To keep byte-address-derived
+    pointers from escaping into general pointer IR, the result may only be used
+    directly as the pointer operand of `pto.load_scalar` or `pto.store_scalar`.
+  }];
+
+  let arguments = (ins
+    AnyInteger:$addr
+  );
+
+  let results = (outs
+    PtrOrMemRef:$result
+  );
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $addr attr-dict `:` type($addr) `->` type($result)
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Scalar pointer load/store
 //===----------------------------------------------------------------------===//

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -67,9 +67,12 @@ createPlanMemoryPass(const PlanMemoryOptions &planMemoryOption = {});
 
 std::unique_ptr<Pass> createPTORemoveRedundantBarrierPass();
 std::unique_ptr<Pass> createPTOViewToMemrefPass();
+std::unique_ptr<Pass> createPTOValidateIntToPtrUsesPass();
 std::unique_ptr<Pass> createPTOMaterializeTileHandlesPass();
 std::unique_ptr<Pass> createInferPTOLayoutPass();
 std::unique_ptr<Pass> createPTOA5NormalizeTMovPass();
+
+LogicalResult validateIntToPtrUses(func::FuncOp func);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -298,6 +298,22 @@ def PTOViewToMemref : Pass<"pto-view-to-memref", "ModuleOp"> {
   ];
 }
 
+def PTOValidateIntToPtrUses : Pass<"pto-validate-inttoptr-uses", "func::FuncOp"> {
+  let summary = "Validate restricted uses of PTO inttoptr results";
+  let description = [{
+    Verifies that `pto.inttoptr` results do not escape into general pointer IR.
+    The result may only be used directly as the pointer operand of
+    `pto.load_scalar` or `pto.store_scalar`.
+  }];
+
+  let constructor = "mlir::pto::createPTOValidateIntToPtrUsesPass()";
+
+  let dependentDialects = [
+    "mlir::pto::PTODialect",
+    "mlir::func::FuncDialect"
+  ];
+}
+
 def PTOMaterializeTileHandles : Pass<"pto-materialize-tile-handles", "ModuleOp"> {
   let summary = "Materialize tile_buf handles from planned memrefs before EmitC";
   let description = [{

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -1987,6 +1987,78 @@ LogicalResult mlir::pto::AddPtrOp::verify() {
   return success();
 }
 
+static LogicalResult verifyPtrLikeForAddressCast(Operation *op, Type type,
+                                                 StringRef name) {
+  if (isa<mlir::pto::PtrType>(type))
+    return success();
+
+  auto memTy = dyn_cast<MemRefType>(type);
+  if (!memTy)
+    return op->emitOpError()
+           << "expects " << name << " to be !pto.ptr<...> or a GM memref";
+
+  if (memTy.getRank() != 1)
+    return op->emitOpError()
+           << "expects lowered memref " << name << " to be rank-1";
+
+  if (!isGmAddressSpaceAttr(memTy.getMemorySpace()))
+    return op->emitOpError()
+           << "expects lowered memref " << name << " to use GM address space";
+
+  return success();
+}
+
+static Type getPointerLikeElementType(Type type) {
+  if (auto ptrTy = dyn_cast<mlir::pto::PtrType>(type))
+    return ptrTy.getElementType();
+  if (auto memTy = dyn_cast<MemRefType>(type))
+    return memTy.getElementType();
+  return Type();
+}
+
+static bool isEmitCSupportedScalarType(Type type) {
+  if (!type)
+    return false;
+  if (type.isF16() || type.isBF16() || type.isF32() || type.isF64())
+    return true;
+  if (auto intTy = dyn_cast<IntegerType>(type))
+    return intTy.getWidth() == 8 || intTy.getWidth() == 16 ||
+           intTy.getWidth() == 32 || intTy.getWidth() == 64;
+  if (mlir::pto::isPTOFloat8Type(type))
+    return true;
+  if (isa<mlir::pto::HiF8Type, mlir::pto::F4E1M2x2Type,
+          mlir::pto::F4E2M1x2Type>(type))
+    return true;
+  return false;
+}
+
+LogicalResult mlir::pto::PtrToIntOp::verify() {
+  Type resultTy = getResult().getType();
+  auto intTy = dyn_cast<IntegerType>(resultTy);
+  if (!intTy || intTy.getWidth() != 64)
+    return emitOpError("result must be i64");
+
+  return verifyPtrLikeForAddressCast(getOperation(), getPtr().getType(),
+                                     "ptr operand");
+}
+
+LogicalResult mlir::pto::IntToPtrOp::verify() {
+  auto addrTy = dyn_cast<IntegerType>(getAddr().getType());
+  if (!addrTy || addrTy.getWidth() != 64)
+    return emitOpError("address operand must be i64");
+
+  if (failed(verifyPtrLikeForAddressCast(getOperation(), getResult().getType(),
+                                         "result")))
+    return failure();
+
+  Type dstElem = getPointerLikeElementType(getResult().getType());
+  if (!isEmitCSupportedScalarType(dstElem))
+    return emitOpError("result element type is not supported by EmitC: ")
+           << dstElem;
+
+  return success();
+}
+
 LogicalResult mlir::pto::LocalArrayGetOp::verify() {
   auto arrayTy = getArray().getType();
   int64_t rank = arrayTy.getRank();

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_dialect_library(PTOTransforms
   PTOInjectBarrierAllSync.cpp
   InsertSync/InsertSyncDebug.cpp
   PTOViewToMemref.cpp
+  PTOValidateIntToPtrUses.cpp
   PTOToEmitC.cpp
   Utils.cpp
   OptMemPlanForPipeline.cpp

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5626,6 +5626,66 @@ struct PTOTAssignToEmitC : public OpConversionPattern<pto::TAssignOp> {
 // pto.load_scalar / pto.store_scalar lowering -> ptr[offset]
 //===----------------------------------------------------------------------===//
 
+static Type getPointerLikeElementType(Type type) {
+  if (auto ptrTy = dyn_cast<pto::PtrType>(type))
+    return ptrTy.getElementType();
+  if (auto memTy = dyn_cast<MemRefType>(type))
+    return memTy.getElementType();
+  return Type();
+}
+
+struct PTOPtrToIntToEmitC : public OpConversionPattern<pto::PtrToIntOp> {
+  using OpConversionPattern<pto::PtrToIntOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(pto::PtrToIntOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    Value ptr = peelUnrealized(adaptor.getPtr());
+    Type dstTy = getTypeConverter()->convertType(op.getResult().getType());
+    if (!dstTy)
+      return failure();
+
+    auto dstOpaque = dyn_cast<emitc::OpaqueType>(dstTy);
+    if (!dstOpaque)
+      return failure();
+
+    auto templateArgs =
+        rewriter.getArrayAttr({emitc::OpaqueAttr::get(rewriter.getContext(),
+                                                      dstOpaque.getValue())});
+    auto cast = rewriter.create<emitc::CallOpaqueOp>(
+        op.getLoc(), dstTy, "reinterpret_cast", ArrayAttr{}, templateArgs,
+        ValueRange{ptr});
+    rewriter.replaceOp(op, cast.getResult(0));
+    return success();
+  }
+};
+
+struct PTOIntToPtrToEmitC : public OpConversionPattern<pto::IntToPtrOp> {
+  using OpConversionPattern<pto::IntToPtrOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(pto::IntToPtrOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    Value addr = peelUnrealized(adaptor.getAddr());
+    Type dstTy = getTypeConverter()->convertType(op.getResult().getType());
+    if (!dstTy)
+      return failure();
+
+    Type dstElemTy = getPointerLikeElementType(op.getResult().getType());
+    if (!dstElemTy)
+      return failure();
+
+    std::string castType =
+        std::string("__gm__ ") + getEmitCScalarTypeToken(dstElemTy) + "*";
+    auto templateArgs =
+        rewriter.getArrayAttr({emitc::OpaqueAttr::get(rewriter.getContext(),
+                                                      castType)});
+    auto cast = rewriter.create<emitc::CallOpaqueOp>(
+        op.getLoc(), dstTy, "reinterpret_cast", ArrayAttr{}, templateArgs,
+        ValueRange{addr});
+    rewriter.replaceOp(op, cast.getResult(0));
+    return success();
+  }
+};
+
 struct PTOLoadScalarToEmitC : public OpConversionPattern<pto::LoadScalarOp> {
   using OpConversionPattern<pto::LoadScalarOp>::OpConversionPattern;
 
@@ -11933,7 +11993,8 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<SubviewToEmitCPattern>(typeConverter, ctx);
   patterns.add<PointerCastConversion>(typeConverter, ctx);
   patterns.add<PTOSetValToSETVAL, PTOGetValToGETVAL, PTOSetValidShapeToEmitC,
-               PTOGetValidShapeToEmitC, PTOTAssignToEmitC, PTOLoadScalarToEmitC,
+               PTOGetValidShapeToEmitC, PTOTAssignToEmitC,
+               PTOPtrToIntToEmitC, PTOIntToPtrToEmitC, PTOLoadScalarToEmitC,
                PTOStoreScalarToEmitC>(typeConverter, ctx);
   patterns.add<PTOTAxpyToEmitC, PTOHistogramToEmitC, PTOGetScaleAddrToEmitC>(
       typeConverter, ctx);

--- a/lib/PTO/Transforms/PTOValidateIntToPtrUses.cpp
+++ b/lib/PTO/Transforms/PTOValidateIntToPtrUses.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace pto {
+namespace func = ::mlir::func;
+#define GEN_PASS_DEF_PTOVALIDATEINTTOPTRUSES
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::pto;
+
+static bool isAllowedIntToPtrUse(Value ptr, OpOperand &use) {
+  Operation *user = use.getOwner();
+  if (isa<LoadScalarOp, StoreScalarOp>(user))
+    return use.getOperandNumber() == 0 && user->getOperand(0) == ptr;
+  return false;
+}
+
+LogicalResult mlir::pto::validateIntToPtrUses(func::FuncOp func) {
+  WalkResult walkResult = func.walk([&](IntToPtrOp op) -> WalkResult {
+    Value ptr = op.getResult();
+    for (OpOperand &use : ptr.getUses()) {
+      if (isAllowedIntToPtrUse(ptr, use))
+        continue;
+
+      Operation *user = use.getOwner();
+      InFlightDiagnostic diag =
+          op.emitOpError()
+          << "result may only be used as the pointer operand of "
+             "pto.load_scalar or pto.store_scalar; found use by '"
+          << user->getName().getStringRef() << "'";
+      diag.attachNote(user->getLoc()) << "disallowed pto.inttoptr use here";
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+
+  return failure(walkResult.wasInterrupted());
+}
+
+namespace {
+struct PTOValidateIntToPtrUsesPass
+    : public mlir::pto::impl::PTOValidateIntToPtrUsesBase<
+          PTOValidateIntToPtrUsesPass> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PTOValidateIntToPtrUsesPass)
+
+  void runOnOperation() override {
+    if (failed(validateIntToPtrUses(getOperation())))
+      signalPassFailure();
+  }
+};
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOValidateIntToPtrUsesPass() {
+  return std::make_unique<PTOValidateIntToPtrUsesPass>();
+}

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -818,6 +818,127 @@ static void markForceDynamicValidShape(Operation *op, bool force,
   return success();
 }
 
+static Value castIndexToI64(IRRewriter &rewriter, Location loc, Value value) {
+  Type i64Ty = rewriter.getI64Type();
+  if (value.getType() == i64Ty)
+    return value;
+  return rewriter.create<arith::IndexCastOp>(loc, i64Ty, value).getResult();
+}
+
+static FailureOr<Value>
+materializePtrToIntAddPtrAddress(IRRewriter &rewriter, Location loc,
+                                 mlir::pto::PtrToIntOp anchor, Value source) {
+  SmallVector<mlir::pto::AddPtrOp, 4> addPtrChain;
+  Value base = source;
+  while (auto add = base.getDefiningOp<mlir::pto::AddPtrOp>()) {
+    addPtrChain.push_back(add);
+    base = add.getOperand(0);
+  }
+
+  if (addPtrChain.empty())
+    return failure();
+
+  auto baseMemTy = dyn_cast<MemRefType>(base.getType());
+  if (!baseMemTy) {
+    anchor.emitOpError(
+        "pto.addptr source base could not be lowered to a GM memref");
+    return failure();
+  }
+
+  Value byteAddress = rewriter.create<mlir::pto::PtrToIntOp>(
+      loc, rewriter.getI64Type(), base);
+  for (auto add : addPtrChain) {
+    auto addPtrTy = dyn_cast<mlir::pto::PtrType>(add.getResult().getType());
+    if (!addPtrTy) {
+      anchor.emitOpError("requires pto.addptr source to have !pto.ptr result "
+                         "type before byte-address lowering");
+      return failure();
+    }
+
+    unsigned elemBytes =
+        mlir::pto::getPTOStorageElemByteSize(addPtrTy.getElementType());
+    if (elemBytes == 0) {
+      anchor.emitOpError("cannot lower pto.addptr source with unknown element "
+                         "byte size to a byte address");
+      return failure();
+    }
+
+    Value byteOffset = castIndexToI64(rewriter, loc, add.getOffset());
+    if (elemBytes != 1) {
+      Value elemBytesValue =
+          rewriter.create<arith::ConstantIntOp>(loc, elemBytes, 64);
+      byteOffset =
+          rewriter.create<arith::MulIOp>(loc, byteOffset, elemBytesValue)
+              .getResult();
+    }
+    byteAddress =
+        rewriter.create<arith::AddIOp>(loc, byteAddress, byteOffset).getResult();
+  }
+
+  return byteAddress;
+}
+
+static LogicalResult lowerIntToPtrOps(func::FuncOp func, MLIRContext *ctx) {
+  DefaultInlineVector<mlir::pto::IntToPtrOp> intToPtrs;
+  func.walk([&](mlir::pto::IntToPtrOp op) { intToPtrs.push_back(op); });
+
+  for (auto op : intToPtrs) {
+    if (!isa<mlir::pto::PtrType>(op.getResult().getType()))
+      continue;
+
+    auto targetTy =
+        dyn_cast<MemRefType>(convertPTOTypeToMemRef(op.getResult().getType()));
+    if (!targetTy) {
+      op.emitError("failed to convert inttoptr result to memref type");
+      return failure();
+    }
+
+    IRRewriter rewriter(ctx);
+    rewriter.setInsertionPoint(op);
+    auto lowered =
+        rewriter.create<mlir::pto::IntToPtrOp>(op.getLoc(), targetTy,
+                                               op.getAddr());
+    lowered->setAttrs(op->getAttrs());
+    rewriter.replaceOp(op, lowered.getResult());
+  }
+
+  return success();
+}
+
+static LogicalResult lowerPtrToIntOps(func::FuncOp func, MLIRContext *ctx) {
+  DefaultInlineVector<mlir::pto::PtrToIntOp> ptrToInts;
+  func.walk([&](mlir::pto::PtrToIntOp op) { ptrToInts.push_back(op); });
+
+  for (auto op : ptrToInts) {
+    Value source = op.getPtr();
+    if (source.getDefiningOp<mlir::pto::AddPtrOp>()) {
+      IRRewriter rewriter(ctx);
+      rewriter.setInsertionPoint(op);
+      FailureOr<Value> byteAddress =
+          materializePtrToIntAddPtrAddress(rewriter, op.getLoc(), op, source);
+      if (failed(byteAddress))
+        return failure();
+      rewriter.replaceOp(op, *byteAddress);
+      continue;
+    }
+
+    if (isa<mlir::pto::PtrType>(source.getType()))
+      continue;
+  }
+
+  DefaultInlineVector<mlir::pto::PtrToIntOp> remaining;
+  func.walk([&](mlir::pto::PtrToIntOp op) {
+    if (isa<mlir::pto::PtrType>(op.getPtr().getType()))
+      remaining.push_back(op);
+  });
+  for (auto op : remaining) {
+    op.emitError("ptrtoint source could not be lowered to a GM memref");
+    return failure();
+  }
+
+  return success();
+}
+
 [[maybe_unused]] static LogicalResult lowerMakeTensorViewOps(func::FuncOp func, MLIRContext *ctx) {
   DefaultInlineVector<mlir::pto::MakeTensorViewOp> makeViews;
   func.walk([&](mlir::pto::MakeTensorViewOp op) { makeViews.push_back(op); });
@@ -1224,11 +1345,19 @@ struct PTOViewToMemrefPass
     for (auto func : mod.getOps<func::FuncOp>()) {
       if (func.isExternal()) continue;
 
+      // ------------------------------------------------------------------
+      // Stage 0: ensure inttoptr values remain scalar-load/store only.
+      // ------------------------------------------------------------------
+      if (failed(validateIntToPtrUses(func))) {
+        signalPassFailure();
+        return;
+      }
+
       Block &entry = func.front();
       auto fnTy = func.getFunctionType();
 
       // ------------------------------------------------------------------
-      // Stage 0: Rewrite Function Signature
+      // Stage 0.10: Rewrite Function Signature
       // ------------------------------------------------------------------
       SmallVector<Type> newInputs;
       for (Type t : fnTy.getInputs()) newInputs.push_back(convertPTOTypeToMemRef(t));
@@ -1245,6 +1374,22 @@ struct PTOViewToMemrefPass
 
       // Update function type
       func.setFunctionType(FunctionType::get(ctx, newInputs, newResults));
+
+      // ------------------------------------------------------------------
+      // Stage 0.20: lower pto.inttoptr result types to GM memrefs.
+      // ------------------------------------------------------------------
+      if (failed(lowerIntToPtrOps(func, ctx))) {
+        signalPassFailure();
+        return;
+      }
+
+      // ------------------------------------------------------------------
+      // Stage 0.30: materialize pto.ptrtoint(addptr ...) byte offsets.
+      // ------------------------------------------------------------------
+      if (failed(lowerPtrToIntOps(func, ctx))) {
+        signalPassFailure();
+        return;
+      }
 
       // ------------------------------------------------------------------
       // Stage 0.5: lower pto.alloc_tile -> memref.alloc + pto.bind_tile

--- a/python/pto/dialects/pto.py
+++ b/python/pto/dialects/pto.py
@@ -176,6 +176,8 @@ __all__ = [
     "get_buf",
     "rls_buf",
     # Scalar pointer helpers
+    "ptrtoint",
+    "inttoptr",
     "load_scalar",
     "store_scalar",
     # Aliases for SyncOpType enums (for terse calls)
@@ -533,6 +535,34 @@ def rls_buf(op_type, buf_id, mode=0, *, loc=None, ip=None):
 # -----------------------------------------------------------------------------
 # Scalar pointer helpers (manual wrappers until python ops are regenerated)
 # -----------------------------------------------------------------------------
+
+
+def ptrtoint(ptr, *, loc=None, ip=None):
+    operands = [
+        get_op_result_or_value(ptr),
+    ]
+    op = _ods_ir.Operation.create(
+        "pto.ptrtoint",
+        results=[_ods_ir.IntegerType.get_signless(64)],
+        operands=operands,
+        loc=loc,
+        ip=ip,
+    )
+    return op.results[0]
+
+
+def inttoptr(result_type, addr, *, loc=None, ip=None):
+    operands = [
+        get_op_result_or_value(addr),
+    ]
+    op = _ods_ir.Operation.create(
+        "pto.inttoptr",
+        results=[result_type],
+        operands=operands,
+        loc=loc,
+        ip=ip,
+    )
+    return op.results[0]
 
 
 def load_scalar(result_type, ptr, offset, *, loc=None, ip=None):

--- a/test/lit/pto/inttoptr_addptr_use_invalid.pto
+++ b/test/lit/pto/inttoptr_addptr_use_invalid.pto
@@ -1,0 +1,16 @@
+// RUN: not ptoas --pto-arch=a3 %s -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @inttoptr_addptr_use_invalid(%addr: i64, %dst: !pto.ptr<ui32>, %idx: index) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %ptr = pto.inttoptr %addr : i64 -> !pto.ptr<ui32>
+    %off = pto.addptr %ptr, %idx : !pto.ptr<ui32> -> !pto.ptr<ui32>
+    %val = pto.load_scalar %off[%c0] : !pto.ptr<ui32> -> ui32
+    pto.store_scalar %val, %dst[%c0] : !pto.ptr<ui32>, ui32
+    return
+  }
+}
+
+// CHECK: pto.inttoptr
+// CHECK: result may only be used as the pointer operand of pto.load_scalar or pto.store_scalar
+// CHECK: pto.addptr

--- a/test/lit/pto/inttoptr_elem_type_invalid.pto
+++ b/test/lit/pto/inttoptr_elem_type_invalid.pto
@@ -1,0 +1,13 @@
+// RUN: not ptoas --pto-arch=a3 %s -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @inttoptr_index_elem_invalid(%addr: i64) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %ptr = pto.inttoptr %addr : i64 -> !pto.ptr<index>
+    %val = pto.load_scalar %ptr[%c0] : !pto.ptr<index> -> index
+    return
+  }
+}
+
+// CHECK: pto.inttoptr
+// CHECK: result element type is not supported by EmitC: 'index'

--- a/test/lit/pto/inttoptr_elem_type_supported.pto
+++ b/test/lit/pto/inttoptr_elem_type_supported.pto
@@ -1,0 +1,18 @@
+// RUN: ptoas --pto-arch=a3 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @inttoptr_supported_elem_types(%addr: i64, %dst_f32: !pto.ptr<f32>, %dst_i32: !pto.ptr<i32>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %ptr_f32 = pto.inttoptr %addr : i64 -> !pto.ptr<f32>
+    %val_f32 = pto.load_scalar %ptr_f32[%c0] : !pto.ptr<f32> -> f32
+    pto.store_scalar %val_f32, %dst_f32[%c0] : !pto.ptr<f32>, f32
+    %ptr_i32 = pto.inttoptr %addr : i64 -> !pto.ptr<i32>
+    %val_i32 = pto.load_scalar %ptr_i32[%c0] : !pto.ptr<i32> -> i32
+    pto.store_scalar %val_i32, %dst_i32[%c0] : !pto.ptr<i32>, i32
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void inttoptr_supported_elem_types
+// CHECK: reinterpret_cast<__gm__ float*>
+// CHECK: reinterpret_cast<__gm__ int32_t*>

--- a/test/lit/pto/inttoptr_invalid.pto
+++ b/test/lit/pto/inttoptr_invalid.pto
@@ -1,0 +1,11 @@
+// RUN: not ptoas --pto-arch=a3 %s -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @inttoptr_invalid(%addr: i32) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %ptr = pto.inttoptr %addr : i32 -> !pto.ptr<ui32>
+    return
+  }
+}
+
+// CHECK: pto.inttoptr
+// CHECK: address operand must be i64

--- a/test/lit/pto/inttoptr_make_tensor_view_invalid.pto
+++ b/test/lit/pto/inttoptr_make_tensor_view_invalid.pto
@@ -1,0 +1,14 @@
+// RUN: not ptoas --pto-arch=a3 %s -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @inttoptr_make_tensor_view_invalid(%addr: i64) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c1 = arith.constant 1 : index
+    %ptr = pto.inttoptr %addr : i64 -> !pto.ptr<ui32>
+    %view = pto.make_tensor_view %ptr, shape = [%c1], strides = [%c1] : !pto.tensor_view<?xui32>
+    return
+  }
+}
+
+// CHECK: pto.inttoptr
+// CHECK: result may only be used as the pointer operand of pto.load_scalar or pto.store_scalar
+// CHECK: pto.make_tensor_view

--- a/test/lit/pto/ptr_int_cast.pto
+++ b/test/lit/pto/ptr_int_cast.pto
@@ -1,0 +1,59 @@
+// RUN: ptoas --pto-arch=a3 --mlir-print-ir-after=pto-view-to-memref %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=IR
+// RUN: ptoas --pto-arch=a3 %s -o - 2>&1 | FileCheck %s --check-prefix=CPP
+
+module {
+  func.func @ptr_int_cast_kernel(%src64: !pto.ptr<ui64>, %dst32: !pto.ptr<ui32>, %idx: index) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %src64_off = pto.addptr %src64, %idx : !pto.ptr<ui64> -> !pto.ptr<ui64>
+    %addr = pto.ptrtoint %src64_off : !pto.ptr<ui64> -> i64
+    %src32 = pto.inttoptr %addr : i64 -> !pto.ptr<ui32>
+    %val = pto.load_scalar %src32[%c0] : !pto.ptr<ui32> -> ui32
+    pto.store_scalar %val, %dst32[%idx] : !pto.ptr<ui32>, ui32
+    return
+  }
+
+  func.func @ptrtoint_addptr_multi_consumer(%src64: !pto.ptr<ui64>, %dst64: !pto.ptr<ui64>, %dst_addr: !pto.ptr<i64>, %idx: index) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %off = pto.addptr %src64, %idx : !pto.ptr<ui64> -> !pto.ptr<ui64>
+    %a = pto.load_scalar %off[%c0] : !pto.ptr<ui64> -> ui64
+    %addr = pto.ptrtoint %off : !pto.ptr<ui64> -> i64
+    pto.store_scalar %a, %dst64[%c0] : !pto.ptr<ui64>, ui64
+    pto.store_scalar %addr, %dst_addr[%c0] : !pto.ptr<i64>, i64
+    return
+  }
+}
+
+// IR-LABEL: func.func @ptr_int_cast_kernel
+// IR: pto.ptrtoint {{.*}} : memref<?xui64> -> i64
+// IR: arith.index_cast {{.*}} : index to i64
+// IR: arith.constant 8 : i64
+// IR: arith.muli {{.*}} : i64
+// IR: arith.addi {{.*}} : i64
+// IR: pto.inttoptr {{.*}} : i64 -> memref<?xui32>
+// IR-NOT: !pto.ptr
+
+// CPP-LABEL: AICORE void ptr_int_cast_kernel
+// CPP-SAME: (__gm__ uint64_t* [[SRC:v[0-9]+]], __gm__ uint32_t* [[DST:v[0-9]+]], int32_t [[IDX:v[0-9]+]])
+// CPP: int64_t [[ADDR:v[0-9]+]] = reinterpret_cast<int64_t>([[SRC]]);
+// CPP: __gm__ uint32_t* [[SRC32:v[0-9]+]] = reinterpret_cast<__gm__ uint32_t*>({{.*}}[[ADDR]]
+// CPP: uint32_t [[VAL:v[0-9]+]] = [[SRC32]][{{.*}}];
+// CPP: [[DST]][[[IDX]]] = [[VAL]];
+
+// IR-LABEL: func.func @ptrtoint_addptr_multi_consumer
+// IR: pto.load_scalar {{.*}} : memref<?xui64> -> ui64
+// IR: pto.ptrtoint {{.*}} : memref<?xui64> -> i64
+// IR: arith.index_cast {{.*}} : index to i64
+// IR: arith.constant 8 : i64
+// IR: arith.muli {{.*}} : i64
+// IR: arith.addi {{.*}} : i64
+// IR-NOT: !pto.ptr
+
+// CPP-LABEL: AICORE void ptrtoint_addptr_multi_consumer
+// CPP-SAME: (__gm__ uint64_t* [[SRC64:v[0-9]+]], __gm__ uint64_t* [[DST64:v[0-9]+]], __gm__ int64_t* [[DSTADDR:v[0-9]+]], int32_t [[IDX2:v[0-9]+]])
+// CPP: const int32_t [[ZERO:v[0-9]+]] = 0;
+// CPP: const int64_t [[ELEM_BYTES:v[0-9]+]] = 8;
+// CPP: uint64_t [[A:v[0-9]+]] = [[SRC64]][[[IDX2]]];
+// CPP: int64_t [[ADDR2:v[0-9]+]] = reinterpret_cast<int64_t>([[SRC64]]);
+// CPP: int64_t [[BYTE_ADDR:v[0-9]+]] = {{.*}}[[ADDR2]]{{.*}}[[IDX2]]{{.*}}[[ELEM_BYTES]]
+// CPP: [[DST64]][[[ZERO]]] = [[A]];
+// CPP: [[DSTADDR]][[[ZERO]]] = [[BYTE_ADDR]];

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -1166,6 +1166,8 @@ int main(int argc, char **argv) {
   if (!disableInferLayout)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createInferPTOLayoutPass());
   pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOA5NormalizeTMovPass());
+  pm.addNestedPass<mlir::func::FuncOp>(
+      pto::createPTOValidateIntToPtrUsesPass());
   pm.addPass(pto::createPTOViewToMemrefPass());
 
   if (effectiveLevel != PTOBuildLevel::Level3) {


### PR DESCRIPTION
Summary: add pto.ptr_cast IR op, verifier, Python helper, manual docs, GM memref lowering, and EmitC reinterpret_cast support. Validation: cmake --build build-codex-ci --target ptoas -j2; llvm-lit -sv --filter=ptr_cast build-codex-ci/test/lit; llvm-lit -sv --filter=issue481_addptr_gm_slot_buffer build-codex-ci/test/lit; python3 -m py_compile python/pto/dialects/pto.py; git diff --cached --check.