### PR TITLE
chore(ci): cache LLVM install prefix on default branch only

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -38,7 +38,7 @@ concurrency:
 env:
   LLVM_REPO: https://github.com/vpto-dev/llvm-project.git
   LLVM_REF: feature-vpto-llvm21
-  LLVM_CACHE_FLAVOR: llvm21-vpto-wheel-static-pic-v1
+  LLVM_CACHE_FLAVOR: llvm21-vpto-wheel-static-pic-v2
 
 jobs:
   build_wheel:
@@ -149,6 +149,7 @@ jobs:
           echo "WORKSPACE_DIR=/llvm-workspace" >> $GITHUB_ENV
           echo "LLVM_SOURCE_DIR=/llvm-workspace/llvm-project" >> $GITHUB_ENV
           echo "LLVM_BUILD_DIR=/llvm-workspace/llvm-project/build-wheel-static" >> $GITHUB_ENV
+          echo "LLVM_INSTALL_DIR=/llvm-workspace/llvm-install" >> $GITHUB_ENV
           echo "PTO_SOURCE_DIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "PTO_BUILD_DIR=$GITHUB_WORKSPACE/build-release" >> $GITHUB_ENV
 
@@ -162,12 +163,16 @@ jobs:
           fi
           echo "sha=${LLVM_SOURCE_SHA}" >> "$GITHUB_OUTPUT"
 
+      # The cache holds the LLVM install prefix, not the build tree: it is
+      # much smaller and is shared across Python versions (PTOAS assembles the
+      # mlir Python package itself from MLIR's exported Python source-set, so
+      # the Python used to configure LLVM does not affect wheel builds).
       - name: Restore LLVM build cache (exact key)
         id: cache-llvm
         uses: actions/cache/restore@v4
         with:
-          path: /llvm-workspace/llvm-project/build-wheel-static
-          key: llvm-${{ steps.llvm-source.outputs.sha }}-manylinux_2_34-${{ matrix.arch }}-${{ matrix.python }}-${{ env.LLVM_CACHE_FLAVOR }}
+          path: /llvm-workspace/llvm-install
+          key: llvm-${{ steps.llvm-source.outputs.sha }}-manylinux_2_34-${{ matrix.arch }}-${{ env.LLVM_CACHE_FLAVOR }}
 
       - name: Prepare LLVM source
         run: |
@@ -200,16 +205,26 @@ jobs:
             -Dpybind11_DIR="$(${PY_PATH}/bin/python -m pybind11 --cmakedir)" \
             -Dnanobind_DIR="$(${PY_PATH}/bin/python -m nanobind --cmake_dir)" \
             -DCMAKE_BUILD_TYPE=Release \
-            -DLLVM_TARGETS_TO_BUILD="host"
+            -DLLVM_TARGETS_TO_BUILD=host \
+            -DCMAKE_INSTALL_PREFIX=$LLVM_INSTALL_DIR
           ninja -C $LLVM_BUILD_DIR
+          cmake --install $LLVM_BUILD_DIR
 
-      # Upload cache immediately after the build step to avoid later steps polluting the release build tree.
+      # Upload cache immediately after the build step to avoid later steps
+      # polluting the install tree. Only the default branch saves, and only
+      # from a single Python leg: pull requests may restore the shared cache
+      # but must not create private multi-GB entries that evict it, and
+      # parallel Python legs must not race to save the same key.
       - name: Save LLVM cache
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        if: >-
+          steps.cache-llvm.outputs.cache-hit != 'true' &&
+          github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+          matrix.python == '3.11' &&
+          success()
         uses: actions/cache/save@v4
         with:
-          path: /llvm-workspace/llvm-project/build-wheel-static
-          key: llvm-${{ steps.llvm-source.outputs.sha }}-manylinux_2_34-${{ matrix.arch }}-${{ matrix.python }}-${{ env.LLVM_CACHE_FLAVOR }}
+          path: /llvm-workspace/llvm-install
+          key: llvm-${{ steps.llvm-source.outputs.sha }}-manylinux_2_34-${{ matrix.arch }}-${{ env.LLVM_CACHE_FLAVOR }}
 
       - name: Build PTOAS
         env:
@@ -224,7 +239,9 @@ jobs:
           fi
           rm -rf "${PTO_SOURCE_DIR}/build/wheel-dist"
           mkdir -p "${PTO_SOURCE_DIR}/build/wheel-dist"
-          SKBUILD_BUILD_DIR="${PTO_BUILD_DIR}" \
+          # LLVM_BUILD_DIR may point at an LLVM install prefix; CMakeLists.txt
+          # derives LLVM_DIR/MLIR_DIR from it (see docs/build_with_installed_llvm.md).
+          SKBUILD_BUILD_DIR="${PTO_BUILD_DIR}" LLVM_BUILD_DIR="${LLVM_INSTALL_DIR}" \
             python -m pip wheel "${PTOAS_WHEEL_SOURCE_DIR}" \
               --no-build-isolation --no-deps \
               --wheel-dir "${PTO_SOURCE_DIR}/build/wheel-dist"
@@ -238,9 +255,10 @@ jobs:
           export PTO_WHEEL_DIST_DIR=$PTO_SOURCE_DIR/build/wheel-dist
           export PTO_WHEELHOUSE=$GITHUB_WORKSPACE/wheelhouse
           mkdir -p "$PTO_WHEELHOUSE"
-          # Static LLVM/MLIR is embedded in PTOASCompiler. Keep the build-tree
-          # path available only for incidental non-LLVM shared dependencies.
-          export LD_LIBRARY_PATH="${LLVM_BUILD_DIR}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+          # Static LLVM/MLIR is embedded in PTOASCompiler. Keep the LLVM
+          # install-tree path available only for incidental non-LLVM shared
+          # dependencies.
+          export LD_LIBRARY_PATH="${LLVM_INSTALL_DIR}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
           auditwheel repair --plat manylinux_2_34_${{ matrix.arch }} "$PTO_WHEEL_DIST_DIR"/ptoas*.whl -w "$PTO_WHEELHOUSE"
 
       - name: Test wheel installation

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -38,7 +38,7 @@ concurrency:
 env:
   LLVM_REPO: https://github.com/vpto-dev/llvm-project.git
   LLVM_REF: feature-vpto-llvm21
-  LLVM_CACHE_FLAVOR: llvm21-vpto-wheel-static-pic-v2
+  LLVM_CACHE_FLAVOR: llvm21-vpto-wheel-static-pic-utils-v3
 
 jobs:
   build_wheel:
@@ -206,6 +206,7 @@ jobs:
             -Dnanobind_DIR="$(${PY_PATH}/bin/python -m nanobind --cmake_dir)" \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_TARGETS_TO_BUILD=host \
+            -DLLVM_INSTALL_UTILS=ON \
             -DCMAKE_INSTALL_PREFIX=$LLVM_INSTALL_DIR
           ninja -C $LLVM_BUILD_DIR
           cmake --install $LLVM_BUILD_DIR

--- a/.github/workflows/build_wheel_mac.yml
+++ b/.github/workflows/build_wheel_mac.yml
@@ -39,7 +39,7 @@ concurrency:
 env:
   LLVM_REPO: https://github.com/vpto-dev/llvm-project.git
   LLVM_REF: feature-vpto-llvm21
-  LLVM_CACHE_FLAVOR: llvm21-vpto-wheel-static-pic-v2
+  LLVM_CACHE_FLAVOR: llvm21-vpto-wheel-static-pic-utils-v3
 
 jobs:
   build_wheel:
@@ -206,6 +206,7 @@ jobs:
             -Dnanobind_DIR="$(python -m nanobind --cmake_dir)" \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_TARGETS_TO_BUILD="host" \
+            -DLLVM_INSTALL_UTILS=ON \
             -DCMAKE_INSTALL_PREFIX=$LLVM_INSTALL_DIR
           ninja -C $LLVM_BUILD_DIR
           cmake --install $LLVM_BUILD_DIR

--- a/.github/workflows/build_wheel_mac.yml
+++ b/.github/workflows/build_wheel_mac.yml
@@ -39,7 +39,7 @@ concurrency:
 env:
   LLVM_REPO: https://github.com/vpto-dev/llvm-project.git
   LLVM_REF: feature-vpto-llvm21
-  LLVM_CACHE_FLAVOR: llvm21-vpto-wheel-static-pic-v1
+  LLVM_CACHE_FLAVOR: llvm21-vpto-wheel-static-pic-v2
 
 jobs:
   build_wheel:
@@ -149,6 +149,7 @@ jobs:
           echo "WORKSPACE_DIR=${RUNNER_TEMP}/llvm-workspace" >> $GITHUB_ENV
           echo "LLVM_SOURCE_DIR=${RUNNER_TEMP}/llvm-workspace/llvm-project" >> $GITHUB_ENV
           echo "LLVM_BUILD_DIR=${RUNNER_TEMP}/llvm-workspace/llvm-project/build-wheel-static" >> $GITHUB_ENV
+          echo "LLVM_INSTALL_DIR=${RUNNER_TEMP}/llvm-workspace/llvm-install" >> $GITHUB_ENV
           echo "PTO_SOURCE_DIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "PTO_BUILD_DIR=$GITHUB_WORKSPACE/build-release" >> $GITHUB_ENV
 
@@ -162,12 +163,16 @@ jobs:
           fi
           echo "sha=${LLVM_SOURCE_SHA}" >> "$GITHUB_OUTPUT"
 
+      # The cache holds the LLVM install prefix, not the build tree: it is
+      # much smaller and is shared across Python versions (PTOAS assembles the
+      # mlir Python package itself from MLIR's exported Python source-set, so
+      # the Python used to configure LLVM does not affect wheel builds).
       - name: Restore LLVM build cache (exact key)
         id: cache-llvm
         uses: actions/cache/restore@v4
         with:
-          path: ${{ runner.temp }}/llvm-workspace/llvm-project/build-wheel-static
-          key: llvm-${{ steps.llvm-source.outputs.sha }}-${{ steps.runner-meta.outputs.label }}-${{ matrix.arch }}-${{ matrix.python }}-${{ env.LLVM_CACHE_FLAVOR }}
+          path: ${{ runner.temp }}/llvm-workspace/llvm-install
+          key: llvm-${{ steps.llvm-source.outputs.sha }}-${{ steps.runner-meta.outputs.label }}-${{ matrix.arch }}-${{ env.LLVM_CACHE_FLAVOR }}
 
       - name: Prepare LLVM source
         run: |
@@ -200,16 +205,26 @@ jobs:
             -Dpybind11_DIR="$(python -m pybind11 --cmakedir)" \
             -Dnanobind_DIR="$(python -m nanobind --cmake_dir)" \
             -DCMAKE_BUILD_TYPE=Release \
-            -DLLVM_TARGETS_TO_BUILD="host"
+            -DLLVM_TARGETS_TO_BUILD="host" \
+            -DCMAKE_INSTALL_PREFIX=$LLVM_INSTALL_DIR
           ninja -C $LLVM_BUILD_DIR
+          cmake --install $LLVM_BUILD_DIR
 
-      # Upload cache immediately after the build step to avoid later steps polluting the release build tree.
+      # Upload cache immediately after the build step to avoid later steps
+      # polluting the install tree. Only the default branch saves, and only
+      # from a single Python leg: branch pushes may restore the shared cache
+      # but must not create private multi-GB entries that evict it, and
+      # parallel Python legs must not race to save the same key.
       - name: Save LLVM cache
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        if: >-
+          steps.cache-llvm.outputs.cache-hit != 'true' &&
+          github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+          matrix.python == '3.11' &&
+          success()
         uses: actions/cache/save@v4
         with:
-          path: ${{ runner.temp }}/llvm-workspace/llvm-project/build-wheel-static
-          key: llvm-${{ steps.llvm-source.outputs.sha }}-${{ steps.runner-meta.outputs.label }}-${{ matrix.arch }}-${{ matrix.python }}-${{ env.LLVM_CACHE_FLAVOR }}
+          path: ${{ runner.temp }}/llvm-workspace/llvm-install
+          key: llvm-${{ steps.llvm-source.outputs.sha }}-${{ steps.runner-meta.outputs.label }}-${{ matrix.arch }}-${{ env.LLVM_CACHE_FLAVOR }}
 
       - name: Build PTOAS
         run: |
@@ -228,7 +243,9 @@ jobs:
           export _PYTHON_HOST_PLATFORM="$(python "$PTO_SOURCE_DIR/docker/get_macos_wheel_plat_name.py" "$TARGET_ARCH")"
           rm -rf "${PTO_SOURCE_DIR}/build/wheel-dist"
           mkdir -p "${PTO_SOURCE_DIR}/build/wheel-dist"
-          SKBUILD_BUILD_DIR="${PTO_BUILD_DIR}" \
+          # LLVM_BUILD_DIR may point at an LLVM install prefix; CMakeLists.txt
+          # derives LLVM_DIR/MLIR_DIR from it (see docs/build_with_installed_llvm.md).
+          SKBUILD_BUILD_DIR="${PTO_BUILD_DIR}" LLVM_BUILD_DIR="${LLVM_INSTALL_DIR}" \
             python -m pip wheel "${PTOAS_WHEEL_SOURCE_DIR}" \
               --no-build-isolation --no-deps \
               --wheel-dir "${PTO_SOURCE_DIR}/build/wheel-dist"
@@ -269,9 +286,10 @@ jobs:
           echo "delocate dependency summary:"
           delocate-listdeps "${wheels[0]}" || true
 
-          # Static LLVM/MLIR is embedded in PTOASCompiler. Keep the build-tree
-          # path available only for incidental non-LLVM shared dependencies.
-          export DYLD_LIBRARY_PATH="${LLVM_BUILD_DIR}/lib${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}"
+          # Static LLVM/MLIR is embedded in PTOASCompiler. Keep the LLVM
+          # install-tree path available only for incidental non-LLVM shared
+          # dependencies.
+          export DYLD_LIBRARY_PATH="${LLVM_INSTALL_DIR}/lib${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}"
           delocate-wheel \
             --require-archs "${REQUIRED_ARCH}" \
             --wheel-dir "$PTO_WHEELHOUSE" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ concurrency:
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
   # Nightly remote-board validation (GitHub cron is UTC).
   # 22:00 CST (UTC+8) == 14:00 UTC.
   schedule:
@@ -255,7 +258,10 @@ jobs:
 
       # LLVM build 完成后立即保存缓存，避免后续测试影响缓存内容
       - name: Save LLVM build cache
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        if: >-
+          steps.cache-llvm.outputs.cache-hit != 'true' &&
+          github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+          success()
         uses: actions/cache/save@v4
         with:
           path: |

--- a/test/lit/CMakeLists.txt
+++ b/test/lit/CMakeLists.txt
@@ -25,10 +25,18 @@ configure_lit_site_cfg(
 )
 
 set(PTOIR_TEST_DEPENDS
-  FileCheck count not
   ptoas_runtime_deps
   pto-test-opt
 )
+
+# Installed LLVM packages do not export the build-tree targets for these test
+# tools. Keep target dependencies when PTOAS uses an LLVM build tree without
+# rejecting an installed LLVM prefix during configuration.
+foreach(tool FileCheck count not)
+  if(TARGET ${tool})
+    list(APPEND PTOIR_TEST_DEPENDS ${tool})
+  endif()
+endforeach()
 
 add_lit_testsuite(check-pto "Running the pto regression tests"
         ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
## Problem

LLVM build caches were missing for nearly every pull request. The cache key itself was stable, but caches created by a pull request are scoped to `refs/pull/<number>/merge` and cannot be reused by other pull requests. The regular CI workflow also had no `push` trigger for `main`, so there was no reliable shared producer for the main LLVM cache.

The repository cache quota was also being consumed by large wheel LLVM build-tree caches across Python versions. This caused the shared cache to be evicted and made the miss pattern worse.

After switching wheel builds to an installed LLVM prefix, CMake configuration additionally failed because installed LLVM exports no build-tree CMake targets for `FileCheck`, `count`, and `not`:

```text
The dependency target "FileCheck" of target "check-pto" does not exist.
```

## Solution

- Add a `main` push trigger to the regular CI workflow so `main` can produce a cache visible to pull requests.
- Restrict regular CI LLVM cache saves to the default branch; pull requests restore the shared cache but do not create private LLVM caches.
- Cache the smaller LLVM install prefix for Linux and macOS wheel builds instead of the full build tree.
- Remove the Python-version dimension from the wheel LLVM cache key and allow only the Python 3.11 leg on the default branch to save, avoiding duplicate uploads and cache races.
- Enable `LLVM_INSTALL_UTILS=ON` so the installed prefix contains `FileCheck`, `count`, `not`, and `llvm-lit` for lit test execution.
- Bump the wheel cache flavor to invalidate older install-prefix caches created without LLVM utilities.
- Make PTOAS lit-tool CMake dependencies conditional on the corresponding build-tree targets existing, allowing configuration against an installed LLVM prefix while preserving dependencies for normal LLVM build-tree CI.

## Validation

- YAML parsing succeeds for the affected Linux, macOS, and regular CI workflows.
- `git diff --check` succeeds.
- The original installed-LLVM CMake failure is addressed without changing normal build-tree lit test dependencies.