### PR TITLE
vpto fix trowexpand op for col major tile

### DIFF
--- a/lib/TileOps/trowexpanddiv_template.py
+++ b/lib/TileOps/trowexpanddiv_template.py
@@ -60,35 +60,64 @@ def _constraint_trowexpanddiv_row_major(src0: pto.Tile, src1: pto.Tile, dst: pto
     constraints=[_constraint_trowexpanddiv_row_major],
 )
 def template_trowexpanddiv_f32(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
-    """Template for pto.trowexpanddiv with f32 dtype and optional high-precision mode."""
+    """Template for pto.trowexpanddiv with f32 dtype and optional high-precision mode.
+
+    When src1 is col_major with shape [M, 1] (a per-row scalar column),
+    vlds on the col_major tile slice would access UB at non-512B-aligned
+    addresses (error 340 on A5).  Use vldas+vldus (unaligned load pipeline)
+    for src1 in that case; keep the aligned vlds path for row_major src1.
+    """
     dtype = dst.element_type
     valid_rows, valid_cols = dst.valid_shape
-
     precision_type = pto.get_op_attr("precisionType", "default")
     if pto.constexpr(precision_type == "high_precision"):
-        for row in range(0, valid_rows, 1):
-            remained = valid_cols
-            for col in range(0, valid_cols, pto.get_lanes(dtype)):
-                mask, remained = pto.make_mask(dtype, remained)
-                # Load the scalar vector from src1[row, :]
-                # For row-major src1, valid_shape[1] is 32/sizeof(dtype) (e.g., 8 for f32)
-                # vdup broadcasts the first element to the full vector width
-                scalar_vec = pto.vlds(src1[row, :])
-                broadcasted = pto.vdup(scalar_vec, mask)
-                lhs = pto.vlds(src0[row, col:])
-                result = _div_ieee754_f32_impl(lhs, broadcasted, mask)
-                pto.vsts(result, dst[row, col:], mask)
+        if pto.constexpr(src1.config.b_layout == pto.BLayout.COL_MAJOR):
+            # col_major / high_precision
+            for row in range(0, valid_rows, 1):
+                align_src1 = pto.vldas(src1[row, :])
+                scalar_vec, _ = pto.vldus(src1[row, :], align_src1)
+                broadcasted = pto.vdup(scalar_vec, pto.make_mask(dtype, pto.PAT.ALL))
+                remained = valid_cols
+                for col in range(0, valid_cols, pto.get_lanes(dtype)):
+                    mask, remained = pto.make_mask(dtype, remained)
+                    lhs = pto.vlds(src0[row, col:])
+                    result = _div_ieee754_f32_impl(lhs, broadcasted, mask)
+                    pto.vsts(result, dst[row, col:], mask)
+        else:
+            # row_major / high_precision
+            for row in range(0, valid_rows, 1):
+                remained = valid_cols
+                for col in range(0, valid_cols, pto.get_lanes(dtype)):
+                    mask, remained = pto.make_mask(dtype, remained)
+                    scalar_vec = pto.vlds(src1[row, :])
+                    broadcasted = pto.vdup(scalar_vec, mask)
+                    lhs = pto.vlds(src0[row, col:])
+                    result = _div_ieee754_f32_impl(lhs, broadcasted, mask)
+                    pto.vsts(result, dst[row, col:], mask)
     else:
-        for row in range(0, valid_rows, 1):
-            remained = valid_cols
-            for col in range(0, valid_cols, pto.get_lanes(dtype)):
-                mask, remained = pto.make_mask(dtype, remained)
-                # Load the scalar vector from src1[row, :]
-                scalar_vec = pto.vlds(src1[row, :])
-                broadcasted = pto.vdup(scalar_vec, mask)
-                lhs = pto.vlds(src0[row, col:])
-                result = pto.vdiv(lhs, broadcasted, mask)
-                pto.vsts(result, dst[row, col:], mask)
+        if pto.constexpr(src1.config.b_layout == pto.BLayout.COL_MAJOR):
+            # col_major / default precision
+            for row in range(0, valid_rows, 1):
+                align_src1 = pto.vldas(src1[row, :])
+                scalar_vec, _ = pto.vldus(src1[row, :], align_src1)
+                broadcasted = pto.vdup(scalar_vec, pto.make_mask(dtype, pto.PAT.ALL))
+                remained = valid_cols
+                for col in range(0, valid_cols, pto.get_lanes(dtype)):
+                    mask, remained = pto.make_mask(dtype, remained)
+                    lhs = pto.vlds(src0[row, col:])
+                    result = pto.vdiv(lhs, broadcasted, mask)
+                    pto.vsts(result, dst[row, col:], mask)
+        else:
+            # row_major / default precision (existing behaviour)
+            for row in range(0, valid_rows, 1):
+                remained = valid_cols
+                for col in range(0, valid_cols, pto.get_lanes(dtype)):
+                    mask, remained = pto.make_mask(dtype, remained)
+                    scalar_vec = pto.vlds(src1[row, :])
+                    broadcasted = pto.vdup(scalar_vec, mask)
+                    lhs = pto.vlds(src0[row, col:])
+                    result = pto.vdiv(lhs, broadcasted, mask)
+                    pto.vsts(result, dst[row, col:], mask)
     return
 
 
@@ -99,33 +128,62 @@ def template_trowexpanddiv_f32(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
     constraints=[_constraint_trowexpanddiv_row_major],
 )
 def template_trowexpanddiv_f16(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
-    """Template for pto.trowexpanddiv with f16 dtype and optional high-precision mode."""
+    """Template for pto.trowexpanddiv with f16 dtype and optional high-precision mode.
+
+    When src1 is col_major with shape [M, 1] (a per-row scalar column),
+    vlds on the col_major tile slice would access UB at non-512B-aligned
+    addresses (error 340 on A5).  Use vldas+vldus (unaligned load pipeline)
+    for src1 in that case; keep the aligned vlds path for row_major src1.
+    """
     dtype = dst.element_type
     valid_rows, valid_cols = dst.valid_shape
-
     precision_type = pto.get_op_attr("precisionType", "default")
     if pto.constexpr(precision_type == "high_precision"):
-        for row in range(0, valid_rows, 1):
-            remained = valid_cols
-            for col in range(0, valid_cols, pto.get_lanes(dtype)):
-                mask, remained = pto.make_mask(dtype, remained)
-                # Load the scalar vector from src1[row, :]
-                # For row-major src1, valid_shape[1] is 32/sizeof(dtype) (e.g., 16 for f16)
-                # vdup broadcasts the first element to the full vector width
-                scalar_vec = pto.vlds(src1[row, :])
-                broadcasted = pto.vdup(scalar_vec, mask)
-                lhs = pto.vlds(src0[row, col:])
-                result = _div_ieee754_f16_impl(lhs, broadcasted, mask)
-                pto.vsts(result, dst[row, col:], mask)
+        if pto.constexpr(src1.config.b_layout == pto.BLayout.COL_MAJOR):
+            # col_major / high_precision
+            for row in range(0, valid_rows, 1):
+                align_src1 = pto.vldas(src1[row, :])
+                scalar_vec, _ = pto.vldus(src1[row, :], align_src1)
+                broadcasted = pto.vdup(scalar_vec, pto.make_mask(dtype, pto.PAT.ALL))
+                remained = valid_cols
+                for col in range(0, valid_cols, pto.get_lanes(dtype)):
+                    mask, remained = pto.make_mask(dtype, remained)
+                    lhs = pto.vlds(src0[row, col:])
+                    result = _div_ieee754_f16_impl(lhs, broadcasted, mask)
+                    pto.vsts(result, dst[row, col:], mask)
+        else:
+            # row_major / high_precision
+            for row in range(0, valid_rows, 1):
+                remained = valid_cols
+                for col in range(0, valid_cols, pto.get_lanes(dtype)):
+                    mask, remained = pto.make_mask(dtype, remained)
+                    scalar_vec = pto.vlds(src1[row, :])
+                    broadcasted = pto.vdup(scalar_vec, mask)
+                    lhs = pto.vlds(src0[row, col:])
+                    result = _div_ieee754_f16_impl(lhs, broadcasted, mask)
+                    pto.vsts(result, dst[row, col:], mask)
     else:
-        for row in range(0, valid_rows, 1):
-            remained = valid_cols
-            for col in range(0, valid_cols, pto.get_lanes(dtype)):
-                mask, remained = pto.make_mask(dtype, remained)
-                # Load the scalar vector from src1[row, :]
-                scalar_vec = pto.vlds(src1[row, :])
-                broadcasted = pto.vdup(scalar_vec, mask)
-                lhs = pto.vlds(src0[row, col:])
-                result = pto.vdiv(lhs, broadcasted, mask)
-                pto.vsts(result, dst[row, col:], mask)
+        if pto.constexpr(src1.config.b_layout == pto.BLayout.COL_MAJOR):
+            # col_major / default precision
+            for row in range(0, valid_rows, 1):
+                align_src1 = pto.vldas(src1[row, :])
+                scalar_vec, _ = pto.vldus(src1[row, :], align_src1)
+                broadcasted = pto.vdup(scalar_vec, pto.make_mask(dtype, pto.PAT.ALL))
+                remained = valid_cols
+                for col in range(0, valid_cols, pto.get_lanes(dtype)):
+                    mask, remained = pto.make_mask(dtype, remained)
+                    lhs = pto.vlds(src0[row, col:])
+                    result = pto.vdiv(lhs, broadcasted, mask)
+                    pto.vsts(result, dst[row, col:], mask)
+        else:
+            # row_major / default precision (existing behaviour)
+            for row in range(0, valid_rows, 1):
+                remained = valid_cols
+                for col in range(0, valid_cols, pto.get_lanes(dtype)):
+                    mask, remained = pto.make_mask(dtype, remained)
+                    scalar_vec = pto.vlds(src1[row, :])
+                    broadcasted = pto.vdup(scalar_vec, mask)
+                    lhs = pto.vlds(src0[row, col:])
+                    result = pto.vdiv(lhs, broadcasted, mask)
+                    pto.vsts(result, dst[row, col:], mask)
     return

--- a/lib/TileOps/trowexpandmul_template.py
+++ b/lib/TileOps/trowexpandmul_template.py
@@ -57,20 +57,41 @@ def template_trowexpandmul(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
 
     Multiply each row of src0 by a per-row scalar from src1[row, 0].
     Semantics: dst[row, col] = src0[row, col] * src1[row, 0]
+
+    When src1 is col_major with shape [M, 1] (a per-row scalar column),
+    vlds on the col_major tile slice would access UB at non-512B-aligned
+    addresses (error 340 on A5).  Use vldas+vldus (unaligned load pipeline)
+    for src1 in that case; keep the aligned vlds path for row_major src1.
     """
     dtype = dst.element_type
     valid_rows, valid_cols = dst.valid_shape
 
-    for row in range(0, valid_rows, 1):
-        remained = valid_cols
-        for col in range(0, valid_cols, pto.get_lanes(dtype)):
-            mask, remained = pto.make_mask(dtype, remained)
-            # Load the scalar vector from src1[row, :]
-            # For row-major src1, valid_shape[1] is 32/sizeof(dtype) (e.g., 8 for f32)
-            # vdup broadcasts the first element to the full vector width
-            scalar_vec = pto.vlds(src1[row, :])
-            broadcasted = pto.vdup(scalar_vec, mask)
-            lhs = pto.vlds(src0[row, col:])
-            result = pto.vmul(lhs, broadcasted, mask)
-            pto.vsts(result, dst[row, col:], mask)
+    if pto.constexpr(src1.config.b_layout == pto.BLayout.COL_MAJOR):
+        # ---- col_major [M, 1] path: unaligned load for src1 ----
+        for row in range(0, valid_rows, 1):
+            # vldas+vldus once per row, broadcast across all col iterations
+            align_src1 = pto.vldas(src1[row, :])
+            scalar_vec, _ = pto.vldus(src1[row, :], align_src1)
+            broadcasted = pto.vdup(scalar_vec, pto.make_mask(dtype, pto.PAT.ALL))
+            remained = valid_cols
+            for col in range(0, valid_cols, pto.get_lanes(dtype)):
+                mask, remained = pto.make_mask(dtype, remained)
+                lhs = pto.vlds(src0[row, col:])
+                result = pto.vmul(lhs, broadcasted, mask)
+                pto.vsts(result, dst[row, col:], mask)
+    else:
+        # ---- row_major path: aligned vlds (existing behaviour) ----
+        for row in range(0, valid_rows, 1):
+            remained = valid_cols
+            for col in range(0, valid_cols, pto.get_lanes(dtype)):
+                mask, remained = pto.make_mask(dtype, remained)
+                # Load the scalar vector from src1[row, :]
+                # For row-major src1, valid_shape[1] is 32/sizeof(dtype)
+                # (e.g., 8 for f32).  vdup broadcasts the first element
+                # to the full vector width.
+                scalar_vec = pto.vlds(src1[row, :])
+                broadcasted = pto.vdup(scalar_vec, mask)
+                lhs = pto.vlds(src0[row, col:])
+                result = pto.vmul(lhs, broadcasted, mask)
+                pto.vsts(result, dst[row, col:], mask)
     return

--- a/lib/TileOps/trowexpandsub_template.py
+++ b/lib/TileOps/trowexpandsub_template.py
@@ -57,20 +57,41 @@ def template_trowexpandsub(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile):
 
     Subtract a per-row scalar from src1[row, 0] from each row of src0.
     Semantics: dst[row, col] = src0[row, col] - src1[row, 0]
+
+    When src1 is col_major with shape [M, 1] (a per-row scalar column),
+    vlds on the col_major tile slice would access UB at non-512B-aligned
+    addresses (error 340 on A5).  Use vldas+vldus (unaligned load pipeline)
+    for src1 in that case; keep the aligned vlds path for row_major src1.
     """
     dtype = dst.element_type
     valid_rows, valid_cols = dst.valid_shape
 
-    for row in range(0, valid_rows, 1):
-        remained = valid_cols
-        for col in range(0, valid_cols, pto.get_lanes(dtype)):
-            mask, remained = pto.make_mask(dtype, remained)
-            # Load the scalar vector from src1[row, :]
-            # For row-major src1, valid_shape[1] is 32/sizeof(dtype) (e.g., 8 for f32)
-            # vdup broadcasts the first element to the full vector width
-            scalar_vec = pto.vlds(src1[row, :])
-            broadcasted = pto.vdup(scalar_vec, mask)
-            lhs = pto.vlds(src0[row, col:])
-            result = pto.vsub(lhs, broadcasted, mask)
-            pto.vsts(result, dst[row, col:], mask)
+    if pto.constexpr(src1.config.b_layout == pto.BLayout.COL_MAJOR):
+        # ---- col_major [M, 1] path: unaligned load for src1 ----
+        for row in range(0, valid_rows, 1):
+            # vldas+vldus once per row, broadcast across all col iterations
+            align_src1 = pto.vldas(src1[row, :])
+            scalar_vec, _ = pto.vldus(src1[row, :], align_src1)
+            broadcasted = pto.vdup(scalar_vec, pto.make_mask(dtype, pto.PAT.ALL))
+            remained = valid_cols
+            for col in range(0, valid_cols, pto.get_lanes(dtype)):
+                mask, remained = pto.make_mask(dtype, remained)
+                lhs = pto.vlds(src0[row, col:])
+                result = pto.vsub(lhs, broadcasted, mask)
+                pto.vsts(result, dst[row, col:], mask)
+    else:
+        # ---- row_major path: aligned vlds (existing behaviour) ----
+        for row in range(0, valid_rows, 1):
+            remained = valid_cols
+            for col in range(0, valid_cols, pto.get_lanes(dtype)):
+                mask, remained = pto.make_mask(dtype, remained)
+                # Load the scalar vector from src1[row, :]
+                # For row-major src1, valid_shape[1] is 32/sizeof(dtype)
+                # (e.g., 8 for f32).  vdup broadcasts the first element
+                # to the full vector width.
+                scalar_vec = pto.vlds(src1[row, :])
+                broadcasted = pto.vdup(scalar_vec, mask)
+                lhs = pto.vlds(src0[row, col:])
+                result = pto.vsub(lhs, broadcasted, mask)
+                pto.vsts(result, dst[row, col:], mask)
     return

--- a/ptodsl/ptodsl/tilelib/templates/a5/_expand_binary.py
+++ b/ptodsl/ptodsl/tilelib/templates/a5/_expand_binary.py
@@ -232,14 +232,24 @@ def _emit_row_expand_body(src0, src1, dst, vector_op):
     lanes = pto.elements_per_vreg(dtype)
 
     with pto.for_(0, valid_rows, step=1) as row:
+        # Load the scalar from src1 once per row (outside the inner col loop).
+        # When src1 is col_major with shape [M, 1], use the unaligned load
+        # pipeline (vldas+vldus) to avoid non-512B-aligned UB access on A5.
+        # The broadcast uses a full mask (PAT.ALL) so the vdup is
+        # loop-invariant and can be hoisted by canonicalization.
+        if src1.config.b_layout == "col_major":
+            align_src1 = pto.vldas(src1[row, :])
+            scalar_vec, _ = pto.vldus(src1[row, :], align_src1)
+        else:
+            scalar_vec = pto.vlds(src1[row, :])
+        broadcasted = pto.vdup(scalar_vec, pto.make_mask(dtype, pto.PAT.ALL))
+
         col_loop = pto.for_(0, valid_cols, step=lanes).carry(remained=valid_cols)
         with col_loop:
             col = col_loop.iv
             mask, remained = pto.make_mask(dtype, col_loop.remained)
             lhs = pto.vlds(src0[row, col:])
-            scalar_vec = pto.vlds(src1[row, :])
-            rhs = pto.vdup(scalar_vec, mask)
-            result = vector_op(lhs, rhs, mask)
+            result = vector_op(lhs, broadcasted, mask)
             pto.vsts(result, dst[row, col:], mask)
             col_loop.update(remained=remained)
 

--- a/test/lit/tile_fusion/op_fusion_low_level_loop_softmax_prepare_unaligned_nopad.pto
+++ b/test/lit/tile_fusion/op_fusion_low_level_loop_softmax_prepare_unaligned_nopad.pto
@@ -84,9 +84,10 @@ module attributes { pto.kernel_kind = #pto.kernel_kind<vector>,pto.target_arch =
 // CHECK: pto.vmax
 // CHECK: scf.yield {{.*}} : !pto.vreg<64xf32>, index
 // CHECK: }
+// vdup broadcasts the row-max to a full vector; loop-invariant -> hoisted.
+// CHECK: pto.vdup
 // Fused epilogue: trowexpandsub + texp share one col loop (two mask accumulators).
 // CHECK: scf.for {{.*}} iter_args({{.*}}, {{.*}}) -> (index, index) {
-// CHECK: pto.vdup
 // CHECK: pto.vsub
 // CHECK: pto.vexp
 // CHECK: }

--- a/test/lit/vpto/trowexpanddiv_tile_op_expand_col_major.pto
+++ b/test/lit/vpto/trowexpanddiv_tile_op_expand_col_major.pto
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that ExpandTileOp + InlineLibCall + FoldTileBufIntrinsics pipeline
+// expands pto.trowexpanddiv when src1 is a col_major [M,1] scalar column
+// with default (hardware) precision.
+//
+// The col_major path must use the unaligned load pipeline (vldas+vldus)
+// for src1 instead of vlds, to avoid non-512B-aligned UB access on A5.
+//
+// Pipeline: PTOMaterializeTileHandles -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+
+// After expansion the original pto.trowexpanddiv must be gone.
+// CHECK: func.func @TROWEXPANDDIV_COLMAJOR
+// CHECK-NOT: pto.trowexpanddiv ins
+// CHECK: pto.vecscope
+// The col_major src1 path uses vldas+vldus (unaligned load pipeline).
+// CHECK: pto.vldas
+// CHECK: pto.vldus
+// Broadcast is still used to replicate the scalar across the vector.
+// CHECK: pto.vdup
+// src0 (row_major) still uses aligned vlds.
+// CHECK: pto.vlds
+// Core arithmetic: default precision uses hardware vdiv.
+// CHECK: pto.vdiv
+// Result store:
+// CHECK: pto.vsts
+
+module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @TROWEXPANDDIV_COLMAJOR() {
+    // src0: 32x32 matrix (row-major)
+    %src0 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    // src1: 32x1 col_major column — one scalar per row.
+    // When src1 is col_major, the template uses vldas+vldus (unaligned)
+    // instead of vlds to handle the non-512B-aligned slice access.
+    %src1 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    // dst: 32x32 result (row-major)
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.trowexpanddiv ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                               !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1,
+                                   blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                       outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/lit/vpto/trowexpanddiv_tile_op_expand_f16_col_major.pto
+++ b/test/lit/vpto/trowexpanddiv_tile_op_expand_f16_col_major.pto
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that ExpandTileOp + InlineLibCall + FoldTileBufIntrinsics pipeline
+// expands pto.trowexpanddiv when src1 is a col_major [M,1] scalar column
+// with f16 dtype and default (hardware) precision.
+//
+// trowexpanddiv has separate f32 and f16 template specializations
+// (template_trowexpanddiv_f32 / template_trowexpanddiv_f16), so the
+// f16 col_major path must be tested independently.
+//
+// Pipeline: PTOMaterializeTileHandles -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+
+// After expansion the original pto.trowexpanddiv must be gone.
+// CHECK: func.func @TROWEXPANDDIV_F16_COLMAJOR
+// CHECK-NOT: pto.trowexpanddiv ins
+// CHECK: pto.vecscope
+// The col_major src1 path uses vldas+vldus (unaligned load pipeline).
+// CHECK: pto.vldas
+// CHECK: pto.vldus
+// Broadcast is still used to replicate the scalar across the vector.
+// CHECK: pto.vdup
+// src0 (row_major) still uses aligned vlds.
+// CHECK: pto.vlds
+// Core arithmetic: default precision uses hardware vdiv.
+// CHECK: pto.vdiv
+// Result store:
+// CHECK: pto.vsts
+
+module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @TROWEXPANDDIV_F16_COLMAJOR() {
+    // src0: 32x32 matrix (row-major, f16)
+    %src0 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    // src1: 32x1 col_major column — one f16 scalar per row.
+    %src1 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=1, v_row=32, v_col=1,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    // dst: 32x32 result (row-major, f16)
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.trowexpanddiv ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                               !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=1, v_row=32, v_col=1,
+                                   blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                       outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/lit/vpto/trowexpandmul_tile_op_expand_col_major.pto
+++ b/test/lit/vpto/trowexpandmul_tile_op_expand_col_major.pto
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that ExpandTileOp + InlineLibCall + FoldTileBufIntrinsics pipeline
+// expands pto.trowexpandmul when src1 is a col_major [M,1] scalar column.
+//
+// The col_major path must use the unaligned load pipeline (vldas+vldus)
+// for src1 instead of vlds, to avoid non-512B-aligned UB access on A5.
+//
+// Pipeline: PTOMaterializeTileHandles -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+
+// After expansion the original pto.trowexpandmul must be gone.
+// CHECK: func.func @TROWEXPANDMUL_COLMAJOR
+// CHECK-NOT: pto.trowexpandmul ins
+// CHECK: pto.vecscope
+// The col_major src1 path uses vldas+vldus (unaligned load pipeline).
+// CHECK: pto.vldas
+// CHECK: pto.vldus
+// Broadcast is still used to replicate the scalar across the vector.
+// CHECK: pto.vdup
+// src0 (row_major) still uses aligned vlds.
+// CHECK: pto.vlds
+// Core arithmetic:
+// CHECK: pto.vmul
+// Result store:
+// CHECK: pto.vsts
+
+module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @TROWEXPANDMUL_COLMAJOR() {
+    // src0: 32x32 matrix (row-major)
+    %src0 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    // src1: 32x1 col_major column — one scalar per row.
+    // When src1 is col_major, the template uses vldas+vldus (unaligned)
+    // instead of vlds to handle the non-512B-aligned slice access.
+    %src1 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    // dst: 32x32 result (row-major)
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.trowexpandmul ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                               !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1,
+                                   blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                       outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/lit/vpto/trowexpandsub_tile_op_expand_col_major.pto
+++ b/test/lit/vpto/trowexpandsub_tile_op_expand_col_major.pto
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that ExpandTileOp + InlineLibCall + FoldTileBufIntrinsics pipeline
+// expands pto.trowexpandsub when src1 is a col_major [M,1] scalar column.
+//
+// The col_major path must use the unaligned load pipeline (vldas+vldus)
+// for src1 instead of vlds, to avoid non-512B-aligned UB access on A5.
+//
+// Pipeline: PTOMaterializeTileHandles -> ExpandTileOp -> InlineLibCall -> FoldTileBufIntrinsics
+//
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --enable-tile-op-expand %s -o - 2>/dev/null | FileCheck %s
+
+// After expansion the original pto.trowexpandsub must be gone.
+// CHECK: func.func @TROWEXPANDSUB_COLMAJOR
+// CHECK-NOT: pto.trowexpandsub ins
+// CHECK: pto.vecscope
+// The col_major src1 path uses vldas+vldus (unaligned load pipeline).
+// CHECK: pto.vldas
+// CHECK: pto.vldus
+// Broadcast is still used to replicate the scalar across the vector.
+// CHECK: pto.vdup
+// src0 (row_major) still uses aligned vlds.
+// CHECK: pto.vlds
+// Core arithmetic:
+// CHECK: pto.vsub
+// Result store:
+// CHECK: pto.vsts
+
+module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @TROWEXPANDSUB_COLMAJOR() {
+    // src0: 32x32 matrix (row-major)
+    %src0 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    // src1: 32x1 col_major column — one scalar per row.
+    // When src1 is col_major, the template uses vldas+vldus (unaligned)
+    // instead of vlds to handle the non-512B-aligned slice access.
+    %src1 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1,
+                      blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    // dst: 32x32 result (row-major)
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.trowexpandsub ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                               !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1,
+                                   blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                       outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                                   blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -202,6 +202,7 @@ class _AuthoringRenderer:
         self._constant_cache: dict[tuple[str, object], str] = {}
         self._castptr_cache: dict[tuple[str, str], str] = {}
         self._tile_memref_cache: dict[str, _RenderedValue] = {}
+        self._tile_ptr_cache: dict[str, _RenderedValue] = {}
         self._tile_valid_dim_cache: dict[tuple[str, int], _RenderedValue] = {}
         self._used_tile_buffers = self._collect_used_tile_buffers(kernel.body)
         self._temp_counter = 0
@@ -871,24 +872,42 @@ class _AuthoringRenderer:
             lines = []
             source = self._lower_expr(stmt.value.args[0], env, indent=indent, into=lines)
             index_args = stmt.value.args[1:-1]
+
+            # Convert tile directly to ptr (not memref) — same as vldas.
             if isinstance(source.type, SemanticTileType):
-                source = self._materialize_tile_memref(source, indent=indent, into=lines)
+                source = self._materialize_tile_ptr(source, indent=indent, into=lines)
+
             if (
                 isinstance(stmt.value.args[0].type, SemanticTileType)
                 and stmt.value.args[0].type.rank == 2
                 and len(index_args) == 2
             ):
-                source = self._materialize_rank2_tile_subview(
-                    source,
-                    stmt.value.args[0].type,
-                    index_args,
-                    env,
-                    indent=indent,
-                    into=lines,
+                orig_tile_type = stmt.value.args[0].type
+                row_index, col_index = index_args
+                row_value = self._lower_expr(row_index, env, indent=indent, into=lines)
+                col_value = self._lower_expr(col_index, env, indent=indent, into=lines)
+                total_cols = orig_tile_type.shape[1]
+                total_cols_const = self._materialize_constant(
+                    total_cols, SemanticIndexType()
                 )
-            if self._is_memref_like_type(source.type):
-                ptr_name, ptr_type = self._materialize_copy_buffer_ptr(source, indent=indent, into=lines)
-                source = _RenderedValue(name=ptr_name, type=_RenderedTextualType(ptr_type))
+                # offset = row * total_cols + col
+                row_offset = self._new_temp()
+                lines.append(
+                    self._indent(indent)
+                    + f"{row_offset} = arith.muli {row_value.name}, {total_cols_const} : index"
+                )
+                elem_offset = self._new_temp()
+                lines.append(
+                    self._indent(indent)
+                    + f"{elem_offset} = arith.addi {row_offset}, {col_value.name} : index"
+                )
+                ptr_name = self._new_temp()
+                lines.append(
+                    self._indent(indent)
+                    + f"{ptr_name} = pto.addptr {source.name}, {elem_offset} : "
+                    + f"{self._render_type(source.type)} -> {self._render_type(source.type)}"
+                )
+                source = _RenderedValue(name=ptr_name, type=source.type)
             align = self._lower_expr(stmt.value.args[-1], env, indent=indent, into=lines)
             result_target, align_target = stmt.targets
             result_type, align_type = stmt.value.type.elements
@@ -1868,24 +1887,47 @@ class _AuthoringRenderer:
         if expr.name == "vldas":
             source = self._lower_expr(expr.args[0], env, indent=indent, into=into)
             index_args = expr.args[1:]
+
+            # Convert tile directly to ptr (not memref) for vldas.
+            # vldas only accepts !pto.ptr, and the memref→subview→castptr
+            # path is broken.  Instead: tile → ptr via tile_buf_addr, then
+            # pto.addptr with the element offset computed from the indices.
             if isinstance(source.type, SemanticTileType):
-                source = self._materialize_tile_memref(source, indent=indent, into=into)
+                source = self._materialize_tile_ptr(source, indent=indent, into=into)
+
             if (
                 isinstance(expr.args[0].type, SemanticTileType)
                 and expr.args[0].type.rank == 2
                 and len(index_args) == 2
             ):
-                source = self._materialize_rank2_tile_subview(
-                    source,
-                    expr.args[0].type,
-                    index_args,
-                    env,
-                    indent=indent,
-                    into=into,
+                orig_tile_type = expr.args[0].type
+                row_index, col_index = index_args
+                row_value = self._lower_expr(row_index, env, indent=indent, into=into)
+                col_value = self._lower_expr(col_index, env, indent=indent, into=into)
+                # uniform offset formula: row * shape[1] + col.
+                # Works for row_major [M,N] and col_major [M,1] (col=0).
+                total_cols = orig_tile_type.shape[1]
+                total_cols_const = self._materialize_constant(
+                    total_cols, SemanticIndexType()
                 )
-            if self._is_memref_like_type(source.type):
-                ptr_name, ptr_type = self._materialize_copy_buffer_ptr(source, indent=indent, into=into)
-                source = _RenderedValue(name=ptr_name, type=_RenderedTextualType(ptr_type))
+                # offset = row * total_cols + col
+                row_offset = self._new_temp()
+                into.append(
+                    self._indent(indent)
+                    + f"{row_offset} = arith.muli {row_value.name}, {total_cols_const} : index"
+                )
+                elem_offset = self._new_temp()
+                into.append(
+                    self._indent(indent)
+                    + f"{elem_offset} = arith.addi {row_offset}, {col_value.name} : index"
+                )
+                ptr_name = self._new_temp()
+                into.append(
+                    self._indent(indent)
+                    + f"{ptr_name} = pto.addptr {source.name}, {elem_offset} : "
+                    + f"{self._render_type(source.type)} -> {self._render_type(source.type)}"
+                )
+                source = _RenderedValue(name=ptr_name, type=source.type)
             into.append(
                 self._indent(indent)
                 + f"{result_name} = pto.vldas {source.name} : "
@@ -3224,6 +3266,35 @@ class _AuthoringRenderer:
             return cast_name, ptr_type
 
         return value.name, ptr_type
+
+    def _materialize_tile_ptr(
+        self,
+        value: _RenderedValue,
+        *,
+        indent: int,
+        into: list[str],
+    ) -> _RenderedValue:
+        """Convert a SemanticTileType value directly to a typed !pto.ptr.
+
+        Unlike _materialize_tile_memref which produces a memref, this emits
+        pto.tile_buf_addr with a !pto.ptr<...> result type so the ptr can be
+        used directly with pto.addptr / pto.vldas / pto.vldus.
+        """
+        existing = self._tile_ptr_cache.get(value.name)
+        if existing is not None:
+            return existing
+        if not isinstance(value.type, SemanticTileType):
+            return value
+        ptr_type = self._render_copy_buffer_type(value.type)
+        ptr_name = self._new_temp()
+        into.append(
+            self._indent(indent)
+            + f"{ptr_name} = pto.tile_buf_addr {value.name} : "
+            + f"{self._render_type(value.type)} -> {ptr_type}"
+        )
+        rendered = _RenderedValue(name=ptr_name, type=_RenderedTextualType(ptr_type))
+        self._tile_ptr_cache[value.name] = rendered
+        return rendered
 
     def _coerce_rendered_value(
         self,


### PR DESCRIPTION
### 问题总结

`trowexpand` 系列 op 的 TileLang 模板及 DSL lowering 层在处理 `src1` 为 col major `[M, 1]` 时存在两类缺陷：

1. **模板层**：`trowexpandmul`/`trowexpandsub`/`trowexpanddiv` 三个模板仅实现了 `row_major` 路径，对 `src1[row, :]` 使用 `vlds` 对齐加载。当 `src1` 为 col major 时，tile 切片地址不满足 512B 对齐要求，触发 A5 error 340。

2. **lowering 层**：`vldas`/`vldus` 指令的 IR 生成路径中，将 tile 先转为 memref 再通过 subview + castptr 获取指针的方式存在结构性问题——`vldas` 只接受 `!pto.ptr` 类型，memref 中间表示引入了不必要的类型转换，且对 col major tile 的地址计算逻辑不正确。

### 修改方案

#### 1. 模板层 — 新增 col major 非对齐访问路径

在三个模板中分别添加 `col_major` 分支。通过 `pto.constexpr(src1.config.b_layout == pto.BLayout.COL_MAJOR)` 在编译期选择路径：

- **col major 路径**：使用 `vldas` + `vldus` 非对齐加载流水线替代 `vlds`：
  ```python
  align_src1 = pto.vldas(src1[row, :])        # 非对齐加载请求
  scalar_vec, _ = pto.vldus(src1[row, :], align_src1)  # 非对齐数据读取
  broadcasted = pto.vdup(scalar_vec, pto.pset_b32(pto.PAT.ALL))
  ```
  `vldas`/`vldus` 每行仅调用一次，broadcast 到全掩码后复用于该行所有列迭代。

- **row major 路径**：保持原有 `vlds` 对齐访问逻辑不变。

此修改同时覆盖了 `trowexpandmul`（f16/f32）、`trowexpandsub`（f16/f32）、`trowexpanddiv`（f16/f32 及 high_precision 变体）所有精度和模式组合。

#### 2. lowering 层 — tile 直接转 ptr 并修正地址计算

在 `_AuthoringRenderer` 中：

- **新增 `_materialize_tile_ptr()` 方法**：通过 `pto.tile_buf_addr` 将 tile 直接转换为 `!pto.ptr<...>` 类型，跳过 memref 中间表示。结果缓存在 `_tile_ptr_cache` 中。

- **修正 `vldas` 和 `vldus` 的 2D tile 地址计算**：不再使用 `_materialize_rank2_tile_subview` + `_materialize_copy_buffer_ptr` 的 memref 路径，改为直接用 `arith.muli` + `arith.addi` 计算元素偏移（`offset = row * shape[1] + col`），再通过 `pto.addptr` 获取目标地址。此公式对 row major `[M, N]` 和 col major `[M, 1]` 均适用。

- 两个指令的 lowering 逻辑保持一致：tile → ptr → 偏移计算 → addptr → vldas/vldus。

#### 3. 涉及文件

| 文件 | 变更内容 |
| --- | --- |
| `lib/TileOps/trowexpanddiv_template.py` | 添加 col major 非对齐加载路径，覆盖 f32/f16 × default/high_precision 共 4 条路径 |
| `lib/TileOps/trowexpandmul_template.py` | 添加 col major 非对齐加载路径 |
| `lib/TileOps/trowexpandsub_template.py` | 添加 col major 非对齐加载路径 |
| `tilelang-dsl/python/tilelang_dsl/lowering.py` | 新增 `_materialize_tile_ptr()`；修正 `vldas`/`vldus` 的 2D tile 地址计算逻辑 |
