### PR TITLE
feat(vmi): dual-output vcmax (1xf32 max, 1xi32 argmax)

### DIFF
--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -1257,6 +1257,11 @@ def VMIvcmaxOp : VMI_Op<"vcmax", [Pure]> {
     - Inactive lanes are treated as -INF (floating-point) or the type's
       minimum representable value (integer).
     - `pmode` controls inactive-result behaviour as for `vcadd`.
+    - Optional second result `$index` requests a packed dual-output form:
+      result 0 is the 1-lane maximum (`f32`), result 1 is the 1-lane first
+      argmax lane index (`i32`). Backend lowers through physical
+      `pto.vcmax` → `pto.vdintlv` → `pto.vbitcast` (two VLs, one-point
+      elements). Currently restricted to ungrouped contiguous `64xf32`.
   }];
   let arguments = (ins
     VMI_VRegTypeConstraint:$source,
@@ -1264,9 +1269,15 @@ def VMIvcmaxOp : VMI_Op<"vcmax", [Pure]> {
     OptionalAttr<I64Attr>:$group,
     OptionalAttr<StrAttr>:$pmode
   );
-  let results = (outs VMI_VRegTypeConstraint:$result);
+  let results = (outs
+    VMI_VRegTypeConstraint:$result,
+    Optional<VMI_VRegTypeConstraint>:$index
+  );
   let hasVerifier = 1;
-  let assemblyFormat = "$source `,` $mask attr-dict `:` type($source) `,` type($mask) `->` type($result)";
+  let assemblyFormat = [{
+    $source `,` $mask attr-dict `:` type($source) `,` type($mask)
+      `->` type($result) (`,` type($index)^)?
+  }];
 }
 
 def VMIvcminOp : VMI_Op<"vcmin", [Pure]> {

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -3054,6 +3054,37 @@ LogicalResult VMIvcmaxOp::verify() {
   if (failed(verifyMaskMatchesData(getOperation(), maskType, sourceType)))
     return failure();
 
+  // Dual-output form: (max: 1xf32, index: 1xi32) via packed vcmax+vdintlv.
+  if (Value indexVal = getIndex()) {
+    auto indexType = cast<VMIVRegType>(indexVal.getType());
+    if (getGroupAttr())
+      return emitOpError("return_index / optional index result does not "
+                         "support group=");
+    if (!isa<Float32Type>(elemTy))
+      return emitOpError("optional index result currently requires f32 source");
+    FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(elemTy);
+    if (failed(lanesPerPart) ||
+        sourceType.getElementCount() != *lanesPerPart)
+      return emitOpError("optional index result currently requires a single "
+                         "physical f32 chunk (")
+             << (succeeded(lanesPerPart) ? *lanesPerPart : 64)
+             << " lanes), got " << sourceType.getElementCount();
+    if (resultType.getElementCount() != 1 ||
+        !isa<Float32Type>(resultType.getElementType()))
+      return emitOpError("optional index form requires 1xf32 value result");
+    if (indexType.getElementCount() != 1 ||
+        !isa<IntegerType>(indexType.getElementType()) ||
+        cast<IntegerType>(indexType.getElementType()).getWidth() != 32)
+      return emitOpError("optional index form requires 1xi32 index result");
+    if (auto pmode = getPmode()) {
+      StringRef val = *pmode;
+      if (val != "zero" && val != "merge")
+        return emitOpError("pmode must be \"zero\" or \"merge\", got \"")
+               << val << "\"";
+    }
+    return success();
+  }
+
   if (auto groupAttr = getGroupAttr()) {
     int64_t C = groupAttr.getInt();
     if (sourceType.getElementCount() % C != 0)

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -803,6 +803,24 @@ struct LayoutSolver {
           return WalkResult::interrupt();
         return WalkResult::advance();
       }
+      if (auto vcmax = dyn_cast<VMIvcmaxOp>(op)) {
+        // Indexed dual-output form survives unified→legacy; assign contiguous
+        // layouts so VMI→VPTO can unpack to physical one-point VLs.
+        if (vcmax.getNumResults() == 2) {
+          requestDataUse(vcmax.getSourceMutable(), getContiguousLayout(),
+                         /*late=*/false, DataLayoutSeedPhase::Reduce);
+          if (failed(requestMaskUse(vcmax.getMaskMutable(),
+                                    getContiguousLayout(), op)))
+            return WalkResult::interrupt();
+          if (failed(setNaturalLayout(vcmax.getResult(), getContiguousLayout(),
+                                      op, DataLayoutSeedPhase::Reduce)))
+            return WalkResult::interrupt();
+          if (failed(setNaturalLayout(vcmax.getIndex(), getContiguousLayout(),
+                                      op, DataLayoutSeedPhase::Reduce)))
+            return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      }
       if (auto reduce = dyn_cast<VMIReduceMaxFOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -851,6 +851,10 @@ static LogicalResult lowerVCadd(VMIvcaddOp op, OpBuilder &builder) {
 
 /// Lower vcmax to legacy full or grouped float/integer maximum reduction.
 static LogicalResult lowerVcmax(VMIvcmaxOp op, OpBuilder &builder) {
+  // Dual-output (value, index) stays on the unified op for direct VMI→VPTO
+  // lowering through packed pto.vcmax + vdintlv + vbitcast.
+  if (op.getNumResults() > 1)
+    return failure();
   if (hasMergePmode(op))
     return failure();
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9924,6 +9924,76 @@ struct OneToNVMIReduceMinMaxOpPattern : OpConversionPattern<SourceOp> {
   }
 };
 
+/// Dual-output ``pto.vmi.vcmax`` → packed ``pto.vcmax`` + ``vdintlv`` +
+/// ``vbitcast`` (value: 1xf32, index: 1xi32 as physical one-point VLs).
+struct OneToNVMIVcmaxReturnIndexOpPattern : OpConversionPattern<VMIvcmaxOp> {
+  using OpConversionPattern<VMIvcmaxOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(VMIvcmaxOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (op.getNumResults() != 2)
+      return rewriter.notifyMatchFailure(
+          op, "value-only vcmax lowers through legacy reduce_max");
+
+    ValueRange sourceParts = adaptor.getSource();
+    ValueRange maskParts = adaptor.getMask();
+    FailureOr<SmallVector<Type>> maybeValueTypes =
+        getConvertedResultTypes(op, 0, *this->getTypeConverter());
+    FailureOr<SmallVector<Type>> maybeIndexTypes =
+        getConvertedResultTypes(op, 1, *this->getTypeConverter());
+    if (failed(maybeValueTypes) || failed(maybeIndexTypes))
+      return failure();
+    if (sourceParts.size() != 1 || maskParts.size() != 1 ||
+        maybeValueTypes->size() != 1 || maybeIndexTypes->size() != 1)
+      return rewriter.notifyMatchFailure(
+          op, "return_index vcmax requires one physical source/mask/result "
+              "chunk");
+
+    auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
+    auto valueType = dyn_cast<VRegType>(maybeValueTypes->front());
+    auto indexType = dyn_cast<VRegType>(maybeIndexTypes->front());
+    if (!sourceType || !valueType || !indexType)
+      return rewriter.notifyMatchFailure(
+          op, "return_index vcmax requires physical vreg parts");
+    if (sourceType != valueType)
+      return rewriter.notifyMatchFailure(
+          op, "return_index vcmax value part must match source vreg type");
+    if (!isa<Float32Type>(sourceType.getElementType()))
+      return rewriter.notifyMatchFailure(
+          op, "return_index vcmax currently requires f32 source");
+    if (!isa<IntegerType>(indexType.getElementType()) ||
+        cast<IntegerType>(indexType.getElementType()).getWidth() != 32)
+      return rewriter.notifyMatchFailure(
+          op, "return_index vcmax index part must be i32 vreg");
+
+    Location loc = op.getLoc();
+    Value packed =
+        rewriter
+            .create<VcmaxOp>(loc, sourceType, sourceParts.front(),
+                             maskParts.front())
+            .getResult();
+    Value zeroScalar =
+        rewriter
+            .create<arith::ConstantOp>(loc, rewriter.getF32FloatAttr(0.0))
+            .getResult();
+    Value zeroVec =
+        rewriter.create<VbrOp>(loc, sourceType, zeroScalar).getResult();
+    auto dintlv =
+        rewriter.create<VdintlvOp>(loc, sourceType, sourceType, packed, zeroVec);
+    FailureOr<Value> indexBits =
+        bitcastVReg(loc, dintlv.getHigh(), indexType, rewriter);
+    if (failed(indexBits))
+      return rewriter.notifyMatchFailure(
+          op, "failed to bitcast packed vcmax index lanes to i32");
+
+    replaceOpWithFlatConvertedValues(
+        rewriter, op, ValueRange{dintlv.getLow(), *indexBits},
+        *this->getTypeConverter());
+    return success();
+  }
+};
+
 struct OneToNVMIExtFOpPattern : OpConversionPattern<VMIExtFOp> {
   using OpConversionPattern<VMIExtFOp>::OpConversionPattern;
 
@@ -11378,7 +11448,7 @@ void populateVMIConversionPatterns(
       OneToNVMICompressOpPattern, OneToNVMICompressStoreOpPattern,
       OneToNVMIReduceAddIOpPattern, OneToNVMIReduceAddFOpPattern,
       OneToNVMIGroupBroadcastOpPattern, OneToNVMIVdhistOpPattern,
-      OneToNVMIVchistOpPattern,
+      OneToNVMIVchistOpPattern, OneToNVMIVcmaxReturnIndexOpPattern,
       OneToNVMIReduceMinMaxOpPattern<VMIReduceMaxFOp, VcmaxOp, VmaxOp>,
       OneToNVMIReduceMinMaxOpPattern<VMIReduceMinFOp, VcminOp, VminOp>,
       OneToNVMIReduceMinMaxOpPattern<VMIReduceMaxIOp, VcmaxOp, VmaxOp>,

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -487,8 +487,41 @@ def _emit_reduce(
     loc=None,
     ip=None,
     reassoc=_UNSPECIFIED,
+    return_index=False,
 ):
     context = f"pto.vmi.{op_name}(...)"
+    if return_index:
+        if op_name != "vcmax":
+            raise TypeError(f"{context} does not support return_index=True")
+        if group is not None:
+            raise TypeError(f"{context} return_index=True does not support group=")
+        source_elem_type = _vmi_element_type(_type_of(source), context=context)
+        if not F32Type.isinstance(source_elem_type):
+            raise TypeError(
+                f"{context} return_index=True currently requires f32 source, "
+                f"got {source_elem_type}"
+            )
+        source_lanes = _vmi_vreg_element_count(_type_of(source), context=context)
+        # One physical VL for f32 is 64 lanes (256B / 4B).
+        if source_lanes != 64:
+            raise TypeError(
+                f"{context} return_index=True currently requires a single "
+                f"physical 64-lane f32 chunk, got lanes={source_lanes}"
+            )
+        value_type = _pto.VMIVRegType.get(1, source_elem_type)
+        index_type = _pto.VMIVRegType.get(1, IntegerType.get_signless(32))
+        # Generated ODS: vmi_vcmax(result, index, source, mask, ...)
+        return _call_value(
+            op_name,
+            value_type,
+            index_type,
+            _raw(source),
+            _required_mask(mask, context=context),
+            group=group,
+            pmode=pmode,
+            loc=loc,
+            ip=ip,
+        )
     if op_name == "vcadd":
         source_elem_type = _vmi_element_type(_type_of(source), context=context)
         if reassoc is _UNSPECIFIED:
@@ -505,9 +538,21 @@ def _emit_reduce(
     kwargs = {"group": group, "pmode": pmode, "loc": loc, "ip": ip}
     if reassoc is not _UNSPECIFIED:
         kwargs["reassoc"] = reassoc
+    result_type = _derive_vmi_reduce_result_type(source, group, context=context)
+    # After optional-index ODS regen, vcmax takes (result, index, source, mask)
+    # with index=None for the value-only form.
+    if op_name == "vcmax":
+        return _call_value(
+            op_name,
+            result_type,
+            None,
+            _raw(source),
+            _required_mask(mask, context=context),
+            **kwargs,
+        )
     return _call_value(
         op_name,
-        _derive_vmi_reduce_result_type(source, group, context=context),
+        result_type,
         _raw(source),
         _required_mask(mask, context=context),
         **kwargs,
@@ -731,7 +776,7 @@ class _VMINamespace:
         return _call_value("vbrc", result_type, raw_value, group=group, loc=loc, ip=ip)
 
     vcadd = staticmethod(lambda source, mask, *, group=None, pmode=None, reassoc=_UNSPECIFIED, loc=None, ip=None: _emit_reduce("vcadd", source, mask, group=group, pmode=pmode, reassoc=reassoc, loc=loc, ip=ip))
-    vcmax = staticmethod(lambda source, mask, *, group=None, pmode=None, loc=None, ip=None: _emit_reduce("vcmax", source, mask, group=group, pmode=pmode, loc=loc, ip=ip))
+    vcmax = staticmethod(lambda source, mask, *, group=None, pmode=None, return_index=False, loc=None, ip=None: _emit_reduce("vcmax", source, mask, group=group, pmode=pmode, return_index=return_index, loc=loc, ip=ip))
     vcmin = staticmethod(lambda source, mask, *, group=None, pmode=None, loc=None, ip=None: _emit_reduce("vcmin", source, mask, group=group, pmode=pmode, loc=loc, ip=ip))
 
     @staticmethod

--- a/ptodsl/tests/test_vmi_vcmax_return_index.py
+++ b/ptodsl/tests/test_vmi_vcmax_return_index.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Small case: ``pto.vmi.vcmax(..., return_index=True)`` → (1xf32, 1xi32)."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "ptodsl"))
+
+from ptodsl import pto
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def vmi_vcmax_return_index_probe():
+    src_tile = pto.alloc_tile(shape=[1, 64], dtype=pto.f32)
+    # 32B-aligned parks for one-point stores (8×f32 / 8×i32).
+    mx_tile = pto.alloc_tile(shape=[1, 8], dtype=pto.f32)
+    idx_tile = pto.alloc_tile(shape=[1, 8], dtype=pto.i32)
+    offset = pto.const(0, dtype=pto.index)
+    mask = pto.vmi.create_mask(pto.const(64, dtype=pto.index), size=64)
+    mask1 = pto.vmi.create_mask(pto.const(1, dtype=pto.index), size=1)
+    src = pto.vmi.vload(src_tile.as_ptr(), offset, size=64)
+    mx, idx = pto.vmi.vcmax(src, mask, return_index=True)
+    pto.vmi.vstore(mx, mx_tile.as_ptr(), offset, mask1)
+    pto.vmi.vstore(idx, idx_tile.as_ptr(), offset, mask1)
+
+
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def vmi_vcmax_value_only_probe():
+    src_tile = pto.alloc_tile(shape=[1, 64], dtype=pto.f32)
+    mx_tile = pto.alloc_tile(shape=[1, 8], dtype=pto.f32)
+    offset = pto.const(0, dtype=pto.index)
+    mask = pto.vmi.create_mask(pto.const(64, dtype=pto.index), size=64)
+    mask1 = pto.vmi.create_mask(pto.const(1, dtype=pto.index), size=1)
+    src = pto.vmi.vload(src_tile.as_ptr(), offset, size=64)
+    mx = pto.vmi.vcmax(src, mask)
+    pto.vmi.vstore(mx, mx_tile.as_ptr(), offset, mask1)
+
+
+def main() -> None:
+    dual = vmi_vcmax_return_index_probe.compile()
+    dual_text = dual.mlir_text()
+    expect(dual_text.count("pto.vmi.vcmax") == 1, "dual probe must emit one VMI vcmax")
+    expect(
+        "-> !pto.vmi.vreg<1xf32>" in dual_text and "!pto.vmi.vreg<1xi32>" in dual_text,
+        f"dual-output vcmax must yield 1xf32 + 1xi32, got:\n{dual_text}",
+    )
+
+    value_only = vmi_vcmax_value_only_probe.compile()
+    value_text = value_only.mlir_text()
+    expect(value_text.count("pto.vmi.vcmax") == 1, "value-only probe must emit one VMI vcmax")
+    expect(
+        "-> !pto.vmi.vreg<1xf32>" in value_text,
+        "value-only vcmax must keep a single 1xf32 result",
+    )
+    expect(
+        "!pto.vmi.vreg<1xi32>" not in value_text,
+        "value-only vcmax must not invent an index result",
+    )
+    print("ptodsl_vmi_vcmax_return_index: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/lit/vmi_new/vmi_to_vpto_vcmax_return_index.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vcmax_return_index.pto
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+module {
+  // Dual-output vcmax stays on the unified op (not rewritten to reduce_maxf)
+  // and lowers through packed pto.vcmax → vdintlv → vbitcast.
+  func.func @vmi_vcmax_return_index(
+      %source: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<64xb32, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<64xf32>, !pto.vreg<64xi32>) {
+    // CHECK-LABEL: @vmi_vcmax_return_index
+    // CHECK: %[[PACKED:.*]] = pto.vcmax
+    // CHECK: %[[ZERO:.*]] = pto.vbr
+    // CHECK: %[[EVEN:.*]], %[[ODD:.*]] = pto.vdintlv %[[PACKED]], %[[ZERO]]
+    // CHECK: %[[IDX:.*]] = pto.vbitcast %[[ODD]]
+    // CHECK: return %[[EVEN]], %[[IDX]]
+    %mx, %idx = pto.vmi.vcmax %source, %mask
+        : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<64xb32, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<1xf32, #pto.vmi.layout<contiguous>>,
+           !pto.vmi.vreg<1xi32, #pto.vmi.layout<contiguous>>
+    %mx_part = "pto.vmi.unpack"(%mx)
+        : (!pto.vmi.vreg<1xf32, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<64xf32>
+    %idx_part = "pto.vmi.unpack"(%idx)
+        : (!pto.vmi.vreg<1xi32, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<64xi32>
+    return %mx_part, %idx_part : !pto.vreg<64xf32>, !pto.vreg<64xi32>
+  }
+}


### PR DESCRIPTION
## Summary
- Expose optional second result on `pto.vmi.vcmax` for packed dual-output: `(max: 1xf32, argmax_index: 1xi32)`.
- Backend keeps the unified op (skips legacy `reduce_max`) and lowers through physical `pto.vcmax` → `pto.vdintlv` → `pto.vbitcast`.
- PTODSL: `pto.vmi.vcmax(..., return_index=True)` returns `(mx, idx)`.
- First cut: ungrouped contiguous `64xf32` only (matches topk_gate staged use).

Cherry-picked from mouliangyu/`feature-vmi` ([mouliangyu/PTOAS#572](https://github.com/mouliangyu/PTOAS/pull/572)) onto official `main`.

**Note:** `vcmin` `return_index` is not in this PR (same as #572). Happy to follow up if needed.

## Test plan
- [x] `pto-test-opt` lit: `test/lit/vmi_new/vmi_to_vpto_vcmax_return_index.pto` → `pto.vcmax` + `vdintlv` + `vbitcast`
- [x] `ptodsl/tests/test_vmi_vcmax_return_index.py` included
- [ ] CI lit / check-pto on this PR


Made with [Cursor](https://cursor.com)