### PR TITLE
fix(vmi): 移除 supplemental group-slot cast 支持

### DIFF
--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -486,8 +486,6 @@ static constexpr LegalCastLayoutPattern kLegalCastLayoutPatterns[] = {
     {bits<16>(), bits<32>(), gs(8, 2), gs(8)},
     {bits<8>(), bits<32>(), gs(1), gs(1)},
     {bits<8>(), bits<32>(), gs(8, 4), gs(8)},
-    {bits<16>(), bits<32>(), gs(8), gs(8)},
-    {bits<8>(), bits<32>(), gs(8), gs(8)},
     {bits<16>(), bits<8>(), gs(1), gs(1)},
     {bits<16>(), bits<8>(), gs(8), gs(8, 2)},
     {bits<32>(), bits<16>(), gs(1), gs(1)},
@@ -529,8 +527,6 @@ static constexpr LegalMaskGranularityCastLayoutPattern
         {mb16(), mb32(), gs(8, 2), gs(8)},
         {mb8(), mb32(), gs(1), gs(1)},
         {mb8(), mb32(), gs(8, 4), gs(8)},
-        {mb16(), mb32(), gs(8), gs(8)},
-        {mb8(), mb32(), gs(8), gs(8)},
         {mb16(), mb8(), gs(1), gs(1)},
         {mb16(), mb8(), gs(8), gs(8, 2)},
         {mb32(), mb16(), gs(1), gs(1)},
@@ -563,25 +559,6 @@ static constexpr InterleaveLayoutPattern kVintlvLayoutPatterns[] = {
     {bits<8, 16, 32, 64>(), chunk<1>(), 0, c(), c(), c(), c(), c()},
     {bits<8, 16>(), chunk<1>(), 1, ls(2), ls(2), ls(2), ls(2), ls(2)},
     {bits<8>(), chunk<1>(), 1, ls(4), ls(4), ls(4), ls(4), ls(4)},
-};
-
-struct SupplementalCastLayoutPattern {
-  ElementBitsPattern sourceBits;
-  ElementBitsPattern resultBits;
-  LayoutPattern sourceLayout;
-  LayoutPattern resultLayout;
-};
-
-static constexpr SupplementalCastLayoutPattern
-    kSupplementalIntegerExtLayoutPatterns[] = {
-    {bits<8>(), bits<32>(), gs(8), gs(8)},
-    {bits<16>(), bits<32>(), gs(8), gs(8)},
-};
-
-static constexpr SupplementalCastLayoutPattern
-    kSupplementalNarrowCastLayoutPatterns[] = {
-    {bits<32>(), bits<8>(), gs(8), gs(8)},
-    {bits<32>(), bits<16>(), gs(8), gs(8)},
 };
 
 struct DenseMemoryLayoutPattern {
@@ -2675,53 +2652,12 @@ LogicalResult VMILayoutSupport::getGroupBroadcastSupport(
       sourceType, resultType, numGroups, reason)));
 }
 
-static LogicalResult matchSupplementalCastLayoutPattern(
-    VMIVRegType sourceType, VMIVRegType resultType,
-    ArrayRef<SupplementalCastLayoutPattern> patterns,
-    std::string *reason) {
-  auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
-      *reason = message.str();
-    return failure();
-  };
-
-  VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
-  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !resultLayout)
-    return fail("requires assigned source/result layouts");
-
-  auto [sourceBits, resultBits] = getCastElementBits(sourceType, resultType);
-  int64_t numGroups =
-      sourceLayout.isGroupSlots()
-          ? sourceLayout.getNumGroups()
-          : (resultLayout.isGroupSlots() ? resultLayout.getNumGroups() : 0);
-  MLIRContext *ctx = sourceType.getContext();
-  for (const SupplementalCastLayoutPattern &pattern : patterns) {
-    if (!matchesElementBitsPattern(pattern.sourceBits, sourceBits) ||
-        !matchesElementBitsPattern(pattern.resultBits, resultBits))
-      continue;
-    if (!matchesLayoutPattern(ctx, pattern.sourceLayout, sourceLayout,
-                              numGroups))
-      continue;
-    if (!matchesLayoutPattern(ctx, pattern.resultLayout, resultLayout,
-                              numGroups))
-      continue;
-    return success();
-  }
-
-  return fail("source/result layouts do not match a supplemental cast table row");
-}
-
 static LogicalResult getNarrowCastSupport(VMIVRegType sourceType,
                                           VMIVRegType resultType,
                                           std::string *reason) {
-  VMILayoutSupport support;
-  if (succeeded(support.getCastLayoutFactForLayouts(
-          sourceType, resultType, sourceType.getLayoutAttr(),
-          resultType.getLayoutAttr(), reason)))
-    return success();
-  return matchSupplementalCastLayoutPattern(
-      sourceType, resultType, kSupplementalNarrowCastLayoutPatterns, reason);
+  return success(succeeded(VMILayoutSupport().getCastLayoutFactForLayouts(
+      sourceType, resultType, sourceType.getLayoutAttr(),
+      resultType.getLayoutAttr(), reason)));
 }
 
 LogicalResult VMILayoutSupport::getTruncFSupport(VMITruncFOp op,
@@ -2744,16 +2680,9 @@ template <typename OpT>
 static LogicalResult getExtISupportImpl(OpT op, std::string *reason) {
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
-
-  FailureOr<VMICastLayoutFact> fact =
-      VMILayoutSupport().getCastLayoutFactForLayouts(
-          sourceType, resultType, sourceType.getLayoutAttr(),
-          resultType.getLayoutAttr(), reason);
-  if (succeeded(fact))
-    return success();
-
-  return matchSupplementalCastLayoutPattern(
-      sourceType, resultType, kSupplementalIntegerExtLayoutPatterns, reason);
+  return success(succeeded(VMILayoutSupport().getCastLayoutFactForLayouts(
+      sourceType, resultType, sourceType.getLayoutAttr(),
+      resultType.getLayoutAttr(), reason)));
 }
 
 LogicalResult VMILayoutSupport::getExtSISupport(VMIExtSIOp op,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10282,113 +10282,67 @@ struct OneToNVMIExtIOpPattern : OpConversionPattern<OpT> {
     VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
     if (sourceLayout && resultLayout && sourceLayout.isGroupSlots() &&
         resultLayout.isGroupSlots()) {
-      if (sourceLayout.getNumGroups() != resultLayout.getNumGroups() ||
-          sourceLayout.getSlots() != 8 || resultLayout.getSlots() != 8 ||
-          sourceParts.size() != resultTypes.size())
-        return rewriter.notifyMatchFailure(
-            op, "unsupported group-slot integer extension shape");
-
       unsigned sourceBits =
           pto::getPTOStorageElemBitWidth(sourceVMIType.getElementType());
       unsigned resultBits =
           pto::getPTOStorageElemBitWidth(resultVMIType.getElementType());
-      if ((sourceBits != 8 && sourceBits != 16) || resultBits != 32)
+      if (sourceLayout.getNumGroups() != resultLayout.getNumGroups() ||
+          sourceLayout.getSlots() != resultLayout.getSlots() ||
+          (sourceLayout.getSlots() != 1 && sourceLayout.getSlots() != 8) ||
+          sourceBits == 0 || sourceBits >= resultBits ||
+          resultBits % sourceBits != 0 ||
+          (resultBits / sourceBits != 2 && resultBits / sourceBits != 4) ||
+          (sourceLayout.getSlots() == 8 &&
+           sourceLayout.getLaneStride() != resultBits / sourceBits) ||
+          resultLayout.getLaneStride() != 1 ||
+          sourceParts.size() != resultTypes.size())
         return rewriter.notifyMatchFailure(
-            op, "group-slot integer extension requires 8/16-bit source and "
-                "32-bit result element widths");
+            op, "unsupported group-slot integer extension shape");
+      int64_t widenFactor = resultBits / sourceBits;
 
+      FailureOr<int64_t> sourceLanes =
+          getDataLanesPerPart(sourceVMIType.getElementType());
+      if (failed(sourceLanes))
+        return rewriter.notifyMatchFailure(
+            op, "failed to derive group-slot integer extension source lanes");
+      auto conversionSourceType = VRegType::get(
+          rewriter.getContext(), *sourceLanes, sourceVMIType.getElementType());
       FailureOr<MaskType> maskType =
-          getMaskTypeForVReg(sourceType, rewriter.getContext());
+          getMaskTypeForVReg(conversionSourceType, rewriter.getContext());
       if (failed(maskType))
         return rewriter.notifyMatchFailure(
             op, "failed to create group-slot integer extension mask type");
       FailureOr<Value> slotMask = createPrefixMaskForActiveLanes(
-          op.getLoc(), *maskType, sourceLayout.getSlots(), rewriter);
+          op.getLoc(), *maskType,
+          sourceLayout.getSlots() * sourceLayout.getLaneStride(), rewriter);
       if (failed(slotMask))
         return rewriter.notifyMatchFailure(
             op, "failed to build group-slot integer extension mask");
 
-      SmallVector<StringRef, 4> partNames;
-      int64_t partFactor = 0;
-      if (sourceBits == 16) {
-        partNames.assign({"EVEN", "ODD"});
-        partFactor = 2;
-      } else {
-        partNames.assign({"P0", "P1", "P2", "P3"});
-        partFactor = 4;
-      }
+      StringAttr part =
+          rewriter.getStringAttr(widenFactor == 2 ? "EVEN" : "P0");
 
       SmallVector<Value> results;
       results.reserve(resultTypes.size());
-      for (auto [chunkIndex, sourcePart, resultType] :
-           llvm::enumerate(sourceParts, resultTypes)) {
+      for (auto [sourcePart, resultType] :
+           llvm::zip_equal(sourceParts, resultTypes)) {
         auto resultVRegType = dyn_cast<VRegType>(resultType);
-        if (!resultVRegType || pto::getPTOStorageElemBitWidth(
-                                   resultVRegType.getElementType()) != 32)
+        if (!resultVRegType ||
+            pto::getPTOStorageElemBitWidth(resultVRegType.getElementType()) !=
+                resultBits)
           return rewriter.notifyMatchFailure(
               op, "unsupported group-slot integer extension result type");
-
-        SmallVector<Value, 4> convertedParts;
-        convertedParts.reserve(partNames.size());
-        for (StringRef partName : partNames) {
-          convertedParts.push_back(
-              rewriter
-                  .create<VcvtOp>(op.getLoc(), resultVRegType, sourcePart,
-                                  *slotMask, /*rnd=*/nullptr, /*sat=*/nullptr,
-                                  rewriter.getStringAttr(partName))
-                  .getResult());
-        }
-
-        FailureOr<MaskType> resultMaskType =
-            getMaskTypeForVReg(resultVRegType, rewriter.getContext());
-        FailureOr<Value> resultAllMask =
-            createAllTrueMaskForVReg(op.getLoc(), resultVRegType, rewriter);
-        if (failed(resultMaskType) || failed(resultAllMask))
+        FailureOr<Value> conversionSource = bitcastVReg(
+            op.getLoc(), sourcePart, conversionSourceType, rewriter);
+        if (failed(conversionSource))
           return rewriter.notifyMatchFailure(
-              op, "failed to build group-slot integer extension result seed");
-
-        auto indexType = VRegType::get(
-            rewriter.getContext(), resultVRegType.getElementCount(),
-            IntegerType::get(rewriter.getContext(), 32));
-        int64_t groupBegin =
-            static_cast<int64_t>(chunkIndex) * sourceLayout.getSlots();
-        int64_t activeSlots = std::min<int64_t>(
-            sourceLayout.getSlots(), sourceLayout.getNumGroups() - groupBegin);
-        if (activeSlots <= 0)
-          return rewriter.notifyMatchFailure(
-              op, "group-slot integer extension has no active slots");
-        Value assembled;
-        for (int64_t slot = 0; slot < activeSlots; ++slot) {
-          int64_t partIndex = slot % partFactor;
-          int64_t sourceLane = slot / partFactor;
-          FailureOr<Value> laneIndexScalar = createScalarOffsetConstant(
-              op.getLoc(), indexType.getElementType(), sourceLane, rewriter);
-          FailureOr<Value> laneMask = createLaneRangeMask(
-              op.getLoc(), *resultMaskType, slot, slot + 1, rewriter);
-          if (failed(laneIndexScalar) || failed(laneMask))
-            return rewriter.notifyMatchFailure(
-                op, "failed to build group-slot integer extension slot mask");
-          Value laneIndex =
-              rewriter
-                  .create<VdupOp>(op.getLoc(), indexType, *laneIndexScalar,
-                                  *resultAllMask, /*position=*/nullptr)
-                  .getResult();
-          Value selected =
-              rewriter
-                  .create<VselrOp>(op.getLoc(), resultVRegType,
-                                   convertedParts[partIndex], laneIndex)
-                  .getResult();
-          if (!assembled) {
-            assembled = selected;
-            continue;
-          }
-          assembled = rewriter
-                          .create<VselOp>(op.getLoc(), resultVRegType, selected,
-                                          assembled, *laneMask)
-                          .getResult();
-        }
-
-        results.push_back(assembled);
+              op, "failed to expose group-slot extension source elements");
+        results.push_back(rewriter
+                              .create<VcvtOp>(op.getLoc(), resultVRegType,
+                                              *conversionSource, *slotMask,
+                                              /*rnd=*/nullptr, /*sat=*/nullptr,
+                                              part)
+                              .getResult());
       }
 
       replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
@@ -10503,15 +10457,11 @@ struct OneToNVMIExtIOpPattern : OpConversionPattern<OpT> {
 //     Lowering shape: emit vcvt into the widened physical carrier selected by
 //     the lane-stride result type.
 //
-// Group-slots logical layouts: group_slots(num_groups=G, slots=1 or 8)
-//   - 32-bit integer -> 16-bit integer, same group_slots layout
-//     Lowering shape: direct vcvt with part = EVEN.
-//   - 32-bit integer -> 8-bit integer, same group_slots layout
-//     Lowering shape: direct vcvt with part = P0.
-//   - 16-bit unsigned integer -> 8-bit unsigned integer, slots = 8,
-//     result lane_stride = 2
-//     Lowering shape: direct vcvt with part = EVEN.
-//   - 32-bit integer -> 8-bit integer, result lane_stride = 4
+// Group-slots logical layouts
+//   - slots = 1 preserves the layout for 2x/4x narrowing.
+//   - slots = 8 records the 2x/4x narrowing factor as the result lane_stride.
+//   - 2x narrowing lowers with part = EVEN; 4x narrowing uses part = P0.
+//   - 32-bit integer -> 8-bit integer, slots = 8, result lane_stride = 4
 //     Lowering shape: no vcvt; keep/bitcast the 32-bit carrier and let the
 //     later store consume it as PK4_B32.
 struct OneToNVMITruncIOpPattern : OpConversionPattern<VMITruncIOp> {
@@ -10538,8 +10488,10 @@ struct OneToNVMITruncIOpPattern : OpConversionPattern<VMITruncIOp> {
       unsigned resultLogicalBits =
           pto::getPTOStorageElemBitWidth(resultVMIType.getElementType());
       bool supportsDirectGroupSlotTrunc =
-          sourceLogicalBits == 32 &&
-          (resultLogicalBits == 16 || resultLogicalBits == 8);
+          (sourceLogicalBits == 32 &&
+           (resultLogicalBits == 16 || resultLogicalBits == 8)) ||
+          (sourceLogicalBits == 16 && resultLogicalBits == 8 &&
+           sourceLayout.getSlots() == 1);
       bool supportsPackedU16ToU8GroupSlotTrunc =
           sourceLogicalBits == 16 && resultLogicalBits == 8 &&
           sourceLayout.getSlots() == 8 && resultLayout.getSlots() == 8 &&
@@ -10602,11 +10554,37 @@ struct OneToNVMITruncIOpPattern : OpConversionPattern<VMITruncIOp> {
           continue;
         }
 
+        if (resultLayout.hasLaneStride() && resultLayout.getLaneStride() == 2 &&
+            resultLogicalBits == 16 && physicalResultBits == 32) {
+          FailureOr<int64_t> conversionResultLanes =
+              getDataLanesPerPart(resultVMIType.getElementType());
+          if (failed(conversionResultLanes))
+            return rewriter.notifyMatchFailure(
+                op, "failed to derive group-slot trunci conversion lanes");
+          auto conversionResultType =
+              VRegType::get(rewriter.getContext(), *conversionResultLanes,
+                            resultVMIType.getElementType());
+          Value converted =
+              rewriter
+                  .create<VcvtOp>(op.getLoc(), conversionResultType, sourcePart,
+                                  *activeSlotMask,
+                                  /*rnd=*/nullptr, sat,
+                                  rewriter.getStringAttr("EVEN"))
+                  .getResult();
+          FailureOr<Value> carrier =
+              bitcastVReg(op.getLoc(), converted, resultType, rewriter);
+          if (failed(carrier))
+            return rewriter.notifyMatchFailure(
+                op, "failed to expose group-slot trunci result carrier");
+          results.push_back(*carrier);
+          continue;
+        }
+
         if (physicalResultBits != 16 && physicalResultBits != 8)
           return rewriter.notifyMatchFailure(
               op, "unsupported group-slot trunci physical type");
 
-        StringAttr part = physicalResultBits == 16
+        StringAttr part = sourceLogicalBits == 2 * resultLogicalBits
                               ? rewriter.getStringAttr("EVEN")
                               : rewriter.getStringAttr("P0");
         results.push_back(rewriter
@@ -12831,8 +12809,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
           << "pto.vmi.extsi supports contiguous signed/signless 8-bit or "
              "16-bit integer physical source chunks to 2x/4x wider integer "
              "deinterleaved results, or matching "
-             "group_slots(num_groups=G, slots=8) 8/16-bit integer source to "
-             "32-bit integer result ("
+             "group_slots(num_groups=G, slots=1) layouts and natural "
+             "group_slots(num_groups=G, slots=8, lane_stride=2/4) to "
+             "group_slots(num_groups=G, slots=8) widening layouts ("
           << reason << ")";
       return WalkResult::interrupt();
     }
@@ -12847,8 +12826,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
           << "pto.vmi.extui supports contiguous unsigned 8-bit or 16-bit "
              "integer physical source chunks to 2x/4x wider unsigned integer "
              "deinterleaved results, or matching "
-             "group_slots(num_groups=G, slots=8) 8/16-bit integer source to "
-             "32-bit integer result ("
+             "group_slots(num_groups=G, slots=1) layouts and natural "
+             "group_slots(num_groups=G, slots=8, lane_stride=2/4) to "
+             "group_slots(num_groups=G, slots=8) widening layouts ("
           << reason << ")";
       return WalkResult::interrupt();
     }
@@ -12862,11 +12842,11 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.trunci supports integer deinterleaved source layouts "
              "whose factor is the 2x/4x narrowing multiple of the contiguous "
-             "or deinterleaved result layout factor, or 32-bit integer "
-             "group_slots(num_groups=G, slots=1 or 8) to 8/16-bit integer "
-             "group_slots(num_groups=G, slots=1 or 8), or 16-bit unsigned "
-             "integer group_slots(num_groups=G, slots=8) to 8-bit unsigned "
-             "integer group_slots(num_groups=G, slots=8, lane_stride=2) ("
+             "or deinterleaved result layout factor, or matching "
+             "group_slots(num_groups=G, slots=1) layouts and natural "
+             "group_slots(num_groups=G, slots=8) to "
+             "group_slots(num_groups=G, slots=8, lane_stride=2/4) narrowing "
+             "layouts ("
           << reason << ")";
       return WalkResult::interrupt();
     }

--- a/test/lit/vmi_new/vmi_layout_assignment_group_slot_load.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_slot_load.pto
@@ -37,13 +37,17 @@ module {
   }
 
   func.func @vmi_layout_assignment_group_slot_load_extui(
-      %src: !pto.ptr<ui8, ub>, %off: index) -> !pto.vmi.vreg<8xui32> {
+      %src: !pto.ptr<ui8, ub>, %off: index)
+      -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>> {
     %c1 = arith.constant 1 : index
     %narrow = pto.vmi.vload %src[%off], %c1 {group = 8}
-        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<8xui8>
+        : !pto.ptr<ui8, ub>
+        -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>
     %wide = pto.vmi.vcvt %narrow
-        : !pto.vmi.vreg<8xui8> -> !pto.vmi.vreg<8xui32>
-    return %wide : !pto.vmi.vreg<8xui32>
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>
+        -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+    return %wide
+        : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
   }
 }
 
@@ -69,6 +73,8 @@ module {
 // CHECK-SAME: -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
 // CHECK: %[[NARROW:.*]] = pto.vmi.group_slot_load
 // CHECK-SAME: -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>
-// CHECK: %[[WIDE:.*]] = pto.vmi.extui %[[NARROW]]
-// CHECK-SAME: !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>> -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+// CHECK: %[[STRIDED:.*]] = pto.vmi.ensure_layout %[[NARROW]]
+// CHECK-SAME: -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>
+// CHECK: %[[WIDE:.*]] = pto.vmi.extui %[[STRIDED]]
+// CHECK-SAME: -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
 // CHECK: return %[[WIDE]]

--- a/test/lit/vmi_new/vmi_to_vpto_group_slot_load.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_slot_load.pto
@@ -60,8 +60,11 @@ module {
     %scale_u8 = pto.vmi.vload%src[%off], %c1 {group = 8}
         : !pto.ptr<ui8, ub>
         -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>
-    %scale_u32 = pto.vmi.vcvt %scale_u8
+    %scale_u8_strided = pto.vmi.ensure_layout %scale_u8
         : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>
+        -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>
+    %scale_u32 = pto.vmi.vcvt %scale_u8_strided
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>
         -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
     %scale_i32 = pto.vmi.vinterpret_cast %scale_u32
         : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
@@ -90,8 +93,11 @@ module {
     %scale_u16 = pto.vmi.vload%src[%off], %c1 {group = 8}
         : !pto.ptr<ui16, ub>
         -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>
-    %scale_u32 = pto.vmi.vcvt %scale_u16
+    %scale_u16_strided = pto.vmi.ensure_layout %scale_u16
         : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>
+        -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
+    %scale_u32 = pto.vmi.vcvt %scale_u16_strided
+        : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
         -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
     %vec = pto.vmi.vbrc %scale_u32 {group = 8}
         : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
@@ -124,13 +130,12 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_load_u8_scale_broadcast(
 // CHECK: pto.pge_b8 "PAT_VL8" : !pto.mask<b8>
-// CHECK: pto.vsldb {{.*}} : !pto.ptr<ui8, ub>, i16, i16, !pto.mask<b8> -> !pto.vreg<256xui8>
-// CHECK-DAG: pto.vcvt {{.*}} {part = "P0"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
-// CHECK-DAG: pto.vcvt {{.*}} {part = "P1"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
-// CHECK-DAG: pto.vcvt {{.*}} {part = "P2"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
-// CHECK-DAG: pto.vcvt {{.*}} {part = "P3"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
-// CHECK: pto.vselr {{.*}} : !pto.vreg<64xui32>, !pto.vreg<64xi32> -> !pto.vreg<64xui32>
-// CHECK: pto.vsel {{.*}} : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
+// CHECK: %[[U8:.*]] = pto.vsldb {{.*}} : !pto.ptr<ui8, ub>, i16, i16, !pto.mask<b8> -> !pto.vreg<256xui8>
+// CHECK: %[[U16:.*]] = pto.vzunpack %[[U8]]
+// CHECK: %[[U32:.*]] = pto.vzunpack %[[U16]]
+// CHECK: pto.pge_b8 "PAT_VL32" : !pto.mask<b8>
+// CHECK: pto.vbitcast {{.*}} : !pto.vreg<64xi32> -> !pto.vreg<256xui8>
+// CHECK: pto.vcvt {{.*}} {part = "P0"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
 // CHECK: pto.vshl
 // CHECK: pto.vselr
 // CHECK: pto.vsts {{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
@@ -140,11 +145,11 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_load_u16_broadcast(
 // CHECK: pto.pge_b16 "PAT_VL8" : !pto.mask<b16>
-// CHECK: pto.vsldb {{.*}} : !pto.ptr<ui16, ub>, i16, i16, !pto.mask<b16> -> !pto.vreg<128xui16>
-// CHECK-DAG: pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
-// CHECK-DAG: pto.vcvt {{.*}} {part = "ODD"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
-// CHECK: pto.vselr {{.*}} : !pto.vreg<64xui32>, !pto.vreg<64xi32> -> !pto.vreg<64xui32>
-// CHECK: pto.vsel {{.*}} : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
+// CHECK: %[[U16:.*]] = pto.vsldb {{.*}} : !pto.ptr<ui16, ub>, i16, i16, !pto.mask<b16> -> !pto.vreg<128xui16>
+// CHECK: %[[U32:.*]] = pto.vzunpack %[[U16]]
+// CHECK: pto.pge_b16 "PAT_VL16" : !pto.mask<b16>
+// CHECK: pto.vbitcast {{.*}} : !pto.vreg<64xi32> -> !pto.vreg<128xui16>
+// CHECK: pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
 // CHECK: pto.vsts {{.*}} : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_integer_casts.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_integer_casts.pto
@@ -98,10 +98,142 @@ module {
     %c1 = arith.constant 1 : index
     %narrow = pto.vmi.vcvt %wide {saturate = "SAT"}
         : !pto.vmi.vreg<8xi32, #pto.vmi.layout<num_groups = 8, slots = 8>>
-        -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>
+        -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>
     pto.vmi.vstore %narrow, %dst[%off], %c1 {group = 8}
-        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>,
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>,
           !pto.ptr<ui8, ub>
+    return
+  }
+
+  func.func @vmi_to_vpto_group_slot_extui_slots1_ui8_to_ui16(
+      %input: !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 1>>)
+      -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>,
+          !pto.vreg<128xui16>, !pto.vreg<128xui16>,
+          !pto.vreg<128xui16>, !pto.vreg<128xui16>,
+          !pto.vreg<128xui16>, !pto.vreg<128xui16>) {
+    %wide = pto.vmi.vcvt %input
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 1>>
+        -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>
+    %p0, %p1, %p2, %p3, %p4, %p5, %p6, %p7 = "pto.vmi.unpack"(%wide)
+        : (!pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>)
+        -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>,
+            !pto.vreg<128xui16>, !pto.vreg<128xui16>,
+            !pto.vreg<128xui16>, !pto.vreg<128xui16>,
+            !pto.vreg<128xui16>, !pto.vreg<128xui16>)
+    return %p0, %p1, %p2, %p3, %p4, %p5, %p6, %p7
+        : !pto.vreg<128xui16>, !pto.vreg<128xui16>,
+          !pto.vreg<128xui16>, !pto.vreg<128xui16>,
+          !pto.vreg<128xui16>, !pto.vreg<128xui16>,
+          !pto.vreg<128xui16>, !pto.vreg<128xui16>
+  }
+
+  func.func @vmi_to_vpto_group_slot_extui_slots1_ui8_to_ui32(
+      %input: !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 1>>,
+      %dst: !pto.ptr<ui32, ub>, %off: index) {
+    %c1 = arith.constant 1 : index
+    %wide = pto.vmi.vcvt %input
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 1>>
+        -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 1>>
+    pto.vmi.vstore %wide, %dst[%off], %c1 {group = 8}
+        : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 1>>,
+          !pto.ptr<ui32, ub>
+    return
+  }
+
+  func.func @vmi_to_vpto_group_slot_extui_slots1_ui16_to_ui32(
+      %input: !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>,
+      %dst: !pto.ptr<ui32, ub>, %off: index) {
+    %c1 = arith.constant 1 : index
+    %wide = pto.vmi.vcvt %input
+        : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>
+        -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 1>>
+    pto.vmi.vstore %wide, %dst[%off], %c1 {group = 8}
+        : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 1>>,
+          !pto.ptr<ui32, ub>
+    return
+  }
+
+  func.func @vmi_to_vpto_group_slot_extui_slots8_ui8_to_ui16(
+      %input: !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>)
+      -> !pto.vreg<128xui16> {
+    %wide = pto.vmi.vcvt %input
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
+        -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>
+    %part = "pto.vmi.unpack"(%wide)
+        : (!pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>)
+        -> !pto.vreg<128xui16>
+    return %part : !pto.vreg<128xui16>
+  }
+
+  func.func @vmi_to_vpto_group_slot_extui_slots8_ui8_to_ui32(
+      %input: !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>)
+      -> !pto.vreg<64xui32> {
+    %wide = pto.vmi.vcvt %input
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>
+        -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+    %part = "pto.vmi.unpack"(%wide)
+        : (!pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>)
+        -> !pto.vreg<64xui32>
+    return %part : !pto.vreg<64xui32>
+  }
+
+  func.func @vmi_to_vpto_group_slot_extsi_slots8_si16_to_si32(
+      %input: !pto.vmi.vreg<8xsi16, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>)
+      -> !pto.vreg<64xsi32> {
+    %wide = pto.vmi.vcvt %input
+        : !pto.vmi.vreg<8xsi16, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
+        -> !pto.vmi.vreg<8xsi32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+    %part = "pto.vmi.unpack"(%wide)
+        : (!pto.vmi.vreg<8xsi32, #pto.vmi.layout<num_groups = 8, slots = 8>>)
+        -> !pto.vreg<64xsi32>
+    return %part : !pto.vreg<64xsi32>
+  }
+
+  func.func @vmi_to_vpto_group_slot_trunci_slots1_ui16_to_ui8(
+      %input: !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>)
+      -> (!pto.vreg<256xui8>, !pto.vreg<256xui8>,
+          !pto.vreg<256xui8>, !pto.vreg<256xui8>,
+          !pto.vreg<256xui8>, !pto.vreg<256xui8>,
+          !pto.vreg<256xui8>, !pto.vreg<256xui8>) {
+    %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>
+        -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 1>>
+    %p0, %p1, %p2, %p3, %p4, %p5, %p6, %p7 = "pto.vmi.unpack"(%narrow)
+        : (!pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 1>>)
+        -> (!pto.vreg<256xui8>, !pto.vreg<256xui8>,
+            !pto.vreg<256xui8>, !pto.vreg<256xui8>,
+            !pto.vreg<256xui8>, !pto.vreg<256xui8>,
+            !pto.vreg<256xui8>, !pto.vreg<256xui8>)
+    return %p0, %p1, %p2, %p3, %p4, %p5, %p6, %p7
+        : !pto.vreg<256xui8>, !pto.vreg<256xui8>,
+          !pto.vreg<256xui8>, !pto.vreg<256xui8>,
+          !pto.vreg<256xui8>, !pto.vreg<256xui8>,
+          !pto.vreg<256xui8>, !pto.vreg<256xui8>
+  }
+
+  func.func @vmi_to_vpto_group_slot_trunci_slots1_ui32_to_ui16(
+      %input: !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 1>>,
+      %dst: !pto.ptr<ui16, ub>, %off: index) {
+    %c1 = arith.constant 1 : index
+    %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 1>>
+        -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>
+    pto.vmi.vstore %narrow, %dst[%off], %c1 {group = 8}
+        : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>,
+          !pto.ptr<ui16, ub>
+    return
+  }
+
+  func.func @vmi_to_vpto_group_slot_trunci_slots8_ui32_to_ui16(
+      %input: !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>,
+      %dst: !pto.ptr<ui16, ub>, %off: index) {
+    %c1 = arith.constant 1 : index
+    %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+        -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
+    pto.vmi.vstore %narrow, %dst[%off], %c1 {group = 8}
+        : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>,
+          !pto.ptr<ui16, ub>
     return
   }
 
@@ -198,11 +330,66 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_trunci_slots8_i32_to_ui8(
 // CHECK: pto.pge_b32 "PAT_VL8"
-// CHECK: pto.vcvt {{.*}} {part = "P0", sat = "SAT"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<256xui8>
+// CHECK-NOT: pto.vcvt
 // CHECK: pto.vsts
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
+
+// CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extui_slots1_ui8_to_ui16(
+// CHECK: %[[VL1:.*]] = pto.pge_b8 "PAT_VL1" : !pto.mask<b8>
+// CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1]] {part = "EVEN"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<128xui16>
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extui_slots1_ui8_to_ui32(
+// CHECK: %[[VL1U8:.*]] = pto.pge_b8 "PAT_VL1" : !pto.mask<b8>
+// CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1U8]] {part = "P0"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extui_slots1_ui16_to_ui32(
+// CHECK: %[[VL1U16EXT:.*]] = pto.pge_b16 "PAT_VL1" : !pto.mask<b16>
+// CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1U16EXT]] {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extui_slots8_ui8_to_ui16(
+// CHECK: %[[VL16:.*]] = pto.pge_b8 "PAT_VL16" : !pto.mask<b8>
+// CHECK: pto.vcvt {{.*}}, %[[VL16]] {part = "EVEN"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<128xui16>
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extui_slots8_ui8_to_ui32(
+// CHECK: %[[VL32:.*]] = pto.pge_b8 "PAT_VL32" : !pto.mask<b8>
+// CHECK: pto.vcvt {{.*}}, %[[VL32]] {part = "P0"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extsi_slots8_si16_to_si32(
+// CHECK: %[[VL16S:.*]] = pto.pge_b16 "PAT_VL16" : !pto.mask<b16>
+// CHECK: pto.vbitcast {{.*}} : !pto.vreg<64xi32> -> !pto.vreg<128xsi16>
+// CHECK: pto.vcvt {{.*}}, %[[VL16S]] {part = "EVEN"} : !pto.vreg<128xsi16>, !pto.mask<b16> -> !pto.vreg<64xsi32>
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_group_slot_trunci_slots1_ui16_to_ui8(
+// CHECK: %[[VL1U16:.*]] = pto.pge_b16 "PAT_VL1" : !pto.mask<b16>
+// CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1U16]] {part = "EVEN", sat = "SAT"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<256xui8>
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_group_slot_trunci_slots1_ui32_to_ui16(
+// CHECK: %[[VL1U32:.*]] = pto.pge_b32 "PAT_VL1" : !pto.mask<b32>
+// CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1U32]] {part = "EVEN", sat = "SAT"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<128xui16>
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_group_slot_trunci_slots8_ui32_to_ui16(
+// CHECK: pto.vcvt {{.*}} {part = "EVEN", sat = "SAT"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<128xui16>
+// CHECK: pto.vbitcast {{.*}} : !pto.vreg<128xui16> -> !pto.vreg<64xi32>
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_trunci_slots8_i32_to_ui8_lane_stride(
 // CHECK-NOT: pto.vcvt


### PR DESCRIPTION
## 背景

现有 group-slot integer cast 同时由主 legal cast table 和 supplemental fallback table 描述。supplemental 路径允许 compact `gs(8) -> gs(8)` widening/narrowing，但该关系没有表达元素宽度变化后的物理 sub-lane 位置，导致 support table、layout assignment 与 VMIToVPTO lowering 之间不一致。

#1056 已合入主线并提供 `gs(8)` 与 `gs(8, lane_stride=2/4)` 的 layout materialization。本 PR 直接基于该能力移除 supplemental 特例，并补全自然合法的 group-slot integer cast。

## 修改

- 删除 supplemental cast pattern/table/fallback，统一由 `kLegalCastLayoutPatterns` 判定 cast layout 合法性。
- 删除主表中重复的 compact `gs(8) ui8/ui16 -> ui32 gs(8)` 特例；compact producer 通过 `ensure_layout` 转成自然的 lane-stride source layout。
- 完成 group-slot integer cast 的自然合法关系：
  - `gs(1) -> gs(1)`：`8 <-> 16`、`16 <-> 32`、`8 <-> 32`。
  - widening：`gs(8, lane_stride=2/4) -> gs(8)`。
  - narrowing：`gs(8) -> gs(8, lane_stride=2/4)`。
- 泛化 integer extension lowering：按 source logical element view 执行一次 `vcvt`，2x 使用 `EVEN`，4x 使用 `P0`。
- 补齐 `gs(1) ui16 -> ui8` 和 `gs(8) ui32 -> ui16 gs(8,2)` narrowing lowering；后者先产生 ui16 conversion result，再暴露 32-bit physical carrier。
- 更新 UE8M0/U16 group-slot broadcast fixtures，使其显式验证自然 relayout + cast 序列。

## 验证

- `llvm-lit -sv build/test/lit/vmi_new`：438/438 通过。
- dav_3510 simulator：`gs(8) ui8 -> ensure_layout gs(8,4) -> ui32 gs(8)`，输入 `[1,2,3,4,5,6,7,8]`，输出 `[1,2,3,4,5,6,7,8]`，compare passed。
- `git diff --check origin/main...HEAD`：通过。

Relates to #1024.
