### PR TITLE
fix(vpto): preserve MXFP4 load offsets and scale strides

### DIFF
--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -3014,6 +3014,7 @@ def PTO_MteL1L0bOp : PTO_MteOp<"mte_l1_l0b", [
 }
 
 def PTO_MteL1L0aMxOp : PTO_MteOp<"mte_l1_l0a_mx", [
+    AttrSizedOperandSegments,
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   ]> {
   let arguments = (ins
@@ -3022,7 +3023,9 @@ def PTO_MteL1L0aMxOp : PTO_MteOp<"mte_l1_l0a_mx", [
     I64:$m,
     I64:$k,
     I64:$start_row,
-    I64:$start_col
+    I64:$start_col,
+    Optional<I64>:$src_stride,
+    Optional<I64>:$dst_stride
   );
 
   let results = (outs);
@@ -3031,12 +3034,14 @@ def PTO_MteL1L0aMxOp : PTO_MteOp<"mte_l1_l0a_mx", [
 
   let assemblyFormat = [{
     $source `,` $destination `,` $m `,` $k `,` $start_row `,` $start_col
+    (`strides` `(` $src_stride^ `,` $dst_stride `)`)?
     attr-dict `:` type($source) `,` type($destination) `,` type($m) `,`
     type($k) `,` type($start_row) `,` type($start_col)
   }];
 }
 
 def PTO_MteL1L0bMxOp : PTO_MteOp<"mte_l1_l0b_mx", [
+    AttrSizedOperandSegments,
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   ]> {
   let arguments = (ins
@@ -3045,7 +3050,9 @@ def PTO_MteL1L0bMxOp : PTO_MteOp<"mte_l1_l0b_mx", [
     I64:$k,
     I64:$n,
     I64:$start_row,
-    I64:$start_col
+    I64:$start_col,
+    Optional<I64>:$src_stride,
+    Optional<I64>:$dst_stride
   );
 
   let results = (outs);
@@ -3054,6 +3061,7 @@ def PTO_MteL1L0bMxOp : PTO_MteOp<"mte_l1_l0b_mx", [
 
   let assemblyFormat = [{
     $source `,` $destination `,` $k `,` $n `,` $start_row `,` $start_col
+    (`strides` `(` $src_stride^ `,` $dst_stride `)`)?
     attr-dict `:` type($source) `,` type($destination) `,` type($k) `,`
     type($n) `,` type($start_row) `,` type($start_col)
   }];

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -815,8 +815,7 @@ deriveLoadCbufToCbControl(Location loc, Value k, Value n, Type elementType,
     Value kBytes = rewriter.create<arith::MulIOp>(loc, k, constant(elemBytes));
     Value kStep = maybeScaleS4KCoord(ceilDivConst(kBytes, 32));
     Value stride = ceilDivConst(n, 16);
-    return LoadCbufToCbControl{mStart, maybeScaleS4KCoord(kStart), mStep, kStep,
-                               stride, stride};
+    return LoadCbufToCbControl{mStart, kStart, mStep, kStep, stride, stride};
   }
 
   uint64_t c0Size =
@@ -830,8 +829,8 @@ deriveLoadCbufToCbControl(Location loc, Value k, Value n, Type elementType,
   Value kStep = maybeScaleS4KCoord(ceilDivConst(nBytes, 32));
   Value srcStride = ceilDivConst(kAlign, 16);
   Value dstStride = ceilDivConst(nAlign, 16);
-  return LoadCbufToCbControl{mStart, maybeScaleS4KCoord(kStart), mStep, kStep,
-                             srcStride, dstStride};
+  return LoadCbufToCbControl{mStart, kStart, mStep, kStep, srcStride,
+                             dstStride};
 }
 
 static FailureOr<LoadCbufToCbControl>
@@ -868,8 +867,7 @@ deriveLoadCbufToCaControl(Location loc, Value m, Value k, Type elementType,
     Value kBytes = rewriter.create<arith::MulIOp>(loc, k, constant(elemBytes));
     Value kStep = maybeScaleS4KCoord(ceilDivConst(kBytes, 32));
     Value stride = ceilDivConst(m, 16);
-    return LoadCbufToCbControl{mStart, maybeScaleS4KCoord(kStart), mStep, kStep,
-                               stride, stride};
+    return LoadCbufToCbControl{mStart, kStart, mStep, kStep, stride, stride};
   }
 
   uint64_t c0Size =
@@ -883,8 +881,8 @@ deriveLoadCbufToCaControl(Location loc, Value m, Value k, Type elementType,
   Value kStep = maybeScaleS4KCoord(ceilDivConst(mBytes, 32));
   Value srcStride = ceilDivConst(kAlign, 16);
   Value dstStride = ceilDivConst(mAlign, 16);
-  return LoadCbufToCbControl{mStart, maybeScaleS4KCoord(kStart), mStep, kStep,
-                             srcStride, dstStride};
+  return LoadCbufToCbControl{mStart, kStart, mStep, kStep, srcStride,
+                             dstStride};
 }
 
 static FailureOr<LoadCbufToMxControl>
@@ -1558,10 +1556,12 @@ struct ExpandLeftLoadMxPattern : public OpRewritePattern<pto::MteL1L0aMxOp> {
       return rewriter.notifyMatchFailure(op,
                                          "failed to derive load_cbuf_to_ca_mx control");
 
+    Value srcStride = op.getSrcStride() ? op.getSrcStride() : control->srcStride;
+    Value dstStride = op.getDstStride() ? op.getDstStride() : control->dstStride;
     rewriter.create<pto::LoadCbufToCaMxOp>(
         loc, source, destination, control->xStartPosition,
         control->yStartPosition, control->xStep, control->yStep,
-        control->srcStride, control->dstStride);
+        srcStride, dstStride);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1590,10 +1590,12 @@ struct ExpandRightLoadMxPattern : public OpRewritePattern<pto::MteL1L0bMxOp> {
       return rewriter.notifyMatchFailure(op,
                                          "failed to derive load_cbuf_to_cb_mx control");
 
+    Value srcStride = op.getSrcStride() ? op.getSrcStride() : control->srcStride;
+    Value dstStride = op.getDstStride() ? op.getDstStride() : control->dstStride;
     rewriter.create<pto::LoadCbufToCbMxOp>(
         loc, source, destination, control->xStartPosition,
         control->yStartPosition, control->xStep, control->yStep,
-        control->srcStride, control->dstStride);
+        srcStride, dstStride);
     rewriter.eraseOp(op);
     return success();
   }

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -5174,6 +5174,8 @@ def mte_l1_l0a_mx(
     *,
     start_row=0,
     start_col=0,
+    src_stride=None,
+    dst_stride=None,
 ):
     """``pto.mte_l1_l0a_mx`` – MX cube-side LEFT staging."""
     _pto.MteL1L0aMxOp(
@@ -5183,6 +5185,12 @@ def mte_l1_l0a_mx(
         _coerce_i64(k, context="mte_l1_l0a_mx k"),
         _coerce_i64(start_row, context="mte_l1_l0a_mx start_row"),
         _coerce_i64(start_col, context="mte_l1_l0a_mx start_col"),
+        src_stride=(
+            None if src_stride is None else _coerce_i64(src_stride, context="mte_l1_l0a_mx src_stride")
+        ),
+        dst_stride=(
+            None if dst_stride is None else _coerce_i64(dst_stride, context="mte_l1_l0a_mx dst_stride")
+        ),
     )
 
 
@@ -5195,6 +5203,8 @@ def mte_l1_l0b_mx(
     *,
     start_row=0,
     start_col=0,
+    src_stride=None,
+    dst_stride=None,
 ):
     """``pto.mte_l1_l0b_mx`` – MX cube-side RIGHT staging."""
     _pto.MteL1L0bMxOp(
@@ -5204,6 +5214,12 @@ def mte_l1_l0b_mx(
         _coerce_i64(n, context="mte_l1_l0b_mx n"),
         _coerce_i64(start_row, context="mte_l1_l0b_mx start_row"),
         _coerce_i64(start_col, context="mte_l1_l0b_mx start_col"),
+        src_stride=(
+            None if src_stride is None else _coerce_i64(src_stride, context="mte_l1_l0b_mx src_stride")
+        ),
+        dst_stride=(
+            None if dst_stride is None else _coerce_i64(dst_stride, context="mte_l1_l0b_mx dst_stride")
+        ),
     )
 
 

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -2134,6 +2134,8 @@ def public_cube_surface_probe(
         k,
         start_row=start_row,
         start_col=start_col,
+        src_stride=8,
+        dst_stride=4,
     )
     pto.mte_l1_l0b_mx(
         rhs_tile_mx.as_ptr(),
@@ -2142,6 +2144,8 @@ def public_cube_surface_probe(
         n,
         start_row=start_col,
         start_col=start_row,
+        src_stride=8,
+        dst_stride=4,
     )
     pto.mad(
         lhs_l0a.as_ptr(),
@@ -6616,6 +6620,10 @@ def main() -> None:
     expect("pto.mte_l1_l0b" in public_surface_text, "mte_l1_l0b(...) should lower to pto.mte_l1_l0b")
     expect("pto.mte_l1_l0a_mx" in public_surface_text, "mte_l1_l0a_mx(...) should lower to pto.mte_l1_l0a_mx")
     expect("pto.mte_l1_l0b_mx" in public_surface_text, "mte_l1_l0b_mx(...) should lower to pto.mte_l1_l0b_mx")
+    expect(
+        public_surface_text.count("strides(") >= 2,
+        "MX L1-to-L0 loads should preserve explicit source/destination strides",
+    )
     expect("pto.tmatmul.mx" in public_surface_text, "pto.tile.matmul_mx should lower to pto.tmatmul.mx")
     expect("pto.tmatmul.mx.acc" in public_surface_text, "pto.tile.matmul_mx_acc should lower to pto.tmatmul.mx.acc")
     expect("pto.tmatmul.mx.bias" in public_surface_text, "pto.tile.matmul_mx_bias should lower to pto.tmatmul.mx.bias")

--- a/test/lit/vpto/cube/cube_bridge_load_buffer_like.pto
+++ b/test/lit/vpto/cube/cube_bridge_load_buffer_like.pto
@@ -30,6 +30,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c0_i64 = arith.constant 0 : i64
     %c2_i64 = arith.constant 2 : i64
     %c4_i64 = arith.constant 4 : i64
+    %c8_i64 = arith.constant 8 : i64
     %c16_i64 = arith.constant 16 : i64
     %c64_i64 = arith.constant 64 : i64
 
@@ -37,17 +38,17 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
       : memref<?xf16, #pto.address_space<mat>>, memref<?xf16, #pto.address_space<left>>, i64, i64, i64, i64
     pto.mte_l1_l0b %src_mat, %dst_right, %c16_i64, %c16_i64, %c0_i64, %c0_i64 {transpose = true}
       : memref<?xf16, #pto.address_space<mat>>, memref<?xf16, #pto.address_space<right>>, i64, i64, i64, i64
-    pto.mte_l1_l0a_mx %src_mat, %dst_left_mx, %c16_i64, %c16_i64, %c0_i64, %c0_i64
+    pto.mte_l1_l0a_mx %src_mat, %dst_left_mx, %c16_i64, %c16_i64, %c0_i64, %c0_i64 strides(%c8_i64, %c4_i64)
       : memref<?xf16, #pto.address_space<mat>>, memref<?xf16, #pto.address_space<left>>, i64, i64, i64, i64
-    pto.mte_l1_l0b_mx %src_mat, %dst_right_mx, %c16_i64, %c16_i64, %c0_i64, %c0_i64
+    pto.mte_l1_l0b_mx %src_mat, %dst_right_mx, %c16_i64, %c16_i64, %c0_i64, %c0_i64 strides(%c8_i64, %c4_i64)
       : memref<?xf16, #pto.address_space<mat>>, memref<?xf16, #pto.address_space<right>>, i64, i64, i64, i64
     pto.mte_l1_l0a %src_hif8, %dst_left_hif8, %c16_i64, %c16_i64, %c0_i64, %c0_i64
       : memref<?x!pto.hif8, #pto.address_space<mat>>, memref<?x!pto.hif8, #pto.address_space<left>>, i64, i64, i64, i64
     pto.mte_l1_l0b %src_hif8, %dst_right_hif8, %c16_i64, %c16_i64, %c0_i64, %c0_i64 {transpose = true}
       : memref<?x!pto.hif8, #pto.address_space<mat>>, memref<?x!pto.hif8, #pto.address_space<right>>, i64, i64, i64, i64
-    pto.mte_l1_l0a %src_fp4, %dst_left_fp4, %c16_i64, %c64_i64, %c0_i64, %c0_i64
+    pto.mte_l1_l0a %src_fp4, %dst_left_fp4, %c16_i64, %c64_i64, %c0_i64, %c4_i64
       : memref<?x!pto.f4E2M1x2, #pto.address_space<mat>>, memref<?x!pto.f4E2M1x2, #pto.address_space<left>>, i64, i64, i64, i64
-    pto.mte_l1_l0b %src_fp4, %dst_right_fp4, %c64_i64, %c16_i64, %c0_i64, %c0_i64 {transpose = true}
+    pto.mte_l1_l0b %src_fp4, %dst_right_fp4, %c64_i64, %c16_i64, %c0_i64, %c4_i64 {transpose = true}
       : memref<?x!pto.f4E2M1x2, #pto.address_space<mat>>, memref<?x!pto.f4E2M1x2, #pto.address_space<right>>, i64, i64, i64, i64
     pto.mte_l1_bt %src_mat, %dst_bias, %c4_i64 nburst(%c2_i64, %c0_i64, %c0_i64)
       : memref<?xf16, #pto.address_space<mat>>, memref<?xf32, #pto.address_space<bias>>, i64, i64, i64, i64
@@ -72,8 +73,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 // ROUNDTRIP-SAME: %{{.*}}: !pto.ptr<f16, l1>, %{{.*}}: !pto.ptr<f16, l0a>, %{{.*}}: !pto.ptr<f16, l0b>, %{{.*}}: !pto.ptr<f16, l0a>, %{{.*}}: !pto.ptr<f16, l0b>, %{{.*}}: !pto.ptr<!pto.hif8, l1>, %{{.*}}: !pto.ptr<!pto.hif8, l0a>, %{{.*}}: !pto.ptr<!pto.hif8, l0b>, %{{.*}}: !pto.ptr<!pto.f4E2M1x2, l1>, %{{.*}}: !pto.ptr<!pto.f4E2M1x2, l0a>, %{{.*}}: !pto.ptr<!pto.f4E2M1x2, l0b>, %{{.*}}: !pto.ptr<f32, bt>) attributes {pto.kernel} {
 // ROUNDTRIP: pto.mte_l1_l0a %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}
 // ROUNDTRIP: pto.mte_l1_l0b %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} {transpose = true}
-// ROUNDTRIP: pto.mte_l1_l0a_mx %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}
-// ROUNDTRIP: pto.mte_l1_l0b_mx %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}
+// ROUNDTRIP: pto.mte_l1_l0a_mx %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} strides(%{{.*}}, %{{.*}})
+// ROUNDTRIP: pto.mte_l1_l0b_mx %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} strides(%{{.*}}, %{{.*}})
 // ROUNDTRIP: pto.mte_l1_l0a %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !pto.ptr<!pto.hif8, l1>, !pto.ptr<!pto.hif8, l0a>
 // ROUNDTRIP: pto.mte_l1_l0b %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} {transpose = true} : !pto.ptr<!pto.hif8, l1>, !pto.ptr<!pto.hif8, l0b>
 // ROUNDTRIP: pto.mte_l1_l0a %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>
@@ -83,12 +84,12 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 // EXPAND-BUFFER-LABEL: func.func @cube_bridge_load_buffer_like(
 // EXPAND-BUFFER: pto.load_cbuf_to_ca
 // EXPAND-BUFFER: pto.load_cbuf_to_cb
-// EXPAND-BUFFER: pto.load_cbuf_to_ca_mx %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}
-// EXPAND-BUFFER: pto.load_cbuf_to_cb_mx
+// EXPAND-BUFFER: pto.load_cbuf_to_ca_mx %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %c8_i64, %c4_i64
+// EXPAND-BUFFER: pto.load_cbuf_to_cb_mx %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %c8_i64, %c4_i64
 // EXPAND-BUFFER: pto.load_cbuf_to_ca
 // EXPAND-BUFFER: pto.load_cbuf_to_cb
-// EXPAND-BUFFER: pto.load_cbuf_to_ca_s4
-// EXPAND-BUFFER: pto.load_cbuf_to_cb_s4
+// EXPAND-BUFFER: pto.load_cbuf_to_ca_s4 %{{.*}}, %{{.*}}, %{{.*}}, %c4_i64
+// EXPAND-BUFFER: pto.load_cbuf_to_cb_s4 %{{.*}}, %{{.*}}, %{{.*}}, %c4_i64
 // EXPAND-BUFFER: pto.copy_cbuf_to_bt
 
 // EXPAND-RIGHT: pto.load_cbuf_to_cb_mx %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !pto.ptr<!pto.hif8, l1>, !pto.ptr<!pto.hif8, l0b>, i64, i64, i64, i64, i64, i64


### PR DESCRIPTION
## 概要

- 在 L1 到 L0 的 wrapper 展开过程中保留用户指定的 packed-FP4 `kStart`
- 为 MX scale load 增加可选的源端和目标端 stride 覆盖参数
- 在 PTODSL 中开放 stride 覆盖能力，同时保留原有的自动推导默认行为
- 补充 PTODSL 与 VPTO 回归测试，覆盖非零 FP4 偏移和显式 MX stride

## 问题背景

packed-FP4 的 L1 到 L0 展开逻辑此前会同时换算 `kStep` 和 `kStart`。因此，用户指定的 `start_col = 4` 最终会被错误生成为原始指令中的 `kStart = 2`，导致相邻 K 子块的数据范围发生重叠。

MX scale wrapper 指令此前只能根据逻辑 tile shape 推导源端和目标端 stride，无法表达某些合法布局。例如，需要 `src_stride = 8`、`dst_stride = 4` 的布局会被静默生成为 `4/4`。

这两类问题都可能正常编译，但在运行时读取错误的数据或 scale 元数据，进而产生静默数值错误。

## 修改内容

- 保持 `kStart` 的原始语义，仅对 packed-FP4 的 `kStep` 进行宽度换算
- 为 `mte_l1_l0a_mx` 和 `mte_l1_l0b_mx` 增加可选的 `src_stride`、`dst_stride` 参数
- wrapper 展开时优先使用显式 stride；未指定时继续采用原有的自动推导逻辑
- 在 PTODSL 中增加对应的可选关键字参数
- 增加回归测试，验证非零 FP4 起始偏移和显式 MX stride 能正确保留到 VPTO

未提供 stride 覆盖参数的现有调用行为保持不变。

## 影响范围

本次修改仅修正 packed-FP4 load 控制参数，并增强 MX scale load 对不同内存布局的表达能力。默认参数和已有调用接口保持兼容，不会改变未使用新参数的代码生成结果。

## 验证情况

- PTOAS 全量构建通过
- `python ptodsl/tests/test_jit_compile.py` 通过
- VPTO wrapper round-trip 检查通过
- VPTO 左、右 MX load wrapper 展开检查通过
- packed-FP4 的 `kStart` 已验证生成为 `4`
- 显式 MX stride 已验证生成为 `8/4`
- `git diff --check` 通过

## 相关工作

#1047 处理的是 MX scale 目标地址编码问题，与本 PR 修复的 load 控制参数问题相互独立。本分支不包含 #1047 的修改。

fix: #1060 