### PR TITLE
fix(sync): keep TLoad WAW barriers for same buffer

### DIFF
--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -184,11 +184,45 @@ static bool isTLoadCompound(const CompoundInstanceElement *compound) {
   return compound && compound->elementOp && isa<pto::TLoadOp>(compound->elementOp);
 }
 
-static bool isTLoadToTLoadWAWExempt(const CompoundInstanceElement *nowCompound,
-                                    const CompoundInstanceElement *frontCompound) {
+static bool isMTE2TLoadPair(const CompoundInstanceElement *nowCompound,
+                            const CompoundInstanceElement *frontCompound) {
   return isTLoadCompound(nowCompound) && isTLoadCompound(frontCompound) &&
          nowCompound->kPipeValue == PipelineType::PIPE_MTE2 &&
          frontCompound->kPipeValue == PipelineType::PIPE_MTE2;
+}
+
+static std::optional<Value> getDirectSubviewSource(Value value) {
+  if (!value) return std::nullopt;
+  if (auto op = value.getDefiningOp<pto::SubViewOp>())
+    return op.getSource();
+  if (auto op = value.getDefiningOp<memref::SubViewOp>())
+    return op.getSource();
+  return std::nullopt;
+}
+
+static bool isDistinctSiblingSubviewPair(const BaseMemInfo *lhs,
+                                         const BaseMemInfo *rhs) {
+  if (!lhs || !rhs) return false;
+  if (lhs->baseBuffer == rhs->baseBuffer) return false;
+  auto lhsSource = getDirectSubviewSource(lhs->baseBuffer);
+  auto rhsSource = getDirectSubviewSource(rhs->baseBuffer);
+  return lhsSource && rhsSource && *lhsSource == *rhsSource;
+}
+
+static bool isTLoadToTLoadWAWExempt(
+    const CompoundInstanceElement *nowCompound,
+    const CompoundInstanceElement *frontCompound,
+    const DepBaseMemInfoPairVec &wawDepVec) {
+  if (!isMTE2TLoadPair(nowCompound, frontCompound)) return false;
+
+  // PTOAS treats sibling subview SSA values of the same direct parent as
+  // non-overlapping by IR contract. Keep the exemption limited to that exact
+  // provenance so same-tile, nested-view, root-vs-view, different-parent, and
+  // unknown aliases still get an MTE2 pipe barrier.
+  return !wawDepVec.empty() &&
+         llvm::all_of(wawDepVec, [](const auto &pair) {
+           return isDistinctSiblingSubviewPair(pair.first, pair.second);
+         });
 }
 
 // ==============================================================================
@@ -476,9 +510,15 @@ bool InsertSyncAnalysis::IsMemInfoHasDependency(
                                           depBaseMemInfosVec);
   hasDependency |= memAnalyzer_.DepBetween(nowCompound->defVec, frontCompound->useVec,
                                           depBaseMemInfosVec);
-  if (!isTLoadToTLoadWAWExempt(nowCompound, frontCompound)) {
-    hasDependency |= memAnalyzer_.DepBetween(nowCompound->defVec, frontCompound->defVec,
-                                            depBaseMemInfosVec);
+
+  DepBaseMemInfoPairVec wawDepVec;
+  bool hasWAWDependency =
+      memAnalyzer_.DepBetween(nowCompound->defVec, frontCompound->defVec,
+                              wawDepVec);
+  if (hasWAWDependency &&
+      !isTLoadToTLoadWAWExempt(nowCompound, frontCompound, wawDepVec)) {
+    depBaseMemInfosVec.append(wawDepVec.begin(), wawDepVec.end());
+    hasDependency = true;
   }
 
   // Special hazard: ACC (L0C) read/read cross-pipe ordering.

--- a/test/lit/pto/issue667_distinct_subviews_no_mte2_barrier.pto
+++ b/test/lit/pto/issue667_distinct_subviews_no_mte2_barrier.pto
@@ -1,11 +1,11 @@
 // RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s | FileCheck %s
 
 module {
-  func.func @issue667_tload_overlap_does_not_need_mte2_barrier(
+  func.func @issue667_distinct_subviews_do_not_need_mte2_barrier(
       %src0: memref<16x128xf32, #pto.address_space<gm>>,
       %src1: memref<16x128xf32, #pto.address_space<gm>>) {
     %c0 = arith.constant 0 : index
-    %c64 = arith.constant 64 : index
+    %c128 = arith.constant 128 : index
     %c0_i64 = arith.constant 0 : i64
 
     %tile = pto.alloc_tile addr = %c0_i64 :
@@ -14,7 +14,7 @@ module {
     %s0 = pto.subview %tile[%c0, %c0] sizes [16, 128] :
       !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=512, v_row=16, v_col=512, blayout=row_major, slayout=none_box, fractal=512, pad=0>
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %s1 = pto.subview %tile[%c0, %c64] sizes [16, 128] :
+    %s1 = pto.subview %tile[%c0, %c128] sizes [16, 128] :
       !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=512, v_row=16, v_col=512, blayout=row_major, slayout=none_box, fractal=512, pad=0>
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
@@ -45,7 +45,7 @@ module {
   }
 }
 
-// CHECK-LABEL: AICORE void issue667_tload_overlap_does_not_need_mte2_barrier(
+// CHECK-LABEL: AICORE void issue667_distinct_subviews_do_not_need_mte2_barrier(
 // CHECK: TLOAD(
 // CHECK-NOT: pipe_barrier(PIPE_MTE2);
 // CHECK: TLOAD(

--- a/test/lit/pto/tload_waw_same_buffer_requires_mte2_barrier.pto
+++ b/test/lit/pto/tload_waw_same_buffer_requires_mte2_barrier.pto
@@ -1,0 +1,71 @@
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s | FileCheck %s
+
+module {
+  func.func @tload_waw_same_tile_requires_mte2_barrier(
+      %src0: memref<16x128xf32, #pto.address_space<gm>>,
+      %src1: memref<16x128xf32, #pto.address_space<gm>>) {
+    %c0_i64 = arith.constant 0 : i64
+    %tile = pto.alloc_tile addr = %c0_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src0 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src1 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @tload_waw_same_subview_requires_mte2_barrier(
+      %src0: memref<16x128xf32, #pto.address_space<gm>>,
+      %src1: memref<16x128xf32, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %tile = pto.alloc_tile addr = %c0_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %view = pto.subview %tile[%c0, %c0] sizes [16, 128] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src0 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%view : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src1 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%view : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @tload_waw_nested_subview_requires_mte2_barrier(
+      %src0: memref<16x64xf32, #pto.address_space<gm>>,
+      %src1: memref<16x64xf32, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %tile = pto.alloc_tile addr = %c0_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %parent = pto.subview %tile[%c0, %c0] sizes [16, 64] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %child = pto.subview %parent[%c0, %c0] sizes [16, 64] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src0 : memref<16x64xf32, #pto.address_space<gm>>)
+              outs(%parent : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src1 : memref<16x64xf32, #pto.address_space<gm>>)
+              outs(%child : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void tload_waw_same_tile_requires_mte2_barrier(
+// CHECK: TLOAD(
+// CHECK-NEXT: pipe_barrier(PIPE_MTE2);
+// CHECK-NEXT: TLOAD(
+
+// CHECK-LABEL: AICORE void tload_waw_same_subview_requires_mte2_barrier(
+// CHECK: TLOAD(
+// CHECK-NEXT: pipe_barrier(PIPE_MTE2);
+// CHECK-NEXT: TLOAD(
+
+// CHECK-LABEL: AICORE void tload_waw_nested_subview_requires_mte2_barrier(
+// CHECK: TLOAD(
+// CHECK-NEXT: pipe_barrier(PIPE_MTE2);
+// CHECK-NEXT: TLOAD(

--- a/test/samples/Sync/test_if_else_tile_result.pto
+++ b/test/samples/Sync/test_if_else_tile_result.pto
@@ -1,5 +1,5 @@
 module attributes {"pto.device-spec" = "Ascend910B1"} {
-  func.func @test_if_else_tile_result(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: i32, %arg3: !pto.ptr<f32>) {
+  func.func @test_if_else_tile_result(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: i32, %arg3: !pto.ptr<f32>) attributes {pto.entry} {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c4 = arith.constant 4 : index


### PR DESCRIPTION
Summary
- Narrow the TLoad->TLoad WAW exemption to only dependency pairs formed by distinct direct subview SSA values.
- Preserve the #667 distinct-subview no-MTE2-barrier optimization under the PTOAS subview non-overlap contract.
- Add regressions for same tile and same subview TLoad WAW hazards, and mark the if/else tile-result sample as pto.entry.

Motivation
- The previous blanket MTE2 TLoad->TLoad WAW exemption skipped alias analysis for same-buffer writes, so consecutive TLOADs into the same tile could be emitted without pipe_barrier(PIPE_MTE2).
- That is unsafe because same-pipe ordering still needs an explicit barrier when two MTE2 operations write the same local buffer.

Design
- Always run WAW alias analysis first.
- Drop the WAW dependency only when every WAW dependency pair is between two different direct pto.subview or memref.subview result values.
- Keep same tile, same subview, root-vs-subview, and unknown provenance conservative.

Testing
- Local: git diff --check
- Local: ninja -C build-codex lib/PTO/Transforms/CMakeFiles/obj.PTOTransforms.dir/InsertSync/InsertSyncAnalysis.cpp.o
- Note: full local ptoas build is currently blocked by local custom LLVM/VPTO environment mismatch (missing custom LLVMFloat*/SimtEntry symbols with llvm-project/build-shared, and missing mlir-tblgen in llvm-project-vpto/build-shared).

Risk / Rollback
- Risk is limited to adding MTE2 pipe barriers for true same-buffer TLoad WAW hazards that were previously skipped.
- Rollback by reverting this PR.