### PR TITLE
fix(ptodsl): preserve original source line numbers after AST rewrite

### DIFF
--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -30,8 +30,9 @@ def rewrite_jit_function(fn, *, static_bindings=None, rewrite_control_flow=True)
     a sibling physical section.
     """
     try:
-        source_lines, source_start_line = inspect.getsourcelines(fn)
-        source = "".join(source_lines)
+        source = inspect.getsource(fn)
+        _, source_start_index = inspect.findsource(fn)
+        source_start_line = source_start_index + 1
     except (OSError, TypeError) as exc:
         # Dynamically-created functions from exec/REPL/notebook contexts may
         # not have retrievable source. Keep existing tracing behavior for those
@@ -46,6 +47,11 @@ def rewrite_jit_function(fn, *, static_bindings=None, rewrite_control_flow=True)
     if function_def is None:
         return fn
 
+    # Preserve the first decorator line as the rewritten function's co_firstlineno.
+    function_first_lineno = min(
+        [function_def.lineno]
+        + [decorator.lineno for decorator in function_def.decorator_list]
+    )
     function_def.decorator_list = []
     closure_vars = inspect.getclosurevars(fn)
     static_env = dict(fn.__globals__)
@@ -63,6 +69,7 @@ def rewrite_jit_function(fn, *, static_bindings=None, rewrite_control_flow=True)
             section_uninitialized_aliases=section_rewriter.section_uninitialized_aliases,
         )
         function_def.body = rewriter.rewrite_block(function_def.body, live_after=set())
+    function_def.lineno = function_first_lineno
     tree = ast.Module(body=[function_def], type_ignores=[])
     ast.fix_missing_locations(tree)
     ast.increment_lineno(tree, source_start_line - 1)

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -30,7 +30,8 @@ def rewrite_jit_function(fn, *, static_bindings=None, rewrite_control_flow=True)
     a sibling physical section.
     """
     try:
-        source = inspect.getsource(fn)
+        source_lines, source_start_line = inspect.getsourcelines(fn)
+        source = "".join(source_lines)
     except (OSError, TypeError) as exc:
         # Dynamically-created functions from exec/REPL/notebook contexts may
         # not have retrievable source. Keep existing tracing behavior for those
@@ -64,6 +65,7 @@ def rewrite_jit_function(fn, *, static_bindings=None, rewrite_control_flow=True)
         function_def.body = rewriter.rewrite_block(function_def.body, live_after=set())
     tree = ast.Module(body=[function_def], type_ignores=[])
     ast.fix_missing_locations(tree)
+    ast.increment_lineno(tree, source_start_line - 1)
 
     locals_ns = {}
     try:

--- a/ptodsl/tests/test_jit_diagnostics.py
+++ b/ptodsl/tests/test_jit_diagnostics.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from ptodsl import pto, scalar
-from ptodsl._ast_rewrite import PTODSLAstRewriteError
+from ptodsl._ast_rewrite import PTODSLAstRewriteError, rewrite_jit_function
 from ptodsl._host_tensors import TensorSpec
 from ptodsl._host_tensors import inspect_host_tensor_metadata
 
@@ -28,6 +28,41 @@ def expect_raises(callback, exc_type, *message_fragments: str) -> None:
         text = str(exc)
         for fragment in message_fragments:
             expect(fragment in text, f"expected diagnostic fragment {fragment!r} in {text!r}")
+    else:
+        raise AssertionError(f"expected {exc_type.__name__} to be raised")
+
+
+def expect_traceback_line(callback, exc_type, function_name: str, marker: str) -> None:
+    source_path = Path(__file__).resolve()
+    source_lines = source_path.read_text(encoding="utf-8").splitlines()
+    marker_lines = [
+        line_number
+        for line_number, line in enumerate(source_lines, start=1)
+        if f"# {marker}" in line
+    ]
+    expect(
+        len(marker_lines) == 1,
+        f"expected exactly one source marker {marker!r}, got {marker_lines}",
+    )
+    expected_line = marker_lines[0]
+
+    try:
+        callback()
+    except exc_type as exc:
+        traceback_lines = []
+        current = exc.__traceback__
+        while current is not None:
+            frame = current.tb_frame
+            if (
+                Path(frame.f_code.co_filename).resolve() == source_path
+                and frame.f_code.co_name == function_name
+            ):
+                traceback_lines.append(current.tb_lineno)
+            current = current.tb_next
+        expect(
+            traceback_lines == [expected_line],
+            f"expected {function_name} traceback line {expected_line}, got {traceback_lines}",
+        )
     else:
         raise AssertionError(f"expected {exc_type.__name__} to be raised")
 
@@ -628,6 +663,17 @@ def taddrelu_a5_probe():
     rhs = pto.alloc_tile(shape=[1, 64], dtype=pto.f32)
     dst = pto.alloc_tile(shape=[1, 64], dtype=pto.f32)
     pto.tile.addrelu(lhs, rhs, dst)
+
+
+def ast_rewrite_code_line_probe():
+    runtime_value = pto.const(1, dtype=pto.i32)
+    return not runtime_value
+
+
+@pto.jit(target="a5")
+def ast_rewrite_traceback_line_probe():
+    runtime_value = pto.const(1, dtype=pto.i32)
+    _ = not runtime_value  # AST_REWRITE_TRACEBACK_LINE_MARKER
 
 
 def main() -> None:
@@ -1275,6 +1321,18 @@ def main() -> None:
         TypeError,
         "host tensor metadata is incomplete or unsupported",
         "data_ptr must return an integer-like data handle",
+    )
+    expect_traceback_line(
+        ast_rewrite_traceback_line_probe.compile,
+        TypeError,
+        "ast_rewrite_traceback_line_probe",
+        "AST_REWRITE_TRACEBACK_LINE_MARKER",
+    )
+    rewritten_line_probe = rewrite_jit_function(ast_rewrite_code_line_probe)
+    expect(
+        rewritten_line_probe.__code__.co_firstlineno
+        == ast_rewrite_code_line_probe.__code__.co_firstlineno,
+        "AST rewrite should preserve the function's original first source line",
     )
     print("ptodsl_jit_diagnostics: PASS")
 

--- a/ptodsl/tests/test_jit_diagnostics.py
+++ b/ptodsl/tests/test_jit_diagnostics.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from ptodsl import pto, scalar
-from ptodsl._ast_rewrite import PTODSLAstRewriteError, rewrite_jit_function
+from ptodsl._ast_rewrite import PTODSLAstRewriteError
 from ptodsl._host_tensors import TensorSpec
 from ptodsl._host_tensors import inspect_host_tensor_metadata
 
@@ -32,24 +32,35 @@ def expect_raises(callback, exc_type, *message_fragments: str) -> None:
         raise AssertionError(f"expected {exc_type.__name__} to be raised")
 
 
-def expect_traceback_line(callback, exc_type, function_name: str, marker: str) -> None:
+def expect_traceback_line(
+    callback,
+    exc_type,
+    function_name: str,
+    marker: str,
+    first_line_marker: str,
+) -> None:
     source_path = Path(__file__).resolve()
     source_lines = source_path.read_text(encoding="utf-8").splitlines()
-    marker_lines = [
-        line_number
-        for line_number, line in enumerate(source_lines, start=1)
-        if f"# {marker}" in line
-    ]
-    expect(
-        len(marker_lines) == 1,
-        f"expected exactly one source marker {marker!r}, got {marker_lines}",
-    )
-    expected_line = marker_lines[0]
+
+    def marker_line(source_marker: str) -> int:
+        marker_lines = [
+            line_number
+            for line_number, line in enumerate(source_lines, start=1)
+            if f"# {source_marker}" in line
+        ]
+        expect(
+            len(marker_lines) == 1,
+            f"expected exactly one source marker {source_marker!r}, got {marker_lines}",
+        )
+        return marker_lines[0]
+
+    expected_line = marker_line(marker)
+    expected_first_line = marker_line(first_line_marker)
 
     try:
         callback()
     except exc_type as exc:
-        traceback_lines = []
+        matching_frames = []
         current = exc.__traceback__
         while current is not None:
             frame = current.tb_frame
@@ -57,11 +68,19 @@ def expect_traceback_line(callback, exc_type, function_name: str, marker: str) -
                 Path(frame.f_code.co_filename).resolve() == source_path
                 and frame.f_code.co_name == function_name
             ):
-                traceback_lines.append(current.tb_lineno)
+                matching_frames.append(current)
             current = current.tb_next
+        expect(matching_frames, f"expected a traceback frame for {function_name}")
+        rewritten_frame = matching_frames[-1]
         expect(
-            traceback_lines == [expected_line],
-            f"expected {function_name} traceback line {expected_line}, got {traceback_lines}",
+            rewritten_frame.tb_lineno == expected_line,
+            f"expected {function_name} traceback line {expected_line}, "
+            f"got {rewritten_frame.tb_lineno}",
+        )
+        expect(
+            rewritten_frame.tb_frame.f_code.co_firstlineno == expected_first_line,
+            f"expected {function_name} first line {expected_first_line}, "
+            f"got {rewritten_frame.tb_frame.f_code.co_firstlineno}",
         )
     else:
         raise AssertionError(f"expected {exc_type.__name__} to be raised")
@@ -665,15 +684,15 @@ def taddrelu_a5_probe():
     pto.tile.addrelu(lhs, rhs, dst)
 
 
-def ast_rewrite_code_line_probe():
-    runtime_value = pto.const(1, dtype=pto.i32)
-    return not runtime_value
+def define_ast_rewrite_traceback_line_probe():
+    @pto.jit(  # AST_REWRITE_FIRST_LINE_MARKER
+        target="a5",
+    )
+    def ast_rewrite_traceback_line_probe():
+        runtime_value = pto.const(1, dtype=pto.i32)
+        _ = not runtime_value  # AST_REWRITE_TRACEBACK_LINE_MARKER
 
-
-@pto.jit(target="a5")
-def ast_rewrite_traceback_line_probe():
-    runtime_value = pto.const(1, dtype=pto.i32)
-    _ = not runtime_value  # AST_REWRITE_TRACEBACK_LINE_MARKER
+    return ast_rewrite_traceback_line_probe
 
 
 def main() -> None:
@@ -1322,17 +1341,13 @@ def main() -> None:
         "host tensor metadata is incomplete or unsupported",
         "data_ptr must return an integer-like data handle",
     )
+    ast_rewrite_traceback_line_probe = define_ast_rewrite_traceback_line_probe()
     expect_traceback_line(
         ast_rewrite_traceback_line_probe.compile,
         TypeError,
         "ast_rewrite_traceback_line_probe",
         "AST_REWRITE_TRACEBACK_LINE_MARKER",
-    )
-    rewritten_line_probe = rewrite_jit_function(ast_rewrite_code_line_probe)
-    expect(
-        rewritten_line_probe.__code__.co_firstlineno
-        == ast_rewrite_code_line_probe.__code__.co_firstlineno,
-        "AST rewrite should preserve the function's original first source line",
+        "AST_REWRITE_FIRST_LINE_MARKER",
     )
     print("ptodsl_jit_diagnostics: PASS")
 


### PR DESCRIPTION
Fixes #1052 
PTODSL `@pto.jit` 的 `ast_rewrite` 原本使用 `inspect.getsource()` 获取函数源码，源码被重新解析后行号从 1 开始，和原文件名一起用于编译，导致调用栈中文件名正确，行号却可能错误，少了函数在源文件中的偏移

这个 PR 改用 `inspect.getsourcelines()` 同时获取函数源码和函数定义的起始行，并在编译前为被解析的函数恢复行号偏移，使得调用栈中能如预期般展示出报错位置对应的正确行号和代码

## 测试

新增测试：

- 触发一次编译异常，确认调用栈显示出报错函数中被标记的行
- 确认被重新解析的函数的首行行号与原函数一致

```bash
python ptodsl/tests/test_jit_diagnostics.py
# ptodsl_jit_diagnostics: PASS
python ptodsl/tests/test_ast_rewrite_example_ir.py
# ptodsl_ast_rewrite_example_ir: PASS
python ptodsl/tests/test_jit_compile.py
# ptodsl_jit_compile: PASS
```