### PR TITLE
feat(pto): add !pto.struct heterogeneous aggregate type and ops

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -306,6 +306,22 @@ the scalar struct world separate from the fractal/layout world, exactly like
   // { PtoStruct_f32_i8 f0; int16_t f1; };
 ```
 
+**Passing a struct to a function.** A `!pto.struct` value lowers to a **pointer**
+to its storage, so it can be passed to a helper `func.func` and mutated there:
+
+```mlir
+func.func private @helper(%s : !pto.struct<f32, i8>, %v : f32) {
+  pto.struct_set %s[0], %v : !pto.struct<f32, i8>, f32   // emits `p->f0 = v;`
+  return
+}
+```
+
+The callee reaches fields through `->`; the caller declares real storage, passes
+its address, and still uses `.` on its own copy. Carrying the struct by value
+would make the callee's writes land in a copy, and an `!emitc.lvalue` is
+rejected outright as a function argument type by both `emitc.func` and the C++
+emitter — the pointer is what makes helper functions expressible at all.
+
 **Generated type name.** The C++ name is derived from the MLIR type spelling of
 the fields (`!pto.struct<f16, i8>` → `PtoStruct_f16_i8`), not from their C++
 spellings. That mapping is injective, so two distinct `!pto.struct` types never

--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -274,19 +274,25 @@ positionally numbered `f0, f1, ...`, matching an LLVM literal struct.
 
 | Parameter | Type | Constraints |
 |-----------|------|-------------|
-| `fieldTypes` (`T0..Tn-1`) | `i8`/`i16`/`i32`/`i64` (signed, unsigned or signless), `f16`/`bf16`/`f32`/`f64`, a `!pto.local_array` of those, or a nested `!pto.struct` | At least one field; recursively scalar-storable |
+| `fieldTypes` (`T0..Tn-1`) | `i8`/`i16`/`i32`/`i64` (signed, unsigned or signless), `f16`/`bf16`/`f32`/`f64`, or a nested `!pto.struct` | At least one field; recursively scalar-storable |
 
 **Constraints (enforced by the type verifier):**
 
 - At least one field
 - Each field is *scalar-storable*: an integer of width 8/16/32/64, one of
-  `f16`/`bf16`/`f32`/`f64`, a nested `!pto.local_array` whose element type is
-  one of those, or a nested `!pto.struct`
+  `f16`/`bf16`/`f32`/`f64`, or a nested `!pto.struct`
 
 A scalar field must map onto a C++ scalar the backend can name exactly. Integer
 widths with no C++ spelling (`i1`, `i24`, ...) and the packed low-precision
 vec/cube formats (`f8`/`f4` variants) are therefore **rejected**: emitting them
 would silently widen or narrow the field in the generated C++.
+
+**`!pto.local_array` is not a valid field type.** A field is reached with
+`emitc.member`, whose result must be an `!emitc.lvalue`, and `!emitc.lvalue`
+cannot wrap the `!emitc.array` that an array field lowers to. There is no way to
+spell the access, so the type verifier rejects it rather than letting the
+backend fail later. Use a nested `!pto.struct` of scalars, or keep the array as
+a separate `!pto.declare_local_array` value alongside the struct.
 
 **Disjoint from tile-buf world.** Vec/cube types (`tile_buf`, `tensor_view`,
 partition view) and other handle types are **rejected** as fields. This keeps
@@ -295,9 +301,9 @@ the scalar struct world separate from the fractal/layout world, exactly like
 
 **Syntax:**
 ```mlir
-!pto.struct<f16, i8>                                 // { half f0; int8_t f1; };
-!pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>>
-  // { PtoStruct_f32_i8 f0; float f1[4]; };
+!pto.struct<f16, i8>                          // { half f0; int8_t f1; };
+!pto.struct<!pto.struct<f32, i8>, i16>
+  // { PtoStruct_f32_i8 f0; int16_t f1; };
 ```
 
 **Generated type name.** The C++ name is derived from the MLIR type spelling of
@@ -313,10 +319,12 @@ collide on one name — mangling from the C++ token instead would give `i32` and
 
 Field positions in `get` / `set` are a constant `path` of indices that may
 descend through nested structs (like LLVM `extractvalue` / `insertvalue`).
-**Dynamic** indexing of a nested `!pto.local_array` field is *not* part of the
-path: obtain the array with `pto.struct_get`, then index it with
-`pto.local_array_get` / `pto.local_array_set` — the same split LLVM makes
-between constant struct GEPs and dynamic array indexing.
+
+The path must **end at a scalar**. A path that stops on a nested `!pto.struct`
+is rejected: the member chain lowers to `emitc.member`, which yields an lvalue,
+and returning a whole aggregate as an SSA value would copy it out of the parent
+struct — so a field inside a nested struct is reached with a longer path
+(`%s[0, 1]`) rather than by first getting the inner struct.
 
 ---
 

--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -274,13 +274,19 @@ positionally numbered `f0, f1, ...`, matching an LLVM literal struct.
 
 | Parameter | Type | Constraints |
 |-----------|------|-------------|
-| `fieldTypes` (`T0..Tn-1`) | scalar `int`/`float`, `!pto.local_array`, or nested `!pto.struct` | At least one field; recursively scalar-storable |
+| `fieldTypes` (`T0..Tn-1`) | `i8`/`i16`/`i32`/`i64` (signed, unsigned or signless), `f16`/`bf16`/`f32`/`f64`, a `!pto.local_array` of those, or a nested `!pto.struct` | At least one field; recursively scalar-storable |
 
 **Constraints (enforced by the type verifier):**
 
 - At least one field
-- Each field is *scalar-storable*: a scalar integer/float, a nested
-  `!pto.local_array`, or a nested `!pto.struct`
+- Each field is *scalar-storable*: an integer of width 8/16/32/64, one of
+  `f16`/`bf16`/`f32`/`f64`, a nested `!pto.local_array` whose element type is
+  one of those, or a nested `!pto.struct`
+
+A scalar field must map onto a C++ scalar the backend can name exactly. Integer
+widths with no C++ spelling (`i1`, `i24`, ...) and the packed low-precision
+vec/cube formats (`f8`/`f4` variants) are therefore **rejected**: emitting them
+would silently widen or narrow the field in the generated C++.
 
 **Disjoint from tile-buf world.** Vec/cube types (`tile_buf`, `tensor_view`,
 partition view) and other handle types are **rejected** as fields. This keeps
@@ -291,8 +297,14 @@ the scalar struct world separate from the fractal/layout world, exactly like
 ```mlir
 !pto.struct<f16, i8>                                 // { half f0; int8_t f1; };
 !pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>>
-  // { PtoStruct_float_int8_t f0; float f1[4]; };
+  // { PtoStruct_f32_i8 f0; float f1[4]; };
 ```
+
+**Generated type name.** The C++ name is derived from the MLIR type spelling of
+the fields (`!pto.struct<f16, i8>` → `PtoStruct_f16_i8`), not from their C++
+spellings. That mapping is injective, so two distinct `!pto.struct` types never
+collide on one name — mangling from the C++ token instead would give `i32` and
+`si32` (both `int32_t`) the same name and emit a duplicate `struct` definition.
 
 **Associated ops** (see Section 4 — mirrors the `local_array` triad):
 - `pto.declare_struct` — declare
@@ -10471,7 +10483,7 @@ Section 2.7 for type-level constraints.
 **Basic Example:**
 
 ```mlir
-%s = pto.declare_struct -> !pto.struct<f16, i8>   // PtoStruct_half_int8_t s;
+%s = pto.declare_struct -> !pto.struct<f16, i8>   // PtoStruct_f16_i8 s;
 ```
 
 ---

--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -264,6 +264,50 @@ The number of indices on `get` / `set` must equal the array's rank
 
 ---
 
+### 2.7 `!pto.struct<T0, T1, ..., Tn-1>`
+
+A **C++ stack-local heterogeneous aggregate** — the heterogeneous dual of
+`!pto.local_array`. Lowers to a plain `struct PtoStruct_X { ... };` definition
+plus a stack variable. The struct's address is decided by the host C++
+compiler, never by PTO memory planning or `pto.pointer_cast`. Fields are
+positionally numbered `f0, f1, ...`, matching an LLVM literal struct.
+
+| Parameter | Type | Constraints |
+|-----------|------|-------------|
+| `fieldTypes` (`T0..Tn-1`) | scalar `int`/`float`, `!pto.local_array`, or nested `!pto.struct` | At least one field; recursively scalar-storable |
+
+**Constraints (enforced by the type verifier):**
+
+- At least one field
+- Each field is *scalar-storable*: a scalar integer/float, a nested
+  `!pto.local_array`, or a nested `!pto.struct`
+
+**Disjoint from tile-buf world.** Vec/cube types (`tile_buf`, `tensor_view`,
+partition view) and other handle types are **rejected** as fields. This keeps
+the scalar struct world separate from the fractal/layout world, exactly like
+`!pto.local_array`.
+
+**Syntax:**
+```mlir
+!pto.struct<f16, i8>                                 // { half f0; int8_t f1; };
+!pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>>
+  // { PtoStruct_float_int8_t f0; float f1[4]; };
+```
+
+**Associated ops** (see Section 4 — mirrors the `local_array` triad):
+- `pto.declare_struct` — declare
+- `pto.struct_get`     — `s.fA.fB...` field read by constant path
+- `pto.struct_set`     — `s.fA.fB... = v;`
+
+Field positions in `get` / `set` are a constant `path` of indices that may
+descend through nested structs (like LLVM `extractvalue` / `insertvalue`).
+**Dynamic** indexing of a nested `!pto.local_array` field is *not* part of the
+path: obtain the array with `pto.struct_get`, then index it with
+`pto.local_array_get` / `pto.local_array_set` — the same split LLVM makes
+between constant struct GEPs and dynamic array indexing.
+
+---
+
 ## 3. Enums & Attributes
 
 ### 3.1 AddressSpace
@@ -10401,6 +10445,102 @@ Operates on the [`!pto.local_array<...>`](#26-ptolocal_arrayd1-x-d2-x--x-dk-x-t)
 ```mlir
 pto.local_array_set %m[%i, %j], %v
    : !pto.local_array<4x8xf32>, f32                        // m[i][j] = v;
+```
+
+---
+
+#### Struct Ops (`pto.declare_struct` / `pto.struct_get` / `pto.struct_set`)
+
+C++ stack-local heterogeneous aggregate ops. Disjoint from the tile-buf /
+scratch memory world: the struct's address is decided by the host C++
+compiler. Naming and asm style mirror the `local_array` triad.
+
+Operates on the [`!pto.struct<...>`](#27-ptostructt0-t1--tn-1) type. See
+Section 2.7 for type-level constraints.
+
+##### `pto.declare_struct` - Declare a Stack-Local Struct
+
+**Summary:** Declare a heterogeneous aggregate on the C++ stack.
+
+**Semantics:** `PtoStruct_X s;`
+
+**Arguments:** None.
+
+**Results:** `!pto.struct<T0, ..., Tn-1>`
+
+**Basic Example:**
+
+```mlir
+%s = pto.declare_struct -> !pto.struct<f16, i8>   // PtoStruct_half_int8_t s;
+```
+
+---
+
+##### `pto.struct_get` - Read a Field by Constant Path
+
+**Summary:** Read the field reached by a constant `path` of field indices,
+descending through nested structs.
+
+**Semantics:** `s.fA.fB...` — a scalar result is snapshotted into a fresh
+variable (value semantics, like `pto.local_array_get`); an aggregate result
+(nested array / struct) is the member-access lvalue itself.
+
+**Arguments:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `s` | `!pto.struct<...>` | The struct |
+| `path` | `DenseI64ArrayAttr` | Constant field indices, e.g. `[0, 2]` |
+
+**Results:** `value` — the field type at the end of `path`.
+
+**Constraints & Verification:**
+
+- `path` is non-empty; every index is in range at its level.
+- An intermediate index may only descend into a nested struct.
+- Result type must equal the field type at the end of `path`.
+
+**Basic Example:**
+
+```mlir
+%r = pto.struct_get %s[0]    : !pto.struct<f16, i8> -> f16      // r = s.f0;
+%v = pto.struct_get %s[0, 1]                                    // v = s.f0.f1;
+   : !pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>> -> i8
+```
+
+---
+
+##### `pto.struct_set` - Write a Field by Constant Path
+
+**Summary:** Write a value into the field reached by a constant `path` of field
+indices, descending through nested structs.
+
+**Semantics:** `s.fA.fB... = value;`
+
+**Arguments:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `s` | `!pto.struct<...>` | The struct |
+| `path` | `DenseI64ArrayAttr` | Constant field indices, e.g. `[0, 2]` |
+| `value` | `AnyType` | Value to write (must match the field type) |
+
+**Results:** None.
+
+**Constraints & Verification:**
+
+- `path` is non-empty; every index is in range at its level.
+- Value type must equal the field type at the end of `path`.
+- The terminal field must be copy-assignable: a `!pto.local_array` terminal is
+  rejected (a C array cannot be assigned). Use `pto.struct_get` to obtain the
+  array, then write elements with `pto.local_array_set`.
+
+**Basic Example:**
+
+```mlir
+pto.struct_set %s[1], %v : !pto.struct<f16, i8>, i8            // s.f1 = v;
+pto.struct_set %s[0, 0], %v                                    // s.f0.f0 = v;
+   : !pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>>, f32
 ```
 
 ---

--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -340,10 +340,25 @@ func.func @make() -> !pto.struct<f32, i8> {
 } else { ... }
 ```
 
+**A function may not return a `!pto.struct` either**, even one that just passes
+an argument back:
+
+```mlir
+// Rejected: laundering. %r is no longer a pto.declare_struct result, so the
+// per-op check above cannot see that `return %r` publishes the caller's local.
+func.func private @passthrough(%s : !pto.struct<f32, i8>) -> !pto.struct<f32, i8> {
+  return %s : !pto.struct<f32, i8>
+}
+```
+
+A function result is the only place provenance can be laundered, so banning it
+leaves exactly two ways to obtain a struct value — declare it, or receive it as
+an argument. Provenance is then always local and always visible to the verifier.
+
 This costs nothing in expressiveness: `pto.struct_set` mutates in place, so a
 struct never needs to be returned or yielded. Declare it in the outer scope and
-pass it down as a function argument instead — the callee writes through the
-pointer and the caller sees the result.
+pass it **down** as a function argument — the callee writes through the pointer
+and the caller sees the result.
 
 **Generated type name.** The C++ name is derived from the MLIR type spelling of
 the fields (`!pto.struct<f16, i8>` → `PtoStruct_f16_i8`), not from their C++
@@ -10531,9 +10546,13 @@ Section 2.7 for type-level constraints.
 
 - The result must not be passed to a terminator (`func.return`, `scf.yield`,
   ...). The value is a pointer to stack storage owned by the declaring scope, so
-  letting it out would expose the address of storage that is about to die. See
-  [Section 2.7](#27-ptostructt0-t1--tn-1); mutation is in place, so declare the
-  struct in the outer scope and pass it down instead.
+  letting it out would expose the address of storage that is about to die.
+- Relatedly, no function may **return** a `!pto.struct` (checked module-wide),
+  which is what stops a pass-through helper from laundering that address past
+  the per-op check.
+
+  See [Section 2.7](#27-ptostructt0-t1--tn-1); mutation is in place, so declare
+  the struct in the outer scope and pass it down instead.
 
 **Basic Example:**
 

--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -322,6 +322,29 @@ would make the callee's writes land in a copy, and an `!emitc.lvalue` is
 rejected outright as a function argument type by both `emitc.func` and the C++
 emitter — the pointer is what makes helper functions expressible at all.
 
+**A struct must not escape the scope that declares it.** Because the value is a
+pointer to stack storage, passing it to a terminator would publish that address
+outside the scope that owns it, so `pto.declare_struct` rejects it:
+
+```mlir
+// Rejected: hands the caller a pointer into a dead frame.
+func.func @make() -> !pto.struct<f32, i8> {
+  %s = pto.declare_struct -> !pto.struct<f32, i8>
+  return %s : !pto.struct<f32, i8>
+}
+
+// Rejected: carries the address out of the region that owns the storage.
+%r = scf.if %c -> (!pto.struct<f32, i8>) {
+  %a = pto.declare_struct -> !pto.struct<f32, i8>
+  scf.yield %a : !pto.struct<f32, i8>
+} else { ... }
+```
+
+This costs nothing in expressiveness: `pto.struct_set` mutates in place, so a
+struct never needs to be returned or yielded. Declare it in the outer scope and
+pass it down as a function argument instead — the callee writes through the
+pointer and the caller sees the result.
+
 **Generated type name.** The C++ name is derived from the MLIR type spelling of
 the fields (`!pto.struct<f16, i8>` → `PtoStruct_f16_i8`), not from their C++
 spellings. That mapping is injective, so two distinct `!pto.struct` types never
@@ -10503,6 +10526,14 @@ Section 2.7 for type-level constraints.
 **Arguments:** None.
 
 **Results:** `!pto.struct<T0, ..., Tn-1>`
+
+**Constraints & Verification:**
+
+- The result must not be passed to a terminator (`func.return`, `scf.yield`,
+  ...). The value is a pointer to stack storage owned by the declaring scope, so
+  letting it out would expose the address of storage that is about to die. See
+  [Section 2.7](#27-ptostructt0-t1--tn-1); mutation is in place, so declare the
+  struct in the outer scope and pass it down instead.
 
 **Basic Example:**
 

--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -264,7 +264,7 @@ The number of indices on `get` / `set` must equal the array's rank
 
 ---
 
-### 2.7 `!pto.struct<T0, T1, ..., Tn-1>`
+### 2.8 `!pto.struct<T0, T1, ..., Tn-1>`
 
 A **C++ stack-local heterogeneous aggregate** — the heterogeneous dual of
 `!pto.local_array`. Lowers to a plain `struct PtoStruct_X { ... };` definition
@@ -351,9 +351,10 @@ func.func private @passthrough(%s : !pto.struct<f32, i8>) -> !pto.struct<f32, i8
 }
 ```
 
-A function result is the only place provenance can be laundered, so banning it
-leaves exactly two ways to obtain a struct value — declare it, or receive it as
-an argument. Provenance is then always local and always visible to the verifier.
+Operation and region results can launder provenance in the same way. Therefore,
+struct storage must originate from `pto.declare_struct` or a function argument.
+Other operation results of this type are rejected; this includes aliases
+produced by `arith.select`, `scf.if`, calls, casts, and loop-carried values.
 
 This costs nothing in expressiveness: `pto.struct_set` mutates in place, so a
 struct never needs to be returned or yielded. Declare it in the outer scope and
@@ -10529,8 +10530,8 @@ C++ stack-local heterogeneous aggregate ops. Disjoint from the tile-buf /
 scratch memory world: the struct's address is decided by the host C++
 compiler. Naming and asm style mirror the `local_array` triad.
 
-Operates on the [`!pto.struct<...>`](#27-ptostructt0-t1--tn-1) type. See
-Section 2.7 for type-level constraints.
+Operates on the [`!pto.struct<...>`](#28-ptostructt0-t1--tn-1) type. See
+Section 2.8 for type-level constraints.
 
 ##### `pto.declare_struct` - Declare a Stack-Local Struct
 
@@ -10550,8 +10551,11 @@ Section 2.7 for type-level constraints.
 - Relatedly, no function may **return** a `!pto.struct` (checked module-wide),
   which is what stops a pass-through helper from laundering that address past
   the per-op check.
+- No other operation may produce a `!pto.struct` result. This prevents
+  `arith.select`, `scf.if`, calls, casts, or loop-carried values from hiding the
+  storage origin.
 
-  See [Section 2.7](#27-ptostructt0-t1--tn-1); mutation is in place, so declare
+  See [Section 2.8](#28-ptostructt0-t1--tn-1); mutation is in place, so declare
   the struct in the outer scope and pass it down instead.
 
 **Basic Example:**
@@ -10633,7 +10637,7 @@ pto.struct_set %s[0, 0], %v                                    // s.f0.f0 = v;
 ```
 
 When the struct is a function argument the same op emits `s->f0 = v;` — see
-[Section 2.7](#27-ptostructt0-t1--tn-1) for why a struct is carried as a
+[Section 2.8](#28-ptostructt0-t1--tn-1) for why a struct is carried as a
 pointer.
 
 ---
@@ -10661,5 +10665,6 @@ pointer.
 | Runtime Intrinsics | 4 | - (Pure) |
 | Debug | 3 | - |
 | Stack-Local Array | 3 | - (Scalar / Host) |
+| Stack-Local Struct | 3 | - (Scalar / Host) |
 
-**Total: 110 operations**
+**Total: 113 operations**

--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -10517,9 +10517,9 @@ Section 2.7 for type-level constraints.
 **Summary:** Read the field reached by a constant `path` of field indices,
 descending through nested structs.
 
-**Semantics:** `s.fA.fB...` — a scalar result is snapshotted into a fresh
-variable (value semantics, like `pto.local_array_get`); an aggregate result
-(nested array / struct) is the member-access lvalue itself.
+**Semantics:** `s.fA.fB...`, read into a fresh variable so the SSA value keeps
+its value if the struct is mutated later (value semantics, like
+`pto.local_array_get`).
 
 **Arguments:**
 
@@ -10528,12 +10528,15 @@ variable (value semantics, like `pto.local_array_get`); an aggregate result
 | `s` | `!pto.struct<...>` | The struct |
 | `path` | `DenseI64ArrayAttr` | Constant field indices, e.g. `[0, 2]` |
 
-**Results:** `value` — the field type at the end of `path`.
+**Results:** `value` — the scalar field type at the end of `path`.
 
 **Constraints & Verification:**
 
 - `path` is non-empty; every index is in range at its level.
 - An intermediate index may only descend into a nested struct.
+- `path` must **end at a scalar field**. A path stopping on a nested
+  `!pto.struct` is rejected — returning the aggregate would copy it out of the
+  parent struct; extend the path to reach a scalar inside it.
 - Result type must equal the field type at the end of `path`.
 
 **Basic Example:**
@@ -10541,7 +10544,7 @@ variable (value semantics, like `pto.local_array_get`); an aggregate result
 ```mlir
 %r = pto.struct_get %s[0]    : !pto.struct<f16, i8> -> f16      // r = s.f0;
 %v = pto.struct_get %s[0, 1]                                    // v = s.f0.f1;
-   : !pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>> -> i8
+   : !pto.struct<!pto.struct<f32, i8>, i16> -> i8
 ```
 
 ---
@@ -10566,18 +10569,22 @@ indices, descending through nested structs.
 **Constraints & Verification:**
 
 - `path` is non-empty; every index is in range at its level.
+- An intermediate index may only descend into a nested struct.
+- `path` must **end at a scalar field**, same as `pto.struct_get`. A path
+  stopping on a nested `!pto.struct` is rejected — extend it to reach a scalar.
 - Value type must equal the field type at the end of `path`.
-- The terminal field must be copy-assignable: a `!pto.local_array` terminal is
-  rejected (a C array cannot be assigned). Use `pto.struct_get` to obtain the
-  array, then write elements with `pto.local_array_set`.
 
 **Basic Example:**
 
 ```mlir
 pto.struct_set %s[1], %v : !pto.struct<f16, i8>, i8            // s.f1 = v;
 pto.struct_set %s[0, 0], %v                                    // s.f0.f0 = v;
-   : !pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>>, f32
+   : !pto.struct<!pto.struct<f32, i8>, i16>, f32
 ```
+
+When the struct is a function argument the same op emits `s->f0 = v;` — see
+[Section 2.7](#27-ptostructt0-t1--tn-1) for why a struct is carried as a
+pointer.
 
 ---
 

--- a/include/PTO/IR/PTO.h
+++ b/include/PTO/IR/PTO.h
@@ -226,6 +226,11 @@ void setExternalArtifactVisibility(func::FuncOp func, bool isExternal);
 /// Validate module-level PTO entry configuration before EmitC lowering.
 LogicalResult validatePTOEntryFunctions(ModuleOp module);
 
+/// Reject any function returning a !pto.struct. A struct value is a pointer to
+/// stack storage, so a function result launders its provenance and defeats the
+/// per-op escape check in DeclareStructOp::verify().
+LogicalResult validateStructNeverReturned(ModuleOp module);
+
 /// Compatibility hook kept for existing pass pipelines. This is now a no-op
 /// because PTO entry state is expressed directly through explicit entry attrs
 /// such as ``pto.entry``.

--- a/include/PTO/IR/PTO.h
+++ b/include/PTO/IR/PTO.h
@@ -226,10 +226,9 @@ void setExternalArtifactVisibility(func::FuncOp func, bool isExternal);
 /// Validate module-level PTO entry configuration before EmitC lowering.
 LogicalResult validatePTOEntryFunctions(ModuleOp module);
 
-/// Reject any function returning a !pto.struct. A struct value is a pointer to
-/// stack storage, so a function result launders its provenance and defeats the
-/// per-op escape check in DeclareStructOp::verify().
-LogicalResult validateStructNeverReturned(ModuleOp module);
+/// Reject !pto.struct function results and operation results other than
+/// pto.declare_struct, so aliases cannot hide stack-storage provenance.
+LogicalResult validateStructProvenance(ModuleOp module);
 
 /// Compatibility hook kept for existing pass pipelines. This is now a no-op
 /// because PTO entry state is expressed directly through explicit entry attrs

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2678,9 +2678,11 @@ def DeclareStructOp : PTO_Op<"declare_struct"> {
     `!pto.struct` value lowers to a pointer to that storage. Handing the value
     to a terminator would publish the address outside the owning scope, so it is
     rejected: returning it would leave the caller holding a pointer to a dead
-    frame. Since `pto.struct_set` mutates in place, a struct never needs to be
-    returned or yielded — declare it in the outer scope and pass it down as a
-    function argument instead.
+    frame. A function may not return a `!pto.struct` at all, which is what stops
+    a trivial pass-through helper from laundering that address past this check.
+    Since `pto.struct_set` mutates in place, a struct never needs to be returned
+    or yielded — declare it in the outer scope and pass it down as a function
+    argument instead.
   }];
 
   let results = (outs StructType:$s);

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2673,9 +2673,19 @@ def DeclareStructOp : PTO_Op<"declare_struct"> {
 
     This op does not participate in PTO memory planning. The resulting struct's
     address is determined by the host C++ compiler.
+
+    The struct is stack storage owned by the scope that declares it, and a
+    `!pto.struct` value lowers to a pointer to that storage. Handing the value
+    to a terminator would publish the address outside the owning scope, so it is
+    rejected: returning it would leave the caller holding a pointer to a dead
+    frame. Since `pto.struct_set` mutates in place, a struct never needs to be
+    returned or yielded — declare it in the outer scope and pass it down as a
+    function argument instead.
   }];
 
   let results = (outs StructType:$s);
+
+  let hasVerifier = 1;
 
   let assemblyFormat = [{
     attr-dict `->` qualified(type($s))

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2661,16 +2661,14 @@ def LocalArraySetOp : PTO_Op<"local_array_set"> {
 // host C++ compiler at codegen time, never by PTO memory planning or
 // `pto.pointer_cast`. Field positions are constant (struct semantics), so
 // `get` / `set` carry a constant `path` of field indices that may descend
-// through nested structs. Dynamic indexing of a nested `!pto.local_array` field
-// is left to `pto.local_array_get` / `pto.local_array_set` after obtaining the
-// array field with `pto.struct_get` — exactly the LLVM split between constant
-// struct GEPs and dynamic array indexing.
+// through nested structs. The path always ends at a scalar; a nested struct is
+// traversed by a longer path, never handed back as a value.
 
 def DeclareStructOp : PTO_Op<"declare_struct"> {
   let summary = "Declare a stack-local heterogeneous aggregate";
   let description = [{
     Lowers to a plain C++ stack variable like `PtoStruct_X s;`. Field types are
-    restricted to scalars (integer / float), nested `!pto.local_array`, or
+    restricted to scalars (integers of width 8/16/32/64, f16/bf16/f32/f64) or a
     nested `!pto.struct`.
 
     This op does not participate in PTO memory planning. The resulting struct's
@@ -2689,13 +2687,12 @@ def StructGetOp : PTO_Op<"struct_get"> {
   let description = [{
     Reads the field reached by following the constant `path` of field indices
     from the struct, descending through nested structs. Lowers to `s.fA.fB...`
-    member access. A scalar result is snapshotted into a fresh variable so the
-    SSA value keeps its value if the struct is mutated later (mirrors
-    `pto.local_array_get`); an aggregate result (nested array / struct) is the
-    member-access lvalue itself, so a nested array field can be fed to
-    `pto.local_array_get` / `pto.local_array_set`.
+    member access, read into a fresh variable so the SSA value keeps its value
+    if the struct is mutated later (mirrors `pto.local_array_get`).
 
-    The result type must equal the type of the field at the end of `path`.
+    The path must end at a scalar field, and the result type must equal that
+    field's type. A path stopping on a nested `!pto.struct` is rejected —
+    extend it to reach a scalar inside.
   }];
 
   let arguments = (ins
@@ -2717,10 +2714,11 @@ def StructSetOp : PTO_Op<"struct_set"> {
   let description = [{
     Writes `value` into the field reached by following the constant `path` of
     field indices, descending through nested structs. Lowers to
-    `s.fA.fB... = value;`. The value type must equal the type of the field at
-    the end of `path`. The terminal field must be copy-assignable in C++, so a
-    `!pto.local_array` terminal is rejected — obtain the array with
-    `pto.struct_get` and write elements with `pto.local_array_set` instead.
+    `s.fA.fB... = value;`.
+
+    The path must end at a scalar field, and the value type must equal that
+    field's type. A path stopping on a nested `!pto.struct` is rejected —
+    extend it to reach a scalar inside.
   }];
 
   let arguments = (ins

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2652,6 +2652,92 @@ def LocalArraySetOp : PTO_Op<"local_array_set"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Stack-local heterogeneous aggregate (struct)
+//===----------------------------------------------------------------------===//
+//
+// Mirrors the `local_array` triad (declare / get / set) for a generic
+// heterogeneous scalar-unit aggregate. The struct's address is decided by the
+// host C++ compiler at codegen time, never by PTO memory planning or
+// `pto.pointer_cast`. Field positions are constant (struct semantics), so
+// `get` / `set` carry a constant `path` of field indices that may descend
+// through nested structs. Dynamic indexing of a nested `!pto.local_array` field
+// is left to `pto.local_array_get` / `pto.local_array_set` after obtaining the
+// array field with `pto.struct_get` — exactly the LLVM split between constant
+// struct GEPs and dynamic array indexing.
+
+def DeclareStructOp : PTO_Op<"declare_struct"> {
+  let summary = "Declare a stack-local heterogeneous aggregate";
+  let description = [{
+    Lowers to a plain C++ stack variable like `PtoStruct_X s;`. Field types are
+    restricted to scalars (integer / float), nested `!pto.local_array`, or
+    nested `!pto.struct`.
+
+    This op does not participate in PTO memory planning. The resulting struct's
+    address is determined by the host C++ compiler.
+  }];
+
+  let results = (outs StructType:$s);
+
+  let assemblyFormat = [{
+    attr-dict `->` qualified(type($s))
+  }];
+}
+
+def StructGetOp : PTO_Op<"struct_get"> {
+  let summary = "Read a field from a stack-local struct by constant path";
+  let description = [{
+    Reads the field reached by following the constant `path` of field indices
+    from the struct, descending through nested structs. Lowers to `s.fA.fB...`
+    member access. A scalar result is snapshotted into a fresh variable so the
+    SSA value keeps its value if the struct is mutated later (mirrors
+    `pto.local_array_get`); an aggregate result (nested array / struct) is the
+    member-access lvalue itself, so a nested array field can be fed to
+    `pto.local_array_get` / `pto.local_array_set`.
+
+    The result type must equal the type of the field at the end of `path`.
+  }];
+
+  let arguments = (ins
+    StructType:$s,
+    DenseI64ArrayAttr:$path
+  );
+  let results = (outs AnyType:$value);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $s custom<StructPath>($path) attr-dict
+      `:` qualified(type($s)) `->` type($value)
+  }];
+}
+
+def StructSetOp : PTO_Op<"struct_set"> {
+  let summary = "Write a field into a stack-local struct by constant path";
+  let description = [{
+    Writes `value` into the field reached by following the constant `path` of
+    field indices, descending through nested structs. Lowers to
+    `s.fA.fB... = value;`. The value type must equal the type of the field at
+    the end of `path`. The terminal field must be copy-assignable in C++, so a
+    `!pto.local_array` terminal is rejected — obtain the array with
+    `pto.struct_get` and write elements with `pto.local_array_set` instead.
+  }];
+
+  let arguments = (ins
+    StructType:$s,
+    DenseI64ArrayAttr:$path,
+    AnyType:$value
+  );
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $s custom<StructPath>($path) `,` $value attr-dict
+      `:` qualified(type($s)) `,` type($value)
+  }];
+}
+
 def DeclareTileMemRefOp : PTO_Op<"declare_tile_memref"> {
   let summary = "Internal memref placeholder for a tile whose address is assigned later";
   let description = [{

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2678,8 +2678,10 @@ def DeclareStructOp : PTO_Op<"declare_struct"> {
     `!pto.struct` value lowers to a pointer to that storage. Handing the value
     to a terminator would publish the address outside the owning scope, so it is
     rejected: returning it would leave the caller holding a pointer to a dead
-    frame. A function may not return a `!pto.struct` at all, which is what stops
-    a trivial pass-through helper from laundering that address past this check.
+    frame. Module-level provenance validation also rejects function results and
+    derived operation results of this type, so aliases cannot launder that
+    address past the direct-use check. Struct storage originates from this op
+    or is received through a function argument.
     Since `pto.struct_set` mutates in place, a struct never needs to be returned
     or yielded — declare it in the outer scope and pass it down as a function
     argument instead.

--- a/include/PTO/IR/PTOTypeDefs.td
+++ b/include/PTO/IR/PTOTypeDefs.td
@@ -303,6 +303,30 @@ def LocalArrayType : TypeDef<PTO_Dialect, "LocalArray"> {
   }];
 }
 
+// ---- !pto.struct<T0, T1, ..., Tn-1> ----
+// Scalar-unit heterogeneous aggregate. The heterogeneous dual of
+// !pto.local_array: it lowers to a plain C++ `struct { ... };` whose address is
+// decided by the host C++ compiler, never by PTO memory planning or
+// pto.pointer_cast. Fields are positionally numbered (f0, f1, ...), matching an
+// LLVM literal struct. A field type may be a scalar (int / float), a nested
+// !pto.local_array, or a nested !pto.struct — this is how nested / complex
+// aggregates are expressed. Vec/cube types (tile_buf / tensor_view) are
+// forbidden by the type verifier, keeping the scalar world disjoint from the
+// fractal/layout world.
+def StructType : TypeDef<PTO_Dialect, "Struct"> {
+  let mnemonic = "struct";
+  let summary = "Scalar-unit heterogeneous aggregate (C++ struct / llvm.struct)";
+  let parameters = (ins ArrayRefParameter<"mlir::Type">:$fieldTypes);
+
+  let hasCustomAssemblyFormat = 1;   // form: !pto.struct<f16, i8, !pto.local_array<4xf32>>
+  let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    size_t getNumFields() const { return getFieldTypes().size(); }
+    mlir::Type getFieldType(unsigned i) const { return getFieldTypes()[i]; }
+  }];
+}
+
 def PipeType : TypeDef<PTO_Dialect, "Pipe"> {
   let mnemonic = "pipe";
   let summary = "Opaque pipe handle type for TPUSH/TPOP communication";

--- a/include/PTO/IR/PTOTypeDefs.td
+++ b/include/PTO/IR/PTOTypeDefs.td
@@ -323,7 +323,10 @@ def LocalArrayType : TypeDef<PTO_Dialect, "LocalArray"> {
 //     !emitc.array an array field lowers to.
 //
 // A value of this type lowers to a *pointer* to the struct's storage, so it can
-// be passed to a helper function and mutated there; see PTOToEmitC.cpp.
+// be passed to a helper function and mutated there. To keep the pointed-to
+// lifetime visible, storage originates from pto.declare_struct or a function
+// argument, and other operations may not produce derived values of this type;
+// see PTOToEmitC.cpp.
 def StructType : TypeDef<PTO_Dialect, "Struct"> {
   let mnemonic = "struct";
   let summary = "Scalar-unit heterogeneous aggregate (C++ struct / llvm.struct)";

--- a/include/PTO/IR/PTOTypeDefs.td
+++ b/include/PTO/IR/PTOTypeDefs.td
@@ -308,17 +308,28 @@ def LocalArrayType : TypeDef<PTO_Dialect, "LocalArray"> {
 // !pto.local_array: it lowers to a plain C++ `struct { ... };` whose address is
 // decided by the host C++ compiler, never by PTO memory planning or
 // pto.pointer_cast. Fields are positionally numbered (f0, f1, ...), matching an
-// LLVM literal struct. A field type may be a scalar (int / float), a nested
-// !pto.local_array, or a nested !pto.struct — this is how nested / complex
-// aggregates are expressed. Vec/cube types (tile_buf / tensor_view) are
-// forbidden by the type verifier, keeping the scalar world disjoint from the
-// fractal/layout world.
+// LLVM literal struct.
+//
+// A field type is either a scalar the backend can name exactly (an integer of
+// width 8/16/32/64, or f16/bf16/f32/f64) or a nested !pto.struct — that is how
+// nested aggregates are expressed. Three things are rejected by the type
+// verifier:
+//   - vec/cube types (tile_buf / tensor_view), keeping the scalar world
+//     disjoint from the fractal/layout world;
+//   - scalars with no exact C++ spelling (i1, i24, the packed f8/f4 formats),
+//     which would otherwise be emitted as `float`;
+//   - !pto.local_array, because a field is reached with emitc.member, whose
+//     result must be an !emitc.lvalue, and !emitc.lvalue cannot wrap the
+//     !emitc.array an array field lowers to.
+//
+// A value of this type lowers to a *pointer* to the struct's storage, so it can
+// be passed to a helper function and mutated there; see PTOToEmitC.cpp.
 def StructType : TypeDef<PTO_Dialect, "Struct"> {
   let mnemonic = "struct";
   let summary = "Scalar-unit heterogeneous aggregate (C++ struct / llvm.struct)";
   let parameters = (ins ArrayRefParameter<"mlir::Type">:$fieldTypes);
 
-  let hasCustomAssemblyFormat = 1;   // form: !pto.struct<f16, i8, !pto.local_array<4xf32>>
+  let hasCustomAssemblyFormat = 1;   // form: !pto.struct<f16, i8, !pto.struct<f32, i8>>
   let genVerifyDecl = 1;
 
   let extraClassDeclaration = [{

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2674,10 +2674,25 @@ static LogicalResult walkStructPath(Operation *op, mlir::pto::StructType root,
   return success();
 }
 
+// Both accessors bottom out at a scalar. A path ending on a nested !pto.struct
+// is rejected: the member chain lowers to `emitc.member`, which yields an
+// lvalue, and handing a whole aggregate back as an SSA value would mean copying
+// it out of the struct — so reaching into a nested struct is spelled as a longer
+// path instead.
+static LogicalResult verifyStructLeafIsScalar(Operation *op, Type fieldTy) {
+  if (!fieldTy.isIntOrFloat())
+    return op->emitOpError()
+           << "struct path must end at a scalar field, but ends at " << fieldTy
+           << "; extend the path to reach a scalar inside it";
+  return success();
+}
+
 LogicalResult mlir::pto::StructGetOp::verify() {
   Type fieldTy;
   if (failed(walkStructPath(getOperation(), getS().getType(), getPath(),
                             fieldTy)))
+    return failure();
+  if (failed(verifyStructLeafIsScalar(getOperation(), fieldTy)))
     return failure();
   if (getValue().getType() != fieldTy)
     return emitOpError() << "result type " << getValue().getType()
@@ -2691,16 +2706,12 @@ LogicalResult mlir::pto::StructSetOp::verify() {
   if (failed(walkStructPath(getOperation(), getS().getType(), getPath(),
                             fieldTy)))
     return failure();
+  if (failed(verifyStructLeafIsScalar(getOperation(), fieldTy)))
+    return failure();
   if (getValue().getType() != fieldTy)
     return emitOpError() << "value type " << getValue().getType()
                          << " does not match field type " << fieldTy
                          << " at the given path";
-  // A C array cannot be copy-assigned, so writing a whole local_array field is
-  // not expressible. Steer the user to the get-then-element-set idiom instead.
-  if (isa<mlir::pto::LocalArrayType>(fieldTy))
-    return emitOpError()
-           << "cannot assign a !pto.local_array field directly; obtain it with "
-              "pto.struct_get, then write elements with pto.local_array_set";
   return success();
 }
 
@@ -13334,14 +13345,13 @@ static bool isStructScalar(Type t) {
   return false;
 }
 
+// A field is either such a scalar or a nested !pto.struct. !pto.local_array is
+// deliberately NOT allowed: a field is reached with `emitc.member`, whose result
+// must be an `!emitc.lvalue`, and `!emitc.lvalue` cannot wrap `!emitc.array`
+// (the type an array field lowers to). There is no way to spell the access, so
+// the restriction is enforced here rather than failing later in the backend.
 static bool isStructStorable(Type t) {
-  if (isStructScalar(t))
-    return true;
-  // A nested array is rendered as `<elem> fN[d0][d1];`, so its element type has
-  // to be exactly nameable too.
-  if (auto arr = llvm::dyn_cast<LocalArrayType>(t))
-    return isStructScalar(arr.getElementType());
-  return llvm::isa<StructType>(t);
+  return isStructScalar(t) || llvm::isa<StructType>(t);
 }
 
 Type StructType::parse(AsmParser &parser) {
@@ -13381,8 +13391,9 @@ LogicalResult StructType::verify(
       return emitError()
              << "'!pto.struct' field " << i << " type " << f
              << " is not scalar-storable; only i8/i16/i32/i64 (signed, "
-                "unsigned or signless), f16/bf16/f32/f64, a !pto.local_array "
-                "of those, or a nested !pto.struct are allowed (tile_buf / "
+                "unsigned or signless), f16/bf16/f32/f64, or a nested "
+                "!pto.struct are allowed (!pto.local_array cannot be a field "
+                "because emitc.member cannot yield an array lvalue; tile_buf / "
                 "tensor_view belong to the vec/cube world)";
   }
   return success();

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2890,6 +2890,45 @@ LogicalResult mlir::pto::validatePTOEntryFunctions(ModuleOp module) {
   return success();
 }
 
+// A !pto.struct is a pointer to stack storage, so a function that returns one
+// launders provenance: the value handed back is no longer a pto.declare_struct
+// result, which is all DeclareStructOp::verify() can see. A helper as small as
+//
+//   func.func @passthrough(%s : !pto.struct<...>) -> !pto.struct<...> {
+//     return %s : !pto.struct<...>
+//   }
+//
+// is enough to route a caller's own local straight back out of its frame, past
+// the direct-use check, and into `return passthrough(&local);`.
+//
+// Banning the struct result type closes that off at the only place laundering
+// can happen. Together with the declare-op check (its result may not reach a
+// terminator) it leaves exactly two ways to obtain a struct value: declare it,
+// or receive it as an argument. Provenance is then always local and always
+// visible. Passing structs *down* into helpers is unaffected, and nothing is
+// lost: pto.struct_set mutates in place, so results are never needed.
+LogicalResult mlir::pto::validateStructNeverReturned(ModuleOp module) {
+  if (!module)
+    return success();
+
+  for (auto func : module.getOps<func::FuncOp>()) {
+    for (auto [i, resultTy] :
+         llvm::enumerate(func.getFunctionType().getResults())) {
+      if (!llvm::isa<StructType>(resultTy))
+        continue;
+      return func.emitOpError()
+             << "result " << i << " has type " << resultTy
+             << ", but a stack-local struct must not be returned: the value is "
+                "a pointer into the callee's frame, and returning it (even "
+                "when it merely passes an argument back through) lets a caller "
+                "leak the address of its own local past the escape check; pass "
+                "the struct down as an argument instead (pto.struct_set "
+                "mutates in place, so a result is never needed)";
+    }
+  }
+  return success();
+}
+
 void mlir::pto::annotatePTOEntryFunctions(ModuleOp module) {
   (void)module;
 }

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2674,6 +2674,28 @@ static LogicalResult walkStructPath(Operation *op, mlir::pto::StructType root,
   return success();
 }
 
+// The declared struct is stack storage owned by the enclosing scope, and the
+// value lowers to a pointer to that storage. Letting it reach a terminator
+// would publish that address outside the owning scope: `return %s` hands the
+// caller a pointer into a dead frame, and `scf.yield %s` carries it out of the
+// region that owns it. Both are rejected here rather than emitted as C++ that
+// looks fine and is undefined at run time.
+LogicalResult mlir::pto::DeclareStructOp::verify() {
+  for (Operation *user : getS().getUsers()) {
+    if (!user->hasTrait<mlir::OpTrait::IsTerminator>())
+      continue;
+    return emitOpError()
+           << "stack-local struct must not escape the scope that declares it, "
+              "but its value is passed to '"
+           << user->getName()
+           << "', which would expose the address of storage that is about to "
+              "die; declare the struct in the outer scope and pass it down as "
+              "a function argument instead (pto.struct_set mutates in place, "
+              "so a struct never needs to be returned or yielded)";
+  }
+  return success();
+}
+
 // Both accessors bottom out at a scalar. A path ending on a nested !pto.struct
 // is rejected: the member chain lowers to `emitc.member`, which yields an
 // lvalue, and handing a whole aggregate back as an SSA value would mean copying

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -13318,8 +13318,30 @@ LogicalResult LocalArrayType::verify(
 // excludes the vec/cube types (tile_buf / tensor_view / partition view) and any
 // other handle type, keeping the scalar struct world disjoint from the
 // fractal/layout world.
+
+// A struct field's scalar type must map onto a C++ scalar that the backend can
+// name exactly: integers of width 8/16/32/64 and f16/bf16/f32/f64. Widths the
+// backend has no spelling for (i1, i24, ...) and the packed low-precision
+// vec/cube formats (f8/f4 variants) would otherwise be emitted as `float`,
+// silently changing the field's width and semantics, so reject them here.
+static bool isStructScalar(Type t) {
+  if (llvm::isa<Float16Type, BFloat16Type, Float32Type, Float64Type>(t))
+    return true;
+  if (auto intTy = llvm::dyn_cast<IntegerType>(t)) {
+    unsigned w = intTy.getWidth();
+    return w == 8 || w == 16 || w == 32 || w == 64;
+  }
+  return false;
+}
+
 static bool isStructStorable(Type t) {
-  return t.isIntOrFloat() || llvm::isa<LocalArrayType, StructType>(t);
+  if (isStructScalar(t))
+    return true;
+  // A nested array is rendered as `<elem> fN[d0][d1];`, so its element type has
+  // to be exactly nameable too.
+  if (auto arr = llvm::dyn_cast<LocalArrayType>(t))
+    return isStructScalar(arr.getElementType());
+  return llvm::isa<StructType>(t);
 }
 
 Type StructType::parse(AsmParser &parser) {
@@ -13358,9 +13380,10 @@ LogicalResult StructType::verify(
     if (!isStructStorable(f))
       return emitError()
              << "'!pto.struct' field " << i << " type " << f
-             << " is not scalar-storable; only scalar integer/float, "
-                "!pto.local_array, or nested !pto.struct are allowed "
-                "(tile_buf / tensor_view belong to the vec/cube world)";
+             << " is not scalar-storable; only i8/i16/i32/i64 (signed, "
+                "unsigned or signless), f16/bf16/f32/f64, a !pto.local_array "
+                "of those, or a nested !pto.struct are allowed (tile_buf / "
+                "tensor_view belong to the vec/cube world)";
   }
   return success();
 }
@@ -18368,7 +18391,7 @@ static ParseResult parseStructPath(OpAsmParser &parser,
     return failure();
   if (failed(parser.parseOptionalRSquare())) {
     do {
-      int64_t idx;
+      int64_t idx = 0;
       if (parser.parseInteger(idx))
         return failure();
       indices.push_back(idx);

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2646,6 +2646,64 @@ LogicalResult mlir::pto::LocalArraySetOp::verify() {
   return success();
 }
 
+// Resolve the field type reached by following a constant `path` of field
+// indices from `root`, descending through nested structs. Emits an actionable
+// op error and returns failure on an empty path, an out-of-range index, or a
+// descent into a non-struct field. On success writes the terminal field type to
+// `fieldTyOut`.
+static LogicalResult walkStructPath(Operation *op, mlir::pto::StructType root,
+                                    llvm::ArrayRef<int64_t> path,
+                                    Type &fieldTyOut) {
+  if (path.empty())
+    return op->emitOpError() << "struct path must have at least one index";
+  Type cur = root;
+  for (auto [depth, idx] : llvm::enumerate(path)) {
+    auto st = dyn_cast<mlir::pto::StructType>(cur);
+    if (!st)
+      return op->emitOpError()
+             << "struct path index " << depth
+             << " descends into non-struct field of type " << cur;
+    if (idx < 0 || idx >= static_cast<int64_t>(st.getNumFields()))
+      return op->emitOpError()
+             << "struct path index " << depth << " (" << idx
+             << ") is out of range for " << st << " with " << st.getNumFields()
+             << " field(s)";
+    cur = st.getFieldType(static_cast<unsigned>(idx));
+  }
+  fieldTyOut = cur;
+  return success();
+}
+
+LogicalResult mlir::pto::StructGetOp::verify() {
+  Type fieldTy;
+  if (failed(walkStructPath(getOperation(), getS().getType(), getPath(),
+                            fieldTy)))
+    return failure();
+  if (getValue().getType() != fieldTy)
+    return emitOpError() << "result type " << getValue().getType()
+                         << " does not match field type " << fieldTy
+                         << " at the given path";
+  return success();
+}
+
+LogicalResult mlir::pto::StructSetOp::verify() {
+  Type fieldTy;
+  if (failed(walkStructPath(getOperation(), getS().getType(), getPath(),
+                            fieldTy)))
+    return failure();
+  if (getValue().getType() != fieldTy)
+    return emitOpError() << "value type " << getValue().getType()
+                         << " does not match field type " << fieldTy
+                         << " at the given path";
+  // A C array cannot be copy-assigned, so writing a whole local_array field is
+  // not expressible. Steer the user to the get-then-element-set idiom instead.
+  if (isa<mlir::pto::LocalArrayType>(fieldTy))
+    return emitOpError()
+           << "cannot assign a !pto.local_array field directly; obtain it with "
+              "pto.struct_get, then write elements with pto.local_array_set";
+  return success();
+}
+
 LogicalResult mlir::pto::CastPtrOp::verify() {
   Type inputType = getInput().getType();
   Type resultType = getResult().getType();
@@ -13253,6 +13311,60 @@ LogicalResult LocalArrayType::verify(
   return success();
 }
 
+// ---- StructType ----
+// Asm form: !pto.struct<T0, T1, ..., Tn-1>
+// A field type must be "scalar-storable": a scalar integer/float, a nested
+// !pto.local_array, or a nested !pto.struct. This allowlist deliberately
+// excludes the vec/cube types (tile_buf / tensor_view / partition view) and any
+// other handle type, keeping the scalar struct world disjoint from the
+// fractal/layout world.
+static bool isStructStorable(Type t) {
+  return t.isIntOrFloat() || llvm::isa<LocalArrayType, StructType>(t);
+}
+
+Type StructType::parse(AsmParser &parser) {
+  SmallVector<Type> fields;
+  if (parser.parseCommaSeparatedList(
+          AsmParser::Delimiter::LessGreater, [&]() -> ParseResult {
+            Type t;
+            if (parser.parseType(t))
+              return failure();
+            fields.push_back(t);
+            return success();
+          }))
+    return Type();
+  return StructType::getChecked(
+      [&]() { return parser.emitError(parser.getNameLoc()); },
+      parser.getContext(), fields);
+}
+
+void StructType::print(AsmPrinter &printer) const {
+  printer << "<";
+  llvm::ArrayRef<Type> fields = getFieldTypes();
+  for (size_t i = 0; i < fields.size(); ++i) {
+    if (i)
+      printer << ", ";
+    printer.printType(fields[i]);
+  }
+  printer << ">";
+}
+
+LogicalResult StructType::verify(
+    llvm::function_ref<InFlightDiagnostic()> emitError,
+    llvm::ArrayRef<Type> fieldTypes) {
+  if (fieldTypes.empty())
+    return emitError() << "'!pto.struct' requires at least one field";
+  for (auto [i, f] : llvm::enumerate(fieldTypes)) {
+    if (!isStructStorable(f))
+      return emitError()
+             << "'!pto.struct' field " << i << " type " << f
+             << " is not scalar-storable; only scalar integer/float, "
+                "!pto.local_array, or nested !pto.struct are allowed "
+                "(tile_buf / tensor_view belong to the vec/cube world)";
+  }
+  return success();
+}
+
 // =============================================================================
 // Decompose Helper (Reverse Engineering AffineMap -> Strides)
 // =============================================================================
@@ -18245,6 +18357,39 @@ static void printStL2Cache(OpAsmPrinter &printer, Operation *op,
   if (!l2cache)
     return;
   printer << "l2cache(" << stringifyStL2Cache(l2cache.getValue()) << ")";
+}
+
+// custom<StructPath>($path): a bracketed list of constant field indices, e.g.
+// `[0, 2]`. Backs pto.struct_get / pto.struct_set so they read as `%s[0, 2]`.
+static ParseResult parseStructPath(OpAsmParser &parser,
+                                   DenseI64ArrayAttr &path) {
+  SmallVector<int64_t> indices;
+  if (parser.parseLSquare())
+    return failure();
+  if (failed(parser.parseOptionalRSquare())) {
+    do {
+      int64_t idx;
+      if (parser.parseInteger(idx))
+        return failure();
+      indices.push_back(idx);
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRSquare())
+      return failure();
+  }
+  path = DenseI64ArrayAttr::get(parser.getContext(), indices);
+  return success();
+}
+
+static void printStructPath(OpAsmPrinter &printer, Operation *op,
+                            DenseI64ArrayAttr path) {
+  printer << "[";
+  llvm::ArrayRef<int64_t> indices = path.asArrayRef();
+  for (size_t i = 0; i < indices.size(); ++i) {
+    if (i)
+      printer << ", ";
+    printer << indices[i];
+  }
+  printer << "]";
 }
 
 // [Include 必须放在最后]

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2890,43 +2890,56 @@ LogicalResult mlir::pto::validatePTOEntryFunctions(ModuleOp module) {
   return success();
 }
 
-// A !pto.struct is a pointer to stack storage, so a function that returns one
-// launders provenance: the value handed back is no longer a pto.declare_struct
-// result, which is all DeclareStructOp::verify() can see. A helper as small as
+// A !pto.struct is represented as a pointer to stack storage. Its provenance
+// therefore has to remain explicit: the value either comes directly from
+// pto.declare_struct or is received as a function entry argument. Operations
+// such as arith.select and scf.if must not manufacture another struct-typed SSA
+// result, because that alias hides the declaration from DeclareStructOp's
+// direct-use escape check. CFG block arguments may relay an existing value:
+// forwarding a declaration directly is already rejected because the branch is
+// a terminator, while forwarding a function argument preserves its lifetime.
 //
-//   func.func @passthrough(%s : !pto.struct<...>) -> !pto.struct<...> {
-//     return %s : !pto.struct<...>
-//   }
-//
-// is enough to route a caller's own local straight back out of its frame, past
-// the direct-use check, and into `return passthrough(&local);`.
-//
-// Banning the struct result type closes that off at the only place laundering
-// can happen. Together with the declare-op check (its result may not reach a
-// terminator) it leaves exactly two ways to obtain a struct value: declare it,
-// or receive it as an argument. Provenance is then always local and always
-// visible. Passing structs *down* into helpers is unaffected, and nothing is
-// lost: pto.struct_set mutates in place, so results are never needed.
-LogicalResult mlir::pto::validateStructNeverReturned(ModuleOp module) {
+// Function results are rejected separately because func.func records them in
+// its signature rather than as SSA results. Passing structs down into helpers
+// remains supported, and pto.struct_set mutates in place, so no derived struct
+// result is needed.
+LogicalResult mlir::pto::validateStructProvenance(ModuleOp module) {
   if (!module)
     return success();
 
-  for (auto func : module.getOps<func::FuncOp>()) {
-    for (auto [i, resultTy] :
-         llvm::enumerate(func.getFunctionType().getResults())) {
-      if (!llvm::isa<StructType>(resultTy))
-        continue;
-      return func.emitOpError()
-             << "result " << i << " has type " << resultTy
-             << ", but a stack-local struct must not be returned: the value is "
-                "a pointer into the callee's frame, and returning it (even "
-                "when it merely passes an argument back through) lets a caller "
-                "leak the address of its own local past the escape check; pass "
-                "the struct down as an argument instead (pto.struct_set "
-                "mutates in place, so a result is never needed)";
+  WalkResult result = module.walk([&](Operation *op) -> WalkResult {
+    if (auto func = dyn_cast<func::FuncOp>(op)) {
+      for (auto [i, resultTy] :
+           llvm::enumerate(func.getFunctionType().getResults())) {
+        if (!isa<StructType>(resultTy))
+          continue;
+        func.emitOpError()
+            << "result " << i << " has type " << resultTy
+            << ", but a stack-local struct must not be returned: the value is "
+               "a pointer into the callee's frame, and returning it (even "
+               "when it merely passes an argument back through) launders its "
+               "provenance; pass the struct down as an argument instead "
+               "(pto.struct_set mutates in place, so a result is never needed)";
+        return WalkResult::interrupt();
+      }
     }
-  }
-  return success();
+
+    if (!isa<DeclareStructOp>(op)) {
+      for (auto [i, opResult] : llvm::enumerate(op->getResults())) {
+        if (!isa<StructType>(opResult.getType()))
+          continue;
+        op->emitOpError()
+            << "result " << i << " has type " << opResult.getType()
+            << ", but only 'pto.declare_struct' may produce a !pto.struct "
+               "result; derived results hide the stack-storage lifetime and "
+               "can escape their declaring scope";
+        return WalkResult::interrupt();
+      }
+    }
+
+    return WalkResult::advance();
+  });
+  return result.wasInterrupted() ? failure() : success();
 }
 
 void mlir::pto::annotatePTOEntryFunctions(ModuleOp module) {

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -13324,8 +13324,8 @@ LogicalResult LocalArrayType::verify(
 
 // ---- StructType ----
 // Asm form: !pto.struct<T0, T1, ..., Tn-1>
-// A field type must be "scalar-storable": a scalar integer/float, a nested
-// !pto.local_array, or a nested !pto.struct. This allowlist deliberately
+// A field type must be "scalar-storable": an exactly-nameable scalar or a
+// nested !pto.struct (see the two predicates below). The allowlist deliberately
 // excludes the vec/cube types (tile_buf / tensor_view / partition view) and any
 // other handle type, keeping the scalar struct world disjoint from the
 // fractal/layout world.

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -972,11 +972,14 @@ public:
     // !pto.struct<...> -> !emitc.opaque<"PtoStruct_...">. The matching C++
     // `struct PtoStruct_... { ... };` definition is emitted at file scope by
     // the pass (see runOnOperation), keyed on the same content-derived name.
-    // A struct stays an lvalue: emitc.member requires an lvalue operand, so
-    // carrying the value form would force a copy out of the variable on every
-    // declare and leave field writes updating the copy instead of the struct.
+    // A struct is carried as a pointer to its storage. It cannot be carried by
+    // value (emitc.member needs an lvalue, so every field write would land in a
+    // copy), and it cannot be carried as an lvalue either: emitc.func rejects
+    // an lvalue argument outright, and the C++ emitter refuses one on func.func
+    // too, which would make a struct impossible to pass to a helper function.
+    // A pointer is legal in a signature and still names the caller's storage.
     addConversion([Ctx](pto::StructType type) -> Type {
-      return emitc::LValueType::get(
+      return emitc::PointerType::get(
           emitc::OpaqueType::get(Ctx, getStructTypeName(type)));
     });
 
@@ -8053,23 +8056,35 @@ struct PTODeclareStructToEmitC
     if (!structTy)
       return rewriter.notifyMatchFailure(op, "failed to map !pto.struct type");
 
-    // structTy is already an !emitc.lvalue, so this is the variable itself and
-    // needs no load: field access has to name the variable, not a copy.
-    rewriter.replaceOpWithNewOp<emitc::VariableOp>(
-        op, getEmitCVariableResultType(structTy),
-        emitc::OpaqueAttr::get(rewriter.getContext(), ""));
+    // The struct converts to a pointer, so declare the storage as a local
+    // variable and hand out its address. buildStructMemberChain recognises the
+    // address-of and walks that variable directly, so a struct that never
+    // leaves the function still prints as `s.f0` rather than `p->f0`.
+    auto ptrTy = dyn_cast<emitc::PointerType>(structTy);
+    if (!ptrTy)
+      return rewriter.notifyMatchFailure(op,
+                                         "!pto.struct did not map to a pointer");
+
+    Value storage = rewriter
+                        .create<emitc::VariableOp>(
+                            op.getLoc(),
+                            emitc::LValueType::get(ptrTy.getPointee()),
+                            emitc::OpaqueAttr::get(rewriter.getContext(), ""))
+                        .getResult();
+    rewriter.replaceOpWithNewOp<emitc::ApplyOp>(op, ptrTy, "&", storage);
     return success();
   }
 };
 
-// The EmitC *value* type of a struct field, i.e. never an lvalue. A nested
-// struct converts to an lvalue (see the type converter), which has to be peeled
-// here so the member result below wraps it exactly once.
+// The EmitC *value* type of a struct field, i.e. the type an lvalue to that
+// field wraps. A nested struct is spelled directly here rather than going
+// through the converter, which would hand back the pointer form used for
+// passing whole structs around — a field lives inside its parent's storage and
+// is reached with `.`, not through another pointer.
 static Type getStructFieldValueType(const TypeConverter *tc, Type fieldPtoTy) {
-  Type converted = tc->convertType(fieldPtoTy);
-  if (auto lvalueTy = dyn_cast_or_null<emitc::LValueType>(converted))
-    return lvalueTy.getValueType();
-  return converted;
+  if (auto st = dyn_cast<pto::StructType>(fieldPtoTy))
+    return emitc::OpaqueType::get(st.getContext(), getStructTypeName(st));
+  return tc->convertType(fieldPtoTy);
 }
 
 // Build the `s.fA.fB...` member-access chain for a constant struct path and
@@ -8079,10 +8094,36 @@ static Type getStructFieldValueType(const TypeConverter *tc, Type fieldPtoTy) {
 // Every step is an `emitc.member`, which requires an lvalue operand and yields
 // an lvalue result, so the chain stays in lvalue form throughout — that is what
 // makes a write land in the struct rather than in a copy of it.
+//
+// `root` is the converted struct, i.e. a pointer. Two shapes reach here:
+//   - a local declared by pto.declare_struct, whose pointer is an address-of;
+//     that is unwrapped back to the variable so the access prints as `s.f0`.
+//   - any other pointer, notably a function argument. `emitc.member_of_ptr`
+//     needs an lvalue *holding* the pointer rather than the raw pointer, so it
+//     is parked in a variable first and the access prints as `p->f0`.
 static FailureOr<Value> buildStructMemberChain(
     ConversionPatternRewriter &rewriter, Location loc, const TypeConverter *tc,
     Value root, mlir::pto::StructType rootPtoTy, llvm::ArrayRef<int64_t> path) {
-  Value cur = peelUnrealized(root);
+  Value ptr = peelUnrealized(root);
+
+  // lvalue of the struct itself when we can name it; otherwise an lvalue
+  // holding the pointer, consumed by the first member_of_ptr step.
+  Value structLValue;
+  Value ptrSlot;
+  auto applyOp = ptr.getDefiningOp<emitc::ApplyOp>();
+  if (applyOp && applyOp.getApplicableOperator() == "&") {
+    structLValue = applyOp.getOperand();
+  } else {
+    if (!isa<emitc::PointerType>(ptr.getType()))
+      return failure();
+    ptrSlot = rewriter
+                  .create<emitc::VariableOp>(
+                      loc, emitc::LValueType::get(ptr.getType()),
+                      emitc::OpaqueAttr::get(rewriter.getContext(), ""))
+                  .getResult();
+    rewriter.create<emitc::AssignOp>(loc, ptrSlot, ptr);
+  }
+
   Type curPtoTy = rootPtoTy;
   for (int64_t idx : path) {
     auto st = cast<mlir::pto::StructType>(curPtoTy);
@@ -8090,14 +8131,20 @@ static FailureOr<Value> buildStructMemberChain(
     Type fieldTy = getStructFieldValueType(tc, fieldPtoTy);
     if (!fieldTy)
       return failure();
-    cur = rewriter
-              .create<emitc::MemberOp>(
-                  loc, emitc::LValueType::get(fieldTy),
-                  rewriter.getStringAttr("f" + std::to_string(idx)), cur)
-              .getResult();
+    Type resultTy = emitc::LValueType::get(fieldTy);
+    auto name = rewriter.getStringAttr("f" + std::to_string(idx));
+    // Only the first step off a bare pointer uses `->`; from there on the
+    // chain is walking storage we can name, so it is all `.`.
+    structLValue =
+        structLValue
+            ? rewriter.create<emitc::MemberOp>(loc, resultTy, name, structLValue)
+                  .getResult()
+            : rewriter
+                  .create<emitc::MemberOfPtrOp>(loc, resultTy, name, ptrSlot)
+                  .getResult();
     curPtoTy = fieldPtoTy;
   }
-  return cur;
+  return structLValue;
 }
 
 // pto.struct_get %s[i, j, ...] -> `s.fi.fj...`. The verifier guarantees the path

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -517,7 +517,6 @@ static std::string sanitizeIdentifier(std::string s) {
 // Mangle a scalar-storable field type into a C++-identifier-safe token. The
 // encoding is injective, so distinct struct types never collide on a name:
 //   - scalar:        the MLIR type spelling (f16, bf16, i8, si32, ui32, ...)
-//   - local_array:   arr<d0>_<d1>_..._<elem>
 //   - nested struct: S_<f0>_<f1>_..._E  (S/E delimiters disambiguate nesting)
 //
 // Scalars are mangled from the MLIR spelling rather than from
@@ -528,12 +527,6 @@ static std::string sanitizeIdentifier(std::string s) {
 // pure identifier characters, so this mangling is collision-free by
 // construction.
 static std::string mangleStructFieldType(Type t) {
-  if (auto arr = dyn_cast<pto::LocalArrayType>(t)) {
-    std::string s = "arr";
-    for (int64_t d : arr.getShape())
-      s += std::to_string(d) + "_";
-    return s + mangleStructFieldType(arr.getElementType());
-  }
   if (auto st = dyn_cast<pto::StructType>(t)) {
     std::string s = "S";
     for (Type f : st.getFieldTypes())
@@ -557,17 +550,9 @@ static std::string getStructTypeName(pto::StructType st) {
   return s;
 }
 
-// Render a single struct field declaration `<cppType> <name><dims>;`. Array
-// fields put their dimensions after the name (C declarator syntax).
+// Render a single struct field declaration `<cppType> <name>;`.
 static std::string renderStructFieldDecl(Type fieldTy,
                                          const std::string &name) {
-  if (auto arr = dyn_cast<pto::LocalArrayType>(fieldTy)) {
-    std::string dims;
-    for (int64_t d : arr.getShape())
-      dims += "[" + std::to_string(d) + "]";
-    return getEmitCScalarTypeToken(arr.getElementType()) + " " + name + dims +
-           ";";
-  }
   if (auto st = dyn_cast<pto::StructType>(fieldTy))
     return getStructTypeName(st) + " " + name + ";";
   return getEmitCScalarTypeToken(fieldTy) + " " + name + ";";
@@ -987,8 +972,12 @@ public:
     // !pto.struct<...> -> !emitc.opaque<"PtoStruct_...">. The matching C++
     // `struct PtoStruct_... { ... };` definition is emitted at file scope by
     // the pass (see runOnOperation), keyed on the same content-derived name.
+    // A struct stays an lvalue: emitc.member requires an lvalue operand, so
+    // carrying the value form would force a copy out of the variable on every
+    // declare and leave field writes updating the copy instead of the struct.
     addConversion([Ctx](pto::StructType type) -> Type {
-      return emitc::OpaqueType::get(Ctx, getStructTypeName(type));
+      return emitc::LValueType::get(
+          emitc::OpaqueType::get(Ctx, getStructTypeName(type)));
     });
 
     addConversion([Ctx](pto::AsyncSessionType type) -> Type {
@@ -8064,19 +8053,32 @@ struct PTODeclareStructToEmitC
     if (!structTy)
       return rewriter.notifyMatchFailure(op, "failed to map !pto.struct type");
 
-    auto var = rewriter
-                   .create<emitc::VariableOp>(
-                       op.getLoc(), structTy,
-                       emitc::OpaqueAttr::get(rewriter.getContext(), ""))
-                   .getResult();
-    rewriter.replaceOp(op, var);
+    // structTy is already an !emitc.lvalue, so this is the variable itself and
+    // needs no load: field access has to name the variable, not a copy.
+    rewriter.replaceOpWithNewOp<emitc::VariableOp>(
+        op, getEmitCVariableResultType(structTy),
+        emitc::OpaqueAttr::get(rewriter.getContext(), ""));
     return success();
   }
 };
 
+// The EmitC *value* type of a struct field, i.e. never an lvalue. A nested
+// struct converts to an lvalue (see the type converter), which has to be peeled
+// here so the member result below wraps it exactly once.
+static Type getStructFieldValueType(const TypeConverter *tc, Type fieldPtoTy) {
+  Type converted = tc->convertType(fieldPtoTy);
+  if (auto lvalueTy = dyn_cast_or_null<emitc::LValueType>(converted))
+    return lvalueTy.getValueType();
+  return converted;
+}
+
 // Build the `s.fA.fB...` member-access chain for a constant struct path and
-// return the final emitc value (a deferred lvalue expression). `rootPtoTy` is
-// the PTO struct type, walked in parallel to look up field types per step.
+// return the final lvalue. `rootPtoTy` is the PTO struct type, walked in
+// parallel to look up field types per step.
+//
+// Every step is an `emitc.member`, which requires an lvalue operand and yields
+// an lvalue result, so the chain stays in lvalue form throughout — that is what
+// makes a write land in the struct rather than in a copy of it.
 static FailureOr<Value> buildStructMemberChain(
     ConversionPatternRewriter &rewriter, Location loc, const TypeConverter *tc,
     Value root, mlir::pto::StructType rootPtoTy, llvm::ArrayRef<int64_t> path) {
@@ -8085,12 +8087,12 @@ static FailureOr<Value> buildStructMemberChain(
   for (int64_t idx : path) {
     auto st = cast<mlir::pto::StructType>(curPtoTy);
     Type fieldPtoTy = st.getFieldType(static_cast<unsigned>(idx));
-    Type fieldTy = tc->convertType(fieldPtoTy);
+    Type fieldTy = getStructFieldValueType(tc, fieldPtoTy);
     if (!fieldTy)
       return failure();
     cur = rewriter
               .create<emitc::MemberOp>(
-                  loc, fieldTy,
+                  loc, emitc::LValueType::get(fieldTy),
                   rewriter.getStringAttr("f" + std::to_string(idx)), cur)
               .getResult();
     curPtoTy = fieldPtoTy;
@@ -8098,11 +8100,11 @@ static FailureOr<Value> buildStructMemberChain(
   return cur;
 }
 
-// pto.struct_get %s[i, j, ...] -> `s.fi.fj...`, snapshotting a scalar result so
-// the SSA value survives later mutation of the struct (mirrors
-// pto.local_array_get). An aggregate result (nested array / struct) passes
-// through as the member lvalue, so a nested array field can then be indexed by
-// pto.local_array_get / pto.local_array_set.
+// pto.struct_get %s[i, j, ...] -> `s.fi.fj...`. The verifier guarantees the path
+// ends on a scalar, so the member lvalue is read with emitc.load. That load is
+// materialized into its own C++ variable, which is what gives the SSA result
+// value semantics: it keeps its value even if a later pto.struct_set writes the
+// same field (mirrors pto.local_array_get).
 struct PTOStructGetToEmitC
     : public OpConversionPattern<mlir::pto::StructGetOp> {
   using OpConversionPattern<mlir::pto::StructGetOp>::OpConversionPattern;
@@ -8119,18 +8121,7 @@ struct PTOStructGetToEmitC
     if (failed(member))
       return rewriter.notifyMatchFailure(op, "failed to map struct field type");
 
-    if (op.getValue().getType().isIntOrFloat()) {
-      auto snapshot =
-          rewriter
-              .create<emitc::VariableOp>(
-                  op.getLoc(), resultTy,
-                  emitc::OpaqueAttr::get(rewriter.getContext(), ""))
-              .getResult();
-      rewriter.create<emitc::AssignOp>(op.getLoc(), snapshot, *member);
-      rewriter.replaceOp(op, snapshot);
-    } else {
-      rewriter.replaceOp(op, *member);
-    }
+    rewriter.replaceOpWithNewOp<emitc::LoadOp>(op, resultTy, *member);
     return success();
   }
 };

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -516,9 +516,17 @@ static std::string sanitizeIdentifier(std::string s) {
 
 // Mangle a scalar-storable field type into a C++-identifier-safe token. The
 // encoding is injective, so distinct struct types never collide on a name:
-//   - scalar:        the emitC scalar token (half, int32_t, ...)
+//   - scalar:        the MLIR type spelling (f16, bf16, i8, si32, ui32, ...)
 //   - local_array:   arr<d0>_<d1>_..._<elem>
 //   - nested struct: S_<f0>_<f1>_..._E  (S/E delimiters disambiguate nesting)
+//
+// Scalars are mangled from the MLIR spelling rather than from
+// getEmitCScalarTypeToken(): that token is many-to-one (i32 and si32 both give
+// "int32_t"), which would emit two `struct` definitions under one name and
+// break the generated C++ with a redefinition. MLIR type printing is injective,
+// and the struct verifier restricts fields to types whose spellings are already
+// pure identifier characters, so this mangling is collision-free by
+// construction.
 static std::string mangleStructFieldType(Type t) {
   if (auto arr = dyn_cast<pto::LocalArrayType>(t)) {
     std::string s = "arr";
@@ -532,13 +540,16 @@ static std::string mangleStructFieldType(Type t) {
       s += "_" + mangleStructFieldType(f);
     return s + "_E";
   }
-  return sanitizeIdentifier(getEmitCScalarTypeToken(t));
+  std::string spelling;
+  llvm::raw_string_ostream os(spelling);
+  t.print(os);
+  return sanitizeIdentifier(os.str());
 }
 
 // Stable, content-derived C++ type name for a !pto.struct, e.g.
-// !pto.struct<f16, i8> -> "PtoStruct_half_int8_t". A pure function of the type,
-// so the type converter and the file-scope definition emitter agree without
-// any shared state.
+// !pto.struct<f16, i8> -> "PtoStruct_f16_i8". A pure function of the type, so
+// the type converter and the file-scope definition emitter agree without any
+// shared state.
 static std::string getStructTypeName(pto::StructType st) {
   std::string s = "PtoStruct";
   for (Type f : st.getFieldTypes())

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -44,6 +44,7 @@
 #include "mlir/Target/Cpp/CppEmitter.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
@@ -497,6 +498,90 @@ static int64_t getEmitCScalarByteWidth(Type elemTy) {
   return 4;
 }
 
+// ---------------------------------------------------------------------------
+// !pto.struct support: a deterministic C++ type name + file-scope definition.
+// ---------------------------------------------------------------------------
+
+// Replace any character that is not a C++ identifier character with '_'. The
+// scalar tokens below are already identifier-safe; this is defensive.
+static std::string sanitizeIdentifier(std::string s) {
+  for (char &c : s) {
+    bool ok = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') ||
+              (c >= 'A' && c <= 'Z') || c == '_';
+    if (!ok)
+      c = '_';
+  }
+  return s;
+}
+
+// Mangle a scalar-storable field type into a C++-identifier-safe token. The
+// encoding is injective, so distinct struct types never collide on a name:
+//   - scalar:        the emitC scalar token (half, int32_t, ...)
+//   - local_array:   arr<d0>_<d1>_..._<elem>
+//   - nested struct: S_<f0>_<f1>_..._E  (S/E delimiters disambiguate nesting)
+static std::string mangleStructFieldType(Type t) {
+  if (auto arr = dyn_cast<pto::LocalArrayType>(t)) {
+    std::string s = "arr";
+    for (int64_t d : arr.getShape())
+      s += std::to_string(d) + "_";
+    return s + mangleStructFieldType(arr.getElementType());
+  }
+  if (auto st = dyn_cast<pto::StructType>(t)) {
+    std::string s = "S";
+    for (Type f : st.getFieldTypes())
+      s += "_" + mangleStructFieldType(f);
+    return s + "_E";
+  }
+  return sanitizeIdentifier(getEmitCScalarTypeToken(t));
+}
+
+// Stable, content-derived C++ type name for a !pto.struct, e.g.
+// !pto.struct<f16, i8> -> "PtoStruct_half_int8_t". A pure function of the type,
+// so the type converter and the file-scope definition emitter agree without
+// any shared state.
+static std::string getStructTypeName(pto::StructType st) {
+  std::string s = "PtoStruct";
+  for (Type f : st.getFieldTypes())
+    s += "_" + mangleStructFieldType(f);
+  return s;
+}
+
+// Render a single struct field declaration `<cppType> <name><dims>;`. Array
+// fields put their dimensions after the name (C declarator syntax).
+static std::string renderStructFieldDecl(Type fieldTy,
+                                         const std::string &name) {
+  if (auto arr = dyn_cast<pto::LocalArrayType>(fieldTy)) {
+    std::string dims;
+    for (int64_t d : arr.getShape())
+      dims += "[" + std::to_string(d) + "]";
+    return getEmitCScalarTypeToken(arr.getElementType()) + " " + name + dims +
+           ";";
+  }
+  if (auto st = dyn_cast<pto::StructType>(fieldTy))
+    return getStructTypeName(st) + " " + name + ";";
+  return getEmitCScalarTypeToken(fieldTy) + " " + name + ";";
+}
+
+// Render the full C++ definition of a !pto.struct as file-scope text.
+static std::string renderStructDef(pto::StructType st) {
+  std::string s = "struct " + getStructTypeName(st) + " {\n";
+  for (auto [i, f] : llvm::enumerate(st.getFieldTypes()))
+    s += "  " + renderStructFieldDecl(f, "f" + std::to_string(i)) + "\n";
+  return s + "};";
+}
+
+// Collect every !pto.struct reachable from `t` into `out` in definition order:
+// a nested struct is inserted before the struct that embeds it, so emitting in
+// `out` order produces valid C++ (no use-before-definition).
+static void collectStructTypes(Type t, llvm::SetVector<pto::StructType> &out) {
+  auto st = dyn_cast<pto::StructType>(t);
+  if (!st || out.contains(st))
+    return;
+  for (Type f : st.getFieldTypes())
+    collectStructTypes(f, out);
+  out.insert(st);
+}
+
 static std::string tileBufBLayoutToken(pto::TileBufConfigAttr configAttr);
 static std::string tileBufSLayoutToken(pto::TileBufConfigAttr configAttr);
 static std::string tileBufPadToken(pto::TileBufConfigAttr configAttr);
@@ -886,6 +971,13 @@ public:
       if (!convertedElem)
         return std::nullopt;
       return emitc::ArrayType::get(type.getShape(), convertedElem);
+    });
+
+    // !pto.struct<...> -> !emitc.opaque<"PtoStruct_...">. The matching C++
+    // `struct PtoStruct_... { ... };` definition is emitted at file scope by
+    // the pass (see runOnOperation), keyed on the same content-derived name.
+    addConversion([Ctx](pto::StructType type) -> Type {
+      return emitc::OpaqueType::get(Ctx, getStructTypeName(type));
     });
 
     addConversion([Ctx](pto::AsyncSessionType type) -> Type {
@@ -7948,6 +8040,109 @@ struct PTOLocalArraySetToEmitC
   }
 };
 
+// pto.declare_struct -> emitc.variable of !emitc.opaque<"PtoStruct_...">.
+// Renders as `PtoStruct_X s;` in the emitted C++.
+struct PTODeclareStructToEmitC
+    : public OpConversionPattern<mlir::pto::DeclareStructOp> {
+  using OpConversionPattern<mlir::pto::DeclareStructOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::DeclareStructOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    Type structTy = getTypeConverter()->convertType(op.getS().getType());
+    if (!structTy)
+      return rewriter.notifyMatchFailure(op, "failed to map !pto.struct type");
+
+    auto var = rewriter
+                   .create<emitc::VariableOp>(
+                       op.getLoc(), structTy,
+                       emitc::OpaqueAttr::get(rewriter.getContext(), ""))
+                   .getResult();
+    rewriter.replaceOp(op, var);
+    return success();
+  }
+};
+
+// Build the `s.fA.fB...` member-access chain for a constant struct path and
+// return the final emitc value (a deferred lvalue expression). `rootPtoTy` is
+// the PTO struct type, walked in parallel to look up field types per step.
+static FailureOr<Value> buildStructMemberChain(
+    ConversionPatternRewriter &rewriter, Location loc, const TypeConverter *tc,
+    Value root, mlir::pto::StructType rootPtoTy, llvm::ArrayRef<int64_t> path) {
+  Value cur = peelUnrealized(root);
+  Type curPtoTy = rootPtoTy;
+  for (int64_t idx : path) {
+    auto st = cast<mlir::pto::StructType>(curPtoTy);
+    Type fieldPtoTy = st.getFieldType(static_cast<unsigned>(idx));
+    Type fieldTy = tc->convertType(fieldPtoTy);
+    if (!fieldTy)
+      return failure();
+    cur = rewriter
+              .create<emitc::MemberOp>(
+                  loc, fieldTy,
+                  rewriter.getStringAttr("f" + std::to_string(idx)), cur)
+              .getResult();
+    curPtoTy = fieldPtoTy;
+  }
+  return cur;
+}
+
+// pto.struct_get %s[i, j, ...] -> `s.fi.fj...`, snapshotting a scalar result so
+// the SSA value survives later mutation of the struct (mirrors
+// pto.local_array_get). An aggregate result (nested array / struct) passes
+// through as the member lvalue, so a nested array field can then be indexed by
+// pto.local_array_get / pto.local_array_set.
+struct PTOStructGetToEmitC
+    : public OpConversionPattern<mlir::pto::StructGetOp> {
+  using OpConversionPattern<mlir::pto::StructGetOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::StructGetOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    Type resultTy = getTypeConverter()->convertType(op.getValue().getType());
+    if (!resultTy)
+      return rewriter.notifyMatchFailure(op, "failed to map struct field type");
+
+    FailureOr<Value> member = buildStructMemberChain(
+        rewriter, op.getLoc(), getTypeConverter(), adaptor.getS(),
+        op.getS().getType(), op.getPath());
+    if (failed(member))
+      return rewriter.notifyMatchFailure(op, "failed to map struct field type");
+
+    if (op.getValue().getType().isIntOrFloat()) {
+      auto snapshot =
+          rewriter
+              .create<emitc::VariableOp>(
+                  op.getLoc(), resultTy,
+                  emitc::OpaqueAttr::get(rewriter.getContext(), ""))
+              .getResult();
+      rewriter.create<emitc::AssignOp>(op.getLoc(), snapshot, *member);
+      rewriter.replaceOp(op, snapshot);
+    } else {
+      rewriter.replaceOp(op, *member);
+    }
+    return success();
+  }
+};
+
+// pto.struct_set %s[i, j, ...], %v -> `s.fi.fj... = v;`.
+struct PTOStructSetToEmitC
+    : public OpConversionPattern<mlir::pto::StructSetOp> {
+  using OpConversionPattern<mlir::pto::StructSetOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::StructSetOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    FailureOr<Value> member = buildStructMemberChain(
+        rewriter, op.getLoc(), getTypeConverter(), adaptor.getS(),
+        op.getS().getType(), op.getPath());
+    if (failed(member))
+      return rewriter.notifyMatchFailure(op, "failed to map struct field type");
+
+    rewriter.create<emitc::AssignOp>(op.getLoc(), *member, adaptor.getValue());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 static std::optional<int64_t> getStaticIndexLikeValue(Value value) {
   if (!value)
     return std::nullopt;
@@ -14273,6 +14468,9 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTODeclareLocalArrayToEmitC>(typeConverter, ctx);
   patterns.add<PTOLocalArrayGetToEmitC>(typeConverter, ctx);
   patterns.add<PTOLocalArraySetToEmitC>(typeConverter, ctx);
+  patterns.add<PTODeclareStructToEmitC>(typeConverter, ctx);
+  patterns.add<PTOStructGetToEmitC>(typeConverter, ctx);
+  patterns.add<PTOStructSetToEmitC>(typeConverter, ctx);
   patterns.add<PTOTReshapeToEmitC>(typeConverter, ctx);
   patterns.add<PTOBitcastToEmitC>(typeConverter, ctx);
   patterns.add<PTOSetQuantScalarToEmitC, PTOSetQuantVectorToEmitC>(
@@ -14405,6 +14603,30 @@ struct EmitPTOManualPass
         }
 	    builder.create<emitc::VerbatimOp>(
 	        loc, builder.getStringAttr("using namespace pto;"));
+
+        // Emit a C++ definition for every !pto.struct used in the module, in
+        // dependency order (nested structs first) so there is no
+        // use-before-definition. The names match the type converter's
+        // content-derived !emitc.opaque tokens.
+        {
+          llvm::SetVector<pto::StructType> structDefs;
+          mop.walk([&](Operation *op) {
+            for (Type t : op->getResultTypes())
+              collectStructTypes(t, structDefs);
+            for (Value v : op->getOperands())
+              collectStructTypes(v.getType(), structDefs);
+            if (auto func = dyn_cast<func::FuncOp>(op)) {
+              for (Type t : func.getArgumentTypes())
+                collectStructTypes(t, structDefs);
+              for (Type t : func.getResultTypes())
+                collectStructTypes(t, structDefs);
+            }
+          });
+          for (pto::StructType st : structDefs)
+            builder.create<emitc::VerbatimOp>(
+                loc, builder.getStringAttr(renderStructDef(st)));
+        }
+
         if (needsGlobalTensorDataHelper) {
 	      builder.create<emitc::VerbatimOp>(
 	          loc, builder.getStringAttr(R"cpp(

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -14593,6 +14593,8 @@ struct EmitPTOManualPass
 
     if (failed(pto::validatePTOEntryFunctions(mop)))
       return signalPassFailure();
+    if (failed(pto::validateStructNeverReturned(mop)))
+      return signalPassFailure();
     pto::annotatePTOEntryFunctions(mop);
 
     // A3 requires explicit FFTS base setup for inter-core sync ops.

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -14593,7 +14593,7 @@ struct EmitPTOManualPass
 
     if (failed(pto::validatePTOEntryFunctions(mop)))
       return signalPassFailure();
-    if (failed(pto::validateStructNeverReturned(mop)))
+    if (failed(pto::validateStructProvenance(mop)))
       return signalPassFailure();
     pto::annotatePTOEntryFunctions(mop);
 

--- a/test/lit/pto/struct_escape_indirect_invalid.pto
+++ b/test/lit/pto/struct_escape_indirect_invalid.pto
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas %s 2>&1 | FileCheck %s
+
+// Indirect escape. @passthrough merely hands its argument back, but that is
+// enough to launder provenance: %r is no longer a pto.declare_struct result, so
+// the per-op escape check cannot see that `return %r` is publishing @leak's own
+// local. Without the function-result ban this emitted, at exit code 0,
+//   AICORE PtoStruct_f32_i8* leak(float v1) {
+//     PtoStruct_f32_i8 v2; ... return passthrough(&v2);
+//   }
+// i.e. the address of a dead frame, with no diagnostic.
+
+module {
+  func.func private @passthrough(%s : !pto.struct<f32, i8>)
+      -> !pto.struct<f32, i8> {
+    return %s : !pto.struct<f32, i8>
+  }
+
+  func.func @leak(%v : f32) -> !pto.struct<f32, i8> {
+    %s = pto.declare_struct -> !pto.struct<f32, i8>
+    pto.struct_set %s[0], %v : !pto.struct<f32, i8>, f32
+    %r = func.call @passthrough(%s)
+       : (!pto.struct<f32, i8>) -> !pto.struct<f32, i8>
+    return %r : !pto.struct<f32, i8>
+  }
+}
+
+// CHECK: a stack-local struct must not be returned

--- a/test/lit/pto/struct_escape_return_invalid.pto
+++ b/test/lit/pto/struct_escape_return_invalid.pto
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas %s 2>&1 | FileCheck %s
+
+// A !pto.struct is stack storage and lowers to a pointer to that storage, so
+// returning a locally declared one would hand the caller a pointer into a dead
+// frame. Without this check the emitted C++ is `PtoStruct_f32_i8 v2; ... return
+// &v2;` — it compiles clean and is undefined at run time.
+
+module {
+  func.func private @make(%v : f32) -> !pto.struct<f32, i8> {
+    %s = pto.declare_struct -> !pto.struct<f32, i8>
+    pto.struct_set %s[0], %v : !pto.struct<f32, i8>, f32
+    return %s : !pto.struct<f32, i8>
+  }
+}
+
+// CHECK: stack-local struct must not escape the scope that declares it

--- a/test/lit/pto/struct_escape_yield_invalid.pto
+++ b/test/lit/pto/struct_escape_yield_invalid.pto
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas %s 2>&1 | FileCheck %s
+
+// Same rule one scope in: yielding a struct declared inside an scf.if region
+// carries its address out of the region that owns the storage. Diagnosed at the
+// declare rather than surfacing later as a failure to legalize pto.struct_get.
+
+module {
+  func.func @yield_out(%c : i1, %v : f32) {
+    %r = scf.if %c -> (!pto.struct<f32, i8>) {
+      %a = pto.declare_struct -> !pto.struct<f32, i8>
+      pto.struct_set %a[0], %v : !pto.struct<f32, i8>, f32
+      scf.yield %a : !pto.struct<f32, i8>
+    } else {
+      %b = pto.declare_struct -> !pto.struct<f32, i8>
+      scf.yield %b : !pto.struct<f32, i8>
+    }
+    %g = pto.struct_get %r[0] : !pto.struct<f32, i8> -> f32
+    return
+  }
+}
+
+// CHECK: stack-local struct must not escape the scope that declares it

--- a/test/lit/pto/struct_func_arg_emitc.pto
+++ b/test/lit/pto/struct_func_arg_emitc.pto
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas %s 2>&1 | FileCheck %s
+
+// A !pto.struct can be passed to a helper function. It lowers to a pointer:
+// carrying it by value would make the callee's writes land in a copy, and an
+// !emitc.lvalue is rejected outright as a function argument type. The callee
+// reaches fields through `->`, the caller passes the address of its own storage
+// and still uses `.` on it.
+
+module {
+  func.func private @helper(%s : !pto.struct<f32, i8>, %v : f32) {
+    pto.struct_set %s[0], %v : !pto.struct<f32, i8>, f32
+    return
+  }
+
+  func.func @caller(%v : f32) {
+    %s = pto.declare_struct -> !pto.struct<f32, i8>
+    pto.struct_set %s[0], %v : !pto.struct<f32, i8>, f32
+    func.call @helper(%s, %v) : (!pto.struct<f32, i8>, f32) -> ()
+    return
+  }
+}
+
+// CHECK: struct PtoStruct_f32_i8 {
+// CHECK:   float f0;
+// CHECK:   int8_t f1;
+// CHECK: };
+
+// The callee takes a pointer and writes the field through it.
+// CHECK: helper(PtoStruct_f32_i8* [[ARG:v[0-9]+]], float
+// CHECK: PtoStruct_f32_i8* [[P:v[0-9]+]];
+// CHECK: [[P]] = [[ARG]];
+// CHECK: [[P]]->f0 = {{v[0-9]+}};
+
+// The caller declares real storage, takes its address for the call, and still
+// reaches its own fields with `.` rather than through the pointer.
+// CHECK-LABEL: caller
+// CHECK: PtoStruct_f32_i8 [[S:v[0-9]+]];
+// CHECK: PtoStruct_f32_i8* [[SP:v[0-9]+]] = &[[S]];
+// CHECK: [[S]].f0 = {{v[0-9]+}};
+// CHECK: helper([[SP]],

--- a/test/lit/pto/struct_get_aggregate_invalid.pto
+++ b/test/lit/pto/struct_get_aggregate_invalid.pto
@@ -8,16 +8,17 @@
 
 // RUN: not ptoas %s 2>&1 | FileCheck %s
 
-// A !pto.local_array cannot be a struct field. A field is reached with
-// emitc.member, whose result must be an !emitc.lvalue, and !emitc.lvalue cannot
-// wrap the !emitc.array an array field lowers to — so the access is not
-// expressible and the type verifier rejects it up front.
+// A path that stops on a nested !pto.struct is rejected: handing the whole
+// aggregate back as an SSA value would copy it out of the parent struct, so a
+// nested field is reached with a longer path instead.
 
 module {
-  func.func @struct_array_field() {
-    %s = pto.declare_struct -> !pto.struct<!pto.local_array<4xf32>>
+  func.func @struct_get_aggregate() {
+    %s = pto.declare_struct -> !pto.struct<!pto.struct<f32, i8>, i16>
+    %inner = pto.struct_get %s[0]
+      : !pto.struct<!pto.struct<f32, i8>, i16> -> !pto.struct<f32, i8>
     return
   }
 }
 
-// CHECK: is not scalar-storable
+// CHECK: struct path must end at a scalar field

--- a/test/lit/pto/struct_invalid_field_type.pto
+++ b/test/lit/pto/struct_invalid_field_type.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas %s 2>&1 | FileCheck %s
+
+// A tile_buf belongs to the vec/cube world and must never be a struct field:
+// the type verifier keeps the scalar struct world disjoint from the
+// fractal/layout world.
+
+module {
+  func.func @struct_bad_field() {
+    %s = pto.declare_struct -> !pto.struct<f32, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>>
+    return
+  }
+}
+
+// CHECK: is not scalar-storable

--- a/test/lit/pto/struct_name_collision_emitc.pto
+++ b/test/lit/pto/struct_name_collision_emitc.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas %s 2>&1 | FileCheck %s
+
+// Struct type names are mangled from the MLIR type spelling, not from the C++
+// scalar token. The C++ token is many-to-one (i32 and si32 both render as
+// `int32_t`), so mangling from it would emit two `struct` definitions sharing
+// one name and the generated C++ would fail to compile with a redefinition.
+// Three structs that differ only in field signedness must therefore produce
+// three distinctly-named definitions.
+
+module {
+  func.func @struct_signedness() {
+    %s0 = pto.declare_struct -> !pto.struct<i32>
+    %s1 = pto.declare_struct -> !pto.struct<si32>
+    %s2 = pto.declare_struct -> !pto.struct<ui32>
+    return
+  }
+}
+
+// CHECK: struct PtoStruct_i32 {
+// CHECK:   int32_t f0;
+// CHECK: };
+// CHECK: struct PtoStruct_si32 {
+// CHECK:   int32_t f0;
+// CHECK: };
+// CHECK: struct PtoStruct_ui32 {
+// CHECK:   uint32_t f0;
+// CHECK: };
+
+// CHECK-LABEL: struct_signedness
+// CHECK: PtoStruct_i32 {{v[0-9]+}};
+// CHECK: PtoStruct_si32 {{v[0-9]+}};
+// CHECK: PtoStruct_ui32 {{v[0-9]+}};

--- a/test/lit/pto/struct_name_collision_emitc.pto
+++ b/test/lit/pto/struct_name_collision_emitc.pto
@@ -33,8 +33,3 @@ module {
 // CHECK: struct PtoStruct_ui32 {
 // CHECK:   uint32_t f0;
 // CHECK: };
-
-// CHECK-LABEL: struct_signedness
-// CHECK: PtoStruct_i32 {{v[0-9]+}};
-// CHECK: PtoStruct_si32 {{v[0-9]+}};
-// CHECK: PtoStruct_ui32 {{v[0-9]+}};

--- a/test/lit/pto/struct_nested_emitc.pto
+++ b/test/lit/pto/struct_nested_emitc.pto
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas %s 2>&1 | FileCheck %s
+
+// Nested aggregate: a struct whose first field is a nested struct and whose
+// second field is a local_array.
+//   - struct_set with a 2-level path writes through the nested struct.
+//   - struct_get of the array field yields the array lvalue, which is then
+//     indexed dynamically with local_array_set / local_array_get.
+
+module {
+  func.func @struct_nested(%vf : f32, %i : index) {
+    %s = pto.declare_struct
+      -> !pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>>
+    pto.struct_set %s[0, 0], %vf
+      : !pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>>, f32
+    %arr = pto.struct_get %s[1]
+      : !pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>>
+      -> !pto.local_array<4xf32>
+    pto.local_array_set %arr[%i], %vf : !pto.local_array<4xf32>, f32
+    %g = pto.local_array_get %arr[%i] : !pto.local_array<4xf32> -> f32
+    pto.local_array_set %arr[%i], %g : !pto.local_array<4xf32>, f32
+    return
+  }
+}
+
+// Nested struct is defined before the struct that embeds it.
+// CHECK: struct PtoStruct_float_int8_t {
+// CHECK:   float f0;
+// CHECK:   int8_t f1;
+// CHECK: };
+// CHECK: struct PtoStruct_S_float_int8_t_E_arr4_float {
+// CHECK:   PtoStruct_float_int8_t f0;
+// CHECK:   float f1[4];
+// CHECK: };
+
+// CHECK-LABEL: struct_nested
+// CHECK: PtoStruct_S_float_int8_t_E_arr4_float [[S:v[0-9]+]];
+// CHECK: [[S]].f0.f0 = {{v[0-9]+}};
+// CHECK: [[S]].f1[{{v[0-9]+}}] = {{v[0-9]+}};
+// CHECK: float [[G:v[0-9]+]];
+// CHECK: [[G]] = [[S]].f1[{{v[0-9]+}}];
+// CHECK: [[S]].f1[{{v[0-9]+}}] = [[G]];

--- a/test/lit/pto/struct_nested_emitc.pto
+++ b/test/lit/pto/struct_nested_emitc.pto
@@ -8,24 +8,21 @@
 
 // RUN: ptoas %s 2>&1 | FileCheck %s
 
-// Nested aggregate: a struct whose first field is a nested struct and whose
-// second field is a local_array.
-//   - struct_set with a 2-level path writes through the nested struct.
-//   - struct_get of the array field yields the array lvalue, which is then
-//     indexed dynamically with local_array_set / local_array_get.
+// Nested aggregate: a struct whose first field is itself a struct. A field
+// inside the nested struct is reached with a 2-level path, which lowers to a
+// chained `s.f0.f0` member access rather than to a copy of the inner struct.
 
 module {
-  func.func @struct_nested(%vf : f32, %i : index) {
-    %s = pto.declare_struct
-      -> !pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>>
+  func.func @struct_nested(%vf : f32, %vi : i16) {
+    %s = pto.declare_struct -> !pto.struct<!pto.struct<f32, i8>, i16>
     pto.struct_set %s[0, 0], %vf
-      : !pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>>, f32
-    %arr = pto.struct_get %s[1]
-      : !pto.struct<!pto.struct<f32, i8>, !pto.local_array<4xf32>>
-      -> !pto.local_array<4xf32>
-    pto.local_array_set %arr[%i], %vf : !pto.local_array<4xf32>, f32
-    %g = pto.local_array_get %arr[%i] : !pto.local_array<4xf32> -> f32
-    pto.local_array_set %arr[%i], %g : !pto.local_array<4xf32>, f32
+      : !pto.struct<!pto.struct<f32, i8>, i16>, f32
+    pto.struct_set %s[1], %vi
+      : !pto.struct<!pto.struct<f32, i8>, i16>, i16
+    %g = pto.struct_get %s[0, 0]
+      : !pto.struct<!pto.struct<f32, i8>, i16> -> f32
+    pto.struct_set %s[0, 0], %g
+      : !pto.struct<!pto.struct<f32, i8>, i16>, f32
     return
   }
 }
@@ -35,15 +32,14 @@ module {
 // CHECK:   float f0;
 // CHECK:   int8_t f1;
 // CHECK: };
-// CHECK: struct PtoStruct_S_f32_i8_E_arr4_f32 {
+// CHECK: struct PtoStruct_S_f32_i8_E_i16 {
 // CHECK:   PtoStruct_f32_i8 f0;
-// CHECK:   float f1[4];
+// CHECK:   int16_t f1;
 // CHECK: };
 
 // CHECK-LABEL: struct_nested
-// CHECK: PtoStruct_S_f32_i8_E_arr4_f32 [[S:v[0-9]+]];
+// CHECK: PtoStruct_S_f32_i8_E_i16 [[S:v[0-9]+]];
 // CHECK: [[S]].f0.f0 = {{v[0-9]+}};
-// CHECK: [[S]].f1[{{v[0-9]+}}] = {{v[0-9]+}};
-// CHECK: float [[G:v[0-9]+]];
-// CHECK: [[G]] = [[S]].f1[{{v[0-9]+}}];
-// CHECK: [[S]].f1[{{v[0-9]+}}] = [[G]];
+// CHECK: [[S]].f1 = {{v[0-9]+}};
+// CHECK: float [[G:v[0-9]+]] = [[S]].f0.f0;
+// CHECK: [[S]].f0.f0 = [[G]];

--- a/test/lit/pto/struct_nested_emitc.pto
+++ b/test/lit/pto/struct_nested_emitc.pto
@@ -31,17 +31,17 @@ module {
 }
 
 // Nested struct is defined before the struct that embeds it.
-// CHECK: struct PtoStruct_float_int8_t {
+// CHECK: struct PtoStruct_f32_i8 {
 // CHECK:   float f0;
 // CHECK:   int8_t f1;
 // CHECK: };
-// CHECK: struct PtoStruct_S_float_int8_t_E_arr4_float {
-// CHECK:   PtoStruct_float_int8_t f0;
+// CHECK: struct PtoStruct_S_f32_i8_E_arr4_f32 {
+// CHECK:   PtoStruct_f32_i8 f0;
 // CHECK:   float f1[4];
 // CHECK: };
 
 // CHECK-LABEL: struct_nested
-// CHECK: PtoStruct_S_float_int8_t_E_arr4_float [[S:v[0-9]+]];
+// CHECK: PtoStruct_S_f32_i8_E_arr4_f32 [[S:v[0-9]+]];
 // CHECK: [[S]].f0.f0 = {{v[0-9]+}};
 // CHECK: [[S]].f1[{{v[0-9]+}}] = {{v[0-9]+}};
 // CHECK: float [[G:v[0-9]+]];

--- a/test/lit/pto/struct_path_oob_invalid.pto
+++ b/test/lit/pto/struct_path_oob_invalid.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas %s 2>&1 | FileCheck %s
+
+// A constant field index past the end of the struct is a verifier error.
+
+module {
+  func.func @struct_path_oob() {
+    %s = pto.declare_struct -> !pto.struct<f32, i8>
+    %r = pto.struct_get %s[5] : !pto.struct<f32, i8> -> f32
+    return
+  }
+}
+
+// CHECK: out of range

--- a/test/lit/pto/struct_provenance_result_invalid.pto
+++ b/test/lit/pto/struct_provenance_result_invalid.pto
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas %s 2>&1 | FileCheck %s
+
+// An intermediate select hides each declaration from the direct terminator-use
+// check. Without module-level provenance validation, scf.if then returns a
+// pointer to branch-local stack storage after that storage's lifetime ends.
+
+module {
+  func.func @region_alias(%c : i1, %pick : i1, %v : f32) {
+    %r = scf.if %c -> (!pto.struct<f32, i8>) {
+      %a = pto.declare_struct -> !pto.struct<f32, i8>
+      %a_alt = pto.declare_struct -> !pto.struct<f32, i8>
+      pto.struct_set %a[0], %v : !pto.struct<f32, i8>, f32
+      %a_alias = arith.select %pick, %a, %a_alt : !pto.struct<f32, i8>
+      scf.yield %a_alias : !pto.struct<f32, i8>
+    } else {
+      %b = pto.declare_struct -> !pto.struct<f32, i8>
+      %b_alt = pto.declare_struct -> !pto.struct<f32, i8>
+      %b_alias = arith.select %pick, %b, %b_alt : !pto.struct<f32, i8>
+      scf.yield %b_alias : !pto.struct<f32, i8>
+    }
+    %g = pto.struct_get %r[0] : !pto.struct<f32, i8> -> f32
+    return
+  }
+}
+
+// CHECK: only 'pto.declare_struct' may produce a !pto.struct result

--- a/test/lit/pto/struct_scalar_emitc.pto
+++ b/test/lit/pto/struct_scalar_emitc.pto
@@ -24,13 +24,13 @@ module {
 }
 
 // The struct definition is emitted at file scope.
-// CHECK: struct PtoStruct_half_int8_t {
+// CHECK: struct PtoStruct_f16_i8 {
 // CHECK:   half f0;
 // CHECK:   int8_t f1;
 // CHECK: };
 
 // CHECK-LABEL: struct_scalar
-// CHECK: PtoStruct_half_int8_t [[S:v[0-9]+]];
+// CHECK: PtoStruct_f16_i8 [[S:v[0-9]+]];
 // CHECK: [[S]].f0 = {{v[0-9]+}};
 // CHECK: [[S]].f1 = {{v[0-9]+}};
 // CHECK: half [[R:v[0-9]+]];

--- a/test/lit/pto/struct_scalar_emitc.pto
+++ b/test/lit/pto/struct_scalar_emitc.pto
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas %s 2>&1 | FileCheck %s
+
+// Heterogeneous stack-local struct: declare, set two scalar fields, get a
+// scalar field (snapshotted before the read-back set reuses it, mirroring
+// local_array_get value semantics).
+
+module {
+  func.func @struct_scalar(%vf : f16, %vi : i8) {
+    %s = pto.declare_struct -> !pto.struct<f16, i8>
+    pto.struct_set %s[0], %vf : !pto.struct<f16, i8>, f16
+    pto.struct_set %s[1], %vi : !pto.struct<f16, i8>, i8
+    %r = pto.struct_get %s[0] : !pto.struct<f16, i8> -> f16
+    pto.struct_set %s[0], %r : !pto.struct<f16, i8>, f16
+    return
+  }
+}
+
+// The struct definition is emitted at file scope.
+// CHECK: struct PtoStruct_half_int8_t {
+// CHECK:   half f0;
+// CHECK:   int8_t f1;
+// CHECK: };
+
+// CHECK-LABEL: struct_scalar
+// CHECK: PtoStruct_half_int8_t [[S:v[0-9]+]];
+// CHECK: [[S]].f0 = {{v[0-9]+}};
+// CHECK: [[S]].f1 = {{v[0-9]+}};
+// CHECK: half [[R:v[0-9]+]];
+// CHECK: [[R]] = [[S]].f0;
+// CHECK: [[S]].f0 = [[R]];

--- a/test/lit/pto/struct_scalar_emitc.pto
+++ b/test/lit/pto/struct_scalar_emitc.pto
@@ -33,6 +33,5 @@ module {
 // CHECK: PtoStruct_f16_i8 [[S:v[0-9]+]];
 // CHECK: [[S]].f0 = {{v[0-9]+}};
 // CHECK: [[S]].f1 = {{v[0-9]+}};
-// CHECK: half [[R:v[0-9]+]];
-// CHECK: [[R]] = [[S]].f0;
+// CHECK: half [[R:v[0-9]+]] = [[S]].f0;
 // CHECK: [[S]].f0 = [[R]];

--- a/test/lit/pto/struct_set_array_invalid.pto
+++ b/test/lit/pto/struct_set_array_invalid.pto
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas %s 2>&1 | FileCheck %s
+
+// A C array cannot be copy-assigned, so writing a whole local_array field is
+// rejected: use struct_get + local_array_set on individual elements instead.
+
+module {
+  func.func @struct_set_array() {
+    %arr = pto.declare_local_array -> !pto.local_array<4xf32>
+    %s = pto.declare_struct -> !pto.struct<!pto.local_array<4xf32>>
+    pto.struct_set %s[0], %arr
+      : !pto.struct<!pto.local_array<4xf32>>, !pto.local_array<4xf32>
+    return
+  }
+}
+
+// CHECK: cannot assign a !pto.local_array field

--- a/test/lit/pto/struct_unrepresentable_scalar_invalid.pto
+++ b/test/lit/pto/struct_unrepresentable_scalar_invalid.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas %s 2>&1 | FileCheck %s
+
+// An integer width the backend has no exact C++ spelling for (i1 here; i24 and
+// the packed f8/f4 vec formats behave the same) must be rejected by the type
+// verifier. Accepting it would emit the field as `float`, silently changing its
+// width and semantics in the generated C++.
+
+module {
+  func.func @struct_bad_scalar() {
+    %s = pto.declare_struct -> !pto.struct<f32, i1>
+    return
+  }
+}
+
+// CHECK: is not scalar-storable


### PR DESCRIPTION
Add a scalar-unit heterogeneous aggregate !pto.struct as the heterogeneous dual of !pto.local_array, mirroring its end-to-end pattern with minimal new mechanism.

- ODS: !pto.struct<T0,...> type + declare_struct / struct_get / struct_set (constant DenseI64ArrayAttr field path, custom<StructPath> assembly).
- IR: type verifier restricts fields to scalar int/float, nested local_array, or nested struct (rejects tile_buf/tensor_view and other handle types, keeping the scalar world disjoint from the vec/cube world); op verifiers walk the path with bounds/type checks and reject whole-array struct_set.
- EmitC: StructType -> emitc.opaque<PtoStruct_<mangled>>; file-scope struct definitions emitted in dependency order (nested first); member-access chain lowering with scalar snapshot semantics, while aggregate fields pass through as lvalues so a nested local_array field can be indexed via local_array_get/set.
- Docs (PTO_IR_manual section 2.7 + op references) and 5 lit tests (scalar/nested codegen + 3 verifier-error cases).