### PR TITLE
Support odd-axis split modes for tpush/tpop

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -9206,8 +9206,11 @@ frontend/framework generated IR. The detailed design document is:
 - `nosplit` is an optional compile-time boolean attribute on
   `pto.aic_initialize_pipe` / `pto.aiv_initialize_pipe`.
 - `split` is a compile-time attribute, not a runtime SSA operand.
-- `split = 0/1/2` corresponds to `TILE_NO_SPLIT`, `TILE_UP_DOWN`, and
-  `TILE_LEFT_RIGHT`.
+- `split = 0/1/2/3/4` corresponds to `TILE_NO_SPLIT`, `TILE_UP_DOWN`,
+  `TILE_LEFT_RIGHT`, `TILE_UP_DOWN_ODD`, and `TILE_LEFT_RIGHT_ODD`.
+- `TILE_UP_DOWN_ODD` splits an odd valid-row count so AIV0 receives
+  `ceil(valid_rows / 2)` rows and AIV1 receives `floor(valid_rows / 2)` rows.
+  `TILE_LEFT_RIGHT_ODD` applies the same rule to valid columns.
 - `pto.tpop_from_aic` and `pto.tpop_from_aiv` are result-valued frontend ops.
 - Pipe entries support two forms:
   - tile entry: `!pto.tile_buf<...>` or the equivalent local memref after view
@@ -9228,17 +9231,19 @@ frontend/framework generated IR. The detailed design document is:
 - For global entries, the matched initialize op's `gm_slot_tensor` describes
   one FIFO slot entry, not the full multi-slot FIFO buffer. Its dtype, shape,
   stride, and layout must match the `tensor_view` returned by `talloc` /
-  `tpop` and form the pto-isa `GlobalData` template argument. `TILE_UP_DOWN` and
-  `TILE_LEFT_RIGHT` split modes derive sub-core GM address offsets from that
-  single-slot descriptor's static rows, columns, and element dtype.
+  `tpop` and form the pto-isa `GlobalData` template argument. `TILE_UP_DOWN`,
+  `TILE_LEFT_RIGHT`, `TILE_UP_DOWN_ODD`, and `TILE_LEFT_RIGHT_ODD` split modes
+  derive each sub-core's GM view from the single-slot descriptor and the tile's
+  valid shape.
 - If a global-entry result op does not carry explicit stride/layout metadata,
   PTOAS treats it as a row-major contiguous GM view. Non-contiguous cases must
   preserve stride/layout through the producing op metadata, the source view, or
   the lowered GM memref layout.
-- A single logical pipe cannot mix `split = 0` with `split = 1` / `2`.
+- A single logical pipe cannot mix `split = 0` with `split = 1` / `2` / `3` /
+  `4`.
   `nosplit = true` requires all bound data-transfer ops to use `split = 0`;
-  `nosplit = false` requires all bound data-transfer ops to use `split = 1`
-  or `split = 2`.
+  `nosplit = false` requires all bound data-transfer ops to use `split = 1`,
+  `2`, `3`, or `4`.
 - Multiple logical pipes are allowed in one function.
 - A frontend logical pipe is uniquely identified by `function + id + direction`.
 - When `dir_mask = 1` or `2`, one `id` denotes one single-direction logical
@@ -9431,7 +9436,7 @@ pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
 - If `nosplit = true`, all frontend data-transfer ops bound to the same logical
   pipe must use `split = 0`
 - If `nosplit = false`, all frontend data-transfer ops bound to the same
-  logical pipe must use `split = 1` or `split = 2`
+  logical pipe must use `split = 1`, `2`, `3`, or `4`
 
 ##### `pto.aiv_initialize_pipe` - Frontend Vector Pipe Initialization
 
@@ -9474,7 +9479,7 @@ pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
 - If `nosplit = true`, all frontend data-transfer ops bound to the same logical
   pipe must use `split = 0`
 - If `nosplit = false`, all frontend data-transfer ops bound to the same
-  logical pipe must use `split = 1` or `split = 2`
+  logical pipe must use `split = 1`, `2`, `3`, or `4`
 
 **Basic Example: GlobalTensor Pipe Entry Without Reserve/Import**
 

--- a/docs/designs/ptoas-tpush-tpop-design.md
+++ b/docs/designs/ptoas-tpush-tpop-design.md
@@ -227,7 +227,7 @@ pto.tfree_from_aiv(%entry : !pto.tensor_view<...>) {id = 0, split = 0}
 
 以上前端数据传输接口中的 `id` 和 `split` 均为编译期常量属性，不是运行时 SSA operand。
 
-- 取值使用 `TileSplitAxis` 枚举语义：`0/1/2` 分别对应 `TILE_NO_SPLIT`、`TILE_UP_DOWN`、`TILE_LEFT_RIGHT`
+- 取值使用 `TileSplitAxis` 枚举语义：`0/1/2/3/4` 分别对应 `TILE_NO_SPLIT`、`TILE_UP_DOWN`、`TILE_LEFT_RIGHT`、`TILE_UP_DOWN_ODD`、`TILE_LEFT_RIGHT_ODD`
 - lowering 到 PTOAS 内部 IR 时，`split` 继续以属性形式保留
 - `global` entry 的 result type 和 matched initialize op 的 `gm_slot_tensor` metadata 是底层 `GlobalData` 模板实参的 IR 描述；其 element type、静态 shape 与 stride/layout 必须描述完整 FIFO slot。若 consumer 只加载 slot 的子区域，应先 pop 完整 slot descriptor，再由该 descriptor 派生更窄的 GM view。
 
@@ -421,6 +421,8 @@ handle。
 - `TILE_NO_SPLIT`
 - `TILE_UP_DOWN`
 - `TILE_LEFT_RIGHT`
+- `TILE_UP_DOWN_ODD`
+- `TILE_LEFT_RIGHT_ODD`
 
 在 PTOAS 设计中，`split` 的角色定义为：
 
@@ -442,7 +444,7 @@ handle。
 
 - 切分前完整 pipe entry 的字节数
 
-即使 `split` 为 `TILE_UP_DOWN` 或 `TILE_LEFT_RIGHT`，`SLOT_SIZE` 仍然表示未切分前的逻辑 pipe entry 总字节数。
+即使 `split` 为 `TILE_UP_DOWN`、`TILE_LEFT_RIGHT`、`TILE_UP_DOWN_ODD` 或 `TILE_LEFT_RIGHT_ODD`，`SLOT_SIZE` 仍然表示未切分前的逻辑 pipe entry 总字节数。
 
 `split` 只影响底层 `TALLOC/TPUSH/TPOP/TFREE` 的执行方式，不影响 `SLOT_SIZE` 的含义。
 
@@ -451,8 +453,10 @@ handle。
 - `TILE_NO_SPLIT`：不增加 sub-core offset
 - `TILE_UP_DOWN`：sub-core offset 为 `get_subblockid() * rows * cols * sizeof(dtype)`
 - `TILE_LEFT_RIGHT`：sub-core offset 为 `get_subblockid() * cols * sizeof(dtype)`
+- `TILE_UP_DOWN_ODD`：奇数有效行由 AIV0/AIV1 按 `ceil(rows / 2)` 与 `floor(rows / 2)` 切分
+- `TILE_LEFT_RIGHT_ODD`：奇数有效列由 AIV0/AIV1 按 `ceil(cols / 2)` 与 `floor(cols / 2)` 切分
 
-其中 `rows`、`cols` 与 `dtype` 来自 entry 对应底层 `GlobalData` 的静态 shape 与 `RawDType`。PTOAS IR 因此要求 `global` entry 的类型和 view metadata 描述完整 FIFO slot，而不是仅描述 consumer 最终要读取的子 tile。
+偶数切分模式中的 `rows`、`cols` 与 `dtype` 来自 entry 对应底层 `GlobalData` 的 shape 与 `RawDType`；奇数切分模式使用运行时 valid shape 决定两个子块的大小。PTOAS IR 因此要求 `global` entry 的类型和 view metadata 描述完整 FIFO slot，而不是仅描述 consumer 最终要读取的子 tile。
 
 ### 4.4 `SLOT_NUM` 规则
 

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -467,7 +467,7 @@ def PTOInferValidatePipeInit : Pass<"pto-infer-validate-pipe-init", "ModuleOp"> 
     Runs after frontend pipe lowering and before memory planning. For each
     logical pipe, this pass:
     - validates that downstream `pto.tpush` / `pto.tpop` / `pto.tfree` users
-      do not mix `split = 0` with `split = 1/2`
+      do not mix `split = 0` with `split = 1/2/3/4`
     - preserves explicit `nosplit` attrs on internal pipe init ops and rejects
       conflicts across peer pipe init pairs
     - infers missing `nosplit` attrs from downstream split usage for backward

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -15231,8 +15231,8 @@ static bool isInsideSectionOrAttributedKernel(Operation *op) {
 }
 
 static LogicalResult verifySplitAttr(Operation *op, int64_t split) {
-  if (split < 0 || split > 2)
-    return op->emitOpError("expects 'split' to be 0, 1, or 2");
+  if (split < 0 || split > 4)
+    return op->emitOpError("expects 'split' to be 0, 1, 2, 3, or 4");
   return success();
 }
 
@@ -16094,7 +16094,7 @@ static LogicalResult verifyAivSubblockIdOperand(Operation *op,
 
   if (split == 0) {
     return op->emitOpError(
-        "expects 'aiv_subblockid' only when 'split' is 1 or 2");
+        "expects 'aiv_subblockid' only when 'split' is 1, 2, 3, or 4");
   }
 
   if (isa<TensorViewType>(pipeEntryType)) {

--- a/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
+++ b/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
@@ -171,7 +171,8 @@ resolveNoSplitComponent(ArrayRef<PipeInitInfo *> component, OpBuilder &builder) 
   for (PipeInitInfo *info : component) {
     if (info->usage == PipeSplitUsage::Mixed) {
       return info->op->emitOpError(
-          "cannot mix 'split = 0' with 'split = 1' or 'split = 2' on the "
+          "cannot mix 'split = 0' with 'split = 1', 'split = 2', "
+          "'split = 3', or 'split = 4' on the "
           "same logical pipe");
     }
 
@@ -202,7 +203,7 @@ resolveNoSplitComponent(ArrayRef<PipeInitInfo *> component, OpBuilder &builder) 
       if (*info->explicitNoSplit) {
         return info->op->emitOpError(
             "explicit 'nosplit = true' conflicts with downstream users that "
-            "require split = 1 or split = 2");
+            "require split = 1, 2, 3, or 4");
       }
       return info->op->emitOpError(
           "explicit 'nosplit = false' conflicts with downstream users that "

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -1114,6 +1114,10 @@ static FailureOr<std::string> getTileSplitToken(int64_t split) {
     return std::string("TileSplitAxis::TILE_UP_DOWN");
   case 2:
     return std::string("TileSplitAxis::TILE_LEFT_RIGHT");
+  case 3:
+    return std::string("TileSplitAxis::TILE_UP_DOWN_ODD");
+  case 4:
+    return std::string("TileSplitAxis::TILE_LEFT_RIGHT_ODD");
   default:
     return failure();
   }

--- a/test/lit/pto/tpush_tpop_aiv_subblockid_invalid.pto
+++ b/test/lit/pto/tpush_tpop_aiv_subblockid_invalid.pto
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
 // RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
 
 module {
@@ -14,4 +22,4 @@ module {
   }
 }
 
-// CHECK: expects 'aiv_subblockid' only when 'split' is 1 or 2
+// CHECK: expects 'aiv_subblockid' only when 'split' is 1, 2, 3, or 4

--- a/test/lit/pto/tpush_tpop_odd_split_emitc.pto
+++ b/test/lit/pto/tpush_tpop_odd_split_emitc.pto
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+// Verifies that odd valid-shape split modes survive frontend pipe lowering and
+// select the matching PTO-ISA template arguments for both TPUSH and TPOP.
+//
+// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
+
+module {
+  func.func @cube_kernel(%full_rows: index, %full_cols: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c16 = arith.constant 16 : index
+
+    %up_down_import = pto.import_reserved_buffer {
+      name = "up_down_fifo",
+      peer_func = @vector_kernel
+    } -> i32
+    %left_right_import = pto.import_reserved_buffer {
+      name = "left_right_fifo",
+      peer_func = @vector_kernel
+    } -> i32
+
+    pto.aic_initialize_pipe {id = 3, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %up_down_import : i32)
+    pto.aic_initialize_pipe {id = 4, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %left_right_import : i32)
+
+    %up_down_tile = pto.alloc_tile valid_row = %full_rows valid_col = %c16
+      : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    %left_right_tile = pto.alloc_tile valid_row = %c16 valid_col = %full_cols
+      : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+
+    pto.tpush_to_aiv(%up_down_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 3, split = 3}
+    pto.tpush_to_aiv(%left_right_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 4, split = 4}
+    return
+  }
+
+  func.func @vector_kernel(%half_rows: index, %half_cols: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c16 = arith.constant 16 : index
+
+    %up_down_local = pto.reserve_buffer {
+      name = "up_down_fifo",
+      size = 8192,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+    %left_right_local = pto.reserve_buffer {
+      name = "left_right_fifo",
+      size = 8192,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+
+    pto.aiv_initialize_pipe {id = 3, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %up_down_local : i32)
+    pto.aiv_initialize_pipe {id = 4, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %left_right_local : i32)
+
+    %up_down_tile = pto.tpop_from_aic(%half_rows, %c16) {id = 3, split = 3}
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tfree_from_aic {id = 3, split = 3}
+
+    %left_right_tile = pto.tpop_from_aic(%c16, %half_cols) {id = 4, split = 4}
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=8, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tfree_from_aic {id = 4, split = 4}
+    return
+  }
+}
+
+// A5-LABEL: AICORE void cube_kernel(
+// A5: TPUSH<{{.*}}TileSplitAxis::TILE_UP_DOWN_ODD>(
+// A5: TPUSH<{{.*}}TileSplitAxis::TILE_LEFT_RIGHT_ODD>(
+
+// A5-LABEL: AICORE void vector_kernel(
+// A5: TPOP<{{.*}}TileSplitAxis::TILE_UP_DOWN_ODD>(
+// A5: TFREE<{{.*}}TileSplitAxis::TILE_UP_DOWN_ODD>(
+// A5: TPOP<{{.*}}TileSplitAxis::TILE_LEFT_RIGHT_ODD>(
+// A5: TFREE<{{.*}}TileSplitAxis::TILE_LEFT_RIGHT_ODD>(

--- a/test/lit/pto/tpush_tpop_split_invalid.pto
+++ b/test/lit/pto/tpush_tpop_split_invalid.pto
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @cube_kernel(%consumer_buf: i32)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %pipe = pto.initialize_l2l_pipe {
+      dir_mask = 1,
+      slot_size = 1024,
+      slot_num = 8,
+      flag_base = 0,
+      nosplit = false
+    }(%consumer_buf : i32) -> !pto.pipe
+    %tile = pto.alloc_tile
+      : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tpush(%tile, %pipe : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>, !pto.pipe) {split = 5}
+    return
+  }
+}
+
+// CHECK: expects 'split' to be 0, 1, 2, 3, or 4


### PR DESCRIPTION
## Summary
- accept split modes 3 and 4 for tpush, tpop, and tfree verification
- emit TILE_UP_DOWN_ODD and TILE_LEFT_RIGHT_ODD PTO-ISA template arguments
- update pipe split inference, documentation, and regression coverage

## Validation
- WSL LLVM 21 build: cmake --build build-codex-odd-split -j1 --target ptoas_runtime_staging
- llvm-lit --filter=tpush_tpop_: 34 passed
- git diff --cached --check