### PR TITLE
fix(vmi): allow signedness-compatible memory element types

### DIFF
--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -484,10 +484,19 @@ static LogicalResult verifyMemoryElementMatches(Operation *op, Type memoryType,
   Type memoryElementType = getMemoryElementType(memoryType);
   if (!memoryElementType)
     return success();
-  if (memoryElementType != dataType.getElementType())
-    return op->emitOpError() << "requires memory " << role
-                             << " element type to match VMI data element type";
-  return success();
+  Type dataElementType = dataType.getElementType();
+  if (memoryElementType == dataElementType)
+    return success();
+  // Integer memory cells are bit-storage; allow signless/signed/unsigned
+  // mismatches at the same width (TileLang parks are si*, reductions often
+  // produce signless i*).
+  auto memoryInt = dyn_cast<IntegerType>(memoryElementType);
+  auto dataInt = dyn_cast<IntegerType>(dataElementType);
+  if (memoryInt && dataInt &&
+      memoryInt.getWidth() == dataInt.getWidth())
+    return success();
+  return op->emitOpError() << "requires memory " << role
+                           << " element type to match VMI data element type";
 }
 
 static LogicalResult verifyContiguousIfLayoutAssigned(Operation *op,


### PR DESCRIPTION
## Summary
- Treat same-width `i*` / `si*` / `ui*` as compatible in `verifyMemoryElementMatches` for VMI load/store memory element checks.
- Unblocks size-1 / `dist_mode="1pt"` parks of signless `vreg<1xi32>` into TileLang `ptr<si32, ub>` destinations.

Integer memory cells are bit-storage; signedness is a frontend typing detail that should not reject otherwise legal 1pt stores.

## Test plan
- [ ] With #1070 applied, TileLang `topk_gate` size-1 `vstore(..., dist_mode="1pt")` of `1xi32` into `si32` UB verifies and compiles
- [ ] Existing VMI lit suite still green

Related: #1070 (1pt store/load), vmin/vmax integer PR.


Made with [Cursor](https://cursor.com)