### PR TITLE
Drop a carried dependence proven absent by disjointness

### DIFF
--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -403,8 +403,9 @@ void InsertSyncAnalysis::InsertSync(
 //
 // An access has no loop-carried dependence on itself when it moves far enough per
 // iteration that the memory two iterations touch never meets. This proves that for
-// a `pto.partition_view` whose offset is affine in the enclosing loop's induction
-// variable, which is the shape a store walking a tensor takes.
+// a `pto.partition_view` whose offset is affine in the induction variable of the loop
+// whose back edge carries the dependence, which is the shape a store walking a tensor
+// takes.
 //
 // Every condition is cumulative and the default is to keep the sync: each helper
 // refuses the moment an input is not a compile-time constant.
@@ -607,11 +608,10 @@ static bool partitionViewIterationsDisjoint(pto::PartitionViewOp view,
 /// Scoped to a self pair: the general case of two different accesses proven never to
 /// meet at any iteration distance needs a pairwise comparison this does not attempt.
 ///
-/// Multi-buffered accesses are refused rather than analysed. A base memory object
-/// with more than one address is a rotating slot set, where the carried dependence is
-/// real and merely sits at the rotation distance; excusing it would drop an ordering
-/// the program needs. This predicate only ever claims that no carried dependence
-/// exists at any distance, so the two cases are kept apart by construction.
+/// The multi-address refusal below is a precondition rather than a discriminator.
+/// A `pto.partition_view` source is constrained to `TensorViewType`; more than one
+/// base address arises only from a multi-tile argument or `pto.subview`, neither of
+/// which can inhabit that type.
 static bool isCarriedSelfDepAffineDisjoint(
     const CompoundInstanceElement *nowCompound,
     const CompoundInstanceElement *frontCompound,
@@ -698,9 +698,7 @@ void InsertSyncAnalysis::MemAnalyze(
 
   // Carried deps whose two iterations provably touch disjoint memory. Kept separate
   // from the forward drop above because this case only arrives on the back-edge pass,
-  // which the forward drop deliberately does not look at. The forward drop's warning
-  // about back edges is about ROTATION -- a real dependence at the rotation distance --
-  // and rotating accesses are refused here, so the two claims cannot be confused.
+  // which the forward drop deliberately does not look at.
   if (forEndIndex.has_value()) {
     scf::ForOp carryingFor = carryingForOf(syncIR_, forEndIndex);
     auto isDroppableCarried = [&](const std::pair<const BaseMemInfo *,

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -16,6 +16,7 @@
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/InsertSync/SyncCommon.h"
 #include "PTO/Transforms/SlotAffineAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
@@ -396,6 +397,228 @@ void InsertSyncAnalysis::InsertSync(
   MemAnalyze(nowCompound, frontCompound, syncRecordList, forEndIndex);
 }
 
+//===----------------------------------------------------------------------===//
+// Affine-disjoint carried accesses
+//===----------------------------------------------------------------------===//
+//
+// An access has no loop-carried dependence on itself when it moves far enough per
+// iteration that the memory two iterations touch never meets. This proves that for
+// a `pto.partition_view` whose offset is affine in the enclosing loop's induction
+// variable, which is the shape a store walking a tensor takes.
+//
+// Every condition is cumulative and the default is to keep the sync: each helper
+// refuses the moment an input is not a compile-time constant.
+
+/// The innermost `scf.for` containing `op`, or null.
+static scf::ForOp enclosingForOf(Operation *op) {
+  for (Operation *p = op ? op->getParentOp() : nullptr; p; p = p->getParentOp())
+    if (auto forOp = dyn_cast<scf::ForOp>(p))
+      return forOp;
+  return {};
+}
+
+/// `v` as a compile-time constant index, or nullopt.
+static std::optional<int64_t> constantIndexOf(Value v) {
+  APInt value;
+  if (!v || !matchPattern(v, m_ConstantInt(&value)))
+    return std::nullopt;
+  return value.getSExtValue();
+}
+
+/// How far `v` moves per iteration of `forOp`: the coefficient of its induction
+/// variable, or nullopt when that is not a compile-time constant.
+///
+/// `v` qualifies when it is a sum of terms that are each either loop-invariant or a
+/// constant multiple of the induction variable. A load, `iv * iv`, a select, or a
+/// non-constant scale on the induction variable all yield nullopt.
+///
+/// Loop-invariance, not constant-ness, is the base case that matters: offsets are
+/// built from the block index and from enclosing loops' induction variables, none of
+/// which folds to a constant, but a value defined outside this loop's body cannot
+/// change between its iterations.
+static std::optional<int64_t> movementPerIteration(Value v, scf::ForOp forOp,
+                                                   unsigned depth = 0) {
+  if (!v || !forOp || depth > 8)
+    return std::nullopt;
+  if (v == forOp.getInductionVar())
+    return 1;
+  if (forOp.isDefinedOutsideOfLoop(v) || constantIndexOf(v))
+    return 0;
+  if (auto add = v.getDefiningOp<arith::AddIOp>()) {
+    auto l = movementPerIteration(add.getLhs(), forOp, depth + 1);
+    auto r = movementPerIteration(add.getRhs(), forOp, depth + 1);
+    if (!l || !r)
+      return std::nullopt;
+    return *l + *r;
+  }
+  if (auto sub = v.getDefiningOp<arith::SubIOp>()) {
+    auto l = movementPerIteration(sub.getLhs(), forOp, depth + 1);
+    auto r = movementPerIteration(sub.getRhs(), forOp, depth + 1);
+    if (!l || !r)
+      return std::nullopt;
+    return *l - *r;
+  }
+  if (auto mul = v.getDefiningOp<arith::MulIOp>()) {
+    // Only a constant scale is usable: `iv * n` with n loop-invariant but unknown
+    // moves by an unknown amount, which must refuse.
+    if (auto c = constantIndexOf(mul.getRhs())) {
+      auto l = movementPerIteration(mul.getLhs(), forOp, depth + 1);
+      if (!l)
+        return std::nullopt;
+      return *l * *c;
+    }
+    if (auto c = constantIndexOf(mul.getLhs())) {
+      auto r = movementPerIteration(mul.getRhs(), forOp, depth + 1);
+      if (!r)
+        return std::nullopt;
+      return *r * *c;
+    }
+  }
+  return std::nullopt;
+}
+
+/// The strides of the tensor view a `pto.partition_view` reads, as compile-time
+/// constants, or nullopt when the view is not a `pto.make_tensor_view` with
+/// constant strides of the expected rank.
+static std::optional<SmallVector<int64_t>> viewStrides(Value source,
+                                                       unsigned rank) {
+  auto make = source.getDefiningOp<pto::MakeTensorViewOp>();
+  if (!make || make.getStrides().size() != rank)
+    return std::nullopt;
+  SmallVector<int64_t> strides;
+  for (Value stride : make.getStrides()) {
+    auto c = constantIndexOf(stride);
+    if (!c)
+      return std::nullopt;
+    strides.push_back(*c);
+  }
+  return strides;
+}
+
+/// Do two consecutive iterations of `view` touch disjoint memory?
+///
+/// Requires, cumulatively: a constant loop step; exactly one dimension whose offset
+/// varies with the induction variable, with a compile-time constant coefficient, and
+/// every other offset loop-invariant; constant sizes in every dimension; constant
+/// view strides; and the separation itself.
+///
+/// The separation is proven in ADDRESS space, not index space. Disjoint index ranges
+/// imply disjoint addresses only if the layout maps distinct index tuples to
+/// distinct addresses, which a strided view does not promise: two dimensions may
+/// share a stride, and a stride may be zero. So the footprint is bounded directly.
+/// One iteration touches addresses within `window` of its base, and the next
+/// iteration's base sits `shift` away, where a `pto.partition_view` selects a
+/// contiguous box -- it carries offsets and sizes and no strides, so its step within
+/// each dimension is one by construction and the view stride alone gives the
+/// address step. Strictly greater means the two windows cannot overlap whatever the
+/// layout does, and a zero stride on the varying dimension makes `shift` zero, so it
+/// refuses without needing a special case.
+///
+/// The bound is tight rather than slack: an access that walks a tensor with no gap
+/// between iterations has `shift` exactly one greater than `window`, which is the
+/// intended reading -- adjacent is disjoint.
+static bool partitionViewIterationsDisjoint(pto::PartitionViewOp view,
+                                            scf::ForOp forOp) {
+  if (!view || !forOp)
+    return false;
+
+  auto step = constantIndexOf(forOp.getStep());
+  if (!step || *step == 0)
+    return false;
+
+  ValueRange offsets = view.getOffsets();
+  ValueRange sizes = view.getSizes();
+  unsigned rank = offsets.size();
+  if (rank == 0 || sizes.size() != rank)
+    return false;
+
+  std::optional<SmallVector<int64_t>> strides = viewStrides(view.getSource(), rank);
+  if (!strides)
+    return false;
+
+  std::optional<unsigned> varyingDim;
+  int64_t coeff = 0;
+  for (unsigned d = 0; d < rank; ++d) {
+    auto c = movementPerIteration(offsets[d], forOp);
+    if (!c)
+      return false; // offset not affine in the induction variable
+    if (*c == 0)
+      continue; // affine but loop-invariant
+    if (varyingDim)
+      return false; // two dimensions moving at once: not modelled
+    varyingDim = d;
+    coeff = *c;
+  }
+  if (!varyingDim)
+    return false; // nothing moves: every iteration hits the same region
+
+  // Products of IR constants, bounded before multiplying: a fabricated stride could
+  // otherwise overflow the accumulation and yield a small window from huge inputs,
+  // which would read as disjoint.
+  constexpr int64_t kMaxFactor = 1LL << 30;
+  auto bounded = [](int64_t v) { return v > -kMaxFactor && v < kMaxFactor; };
+
+  int64_t window = 0;
+  for (unsigned d = 0; d < rank; ++d) {
+    auto size = constantIndexOf(sizes[d]);
+    if (!size || *size <= 0)
+      return false;
+    int64_t stride = (*strides)[d];
+    if (!bounded(*size) || !bounded(stride))
+      return false;
+    window += (*size - 1) * std::abs(stride);
+    if (!bounded(window))
+      return false;
+  }
+
+  int64_t indexDelta = coeff * *step;
+  int64_t shift = indexDelta * (*strides)[*varyingDim];
+  if (!bounded(indexDelta) || !bounded(shift))
+    return false;
+  return std::abs(shift) > window;
+}
+
+/// The carried dependence `pair` claims between `element` and its own next execution
+/// does not exist, because both sides are the same `pto.partition_view` and
+/// consecutive iterations of it touch disjoint memory.
+///
+/// Scoped to a self pair: the general case of two different accesses proven never to
+/// meet at any iteration distance needs a pairwise comparison this does not attempt.
+///
+/// Multi-buffered accesses are refused rather than analysed. A base memory object
+/// with more than one address is a rotating slot set, where the carried dependence is
+/// real and merely sits at the rotation distance; excusing it would drop an ordering
+/// the program needs. This predicate only ever claims that no carried dependence
+/// exists at any distance, so the two cases are kept apart by construction.
+static bool isCarriedSelfDepAffineDisjoint(
+    const CompoundInstanceElement *nowCompound,
+    const CompoundInstanceElement *frontCompound,
+    const std::pair<const BaseMemInfo *, const BaseMemInfo *> &pair) {
+  if (nowCompound != frontCompound || !nowCompound)
+    return false;
+  if (!pair.first || !pair.second || !(*pair.first == *pair.second))
+    return false;
+  if (pair.first->baseAddresses.size() > 1 ||
+      pair.second->baseAddresses.size() > 1)
+    return false;
+
+  scf::ForOp forOp = enclosingForOf(nowCompound->elementOp);
+  if (!forOp)
+    return false;
+
+  auto viewOf = [](const BaseMemInfo *mi) -> pto::PartitionViewOp {
+    if (!mi || !mi->baseBuffer)
+      return {};
+    return mi->baseBuffer.getDefiningOp<pto::PartitionViewOp>();
+  };
+  pto::PartitionViewOp a = viewOf(pair.first);
+  pto::PartitionViewOp b = viewOf(pair.second);
+  if (!a || a != b)
+    return false;
+
+  return partitionViewIterationsDisjoint(a, forOp);
+}
+
 // Returns true if a *same-iter* multi-buffer dep pair can be dropped
 // because the producer's and consumer's slot SSA expressions are provably
 // disjoint modulo N. Only applied to forward (non-back-edge) deps -- the
@@ -434,8 +657,9 @@ void InsertSyncAnalysis::MemAnalyze(
 
   // Same-iter (forward) deps: drop pairs that the affine analysis proves
   // touch disjoint slots in every iteration of the multi-buffer loop.
-  // Back-edge deps stay untouched -- they still need per-slot syncing
-  // through the dyn-event-id pipeline.
+  // THIS drop never looks at back-edge deps: a rotating slot set still needs
+  // per-slot syncing through the dyn-event-id pipeline, so a slot-disjointness
+  // argument does not transfer to the back edge.
   if (!forEndIndex.has_value()) {
     auto isDroppable = [](const std::pair<const BaseMemInfo *,
                                           const BaseMemInfo *> &pair) {
@@ -443,6 +667,23 @@ void InsertSyncAnalysis::MemAnalyze(
     };
     depVec.erase(std::remove_if(depVec.begin(), depVec.end(), isDroppable),
                  depVec.end());
+    if (depVec.empty())
+      return;
+  }
+
+  // Carried deps whose two iterations provably touch disjoint memory. Kept separate
+  // from the forward drop above because this case only arrives on the back-edge pass,
+  // which the forward drop deliberately does not look at. The forward drop's warning
+  // about back edges is about ROTATION -- a real dependence at the rotation distance --
+  // and rotating accesses are refused here, so the two claims cannot be confused.
+  if (forEndIndex.has_value()) {
+    auto isDroppableCarried = [&](const std::pair<const BaseMemInfo *,
+                                                  const BaseMemInfo *> &pair) {
+      return isCarriedSelfDepAffineDisjoint(nowCompound, frontCompound, pair);
+    };
+    depVec.erase(
+        std::remove_if(depVec.begin(), depVec.end(), isDroppableCarried),
+        depVec.end());
     if (depVec.empty())
       return;
   }

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -409,12 +409,34 @@ void InsertSyncAnalysis::InsertSync(
 // Every condition is cumulative and the default is to keep the sync: each helper
 // refuses the moment an input is not a compile-time constant.
 
-/// The innermost `scf.for` containing `op`, or null.
-static scf::ForOp enclosingForOf(Operation *op) {
-  for (Operation *p = op ? op->getParentOp() : nullptr; p; p = p->getParentOp())
-    if (auto forOp = dyn_cast<scf::ForOp>(p))
-      return forOp;
-  return {};
+/// The `scf.for` whose back edge `forEndIndex` denotes, or null.
+///
+/// THE INNERMOST ENCLOSING LOOP IS THE WRONG ANSWER, and silently so. A carried
+/// dependence is analysed once per back edge, and for an access inside a nest the
+/// outer back edge and the inner one are different questions: inner iterations can
+/// be disjoint while the outer loop restarts and revisits the same addresses. Proving
+/// disjointness against the innermost enclosing loop therefore answers the inner
+/// question and applies the result to whichever edge is under analysis.
+///
+/// `forEndIndex` indexes `syncIR_`, and its element is the loop's LOOP_END marker.
+/// `UpdateForOpInfo` records the op on both markers, so the loop is recovered exactly
+/// rather than inferred. Note the index refers to `syncIR_` even while a back edge is
+/// being analysed over the copied body slice, so it must not be resolved against the
+/// SyncIRs the current traversal happens to walk.
+///
+/// Null on every path that does not resolve to an `scf.for`: an out-of-range index, an
+/// element that is not a loop, a loop marker with no op, and an `scf.while`, which
+/// reaches the same element type through `UpdateWhileOpInfo`. Callers must treat null
+/// as "not proven".
+static scf::ForOp carryingForOf(const SyncIRs &syncIR,
+                                const std::optional<unsigned> &forEndIndex) {
+  if (!forEndIndex.has_value() || forEndIndex.value() >= syncIR.size())
+    return {};
+  const auto *loopEl =
+      dyn_cast_or_null<LoopInstanceElement>(syncIR[forEndIndex.value()].get());
+  if (!loopEl || !loopEl->elementOp)
+    return {};
+  return dyn_cast<scf::ForOp>(loopEl->elementOp);
 }
 
 /// `v` as a compile-time constant index, or nullopt.
@@ -593,7 +615,8 @@ static bool partitionViewIterationsDisjoint(pto::PartitionViewOp view,
 static bool isCarriedSelfDepAffineDisjoint(
     const CompoundInstanceElement *nowCompound,
     const CompoundInstanceElement *frontCompound,
-    const std::pair<const BaseMemInfo *, const BaseMemInfo *> &pair) {
+    const std::pair<const BaseMemInfo *, const BaseMemInfo *> &pair,
+    scf::ForOp carryingFor) {
   if (nowCompound != frontCompound || !nowCompound)
     return false;
   if (!pair.first || !pair.second || !(*pair.first == *pair.second))
@@ -602,8 +625,10 @@ static bool isCarriedSelfDepAffineDisjoint(
       pair.second->baseAddresses.size() > 1)
     return false;
 
-  scf::ForOp forOp = enclosingForOf(nowCompound->elementOp);
-  if (!forOp)
+  // The loop under analysis, not the innermost one enclosing the access. Null means
+  // the back edge did not resolve to an `scf.for`, which is never a proof of
+  // disjointness.
+  if (!carryingFor)
     return false;
 
   auto viewOf = [](const BaseMemInfo *mi) -> pto::PartitionViewOp {
@@ -616,7 +641,7 @@ static bool isCarriedSelfDepAffineDisjoint(
   if (!a || a != b)
     return false;
 
-  return partitionViewIterationsDisjoint(a, forOp);
+  return partitionViewIterationsDisjoint(a, carryingFor);
 }
 
 // Returns true if a *same-iter* multi-buffer dep pair can be dropped
@@ -677,9 +702,11 @@ void InsertSyncAnalysis::MemAnalyze(
   // about back edges is about ROTATION -- a real dependence at the rotation distance --
   // and rotating accesses are refused here, so the two claims cannot be confused.
   if (forEndIndex.has_value()) {
+    scf::ForOp carryingFor = carryingForOf(syncIR_, forEndIndex);
     auto isDroppableCarried = [&](const std::pair<const BaseMemInfo *,
                                                   const BaseMemInfo *> &pair) {
-      return isCarriedSelfDepAffineDisjoint(nowCompound, frontCompound, pair);
+      return isCarriedSelfDepAffineDisjoint(nowCompound, frontCompound, pair,
+                                            carryingFor);
     };
     depVec.erase(
         std::remove_if(depVec.begin(), depVec.end(), isDroppableCarried),

--- a/test/lit/pto/sync_affine_disjoint_carried.pto
+++ b/test/lit/pto/sync_affine_disjoint_carried.pto
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A store whose destination advances by at least its own footprint per iteration has
+// no loop-carried dependence on itself, so the barrier ordering it against its own
+// next execution is not needed. The three refusal cases are pinned alongside the
+// drop: a predicate that fired unconditionally would pass a test that only checked
+// the drop.
+
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync --emit-pto-ir %s \
+// RUN:   | FileCheck %s
+
+module attributes {pto.target_arch = "a2a3"} {
+  // Advances 512 per iteration against a 64-element footprint: disjoint.
+  // CHECK-LABEL: func.func @gap_wider_than_extent
+  // CHECK:         scf.for
+  // CHECK-NOT:       pto.barrier <PIPE_MTE3>
+  // CHECK:         pto.tstore
+  func.func @gap_wider_than_extent(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c64 = arith.constant 64 : index
+    %c512 = arith.constant 512 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    scf.for %i = %c0 to %c8 step %c1 {
+      %off = arith.muli %i, %c512 : index
+      %out = pto.partition_view %dst, offsets = [%c0, %off], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+      pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<1x64xbf16>)
+    }
+    return
+  }
+
+  // Advances exactly its own footprint. Adjacent, not overlapping, so still
+  // disjoint -- and this is the boundary the corpus actually walks, a store
+  // covering a tensor with no gap between iterations. Enforced by the strict
+  // greater-than on the address window in `partitionViewIterationsDisjoint`.
+  // CHECK-LABEL: func.func @gap_equals_extent
+  // CHECK:         scf.for
+  // CHECK-NOT:       pto.barrier <PIPE_MTE3>
+  // CHECK:         pto.tstore
+  func.func @gap_equals_extent(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    scf.for %i = %c0 to %c8 step %c1 {
+      %off = arith.muli %i, %c64 : index
+      %out = pto.partition_view %dst, offsets = [%c0, %off], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+      pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<1x64xbf16>)
+    }
+    return
+  }
+
+  // Advances 32 against a 64-element footprint: consecutive iterations overlap in
+  // the second half of each store, so the barrier must stay.
+  // CHECK-LABEL: func.func @gap_narrower_than_extent
+  // CHECK:         scf.for
+  // CHECK:           pto.barrier <PIPE_MTE3>
+  // CHECK:           pto.tstore
+  func.func @gap_narrower_than_extent(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    scf.for %i = %c0 to %c8 step %c1 {
+      %off = arith.muli %i, %c32 : index
+      %out = pto.partition_view %dst, offsets = [%c0, %off], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+      pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<1x64xbf16>)
+    }
+    return
+  }
+
+  // The destination does not move: every iteration writes the same 64 elements.
+  // A genuine loop-carried write-after-write, so the barrier must stay.
+  // CHECK-LABEL: func.func @no_movement
+  // CHECK:         scf.for
+  // CHECK:           pto.barrier <PIPE_MTE3>
+  // CHECK:           pto.tstore
+  func.func @no_movement(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    scf.for %i = %c0 to %c8 step %c1 {
+      %out = pto.partition_view %dst, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+      pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<1x64xbf16>)
+    }
+    return
+  }
+
+  // The destination advances by a value the analysis cannot bound: the induction
+  // variable is scaled by a loop-invariant that is not a compile-time constant, so
+  // the movement per iteration is unknown and the barrier must stay.
+  // CHECK-LABEL: func.func @unknown_movement
+  // CHECK:         scf.for
+  // CHECK:           pto.barrier <PIPE_MTE3>
+  // CHECK:           pto.tstore
+  func.func @unknown_movement(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>, %arg2: index) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    scf.for %i = %c0 to %c8 step %c1 {
+      %off = arith.muli %i, %arg2 : index
+      %out = pto.partition_view %dst, offsets = [%c0, %off], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+      pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<1x64xbf16>)
+    }
+    return
+  }
+}

--- a/test/lit/pto/sync_affine_disjoint_carried.pto
+++ b/test/lit/pto/sync_affine_disjoint_carried.pto
@@ -153,4 +153,41 @@ module attributes {pto.target_arch = "a2a3"} {
     }
     return
   }
+
+  // A ZERO STRIDE ON THE MOVING DIMENSION: the index advances, the address does not.
+  //
+  // The offset walks dimension 0 by one per iteration, so index movement is nonzero and
+  // the predicate finds exactly one varying dimension. But that dimension's view stride
+  // is zero, so the address shift is zero while the window is still the full extent of
+  // the box. Zero is not greater than the window, so the barrier is KEPT -- and it is
+  // REQUIRED, because with a zero stride every iteration writes the identical elements.
+  //
+  // This is the case the disjointness proof is stated in ADDRESS space to survive.
+  // Comparing index ranges instead would find iteration i and i+1 disjoint -- their row
+  // indices differ -- and drop an ordering that guards a genuine overwrite. The proof's
+  // own reasoning says this refuses without needing a special case; nothing tested that
+  // claim before.
+  // CHECK-LABEL: func.func @zero_stride_on_varying_dim
+  // CHECK:         scf.for
+  // CHECK:           pto.barrier <PIPE_MTE3>
+  // CHECK:           pto.tstore
+  func.func @zero_stride_on_varying_dim(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c0, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    scf.for %i = %c0 to %c8 step %c1 {
+      %out = pto.partition_view %dst, offsets = [%i, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+      pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<1x64xbf16>)
+    }
+    return
+  }
 }

--- a/test/lit/pto/sync_affine_disjoint_carried.pto
+++ b/test/lit/pto/sync_affine_disjoint_carried.pto
@@ -190,4 +190,71 @@ module attributes {pto.target_arch = "a2a3"} {
     }
     return
   }
+
+  // WALKING A NON-UNIT-STRIDE DIMENSION. The five shapes above all move dimension 1,
+  // whose view stride is one, so their address shift equals their index delta and the
+  // multiply by the stride never decides anything. This one moves dimension 0 at stride
+  // 4096: one row per iteration gives a shift of 4096 against a window of 63.
+  //
+  // It is the first shape whose DROP rests on that multiply. Treating the varying
+  // dimension's stride as one leaves a shift of 1 against the same window and the barrier
+  // returns -- a change that moves this function and no other in this file.
+  // CHECK-LABEL: func.func @row_walk_drops
+  // CHECK:         scf.for
+  // CHECK-NOT:       pto.barrier <PIPE_MTE3>
+  // CHECK:           pto.tstore
+  func.func @row_walk_drops(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    scf.for %i = %c0 to %c8 step %c1 {
+      %out = pto.partition_view %dst, offsets = [%i, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+      pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<1x64xbf16>)
+    }
+    return
+  }
+
+  // THE NEAR MISS. The box is two rows deep, so one iteration spans 4096 + 63 while
+  // consecutive iterations are only 4096 apart: box i and box i+1 share a row, and the
+  // barrier is required.
+  //
+  // What defeats the comparison is the extent of the dimension being WALKED, which
+  // contributes 4096 to the window -- enough on its own, because the comparison is
+  // strict. The 63 from the stationary dimension is slack here: removing it leaves the
+  // verdict unchanged. `gap_narrower_than_extent` above rests on the same term at unit
+  // stride; what is particular to this shape is that the window's magnitude comes from a
+  // non-unit stride rather than from element count.
+  // CHECK-LABEL: func.func @row_walk_near_miss_keeps
+  // CHECK:         scf.for
+  // CHECK:           pto.barrier <PIPE_MTE3>
+  // CHECK:           pto.tstore
+  func.func @row_walk_near_miss_keeps(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c2 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=2, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c2, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<2x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<2x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=2, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    scf.for %i = %c0 to %c8 step %c1 {
+      %out = pto.partition_view %dst, offsets = [%i, %c0], sizes = [%c2, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<2x64xbf16>
+      pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=2, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<2x64xbf16>)
+    }
+    return
+  }
 }

--- a/test/lit/pto/sync_affine_disjoint_nested.pto
+++ b/test/lit/pto/sync_affine_disjoint_nested.pto
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// The carried-self-dep drop must be proved against the loop whose BACK EDGE is under
+// analysis, not against the innermost loop enclosing the op. The two differ whenever the
+// access sits in a nest: inner iterations can be disjoint while the outer loop restarts
+// and revisits the same addresses, so a drop proved on the inner loop removes an ordering
+// the outer loop still needs.
+
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync --emit-pto-ir %s \
+// RUN:   | FileCheck %s
+
+module attributes {pto.target_arch = "a2a3"} {
+  // Inner advances by exactly its own footprint, so consecutive inner iterations are
+  // disjoint. The outer loop contributes nothing to the address, so every outer iteration
+  // rewrites the same region: a real carried WAW across the outer back edge. KEEP.
+  // CHECK-LABEL: func.func @nested_outer_repeats
+  // CHECK:         scf.for
+  // CHECK:           scf.for
+  // CHECK:             pto.barrier <PIPE_MTE3>
+  // CHECK:             pto.tstore
+  func.func @nested_outer_repeats(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    scf.for %o = %c0 to %c2 step %c1 {
+      scf.for %i = %c0 to %c8 step %c1 {
+        %off = arith.muli %i, %c64 : index
+        %out = pto.partition_view %dst, offsets = [%c0, %off], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+        pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<1x64xbf16>)
+      }
+    }
+    return
+  }
+
+  // The carrying loop is an `scf.while`, which reaches the same loop-element type through
+  // UpdateWhileOpInfo. Its back edge resolves to a WhileOp, not a ForOp, so there is no
+  // iteration space to reason about and the predicate must refuse. Without that refusal
+  // the innermost `scf.for` is used instead and the barrier is dropped, exactly as above.
+  // CHECK-LABEL: func.func @while_outer_repeats
+  // CHECK:         scf.while
+  // CHECK:           scf.for
+  // CHECK:             pto.barrier <PIPE_MTE3>
+  // CHECK:             pto.tstore
+  func.func @while_outer_repeats(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %fin = scf.while (%w = %c0) : (index) -> index {
+      %cond = arith.cmpi slt, %w, %c2 : index
+      scf.condition(%cond) %w : index
+    } do {
+    ^bb0(%wa: index):
+      scf.for %i = %c0 to %c8 step %c1 {
+        %off = arith.muli %i, %c64 : index
+        %out = pto.partition_view %dst, offsets = [%c0, %off], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+        pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<1x64xbf16>)
+      }
+      %next = arith.addi %wa, %c1 : index
+      scf.yield %next : index
+    }
+    return
+  }
+}

--- a/test/lit/pto/sync_affine_disjoint_nested.pto
+++ b/test/lit/pto/sync_affine_disjoint_nested.pto
@@ -175,4 +175,56 @@ module attributes {pto.target_arch = "a2a3"} {
     }
     return
   }
+
+  // THE CANONICAL TWO-LEVEL !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>D STORE, and it forfeits the optimisation entirely.
+  //
+  // The offset mixes BOTH induction variables: a block term from the outer loop and a
+  // tile term from the inner one. Per edge:
+  //   inner: the outer term is loop-invariant here, so movement is 64 against a 63-byte
+  //          window -- dropped.
+  //   outer: movement resolves the block term to 512 and then meets the INNER induction
+  //          variable, which is not the outer loop's own, is not defined outside it
+  //          (the outer loop is an ancestor of the inner one), is not a constant and has
+  //          no defining op. Movement is therefore unknown and the edge refuses.
+  // One barrier survives, from the outer edge.
+  //
+  // THE REFUSAL IS REQUIRED, NOT MERELY UNPROVEN. The inner loop sweeps 16 iterations of
+  // 64, so one outer iteration covers 1024 bytes while consecutive outer iterations are
+  // only 512 apart: outer iterations genuinely revisit addresses the previous one wrote.
+  // A future movement analysis that treated an enclosed loop's induction variable as
+  // invariant would compute 512 > 63 and drop a real write-after-write here. The trip
+  // count is load-bearing for that reason and must not be lowered to make the arithmetic
+  // tidier.
+  //
+  // CHECK-LABEL: func.func @nested_mixed_ivs
+  // CHECK:         scf.for
+  // CHECK:           scf.for
+  // CHECK:             pto.barrier <PIPE_MTE3>
+  // CHECK:             pto.tstore
+  func.func @nested_mixed_ivs(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c16 = arith.constant 16 : index
+    %c64 = arith.constant 64 : index
+    %c512 = arith.constant 512 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    scf.for %o = %c0 to %c2 step %c1 {
+      %blk = arith.muli %o, %c512 : index
+      scf.for %i = %c0 to %c16 step %c1 {
+        %tl = arith.muli %i, %c64 : index
+        %off = arith.addi %blk, %tl : index
+        %out = pto.partition_view %dst, offsets = [%c0, %off], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+        pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<1x64xbf16>)
+      }
+    }
+    return
+  }
 }

--- a/test/lit/pto/sync_affine_disjoint_nested.pto
+++ b/test/lit/pto/sync_affine_disjoint_nested.pto
@@ -86,4 +86,93 @@ module attributes {pto.target_arch = "a2a3"} {
     }
     return
   }
+
+  // A store that is a SIBLING of the inner loop, not inside it. Its own innermost
+  // enclosing loop IS the outer one, so the outer loop's back edge is the only edge that
+  // ever asks about it -- DealWithLoopSync(inner) walks only [inner.beginId,
+  // inner.endId), which excludes this store. It advances 64 against a 63-byte window, so
+  // it is dropped.
+  //
+  // WHAT THIS PINS, PRECISELY: that the fix did not degenerate into "the access sits in a
+  // nest, therefore refuse". It is NOT evidence that an outer edge can drop -- after the
+  // fix no edge but the store's own innermost one ever drops, because any offset
+  // mentioning an inner induction variable makes an enclosing edge's movement unknown,
+  // and any offset that does not leaves the innermost edge with nothing varying, whose
+  // kept barrier then short-circuits the enclosing passes.
+  //
+  // It also pins the resolution target: `forEndIndex` indexes the analysis-wide SyncIRs,
+  // in which the sibling inner loop's own LOOP_BEGIN and LOOP_END markers sit between this
+  // store and the outer LOOP_END. Resolving the index against the wrong container, or off
+  // by a marker, lands on the inner loop and drops nothing here.
+  //
+  // THE INNER BODY MUST CONTAIN NO MTE3 ACCESS. A surviving MTE3 dep pair in there parks
+  // its barrier at this store's own anchor, and this test then passes while proving
+  // nothing. The tload below is MTE2 on a separate tile, deliberately.
+  // CHECK-LABEL: func.func @outer_body_sibling_drops
+  // CHECK:         scf.for
+  // CHECK:           scf.for
+  // CHECK-NOT:       pto.barrier <PIPE_MTE3>
+  // CHECK:         pto.tstore
+  func.func @outer_body_sibling_drops(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %cs_i64 = arith.constant 4096 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c8 = arith.constant 8 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %scratch = pto.alloc_tile addr = %cs_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    scf.for %o = %c0 to %c4 step %c1 {
+      scf.for %i = %c0 to %c8 step %c1 {
+        pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%scratch : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      }
+      %off = arith.muli %o, %c64 : index
+      %out = pto.partition_view %dst, offsets = [%c0, %off], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+      pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<1x64xbf16>)
+    }
+    return
+  }
+
+  // The same geometry advancing 32 against the same 63-byte window: consecutive outer
+  // iterations overlap, so the barrier is KEPT. Without this twin the case above would
+  // pass against a predicate that dropped unconditionally on this shape.
+  // CHECK-LABEL: func.func @outer_body_sibling_keeps
+  // CHECK:         scf.for
+  // CHECK:           scf.for
+  // CHECK:         pto.barrier <PIPE_MTE3>
+  // CHECK:         pto.tstore
+  func.func @outer_body_sibling_keeps(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %cs_i64 = arith.constant 4096 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c8 = arith.constant 8 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %src = pto.make_tensor_view %arg1, shape = [%c1024, %c64], strides = [%c64, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %dst = pto.make_tensor_view %arg0, shape = [%c1024, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xbf16>
+    %tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %scratch = pto.alloc_tile addr = %cs_i64 valid_row = %c1 valid_col = %c64 : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %in = pto.partition_view %src, offsets = [%c0, %c0], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+    pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    scf.for %o = %c0 to %c4 step %c1 {
+      scf.for %i = %c0 to %c8 step %c1 {
+        pto.tload ins(%in : !pto.partition_tensor_view<1x64xbf16>) outs(%scratch : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      }
+      %off = arith.muli %o, %c32 : index
+      %out = pto.partition_view %dst, offsets = [%c0, %off], sizes = [%c1, %c64] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<1x64xbf16>
+      pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out : !pto.partition_tensor_view<1x64xbf16>)
+    }
+    return
+  }
 }


### PR DESCRIPTION

This proves that case for a `pto.partition_view` whose offset is affine in the
enclosing loop's induction variable, and drops the dependence. The proof is in
address space rather than index space: disjoint index ranges imply disjoint
addresses only if the layout maps distinct index tuples to distinct addresses,
which a strided view does not promise. One iteration touches addresses within a
bounded window of its base, and the next iteration's base sits further away than
that window is wide.

The predicate refuses unless every input is a compile-time constant, and refuses
multi-buffered accesses outright: a rotating slot set has a real carried
dependence at the rotation distance, which is a different claim from no dependence
at any distance.

Measured on the sample corpus, 15 sites across 15 files. A further 15 same-pipe
barriers on 7 other kernels are refused, so the predicate discriminates rather
than firing everywhere. Effect on the rope-pack kernel, three runs each:

  A3   35.402 -> 8.980 us   (-74.6%)
  A5   68.990 -> 22.010 us  (-68.1%)

Emitted output is byte-identical on both architectures under randomised inputs
with a poisoned destination buffer.

Four refusal cases are pinned alongside the drop, because a predicate that fired
unconditionally would pass a test that only checked the drop: movement narrower
than the footprint, zero movement, movement the analysis cannot bound, and the
boundary case where movement exactly equals the footprint (adjacent, so disjoint).