### PR TITLE
fix(emitc): handle DCCI for partition tensor views

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -14720,6 +14720,13 @@ static AICORE inline void ptoas_auto_sync_tail(
   }
 }
 
+template <typename Element, typename Shape, typename Stride,
+          pto::Layout TensorLayout>
+static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(
+    pto::GlobalTensor<Element, Shape, Stride, TensorLayout> &tensor) {
+  dcci((__gm__ void*)tensor.data(), cache_line_t::SINGLE_CACHE_LINE);
+}
+
 template <typename Ptr>
 static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
   dcci((__gm__ void*)ptr, cache_line_t::SINGLE_CACHE_LINE);

--- a/test/dsl/issue_995_repro.pto
+++ b/test/dsl/issue_995_repro.pto
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @k(%arg0: !pto.ptr<f32>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c16_index = arith.constant 16 : index
+    %c1_index = arith.constant 1 : index
+    %c0_index = arith.constant 0 : index
+    %view = pto.make_tensor_view %arg0, shape = [%c16_index, %c16_index], strides = [%c16_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf32>
+    %pview = pto.partition_view %view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c16_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
+    pto.cmo.cacheinvalid %pview single_cache_line : !pto.partition_tensor_view<16x16xf32>
+    return
+  }
+}

--- a/test/lit/pto/issue995_cmo_partition_view_emitc.pto
+++ b/test/lit/pto/issue995_cmo_partition_view_emitc.pto
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @single_line_ptr(%arg0: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    pto.cmo.cacheinvalid %arg0 single_cache_line : !pto.ptr<f32>
+    return
+  }
+
+  func.func @single_line_partition_view(%arg0: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %view = pto.make_tensor_view %arg0,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xf32>
+    %pview = pto.partition_view %view,
+      offsets = [%c0, %c0], sizes = [%c16, %c16]
+      : !pto.tensor_view<?x?xf32>
+        -> !pto.partition_tensor_view<16x16xf32>
+    pto.cmo.cacheinvalid %pview single_cache_line
+      : !pto.partition_tensor_view<16x16xf32>
+    return
+  }
+}
+
+// CHECK: template <typename Element, typename Shape, typename Stride,
+// CHECK-NEXT:           pto::Layout TensorLayout>
+// CHECK-NEXT: static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(
+// CHECK-NEXT:     pto::GlobalTensor<Element, Shape, Stride, TensorLayout> &tensor) {
+// CHECK-NEXT:   dcci((__gm__ void*)tensor.data(), cache_line_t::SINGLE_CACHE_LINE);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: AICORE void single_line_ptr(
+// CHECK: PTOAS__DCCI_SINGLE_CACHE_LINE({{[_A-Za-z][_A-Za-z0-9]*}});
+
+// CHECK-LABEL: AICORE void single_line_partition_view(
+// CHECK: GlobalTensor<float, {{.*}}> [[PVIEW:[_A-Za-z][_A-Za-z0-9]*]] = GlobalTensor<float, {{.*}}>(
+// CHECK: PTOAS__DCCI_SINGLE_CACHE_LINE([[PVIEW]]);

--- a/test/lit/pto/issue995_cmo_partition_view_emitc.pto
+++ b/test/lit/pto/issue995_cmo_partition_view_emitc.pto
@@ -31,6 +31,25 @@ module {
       : !pto.partition_tensor_view<16x16xf32>
     return
   }
+
+  func.func @single_line_partition_view_nonzero_offset(
+      %arg0: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %view = pto.make_tensor_view %arg0,
+      shape = [%c32, %c32], strides = [%c32, %c1]
+      {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xf32>
+    %pview = pto.partition_view %view,
+      offsets = [%c1, %c2], sizes = [%c16, %c16]
+      : !pto.tensor_view<?x?xf32>
+        -> !pto.partition_tensor_view<16x16xf32>
+    pto.cmo.cacheinvalid %pview single_cache_line
+      : !pto.partition_tensor_view<16x16xf32>
+    return
+  }
 }
 
 // CHECK: template <typename Element, typename Shape, typename Stride,
@@ -46,3 +65,11 @@ module {
 // CHECK-LABEL: AICORE void single_line_partition_view(
 // CHECK: GlobalTensor<float, {{.*}}> [[PVIEW:[_A-Za-z][_A-Za-z0-9]*]] = GlobalTensor<float, {{.*}}>(
 // CHECK: PTOAS__DCCI_SINGLE_CACHE_LINE([[PVIEW]]);
+
+// CHECK-LABEL: AICORE void single_line_partition_view_nonzero_offset(
+// CHECK-DAG: const int64_t [[COL_OFFSET:[_A-Za-z][_A-Za-z0-9]*]] = 2;
+// CHECK-DAG: const int64_t [[ZERO:[_A-Za-z][_A-Za-z0-9]*]] = 0;
+// CHECK-DAG: const int64_t [[ROW_STRIDE:[_A-Za-z][_A-Za-z0-9]*]] = 32;
+// CHECK-DAG: const int64_t [[ONE:[_A-Za-z][_A-Za-z0-9]*]] = 1;
+// CHECK: GlobalTensor<float, {{.*}}> [[OFFSET_PVIEW:[_A-Za-z][_A-Za-z0-9]*]] = GlobalTensor<float, {{.*}}>({{[_A-Za-z][_A-Za-z0-9]*}} + (([[ZERO]] + [[ONE]] * [[ROW_STRIDE]]) + [[COL_OFFSET]] * [[ONE]]),
+// CHECK: PTOAS__DCCI_SINGLE_CACHE_LINE([[OFFSET_PVIEW]]);


### PR DESCRIPTION
## Summary

- add a `GlobalTensor` overload for single-cache-line DCCI emission and extract its GM address with `tensor.data()`
- preserve the existing generic pointer helper for pointer and tensor-view lowering
- add a minimal issue reproducer and lit coverage for both pointer and partition-tensor-view operands

## Root cause

`pto.partition_view` lowers to a `GlobalTensor` object. The existing generic helper attempted to cast that object directly to `__gm__ void *`, producing uncompilable generated C++. The dedicated overload converts the underlying data pointer instead.

## Validation

- WSL-native build of `ptoas_runtime_staging` against LLVM/MLIR 21.1.8: PASS
- `ptoas --version`: `ptoas 0.52`
- issue reproducer compiled with `--pto-level=level3`: PASS
- generated C++ contains the `GlobalTensor` overload using `tensor.data()`: PASS
- targeted lit tests: 3/3 PASS
  - `pto/issue995_cmo_partition_view_emitc.pto`
  - `pto/cmo_cacheinvalid_single_line_invalid.pto`
  - `pto/signal_payload_cache_consistency.pto`

Fixes #995
