### PR TITLE
Multi path fusion plan

### DIFF
--- a/docs/designs/vf_costmodel_external_planner_protocol.md
+++ b/docs/designs/vf_costmodel_external_planner_protocol.md
@@ -1,12 +1,14 @@
-# PTOAS + VfSim Costmodel 接口设计
+# PTOAS + VfSim Cost Model Interface Design
 
-本文描述 PTOAS 以源码级 submodule 方式接入 VfSimulator costmodel 的当前接口形式。
-当前实现面向 A5 tile fusion 路径：PTOAS 负责生成合法 fusion group，VfSim 基于
-已选 group 做 costmodel 优化决策，并把结果写回同一份 MLIR IR。
+This document describes the current interface through which PTOAS integrates the
+VfSimulator cost model as a source-level submodule. The current implementation
+targets the A5 tile-fusion path: PTOAS generates legal fusion groups, VfSim uses
+the selected groups to make cost-model optimization decisions, and VfSim writes
+the results back to the same MLIR IR.
 
-## 接入形式
+## Integration Model
 
-VfSimulator 作为 PTOAS 的 git submodule 引入：
+VfSimulator is included in PTOAS as a git submodule:
 
 ```text
 PTOAS/
@@ -14,20 +16,21 @@ PTOAS/
     VfSimulator/
 ```
 
-PTOAS 仓库只记录 submodule commit；VfSimulator 的源码历史仍由 VfSimulator 仓库维护。
-当前 `PTO_ENABLE_VFSIM_COSTMODEL=ON` 只支持 build-tree/source-tree 开发使用，
-尚不支持 install/export。
+The PTOAS repository records only the submodule commit. The source history of
+VfSimulator remains in the VfSimulator repository. Currently,
+`PTO_ENABLE_VFSIM_COSTMODEL=ON` supports only build-tree/source-tree development;
+install/export use is not yet supported.
 
-## 控制选项
+## Control Options
 
-| 选项 | 类型 | 作用 |
+| Option | Type | Purpose |
 |---|---|---|
-| `-DPTO_ENABLE_VFSIM_COSTMODEL=ON` | CMake 编译期选项 | 编译并链接 VfSim native planner。默认 `OFF`。 |
-| `--enable-vfsim-costmodel-optimization` | `ptoas` 运行期选项 | 启用 VfSim costmodel 优化，负责生成/标注 costmodel 决策 attrs。 |
-| `--enable-unroll-after-loop-fusion` | `ptoas` 运行期选项 | 启用 VPTO 后端 unroll pass，负责消费已有 `pto.fusion.row/col_unroll_factor` attrs。 |
-| `--dump-vfsim-unroll-test` | `ptoas` 运行期调试选项 | 只打印 VfSim 对各个 unroll candidate 的预测 cycle，不控制优化是否启用。 |
+| `-DPTO_ENABLE_VFSIM_COSTMODEL=ON` | CMake configure-time option | Builds and links the native VfSim planner. Defaults to `OFF`. |
+| `--enable-vfsim-costmodel-optimization` | `ptoas` runtime option | Enables VfSim cost-model optimization, which generates and annotates cost-model decision attributes. |
+| `--enable-unroll-after-loop-fusion` | `ptoas` runtime option | Enables the VPTO backend unroll pass, which consumes existing `pto.fusion.row/col_unroll_factor` attributes. |
+| `--dump-vfsim-unroll-test` | `ptoas` runtime debugging option | Prints the cycle prediction for each VfSim unroll candidate. It does not control whether optimization is enabled. |
 
-用户侧常用命令形态：
+A typical command is:
 
 ```bash
 ptoas \
@@ -40,60 +43,62 @@ ptoas \
   input.pto
 ```
 
-## 构建接入
+## Build Integration
 
-| 文件 | 作用 |
+| File | Purpose |
 |---|---|
-| `CMakeLists.txt` | 引入 `cmake/VfSimulator.cmake`。 |
-| `cmake/VfSimulator.cmake` | 定义 `PTO_ENABLE_VFSIM_COSTMODEL`，校验 submodule，加入 `3rdparty/VfSimulator/native`。 |
-| `lib/PTO/Transforms/CMakeLists.txt` | 将 `vfsim::native_core` 和 `vfsim::ir_planner` 链接进 `PTOTransforms`。 |
+| `CMakeLists.txt` | Includes `cmake/VfSimulator.cmake`. |
+| `cmake/VfSimulator.cmake` | Defines `PTO_ENABLE_VFSIM_COSTMODEL`, validates the submodule, and adds `3rdparty/VfSimulator/native`. |
+| `lib/PTO/Transforms/CMakeLists.txt` | Links `vfsim::native_core` and `vfsim::ir_planner` into `PTOTransforms`. |
 
-VfSim native 侧主要 target：
+The main native VfSim targets are:
 
 ```text
 vfsim::native_core
 vfsim::ir_planner
 ```
 
-## 编译链路
+## Compilation Pipeline
 
 ```text
 PreFusionAnalysis
   -> FusionPlan
-       - PTOAS 生成合法 fusion group
-       - PTOAS 写入 pto.fusion.group_id / pto.fusion.order
-       - 启用 --enable-vfsim-costmodel-optimization 时调用 VfSim planner
-       - VfSim 写回 pto.fusion.row_unroll_factor / pto.fusion.col_unroll_factor
+       - PTOAS generates legal fusion groups
+       - PTOAS writes pto.fusion.group_id / pto.fusion.order
+       - When --enable-vfsim-costmodel-optimization is enabled, calls the VfSim planner
+       - VfSim writes back pto.fusion.row_unroll_factor / pto.fusion.col_unroll_factor
   -> OpScheduling
   -> FusionRegionGen
-       - 将 tileop group 包成 pto.fusion_region
-       - 将一致的 row/col unroll attrs 提升到 pto.fusion_region
+       - Wraps each tileop group in a pto.fusion_region
+       - Promotes consistent row/col unroll attributes to pto.fusion_region
   -> ExpandTileOp / Inline / shape-only fold
   -> PTOLowLevelLoopFusion
   -> PTOUnrollAfterLoopFusion
-       - 启用 --enable-unroll-after-loop-fusion 时消费 row/col unroll attrs
-       - 成功消费后将对应 factor 复位为 1
+       - When --enable-unroll-after-loop-fusion is enabled, consumes the row/col unroll attributes
+       - Resets a successfully consumed factor to 1
   -> FlattenFusionRegion
 ```
 
-EmitC 路径可以运行 FusionPlan 和 VfSim planner，但当前 unroll attrs 只由 VPTO
-后端的 `PTOUnrollAfterLoopFusion` 消费。
+The EmitC path can run `FusionPlan` and the VfSim planner, but the unroll
+attributes are currently consumed only by `PTOUnrollAfterLoopFusion` in the
+VPTO backend.
 
-## PTOAS 调用点
+## PTOAS Call Sites
 
-| 文件 | 符号 | 作用 |
+| File | Symbol | Purpose |
 |---|---|---|
-| `include/PTO/Transforms/Passes.td` | `FusionPlan` options | 定义 `enableVfSimCostmodelOptimization` 和 `dumpVfSimUnrollTest` pass options。 |
-| `tools/ptoas/ptoas.cpp` | `enableVfSimCostmodelOptimization` | 定义用户侧 `--enable-vfsim-costmodel-optimization`。 |
-| `tools/ptoas/ptoas.cpp` | `enableUnrollAfterLoopFusion` | 定义用户侧 `--enable-unroll-after-loop-fusion`。 |
-| `tools/ptoas/ptoas.cpp` | `compilePTOASModule` | 将 costmodel 选项传入 `FusionPlanOptions`；将 unroll 选项用于 VPTO 后端 pass 插入。 |
-| `lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp` | `runVfSimFusionPlanner` | 调用 `vfsim::planTileFusionIR`。 |
-| `lib/PTO/Transforms/TileFusion/PTOFusionRegionGen.cpp` | `getCommonSpanI64Attr` | 校验并提升 row/col unroll attrs 到 `pto.fusion_region`。 |
-| `lib/PTO/Transforms/TileFusion/PTOUnrollAfterLoopFusion.cpp` | `PTOUnrollAfterLoopFusion` | 消费 `pto.fusion_region` 上的 row/col unroll attrs。 |
+| `include/PTO/Transforms/Passes.td` | `FusionPlan` and `FusionPlanSearch` options | Defines the `enableVfSimCostmodelOptimization` and `dumpVfSimUnrollTest` pass options. |
+| `tools/ptoas/ptoas.cpp` | `enableVfSimCostmodelOptimization` | Defines the user-facing `--enable-vfsim-costmodel-optimization` option. |
+| `tools/ptoas/ptoas.cpp` | `enableUnrollAfterLoopFusion` | Defines the user-facing `--enable-unroll-after-loop-fusion` option. |
+| `tools/ptoas/ptoas.cpp` | `compilePTOASModule` | Passes the cost-model option to `FusionPlanOptions` and uses the unroll option to insert the VPTO backend pass. |
+| `lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp` | `runVfSimFusionPlanner` | Calls `vfsim::planTileFusionIR`. |
+| `lib/PTO/Transforms/TileFusion/PTOFusionPlanSearch.cpp` | `runVfSimFusionPlanner` | Calls `vfsim::planTileFusionIR` after selecting the highest-ranked fusion groups. |
+| `lib/PTO/Transforms/TileFusion/PTOFusionRegionGen.cpp` | `getCommonSpanI64Attr` | Validates and promotes the row/col unroll attributes to `pto.fusion_region`. |
+| `lib/PTO/Transforms/TileFusion/PTOUnrollAfterLoopFusion.cpp` | `PTOUnrollAfterLoopFusion` | Consumes the row/col unroll attributes on `pto.fusion_region`. |
 
 ## VfSim C++ API
 
-VfSim 向 PTOAS 暴露源码级 C++ API：
+VfSim exposes a source-level C++ API to PTOAS:
 
 ```cpp
 namespace vfsim {
@@ -110,39 +115,39 @@ mlir::LogicalResult planTileFusionIR(
 } // namespace vfsim
 ```
 
-接口约定：
+Interface contract:
 
-| 项 | 约定 |
+| Item | Contract |
 |---|---|
-| 输入 IR | FusionPlan 后的 MLIR operation；当前自动 tileop fusion 路线传入 `func::FuncOp`。 |
-| 输入内容 | PTOAS 已写好 `pto.fusion.group_id` 和 `pto.fusion.order` 的 tileop-level IR。 |
-| 输出方式 | VfSim 原地写回 `pto.fusion.row_unroll_factor` / `pto.fusion.col_unroll_factor`。 |
-| 返回值 | `success()` 表示 planner 完成、没有可处理 group，或某些 group 被 warning 降级跳过；`failure()` 表示接口级错误。 |
-| 修改范围 | Planner 只能写 attrs，不允许增删、替换、移动 op，也不允许修改 operand/result/type。 |
+| Input IR | An MLIR operation after `FusionPlan` or `FusionPlanSearch`; both paths pass a `func::FuncOp`. |
+| Input contents | Tileop-level IR on which PTOAS has already written `pto.fusion.group_id` and `pto.fusion.order`. |
+| Output method | VfSim writes `pto.fusion.row_unroll_factor` / `pto.fusion.col_unroll_factor` in place. |
+| Return value | `success()` means that the planner completed, found no processable groups, or skipped some groups after warning and falling back. `failure()` means an interface-level error. |
+| Allowed modifications | The planner may write attributes only. It must not add, remove, replace, or move operations, or modify operands, results, or types. |
 
-## 输入 IR
+## Input IR
 
-PTOAS 传给 VfSim 的 IR 必须已经包含：
+The IR passed from PTOAS to VfSim must already contain:
 
-| 属性 | 含义 |
+| Attribute | Meaning |
 |---|---|
-| `pto.fusion.group_id` | PTOAS 已选择的 fusion group ID。 |
-| `pto.fusion.order` | group 内 tileop 的执行顺序。 |
+| `pto.fusion.group_id` | The fusion-group ID selected by PTOAS. |
+| `pto.fusion.order` | The execution order of a tileop within the group. |
 
-VfSim 从 IR 中读取：
+VfSim reads the following information from the IR:
 
-| 信息 | 来源 |
+| Information | Source |
 |---|---|
-| group 边界 | `pto.fusion.group_id` |
-| group 内顺序 | `pto.fusion.order` |
-| tileop 类型 | MLIR op name，例如 `pto.tadd` |
-| 数据依赖 | SSA use-def |
-| 输入输出 value | tileop operands |
-| dtype | operand/result type |
-| shape | tile buffer type |
-| 模板参数 | tileop attrs |
+| Group boundaries | `pto.fusion.group_id` |
+| Order within a group | `pto.fusion.order` |
+| Tileop type | MLIR operation name, for example `pto.tadd` |
+| Data dependencies | SSA use-def chains |
+| Input and output values | Tileop operands |
+| Data type | Operand/result types |
+| Shape | Tile-buffer types |
+| Template parameters | Tileop attributes |
 
-示例：
+Example:
 
 ```mlir
 pto.tadd ins(%b, %c : !pto.tile_buf<vec, 32x128xf32>,
@@ -158,25 +163,27 @@ pto.tmul ins(%a, %b : !pto.tile_buf<vec, 32x128xf32>,
           pto.fusion.order = 1 : i64}
 ```
 
-VfSim 不重新判断这组 tileop 是否可以融合，只基于 PTOAS 已选 group 生成优化决策。
+VfSim does not reassess whether the tileops in a group may be fused. It makes
+optimization decisions only for groups already selected by PTOAS.
 
-## 输出 IR
+## Output IR
 
-VfSim 输出仍然是同一份 tileop-level IR，通过 attrs 表示优化计划：
+VfSim outputs the same tileop-level IR and represents its optimization plan
+through attributes:
 
-| 属性 | 含义 |
+| Attribute | Meaning |
 |---|---|
-| `pto.fusion.row_unroll_factor` | 当 row loop 是实际最内层 loop 时使用的 unroll factor。 |
-| `pto.fusion.col_unroll_factor` | 当 col loop 是实际最内层 loop 时使用的 unroll factor。 |
+| `pto.fusion.row_unroll_factor` | The unroll factor to use when the row loop is the actual innermost loop. |
+| `pto.fusion.col_unroll_factor` | The unroll factor to use when the column loop is the actual innermost loop. |
 
-当前 unroll 语义：
+Current unroll semantics:
 
-| 情况 | VfSim 输出 |
+| Condition | VfSim output |
 |---|---|
-| col trip count 为 1 | `row_unroll_factor > 1`，`col_unroll_factor = 1` |
-| col trip count 大于 1 | `row_unroll_factor = 1`，`col_unroll_factor > 1` |
+| Column trip count is 1 | `row_unroll_factor > 1`, `col_unroll_factor = 1` |
+| Column trip count is greater than 1 | `row_unroll_factor = 1`, `col_unroll_factor > 1` |
 
-示例：
+Example:
 
 ```mlir
 pto.tadd ... {
@@ -194,10 +201,10 @@ pto.tmul ... {
 }
 ```
 
-## RegionGen 属性提升
+## Attribute Promotion in RegionGen
 
-`FusionRegionGen` 会把同一个 group 包成 `pto.fusion_region`，并将一致的
-row/col unroll attrs 从 tileop 提升到 region：
+`FusionRegionGen` wraps each group in a `pto.fusion_region` and promotes
+consistent row/column unroll attributes from the tileops to the region:
 
 ```mlir
 %0 = pto.fusion_region {
@@ -211,33 +218,38 @@ row/col unroll attrs 从 tileop 提升到 region：
 } : !pto.tile_buf<vec, 32x128xf32>
 ```
 
-提升规则：
+Promotion rules:
 
-- 同一个 group 内，某个 unroll attr 要么所有成员都没有，要么所有成员都有。
-- 如果所有成员都有，值必须一致。
-- factor 必须是正整数。
-- 部分成员有、部分成员没有，或者值不一致，会报错。
+- For a given unroll attribute, either every member of a group has the
+  attribute or none of them do.
+- If every member has the attribute, all values must be identical.
+- The factor must be a positive integer.
+- An error is reported if only some members have the attribute or if their
+  values differ.
 
-## VPTO Unroll 消费
+## VPTO Unroll Consumption
 
-`PTOUnrollAfterLoopFusion` 在 VPTO low-level loop fusion 后运行。它读取
-`pto.fusion_region` 上的：
+`PTOUnrollAfterLoopFusion` runs after VPTO low-level loop fusion. It reads the
+following attributes from `pto.fusion_region`:
 
 ```text
 pto.fusion.row_unroll_factor
 pto.fusion.col_unroll_factor
 ```
 
-消费规则：
+Consumption rules:
 
-- 只展开当前最内层 `scf.for`。
-- 只处理常量 trip count，且 trip count 必须能被 factor 整除。
-- 当前约定下，col loop 存在时消费 `col_unroll_factor`；col loop 已被折叠后，
-  row loop 成为最内层时消费 `row_unroll_factor`。
-- 成功消费某个 factor 后，将该 region 上对应 attr 复位为 `1`，避免同一 factor
-  在后续 greedy/walk 过程中被重复应用。
+- Only the current innermost `scf.for` is unrolled.
+- Only constant trip counts are supported, and the trip count must be divisible
+  by the factor.
+- Under the current convention, `col_unroll_factor` is consumed when a column
+  loop exists. If the column loop has been folded, the row loop becomes the
+  innermost loop and `row_unroll_factor` is consumed.
+- After a factor is successfully consumed, the corresponding attribute on the
+  region is reset to `1` to prevent the same factor from being applied again
+  during subsequent greedy/walk processing.
 
-示意：
+Illustration:
 
 ```mlir
 // Before PTOUnrollAfterLoopFusion
@@ -267,41 +279,42 @@ pto.fusion_region {
 }
 ```
 
-## VfSim Planner 行为
+## VfSim Planner Behavior
 
-VfSim native planner 位于 `3rdparty/VfSimulator/native`。
+The native VfSim planner is located in `3rdparty/VfSimulator/native`.
 
-| 文件 | 作用 |
+| File | Purpose |
 |---|---|
-| `IRPlanner.h` | 定义 `PlannerOptions` 和 `planTileFusionIR`。 |
-| `IRPlanner.cpp` | 收集 fusion group，枚举 unroll candidate，调用 native VfInfo simulator，写回 attrs。 |
-| `TileOpTemplates.h/cpp` | 将 PTOAS tileop group lower 成 VfSim `VfInfo` micro-op program。 |
-| `ParamDB.h/cpp` | 加载 ISA/uarch/forwarding/initiation-interval 参数。 |
+| `IRPlanner.h` | Defines `PlannerOptions` and `planTileFusionIR`. |
+| `IRPlanner.cpp` | Collects fusion groups, enumerates unroll candidates, invokes the native `VfInfo` simulator, and writes the attributes back. |
+| `TileOpTemplates.h/cpp` | Lowers PTOAS tileop groups to VfSim `VfInfo` micro-op programs. |
+| `ParamDB.h/cpp` | Loads ISA, microarchitecture, forwarding, and initiation-interval parameters. |
 
-候选枚举规则：
+Candidate enumeration rules:
 
-- 搜索范围是 `1..maxUnroll`。
-- 当前默认 `maxUnroll = 8`。
-- 只考虑能够整除目标 loop trip count 的 factor。
+- The search range is `1..maxUnroll`.
+- The current default is `maxUnroll = 8`.
+- Only factors that evenly divide the target loop trip count are considered.
 
-降级诊断：
+Fallback diagnostics:
 
-| 场景 | 行为 |
+| Scenario | Behavior |
 |---|---|
-| 参数表加载失败 | 打印 warning，planner 对本次编译降级，不写 unroll attrs，PTOAS 继续编译。 |
-| group 中存在不支持的 tileop/template | 打印 warning，跳过该 group。 |
-| micro-op/dtype 参数缺失或所有 candidate 仿真失败 | 打印 warning，跳过该 group。 |
+| Parameter-table loading fails | Prints a warning, falls back for this compilation without writing unroll attributes, and allows PTOAS compilation to continue. |
+| A group contains an unsupported tileop/template | Prints a warning and skips that group. |
+| Micro-op/data-type parameters are missing, or simulation fails for every candidate | Prints a warning and skips that group. |
 
-`--dump-vfsim-unroll-test` 只额外打印候选值预测结果，例如：
+`--dump-vfsim-unroll-test` additionally prints predicted candidate results, for
+example:
 
 ```text
 unroll=1 trip=2 dtype=fp32 cycles=278
 unroll=2 trip=2 dtype=fp32 cycles=131
 ```
 
-## 当前模板覆盖范围
+## Current Template Coverage
 
-当前源码级 planner 主要覆盖 elementwise 风格 tileop。
+The current source-level planner primarily covers elementwise-style tileops.
 
 | TileOp | Micro-op |
 |---|---|
@@ -314,25 +327,26 @@ unroll=2 trip=2 dtype=fp32 cycles=131
 | `tabs` | `VABS` |
 | `texp` | `VEXP` |
 | `tadds` | `VADDS` |
-| `tsubs` | `VSUB`，标量通过 `VBR` 转成向量 |
+| `tsubs` | `VSUB`; the scalar is converted to a vector through `VBR` |
 | `tmuls` | `VMULS` |
-| `tdivs` | `VDIV`，标量通过 `VBR` 转成向量 |
+| `tdivs` | `VDIV`; the scalar is converted to a vector through `VBR` |
 | `tmaxs` | `VMAXS` |
 | `tmins` | `VMINS` |
-| `tcvt` | `VCVT_F16_TO_F32` 或 `VCVT_F32_TO_F16` |
+| `tcvt` | `VCVT_F16_TO_F32` or `VCVT_F32_TO_F16` |
 
-模板选择原则：
+Template-selection rules:
 
-- 根据 op name 选择 tileop 模板族。
-- 根据 dtype 选择 micro-op 参数和 vector lanes。
-- 根据 shape / valid shape 推导 row/col loop 结构。
-- 模板语义需要与 VPTO 后端 tileop template 保持一致。
+- Select the tileop template family based on the operation name.
+- Select micro-op parameters and vector lanes based on the data type.
+- Derive the row/column loop structure from the shape and valid shape.
+- Keep template semantics consistent with the VPTO backend tileop templates.
 
-## 手写 VF IR 扩展方向
+## Future Direction for Hand-Written VF IR
 
-除自动 tileop fusion 路线外，后续也可以支持开发者直接提供 VF/micro-op IR。
-该路线仍可复用源码级 submodule 接入方式，但输入不再是 tileop group，而是开发者
-已经写好的 VF IR。
+In addition to the automatic tileop-fusion path, a future extension could allow
+developers to provide VF/micro-op IR directly. This path could reuse the
+source-level submodule integration, but its input would be developer-authored VF
+IR rather than a tileop group.
 
 ```text
 developer VF IR
@@ -340,4 +354,5 @@ developer VF IR
   -> VF IR with cost/advice attrs or diagnostic report
 ```
 
-该路线不决定 fusion group，而是评估已有 VF 实现，并给出预测和优化建议。
+This path would not select fusion groups. It would evaluate an existing VF
+implementation and provide predictions and optimization advice.

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -85,6 +85,9 @@ std::unique_ptr<Pass> createPrintPreFusionAnalysisPass();
 std::unique_ptr<Pass> createFusionPlanPass();
 std::unique_ptr<Pass>
 createFusionPlanPass(const FusionPlanOptions &options);
+std::unique_ptr<Pass> createFusionPlanSearchPass();
+std::unique_ptr<Pass>
+createFusionPlanSearchPass(const FusionPlanSearchOptions &options);
 std::unique_ptr<Pass> createOpSchedulingPass();
 std::unique_ptr<Pass> createPTOMarkLastUsePass();
 std::unique_ptr<Pass> createPTOFusionRegionGenPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -294,6 +294,27 @@ def FusionPlan : Pass<"pto-fusion-plan", "func::FuncOp"> {
   ];
 }
 
+def FusionPlanSearch : Pass<"pto-fusion-plan-search", "func::FuncOp"> {
+  let summary = "Search competing tile-fusion groups from block-local analysis";
+  let description = [{
+    Consumes PreFusionAnalysis results, explores a bounded frontier of
+    competing block-local fusion groups for currently supported tile-native
+    compute ops, chooses the highest-ranked group, and annotates accepted group
+    members with:
+      - pto.fusion.group_id
+      - pto.fusion.order
+  }];
+  let constructor = "mlir::pto::createFusionPlanSearchPass()";
+  let dependentDialects = ["mlir::pto::PTODialect"];
+  let options = [
+    Option<"enableShapeInference", "enable-shape-inference",
+           "bool", /*default=*/"false",
+           "Enable shape inference (ShapeConstraintSolver) for tile fusion. "
+           "When disabled (default), fall back to static/direct-bound "
+           "iteration-domain inference.">
+  ];
+}
+
 def OpScheduling : Pass<"pto-op-scheduling", "func::FuncOp"> {
   let summary = "Compact planned fusion groups into block-local contiguous spans";
   let description = [{

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -277,7 +277,8 @@ def FusionPlan : Pass<"pto-fusion-plan", "func::FuncOp"> {
            "bool", /*default=*/"false",
            "Enable shape inference (ShapeConstraintSolver) for tile fusion. "
            "When disabled (default), fall back to static/direct-bound "
-           "iteration-domain inference.  Only FusionPlan consumes this option; "
+           "iteration-domain inference. Only fusion planning passes consume "
+           "this option; "
            "FusionRegionGen consumes only the shared pre-fusion dataflow graph "
            "(cached by the analysis manager) and never consults iteration-domain "
            "classes, so it does not need the option.">,
@@ -303,6 +304,8 @@ def FusionPlanSearch : Pass<"pto-fusion-plan-search", "func::FuncOp"> {
     members with:
       - pto.fusion.group_id
       - pto.fusion.order
+    When enabled, the optional VfSimulator post-planning step may also annotate
+    pto.fusion.row_unroll_factor and pto.fusion.col_unroll_factor.
   }];
   let constructor = "mlir::pto::createFusionPlanSearchPass()";
   let dependentDialects = ["mlir::pto::PTODialect"];
@@ -311,7 +314,17 @@ def FusionPlanSearch : Pass<"pto-fusion-plan-search", "func::FuncOp"> {
            "bool", /*default=*/"false",
            "Enable shape inference (ShapeConstraintSolver) for tile fusion. "
            "When disabled (default), fall back to static/direct-bound "
-           "iteration-domain inference.">
+           "iteration-domain inference.">,
+    Option<"enableVfSimCostmodelOptimization",
+           "enable-vfsim-costmodel-optimization",
+           "bool", /*default=*/"false",
+           "Invoke the optional VfSimulator costmodel planner after PTOAS has "
+           "emitted FusionPlanSearch group/order metadata.">,
+    Option<"dumpVfSimUnrollTest", "dump-vfsim-unroll-test",
+           "bool", /*default=*/"false",
+           "Print VfSimulator unroll candidate timings for accepted fusion "
+           "groups. This is a debug dump only and does not enable or disable "
+           "the VfSimulator planner.">
   ];
 }
 

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -17,6 +17,7 @@ add_mlir_dialect_library(PTOTransforms
   TileFusion/PTOPreFusionAnalysis.cpp
   TileFusion/PTOPrintPreFusionAnalysis.cpp
   TileFusion/PTOFusionPlan.cpp
+  TileFusion/PTOFusionPlanSearch.cpp
   TileFusion/PTOOpScheduling.cpp
   TileFusion/PTOMarkLastUse.cpp
   TileFusion/PTOFusionRegionGen.cpp

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
@@ -523,6 +523,9 @@ public:
 };
 
 class ConservativeDAGGreedyStrategyEngine final : public StrategyEngine {
+  // Keep a bounded, deterministically ranked frontier to prevent exponential
+  // compile-time growth. This selects the best group among retained candidates;
+  // it does not guarantee the global optimum across every connected subset.
   static constexpr unsigned kMaxCandidatesPerGroupSize = 64;
 
   struct GroupCandidate {

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
@@ -21,6 +21,7 @@
 #include "llvm/ADT/StringSwitch.h"
 
 #include <algorithm>
+#include <optional>
 
 #ifdef PTO_ENABLE_VFSIM_IR_PLANNER
 #include "native/IRPlanner.h"
@@ -522,6 +523,56 @@ public:
 };
 
 class ConservativeDAGGreedyStrategyEngine final : public StrategyEngine {
+  static constexpr unsigned kMaxCandidatesPerGroupSize = 64;
+
+  struct GroupCandidate {
+    SmallVector<const pto::FusionComputeNode *, 8> members;
+    DenseSet<unsigned> memberIds;
+    PlanningCost cost;
+  };
+
+  static bool haveSameMembers(const GroupCandidate &lhs,
+                              const GroupCandidate &rhs) {
+    if (lhs.members.size() != rhs.members.size())
+      return false;
+    return llvm::equal(
+        lhs.members, rhs.members,
+        [](const pto::FusionComputeNode *lhsNode,
+           const pto::FusionComputeNode *rhsNode) {
+          return lhsNode->id == rhsNode->id;
+        });
+  }
+
+  static bool isBetterCandidate(const GroupCandidate &lhs,
+                                const GroupCandidate &rhs) {
+    if (lhs.cost.total() != rhs.cost.total())
+      return lhs.cost.total() > rhs.cost.total();
+    if (lhs.members.size() != rhs.members.size())
+      return lhs.members.size() > rhs.members.size();
+
+    for (auto [lhsNode, rhsNode] : llvm::zip(lhs.members, rhs.members)) {
+      if (lhsNode->blockOrder != rhsNode->blockOrder)
+        return lhsNode->blockOrder < rhsNode->blockOrder;
+      if (lhsNode->id != rhsNode->id)
+        return lhsNode->id < rhsNode->id;
+    }
+    return false;
+  }
+
+  static void
+  addOrUpdateCandidate(SmallVectorImpl<GroupCandidate> &candidates,
+                       GroupCandidate candidate) {
+    auto existing = llvm::find_if(candidates, [&](const GroupCandidate &other) {
+      return haveSameMembers(candidate, other);
+    });
+    if (existing == candidates.end()) {
+      candidates.push_back(std::move(candidate));
+      return;
+    }
+    if (isBetterCandidate(candidate, *existing))
+      *existing = std::move(candidate);
+  }
+
 public:
   SmallVector<PlannedFusionGroup, 8>
   planBlock(const PlanningContext &ctx,
@@ -537,36 +588,57 @@ public:
       if (!seedDecision.accept)
         continue;
 
-      SmallVector<const pto::FusionComputeNode *, 8> groupMembers;
-      DenseSet<unsigned> groupNodeIds;
-      groupMembers.push_back(&seed);
-      groupNodeIds.insert(seed.id);
+      GroupCandidate seedCandidate;
+      seedCandidate.members.push_back(&seed);
+      seedCandidate.memberIds.insert(seed.id);
+      seedCandidate.cost =
+          costModel.evaluateGroup(ctx, seedCandidate.members);
 
-      bool changed = true;
-      while (changed) {
-        changed = false;
-        for (const pto::FusionComputeNode &candidate :
-             ctx.blockAnalysis.computeNodes) {
-          if (assignedNodes.contains(candidate.id) ||
-              groupNodeIds.contains(candidate.id))
-            continue;
+      SmallVector<GroupCandidate, 64> frontier;
+      frontier.push_back(std::move(seedCandidate));
+      std::optional<GroupCandidate> bestCandidate;
 
-          PlanningDecision appendDecision =
-              costModel.evaluateAppend(ctx, groupMembers, candidate);
-          if (!appendDecision.accept)
-            continue;
+      while (!frontier.empty()) {
+        SmallVector<GroupCandidate, 64> nextFrontier;
+        for (const GroupCandidate &current : frontier) {
+          for (const pto::FusionComputeNode &candidate :
+               ctx.blockAnalysis.computeNodes) {
+            if (assignedNodes.contains(candidate.id) ||
+                current.memberIds.contains(candidate.id))
+              continue;
 
-          groupMembers.push_back(&candidate);
-          groupNodeIds.insert(candidate.id);
-          changed = true;
+            PlanningDecision appendDecision =
+                costModel.evaluateAppend(ctx, current.members, candidate);
+            if (!appendDecision.accept)
+              continue;
+
+            GroupCandidate successor = current;
+            successor.members.push_back(&candidate);
+            successor.members = buildStableInGroupOrder(successor.members);
+            successor.memberIds.insert(candidate.id);
+            successor.cost =
+                costModel.evaluateGroup(ctx, successor.members);
+            addOrUpdateCandidate(nextFrontier, std::move(successor));
+          }
         }
+
+        llvm::stable_sort(nextFrontier, isBetterCandidate);
+        if (nextFrontier.size() > kMaxCandidatesPerGroupSize)
+          nextFrontier.resize(kMaxCandidatesPerGroupSize);
+
+        for (const GroupCandidate &candidate : nextFrontier)
+          if (!bestCandidate ||
+              isBetterCandidate(candidate, *bestCandidate))
+            bestCandidate = candidate;
+
+        frontier = std::move(nextFrontier);
       }
 
-      if (groupMembers.size() < 2)
+      if (!bestCandidate || bestCandidate->members.size() < 2)
         continue;
 
       PlannedFusionGroup group;
-      group.members = buildStableInGroupOrder(groupMembers);
+      group.members = bestCandidate->members;
       groups.push_back(group);
       for (const pto::FusionComputeNode *member : group.members)
         assignedNodes.insert(member->id);

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
@@ -253,6 +253,31 @@ countConnectionsToGroup(const pto::FusionBlockAnalysis &blockAnalysis,
   return connections;
 }
 
+static unsigned
+countInternalEdges(const pto::FusionBlockAnalysis &blockAnalysis,
+                   ArrayRef<const pto::FusionComputeNode *> group) {
+  DenseSet<unsigned> memberIds;
+  for (const pto::FusionComputeNode *member : group)
+    memberIds.insert(member->id);
+
+  return llvm::count_if(blockAnalysis.edges,
+                        [&](const pto::FusionDFGEdge &edge) {
+                          return memberIds.contains(edge.producerNode) &&
+                                 memberIds.contains(edge.consumerNode);
+                        });
+}
+
+static unsigned
+countInternalConnections(const pto::FusionBlockAnalysis &blockAnalysis,
+                         ArrayRef<const pto::FusionComputeNode *> group) {
+  unsigned connections = 0;
+  for (auto [index, lhs] : llvm::enumerate(group))
+    for (const pto::FusionComputeNode *rhs : group.drop_front(index + 1))
+      if (nodesHaveDirectDataFlowConnection(blockAnalysis, *lhs, *rhs))
+        ++connections;
+  return connections;
+}
+
 static GroupFootprint
 computeGroupFootprint(ArrayRef<const pto::FusionComputeNode *> members) {
   DenseSet<Value> producedTiles;
@@ -280,6 +305,22 @@ computeGroupFootprint(ArrayRef<const pto::FusionComputeNode *> members) {
   return footprint;
 }
 
+static PlanningCost
+computePlanningCost(ArrayRef<const pto::FusionComputeNode *> members,
+                    unsigned connectionCount, int64_t loopMergeBenefit,
+                    unsigned liveTileLimit, unsigned vfParameterLimit) {
+  GroupFootprint footprint = computeGroupFootprint(members);
+
+  PlanningCost cost;
+  cost.dependencyBenefit = 4 * static_cast<int64_t>(connectionCount);
+  cost.loopMergeBenefit = loopMergeBenefit;
+  cost.liveTilePenalty = std::max<int64_t>(
+      0, static_cast<int64_t>(footprint.liveTileCount) - liveTileLimit);
+  cost.vfParameterPenalty = std::max<int64_t>(
+      0, static_cast<int64_t>(footprint.vfParameterCount) - vfParameterLimit);
+  return cost;
+}
+
 class CostModel {
 public:
   virtual ~CostModel() = default;
@@ -287,6 +328,10 @@ public:
   virtual PlanningDecision evaluateSeed(const PlanningContext &ctx,
                                         const pto::FusionComputeNode &candidate)
       const = 0;
+
+  virtual PlanningCost
+  evaluateGroup(const PlanningContext &ctx,
+                ArrayRef<const pto::FusionComputeNode *> members) const = 0;
 
   virtual PlanningDecision
   evaluateAppend(const PlanningContext &ctx,
@@ -310,6 +355,14 @@ public:
 
     decision.accept = true;
     return decision;
+  }
+
+  PlanningCost evaluateGroup(
+      const PlanningContext &ctx,
+      ArrayRef<const pto::FusionComputeNode *> members) const override {
+    return computePlanningCost(
+        members, countInternalEdges(ctx.blockAnalysis, members),
+        /*loopMergeBenefit=*/2, /*liveTileLimit=*/4, /*vfParameterLimit=*/6);
   }
 
   PlanningDecision
@@ -339,16 +392,10 @@ public:
     SmallVector<const pto::FusionComputeNode *, 8> proposedGroup(
         currentGroup.begin(), currentGroup.end());
     proposedGroup.push_back(&candidate);
-    GroupFootprint footprint = computeGroupFootprint(proposedGroup);
-
-    decision.cost.dependencyBenefit =
-        4 * static_cast<int64_t>(
-                countEdgesFromGroup(ctx.blockAnalysis, currentGroup, candidate));
-    decision.cost.loopMergeBenefit = 2;
-    decision.cost.liveTilePenalty =
-        std::max<int64_t>(0, static_cast<int64_t>(footprint.liveTileCount) - 4);
-    decision.cost.vfParameterPenalty = std::max<int64_t>(
-        0, static_cast<int64_t>(footprint.vfParameterCount) - 6);
+    decision.cost = computePlanningCost(
+        proposedGroup,
+        countEdgesFromGroup(ctx.blockAnalysis, currentGroup, candidate),
+        /*loopMergeBenefit=*/2, /*liveTileLimit=*/4, /*vfParameterLimit=*/6);
     decision.accept = decision.cost.total() > 0;
     return decision;
   }
@@ -370,6 +417,15 @@ public:
 
     decision.accept = true;
     return decision;
+  }
+
+  PlanningCost evaluateGroup(
+      const PlanningContext &ctx,
+      ArrayRef<const pto::FusionComputeNode *> members) const override {
+    return computePlanningCost(
+        members, countInternalConnections(ctx.blockAnalysis, members),
+        /*loopMergeBenefit=*/4, /*liveTileLimit=*/10,
+        /*vfParameterLimit=*/12);
   }
 
   PlanningDecision
@@ -401,14 +457,9 @@ public:
     SmallVector<const pto::FusionComputeNode *, 8> proposedGroup(
         currentGroup.begin(), currentGroup.end());
     proposedGroup.push_back(&candidate);
-    GroupFootprint footprint = computeGroupFootprint(proposedGroup);
-
-    decision.cost.dependencyBenefit = 4 * static_cast<int64_t>(connectionCount);
-    decision.cost.loopMergeBenefit = 4;
-    decision.cost.liveTilePenalty = std::max<int64_t>(
-        0, static_cast<int64_t>(footprint.liveTileCount) - 10);
-    decision.cost.vfParameterPenalty = std::max<int64_t>(
-        0, static_cast<int64_t>(footprint.vfParameterCount) - 12);
+    decision.cost = computePlanningCost(
+        proposedGroup, connectionCount, /*loopMergeBenefit=*/4,
+        /*liveTileLimit=*/10, /*vfParameterLimit=*/12);
     decision.accept = decision.cost.total() > 0;
     return decision;
   }

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlanSearch.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlanSearch.cpp
@@ -6,6 +6,10 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+// This pass owns the bounded, cost-ranked search across competing DFG paths.
+// PTOFusionPlan.cpp intentionally retains the original single-path greedy
+// planner used by the production fusion pipeline.
+
 #include "PTO/Transforms/TileFusion/FusionAnalysis.h"
 #include "PTO/Transforms/TileFusion/FusionOpSemantics.h"
 
@@ -21,19 +25,16 @@
 #include "llvm/ADT/StringSwitch.h"
 
 #include <algorithm>
-
-#ifdef PTO_ENABLE_VFSIM_IR_PLANNER
-#include "native/IRPlanner.h"
-#endif
+#include <optional>
 
 namespace mlir {
 namespace pto {
 // Passes.h (included above) pulls in the global GEN_PASS_DECL block, which
-// defines GEN_PASS_DECL_FUSIONPLAN and leaves it set.  Undef it before
+// defines GEN_PASS_DECL_FUSIONPLANSEARCH and leaves it set.  Undef it before
 // re-including the .inc for GEN_PASS_DEF so the options struct is not defined
 // twice.
-#undef GEN_PASS_DECL_FUSIONPLAN
-#define GEN_PASS_DEF_FUSIONPLAN
+#undef GEN_PASS_DECL_FUSIONPLANSEARCH
+#define GEN_PASS_DEF_FUSIONPLANSEARCH
 #include "PTO/Transforms/Passes.h.inc"
 } // namespace pto
 } // namespace mlir
@@ -42,13 +43,8 @@ using namespace mlir;
 
 namespace {
 
-static constexpr llvm::StringLiteral kFusionGroupIdAttr =
-    "pto.fusion.group_id";
+static constexpr llvm::StringLiteral kFusionGroupIdAttr = "pto.fusion.group_id";
 static constexpr llvm::StringLiteral kFusionOrderAttr = "pto.fusion.order";
-static constexpr llvm::StringLiteral kFusionRowUnrollAttr =
-    "pto.fusion.row_unroll_factor";
-static constexpr llvm::StringLiteral kFusionColUnrollAttr =
-    "pto.fusion.col_unroll_factor";
 
 struct PlannedFusionGroup {
   SmallVector<const pto::FusionComputeNode *, 8> members;
@@ -88,9 +84,9 @@ static bool isCurrentlyPlannableOp(StringRef opName) {
       .Default(false);
 }
 
-static bool isProvenIterationDomain(
-    const pto::FusionBlockAnalysis &blockAnalysis,
-    const pto::FusionComputeNode &node) {
+static bool
+isProvenIterationDomain(const pto::FusionBlockAnalysis &blockAnalysis,
+                        const pto::FusionComputeNode &node) {
   if (node.iterationDomainClass >= blockAnalysis.iterationDomainClasses.size())
     return false;
   return blockAnalysis.iterationDomainClasses[node.iterationDomainClass]
@@ -99,10 +95,8 @@ static bool isProvenIterationDomain(
 
 static bool hasHardBoundaryBetween(const pto::FusionComputeNode &a,
                                    const pto::FusionComputeNode &b) {
-  const pto::FusionComputeNode &earlier =
-      a.blockOrder < b.blockOrder ? a : b;
-  const pto::FusionComputeNode &later =
-      a.blockOrder < b.blockOrder ? b : a;
+  const pto::FusionComputeNode &earlier = a.blockOrder < b.blockOrder ? a : b;
+  const pto::FusionComputeNode &later = a.blockOrder < b.blockOrder ? b : a;
 
   Operation *cursor = earlier.op->getNextNode();
   while (cursor && cursor != later.op) {
@@ -114,19 +108,18 @@ static bool hasHardBoundaryBetween(const pto::FusionComputeNode &a,
   return false;
 }
 
-static bool hasHardBoundaryToGroup(
-    ArrayRef<const pto::FusionComputeNode *> group,
-    const pto::FusionComputeNode &candidate) {
+static bool
+hasHardBoundaryToGroup(ArrayRef<const pto::FusionComputeNode *> group,
+                       const pto::FusionComputeNode &candidate) {
   for (const pto::FusionComputeNode *member : group)
     if (hasHardBoundaryBetween(*member, candidate))
       return true;
   return false;
 }
 
-static bool dependsOnPreviousNode(
-    const pto::FusionBlockAnalysis &blockAnalysis,
-    const pto::FusionComputeNode &previous,
-    const pto::FusionComputeNode &current) {
+static bool dependsOnPreviousNode(const pto::FusionBlockAnalysis &blockAnalysis,
+                                  const pto::FusionComputeNode &previous,
+                                  const pto::FusionComputeNode &current) {
   for (unsigned edgeId : current.incomingEdges) {
     if (edgeId >= blockAnalysis.edges.size())
       continue;
@@ -155,8 +148,7 @@ buildStableInGroupOrder(ArrayRef<const pto::FusionComputeNode *> members) {
 }
 
 static void assignStableGroupMetadata(ArrayRef<PlannedFusionGroup> groups,
-                                      MLIRContext *ctx,
-                                      int64_t &nextGroupId) {
+                                      MLIRContext *ctx, int64_t &nextGroupId) {
   SmallVector<const PlannedFusionGroup *, 8> orderedGroups;
   orderedGroups.reserve(groups.size());
   for (const PlannedFusionGroup &group : groups)
@@ -178,10 +170,9 @@ static void assignStableGroupMetadata(ArrayRef<PlannedFusionGroup> groups,
     for (auto [order, node] : llvm::enumerate(stableOrder)) {
       node->op->setAttr(kFusionGroupIdAttr,
                         IntegerAttr::get(IntegerType::get(ctx, 64), groupId));
-      node->op->setAttr(
-          kFusionOrderAttr,
-          IntegerAttr::get(IntegerType::get(ctx, 64),
-                           static_cast<int64_t>(order)));
+      node->op->setAttr(kFusionOrderAttr,
+                        IntegerAttr::get(IntegerType::get(ctx, 64),
+                                         static_cast<int64_t>(order)));
     }
   }
 }
@@ -214,9 +205,10 @@ struct GroupFootprint {
   unsigned vfParameterCount = 0;
 };
 
-static bool nodesHaveDirectDataFlowConnection(
-    const pto::FusionBlockAnalysis &blockAnalysis,
-    const pto::FusionComputeNode &lhs, const pto::FusionComputeNode &rhs) {
+static bool
+nodesHaveDirectDataFlowConnection(const pto::FusionBlockAnalysis &blockAnalysis,
+                                  const pto::FusionComputeNode &lhs,
+                                  const pto::FusionComputeNode &rhs) {
   for (unsigned edgeId : lhs.outgoingEdges) {
     if (edgeId >= blockAnalysis.edges.size())
       continue;
@@ -253,6 +245,31 @@ countConnectionsToGroup(const pto::FusionBlockAnalysis &blockAnalysis,
   return connections;
 }
 
+static unsigned
+countInternalEdges(const pto::FusionBlockAnalysis &blockAnalysis,
+                   ArrayRef<const pto::FusionComputeNode *> group) {
+  DenseSet<unsigned> memberIds;
+  for (const pto::FusionComputeNode *member : group)
+    memberIds.insert(member->id);
+
+  return llvm::count_if(blockAnalysis.edges,
+                        [&](const pto::FusionDFGEdge &edge) {
+                          return memberIds.contains(edge.producerNode) &&
+                                 memberIds.contains(edge.consumerNode);
+                        });
+}
+
+static unsigned
+countInternalConnections(const pto::FusionBlockAnalysis &blockAnalysis,
+                         ArrayRef<const pto::FusionComputeNode *> group) {
+  unsigned connections = 0;
+  for (auto [index, lhs] : llvm::enumerate(group))
+    for (const pto::FusionComputeNode *rhs : group.drop_front(index + 1))
+      if (nodesHaveDirectDataFlowConnection(blockAnalysis, *lhs, *rhs))
+        ++connections;
+  return connections;
+}
+
 static GroupFootprint
 computeGroupFootprint(ArrayRef<const pto::FusionComputeNode *> members) {
   DenseSet<Value> producedTiles;
@@ -280,13 +297,33 @@ computeGroupFootprint(ArrayRef<const pto::FusionComputeNode *> members) {
   return footprint;
 }
 
+static PlanningCost
+computePlanningCost(ArrayRef<const pto::FusionComputeNode *> members,
+                    unsigned connectionCount, int64_t loopMergeBenefit,
+                    unsigned liveTileLimit, unsigned vfParameterLimit) {
+  GroupFootprint footprint = computeGroupFootprint(members);
+
+  PlanningCost cost;
+  cost.dependencyBenefit = 4 * static_cast<int64_t>(connectionCount);
+  cost.loopMergeBenefit = loopMergeBenefit;
+  cost.liveTilePenalty = std::max<int64_t>(
+      0, static_cast<int64_t>(footprint.liveTileCount) - liveTileLimit);
+  cost.vfParameterPenalty = std::max<int64_t>(
+      0, static_cast<int64_t>(footprint.vfParameterCount) - vfParameterLimit);
+  return cost;
+}
+
 class CostModel {
 public:
   virtual ~CostModel() = default;
 
-  virtual PlanningDecision evaluateSeed(const PlanningContext &ctx,
-                                        const pto::FusionComputeNode &candidate)
-      const = 0;
+  virtual PlanningDecision
+  evaluateSeed(const PlanningContext &ctx,
+               const pto::FusionComputeNode &candidate) const = 0;
+
+  virtual PlanningCost
+  evaluateGroup(const PlanningContext &ctx,
+                ArrayRef<const pto::FusionComputeNode *> members) const = 0;
 
   virtual PlanningDecision
   evaluateAppend(const PlanningContext &ctx,
@@ -310,6 +347,14 @@ public:
 
     decision.accept = true;
     return decision;
+  }
+
+  PlanningCost evaluateGroup(
+      const PlanningContext &ctx,
+      ArrayRef<const pto::FusionComputeNode *> members) const override {
+    return computePlanningCost(
+        members, countInternalEdges(ctx.blockAnalysis, members),
+        /*loopMergeBenefit=*/2, /*liveTileLimit=*/4, /*vfParameterLimit=*/6);
   }
 
   PlanningDecision
@@ -339,16 +384,10 @@ public:
     SmallVector<const pto::FusionComputeNode *, 8> proposedGroup(
         currentGroup.begin(), currentGroup.end());
     proposedGroup.push_back(&candidate);
-    GroupFootprint footprint = computeGroupFootprint(proposedGroup);
-
-    decision.cost.dependencyBenefit =
-        4 * static_cast<int64_t>(
-                countEdgesFromGroup(ctx.blockAnalysis, currentGroup, candidate));
-    decision.cost.loopMergeBenefit = 2;
-    decision.cost.liveTilePenalty =
-        std::max<int64_t>(0, static_cast<int64_t>(footprint.liveTileCount) - 4);
-    decision.cost.vfParameterPenalty = std::max<int64_t>(
-        0, static_cast<int64_t>(footprint.vfParameterCount) - 6);
+    decision.cost = computePlanningCost(
+        proposedGroup,
+        countEdgesFromGroup(ctx.blockAnalysis, currentGroup, candidate),
+        /*loopMergeBenefit=*/2, /*liveTileLimit=*/4, /*vfParameterLimit=*/6);
     decision.accept = decision.cost.total() > 0;
     return decision;
   }
@@ -370,6 +409,15 @@ public:
 
     decision.accept = true;
     return decision;
+  }
+
+  PlanningCost evaluateGroup(
+      const PlanningContext &ctx,
+      ArrayRef<const pto::FusionComputeNode *> members) const override {
+    return computePlanningCost(
+        members, countInternalConnections(ctx.blockAnalysis, members),
+        /*loopMergeBenefit=*/4, /*liveTileLimit=*/10,
+        /*vfParameterLimit=*/12);
   }
 
   PlanningDecision
@@ -401,14 +449,9 @@ public:
     SmallVector<const pto::FusionComputeNode *, 8> proposedGroup(
         currentGroup.begin(), currentGroup.end());
     proposedGroup.push_back(&candidate);
-    GroupFootprint footprint = computeGroupFootprint(proposedGroup);
-
-    decision.cost.dependencyBenefit = 4 * static_cast<int64_t>(connectionCount);
-    decision.cost.loopMergeBenefit = 4;
-    decision.cost.liveTilePenalty = std::max<int64_t>(
-        0, static_cast<int64_t>(footprint.liveTileCount) - 10);
-    decision.cost.vfParameterPenalty = std::max<int64_t>(
-        0, static_cast<int64_t>(footprint.vfParameterCount) - 12);
+    decision.cost = computePlanningCost(
+        proposedGroup, connectionCount, /*loopMergeBenefit=*/4,
+        /*liveTileLimit=*/10, /*vfParameterLimit=*/12);
     decision.accept = decision.cost.total() > 0;
     return decision;
   }
@@ -470,7 +513,58 @@ public:
   }
 };
 
-class ConservativeDAGGreedyStrategyEngine final : public StrategyEngine {
+class CostGuidedSearchStrategyEngine final : public StrategyEngine {
+  // Keep a bounded, deterministically ranked frontier to prevent exponential
+  // compile-time growth. This selects the best group among retained candidates;
+  // it does not guarantee the global optimum across every connected subset.
+  static constexpr unsigned kMaxCandidatesPerGroupSize = 64;
+
+  struct GroupCandidate {
+    SmallVector<const pto::FusionComputeNode *, 8> members;
+    DenseSet<unsigned> memberIds;
+    PlanningCost cost;
+  };
+
+  static bool haveSameMembers(const GroupCandidate &lhs,
+                              const GroupCandidate &rhs) {
+    if (lhs.members.size() != rhs.members.size())
+      return false;
+    return llvm::equal(lhs.members, rhs.members,
+                       [](const pto::FusionComputeNode *lhsNode,
+                          const pto::FusionComputeNode *rhsNode) {
+                         return lhsNode->id == rhsNode->id;
+                       });
+  }
+
+  static bool isBetterCandidate(const GroupCandidate &lhs,
+                                const GroupCandidate &rhs) {
+    if (lhs.cost.total() != rhs.cost.total())
+      return lhs.cost.total() > rhs.cost.total();
+    if (lhs.members.size() != rhs.members.size())
+      return lhs.members.size() > rhs.members.size();
+
+    for (auto [lhsNode, rhsNode] : llvm::zip(lhs.members, rhs.members)) {
+      if (lhsNode->blockOrder != rhsNode->blockOrder)
+        return lhsNode->blockOrder < rhsNode->blockOrder;
+      if (lhsNode->id != rhsNode->id)
+        return lhsNode->id < rhsNode->id;
+    }
+    return false;
+  }
+
+  static void addOrUpdateCandidate(SmallVectorImpl<GroupCandidate> &candidates,
+                                   GroupCandidate candidate) {
+    auto existing = llvm::find_if(candidates, [&](const GroupCandidate &other) {
+      return haveSameMembers(candidate, other);
+    });
+    if (existing == candidates.end()) {
+      candidates.push_back(std::move(candidate));
+      return;
+    }
+    if (isBetterCandidate(candidate, *existing))
+      *existing = std::move(candidate);
+  }
+
 public:
   SmallVector<PlannedFusionGroup, 8>
   planBlock(const PlanningContext &ctx,
@@ -486,36 +580,54 @@ public:
       if (!seedDecision.accept)
         continue;
 
-      SmallVector<const pto::FusionComputeNode *, 8> groupMembers;
-      DenseSet<unsigned> groupNodeIds;
-      groupMembers.push_back(&seed);
-      groupNodeIds.insert(seed.id);
+      GroupCandidate seedCandidate;
+      seedCandidate.members.push_back(&seed);
+      seedCandidate.memberIds.insert(seed.id);
+      seedCandidate.cost = costModel.evaluateGroup(ctx, seedCandidate.members);
 
-      bool changed = true;
-      while (changed) {
-        changed = false;
-        for (const pto::FusionComputeNode &candidate :
-             ctx.blockAnalysis.computeNodes) {
-          if (assignedNodes.contains(candidate.id) ||
-              groupNodeIds.contains(candidate.id))
-            continue;
+      SmallVector<GroupCandidate, 64> frontier;
+      frontier.push_back(std::move(seedCandidate));
+      std::optional<GroupCandidate> bestCandidate;
 
-          PlanningDecision appendDecision =
-              costModel.evaluateAppend(ctx, groupMembers, candidate);
-          if (!appendDecision.accept)
-            continue;
+      while (!frontier.empty()) {
+        SmallVector<GroupCandidate, 64> nextFrontier;
+        for (const GroupCandidate &current : frontier) {
+          for (const pto::FusionComputeNode &candidate :
+               ctx.blockAnalysis.computeNodes) {
+            if (assignedNodes.contains(candidate.id) ||
+                current.memberIds.contains(candidate.id))
+              continue;
 
-          groupMembers.push_back(&candidate);
-          groupNodeIds.insert(candidate.id);
-          changed = true;
+            PlanningDecision appendDecision =
+                costModel.evaluateAppend(ctx, current.members, candidate);
+            if (!appendDecision.accept)
+              continue;
+
+            GroupCandidate successor = current;
+            successor.members.push_back(&candidate);
+            successor.members = buildStableInGroupOrder(successor.members);
+            successor.memberIds.insert(candidate.id);
+            successor.cost = costModel.evaluateGroup(ctx, successor.members);
+            addOrUpdateCandidate(nextFrontier, std::move(successor));
+          }
         }
+
+        llvm::stable_sort(nextFrontier, isBetterCandidate);
+        if (nextFrontier.size() > kMaxCandidatesPerGroupSize)
+          nextFrontier.resize(kMaxCandidatesPerGroupSize);
+
+        for (const GroupCandidate &candidate : nextFrontier)
+          if (!bestCandidate || isBetterCandidate(candidate, *bestCandidate))
+            bestCandidate = candidate;
+
+        frontier = std::move(nextFrontier);
       }
 
-      if (groupMembers.size() < 2)
+      if (!bestCandidate || bestCandidate->members.size() < 2)
         continue;
 
       PlannedFusionGroup group;
-      group.members = buildStableInGroupOrder(groupMembers);
+      group.members = bestCandidate->members;
       groups.push_back(group);
       for (const pto::FusionComputeNode *member : group.members)
         assignedNodes.insert(member->id);
@@ -529,28 +641,15 @@ static void clearPlanningAttrs(func::FuncOp func) {
   func.walk([](Operation *op) {
     op->removeAttr(kFusionGroupIdAttr);
     op->removeAttr(kFusionOrderAttr);
-    op->removeAttr(kFusionRowUnrollAttr);
-    op->removeAttr(kFusionColUnrollAttr);
   });
 }
 
-static LogicalResult runVfSimFusionPlanner(func::FuncOp func,
-                                           bool dumpCandidates) {
-#ifdef PTO_ENABLE_VFSIM_IR_PLANNER
-  vfsim::PlannerOptions options;
-  options.dumpCandidates = dumpCandidates;
-  return vfsim::planTileFusionIR(func.getOperation(), options);
-#else
-  return func.emitError()
-         << "--enable-vfsim-costmodel-optimization requires configuring PTOAS with "
-            "-DPTO_ENABLE_VFSIM_COSTMODEL=ON";
-#endif
-}
+struct FusionPlanSearchPass
+    : public pto::impl::FusionPlanSearchBase<FusionPlanSearchPass> {
+  using pto::impl::FusionPlanSearchBase<
+      FusionPlanSearchPass>::FusionPlanSearchBase;
 
-struct FusionPlanPass : public pto::impl::FusionPlanBase<FusionPlanPass> {
-  using pto::impl::FusionPlanBase<FusionPlanPass>::FusionPlanBase;
-
-  FusionPlanPass() = default;
+  FusionPlanSearchPass() = default;
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
@@ -573,7 +672,8 @@ struct FusionPlanPass : public pto::impl::FusionPlanBase<FusionPlanPass> {
       return;
     }
     pto::PreFusionAnalysisResult analysis = sharedAnalysis.getResult();
-    if (failed(pto::inferIterationDomainClasses(analysis, enableShapeInference))) {
+    if (failed(
+            pto::inferIterationDomainClasses(analysis, enableShapeInference))) {
       signalPassFailure();
       return;
     }
@@ -581,19 +681,13 @@ struct FusionPlanPass : public pto::impl::FusionPlanBase<FusionPlanPass> {
     MLIRContext *ctx = &getContext();
     int64_t nextGroupId = 0;
     ConservativeDAGGreedyCostModel costModel;
-    ConservativeDAGGreedyStrategyEngine strategyEngine;
+    CostGuidedSearchStrategyEngine strategyEngine;
 
     for (const pto::FusionBlockAnalysis &blockAnalysis : analysis.blocks) {
       PlanningContext planningCtx{blockAnalysis};
       SmallVector<PlannedFusionGroup, 8> groups =
           strategyEngine.planBlock(planningCtx, costModel);
       assignStableGroupMetadata(groups, ctx, nextGroupId);
-    }
-
-    if (enableVfSimCostmodelOptimization &&
-        failed(runVfSimFusionPlanner(func, dumpVfSimUnrollTest))) {
-      signalPassFailure();
-      return;
     }
 
     // The fusion metadata we annotate (group_id/order) is a planning *output*;
@@ -607,11 +701,11 @@ struct FusionPlanPass : public pto::impl::FusionPlanBase<FusionPlanPass> {
 
 } // namespace
 
-std::unique_ptr<Pass> mlir::pto::createFusionPlanPass() {
-  return std::make_unique<FusionPlanPass>();
+std::unique_ptr<Pass> mlir::pto::createFusionPlanSearchPass() {
+  return std::make_unique<FusionPlanSearchPass>();
 }
 
-std::unique_ptr<Pass>
-mlir::pto::createFusionPlanPass(const pto::FusionPlanOptions &options) {
-  return std::make_unique<FusionPlanPass>(options);
+std::unique_ptr<Pass> mlir::pto::createFusionPlanSearchPass(
+    const pto::FusionPlanSearchOptions &options) {
+  return std::make_unique<FusionPlanSearchPass>(options);
 }

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlanSearch.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlanSearch.cpp
@@ -9,6 +9,9 @@
 // This pass owns the bounded, cost-ranked search across competing DFG paths.
 // PTOFusionPlan.cpp intentionally retains the original single-path greedy
 // planner used by the production fusion pipeline.
+// Apart from group selection, this pass must preserve FusionPlan's metadata
+// lifecycle and optional post-planning integrations, including the VfSimulator
+// unroll planner.
 
 #include "PTO/Transforms/TileFusion/FusionAnalysis.h"
 #include "PTO/Transforms/TileFusion/FusionOpSemantics.h"
@@ -26,6 +29,10 @@
 
 #include <algorithm>
 #include <optional>
+
+#ifdef PTO_ENABLE_VFSIM_IR_PLANNER
+#include "native/IRPlanner.h"
+#endif
 
 namespace mlir {
 namespace pto {
@@ -45,6 +52,10 @@ namespace {
 
 static constexpr llvm::StringLiteral kFusionGroupIdAttr = "pto.fusion.group_id";
 static constexpr llvm::StringLiteral kFusionOrderAttr = "pto.fusion.order";
+static constexpr llvm::StringLiteral kFusionRowUnrollAttr =
+    "pto.fusion.row_unroll_factor";
+static constexpr llvm::StringLiteral kFusionColUnrollAttr =
+    "pto.fusion.col_unroll_factor";
 
 struct PlannedFusionGroup {
   SmallVector<const pto::FusionComputeNode *, 8> members;
@@ -593,7 +604,22 @@ static void clearPlanningAttrs(func::FuncOp func) {
   func.walk([](Operation *op) {
     op->removeAttr(kFusionGroupIdAttr);
     op->removeAttr(kFusionOrderAttr);
+    op->removeAttr(kFusionRowUnrollAttr);
+    op->removeAttr(kFusionColUnrollAttr);
   });
+}
+
+static LogicalResult runVfSimFusionPlanner(func::FuncOp func,
+                                           bool dumpCandidates) {
+#ifdef PTO_ENABLE_VFSIM_IR_PLANNER
+  vfsim::PlannerOptions options;
+  options.dumpCandidates = dumpCandidates;
+  return vfsim::planTileFusionIR(func.getOperation(), options);
+#else
+  return func.emitError() << "--enable-vfsim-costmodel-optimization requires "
+                             "configuring PTOAS with "
+                             "-DPTO_ENABLE_VFSIM_COSTMODEL=ON";
+#endif
 }
 
 struct FusionPlanSearchPass
@@ -640,6 +666,12 @@ struct FusionPlanSearchPass
       SmallVector<PlannedFusionGroup, 8> groups =
           strategyEngine.planBlock(planningCtx, costModel);
       assignStableGroupMetadata(groups, ctx, nextGroupId);
+    }
+
+    if (enableVfSimCostmodelOptimization &&
+        failed(runVfSimFusionPlanner(func, dumpVfSimUnrollTest))) {
+      signalPassFailure();
+      return;
     }
 
     // The fusion metadata we annotate (group_id/order) is a planning *output*;

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlanSearch.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlanSearch.cpp
@@ -465,54 +465,6 @@ public:
   planBlock(const PlanningContext &ctx, const CostModel &costModel) const = 0;
 };
 
-class ConservativeGreedyStrategyEngine final : public StrategyEngine {
-public:
-  SmallVector<PlannedFusionGroup, 8>
-  planBlock(const PlanningContext &ctx,
-            const CostModel &costModel) const override {
-    SmallVector<PlannedFusionGroup, 8> groups;
-    SmallVector<const pto::FusionComputeNode *, 8> chain;
-
-    auto flushChain = [&]() {
-      if (chain.size() < 2) {
-        chain.clear();
-        return;
-      }
-
-      PlannedFusionGroup group;
-      group.members = chain;
-      groups.push_back(std::move(group));
-      chain.clear();
-    };
-
-    for (const pto::FusionComputeNode &node : ctx.blockAnalysis.computeNodes) {
-      PlanningDecision seedDecision = costModel.evaluateSeed(ctx, node);
-      if (!seedDecision.accept) {
-        flushChain();
-        continue;
-      }
-
-      if (chain.empty()) {
-        chain.push_back(&node);
-        continue;
-      }
-
-      PlanningDecision appendDecision =
-          costModel.evaluateAppend(ctx, chain, node);
-      if (!appendDecision.accept) {
-        flushChain();
-        chain.push_back(&node);
-        continue;
-      }
-
-      chain.push_back(&node);
-    }
-
-    flushChain();
-    return groups;
-  }
-};
-
 class CostGuidedSearchStrategyEngine final : public StrategyEngine {
   // Keep a bounded, deterministically ranked frontier to prevent exponential
   // compile-time growth. This selects the best group among retained candidates;

--- a/test/lit/tile_fusion/fusion_plan_cost_guided_search.pto
+++ b/test/lit/tile_fusion/fusion_plan_cost_guided_search.pto
@@ -6,9 +6,9 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// Guards cost-guided FusionPlan search across competing block-local DFG paths.
+// Guards cost-guided FusionPlanSearch across competing block-local DFG paths.
 //
-// RUN: ptoas --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-plan -o /dev/null 2>&1 | FileCheck %s
+// RUN: pto-test-opt --pto-fusion-plan-search --mlir-print-ir-after=pto-fusion-plan-search %s -o /dev/null 2>&1 | FileCheck %s
 
 module {
   // The six-op prefix has live-tile/VF-parameter footprint 12. The first
@@ -59,7 +59,7 @@ module {
 
 }
 
-// CHECK: // -----// IR Dump After FusionPlan (pto-fusion-plan) //----- //
+// CHECK: // -----// IR Dump After FusionPlanSearch (pto-fusion-plan-search) //----- //
 // CHECK-LABEL: func.func @prefer_higher_group_cost(
 // CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
 // CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}

--- a/test/lit/tile_fusion/fusion_plan_cost_guided_search.pto
+++ b/test/lit/tile_fusion/fusion_plan_cost_guided_search.pto
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards cost-guided FusionPlan search across competing block-local DFG paths.
+//
+// RUN: ptoas --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-plan -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  // The six-op prefix has live-tile/VF-parameter footprint 12. The first
+  // branch is immediately profitable, but raises the footprint enough to
+  // reject both later appends:
+  //
+  //   cost(prefix + first)          = 24
+  //   cost(prefix + second + join)  = 28
+  //
+  // Candidate-group search must therefore choose the later, higher-cost path.
+  // The independent two-op component must still form the next fusion group.
+  func.func @prefer_higher_group_cost(
+      %arg0: !pto.tile_buf<vec, 32x32xf32>,
+      %arg1: !pto.tile_buf<vec, 32x32xf32>,
+      %arg2: !pto.tile_buf<vec, 32x32xf32>,
+      %arg3: !pto.tile_buf<vec, 32x32xf32>,
+      %arg4: !pto.tile_buf<vec, 32x32xf32>,
+      %arg5: !pto.tile_buf<vec, 32x32xf32>,
+      %arg6: !pto.tile_buf<vec, 32x32xf32>,
+      %arg7: !pto.tile_buf<vec, 32x32xf32>,
+      %arg8: !pto.tile_buf<vec, 32x32xf32>) {
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp2 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp3 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp4 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp5 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %first = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %second = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %join = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %independent0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %independent1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.tadd ins(%arg0, %arg1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %arg2 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp1, %arg3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp2, %arg4 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp3 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp3, %arg5 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp4 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.texp ins(%tmp4 : !pto.tile_buf<vec, 32x32xf32>) outs(%tmp5 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.texp ins(%tmp5 : !pto.tile_buf<vec, 32x32xf32>) outs(%first : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp5, %arg6 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%second : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%second, %tmp0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%join : !pto.tile_buf<vec, 32x32xf32>)
+
+    pto.tadd ins(%arg7, %arg8 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%independent0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.texp ins(%independent0 : !pto.tile_buf<vec, 32x32xf32>) outs(%independent1 : !pto.tile_buf<vec, 32x32xf32>)
+    return
+  }
+
+  // Both branches have the same whole-group cost, and accepting either one
+  // makes the other append unprofitable. Stable block order must break the tie.
+  func.func @stable_equal_cost_tie(
+      %arg0: !pto.tile_buf<vec, 32x32xf32>,
+      %arg1: !pto.tile_buf<vec, 32x32xf32>,
+      %arg2: !pto.tile_buf<vec, 32x32xf32>,
+      %arg3: !pto.tile_buf<vec, 32x32xf32>,
+      %arg4: !pto.tile_buf<vec, 32x32xf32>,
+      %arg5: !pto.tile_buf<vec, 32x32xf32>,
+      %arg6: !pto.tile_buf<vec, 32x32xf32>) {
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp2 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp3 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp4 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %tmp5 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %first = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+    %second = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
+
+    pto.tadd ins(%arg0, %arg1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp0, %arg2 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp1, %arg3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp2, %arg4 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp3 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp3, %arg5 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp4 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp4, %arg6 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp5 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.texp ins(%tmp5 : !pto.tile_buf<vec, 32x32xf32>) outs(%first : !pto.tile_buf<vec, 32x32xf32>)
+    pto.texp ins(%tmp5 : !pto.tile_buf<vec, 32x32xf32>) outs(%second : !pto.tile_buf<vec, 32x32xf32>)
+    return
+  }
+}
+
+// CHECK: // -----// IR Dump After FusionPlan (pto-fusion-plan) //----- //
+// CHECK-LABEL: func.func @prefer_higher_group_cost(
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 2 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 3 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 4 : i64}
+// CHECK: pto.texp{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 5 : i64}
+// CHECK: pto.texp
+// CHECK-NOT: pto.fusion.group_id
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 6 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 7 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 1 : i64, pto.fusion.order = 0 : i64}
+// CHECK: pto.texp{{.*}}{pto.fusion.group_id = 1 : i64, pto.fusion.order = 1 : i64}
+
+// CHECK-LABEL: func.func @stable_equal_cost_tie(
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 2 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 3 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 4 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 5 : i64}
+// CHECK: pto.texp{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 6 : i64}
+// CHECK: pto.texp
+// CHECK-NOT: pto.fusion.group_id

--- a/test/lit/tile_fusion/fusion_plan_cost_guided_tie.pto
+++ b/test/lit/tile_fusion/fusion_plan_cost_guided_tie.pto
@@ -6,30 +6,21 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// Guards cost-guided FusionPlan search across competing block-local DFG paths.
+// Guards the stable tie-break for equal-cost FusionPlan candidates.
 //
 // RUN: ptoas --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-plan -o /dev/null 2>&1 | FileCheck %s
 
 module {
-  // The six-op prefix has live-tile/VF-parameter footprint 12. The first
-  // branch is immediately profitable, but raises the footprint enough to
-  // reject both later appends:
-  //
-  //   cost(prefix + first)          = 24
-  //   cost(prefix + second + join)  = 28
-  //
-  // Candidate-group search must therefore choose the later, higher-cost path.
-  // The independent two-op component must still form the next fusion group.
-  func.func @prefer_higher_group_cost(
+  // Both branches have the same whole-group cost, and accepting either one
+  // makes the other append unprofitable. Stable block order must break the tie.
+  func.func @stable_equal_cost_tie(
       %arg0: !pto.tile_buf<vec, 32x32xf32>,
       %arg1: !pto.tile_buf<vec, 32x32xf32>,
       %arg2: !pto.tile_buf<vec, 32x32xf32>,
       %arg3: !pto.tile_buf<vec, 32x32xf32>,
       %arg4: !pto.tile_buf<vec, 32x32xf32>,
       %arg5: !pto.tile_buf<vec, 32x32xf32>,
-      %arg6: !pto.tile_buf<vec, 32x32xf32>,
-      %arg7: !pto.tile_buf<vec, 32x32xf32>,
-      %arg8: !pto.tile_buf<vec, 32x32xf32>) {
+      %arg6: !pto.tile_buf<vec, 32x32xf32>) {
     %tmp0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
     %tmp1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
     %tmp2 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
@@ -38,38 +29,27 @@ module {
     %tmp5 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
     %first = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
     %second = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
-    %join = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
-    %independent0 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
-    %independent1 = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
 
     pto.tadd ins(%arg0, %arg1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
     pto.tadd ins(%tmp0, %arg2 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
     pto.tadd ins(%tmp1, %arg3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
     pto.tadd ins(%tmp2, %arg4 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp3 : !pto.tile_buf<vec, 32x32xf32>)
     pto.tadd ins(%tmp3, %arg5 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp4 : !pto.tile_buf<vec, 32x32xf32>)
-    pto.texp ins(%tmp4 : !pto.tile_buf<vec, 32x32xf32>) outs(%tmp5 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.tadd ins(%tmp4, %arg6 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp5 : !pto.tile_buf<vec, 32x32xf32>)
     pto.texp ins(%tmp5 : !pto.tile_buf<vec, 32x32xf32>) outs(%first : !pto.tile_buf<vec, 32x32xf32>)
-    pto.tadd ins(%tmp5, %arg6 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%second : !pto.tile_buf<vec, 32x32xf32>)
-    pto.tadd ins(%second, %tmp0 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%join : !pto.tile_buf<vec, 32x32xf32>)
-
-    pto.tadd ins(%arg7, %arg8 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%independent0 : !pto.tile_buf<vec, 32x32xf32>)
-    pto.texp ins(%independent0 : !pto.tile_buf<vec, 32x32xf32>) outs(%independent1 : !pto.tile_buf<vec, 32x32xf32>)
+    pto.texp ins(%tmp5 : !pto.tile_buf<vec, 32x32xf32>) outs(%second : !pto.tile_buf<vec, 32x32xf32>)
     return
   }
-
 }
 
 // CHECK: // -----// IR Dump After FusionPlan (pto-fusion-plan) //----- //
-// CHECK-LABEL: func.func @prefer_higher_group_cost(
+// CHECK-LABEL: func.func @stable_equal_cost_tie(
 // CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
 // CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}
 // CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 2 : i64}
 // CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 3 : i64}
 // CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 4 : i64}
-// CHECK: pto.texp{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 5 : i64}
+// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 5 : i64}
+// CHECK: pto.texp{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 6 : i64}
 // CHECK: pto.texp
 // CHECK-NOT: pto.fusion.group_id
-// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 6 : i64}
-// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 7 : i64}
-// CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 1 : i64, pto.fusion.order = 0 : i64}
-// CHECK: pto.texp{{.*}}{pto.fusion.group_id = 1 : i64, pto.fusion.order = 1 : i64}

--- a/test/lit/tile_fusion/fusion_plan_cost_guided_tie.pto
+++ b/test/lit/tile_fusion/fusion_plan_cost_guided_tie.pto
@@ -6,9 +6,9 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// Guards the stable tie-break for equal-cost FusionPlan candidates.
+// Guards the stable tie-break for equal-cost FusionPlanSearch candidates.
 //
-// RUN: ptoas --pto-arch=a5 --pto-level=level2 --enable-op-fusion --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-plan -o /dev/null 2>&1 | FileCheck %s
+// RUN: pto-test-opt --pto-fusion-plan-search --mlir-print-ir-after=pto-fusion-plan-search %s -o /dev/null 2>&1 | FileCheck %s
 
 module {
   // Both branches have the same whole-group cost, and accepting either one
@@ -42,7 +42,7 @@ module {
   }
 }
 
-// CHECK: // -----// IR Dump After FusionPlan (pto-fusion-plan) //----- //
+// CHECK: // -----// IR Dump After FusionPlanSearch (pto-fusion-plan-search) //----- //
 // CHECK-LABEL: func.func @stable_equal_cost_tie(
 // CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64}
 // CHECK: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64}

--- a/test/lit/tile_fusion/fusion_plan_cost_guided_tie.pto
+++ b/test/lit/tile_fusion/fusion_plan_cost_guided_tie.pto
@@ -30,7 +30,8 @@ module {
     %first = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
     %second = pto.alloc_tile : !pto.tile_buf<vec, 32x32xf32>
 
-    pto.tadd ins(%arg0, %arg1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>)
+    // FusionPlanSearch must clear stale decisions before selecting new groups.
+    pto.tadd ins(%arg0, %arg1 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp0 : !pto.tile_buf<vec, 32x32xf32>) {pto.fusion.col_unroll_factor = 5 : i64, pto.fusion.row_unroll_factor = 7 : i64}
     pto.tadd ins(%tmp0, %arg2 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp1 : !pto.tile_buf<vec, 32x32xf32>)
     pto.tadd ins(%tmp1, %arg3 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp2 : !pto.tile_buf<vec, 32x32xf32>)
     pto.tadd ins(%tmp2, %arg4 : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%tmp3 : !pto.tile_buf<vec, 32x32xf32>)

--- a/test/lit/tile_fusion/vfsim_unroll_tadd_tmul_32x128.pto
+++ b/test/lit/tile_fusion/vfsim_unroll_tadd_tmul_32x128.pto
@@ -24,6 +24,7 @@
 //       the row loop body.
 //
 // REQUIRES: vfsim-costmodel
+// RUN: pto-test-opt --pto-fusion-plan-search='enable-vfsim-costmodel-optimization=true' --mlir-print-ir-after=pto-fusion-plan-search %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=SEARCH
 // RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-vfsim-costmodel-optimization --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-region-gen -o /dev/null 2>&1 | FileCheck %s --check-prefix=REGION
 // RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-vfsim-costmodel-optimization --emit-vpto %s --mlir-print-ir-after=pto-low-level-loop-fusion -o /dev/null 2>&1 | FileCheck %s --check-prefix=LLF
 // RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-vfsim-costmodel-optimization --enable-unroll-after-loop-fusion --emit-vpto %s --mlir-print-ir-after=pto-unroll-after-loop-fusion -o /dev/null 2>&1 | FileCheck %s --check-prefix=UNROLL
@@ -75,6 +76,10 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     return
   }
 }
+
+// SEARCH-LABEL: func.func @vfsim_unroll_tadd_tmul_32x128(
+// SEARCH: pto.tadd{{.*}}{pto.fusion.col_unroll_factor = 2 : i64, pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64, pto.fusion.row_unroll_factor = 1 : i64}
+// SEARCH: pto.tmul{{.*}}{pto.fusion.col_unroll_factor = 2 : i64, pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64, pto.fusion.row_unroll_factor = 1 : i64}
 
 // REGION-LABEL: func.func @vfsim_unroll_tadd_tmul_32x128(
 // REGION: pto.fusion_region {


### PR DESCRIPTION
 ## Summary

  Improve tile-fusion planning by exploring competing fusion groups instead of committing to the first acceptable DFG path.

  ## Key changes

  - Add whole-group cost evaluation alongside existing append legality checks.
  - Reuse shared cost computation for append and group evaluation.
  - Explore multiple candidate groups, retaining up to 64 candidates per group size.
  - Rank candidates by:
      1. Whole-group cost.
      2. Group size.
      3. Stable block/node order.

  - Preserve the existing append acceptance rules and fusion metadata contract.
  - Add regression coverage for:
      - Selecting a higher-value multi-step path.
      - Stable equal-cost tie-breaking.
      - Formation of subsequent independent fusion groups.
      
  ## Testing

  llvm-lit -sv build/test/lit \
    --filter 'fusion_plan_cost_guided_(search|tie)'