### PR TITLE
Allow selected zero-valid tileop verifier paths

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -154,7 +154,11 @@ A logical partition (slice) of a `tensor_view`. Holds shape and stride informati
 | `fractal` | `int32` | Fractal size |
 | `pad` | `PadValue` mnemonic or integer literal | Padding policy/value selector (tests commonly use `pad=0`) |
 
-Here, `?` denotes a dynamic symbol resolved at runtime.
+Here, `?` denotes a dynamic symbol resolved at runtime. Static and dynamic
+valid dimensions are non-negative counts; a static `v_row=0` or `v_col=0`
+represents an empty valid region. Physical `rows`/`cols` may still describe the
+storage extent, for example an even physical row count with an odd or zero
+`v_row` on a tail tile.
 
 For `dtype=!pto.f4E1M2x2` and `dtype=!pto.f4E2M1x2`, the `rows`/`cols` and
 `v_row`/`v_col` values are physical packed extents. In other words, the packed
@@ -657,7 +661,7 @@ result.valid = clip(explicit_valid_or_sizes, sizes)
 - `valid_row` and `valid_col` must be both present or both absent.
 - If `valid_row/valid_col` are omitted, result `valid_shape` defaults to `sizes`.
 - If `valid_row/valid_col` are provided:
-  - constant values must be positive and `<= sizes` in each dimension
+  - constant values must be non-negative and `<= sizes` in each dimension
   - non-constant values are represented as dynamic valid dims in the result type
 - The inferred result type uses:
   - `shape = sizes` (logical subview size)
@@ -667,6 +671,8 @@ result.valid = clip(explicit_valid_or_sizes, sizes)
   - if explicit `valid_row/valid_col` are provided, `valid_shape` is clipped by `sizes`
 - Lowering keeps parent physical stride/base semantics for non-compact access,
   so EmitC behavior remains unchanged from the previous implementation.
+- If an explicit valid dimension is zero, the subview still has the requested
+  physical `sizes`, but its valid region is empty in that dimension.
 
 **Hardware Mapping:**
 
@@ -856,7 +862,7 @@ For each element (i, j) in the tile valid region:
   - Tile element type must be one of: `i8`, `i16`, `i32`, `i64`, `f16`, `bf16`, `f32`.
   - The destination tile must use `loc=vec` or `loc=mat`.
   - The destination tile element type and source partition element type must have the same bitwidth.
-  - Runtime: all source partition extents and the destination valid region must be positive.
+  - Runtime: all source partition extents must be positive; the destination valid region must be non-negative.
 - **Implementation checks (A5)**
   - The source partition and destination tile element types must be one of `i8/i16/i32/i64/f16/bf16/f32/f8E4M3*/f8E5M2*/!pto.hif8/!pto.f4E1M2x2/!pto.f4E2M1x2`.
   - The destination tile element size must be `1`, `2`, `4`, or `8` bytes, and must match the source partition element size.
@@ -902,7 +908,7 @@ op is modeled as writing the prefetched data into `dst`.
 - `src` must be a partition view before lowering, or the corresponding lowered ranked memref form after `PTOViewToMemref`.
 - `dst` must be a tile buffer before lowering, or the corresponding lowered ranked memref form after `PTOViewToMemref`.
 - `dst` must use `loc=vec` or `loc=mat`.
-- Static source extents and static destination valid extents must be positive when known.
+- Static source extents must be positive when known; static destination valid extents must be non-negative when known.
 - `src` and `dst` element types must have the same element size in bytes.
 - Low-precision element types (`f8E4M3*`, `f8E5M2*`, `!pto.hif8`, `!pto.f4E1M2x2`, `!pto.f4E2M1x2`) are only accepted on A5.
 
@@ -1000,7 +1006,8 @@ For each element (i, j) in the tile valid region:
 
 - Common checks:
   - `src` must be `!pto.tile_buf`, `dst` must be `!pto.partition_tensor_view`.
-  - Static `dst` shape dims and static `src` valid-shape dims must be positive.
+  - Static `dst` shape dims must be positive, and static `src` valid-shape dims
+    must be non-negative.
   - If `preQuantScalar` is present, `src` must be `loc=acc`.
   - If `reluPreMode != no_relu`, `src` must be `loc=acc`.
 - A2/A3 checks:
@@ -1324,7 +1331,7 @@ For each (i, j):
     - `(f32, bf16, bf16)`
   - Shape constraints: `lhs.rows == dst.rows`, `lhs.cols == rhs.rows`, and `rhs.cols == dst.cols`.
   - Tile locations: `lhs.loc=left`, `rhs.loc=right`, `dst.loc=acc`.
-  - Runtime: `m/k/n` (taken from `lhs valid row`, `lhs valid column`, `rhs valid column`) must be in `[1, 4095]`.
+  - Runtime: `m/k/n` (taken from `lhs valid row`, `lhs valid column`, `rhs valid column`) must be in `[0, 4095]`.
 - **Implementation checks (A5)**
   - The destination element type must be `i32` or `f32`.
     - If the destination element type is `i32`, the lhs and rhs element types must both be `i8`.
@@ -1334,7 +1341,7 @@ For each (i, j):
     - `lhs.loc=left`, `lhs.blayout=col_major`, `lhs.slayout=row_major`
     - `rhs.loc=right`, `rhs.blayout=row_major`, `rhs.slayout=col_major`
     - `dst.loc=acc`, `dst.blayout=col_major`, `dst.slayout=row_major`
-  - Runtime: `m/k/n` (taken from `lhs valid row`, `lhs valid column`, `rhs valid column`) must be in `[1, 4095]`.
+  - Runtime: `m/k/n` (taken from `lhs valid row`, `lhs valid column`, `rhs valid column`) must be in `[0, 4095]`.
 
 **Hardware Mapping:**
 
@@ -1601,7 +1608,7 @@ For each row i:
     - `(f32, bf16, bf16)`
   - Shape constraints: `lhs.rows == dst.rows`, `lhs.cols == rhs.rows`, and `rhs.cols == dst.cols`.
   - Tile locations: `lhs.loc=left`, `rhs.loc=right`, `dst.loc=acc`.
-  - Runtime: `m` must be `1`; `k/n` (taken from `rhs valid row`, `rhs valid column`) must be in `[1, 4095]`.
+  - Runtime: `m` must be `1`; `k/n` (taken from `rhs valid row`, `rhs valid column`) must be in `[0, 4095]`.
 - **Implementation checks (A5)**
   - The destination element type must be `i32` or `f32`.
     - If the destination element type is `i32`, the lhs and rhs element types must both be `i8`.
@@ -1612,7 +1619,7 @@ For each row i:
     - `rhs.loc=right`, `rhs.blayout=row_major`, `rhs.slayout=col_major`
     - `dst.loc=acc`, `dst.blayout=col_major`, `dst.slayout=row_major`
   - No explicit runtime range checks on `m/k/n` are enforced in `TMATMUL_IMPL` on this target.
-  - Runtime: `m` must be `1`; `k/n` (taken from `rhs valid row`, `rhs valid column`) must be in `[1, 4095]`.
+  - Runtime: `m` must be `1`; `k/n` (taken from `rhs valid row`, `rhs valid column`) must be in `[0, 4095]`.
 
 **Hardware Mapping:**
 
@@ -1659,7 +1666,7 @@ dst = acc_in + (lhs * rhs)
     - `(f32, bf16, bf16)`
   - Shape constraints: `lhs.rows == dst.rows`, `lhs.cols == rhs.rows`, and `rhs.cols == dst.cols`.
   - Tile locations: `lhs.loc=left`, `rhs.loc=right`, `dst.loc=acc`.
-  - Runtime: `m` must be `1`; `k/n` (taken from `rhs valid row`, `rhs valid column`) must be in `[1, 4095]`.
+  - Runtime: `m` must be `1`; `k/n` (taken from `rhs valid row`, `rhs valid column`) must be in `[0, 4095]`.
 - **Implementation checks (A5)**
   - The destination element type must be `i32` or `f32`.
     - If the destination element type is `i32`, the lhs and rhs element types must both be `i8`.
@@ -1670,7 +1677,7 @@ dst = acc_in + (lhs * rhs)
     - `rhs.loc=right`, `rhs.blayout=row_major`, `rhs.slayout=col_major`
     - `dst.loc=acc`, `dst.blayout=col_major`, `dst.slayout=row_major`
   - No explicit runtime range checks on `m/k/n` are enforced in `TMATMUL_IMPL` on this target.
-  - Runtime: `m` must be `1`; `k/n` (taken from `rhs valid row`, `rhs valid column`) must be in `[1, 4095]`.
+  - Runtime: `m` must be `1`; `k/n` (taken from `rhs valid row`, `rhs valid column`) must be in `[0, 4095]`.
 
 **Hardware Mapping:**
 
@@ -1716,7 +1723,7 @@ dst = (lhs * rhs) + bias
     - `(f32, bf16, bf16)`
   - Shape constraints: `lhs.rows == dst.rows`, `lhs.cols == rhs.rows`, and `rhs.cols == dst.cols`.
   - Tile locations: `lhs.loc=left`, `rhs.loc=right`, `dst.loc=acc`.
-  - Runtime: `m` must be `1`; `k/n` (taken from `rhs valid row`, `rhs valid column`) must be in `[1, 4095]`.
+  - Runtime: `m` must be `1`; `k/n` (taken from `rhs valid row`, `rhs valid column`) must be in `[0, 4095]`.
   - Bias checks:
     - The bias tile element type must exactly match the result tile element type.
     - The bias tile must be configured as a single row.
@@ -1731,7 +1738,7 @@ dst = (lhs * rhs) + bias
     - `rhs.loc=right`, `rhs.blayout=row_major`, `rhs.slayout=col_major`
     - `dst.loc=acc`, `dst.blayout=col_major`, `dst.slayout=row_major`
   - No explicit runtime range checks on `m/k/n` are enforced in `TMATMUL_IMPL` on this target.
-  - Runtime: `m` must be `1`; `k/n` (taken from `rhs valid row`, `rhs valid column`) must be in `[1, 4095]`.
+  - Runtime: `m` must be `1`; `k/n` (taken from `rhs valid row`, `rhs valid column`) must be in `[0, 4095]`.
   - Bias checks:
     - The bias tile element type must exactly match the result tile element type.
     - The bias tile must be configured as a single row.
@@ -4091,7 +4098,7 @@ pto.tlrelu ins(<src>, <slope> : <src_type>, <slope_type>)
 - **Implementation checks (A2A3)**
   - Tile element type must be one of: `f16`, `f32`.
   - Tile must use `loc=vec`.
-  - Valid bounds: `0 < valid row <= rows` and `0 < valid column <= cols`.
+  - Valid bounds: `0 <= valid row <= rows` and `0 <= valid column <= cols`.
   - Runtime: `src` and `dst` tiles should have the same `validRow/validCol`.
 - **Implementation checks (A5)**
   - Tile element type must be one of: `f16`, `f32`.

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -114,6 +114,7 @@ static bool isTileLikeType(Type ty);
 static SmallVector<int64_t, 4> getShapeVec(Type ty);
 static SmallVector<int64_t, 4> getValidShapeVec(Type ty);
 static SmallVector<int64_t, 4> getValidShapeVec(Value value);
+static bool isKnownZeroOrUnitExtent(int64_t value);
 static bool isByteIntegerType(Type ty);
 static LogicalResult verifyTileBufCommon(Operation *op, Type ty, StringRef name,
                                          bool allowLowPrecision = false);
@@ -2399,8 +2400,8 @@ LogicalResult TLoadOp::verify() {
     }
     auto dstValid = dstTile.getValidShape();
     for (unsigned i = 0; i < dstValid.size(); ++i) {
-      if (dstValid[i] != ShapedType::kDynamic && dstValid[i] <= 0) {
-        emitOpError() << "expects dst valid_shape[" << i << "] to be positive";
+      if (dstValid[i] != ShapedType::kDynamic && dstValid[i] < 0) {
+        emitOpError() << "expects dst valid_shape[" << i << "] to be non-negative";
         return failure();
       }
     }
@@ -2494,8 +2495,9 @@ LogicalResult TPrefetchOp::verify() {
         return failure();
       auto dstValid = dstTile.getValidShape();
       for (unsigned i = 0; i < dstValid.size(); ++i) {
-        if (dstValid[i] != ShapedType::kDynamic && dstValid[i] <= 0)
-          return emitOpError() << "expects dst valid_shape[" << i << "] to be positive";
+        if (dstValid[i] != ShapedType::kDynamic && dstValid[i] < 0)
+          return emitOpError() << "expects dst valid_shape[" << i
+                               << "] to be non-negative";
       }
       auto dstSpace = getPTOMemorySpaceEnum(dstTile);
       if (!dstSpace || (*dstSpace != pto::AddressSpace::VEC &&
@@ -2805,8 +2807,8 @@ LogicalResult TStoreOp::verify() {
     }
     auto srcValid = srcTile.getValidShape();
     for (auto [idx, dim] : llvm::enumerate(srcValid)) {
-      if (dim != ShapedType::kDynamic && dim <= 0) {
-        emitOpError() << "expects src valid_shape[" << idx << "] to be positive";
+      if (dim != ShapedType::kDynamic && dim < 0) {
+        emitOpError() << "expects src valid_shape[" << idx << "] to be non-negative";
         return failure();
       }
     }
@@ -2899,8 +2901,8 @@ LogicalResult TStoreOp::verify() {
       return emitOpError("expects A2/A3 acc tstore src cols to be in [1, 4095]");
     auto srcValid = srcTile.getValidShape();
     if (srcValid[1] != ShapedType::kDynamic &&
-        (srcValid[1] < 1 || srcValid[1] > 4095))
-      return emitOpError("expects A2/A3 acc tstore src valid_shape[1] to be in [1, 4095]");
+        (srcValid[1] < 0 || srcValid[1] > 4095))
+      return emitOpError("expects A2/A3 acc tstore src valid_shape[1] to be in [0, 4095]");
     return success();
   };
 
@@ -3393,6 +3395,8 @@ static LogicalResult verifyMGatherMScatterMemOperand(Operation *op,
 
 static bool hasCompatibleKnownExtent(int64_t lhs, int64_t rhs);
 static bool isKnownUnitExtent(int64_t value);
+static bool isKnownZeroOrUnitExtent(int64_t value);
+static bool hasCompatibleKnownExtentOrZero(int64_t lhs, int64_t rhs);
 
 static LogicalResult verifyMGatherMScatterTileShape(Operation *op, Type dataTy,
                                                     Type idxTy,
@@ -3415,20 +3419,20 @@ static LogicalResult verifyMGatherMScatterTileShape(Operation *op, Type dataTy,
       static_cast<int32_t>(pto::BLayout::ColMajor);
 
   const bool rowCoalesce1xR =
-      idxRowMajor && isKnownUnitExtent(idxValid[0]) &&
+      idxRowMajor && isKnownZeroOrUnitExtent(idxValid[0]) &&
       hasCompatibleKnownExtent(idxValid[1], dataValid[0]);
   const bool rowCoalesceRx1 =
       idxColMajor && hasCompatibleKnownExtent(idxValid[0], dataValid[0]) &&
-      isKnownUnitExtent(idxValid[1]);
+      isKnownZeroOrUnitExtent(idxValid[1]);
   const bool elemCoalesce =
       hasCompatibleKnownExtent(idxValid[0], dataValid[0]) &&
       hasCompatibleKnownExtent(idxValid[1], dataValid[1]);
 
   if (!(rowCoalesce1xR || rowCoalesceRx1 || elemCoalesce))
     return op->emitOpError()
-           << "expects idx valid_shape to be [1, " << dataName
+           << "expects idx valid_shape to be [0|1, " << dataName
            << ".valid_row], [" << dataName
-           << ".valid_row, 1], or match " << dataName << " valid_shape";
+           << ".valid_row, 0|1], or match " << dataName << " valid_shape";
 
   return success();
 }
@@ -3917,6 +3921,15 @@ static bool isKnownUnitExtent(int64_t value) {
   return value == ShapedType::kDynamic || value == 1;
 }
 
+static bool isKnownZeroOrUnitExtent(int64_t value) {
+  return value == ShapedType::kDynamic || value == 0 || value == 1;
+}
+
+static bool hasCompatibleKnownExtentOrZero(int64_t lhs, int64_t rhs) {
+  return lhs == ShapedType::kDynamic || rhs == ShapedType::kDynamic ||
+         lhs == 0 || lhs == rhs;
+}
+
 static LogicalResult verifyVecTileStorage(Operation *op, Type ty, StringRef name) {
   if (failed(verifyTileBufCommon(op, ty, name)))
     return failure();
@@ -4021,10 +4034,10 @@ static LogicalResult verifyMatTileOperandsA2A3(Operation *op, Type lhsTy,
     int64_t m = lhsValid[0];
     int64_t k = lhsValid[1];
     int64_t n = rhsValid[1];
-    if ((m != ShapedType::kDynamic && (m < 1 || m > 4095)) ||
-        (k != ShapedType::kDynamic && (k < 1 || k > 4095)) ||
-        (n != ShapedType::kDynamic && (n < 1 || n > 4095)))
-      return op->emitOpError("expects m, k, and n valid sizes to be in [1, 4095]");
+    if ((m != ShapedType::kDynamic && (m < 0 || m > 4095)) ||
+        (k != ShapedType::kDynamic && (k < 0 || k > 4095)) ||
+        (n != ShapedType::kDynamic && (n < 0 || n > 4095)))
+      return op->emitOpError("expects m, k, and n valid sizes to be in [0, 4095]");
   }
   return success();
 }
@@ -6226,10 +6239,10 @@ mlir::LogicalResult mlir::pto::TLReluOp::verify() {
     auto valid = getValidShapeVec(srcTy);
     if (valid.size() != 2)
       return emitOpError("expects src to have rank-2 valid_shape");
-    if (valid[0] != ShapedType::kDynamic && valid[0] <= 0)
-      return emitOpError("expects src valid_shape[0] to be positive");
-    if (valid[1] != ShapedType::kDynamic && valid[1] <= 0)
-      return emitOpError("expects src valid_shape[1] to be positive");
+    if (valid[0] != ShapedType::kDynamic && valid[0] < 0)
+      return emitOpError("expects src valid_shape[0] to be non-negative");
+    if (valid[1] != ShapedType::kDynamic && valid[1] < 0)
+      return emitOpError("expects src valid_shape[1] to be non-negative");
     Type elemTy = getElemTy(srcTy);
     if (!(elemTy.isF16() || elemTy.isF32()))
       return emitOpError() << "expects A2/A3 tlrelu element type to be f16 or f32";
@@ -6884,8 +6897,8 @@ LogicalResult THistogramOp::verify() {
       if (!hasCompatibleKnownExtent(srcShape[0], idxShape[0]) ||
           !hasCompatibleKnownExtent(srcValid[0], idxValid[0]))
         return emitOpError("expects idx rows and valid rows to match src when src element type is ui16");
-      if (!isKnownUnitExtent(idxShape[1]) || !isKnownUnitExtent(idxValid[1]))
-        return emitOpError("expects idx to have exactly one column when src element type is ui16");
+      if (!isKnownUnitExtent(idxShape[1]) || !isKnownZeroOrUnitExtent(idxValid[1]))
+        return emitOpError("expects idx to have exactly one physical column and 0 or 1 valid column when src element type is ui16");
     } else {
       if (byte != 3) {
         if (idxTB.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
@@ -6903,15 +6916,16 @@ LogicalResult THistogramOp::verify() {
         else if (byte == 0)
           expectedIdxRows = 3;
         if (!hasCompatibleKnownExtent(idxShape[0], expectedIdxRows) ||
-            !hasCompatibleKnownExtent(idxValid[0], expectedIdxRows))
+            !hasCompatibleKnownExtentOrZero(idxValid[0], expectedIdxRows))
           return emitOpError(
-              "expects idx rows/valid rows to match the byte-selected filter depth when src element type is ui32 and byte is 0, 1, or 2");
+              "expects idx rows to match the byte-selected filter depth and idx valid rows to be 0 or match it when src element type is ui32 and byte is 0, 1, or 2");
       }
     }
     if (dstShape[1] != ShapedType::kDynamic && dstShape[1] < 256)
       return emitOpError("expects dst shape[1] to be at least 256");
-    if (dstValid[1] != ShapedType::kDynamic && dstValid[1] < 256)
-      return emitOpError("expects dst valid_shape[1] to be at least 256");
+    if (dstValid[1] != ShapedType::kDynamic && dstValid[1] != 0 &&
+        dstValid[1] < 256)
+      return emitOpError("expects dst valid_shape[1] to be 0 or at least 256");
     return success();
   };
 
@@ -8030,8 +8044,8 @@ mlir::LogicalResult mlir::pto::TRemOp::verify() {
   auto tmpValid = getValidShapeVec(tmpTy);
   if (dstValid.size() != 2 || tmpValid.size() != 2)
     return emitOpError("expects tmp and dst to be rank-2 tiles");
-  if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 1)
-    return emitOpError("expects tmp to have at least 1 valid row");
+  if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 0)
+    return emitOpError("expects tmp to have non-negative valid rows");
   if (dstValid[1] != ShapedType::kDynamic && tmpValid[1] != ShapedType::kDynamic &&
       tmpValid[1] < dstValid[1])
     return emitOpError("expects tmp valid columns to cover dst valid columns");
@@ -8083,8 +8097,8 @@ mlir::LogicalResult mlir::pto::TRemSOp::verify() {
   auto tmpValid = getValidShapeVec(tt);
   if (dstValid.size() != 2 || tmpValid.size() != 2)
     return emitOpError("expects tmp and dst to be rank-2 tiles");
-  if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 1)
-    return emitOpError("expects tmp to have at least 1 valid row");
+  if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 0)
+    return emitOpError("expects tmp to have non-negative valid rows");
   if (dstValid[1] != ShapedType::kDynamic && tmpValid[1] != ShapedType::kDynamic &&
       tmpValid[1] < dstValid[1])
     return emitOpError("expects tmp valid columns to cover dst valid columns");
@@ -9481,9 +9495,9 @@ mlir::LogicalResult mlir::pto::TStoreFPOp::verify() {
     if (srcValid.size() != 2)
       return emitOpError() << "expects src to have a rank-2 valid_shape";
     if (srcValid[1] != ShapedType::kDynamic &&
-        (srcValid[1] < 1 || srcValid[1] > 4095))
+        (srcValid[1] < 0 || srcValid[1] > 4095))
       return emitOpError()
-             << "expects src.valid_shape[1] to be in the range [1, 4095]";
+             << "expects src.valid_shape[1] to be in the range [0, 4095]";
     return mlir::success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
@@ -10557,14 +10571,14 @@ mlir::LogicalResult mlir::pto::SubViewOp::verify() {
   if (hasValidRow) {
     int64_t vRow = 0, vCol = 0;
     if (getConstIndex(getValidRow(), vRow)) {
-      if (vRow <= 0)
-        return emitOpError("valid_row must be positive when constant");
+      if (vRow < 0)
+        return emitOpError("valid_row must be non-negative when constant");
       if (vRow > sizeR)
         return emitOpError("valid_row must be <= subview row size");
     }
     if (getConstIndex(getValidCol(), vCol)) {
-      if (vCol <= 0)
-        return emitOpError("valid_col must be positive when constant");
+      if (vCol < 0)
+        return emitOpError("valid_col must be non-negative when constant");
       if (vCol > sizeC)
         return emitOpError("valid_col must be <= subview col size");
     }

--- a/test/lit/pto/issue708_zero_valid_col_reduction_invalid.pto
+++ b/test/lit/pto/issue708_zero_valid_col_reduction_invalid.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @issue708_reject_zero_dst_row_col_reduction() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=8, v_row=16, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=8, v_row=16, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=8, v_row=0, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcolargmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=8, v_row=16, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=8, v_row=16, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=8, v_row=0, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tcolargmax' op expects dst valid_shape[0] to be 1

--- a/test/lit/pto/issue708_zero_valid_row_reduction_invalid.pto
+++ b/test/lit/pto/issue708_zero_valid_row_reduction_invalid.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @issue708_reject_zero_dst_col_row_reduction() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=0, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=0, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.trowmax' op expects dst valid_shape[1] to be 1

--- a/test/lit/pto/issue708_zero_valid_rowexpand_invalid.pto
+++ b/test/lit/pto/issue708_zero_valid_rowexpand_invalid.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @issue708_reject_one_sided_empty_rowexpand() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=0, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpand ins(%src : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=0, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.trowexpand' op expects dst valid_shape[1] to be non-zero

--- a/test/lit/pto/issue708_zero_valid_subview.pto
+++ b/test/lit/pto/issue708_zero_valid_subview.pto
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @issue708_zero_valid_subview_row(
+      %dst: memref<5x128xf32, #pto.address_space<gm>>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tail = pto.subview %src[%c0, %c0] sizes [5, 128] valid [%c0, %c128] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=0, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tstore ins(%tail : !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=0, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : memref<5x128xf32, #pto.address_space<gm>>)
+    return
+  }
+
+  func.func @issue708_zero_valid_subview_col(
+      %dst: memref<5x128xf32, #pto.address_space<gm>>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c5 = arith.constant 5 : index
+    %c128 = arith.constant 128 : index
+
+    %src = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tail = pto.subview %src[%c0, %c0] sizes [5, 128] valid [%c5, %c0] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=5, v_col=0, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tstore ins(%tail : !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=5, v_col=0, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : memref<5x128xf32, #pto.address_space<gm>>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @issue708_zero_valid_subview_row
+// CHECK: %[[ROW:[0-9A-Za-z_]+]] = pto.bind_tile {{.*}}, %c0, %c128
+// CHECK-SAME: pto.view_semantics = "subview"
+// CHECK: pto.tstore ins(%[[ROW]]
+
+// CHECK-LABEL: func.func @issue708_zero_valid_subview_col
+// CHECK: %[[COL:[0-9A-Za-z_]+]] = pto.bind_tile {{.*}}, %c5, %c0
+// CHECK-SAME: pto.view_semantics = "subview"
+// CHECK: pto.tstore ins(%[[COL]]

--- a/test/lit/pto/issue708_zero_valid_tgemv_invalid.pto
+++ b/test/lit/pto/issue708_zero_valid_tgemv_invalid.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @issue708_reject_zero_dst_row_tgemv() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %lhs = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %rhs = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=16, v_row=32, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=1, cols=16, v_row=0, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tgemv ins(%lhs, %rhs : !pto.tile_buf<loc=left, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=16, v_row=32, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+              outs(%dst : !pto.tile_buf<loc=acc, dtype=f32, rows=1, cols=16, v_row=0, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tgemv' op expects dst valid_shape[0] to be 1 for tgemv

--- a/test/lit/pto/issue708_zero_valid_tileops.pto
+++ b/test/lit/pto/issue708_zero_valid_tileops.pto
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @issue708_zero_valid_dma(
+      %src: !pto.ptr<f32>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %tv = pto.make_tensor_view %src, shape = [%c16, %c16], strides = [%c16, %c1] : !pto.tensor_view<?x?xf32>
+    %pv = pto.partition_view %tv, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
+    %row0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=0, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %col0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=0, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tload ins(%pv : !pto.partition_tensor_view<16x16xf32>)
+              outs(%row0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=0, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tprefetch ins(%pv : !pto.partition_tensor_view<16x16xf32>)
+                  outs(%col0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=0, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @issue708_zero_valid_matrix() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %lhs = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f16, rows=16, cols=32, v_row=0, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %rhs = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=16, v_row=32, v_col=0, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=0, v_col=0, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tmatmul ins(%lhs, %rhs : !pto.tile_buf<loc=left, dtype=f16, rows=16, cols=32, v_row=0, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=16, v_row=32, v_col=0, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+                outs(%dst : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=0, v_col=0, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+    return
+  }
+
+  func.func @issue708_zero_valid_vector() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %rem_src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=0, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %rem_tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=0, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trem ins(%rem_src, %rem_src, %rem_tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=0, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=0, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=0, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%rem_src : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=0, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @issue708_zero_valid_dma
+// CHECK: pto.tload
+// CHECK: pto.tprefetch
+// CHECK-LABEL: func.func @issue708_zero_valid_matrix
+// CHECK: pto.tmatmul
+// CHECK-LABEL: func.func @issue708_zero_valid_vector
+// CHECK: pto.trem


### PR DESCRIPTION
Fixes #708.

This PR relaxes verifier/type semantics for selected zero-valid tile regions:
- permit explicit subview valid_row/valid_col constants of 0 and allow the result tilebuf to carry v_row=0 or v_col=0
- allow selected tileop verifier paths to accept valid_shape 0 where the operation can consistently describe an empty valid region, including load/prefetch, matmul valid m/k/n bounds, rem tmp rows, histogram/mgather-style fixed valid extents, and store valid-column ranges
- keep tgemv row-valid, row/col reduction, and rowexpand one-sided empty cases at their previous stricter verifier constraints
- keep EmitC no-op/erase behavior out of scope

Validation:
- cmake --build build-wsl --target ptoas -j8
- issue708_zero_valid_tileops.pto
- issue708_zero_valid_subview.pto
- subview_validshape_guard.pto
- issue708_zero_valid_tgemv_invalid.pto
- issue708_zero_valid_row_reduction_invalid.pto
- issue708_zero_valid_col_reduction_invalid.pto
- issue708_zero_valid_rowexpand_invalid.pto
- tstore_forms_emitc.pto --check-prefix=A3
- tcvt_emitc.pto --check-prefix=A3/A5