### PR TITLE
test(sync): guard TCI scalar-pipe vector consumer sync

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -7723,7 +7723,7 @@ dst[i, j] = S + linear_index(i, j)   // or descending if requested
 
 **Hardware Mapping:**
 
-- Executes on the **Vector pipeline** (`PIPE_V`)
+- Executes on the **Scalar pipeline** (`PIPE_S`)
 
 **Basic Example:**
 

--- a/test/lit/pto/issue771_tci_vec_consumer_sync.pto
+++ b/test/lit/pto/issue771_tci_vec_consumer_sync.pto
@@ -1,0 +1,26 @@
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --pto-insert-sync-debug=2 %s -o - 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @tci_cast_expand_consumer_sync() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %start = arith.constant 0 : i32
+    %idx_i32 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx_f32 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ones = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %out = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tci ins(%start : i32)
+            outs(%idx_i32 : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tcvt ins(%idx_i32 {rmode = #pto<round_mode ROUND>} : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%idx_f32 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tcolexpandmul ins(%ones, %idx_f32 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                     outs(%out : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: After Sync Motion
+// CHECK:      COMPOUND pto.tci [PIPE_S]
+// CHECK-NEXT:   POST: set_flag <PIPE_S -> PIPE_V>
+// CHECK-NEXT: COMPOUND pto.tcvt [PIPE_V]
+// CHECK-NEXT:   PRE : wait_flag <PIPE_S -> PIPE_V>
+// CHECK:      COMPOUND pto.tcolexpandmul [PIPE_V]


### PR DESCRIPTION
Summary
- Add an issue #771 regression for the full `TCI -> TCVT -> TCOLEXPANDMUL` vector-consumer chain.
- Correct the `pto.tci` hardware mapping in the PTO IR manual from `PIPE_V` to `PIPE_S`.

Motivation
- Fixes #771.
- On device, `TCI` writes must be synchronized from its actual scalar pipe before downstream vector consumers read the tile. The current main branch already models `TCI` as `PIPE_S`; this PR guards that behavior with the repro-shaped chain so it does not regress back to a `PIPE_V` barrier-only path.

Design
- The new lit test checks InsertSync debug output after sync motion:
  - `pto.tci [PIPE_S]`
  - `set_flag <PIPE_S -> PIPE_V>` after `TCI`
  - `wait_flag <PIPE_S -> PIPE_V>` before `TCVT`
  - downstream `TCOLEXPANDMUL` remains a vector consumer
- No CLI, IR syntax, or codegen API changes.

Testing
- PASS: `/Users/lishengtao/Documents/PTO/_codex_worktrees/fix-issue735-tci-pipe/build/tools/ptoas/ptoas --pto-arch=a3 --enable-insert-sync --pto-insert-sync-debug=2 test/lit/pto/issue771_tci_vec_consumer_sync.pto -o - 2>&1 | /Users/lishengtao/Documents/PTO/llvm-workspace/llvm-project/build-shared/bin/FileCheck test/lit/pto/issue771_tci_vec_consumer_sync.pto`
- PASS: `/Users/lishengtao/Documents/PTO/_codex_worktrees/fix-issue735-tci-pipe/build/tools/ptoas/ptoas --pto-arch=a3 --enable-insert-sync --pto-insert-sync-debug=2 test/lit/pto/issue735_tci_pipe_s_sync.pto -o - 2>&1 | /Users/lishengtao/Documents/PTO/llvm-workspace/llvm-project/build-shared/bin/FileCheck test/lit/pto/issue735_tci_pipe_s_sync.pto`
- NOTE: configuring the current worktree locally succeeded, but `ninja -C build ptoas` is blocked by the local LLVM/CANN dependency mismatch (`SimtEntry` and CANN 9.0 LLVM float type symbols missing), unrelated to this docs/test-only change.

Risk / Rollback
- Risk: low. This PR only adds a regression test and corrects stale documentation.
- Rollback: revert this PR.
