### PR TITLE
feat(vmi): size-1 / dist_mode=1pt → vsts 1PT_B* / vlds BRC_B*

### DIFF
--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -1377,6 +1377,8 @@ def VMIvStoreOp : VMI_Op<"vstore",
     dist-mode controls the memory access pattern:
     - "continuous" (default): contiguous stride-1 store  → 1 value
     - "dintlv":             interleaved dual store        → 2 values (%lo, %hi)
+    - "1pt":                first-element-only store      → size-1 value
+                            (lowers to ``vsts`` ``1PT_B*``, 4B/2B/1B align)
 
     group mode (mutually exclusive with dist-mode):
     - {group = C}: grouped vector store with row stride

--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -1340,6 +1340,12 @@ def VMIvLoadOp : VMI_Op<"vload",
     - "dintlv":             deinterleaved dual load      → 2 results (%lo, %hi)
     - "unpack":             widening unpack load         → 1 result
     - "brc":                broadcast load               → 1 result
+    - "1pt":                size-1 one-element load      → size-1 result
+                            (lowers to ``vlds`` ``BRC_B*``, natural align;
+                            VLDS has no ``1PT_B*`` token — that is store-only)
+
+    Size-1 continuous loads (``!pto.vmi.vreg<1xT>``) also auto-select
+    ``BRC_B*`` so packed / unaligned UB addresses are legal (NORM needs 32B).
 
     group mode (mutually exclusive with dist-mode):
     - {group = C}: grouped vector load with row stride  → 1 result
@@ -1378,7 +1384,8 @@ def VMIvStoreOp : VMI_Op<"vstore",
     - "continuous" (default): contiguous stride-1 store  → 1 value
     - "dintlv":             interleaved dual store        → 2 values (%lo, %hi)
     - "1pt":                first-element-only store      → size-1 value
-                            (lowers to ``vsts`` ``1PT_B*``, 4B/2B/1B align)
+                            (lowers to ``vsts`` ``1PT_B*``, 4B/2B/1B align;
+                            size-1 continuous stores auto-select the same)
 
     group mode (mutually exclusive with dist-mode):
     - {group = C}: grouped vector store with row stride

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -2546,8 +2546,9 @@ static bool isSupportedVCmpPredicate(StringRef cmpMode) {
 //===----------------------------------------------------------------------===//
 
 static const std::set<StringRef> &validDistModes() {
+  // "1pt": size-1 first-element store → VMIToVPTO emits vsts 1PT_B*
   static const std::set<StringRef> modes = {"continuous", "unpack", "dintlv",
-                                            "brc"};
+                                            "brc", "1pt"};
   return modes;
 }
 
@@ -3786,6 +3787,12 @@ LogicalResult VMIvStoreOp::verify() {
   if (distMode && (*distMode == "unpack" || *distMode == "brc"))
     return emitOpError("dist-mode \"")
            << *distMode << "\" is not valid for vstore";
+  if (distMode && *distMode == "1pt") {
+    auto valueType = cast<VMIVRegType>(getValues()[0].getType());
+    if (valueType.getElementCount() != 1)
+      return emitOpError(
+          "dist-mode \"1pt\" requires a size-1 VMI vector value");
+  }
 
   auto pmode = getPmode();
   if (pmode && !validPModes().count(*pmode))
@@ -4140,6 +4147,8 @@ LogicalResult VMIvLoadOp::verify() {
 
   if (distMode && !validDistModes().count(*distMode))
     return emitOpError("invalid dist-mode: \"") << *distMode << "\"";
+  if (distMode && *distMode == "1pt")
+    return emitOpError("dist-mode \"1pt\" is not valid for vload");
   auto pmode = getPmode();
   if (pmode && !validPModes().count(*pmode))
     return emitOpError("invalid pmode: \"") << *pmode << "\"";

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -2546,7 +2546,9 @@ static bool isSupportedVCmpPredicate(StringRef cmpMode) {
 //===----------------------------------------------------------------------===//
 
 static const std::set<StringRef> &validDistModes() {
-  // "1pt": size-1 first-element store → VMIToVPTO emits vsts 1PT_B*
+  // "1pt": size-1 one-element memory access.
+  //   store → VMIToVPTO emits vsts 1PT_B* (4B/2B/1B align)
+  //   load  → VMIToVPTO emits vlds BRC_B* (same natural align; VLDS has no 1PT)
   static const std::set<StringRef> modes = {"continuous", "unpack", "dintlv",
                                             "brc", "1pt"};
   return modes;
@@ -4147,8 +4149,12 @@ LogicalResult VMIvLoadOp::verify() {
 
   if (distMode && !validDistModes().count(*distMode))
     return emitOpError("invalid dist-mode: \"") << *distMode << "\"";
-  if (distMode && *distMode == "1pt")
-    return emitOpError("dist-mode \"1pt\" is not valid for vload");
+  if (distMode && *distMode == "1pt") {
+    auto resType = cast<VMIVRegType>(getResults().front().getType());
+    if (resType.getElementCount() != 1)
+      return emitOpError(
+          "dist-mode \"1pt\" requires a size-1 VMI vector result");
+  }
   auto pmode = getPmode();
   if (pmode && !validPModes().count(*pmode))
     return emitOpError("invalid pmode: \"") << *pmode << "\"";

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -578,7 +578,9 @@ static LogicalResult lowerVLoad(VMIvLoadOp op, OpBuilder &builder) {
   Value source = op.getSource();
   Value offset = op.getOffset();
 
-  if (distMode == "continuous") {
+  if (distMode == "continuous" || distMode == "1pt") {
+    // "1pt" is the size-1 spelling; VMIToVPTO emits BRC_B* for element_count==1
+    // (VLDS has no 1PT token). Verifier already requires size-1 for "1pt".
     auto loadOp = builder.create<VMILoadOp>(
         loc, op.getResults().front().getType(), source, offset);
     op.getResults().front().replaceAllUsesWith(loadOp.getResult());

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -673,6 +673,40 @@ static LogicalResult lowerVStore(VMIvStoreOp op, OpBuilder &builder) {
   Value offset = op.getOffset();
   auto values = op.getValues();
 
+  // "1pt": first-element-only store → masked_store; VMIToVPTO emits 1PT_B*
+  // when the semantic vreg has element_count == 1 (topk-style parks).
+  if (distMode == "1pt") {
+    if (values.empty())
+      return failure();
+    auto valueType = cast<VMIVRegType>(values[0].getType());
+    if (valueType.getElementCount() != 1)
+      return op.emitError(
+          "vstore dist_mode=\"1pt\" requires a size-1 VMI vreg "
+          "(use pto.vsts(..., dist=\"1PT_B*\") for VL-wide one-point stores)");
+    Value mask;
+    if (!op.getMask().empty()) {
+      mask = op.getMask().front();
+    } else {
+      auto elemType = valueType.getElementType();
+      unsigned bits = 32;
+      if (auto it = dyn_cast<IntegerType>(elemType))
+        bits = it.getWidth();
+      else if (auto ft = dyn_cast<FloatType>(elemType))
+        bits = ft.getWidth();
+      auto gran = StringAttr::get(builder.getContext(),
+                                  bits <= 8 ? "b8" : bits <= 16 ? "b16" : "b32");
+      auto maskType = VMIMaskType::get(builder.getContext(),
+                                       /*elementCount=*/1, gran,
+                                       valueType.getLayout());
+      auto one = builder.create<arith::ConstantOp>(loc, builder.getIndexAttr(1));
+      mask = builder.create<VMICreateMaskOp>(loc, maskType, one.getResult())
+                 .getResult();
+    }
+    builder.create<VMIMaskedStoreOp>(loc, values[0], dest, offset, mask);
+    op->erase();
+    return success();
+  }
+
   if (distMode == "continuous") {
     if (values.empty())
       return failure();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3359,6 +3359,19 @@ std::optional<std::string> getPointStoreDistToken(Type elementType) {
   return (Twine("1PT_B") + Twine(elementBits)).str();
 }
 
+/// Size-1 VMI stores must lower to ``1PT_B*`` (4B/2B/1B natural align), not
+/// default NORM ``vsts`` (32B align). Camodel rejects unaligned NORM/VLDS.
+static StringAttr getContiguousStoreDistAttr(ConversionPatternRewriter &rewriter,
+                                             VMIVRegType valueVMIType) {
+  if (valueVMIType.getElementCount() != 1)
+    return nullptr;
+  std::optional<std::string> point =
+      getPointStoreDistToken(valueVMIType.getElementType());
+  if (!point)
+    return nullptr;
+  return rewriter.getStringAttr(*point);
+}
+
 struct VPTOCmpMode {
   StringRef mode;
   std::optional<IntegerType::SignednessSemantics> signedness;
@@ -7020,9 +7033,10 @@ struct OneToNVMIStoreOpPattern : OpConversionPattern<VMIStoreOp> {
             op, "unsupported element type for store mask");
       Value chunkOffset = createChunkOffset(op.getLoc(), *offset,
                                             index * *lanesPerPart, rewriter);
-      rewriter.create<VstsOp>(op.getLoc(),
-                              /*updated_base=*/Type{}, value, *destination,
-                              chunkOffset, /*dist=*/nullptr, *mask);
+      rewriter.create<VstsOp>(
+          op.getLoc(),
+          /*updated_base=*/Type{}, value, *destination, chunkOffset,
+          getContiguousStoreDistAttr(rewriter, valueVMIType), *mask);
     }
 
     rewriter.eraseOp(op);
@@ -7813,9 +7827,10 @@ struct OneToNVMIMaskedStoreOpPattern
             op, "failed to materialize masked_store predicate");
       Value chunkOffset = createChunkOffset(op.getLoc(), *offset,
                                             index * *lanesPerPart, rewriter);
-      rewriter.create<VstsOp>(op.getLoc(),
-                              /*updated_base=*/Type{}, value, *destination,
-                              chunkOffset, /*dist=*/nullptr, *storeMask);
+      rewriter.create<VstsOp>(
+          op.getLoc(),
+          /*updated_base=*/Type{}, value, *destination, chunkOffset,
+          getContiguousStoreDistAttr(rewriter, valueVMIType), *storeMask);
     }
 
     rewriter.eraseOp(op);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3359,6 +3359,16 @@ std::optional<std::string> getPointStoreDistToken(Type elementType) {
   return (Twine("1PT_B") + Twine(elementBits)).str();
 }
 
+/// Size-1 VMI loads must lower to ``BRC_B*`` (natural element align), not
+/// default NORM ``vlds`` (32B align). Camodel rejects unaligned NORM/VLDS.
+/// Hardware has no load-side ``1PT_B*``; BRC is the one-element load token.
+std::optional<std::string> getPointLoadDistToken(Type elementType) {
+  unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
+  if (elementBits != 8 && elementBits != 16 && elementBits != 32)
+    return std::nullopt;
+  return (Twine("BRC_B") + Twine(elementBits)).str();
+}
+
 /// Size-1 VMI stores must lower to ``1PT_B*`` (4B/2B/1B natural align), not
 /// default NORM ``vsts`` (32B align). Camodel rejects unaligned NORM/VLDS.
 static StringAttr getContiguousStoreDistAttr(ConversionPatternRewriter &rewriter,
@@ -3367,6 +3377,17 @@ static StringAttr getContiguousStoreDistAttr(ConversionPatternRewriter &rewriter
     return nullptr;
   std::optional<std::string> point =
       getPointStoreDistToken(valueVMIType.getElementType());
+  if (!point)
+    return nullptr;
+  return rewriter.getStringAttr(*point);
+}
+
+static StringAttr getContiguousLoadDistAttr(ConversionPatternRewriter &rewriter,
+                                            VMIVRegType resultVMIType) {
+  if (resultVMIType.getElementCount() != 1)
+    return nullptr;
+  std::optional<std::string> point =
+      getPointLoadDistToken(resultVMIType.getElementType());
   if (!point)
     return nullptr;
   return rewriter.getStringAttr(*point);
@@ -5935,6 +5956,7 @@ struct OneToNVMILoadOpPattern : OpConversionPattern<VMILoadOp> {
 
     SmallVector<Value> contiguousParts;
     contiguousParts.reserve(contiguousTypes.size());
+    StringAttr loadDist = getContiguousLoadDistAttr(rewriter, resultVMIType);
     for (auto [index, resultType] : llvm::enumerate(contiguousTypes)) {
       auto vregType = dyn_cast<VRegType>(resultType);
       if (!vregType)
@@ -5945,7 +5967,7 @@ struct OneToNVMILoadOpPattern : OpConversionPattern<VMILoadOp> {
                                     .create<VldsOp>(op.getLoc(), resultType,
                                                     /*updated_base=*/Type{},
                                                     *source, chunkOffset,
-                                                    /*dist=*/nullptr)
+                                                    loadDist)
                                     .getResult());
     }
 
@@ -6699,6 +6721,7 @@ struct OneToNVMIMaskedLoadOpPattern
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
+    StringAttr loadDist = getContiguousLoadDistAttr(rewriter, resultVMIType);
     for (auto [index, maskPassthruAndType] : llvm::enumerate(
              llvm::zip_equal(maskParts, passthruParts, resultTypes))) {
       auto [mask, passthru, resultType] = maskPassthruAndType;
@@ -6713,7 +6736,7 @@ struct OneToNVMIMaskedLoadOpPattern
           rewriter
               .create<VldsOp>(op.getLoc(), resultType,
                               /*updated_base=*/Type{}, *source, chunkOffset,
-                              /*dist=*/nullptr)
+                              loadDist)
               .getResult();
       results.push_back(
           rewriter

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -536,8 +536,13 @@ class _VMINamespace:
             block_stride=block_stride,
             repeat_stride=repeat_stride,
             allow_group_brc=True,
-            allowed_dist_modes={None, "continuous", "dintlv", "unpack", "brc"},
+            allowed_dist_modes={None, "continuous", "dintlv", "unpack", "brc", "1pt"},
         )
+        if dist_mode == "1pt" and size != 1:
+            raise TypeError('pto.vmi.vload(...) with dist_mode="1pt" requires size=1')
+        # Size-1 continuous loads need BRC_B* (natural align); auto-promote.
+        if dist_mode is None and size == 1:
+            dist_mode = "1pt"
         result_types = _resolve_vmi_vload_result_types(
             source,
             size,

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -583,7 +583,7 @@ class _VMINamespace:
             block_stride=block_stride,
             repeat_stride=repeat_stride,
             allow_group_brc=False,
-            allowed_dist_modes={None, "continuous", "dintlv"},
+            allowed_dist_modes={None, "continuous", "dintlv", "1pt"},
         )
         if group is not None and mask is not None:
             raise TypeError("pto.vmi.vstore(...) group mode does not take a mask operand")
@@ -592,6 +592,8 @@ class _VMINamespace:
                 raise TypeError('pto.vmi.vstore(...) with dist_mode="dintlv" requires an (even, odd) pair')
         elif _is_sequence(values):
             raise TypeError("pto.vmi.vstore(...) expects a single VMI vector unless dist_mode=\"dintlv\"")
+        if dist_mode == "1pt" and _is_sequence(values):
+            raise TypeError('pto.vmi.vstore(...) with dist_mode="1pt" expects a single size-1 VMI vector')
         return _generated("vstore")(
             _raw_sequence(values),
             _raw(destination),

--- a/test/lit/vmi_new/vmi_to_vpto_size1_load_1pt.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_size1_load_1pt.pto
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Size-1 continuous / 1pt loads must emit BRC_B32 (natural align), not NORM.
+// VLDS has no 1PT_B* token; BRC is the one-element load distribution.
+
+module {
+  func.func @vmi_to_vpto_size1_continuous_load_brc(
+      %src: !pto.ptr<i32, ub>,
+      %offset: index) -> !pto.vmi.vreg<1xi32> {
+    %v = pto.vmi.vload %src[%offset]
+        : !pto.ptr<i32, ub> -> !pto.vmi.vreg<1xi32>
+    return %v : !pto.vmi.vreg<1xi32>
+  }
+
+  func.func @vmi_to_vpto_size1_explicit_1pt_load(
+      %src: !pto.ptr<i32, ub>,
+      %offset: index) -> !pto.vmi.vreg<1xi32> {
+    %v = pto.vmi.vload %src[%offset] {dist_mode = "1pt"}
+        : !pto.ptr<i32, ub> -> !pto.vmi.vreg<1xi32>
+    return %v : !pto.vmi.vreg<1xi32>
+  }
+}
+
+// CHECK-LABEL: func.func @vmi_to_vpto_size1_continuous_load_brc(
+// CHECK: pto.vlds {{.*}} {dist = "BRC_B32"}
+// CHECK-NOT: pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_size1_explicit_1pt_load(
+// CHECK: pto.vlds {{.*}} {dist = "BRC_B32"}
+// CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_size1_store_1pt.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_size1_store_1pt.pto
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Size-1 masked / 1pt stores must emit 1PT_B32 (4B align), not default NORM.
+
+module {
+  func.func @vmi_to_vpto_size1_masked_store_1pt(
+      %value: !pto.vmi.vreg<1xi32>,
+      %mask: !pto.vmi.mask<1xb32>,
+      %dst: !pto.ptr<i32, ub>,
+      %offset: index) {
+    pto.vmi.vstore %value, %dst[%offset], %mask
+        : !pto.vmi.vreg<1xi32>,
+          !pto.ptr<i32, ub>,
+          !pto.vmi.mask<1xb32>
+    return
+  }
+
+  func.func @vmi_to_vpto_size1_explicit_1pt(
+      %value: !pto.vmi.vreg<1xi32>,
+      %dst: !pto.ptr<i32, ub>,
+      %offset: index) {
+    pto.vmi.vstore %value, %dst[%offset] {dist_mode = "1pt"}
+        : !pto.vmi.vreg<1xi32>,
+          !pto.ptr<i32, ub>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @vmi_to_vpto_size1_masked_store_1pt(
+// CHECK: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK-NOT: pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_size1_explicit_1pt(
+// CHECK: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK-NOT: pto.vmi.


### PR DESCRIPTION
## Summary
- Allow VMI `dist_mode="1pt"` for **size-1** memory ops used by packed parks (e.g. topk_gate).
- **Stores:** size-1 continuous / explicit `1pt` lower to `vsts` `1PT_B*` (natural 4B/2B/1B align) instead of NORM (32B), which camodel rejects on unaligned UB.
- **Loads:** size-1 continuous / explicit `1pt` lower to `vlds` `BRC_B*` (VLDS has no `1PT_B*` token; BRC is the one-element load dist).
- PTODSL `pto.vmi.vload` / `vstore` accept `"1pt"` and auto-promote `size=1` continuous accesses.

Cherry-picked from the earlier mouliangyu/`feature-vmi` stack ([mouliangyu/PTOAS#573](https://github.com/mouliangyu/PTOAS/pull/573)) onto official `main` now that VMI lives there.

## Test plan
- [x] `pto-test-opt` lit: `test/lit/vmi_new/vmi_to_vpto_size1_store_1pt.pto` → `1PT_B32`
- [x] `pto-test-opt` lit: `test/lit/vmi_new/vmi_to_vpto_size1_load_1pt.pto` → `BRC_B32`
- [x] Related: `vmi_layout_assignment_group_slot_broadcast_load_brc_b32.pto` PASS
- [x] Related: `vmi_lane_stride_dense_load_store.pto` (both RUN lines) PASS
- [ ] CI `check-pto` / lit suite on this PR


Made with [Cursor](https://cursor.com)