### PR TITLE
Fix local_array_get snapshot lowering

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2252,8 +2252,9 @@ def DeclareLocalArrayOp : PTO_Op<"declare_local_array"> {
 def LocalArrayGetOp : PTO_Op<"local_array_get"> {
   let summary = "Read one element from a stack-local array";
   let description = [{
-    Lowers to `a[i0][i1]...[iN-1]` (an rvalue) in the emitted C++. The number
-    of indices must equal the array's rank.
+    Lowers to a scalar snapshot initialized from `a[i0][i1]...[iN-1]` in the
+    emitted C++. This preserves SSA value semantics if the array is mutated
+    later. The number of indices must equal the array's rank.
   }];
 
   let arguments = (ins

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6814,11 +6814,9 @@ struct PTODeclareLocalArrayToEmitC
   }
 };
 
-// pto.local_array_get %a[%i0, %i1, ...] -> rvalue.
-// Lowers to a single emitc.subscript with the full index pack; the C++ emitter
-// prints it as `a[i0][i1]...`. The adaptor already exposes target-typed values
-// (the type converter has remapped !pto.local_array -> !emitc.array and
-// index/integer indices), so they're forwarded directly to the builder.
+// pto.local_array_get %a[%i0, %i1, ...] -> scalar snapshot.
+// Materialize the subscript read immediately so the MLIR SSA result keeps its
+// value even if a later pto.local_array_set mutates the same backing array slot.
 struct PTOLocalArrayGetToEmitC
     : public OpConversionPattern<mlir::pto::LocalArrayGetOp> {
   using OpConversionPattern<
@@ -6833,9 +6831,22 @@ struct PTOLocalArrayGetToEmitC
       return rewriter.notifyMatchFailure(
           op, "failed to map local_array element type");
 
+    Value array = peelUnrealized(adaptor.getArray());
+    SmallVector<Value> indices;
+    indices.reserve(adaptor.getIndices().size());
+    for (Value index : adaptor.getIndices())
+      indices.push_back(peelUnrealized(index));
+
     auto sub = rewriter.create<emitc::SubscriptOp>(
-        op.getLoc(), resultTy, adaptor.getArray(), adaptor.getIndices());
-    rewriter.replaceOp(op, sub.getResult());
+        op.getLoc(), resultTy, array, indices);
+    auto snapshot =
+        rewriter
+            .create<emitc::VariableOp>(
+                op.getLoc(), resultTy,
+                emitc::OpaqueAttr::get(rewriter.getContext(), ""))
+            .getResult();
+    rewriter.create<emitc::AssignOp>(op.getLoc(), snapshot, sub.getResult());
+    rewriter.replaceOp(op, snapshot);
     return success();
   }
 };

--- a/test/lit/pto/issue713_local_array_get_snapshot.pto
+++ b/test/lit/pto/issue713_local_array_get_snapshot.pto
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 %s -o - 2>&1 | FileCheck %s --check-prefix=CPP
+
+module {
+  func.func @issue713_local_array_get_snapshot(%out: !pto.ptr<i32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_index = arith.constant 0 : index
+    %c1_index = arith.constant 1 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c7_i32 = arith.constant 7 : i32
+
+    %arr = pto.declare_local_array -> !pto.local_array<2xi32>
+    pto.local_array_set %arr[%c0_index], %c7_i32 : !pto.local_array<2xi32>, i32
+    pto.local_array_set %arr[%c1_index], %c0_i32 : !pto.local_array<2xi32>, i32
+
+    %cur = pto.local_array_get %arr[%c0_index] : !pto.local_array<2xi32> -> i32
+    %new = arith.addi %cur, %c1_i32 : i32
+    pto.local_array_set %arr[%c0_index], %new : !pto.local_array<2xi32>, i32
+
+    %sum = arith.addi %c100_i32, %cur : i32
+    pto.store_scalar %sum, %out[%c0_index] : !pto.ptr<i32>, i32
+    return
+  }
+}
+
+// CPP-LABEL: AICORE void issue713_local_array_get_snapshot
+// CPP-SAME: (__gm__ int32_t* [[OUT:v[0-9]+]])
+// CPP: int32_t [[ARR:v[0-9]+]][2];
+// CPP: [[ARR]][{{v[0-9]+}}] = {{v[0-9]+}};
+// CPP: [[ARR]][{{v[0-9]+}}] = {{v[0-9]+}};
+// CPP: int32_t [[CUR:v[0-9]+]];
+// CPP-NEXT: [[CUR]] = [[ARR]][{{v[0-9]+}}];
+// CPP-NEXT: uint32_t [[NEW_U:v[0-9]+]] = (uint32_t) [[CUR]];
+// CPP-NEXT: [[ARR]][{{v[0-9]+}}] = {{.*}}[[NEW_U]]{{.*}};
+// CPP-NOT: [[ARR]][
+// CPP: uint32_t [[SUM_U:v[0-9]+]] = (uint32_t) [[CUR]];
+// CPP-NEXT: int32_t [[SUM:v[0-9]+]] = {{.*}}[[SUM_U]]{{.*}};
+// CPP-NEXT: [[OUT]][{{v[0-9]+}}] = [[SUM]];

--- a/test/lit/pto/local_array_1d_emitc.pto
+++ b/test/lit/pto/local_array_1d_emitc.pto
@@ -9,8 +9,8 @@
 // RUN: ptoas %s 2>&1 | FileCheck %s
 
 // Stack-local 1D array: declare, set by dynamic index, get by another dynamic
-// index, set the read-back. Expected: lowers to `int32_t a[16];` plus
-// `a[i] = v;` / `a[i] = a[j];` in the emitted C++.
+// index, set the read-back. Expected: the get is snapshotted before the later
+// set reuses the value.
 
 module {
   func.func @local_array_1d(%i : index, %j : index, %v : i32) {
@@ -25,4 +25,6 @@ module {
 // CHECK-LABEL: local_array_1d
 // CHECK: int32_t [[A:v[0-9]+]][16];
 // CHECK: [[A]][{{v[0-9]+}}] = {{v[0-9]+}};
-// CHECK: [[A]][{{v[0-9]+}}] = [[A]][{{v[0-9]+}}];
+// CHECK: int32_t [[R:v[0-9]+]];
+// CHECK: [[R]] = [[A]][{{v[0-9]+}}];
+// CHECK: [[A]][{{v[0-9]+}}] = [[R]];

--- a/test/lit/pto/local_array_2d_emitc.pto
+++ b/test/lit/pto/local_array_2d_emitc.pto
@@ -9,8 +9,8 @@
 // RUN: ptoas %s 2>&1 | FileCheck %s
 
 // Stack-local 2D array: declare, set at (i, j), get at (j, i), set the
-// read-back to (i, j). Expected: lowers to `float m[8][8];` plus chained
-// `m[i][j] = v;` / `m[i][j] = m[j][i];` in the emitted C++.
+// read-back to (i, j). Expected: the get is snapshotted before the later set
+// reuses the value.
 
 module {
   func.func @local_array_2d(%i : index, %j : index, %v : f32) {
@@ -25,4 +25,6 @@ module {
 // CHECK-LABEL: local_array_2d
 // CHECK: float [[M:v[0-9]+]][8][8];
 // CHECK: [[M]][{{v[0-9]+}}][{{v[0-9]+}}] = {{v[0-9]+}};
-// CHECK: [[M]][{{v[0-9]+}}][{{v[0-9]+}}] = [[M]][{{v[0-9]+}}][{{v[0-9]+}}];
+// CHECK: float [[R:v[0-9]+]];
+// CHECK: [[R]] = [[M]][{{v[0-9]+}}][{{v[0-9]+}}];
+// CHECK: [[M]][{{v[0-9]+}}][{{v[0-9]+}}] = [[R]];

--- a/test/lit/pto/local_array_get_rvalue_emitc.pto
+++ b/test/lit/pto/local_array_get_rvalue_emitc.pto
@@ -8,9 +8,8 @@
 
 // RUN: ptoas %s 2>&1 | FileCheck %s
 
-// Verify that pto.local_array_get behaves as a real scalar rvalue: its result
-// flows into arith ops without an explicit load. The expected C++ shape is
-// `t = a[j] + 1; a[i] = t;` (or any expression-folded equivalent).
+// Verify that pto.local_array_get behaves as a real scalar SSA value: its
+// result is snapshotted before it flows into later arith ops.
 
 module {
   func.func @local_array_get_rvalue(%i : index, %j : index) {
@@ -25,7 +24,7 @@ module {
 
 // CHECK-LABEL: local_array_get_rvalue
 // CHECK: int32_t [[A:v[0-9]+]][16];
-// `a[i] = ...a[j]... + ...;` — confirms the get result flows through arith as
-// a scalar rvalue. The exact cast/paren shape comes from arith.addi's signless
-// overflow-aware lowering; we only pin the subscript-rvalue flow here.
-// CHECK: [[A]][{{v[0-9]+}}] = {{.*}}[[A]][{{v[0-9]+}}]{{.*}};
+// CHECK: int32_t [[R:v[0-9]+]];
+// CHECK: [[R]] = [[A]][{{v[0-9]+}}];
+// CHECK: uint32_t [[R_U:v[0-9]+]] = (uint32_t) [[R]];
+// CHECK: [[A]][{{v[0-9]+}}] = {{.*}}[[R_U]]{{.*}};


### PR DESCRIPTION
## Summary
- Materialize pto.local_array_get as a scalar snapshot during EmitC lowering.
- Preserve SSA value semantics when a later pto.local_array_set mutates the same array slot.
- Add and update lit coverage for local array get snapshot behavior.

Fixes #713

## Testing
- ninja -C build-codex-ci ptoas
- ptoas local_array_1d_emitc.pto | FileCheck local_array_1d_emitc.pto
- ptoas local_array_2d_emitc.pto | FileCheck local_array_2d_emitc.pto
- ptoas local_array_get_rvalue_emitc.pto | FileCheck local_array_get_rvalue_emitc.pto
- ptoas --pto-arch=a3 issue713_local_array_get_snapshot.pto -o - | FileCheck issue713_local_array_get_snapshot.pto --check-prefix=CPP
