### PR TITLE
fix(insert-sync): track explicit local address provenance

### DIFF
--- a/docs/designs/ptoas-auto-sync-design.md
+++ b/docs/designs/ptoas-auto-sync-design.md
@@ -88,10 +88,12 @@
 | `scope` | `pto::AddressSpace` | 地址空间（GM/MAT/VEC/ACC/LEFT/RIGHT 等） |
 | `baseAddresses` | `SmallVector<uint64_t>` | 已知的偏移列表，配合 `allocateSize` 做精确区间重叠 |
 | `allocateSize` | `uint64_t` | 字节大小 |
+| `hasKnownPhysicalAddresses` | `bool` | `baseAddresses` 是否为已知 absolute 本地物理地址 |
+| `aliasesUnknownRange` | `bool` | 地址值或范围未知时，是否必须保守 alias 同地址空间内的任意缓冲区 |
 
-`operator==`（第 111 行）要求 `baseAddresses`、`rootBuffer`、`scope`、
-`allocateSize`、`baseBuffer` 全部相等才算同一缓冲；这是别名分析里的「严格相等」
-判定，命中后可直接走依赖路径。
+`operator==` 要求 `baseAddresses`、`rootBuffer`、`scope`、
+`allocateSize`、`baseBuffer` 和两个地址状态字段全部相等才算同一缓冲；
+这是别名分析里的「严格相等」判定，命中后可直接走依赖路径。
 
 ### 3.4 同步指令：`SyncOperation`
 
@@ -381,8 +383,12 @@ hazard 判定按三类关系展开：
 
 1. `scope` 不同，直接不别名。
 2. `GM` 先比较 root，必要时追踪 `realRoot`。
-3. 地址和大小都已知，就做区间重叠。
-4. 信息缺失（地址未知、size 未知），保守按“可能重叠”。
+3. 任一侧设置 `aliasesUnknownRange` 时，保守按“可能重叠”。
+4. 两侧都是已知 absolute 本地物理地址时，即使 allocation SSA root 不同，
+   也按半开字节区间 `[base, base + size)` 判断重叠；区间端点相接不算 alias。
+5. 其余 root-relative 地址保持原有 root/view 链分析；不同 root 下相同的相对
+   offset（例如 level-2 规划前的 `baseAddresses={0}`）不会被误当作同一物理地址。
+6. size 未知，或 absolute view offset / 区间端点计算溢出时，保守按“可能重叠”。
 
 这套规则在信息不足时会偏保守，但不会牺牲正确性。后续会继续补强动态 shape/offset 场景下的精细分析。
 

--- a/docs/designs/ptoas-auto-sync-design.md
+++ b/docs/designs/ptoas-auto-sync-design.md
@@ -90,9 +90,10 @@
 | `allocateSize` | `uint64_t` | 字节大小 |
 | `hasKnownPhysicalAddresses` | `bool` | `baseAddresses` 是否为已知 absolute 本地物理地址 |
 | `aliasesUnknownRange` | `bool` | 地址值或范围未知时，是否必须保守 alias 同地址空间内的任意缓冲区 |
+| `hasInexactSubviewRange` | `bool` | 当前范围是否为动态 subview 的保守父级包络，防止后续静态 view 错误收窄 |
 
 `operator==` 要求 `baseAddresses`、`rootBuffer`、`scope`、
-`allocateSize`、`baseBuffer` 和两个地址状态字段全部相等才算同一缓冲；
+`allocateSize`、`baseBuffer` 和三个地址状态字段全部相等才算同一缓冲；
 这是别名分析里的「严格相等」判定，命中后可直接走依赖路径。
 
 ### 3.4 同步指令：`SyncOperation`

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -321,6 +321,16 @@ def GetTensorViewStrideOp : PTO_Op<"get_tensor_view_stride", [Pure]> {
 
 def AllocTileOp : PTO_Op<"alloc_tile", [AttrSizedOperandSegments]> {
   let summary = "Allocates a tile buffer (logical buffer).";
+  let description = [{
+    Without `addr`, this op declares a logical local allocation whose physical
+    address is selected by PTOAS memory planning.
+
+    Under `--pto-level=level3`, `addr` is required and denotes an absolute byte
+    address in the tile's local address space. Synchronization analysis compares
+    constant absolute ranges across distinct allocation SSA roots. If an
+    absolute address is dynamic, analysis conservatively treats it as possibly
+    aliasing any allocation in the same local address space.
+  }];
 
   let arguments = (ins
     Optional<I64>:$addr,

--- a/include/PTO/Transforms/InsertSync/SyncCommon.h
+++ b/include/PTO/Transforms/InsertSync/SyncCommon.h
@@ -88,11 +88,13 @@ struct BaseMemInfo {
       Value baseBuffer, Value rootBuffer, pto::AddressSpace scope,
       SmallVector<uint64_t> baseAddresses, uint64_t allocateSize,
       bool hasKnownPhysicalAddresses = false,
-      bool aliasesUnknownRange = false)
+      bool aliasesUnknownRange = false,
+      bool hasInexactSubviewRange = false)
       : baseBuffer(baseBuffer), rootBuffer(rootBuffer), scope(scope),
         baseAddresses(std::move(baseAddresses)), allocateSize(allocateSize),
         hasKnownPhysicalAddresses(hasKnownPhysicalAddresses),
-        aliasesUnknownRange(aliasesUnknownRange) {}
+        aliasesUnknownRange(aliasesUnknownRange),
+        hasInexactSubviewRange(hasInexactSubviewRange) {}
  
   /// baseBuffer: 当前操作直接使用的 Buffer (可能是 View 或 Alias)
   Value baseBuffer;
@@ -109,6 +111,10 @@ struct BaseMemInfo {
   // through integer IR. When set, this memory object aliases any range in the
   // same address space.
   bool aliasesUnknownRange;
+  // True when this range is a conservative parent envelope for a subview
+  // whose exact offset could not be modeled. Exact child views must not narrow
+  // that envelope.
+  bool hasInexactSubviewRange;
  
   bool areVectorEqual(const SmallVector<uint64_t>& vec1,
                       const SmallVector<uint64_t>& vec2) const {
@@ -127,6 +133,8 @@ struct BaseMemInfo {
       return false;
     if (aliasesUnknownRange != other.aliasesUnknownRange)
       return false;
+    if (hasInexactSubviewRange != other.hasInexactSubviewRange)
+      return false;
     // allocateSize 和 baseBuffer 的严格相等性在某些别名分析中可能太强了，
     // 但为了保持原有逻辑，先保留。重点是 rootBuffer 必须一致。
     if (allocateSize != other.allocateSize) return false;
@@ -137,13 +145,15 @@ struct BaseMemInfo {
   std::unique_ptr<BaseMemInfo> clone() const {
     return std::make_unique<BaseMemInfo>(
         baseBuffer, rootBuffer, scope, baseAddresses, allocateSize,
-        hasKnownPhysicalAddresses, aliasesUnknownRange);
+        hasKnownPhysicalAddresses, aliasesUnknownRange,
+        hasInexactSubviewRange);
   }
 
   std::unique_ptr<BaseMemInfo> clone(Value cloneBaseBuffer) const {
     return std::make_unique<BaseMemInfo>(
         cloneBaseBuffer, rootBuffer, scope, baseAddresses, allocateSize,
-        hasKnownPhysicalAddresses, aliasesUnknownRange);
+        hasKnownPhysicalAddresses, aliasesUnknownRange,
+        hasInexactSubviewRange);
   }
 };
  

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -402,21 +402,109 @@ void InsertSyncAnalysis::InsertSync(
 // back-edge path still needs to sync per-slot via dyn event id (the
 // prefetch idiom). When the analysis is inconclusive (kUnknown / kEqual)
 // the dep is kept and the existing conservative path runs.
+static bool rangesOverlapConservatively(uint64_t aStart, uint64_t aSize,
+                                        uint64_t bStart, uint64_t bSize) {
+  if (aSize == 0 || bSize == 0 ||
+      aSize > std::numeric_limits<uint64_t>::max() - aStart ||
+      bSize > std::numeric_limits<uint64_t>::max() - bStart)
+    return true;
+  return std::max(aStart, bStart) < std::min(aStart + aSize, bStart + bSize);
+}
+
+// Slot-indexed synchronization is safe only when slot i on one side can
+// physically alias slot i on the other side and every off-diagonal pair is
+// disjoint. Equal address-vector lengths alone do not establish that mapping
+// for shifted or partially overlapping physical allocations.
+static bool hasIdentityPhysicalSlotMapping(const BaseMemInfo *a,
+                                           const BaseMemInfo *b) {
+  if (!a || !b || a->aliasesUnknownRange || b->aliasesUnknownRange ||
+      a->hasInexactSubviewRange || b->hasInexactSubviewRange ||
+      a->baseAddresses.size() < 2 ||
+      a->baseAddresses.size() != b->baseAddresses.size() ||
+      a->hasKnownPhysicalAddresses != b->hasKnownPhysicalAddresses)
+    return false;
+
+  if (!a->hasKnownPhysicalAddresses && a->rootBuffer != b->rootBuffer)
+    return false;
+
+  for (size_t i = 0; i < a->baseAddresses.size(); ++i) {
+    for (size_t j = 0; j < b->baseAddresses.size(); ++j) {
+      bool overlaps =
+          rangesOverlapConservatively(a->baseAddresses[i], a->allocateSize,
+                                      b->baseAddresses[j], b->allocateSize);
+      if ((i == j) != overlaps)
+        return false;
+    }
+  }
+  return true;
+}
+
 static bool isForwardDepDroppableBySlotAffine(const BaseMemInfo *a,
                                               const BaseMemInfo *b) {
-  if (!a || !b)
-    return false;
-  size_t aN = a->baseAddresses.size();
-  size_t bN = b->baseAddresses.size();
-  size_t n = std::max(aN, bN);
-  if (n < 2)
+  if (!hasIdentityPhysicalSlotMapping(a, b))
     return false;
   Value slotA = findMultiTileSlotExpr(a->baseBuffer);
   Value slotB = findMultiTileSlotExpr(b->baseBuffer);
   if (!slotA || !slotB)
     return false;
-  return compareSlotSSA(slotA, slotB, static_cast<uint32_t>(n)) ==
+  return compareSlotSSA(slotA, slotB,
+                        static_cast<uint32_t>(a->baseAddresses.size())) ==
          SlotRelation::kDisjoint;
+}
+
+static std::optional<size_t>
+getAlternativeSlotPairCount(const BaseMemInfo *a, const BaseMemInfo *b) {
+  if (!hasIdentityPhysicalSlotMapping(a, b) ||
+      !findMultiTileSlotExpr(a->baseBuffer) ||
+      !findMultiTileSlotExpr(b->baseBuffer))
+    return std::nullopt;
+  return a->baseAddresses.size();
+}
+
+struct DynamicEventSlotMapping {
+  int eventIdNum;
+  Value consumerSlot;
+  Value producerSlot;
+};
+
+static bool isLocalMemInfo(const BaseMemInfo *info) {
+  return info && (info->scope == pto::AddressSpace::MAT ||
+                  info->scope == pto::AddressSpace::VEC);
+}
+
+// A single set/wait pair can carry only one producer and one consumer slot
+// expression. Require every local dependency pair to agree on both expressions
+// modulo N as well as on the physical lane mapping.
+static std::optional<DynamicEventSlotMapping>
+getDynamicEventSlotMapping(const DepBaseMemInfoPairVec &depPairs) {
+  std::optional<DynamicEventSlotMapping> mapping;
+  for (const auto &pair : depPairs) {
+    if (!isLocalMemInfo(pair.first) && !isLocalMemInfo(pair.second))
+      continue;
+
+    auto pairCount = getAlternativeSlotPairCount(pair.first, pair.second);
+    if (!pairCount)
+      return std::nullopt;
+    int pairN = static_cast<int>(*pairCount);
+    Value consumerSlot = findMultiTileSlotExpr(pair.first->baseBuffer);
+    Value producerSlot = findMultiTileSlotExpr(pair.second->baseBuffer);
+    if (!consumerSlot || !producerSlot)
+      return std::nullopt;
+
+    if (!mapping) {
+      mapping = DynamicEventSlotMapping{pairN, consumerSlot, producerSlot};
+      continue;
+    }
+    if (mapping->eventIdNum != pairN)
+      return std::nullopt;
+    uint32_t n = static_cast<uint32_t>(pairN);
+    if (compareSlotSSA(mapping->consumerSlot, consumerSlot, n) !=
+            SlotRelation::kEqual ||
+        compareSlotSSA(mapping->producerSlot, producerSlot, n) !=
+            SlotRelation::kEqual)
+      return std::nullopt;
+  }
+  return mapping;
 }
 
 void InsertSyncAnalysis::MemAnalyze(
@@ -577,32 +665,13 @@ void InsertSyncAnalysis::InsertSyncOperation(
     // dyn event IDs are warranted, also plumb the per-side slot SSA so
     // codegen can lower into `pto.set_flag_dyn` / `pto.wait_flag_dyn`.
     if (forEndIndex.has_value()) {
-      int eventIdNum = GetEventIdNum(depBaseMemInfosVec);
-      if (eventIdNum > 1) {
-        // Each dep pair has (now=consumer, front=producer). The producer's
-        // slot SSA gates the `set_flag_dyn`; the consumer's gates the
-        // `wait_flag_dyn`. Walk the first viable dep pair to extract them.
-        Value producerSlot;
-        Value consumerSlot;
-        for (auto &pair : depBaseMemInfosVec) {
-          if (pair.second && pair.second->baseBuffer)
-            producerSlot = findMultiTileSlotExpr(pair.second->baseBuffer);
-          if (pair.first && pair.first->baseBuffer)
-            consumerSlot = findMultiTileSlotExpr(pair.first->baseBuffer);
-          if (producerSlot && consumerSlot)
-            break;
-        }
-        if (!producerSlot || !consumerSlot) {
-          // No slot SSA threaded through -- fall back to single event id.
-          // This keeps non-multi-buffer codepaths untouched even if their
-          // baseAddresses happen to have multiple entries for another reason.
-          eventIdNum = 1;
-        } else {
-          setOp->slotSSAExpr = producerSlot;
-          setOp->slotCount = static_cast<uint32_t>(eventIdNum);
-          waitOp->slotSSAExpr = consumerSlot;
-          waitOp->slotCount = static_cast<uint32_t>(eventIdNum);
-        }
+      int eventIdNum = 1;
+      if (auto mapping = getDynamicEventSlotMapping(depBaseMemInfosVec)) {
+        eventIdNum = mapping->eventIdNum;
+        setOp->slotSSAExpr = mapping->producerSlot;
+        setOp->slotCount = static_cast<uint32_t>(eventIdNum);
+        waitOp->slotSSAExpr = mapping->consumerSlot;
+        waitOp->slotCount = static_cast<uint32_t>(eventIdNum);
       }
       setOp->eventIdNum = eventIdNum;
       waitOp->eventIdNum = eventIdNum;
@@ -762,40 +831,10 @@ SmallVector<Value> InsertSyncAnalysis::GetMemInfoBuffers(
 
 int InsertSyncAnalysis::GetEventIdNum(
     const DepBaseMemInfoPairVec &depBaseMemInfosVec) {
-  // A back-edge dependency benefits from N dynamic event IDs whenever at
-  // least one side is a multi-buffer access. We detect that from the
-  // BaseMemInfo's `baseAddresses` size, which the translator and alias
-  // propagation keep aligned with the represented slot set:
-  //   - kSingle / const-slot              : size == 1
-  //   - dyn-slot (PTOIRTranslator default) : size == N (all slots, conservative)
-  // For the alias to even reach this point both sides share a root, so the
-  // slot count derived from either side's full address set should be the
-  // same N. We pick the max to be robust against accidental narrowing.
-  int eventIdNum = 1;
-  for (const auto &pair : depBaseMemInfosVec) {
-    bool isLocalA =
-        pair.first && (pair.first->scope == pto::AddressSpace::MAT ||
-                       pair.first->scope == pto::AddressSpace::VEC);
-    bool isLocalB =
-        pair.second && (pair.second->scope == pto::AddressSpace::MAT ||
-                        pair.second->scope == pto::AddressSpace::VEC);
-    if (!isLocalA && !isLocalB)
-      continue;
-    size_t aN = pair.first ? pair.first->baseAddresses.size() : 1;
-    size_t bN = pair.second ? pair.second->baseAddresses.size() : 1;
-    int pairN = static_cast<int>(std::max(aN, bN));
-    if (pairN <= 1)
-      continue;
-    if (eventIdNum == 1) {
-      eventIdNum = pairN;
-    } else if (eventIdNum != pairN) {
-      // Multiple dep pairs disagreeing on N: fall back to single event id
-      // for safety. With more work this could be relaxed by per-pair
-      // multi-buffer reasoning.
-      return 1;
-    }
-  }
-  return eventIdNum;
+  // Dynamic event IDs are safe only when every local dependency pair agrees
+  // on one identity physical-slot mapping and compatible slot expressions.
+  auto mapping = getDynamicEventSlotMapping(depBaseMemInfosVec);
+  return mapping ? mapping->eventIdNum : 1;
 }
 
 bool InsertSyncAnalysis::IsGMHazard(

--- a/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
+++ b/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
@@ -218,6 +218,17 @@ bool MemoryDependentAnalyzer::MemAlias(const BaseMemInfo *a,
     return isBufferAddressRangeOverlap(a, b);
   }
 
+  // A known physical address and a root-relative offset are not directly
+  // comparable. This mixed state is not expected after level-3 planning, but
+  // treating distinct roots as disjoint would be an unsafe default if a future
+  // pipeline combines planned and symbolic local buffers.
+  if (a->hasKnownPhysicalAddresses != b->hasKnownPhysicalAddresses) {
+    if (isTraceEnabled())
+      llvm::errs() << "    -> Mixed local address provenance. "
+                      "Conservatively aliasing.\n";
+    return true;
+  }
+
   if (a->rootBuffer == b->rootBuffer) {
     if (a->baseAddresses.empty() || b->baseAddresses.empty()) return true;
     if (a->allocateSize == 0 || b->allocateSize == 0) return true;

--- a/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
+++ b/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
@@ -15,6 +15,8 @@
 #include "PTO/Transforms/InsertSync/InsertSyncDebug.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "llvm/Support/Debug.h"
+
+#include <limits>
  
 #define DEBUG_TYPE "pto-inject-sync"
  
@@ -299,6 +301,14 @@ bool MemoryDependentAnalyzer::isBufferOverlap(const BaseMemInfo *a,
                                               int bIndex) {
   uint64_t aStart = a->baseAddresses[aIndex];
   uint64_t bStart = b->baseAddresses[bIndex];
+
+  // Invalid/overflowing half-open ranges are not safe to classify as
+  // disjoint. Conservatively report overlap if either end cannot be
+  // represented.
+  if (a->allocateSize > std::numeric_limits<uint64_t>::max() - aStart ||
+      b->allocateSize > std::numeric_limits<uint64_t>::max() - bStart)
+    return true;
+
   uint64_t aEnd = aStart + a->allocateSize;
   uint64_t bEnd = bStart + b->allocateSize;
  

--- a/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/Matchers.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -139,6 +140,7 @@ static void markAddressRangeUnknown(BaseMemInfo &info) {
   info.allocateSize = 0;
   info.hasKnownPhysicalAddresses = false;
   info.aliasesUnknownRange = true;
+  info.hasInexactSubviewRange = false;
 }
 
 static bool isLocalAddressSpace(pto::AddressSpace space) {
@@ -930,9 +932,25 @@ void PTOIRTranslator::UpdateTileSubViewAliasBufferInfo(pto::SubViewOp op) {
   if (!result || !source) return;
   if (!buffer2MemInfoMap_.contains(source)) return;
 
+  auto retainConservativeParentRange = [&]() {
+    auto &resultMemInfoVec = buffer2MemInfoMap_[result];
+    for (auto &parentInfo : buffer2MemInfoMap_[source]) {
+      auto newInfo = parentInfo->clone(result);
+      newInfo->hasInexactSubviewRange = true;
+      resultMemInfoVec.emplace_back(std::move(newInfo));
+    }
+  };
+
   auto sourceType = dyn_cast<pto::TileBufType>(source.getType());
   if (!sourceType) {
     UpdateConservativeAliasBufferInfo(result, source);
+    return;
+  }
+
+  if (llvm::any_of(buffer2MemInfoMap_[source], [](const auto &parentInfo) {
+        return !parentInfo || parentInfo->hasInexactSubviewRange;
+      })) {
+    retainConservativeParentRange();
     return;
   }
 
@@ -942,7 +960,7 @@ void PTOIRTranslator::UpdateTileSubViewAliasBufferInfo(pto::SubViewOp op) {
                      : getPtoSubViewBaseAddresses(
                            op, sourceType, static_cast<int64_t>(elemBytes));
   if (!subViewAddresses || subViewAddresses->empty()) {
-    UpdateConservativeAliasBufferInfo(result, source);
+    retainConservativeParentRange();
     return;
   }
 
@@ -958,7 +976,7 @@ void PTOIRTranslator::UpdateTileSubViewAliasBufferInfo(pto::SubViewOp op) {
   for (auto &parentInfo : buffer2MemInfoMap_[source]) {
     if (!parentInfo || parentInfo->baseAddresses.size() != 1 ||
         parentInfo->allocateSize == 0) {
-      UpdateConservativeAliasBufferInfo(result, source);
+      retainConservativeParentRange();
       return;
     }
   }
@@ -985,6 +1003,7 @@ void PTOIRTranslator::UpdateTileSubViewAliasBufferInfo(pto::SubViewOp op) {
     }
     newInfo->baseAddresses = std::move(addresses);
     newInfo->allocateSize = segmentSize;
+    newInfo->hasInexactSubviewRange = false;
     resultMemInfoVec.emplace_back(std::move(newInfo));
   }
 }

--- a/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
@@ -24,6 +24,7 @@
 // [P0 新增] 引入副作用接口和 PTO 接口
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
+#include <limits>
 #include <optional>
 
 #define DEBUG_TYPE "pto-ir-translator"
@@ -125,6 +126,19 @@ static std::optional<uint64_t> getKnownPhysicalAddress(Value value) {
   if (!getConstIndexValue(value, address) || address < 0)
     return std::nullopt;
   return static_cast<uint64_t>(address);
+}
+
+static std::optional<uint64_t> addByteOffset(uint64_t base, uint64_t offset) {
+  if (offset > std::numeric_limits<uint64_t>::max() - base)
+    return std::nullopt;
+  return base + offset;
+}
+
+static void markAddressRangeUnknown(BaseMemInfo &info) {
+  info.baseAddresses.clear();
+  info.allocateSize = 0;
+  info.hasKnownPhysicalAddresses = false;
+  info.aliasesUnknownRange = true;
 }
 
 static bool isLocalAddressSpace(pto::AddressSpace space) {
@@ -430,9 +444,13 @@ LogicalResult PTOIRTranslator::UpdateAllocTileOpMemInfo(pto::AllocTileOp op) {
   }
 
   // 3. 注册 Buffer 信息
+  bool hasKnownPhysicalAddress =
+      knownPhysicalAddress.has_value() && isLocalAddressSpace(space);
+  bool aliasesUnknownRange =
+      op.getAddr() && isLocalAddressSpace(space) && !knownPhysicalAddress;
   auto newMemInfo = std::make_unique<BaseMemInfo>(
       res, res, space, SmallVector<uint64_t>{baseAddr}, sizeInBytes,
-      knownPhysicalAddress.has_value() && isLocalAddressSpace(space));
+      hasKnownPhysicalAddress, aliasesUnknownRange);
 
   buffer2MemInfoMap_[res].emplace_back(newMemInfo->clone());
   return success();
@@ -951,8 +969,20 @@ void PTOIRTranslator::UpdateTileSubViewAliasBufferInfo(pto::SubViewOp op) {
     SmallVector<uint64_t> addresses;
     addresses.reserve(subViewAddresses->size());
     uint64_t parentBase = parentInfo->baseAddresses[0];
-    for (uint64_t offset : *subViewAddresses)
-      addresses.push_back(parentBase + offset);
+    bool overflowed = false;
+    for (uint64_t offset : *subViewAddresses) {
+      std::optional<uint64_t> address = addByteOffset(parentBase, offset);
+      if (!address) {
+        overflowed = true;
+        break;
+      }
+      addresses.push_back(*address);
+    }
+    if (overflowed) {
+      markAddressRangeUnknown(*newInfo);
+      resultMemInfoVec.emplace_back(std::move(newInfo));
+      continue;
+    }
     newInfo->baseAddresses = std::move(addresses);
     newInfo->allocateSize = segmentSize;
     resultMemInfoVec.emplace_back(std::move(newInfo));

--- a/test/lit/pto/alloc_tile_physical_overlap_sync.pto
+++ b/test/lit/pto/alloc_tile_physical_overlap_sync.pto
@@ -7,8 +7,9 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // Explicit local alloc_tile addresses are physical UB addresses. Distinct SSA
-// roots whose ranges overlap must synchronize an asynchronous MTE3 read before
-// a later V-pipe write reuses the range.
+// roots whose ranges overlap must synchronize cross-pipe reuse. Known disjoint
+// and boundary-touching half-open ranges must remain independent, while dynamic
+// absolute addresses conservatively alias.
 //
 // RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
 
@@ -42,6 +43,110 @@ module attributes {pto.target_arch = "a2a3"} {
               outs(%reused : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
+
+  // Models the gather failure directly: PIPE_V is still reading the assembled
+  // 4 KiB tile at [4096,8192) when PIPE_MTE2 overwrites the 32-byte index row
+  // at [4608,4640). The distinct alloc_tile roots must still produce a
+  // PIPE_V -> PIPE_MTE2 WAR dependency.
+  func.func @alloc_tile_explicit_overlap_v_to_mte2(
+      %assembled_src: !pto.partition_tensor_view<32x32xf32>,
+      %index_src: !pto.partition_tensor_view<1x8xf32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c4096_i64 = arith.constant 4096 : i64
+    %c4608_i64 = arith.constant 4608 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %one = arith.constant 1.000000e+00 : f32
+
+    %assembled = pto.alloc_tile addr = %c4096_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %vector_out = pto.alloc_tile addr = %c8192_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %index_row = pto.alloc_tile addr = %c4608_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%assembled_src : !pto.partition_tensor_view<32x32xf32>)
+              outs(%assembled : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmuls ins(%assembled, %one : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%vector_out : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%index_src : !pto.partition_tensor_view<1x8xf32>)
+              outs(%index_row : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @alloc_tile_explicit_disjoint_no_sync(
+      %assembled_src: !pto.partition_tensor_view<32x32xf32>,
+      %index_src: !pto.partition_tensor_view<1x8xf32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %c16384_i64 = arith.constant 16384 : i64
+    %one = arith.constant 1.000000e+00 : f32
+
+    %assembled = pto.alloc_tile addr = %c4096_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %vector_out = pto.alloc_tile addr = %c8192_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %index_row = pto.alloc_tile addr = %c16384_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%assembled_src : !pto.partition_tensor_view<32x32xf32>)
+              outs(%assembled : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmuls ins(%assembled, %one : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%vector_out : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%index_src : !pto.partition_tensor_view<1x8xf32>)
+              outs(%index_row : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @alloc_tile_explicit_boundary_no_sync(
+      %assembled_src: !pto.partition_tensor_view<32x32xf32>,
+      %index_src: !pto.partition_tensor_view<1x8xf32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %c12288_i64 = arith.constant 12288 : i64
+    %one = arith.constant 1.000000e+00 : f32
+
+    %assembled = pto.alloc_tile addr = %c4096_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %vector_out = pto.alloc_tile addr = %c12288_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %index_row = pto.alloc_tile addr = %c8192_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%assembled_src : !pto.partition_tensor_view<32x32xf32>)
+              outs(%assembled : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmuls ins(%assembled, %one : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%vector_out : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%index_src : !pto.partition_tensor_view<1x8xf32>)
+              outs(%index_row : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @alloc_tile_unknown_absolute_sync(
+      %assembled_src: !pto.partition_tensor_view<32x32xf32>,
+      %index_src: !pto.partition_tensor_view<1x8xf32>,
+      %assembled_addr: i64,
+      %index_addr: i64)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c8192_i64 = arith.constant 8192 : i64
+    %one = arith.constant 1.000000e+00 : f32
+
+    %assembled = pto.alloc_tile addr = %assembled_addr :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %vector_out = pto.alloc_tile addr = %c8192_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %index_row = pto.alloc_tile addr = %index_addr :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%assembled_src : !pto.partition_tensor_view<32x32xf32>)
+              outs(%assembled : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmuls ins(%assembled, %one : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%vector_out : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%index_src : !pto.partition_tensor_view<1x8xf32>)
+              outs(%index_row : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
 }
 
 // CHECK-LABEL: AICORE void alloc_tile_physical_overlap_sync(
@@ -49,3 +154,25 @@ module attributes {pto.target_arch = "a2a3"} {
 // CHECK-NEXT: set_flag(PIPE_MTE3, PIPE_V, EVENT_ID[[MTE3_TO_V:[0-9]+]]);
 // CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID[[MTE3_TO_V]]);
 // CHECK-NEXT: TMULS(
+
+// CHECK-LABEL: AICORE void alloc_tile_explicit_overlap_v_to_mte2(
+// CHECK:      TMULS(
+// CHECK-NEXT: set_flag(PIPE_V, PIPE_MTE2, EVENT_ID[[V_TO_MTE2:[0-9]+]]);
+// CHECK-NEXT: wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID[[V_TO_MTE2]]);
+// CHECK:      TLOAD(
+
+// CHECK-LABEL: AICORE void alloc_tile_explicit_disjoint_no_sync(
+// CHECK:      TMULS(
+// CHECK-NOT:  set_flag(PIPE_V, PIPE_MTE2
+// CHECK:      TLOAD(
+
+// CHECK-LABEL: AICORE void alloc_tile_explicit_boundary_no_sync(
+// CHECK:      TMULS(
+// CHECK-NOT:  set_flag(PIPE_V, PIPE_MTE2
+// CHECK:      TLOAD(
+
+// CHECK-LABEL: AICORE void alloc_tile_unknown_absolute_sync(
+// CHECK:      TMULS(
+// CHECK-NEXT: set_flag(PIPE_V, PIPE_MTE2, EVENT_ID[[UNKNOWN_V_TO_MTE2:[0-9]+]]);
+// CHECK-NEXT: wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID[[UNKNOWN_V_TO_MTE2]]);
+// CHECK:      TLOAD(

--- a/test/lit/pto/alloc_tile_physical_overlap_sync.pto
+++ b/test/lit/pto/alloc_tile_physical_overlap_sync.pto
@@ -147,6 +147,39 @@ module attributes {pto.target_arch = "a2a3"} {
               outs(%index_row : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
+
+  // A static child of an inexact dynamic subview must retain the conservative
+  // parent envelope. At runtime %row = 1 places %child at [4352,4384), which
+  // overlaps the distinct allocation written by the following MTE2 load.
+  func.func @chained_dynamic_subview_remains_conservative(
+      %index_src: !pto.partition_tensor_view<1x8xf32>,
+      %row: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c4096_i64 = arith.constant 4096 : i64
+    %c4352_i64 = arith.constant 4352 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %one = arith.constant 1.000000e+00 : f32
+
+    %root = pto.alloc_tile addr = %c4096_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dynamic = pto.subview %root[%row, %c0] sizes [1, 64] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %child = pto.subview %dynamic[%c0, %c0] sizes [1, 8] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %vector_out = pto.alloc_tile addr = %c8192_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %target = pto.alloc_tile addr = %c4352_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tmuls ins(%child, %one : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%vector_out : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%index_src : !pto.partition_tensor_view<1x8xf32>)
+              outs(%target : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
 }
 
 // CHECK-LABEL: AICORE void alloc_tile_physical_overlap_sync(
@@ -175,4 +208,10 @@ module attributes {pto.target_arch = "a2a3"} {
 // CHECK:      TMULS(
 // CHECK-NEXT: set_flag(PIPE_V, PIPE_MTE2, EVENT_ID[[UNKNOWN_V_TO_MTE2:[0-9]+]]);
 // CHECK-NEXT: wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID[[UNKNOWN_V_TO_MTE2]]);
+// CHECK:      TLOAD(
+
+// CHECK-LABEL: AICORE void chained_dynamic_subview_remains_conservative(
+// CHECK:      TMULS(
+// CHECK-NEXT: set_flag(PIPE_V, PIPE_MTE2, EVENT_ID[[DYNAMIC_VIEW_V_TO_MTE2:[0-9]+]]);
+// CHECK-NEXT: wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID[[DYNAMIC_VIEW_V_TO_MTE2]]);
 // CHECK:      TLOAD(

--- a/test/lit/pto/multi_slot_physical_lane_mapping.pto
+++ b/test/lit/pto/multi_slot_physical_lane_mapping.pto
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync --mlir-print-ir-after=pto-insert-sync %s 2>&1 1>/dev/null | FileCheck %s
+
+// Dynamic event IDs require slot index i on the producer and consumer to name
+// the same physical range. Here each tile is 512 bytes:
+//
+//   producer: [4096, 4608], consumer: [4608, 5120]
+//
+// The dependency is producer slot 1 -> consumer slot 0. Keying both sides by
+// the same runtime slot index would set and wait on different hardware events,
+// so this shifted mapping must fall back to one static event.
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @shifted_slots_use_static_backedge(
+      %gm: !pto.partition_tensor_view<16x16xf16>,
+      %dst: !pto.partition_tensor_view<16x16xf16>,
+      %n: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %producer_base = arith.constant 4096 : i64
+    %consumer_base = arith.constant 4608 : i64
+
+    %producer_slots = pto.alloc_multi_tile addr = %producer_base
+        : !pto.multi_tile_buf<vec, 16x16xf16, count=2>
+    %consumer_slots = pto.alloc_multi_tile addr = %consumer_base
+        : !pto.multi_tile_buf<vec, 16x16xf16, count=2>
+
+    scf.for %i = %c0 to %n step %c1 {
+      %idx = arith.remui %i, %c2 : index
+      %producer = pto.multi_tile_get %producer_slots[%idx]
+          : !pto.multi_tile_buf<vec, 16x16xf16, count=2>
+         -> !pto.tile_buf<vec, 16x16xf16>
+      %consumer = pto.multi_tile_get %consumer_slots[%idx]
+          : !pto.multi_tile_buf<vec, 16x16xf16, count=2>
+         -> !pto.tile_buf<vec, 16x16xf16>
+      pto.tload ins(%gm : !pto.partition_tensor_view<16x16xf16>)
+                outs(%producer : !pto.tile_buf<vec, 16x16xf16>)
+      pto.tstore ins(%consumer : !pto.tile_buf<vec, 16x16xf16>)
+                 outs(%dst : !pto.partition_tensor_view<16x16xf16>)
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @shifted_slots_use_static_backedge
+// CHECK: pto.set_flag[<PIPE_MTE3>, <PIPE_MTE2>, <[[EVENT:EVENT_ID[0-9]+]]>]
+// CHECK: scf.for
+// CHECK: pto.wait_flag[<PIPE_MTE3>, <PIPE_MTE2>, <[[EVENT]]>]
+// CHECK-NOT: pto.set_flag_dyn
+// CHECK-NOT: pto.wait_flag_dyn
+// CHECK: return

--- a/test/lit/pto/plan_memory_address_provenance_no_false_alias.pto
+++ b/test/lit/pto/plan_memory_address_provenance_no_false_alias.pto
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Address-less level-2 allocations start as root-relative offsets. They must
+// not all alias merely because their pre-planning baseAddresses are zero.
+// PlanMemory assigns disjoint physical ranges here, and InsertSync must not add
+// a spurious PIPE_V -> PIPE_MTE2 dependency between the first TMULS and the
+// unrelated second TLOAD.
+//
+// RUN: ptoas --pto-arch=a3 --pto-level=level2 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --check-prefix=SYNC
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @plan_memory_address_provenance_no_false_alias(
+      %assembled_src: !pto.partition_tensor_view<32x32xf32>,
+      %index_src: !pto.partition_tensor_view<1x8xf32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %one = arith.constant 1.000000e+00 : f32
+
+    %assembled = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %vector_out = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %index_row = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%assembled_src : !pto.partition_tensor_view<32x32xf32>)
+              outs(%assembled : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmuls ins(%assembled, %one : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%vector_out : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%index_src : !pto.partition_tensor_view<1x8xf32>)
+              outs(%index_row : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    // Keep the assembled tile live across the index load so PlanMemory cannot
+    // legally reuse its physical range for index_row.
+    pto.tmuls ins(%assembled, %one : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%vector_out : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// SYNC-LABEL: AICORE void plan_memory_address_provenance_no_false_alias(
+// SYNC:      TMULS(
+// SYNC-NOT:  set_flag(PIPE_V, PIPE_MTE2
+// SYNC:      TLOAD(


### PR DESCRIPTION
## Summary
- distinguish root-relative, known-absolute, and unknown-absolute local addresses
- compare known half-open physical ranges across allocation roots and conservatively alias dynamic or overflowing ranges
- model alternative multi-buffer slots separately from discontiguous view segments
- invalidate known ranges for dynamic reinterpret offsets and for reinterpret casts after subview-adjusted, segmented, or chained views
- make `AddressListKind` authoritative for back-edge event selection and affine slot pruning; mixed or incompatible hazards use one static event
- retain a tagged parent envelope for unsupported subviews only when the parent footprint is proven safe; descendants cannot incorrectly narrow it, and padded/strided parents remain unknown
- add gather-style overlap, disjoint/boundary, dynamic-address, multi-slot, reinterpret, segmented back-edge, mixed back-edge, and conservative-subview regressions

## Testing
- CI for `b083a9c9` is green: main build-and-test plus x86_64 and aarch64 wheel/build checks passed; remote NPU validation was skipped
- affected InsertSync objects compile with `PTOAS_ENABLE_WERROR=ON`; a local `ptoas` link also succeeds with temporary narrowed pass registration because this checkout's minimal LLVM 21 configuration has unrelated all-pass registration link failures
- 11 focused lit files: passed with at most `-j2`
- all 21 `multi_tile_` lit tests: passed with `-j2`
- all 20 subview/reinterpret lit tests: passed with `-j2`
- generated C++ was inspected for the new negative and positive controls:
  - dynamic subview of a contiguous parent remains disjoint without a false V-to-MTE2 sync
  - a child of an inexact dynamic subview remains conservative and emits the required sync
  - a dynamic subview of a padded/strided parent is unknown and emits the required sync
  - a mixed segmented/alternative-slot back-edge uses one static event
- the pre-fix binary misses the required synchronization in the dynamic reinterpret, subview-plus-reinterpret, and mixed back-edge controls; the corrected binary passes them
- a broad local lit sweep was not treated as authoritative because the minimal LLVM registration workaround exposes unrelated baseline/toolchain failures; targeted InsertSync coverage above passes
- NPU validation is deferred: the remote device agent was stopped because its environment would first require a long VLLM rebuild
