### PR TITLE
Fix metadata shape parsing for pipe tile indexing

### DIFF
--- a/ptodsl/ptodsl/_surface_values.py
+++ b/ptodsl/ptodsl/_surface_values.py
@@ -629,7 +629,7 @@ def emit_as_ptr(surface_value):
 
 
 _TILE_TYPE_RE = re.compile(
-    r"!pto\.tile_buf<(?P<space>[^,]+),\s*(?P<shape>.+?)x(?P<elem>[^,x>]+),\s*valid=(?P<valid>[^,>]+)(?:,.*)?>"
+    r"!pto\.tile_buf<(?P<space>[^,]+),\s*(?P<shape>.+?)x(?P<elem>[^,x>]+)(?:,\s*blayout=[^,>]+)?(?:,\s*slayout=[^,>]+)?(?:,\s*valid=(?P<valid>[^,>]+))?(?:,.*)?>"
 )
 
 
@@ -696,10 +696,14 @@ def parse_tile_type_metadata(type_obj):
         None if dim == "?" else int(dim)
         for dim in match.group("shape").split("x")
     ]
-    valid_dims = [
-        None if dim == "?" else int(dim)
-        for dim in match.group("valid").split("x")
-    ]
+    valid_group = match.group("valid")
+    if valid_group:
+        valid_dims = [
+            None if dim == "?" else int(dim)
+            for dim in valid_group.split("x")
+        ]
+    else:
+        valid_dims = list(shape_dims)
     return {
         "memory_space": match.group("space"),
         "shape_dims": tuple(shape_dims),

--- a/ptodsl/ptodsl/_surface_values.py
+++ b/ptodsl/ptodsl/_surface_values.py
@@ -629,7 +629,7 @@ def emit_as_ptr(surface_value):
 
 
 _TILE_TYPE_RE = re.compile(
-    r"!pto\.tile_buf<(?P<space>[^,]+),\s*(?P<shape>.+?)x(?P<elem>[^,x>]+)(?:,\s*blayout=[^,>]+)?(?:,\s*slayout=[^,>]+)?(?:,\s*valid=(?P<valid>[^,>]+))?(?:,.*)?>"
+    r"!pto\.tile_buf<(?P<space>[^,]+),\s*(?P<shape>[0-9?x\s]+)x(?P<elem>[^,>]+)(?:,\s*blayout=[^,>]+)?(?:,\s*slayout=[^,>]+)?(?:,\s*valid=(?P<valid>[^,>]+))?(?:,.*)?>"
 )
 
 

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -1503,6 +1503,23 @@ def vector_post_update_surface_probe():
     _ = block_base
 
 
+@pto.jit(name="pipe_tile_metadata_probe", target="a5", kernel_kind="vector")
+def pipe_tile_metadata_probe():
+    c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
+    c2v = pto.pipe.c2v(slot_size=1024, consumer_buf=c2v_buf, id=0)
+    dst_type = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+
+    @pto.simd
+    def _inner():
+        c2v.init_simd()
+        fifo_tile = c2v.pop(result_type=dst_type, split=0)
+        # Slicing requires tile shape metadata parsing
+        val = pto.vlds(fifo_tile[0, 0:])
+        c2v.free(split=0)
+
+    _inner()
+
+
 @pto.jit(target="a5")
 def auto_mode_explicit_surface_violation_probe():
     zero_u64 = pto.const(0, dtype=pto.ui64)
@@ -2850,6 +2867,10 @@ def main() -> None:
     expect(', "DS"' in mask_surface_text, "plds(..., dist=pto.PredicateDist.DS) should preserve the documented DIST token")
     expect(', "PK"' in mask_surface_text, "psts(..., dist=pto.PredicateDist.PK) should preserve the documented DIST token")
     expect("pto.init_align" in mask_surface_text, "init_align() should lower to pto.init_align")
+
+    pipe_metadata_text = pipe_tile_metadata_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(pipe_metadata_text, "pipe tile metadata probe")
+    expect("pto.vlds" in pipe_metadata_text, "vlds from a popped tile should lower successfully without shape metadata errors")
 
     launch_handle = block64[1, None]
     expect(callable(launch_handle), "compiled[grid, stream] should return a launch callable")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -1508,6 +1508,8 @@ def pipe_tile_metadata_probe():
     c2v_buf = pto.reserve_buffer("c2v_fifo", size=8192, location="vec")
     c2v = pto.pipe.c2v(slot_size=1024, consumer_buf=c2v_buf, id=0)
     dst_type = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
+    dst_type_f4e2 = pto.alloc_tile(shape=[16, 32], dtype=pto.f4e2m1x2)
+    dst_type_f4e1 = pto.alloc_tile(shape=[16, 32], dtype=pto.f4e1m2x2)
 
     @pto.simd
     def _inner():
@@ -1515,6 +1517,14 @@ def pipe_tile_metadata_probe():
         fifo_tile = c2v.pop(result_type=dst_type, split=0)
         # Slicing requires tile shape metadata parsing
         val = pto.vlds(fifo_tile[0, 0:])
+        c2v.free(split=0)
+
+        fifo_tile_f4e2 = c2v.pop(result_type=dst_type_f4e2, split=0)
+        _ = fifo_tile_f4e2[0, 0:]
+        c2v.free(split=0)
+
+        fifo_tile_f4e1 = c2v.pop(result_type=dst_type_f4e1, split=0)
+        _ = fifo_tile_f4e1[0, 0:]
         c2v.free(split=0)
 
     _inner()


### PR DESCRIPTION
## Description
This PR fixes a `RuntimeError: tile indexing requires tile shape metadata` exception that occurs when attempting to slice or index into a dynamically-shaped tile popped from a pipe (e.g. `pto.pipe.c2v.pop()`) and potentially other places.

### Root Cause
When popping tiles from a pipe dynamically, the `!pto.tile_buf` MLIR type string doesn't always contain the `valid=` shape metadata attribute. The `_TILE_TYPE_RE` regular expression in `ptodsl/_surface_values.py` strictly expected the `valid=` metadata to be present. As a result, when indexing a popped tile (e.g. `val = pto.vlds(fifo_tile[0, 0:])`), the regex would fail to match the type string, stripping the tile of its metadata and throwing the `RuntimeError`.

### Changes Made
- **Relaxed Regex Matching**: Updated `_TILE_TYPE_RE` in `ptodsl/_surface_values.py` to treat the `valid=` attribute (along with `blayout=` and `slayout=`) as optional non-capturing groups when parsing MLIR type strings.
- **Added Compiler Tests**: Added `pipe_tile_metadata_probe` to `ptodsl/tests/test_jit_compile.py` to explicitly test that dynamically popped tiles can be sliced and lowered correctly to `pto.vlds` without crashing the compiler.

### Verification
- Tested locally by running `python ptodsl/tests/test_jit_compile.py`, which now successfully passes the new pipe metadata probe.
