### PR TITLE
Added  three absolute synchronization gates ( Correctness tests) 

### DIFF
--- a/include/PTO/Transforms/InsertSync/SyncEventIdAllocation.h
+++ b/include/PTO/Transforms/InsertSync/SyncEventIdAllocation.h
@@ -40,6 +40,12 @@ using SyncCycle = DenseMap<int, EventCyclePool>;
  
 class SyncEventIdAllocation {
 public:
+  /// Number of event ids reserved at the tail of the intra-core pool
+  /// [0, kTotalEventIdNum) for the direction `src -> dst`; 0 when the direction
+  /// reserves nothing. Exposed so the device-id-legality gate reads the same
+  /// reservation map this allocator obeys, rather than duplicating it.
+  static uint64_t GetReservedEventIdNum(PipelineType src, PipelineType dst);
+
   SyncEventIdAllocation(SyncIRs &syncIR, SyncOperations &syncOperations)
       : syncIR_(syncIR), syncOperations_(syncOperations) {
     reserveBlockAllEventIds();
@@ -124,6 +130,7 @@ private:
   static const llvm::DenseMap<std::pair<PipelineType, PipelineType>, uint64_t>
       reservedEventIdNum;
   uint64_t reservedBlockSyncEventIdNum{0};
+
 };
  
 } // namespace pto

--- a/include/PTO/Transforms/InsertSync/SyncOracleExtract.h
+++ b/include/PTO/Transforms/InsertSync/SyncOracleExtract.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- SyncOracleExtract.h - Shared sync-op extractor (oracle) ---*- C++ -*-===//
+//
+// The shared walk-surface the oracle gates ride on: the emitted `pto.set_flag` /
+// `pto.wait_flag` / `pto.get_buf` / `pto.rls_buf` / `pto.barrier` ops of one
+// function. G3 reads the ids, G2 reads their live ranges.
+//
+// `SyncOpRecord` describes the same synchronization before codegen, as an allocator
+// holds it. Only G3 has an overload taking it, and only the gate self-test feeds it,
+// because nothing else in this build produces pre-codegen records.
+//
+// Extraction is deterministic (program order), so a rendering is stable across runs.
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_PTO_TRANSFORMS_INSERTSYNC_SYNCORACLEEXTRACT_H
+#define MLIR_DIALECT_PTO_TRANSFORMS_INSERTSYNC_SYNCORACLEEXTRACT_H
+
+#include "PTO/Transforms/InsertSync/SyncCommon.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+
+namespace mlir {
+namespace pto {
+namespace oracle {
+
+/// One emitted synchronization op, read out of the IR after codegen.
+/// `eventId` is set only for set_flag/wait_flag; `bufId` only for
+/// get_buf/rls_buf; both are -1 when not applicable.
+struct IRSyncRecord {
+  std::string opName;
+  std::string srcPipe;
+  std::string dstPipe;
+  /// Typed pipes for the gates. The strings above are for rendering only;
+  /// gates must never string-match a pipe name.
+  PipelineType srcPipeType = PipelineType::PIPE_UNASSIGNED;
+  PipelineType dstPipeType = PipelineType::PIPE_UNASSIGNED;
+  int64_t eventId = -1;
+  int64_t bufId = -1;
+  /// get_buf/rls_buf `mode`. 0 = the bidirectional token (the only mode PTOAS
+  /// emits today). Non-zero = the directional mode (set_flagV2/wait_flagV2),
+  /// deferred -- see the buffer-ID legality notes in SyncOracleGates.h, which
+  /// applies the strict pairing rules only to mode 0.
+  int64_t mode = 0;
+  /// Enclosing block. A get_buf and its rls_buf must sit in the SAME block, or
+  /// the pair may not both execute (counter desync). Null for non-buf ops.
+  mlir::Block *block = nullptr;
+  unsigned order = 0; // program order within the function
+};
+
+/// One entry of the in-memory SyncOperation set, before codegen. `eventIds` is
+/// empty until an allocator assigns them.
+struct SyncOpRecord {
+  std::string type;
+  /// `static_cast<int>(SyncOperation::TYPE)`; -1 when unset. Gates switch on
+  /// this, never on the `type` string.
+  int typeCode = -1;
+  int srcPipe = -1;
+  int dstPipe = -1;
+  llvm::SmallVector<int, 2> eventIds;
+  unsigned syncIndex = 0;
+  unsigned irIndex = 0;
+};
+
+/// Human-readable name of an InsertSync PipelineType ("MTE2", "V", "ALL", ...).
+llvm::StringRef pipelineTypeName(PipelineType pipe);
+
+/// Render a report and write it to stderr atomically.
+///
+/// STDERR, NEVER STDOUT: stdout carries the emitted kernel source, so a report
+/// written there is spliced into the C++ and it stops compiling.
+///
+/// MLIR runs nested func::FuncOp passes in PARALLEL and ptoas does not disable
+/// threading, so unsynchronized writes from several functions interleave mid-line.
+/// Every oracle pass must print through here. Ordering *between* functions stays
+/// nondeterministic, so no consumer may depend on it.
+void emitReport(llvm::function_ref<void(llvm::raw_ostream &)> body);
+
+/// Extract the emitted sync ops from `func`, in program order.
+llvm::SmallVector<IRSyncRecord> extractFromIR(func::FuncOp func);
+
+
+/// Deterministic, diff-friendly rendering (one record per line).
+void printIRRecords(llvm::raw_ostream &os, llvm::StringRef funcName,
+                    llvm::ArrayRef<IRSyncRecord> records);
+void printSyncOpRecords(llvm::raw_ostream &os, llvm::StringRef funcName,
+                        llvm::ArrayRef<SyncOpRecord> records);
+
+} // namespace oracle
+} // namespace pto
+} // namespace mlir
+
+#endif // MLIR_DIALECT_PTO_TRANSFORMS_INSERTSYNC_SYNCORACLEEXTRACT_H

--- a/include/PTO/Transforms/InsertSync/SyncOracleExtract.h
+++ b/include/PTO/Transforms/InsertSync/SyncOracleExtract.h
@@ -77,6 +77,13 @@ struct SyncOpRecord {
 /// Human-readable name of an InsertSync PipelineType ("MTE2", "V", "ALL", ...).
 llvm::StringRef pipelineTypeName(PipelineType pipe);
 
+/// The pipe a `get_buf`/`rls_buf` `op_type` names.
+///
+/// `PTO_PipeLikeAttr` admits three spellings -- pipe_event_type, sync_op_type, and a
+/// plain PipeAttr. A decoder handling only the first two returns PIPE_UNASSIGNED for
+/// the third rather than failing, so its caller silently loses the op.
+pto::PIPE bufSyncPipe(mlir::Attribute opTypeAttr);
+
 /// Render a report and write it to stderr atomically.
 ///
 /// STDERR, NEVER STDOUT: stdout carries the emitted kernel source, so a report

--- a/include/PTO/Transforms/InsertSync/SyncOracleExtract.h
+++ b/include/PTO/Transforms/InsertSync/SyncOracleExtract.h
@@ -57,6 +57,11 @@ struct IRSyncRecord {
   /// Enclosing block. A get_buf and its rls_buf must sit in the SAME block, or
   /// the pair may not both execute (counter desync). Null for non-buf ops.
   mlir::Block *block = nullptr;
+  /// The op itself, for gates that must ask where it sits in the control flow. An
+  /// event pair is checked on its enclosing conditionals, which a block pointer
+  /// alone cannot answer: two blocks differ for loop nesting too, and that case is
+  /// legitimate.
+  mlir::Operation *op = nullptr;
   unsigned order = 0; // program order within the function
 };
 

--- a/include/PTO/Transforms/InsertSync/SyncOracleGates.h
+++ b/include/PTO/Transforms/InsertSync/SyncOracleGates.h
@@ -493,6 +493,9 @@ struct SelfCoverageReport {
   /// (a1) A5 PIPE_V->PIPE_V: ordered by the target guarantee the codegen relies
   /// on when it declines to emit a barrier. NOT "A5 same-pipe".
   unsigned archGuaranteed = 0;
+  /// (a3) PIPE_S->PIPE_S. Counted apart from `archGuaranteed` because no hardware
+  /// guarantee is claimed for it -- see the exemption site for what it does rest on.
+  unsigned pipeSelfOrdered = 0;
   unsigned uncoveredSamePipe = 0;   // diagnosis split: both endpoints one pipe
   unsigned uncoveredCrossPipe = 0;  // the interesting ones
   unsigned compounds = 0;      // SyncIR compounds seen (consistency check)

--- a/include/PTO/Transforms/InsertSync/SyncOracleGates.h
+++ b/include/PTO/Transforms/InsertSync/SyncOracleGates.h
@@ -1,0 +1,510 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- SyncOracleGates.h - Oracle correctness gates -------------*- C++ -*-===//
+//
+// Correctness gates over the sync a compilation emitted, read through
+// SyncOracleExtract.h. Each judges one compilation on its own -- there is no
+// reference file and nothing is compared against another run:
+//
+//   G3       device-id legality: every id is one the hardware and the compiler's
+//            own reservations permit, for that op, direction and arch.
+//   G2       non-interference: no two overlapping intervals share an id.
+//   G1-self  every dependency `DepBetween` reports is ordered by emitted sync.
+//
+// G3's rules, and why each is not already covered elsewhere:
+//
+//   R1 event id range. Intra-core set/wait ids live in [0, kTotalEventIdNum).
+//       The IR spelling cannot express a violation (`pto.set_flag`'s event_id is
+//       an EVENT_ID0..EVENT_ID7 *enum*), but the in-memory `SyncOperation::
+//       eventIds` is a plain SmallVector<int> that an allocator writes freely.
+//       That is the surface this rule guards.
+//
+//   R2 per-direction reservation. `SyncEventIdAllocation::reservedEventIdNum`
+//       reserves the tail of the pool for some directions (today: V<->S reserve
+//       one id, so only [0, 7) is available there). Representable in real IR,
+//       so this gate checks it.
+//
+//   R3 block-sync-all reserved ids. When a SYNC_BLOCK_ALL exists, ids
+//       kBlockSyncAllCubeEventId (14) / kBlockSyncAllVectorEventId (15) belong
+//       to it alone and the block set/wait pool shrinks to
+//       [0, kBlockSyncSetWaitEventIdNum - kReservedBlockSyncEventIdNum).
+//       NOTE: nothing in this build emits a block-sync op, so this rule is
+//       unexercised. It is encoded because its id space is where a stomp appears.
+//
+//   R4 buffer id range. Buffer ids must lie in [0, 31]. Checked on the emitted
+//       ops, a second surface after the op verifier: the pre-codegen record type
+//       cannot represent a buffer id at all.
+//
+//   R5 buffer id arch capacity. Buffer-id sync is exposed only where K > 0
+//       (K=0 on A3, K=32 on A5), so a buf-id op with buf_id >= K for the arch
+//       being compiled is rejected. K reaches the gate from the caller.
+//
+// Barriers carry no id; an id on a barrier is an allocator bug, so it is
+// reported too.
+//
+// Ops whose ids live in a *different* id space are deliberately out of scope:
+// `pto.sync.set` / `pto.sync.wait` carry a cross-core FFTS/intra-block flag id
+// (lowered through `createFFTSMsg` / `set_intra_block`), not an intra-core event
+// id -- the in-tree corpus legitimately uses values such as 17 there.
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_PTO_TRANSFORMS_INSERTSYNC_SYNCORACLEGATES_H
+#define MLIR_DIALECT_PTO_TRANSFORMS_INSERTSYNC_SYNCORACLEGATES_H
+
+#include "PTO/Transforms/InsertSync/SyncCommon.h"
+#include "PTO/Transforms/InsertSync/SyncEventIdAllocation.h"
+#include "PTO/Transforms/InsertSync/SyncOracleExtract.h"
+#include "llvm/ADT/StringMap.h"
+
+namespace mlir {
+namespace pto {
+namespace oracle {
+
+/// Everything G3 needs to know about the target of one compilation.
+struct DeviceIdLimits {
+  /// Size of a per-(src,dst) intra-core event pool.
+  unsigned intraCoreEventIdNum = kTotalEventIdNum;
+  /// Size of the block-sync set/wait pool, before block-all reservation.
+  unsigned blockSyncEventIdNum = kBlockSyncSetWaitEventIdNum;
+  /// K: buffer ids this arch exposes. 0 on A3, 32 on A5.
+  unsigned bufIdCapacity = 0;
+  /// Width of the hardware buf_id field; mirrors `verifyBufSyncOp`'s [0, 31].
+  unsigned bufIdHwMax = 32;
+};
+
+enum class IdViolationKind {
+  EventIdOutOfRange,
+  EventIdReservedForDirection,
+  EventIdReservedForBlockAll,
+  BlockAllEventIdWrong,
+  BarrierCarriesEventId,
+  BufIdOutOfRange,
+  BufIdExceedsArchCapacity,
+  EventIdCollidesWithMacroHidden,
+  /// A (direction, event id) has a different number of `set_flag` and `wait_flag`
+  /// ops in the emitted IR. Checked on the EMITTED ops because a pre-codegen count
+  /// includes syncs the emitter may still drop: `MergeSyncList` discards a sync that
+  /// `IsSyncExist` already finds in the destination list, so two indistinguishable
+  /// ops merged onto one element leave a wait with no set -- a hang that counting
+  /// before codegen cannot see.
+  EventSetWaitUnbalanced,
+};
+
+llvm::StringRef idViolationKindName(IdViolationKind kind);
+
+struct IdViolation {
+  IdViolationKind kind;
+  unsigned order; // program order (IR view) / sync index (SyncOperation view)
+  std::string opName;
+  int64_t id;
+  std::string detail; // human-readable statement of the rule that was broken
+};
+
+/// G3 over the emitted IR.
+llvm::SmallVector<IdViolation>
+checkDeviceIdLegality(llvm::ArrayRef<IRSyncRecord> records,
+                      const DeviceIdLimits &limits);
+
+/// G3 over the pre-codegen SyncOperation set -- the ids an allocator just wrote.
+llvm::SmallVector<IdViolation>
+checkDeviceIdLegality(llvm::ArrayRef<SyncOpRecord> records,
+                      const DeviceIdLimits &limits);
+
+/// Deterministic rendering. `view` is "ir" or "syncops".
+void printIdViolations(llvm::raw_ostream &os, llvm::StringRef funcName,
+                       llvm::StringRef view, size_t recordCount,
+                       llvm::ArrayRef<IdViolation> violations);
+
+//===----------------------------------------------------------------------===//
+// G2: non-interference
+//===----------------------------------------------------------------------===//
+//
+// Coverage alone cannot see this class of bug. An allocation can order every
+// hazard it is supposed to order (G1 green) and still be wrong, because two
+// hazards whose lifetimes overlap were handed the SAME id: the first hazard's
+// wait can be satisfied by the second hazard's set, and the ordering it was
+// meant to establish silently evaporates, and the op count is unchanged, so
+// nothing that counts ops can see it either.
+//
+// The invariant, which generalizes `BufidSyncIdAlloc::validateNoSamePhysicalIdNesting`
+// from buffer ids to every id class:
+//
+//     For a given id key, the intervals that use that id must be pairwise
+//     disjoint -- never nested, never overlapping.
+//
+// The key differs per id class, and getting it wrong makes the gate either
+// blind or wrong:
+//
+//   * event ids: key = (srcPipe, dstPipe, eventId). Event flags are per-
+//     (src,dst)-direction DISJOINT hardware, so EVENT_ID0 may be live in
+//     MTE2->V and in V->MTE3 simultaneously. Keying on the id alone would raise
+//     a false violation on correct code.
+//   * buffer ids: key = bufId alone. The buffer-id pool is global across pipes,
+//     matching validateNoSamePhysicalIdNesting, which keys on physicalId only.
+//
+// Implementation is a linear scan in program order keeping a stack of open intervals
+// per key: a set/get pushes and reports any interval already open on that key, a
+// wait/rls pops, a pop on an empty stack is a close without an open, and anything
+// left on the stack at the end is a leaked id.
+//
+// A loop-carried pair -- a `wait` satisfied by the PREVIOUS iteration's `set`, so
+// the wait precedes the set in program order -- surfaces as `wait-without-set`
+// plus `unclosed`. The sync pass makes such a hazard work by priming the flag
+// before the loop and draining it after, so on well-formed output neither kind
+// fires. An unprimed loop-carried pair blocks forever on iteration 1, and these
+// two kinds are the only thing that detects it. Do not weaken them: if cyclic
+// matching is ever added it must DISTINGUISH a primed backward pair from an
+// unprimed one, not accept both.
+
+// --- Buffer-ID legality ---------------------------------------------------
+//
+// These are HARDWARE rules, not design choices: violating them desynchronises
+// the id's global get/rel counters, and a get_buf that can never pop HANGS the
+// core. They are therefore checked as part of G2, and they are immune to any
+// allocator-design decision -- which is why this gate can be built before the
+// allocator exists.
+//
+//   B1 no re-acquire of a live id. Covers BOTH the same-pipe case
+//      same-id nesting: get,get,rel,rel double-increments the counter so a get
+//      may never pop) AND the cross-pipe same-id interleave (
+//      get(MTE2,#0) get(V,#0) rel(MTE2,#0) rel(V,#0) is illegal). Both surface
+//      as "this id was opened twice before closing".
+//   B2 no rls_buf without a live get_buf.
+//   B3 no get_buf left unreleased.
+//   B4 pipe-matched pairing -- a rls_buf closes a get_buf on the SAME pipe. The
+//      token brackets one op on one pipe; a cross-pipe close is not a pair.
+//   B5 an id must span exactly 2 distinct pipes: buffer-ID is
+//      ONLY for sync between two different pipes; same-pipe ordering needs
+//      bar.pipe. A single-pipe id synchronises nothing and burns an id.
+//   B6 an id SHOULD NOT span more than 2 pipes ("not
+//      recommended" -- soft). WARNING, not an error, and deliberately so: the
+//      shipping BufidSync pass already emits one id across MTE2/V/MTE3 on real
+//      kernels (measured). Making it an error would fail on known-good output.
+//      It is reported because it is exactly the coalescing bound the unified
+//      allocator has to decide about.
+//   B7 a get_buf and its rls_buf must sit in the SAME block. A pair split
+//      across if/else arms would be matched by any flat program-order walk, yet
+//      at run time only one arm executes -- the counters desync (the ASC
+//      alloc/free-balance invariant). Shipping BufidSync anchors both ops on the
+//      same op, so this holds by construction there.
+//
+// MODE. get_buf/rls_buf carry a `mode` operand. Mode 0 is the bidirectional
+// token -- the only mode PTOAS emits -- and the strict rules above apply to it.
+// Non-zero mode is the directional variant (set_flagV2/wait_flagV2), which the
+// spec explicitly frees from strict pairing; it is a deferred mechanism, so the
+// pairing rules are NOT applied to it and its presence is reported instead. The
+// gate keys on `mode` from day one so that mechanism is additive, not a rewrite.
+
+enum class InterferenceKind {
+  EventIdNested,
+  EventIdWaitWithoutSet,
+  EventIdUnclosed,
+  BufIdNested,                 // B1
+  BufIdReleaseWithoutAcquire,  // B2
+  BufIdUnclosed,               // B3
+  BufIdPipeMismatch,           // B4
+  BufIdSinglePipe,             // B5
+  BufIdTooManyPipes,           // B6 (warning)
+  BufIdPairSplitAcrossBlocks,  // B7
+  BufIdDirectionalModeUnsupported, // mode != 0 (deferred mechanism)
+};
+
+/// A warning is reported but does not fail the gate. Used only where the spec
+/// itself says "not recommended" rather than "illegal" -- see B6.
+enum class Severity { Error, Warning };
+
+llvm::StringRef interferenceKindName(InterferenceKind kind);
+llvm::StringRef severityName(Severity severity);
+
+struct InterferenceViolation {
+  InterferenceKind kind;
+  Severity severity = Severity::Error;
+  unsigned order;     // program order of the offending op
+  unsigned openedAt;  // program order of the still-live interval, when relevant
+  std::string opName;
+  std::string key; // rendered id key, e.g. "MTE2->V id=0" or "buf_id=0"
+  std::string detail;
+};
+
+/// G2 over the emitted IR.
+llvm::SmallVector<InterferenceViolation>
+checkNonInterference(llvm::ArrayRef<IRSyncRecord> records);
+
+/// KNOWN LIMITATION: G2 does not check ROTATING (multi-id) hazards at all.
+/// `set_flag_dyn` / `wait_flag_dyn` carry a runtime id, recorded as -1, so those ops
+/// never enter the id check and a collision between two rotating hazards would not be
+/// reported. The ids are recoverable statically -- the selector is an N-way
+/// `arith.select` chain over constants -- so closing this is mechanical.
+
+/// Number of Error-severity violations (warnings do not fail the gate).
+unsigned countErrors(llvm::ArrayRef<InterferenceViolation> violations);
+
+void printInterferenceViolations(
+    llvm::raw_ostream &os, llvm::StringRef funcName, llvm::StringRef view,
+    size_t recordCount, llvm::ArrayRef<InterferenceViolation> violations);
+
+//===----------------------------------------------------------------------===//
+// The happens-before edge model
+//===----------------------------------------------------------------------===//
+//
+// `computeCoverage` derives the orderings a function's emitted sync establishes.
+// G1-self consumes it: a dependency is covered when the model orders its endpoints.
+//
+// Anchors are the ops carrying `OpPipeInterface` and a read/write memory effect,
+// numbered in program order; sync ops are never anchors. An edge (i, j) means the
+// emitted sync orders anchor i before anchor j, and edges come only from emitted
+// sync:
+//
+//     barrier <PIPE_ALL> at slot s   =>  all i < s, all j >= s
+//     barrier <X> at slot s          =>  i < s on pipe X, j >= s on pipe X
+//     set_flag(P,Q,e)@s / wait@w     =>  i < s on pipe P, j >= w on pipe Q
+//     rls_buf(b)@r on P, get_buf(b)@g>r on Q
+//                                    =>  i < r on pipe P, j >= g on pipe Q
+//
+// The last rule is the buffer token's happens-before: `get_buf` acquires what the
+// previous holder released. Without it a buffer-id allocation appears to order
+// nothing and every dependency on it reads as uncovered.
+//
+// Program order is NOT an edge, not even within one pipe: `pto.barrier` is an
+// intra-pipeline barrier, so crediting program order would credit orderings nothing
+// established. Two exceptions, both narrow:
+//   - two accesses to the SAME tile buffer are ordered by program order, so nothing
+//     is owed for such a pair on any arch;
+//   - A5 additionally guarantees PIPE_V intra-pipe ordering, which is why
+//     `SyncCodegen::CreateBarrierOp` emits nothing for a V->V pair there and the
+//     backend rejects one. A2 and A3 have no such guarantee.
+//
+//===----------------------------------------------------------------------===//
+// THE ITERATION DIMENSION -- loop-carried (backward) orderings.
+//===----------------------------------------------------------------------===//
+//
+// The forward model is a flat sequence, so "iteration k before iteration k+1" is
+// inexpressible in it, not merely filtered by the `i < j` guard. A second,
+// distance-annotated edge class is therefore carried alongside:
+//
+//   CarriedEdge{from=j, to=i, distance=1}
+//       "anchor j in iteration k happens-before anchor i in iteration k+1"
+//
+// Three rules build it, kept strictly separate:
+//
+//   RULE 1 (detect). Within ONE loop body, match set/wait (and rls/get) forward
+//   per key; whatever is LEFT OVER wraps, so an unmatched in-body set pairs with an
+//   unmatched in-body wait at a lower slot. The head/tail compensation ops take no
+//   part -- they sit outside the body, so a correct kernel and one missing its
+//   compensation are detected identically. The forward pass already consumes the
+//   compensation as two forward pairs, which is why bidirectional pairing alone
+//   would establish nothing here.
+//
+//   RULE 2 (generate). For a carried pair (set@p, wait@q), emit (x, y, d=1) for
+//   body anchors x < p on the src pipe and y >= q on the dst pipe. BOTH endpoints
+//   are restricted to the carrying loop's body: a prologue anchor has no
+//   iteration index, so a d=1 edge touching one would be meaningless.
+//
+//   RULE 3 (credit). An EVENT carried pair earns its edges only if PRIMED:
+//     P1' a set_flag H on the same (srcPipe, dstPipe, id) lies in a block on L's
+//         ANCESTOR SPINE -- the block holding L, or the block holding one of L's
+//         ancestor ops. REACHABILITY, not nesting: a head under an `scf.if`, or in
+//         a possibly-zero-trip sibling loop, may never run, and `scf.if` is not a
+//         LoopLikeOpInterface so a nesting test cannot see it.
+//     P2  H precedes L in program order.
+//     P3  H is still live at loop entry -- no wait_flag on the same key lies
+//         outside L between H and L.
+//   An unprimed backward pair establishes nothing: iteration 1's wait blocks
+//   forever. Rule 1 alone cannot tell a correct kernel from a deadlocking one,
+//   since both carry the in-body pair; credit is what discriminates.
+//
+//   RULE 3b. The same reachability test on the in-body side: the carried producer,
+//   consumer and any covering barrier must be DIRECT children of L's body, or
+//   iterations 2..N have nothing to wait on.
+//
+//   BARRIER COVERAGE. A candidate may serialize instead of pairing, leaving Rule 1
+//   no pair to find. A barrier at body slot `s` covers (x, y, d=1) iff
+//   `x < s || y >= s`; the only uncovered case is the wrap gap `y < s <= x`.
+//
+//   BUFFER TOKENS ARE EXEMPT FROM RULE 3: the ticket lock starts free, so
+//   iteration 1's `get_buf` needs no priming op.
+//
+// Only the HEAD set is required, not the tail wait. A missing drain is a leaked
+// flag, which is G2's `event-id-unclosed`; demanding it here would duplicate G2.
+//
+// KNOWN GAPS. None can produce a false PASS -- each is either a false FAILURE on a
+// shape no in-tree mode emits, or a weakening shared by both sides:
+//   - PRIME ID MISMATCH: a compensation priming with a different id than the
+//     in-body pair loses credit. Both share one id today; rotation must defuse it.
+//   - PEELED FIRST ITERATION: needs no priming, but P1' still demands one. Nothing
+//     in-tree peels. A guarded PRIME is a different shape and is correctly rejected.
+//   - LIVENESS IS A LINEAR SCAN, not dataflow: a consuming wait inside a not-taken
+//     `scf.if` still counts, so credit can be withheld from a primed pair.
+//     Conservative by construction.
+//   - NESTED-LOOP PRODUCER: a carried pair whose producer sits in a nested loop is
+//     attributed to that loop, so an outer stranded consumer finds no partner. Both
+//     sides lose it equally, so it weakens the gate rather than inverting a verdict.
+//
+// ROTATING PAIRS are modelled, in `computeCoverage`, on both sides: a dyn pair
+// contributes a CARRIED edge at distance N recovered from the selector's own
+// `arith.remui` modulus, and no forward edge (within one iteration the set and wait
+// touch different ids). Demand is likewise at distance N, from
+// `baseAddresses.size()`, because with N slots iteration k+1 touches a different
+// slot and the real conflict is at reuse. WIDEN, NEVER DROP: the forward precedent
+// `isForwardDepDroppableBySlotAffine` drops a slot-disjoint dep, which is wrong on
+// the back edge -- it would excuse the dependency and let an unrotated kernel pass.
+// The closure is capped at 32; above the cap a composition falls to UNCOVERED.
+
+struct CarriedEdge {
+  unsigned from = 0;
+  unsigned to = 0;
+  unsigned distance = 1;
+  bool operator<(const CarriedEdge &o) const {
+    return std::tie(from, to, distance) < std::tie(o.from, o.to, o.distance);
+  }
+  bool operator==(const CarriedEdge &o) const {
+    return from == o.from && to == o.to && distance == o.distance;
+  }
+};
+
+struct CoverageProfile {
+  unsigned anchorCount = 0;
+  /// Sorted, unique. `first < second`, both anchor indices.
+  llvm::SmallVector<std::pair<unsigned, unsigned>> edges;
+  /// Sorted, unique. Loop-carried orderings; `from`/`to` are the same global
+  /// anchor indices as `edges`, and `from < to` is NOT implied.
+  llvm::SmallVector<CarriedEdge> carriedEdges;
+};
+
+/// Walks `func` and derives the happens-before edges its emitted sync induces.
+///
+/// `anchorIndex`, when non-null, receives the Operation* -> anchor-index map
+/// built by the same walk. G1-self needs it to map a dependency's endpoints into
+/// this coordinate system, and taking it from here rather than rebuilding it is
+/// what guarantees the two views cannot drift.
+CoverageProfile
+computeCoverage(func::FuncOp func,
+                llvm::DenseMap<Operation *, unsigned> *anchorIndex = nullptr);
+
+//===----------------------------------------------------------------------===//
+// G1-self: ABSOLUTE coverage against the dependency analysis
+//===----------------------------------------------------------------------===//
+//
+// G1 proper is DIFFERENTIAL: it compares the candidate against the reference's
+// coverage, so a green result can only ever mean "matches the reference", and its
+// strength is bounded by that reference. G1-self is ABSOLUTE: it asserts that
+// every dependency the FRONT-END dependency analysis reports has an emitted sync
+// ordering its source before its destination.
+//
+// WHERE THE EXPECTED SET COMES FROM, and why it is not circular. The expected set
+// is built by running `PTOIRTranslator` (def/use extraction and pipe assignment)
+// and then calling `MemoryDependentAnalyzer::DepBetween` over the resulting
+// `CompoundInstanceElement::defVec` / `useVec` DIRECTLY. Nothing in it reads
+// InsertSync's decisions: not which hazards it chose to sync, not the mechanism
+// it picked, not the ids it allocated, not its emitted ops. In particular this
+// check deliberately does NOT call `InsertSyncAnalysis::IsMemInfoHasDependency`,
+// which layers InsertSync's POLICY on top of DepBetween (the tload->tload WAW
+// exemption, the ACC read/read special case). Policy is what this gate audits,
+// so it cannot be part of the oracle.
+//
+// HONEST LIMIT OF "ABSOLUTE". G1-self shares the front end -- def/use
+// extraction and the alias analysis -- with InsertSync, because that IS the
+// dependency side. So it cannot catch a dependency the front end itself fails to
+// see (an alias `MemAlias` misses). It is independent of InsertSync's SYNC
+// decisions, which is what makes it non-circular; it is not independent of the
+// memory model. Claim accordingly.
+//
+// SELF-PAIRS ARE ENUMERATED SEPARATELY. The main pair loop is `for j = i + 1`, so
+// it never pairs a compound with itself; a same-op loop-carried hazard -- op x in
+// iteration k against the same op in k+1 -- is asked about by a second loop, which
+// records the three hazard classes as `waw`/`raw`/`war/carried-self`. Only ops
+// inside a loop are considered: without a back edge there is no second execution.
+//
+// Coverage answers these without special-casing. A same-pipe body barrier records a
+// carried edge over every (x, y) anchor pair in its loop span subject to
+// `x < slot || y >= slot`, which is trivially true when x == y, so the barrier
+// contributes a carried SELF-edge at distance 1. Nothing else seeds the closure
+// diagonal -- every cell starts at `kUnreached` -- so a self-pair is covered
+// exactly when some emitted op orders the op against its own next execution.
+//
+// ONE LIMIT ON THAT, and it matters when reading a green result: coverage is keyed
+// on the anchor pair alone, with no loop-nest attribution. A distance-1 self-edge
+// contributed by an ENCLOSING loop's back edge therefore credits a dependence
+// carried by an inner loop, so the diagonal can read covered whether or not
+// anything orders the op one nest level down.
+//
+// COVERED, per mechanism. The covering relation is `c subset-of h`: the sync's
+// interval must be CONTAINED in the dependency's. Reusing `computeCoverage`
+// gives exactly that for all three mechanisms, which is the main reason to reuse
+// it rather than re-derive:
+//   event     set@s / wait@w  =>  edge (i, j) for i < s, j >= w. So the edge
+//             exists iff [s, w) lies inside (i, j] -- containment, not mere
+//             co-occurrence.
+//   barrier   PIPE_ALL at s   =>  edge (i, j) for i < s <= j: a barrier strictly
+//             between the two endpoints.
+//   buffer-ID rls(b)@r, get(b)@g>r => edge (i, j) for i < r, j >= g. This is the
+//             TOKEN PROTOCOL -- release before acquire ON THE SAME buf_id -- not
+//             co-location. A check blind to the protocol would bless a
+//             split-endpoint hazard that is silently unordered.
+//
+// TRANSITIVITY IS TAKEN, and it must be. Happens-before is transitive, but
+// `computeCoverage`'s edge set is not closed: pipe filtering means a chain
+// a(PIPE_A) -> b(PIPE_B) -> c(PIPE_C) is covered by two pair-wise syncs while the
+// direct edge (a, c) is absent, since neither sync matches both endpoints' pipes.
+// Checking against the raw set would report a false "uncovered" there. So the
+// relation is closed before checking, with distances composing as
+// 0+0=0, 0+1=1, 1+0=1, and 1+1 DROPPED (distance 2 is not represented, and
+// dropping is the conservative direction).
+//
+// THE MAPPING, and what happens to what it cannot map. Dependencies live over
+// `BaseMemInfo`, which carries no `Operation*`; coverage lives over anchor
+// indices. The bridge is `CompoundInstanceElement::elementOp` -> the anchor index
+// assigned by `computeCoverage`'s walk. A dependency whose endpoint op is not an
+// anchor (no `OpPipeInterface`, or no read/write memory effect) CANNOT be
+// expressed in the coverage coordinate system. Those are counted and reported as
+// `unmappable`, never silently dropped -- silent drops are exactly how this check
+// would become vacuous.
+
+struct SelfCoverageViolation {
+  unsigned srcAnchor;
+  unsigned dstAnchor;
+  unsigned distance; // 0 = same iteration, 1 = loop-carried
+  std::string hazard;  // raw | war | waw
+  std::string srcName;
+  std::string dstName;
+  std::string srcPipe;
+  std::string dstPipe;
+};
+
+struct SelfCoverageReport {
+  unsigned dependencies = 0;   // total requirements derived from DepBetween
+  unsigned covered = 0;
+  unsigned carriedDeps = 0;    // of those, how many are loop-carried (d=1)
+  unsigned carriedCovered = 0;
+  unsigned unmappable = 0;     // endpoint has no anchor representation
+  unsigned armExcluded = 0;    // (a2) pairs on mutually exclusive scf.if arms
+  /// (a1) A5 PIPE_V->PIPE_V: ordered by the target guarantee the codegen relies
+  /// on when it declines to emit a barrier. NOT "A5 same-pipe".
+  unsigned archGuaranteed = 0;
+  unsigned uncoveredSamePipe = 0;   // diagnosis split: both endpoints one pipe
+  unsigned uncoveredCrossPipe = 0;  // the interesting ones
+  unsigned compounds = 0;      // SyncIR compounds seen (consistency check)
+  llvm::SmallVector<SelfCoverageViolation> violations;
+};
+
+/// G1-self: every dependency `DepBetween` reports must be ordered by emitted sync.
+SelfCoverageReport computeSelfCoverage(func::FuncOp func);
+
+/// `cap` bounds the violations printed per function; 0 prints all. A capped report
+/// HIDES CLASSES -- two cross-pipe carried outliers on `rope_kv_cache` sat past the
+/// default cap and went undiagnosed through a whole round of analysis -- so raise it
+/// when attributing causes.
+void printSelfCoverage(llvm::raw_ostream &os, llvm::StringRef funcName,
+                       const SelfCoverageReport &report, unsigned cap = 8);
+
+} // namespace oracle
+} // namespace pto
+} // namespace mlir
+
+#endif // MLIR_DIALECT_PTO_TRANSFORMS_INSERTSYNC_SYNCORACLEGATES_H

--- a/include/PTO/Transforms/InsertSync/SyncOracleGates.h
+++ b/include/PTO/Transforms/InsertSync/SyncOracleGates.h
@@ -205,6 +205,12 @@ enum class InterferenceKind {
   EventIdNested,
   EventIdWaitWithoutSet,
   EventIdUnclosed,
+  /// A set_flag and the wait_flag closing it sit under DIFFERENT conditionals, so
+  /// some path runs one without the other: a wait with no set hangs, a set with no
+  /// wait leaks the id. Loop nesting is deliberately not compared -- a set outside a
+  /// loop priming a wait inside it is the intended idiom, and the zero-trip case is
+  /// checked on the loop spine instead.
+  EventIdPairGuardMismatch,
   BufIdNested,                 // B1
   BufIdReleaseWithoutAcquire,  // B2
   BufIdUnclosed,               // B3

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -149,9 +149,28 @@ std::unique_ptr<Pass> createPTOInlineBackendHelpersPass(
 // Registration
 //===----------------------------------------------------------------------===//
 
+/// G3: device-id legality. `bufidCapacity` is K, the number of buffer ids the arch
+/// exposes: 0 on A3, 32 on A5.
+///
+/// `injectFault` names a synthetic fault to append to the gate's own record list, so
+/// that the gate can be shown to catch a class the IR cannot express -- an event id
+/// outside [0, 8) is unrepresentable, because `pto.set_flag` spells its id as an
+/// EVENT_ID0..EVENT_ID7 enum. Empty in normal use.
+std::unique_ptr<Pass> createPTOCheckSyncIdsPass(unsigned bufidCapacity = 0,
+                                               llvm::StringRef injectFault = "");
+
+/// G2: assert no two overlapping intervals share a sync id.
+std::unique_ptr<Pass> createPTOCheckSyncInterferencePass();
+
+/// G1-self: assert every dependence the front end reports is ordered by emitted
+/// sync. `maxViolations` caps the per-function detail lines; 0 prints all.
+std::unique_ptr<Pass> createPTOCheckSyncSelfCoveragePass(unsigned maxViolations = 8);
+
 #undef GEN_PASS_DECL
 #define GEN_PASS_REGISTRATION
 #include "PTO/Transforms/Passes.h.inc"
+
+
 
 } // namespace pto
 } // namespace mlir

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -1375,4 +1375,62 @@ def VPTOMaskSimplify
   let dependentDialects = ["mlir::pto::PTODialect"];
 }
 
+def PTOCheckSyncIds : Pass<"pto-check-sync-ids", "func::FuncOp"> {
+  let summary = "Oracle gate G3: device-id legality of the emitted synchronization";
+  let description = [{
+    Read-only apart from diagnostics. Checks that every static synchronization id
+    in the function is one the target permits: intra-core event ids inside their
+    per-direction pool, honouring the reserved tail, and buffer ids inside both the
+    hardware field and the arch's exposed buffer-id capacity, which the pass receives
+    from its caller and defaults to zero. Rotating ids on `set_flag_dyn` /
+    `wait_flag_dyn` resolve at runtime and are not checked. Fails the pass on any
+    violation.
+  }];
+
+  let constructor = "mlir::pto::createPTOCheckSyncIdsPass()";
+}
+
+def PTOCheckSyncInterference : Pass<"pto-check-sync-interference", "func::FuncOp"> {
+  let summary = "Oracle gate G2: no two overlapping intervals may share a sync id";
+  let description = [{
+    Read-only apart from diagnostics. Generalizes
+    `BufidSyncIdAlloc::validateNoSamePhysicalIdNesting` from buffer ids to every
+    id class: for each id key the live intervals must be pairwise disjoint.
+    Event ids are keyed by (srcPipe, dstPipe, eventId) because event flags are
+    per-direction disjoint hardware; buffer ids are keyed by buf_id alone
+    because that pool is global. Fails the pass on any nesting, on a close
+    without an open, or on a leaked id.
+  }];
+
+  let constructor = "mlir::pto::createPTOCheckSyncInterferencePass()";
+}
+
+def PTOCheckSyncSelfCoverage
+    : Pass<"pto-check-sync-self-coverage", "func::FuncOp"> {
+  let summary = "Oracle gate G1-self: every analysed dependency must be ordered by emitted sync";
+  let description = [{
+    ABSOLUTE, not differential -- there is no reference file. Rebuilds the
+    front-end SyncIR (`PTOIRTranslator`) and calls
+    `MemoryDependentAnalyzer::DepBetween` over the resulting def/use vectors
+    directly, then asserts that every dependency it reports is ordered by the
+    emitted sync, using the transitive closure of `computeCoverage`'s edge set
+    (loop-carried dependencies are checked against carried edges at d=1).
+
+    The expected set reads none of the sync pass's decisions -- not its hazard
+    selection, mechanism choice, ids, or emitted ops -- so a green result is
+    independent of them. It is NOT a proof of correctness: pairs on mutually
+    exclusive `scf.if` arms are excluded, and on A5 `PIPE_V`->`PIPE_V` pairs are
+    credited to the target's intra-pipe ordering guarantee. Both exclusions are
+    counted and reported rather than dropped.
+    `InsertSyncAnalysis::IsMemInfoHasDependency`, which layers policy on top of
+    `DepBetween`. It cannot, however, catch a dependency the front-end alias
+    analysis itself misses; see SyncOracleGates.h for that limit.
+
+    Dependencies whose endpoint op is not an anchor are reported as `unmappable`
+    rather than dropped.
+  }];
+
+  let constructor = "mlir::pto::createPTOCheckSyncSelfCoveragePass()";
+}
+
 #endif // MLIR_DIALECT_PTO_PASSES

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -117,6 +117,8 @@ add_mlir_dialect_library(PTOTransforms
   InsertSync/RemoveRedundantSync.cpp
   InsertSync/SyncEventIdAllocation.cpp
   InsertSync/SyncCodegen.cpp
+  InsertSync/SyncOracleExtract.cpp
+  InsertSync/SyncOracleGates.cpp
   BufidSync/BufidSyncPass.cpp
   BufidSync/BufidSyncAnalysis.cpp
   BufidSync/BufidSyncIdAlloc.cpp

--- a/lib/PTO/Transforms/InsertSync/SyncEventIdAllocation.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncEventIdAllocation.cpp
@@ -133,6 +133,13 @@ size_t SyncEventIdAllocation::GetCompilerAvailableEventIdNum(const SyncOperation
   return kTotalEventIdNum;
 }
 
+uint64_t SyncEventIdAllocation::GetReservedEventIdNum(PipelineType src,
+                                                      PipelineType dst) {
+  auto it = reservedEventIdNum.find({src, dst});
+  return it == reservedEventIdNum.end() ? 0 : it->second;
+}
+
+
 void SyncEventIdAllocation::SetEventId(SyncOperation *sync) {
   const size_t poolSize = getEventIdPoolSize(sync, reservedBlockSyncEventIdNum);
   const size_t availableEventIdNum = GetCompilerAvailableEventIdNum(sync);

--- a/lib/PTO/Transforms/InsertSync/SyncOracleExtract.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncOracleExtract.cpp
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- SyncOracleExtract.cpp - Shared sync-op extractor (oracle) ----------===//
+//
+// Implements the two extraction views (see SyncOracleExtract.h) that the gates
+// read a compilation's emitted sync through.
+//===----------------------------------------------------------------------===//
+
+#include "PTO/Transforms/InsertSync/SyncOracleExtract.h"
+#include "PTO/Transforms/Passes.h"
+#include "PTO/IR/PTO.h"
+#include "PTO/IR/PTOSyncUtils.h"
+#include "llvm/Support/Mutex.h"
+
+namespace mlir {
+namespace pto {
+namespace func = ::mlir::func;
+
+#include "PTO/Transforms/Passes.h.inc"
+
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::pto;
+
+void mlir::pto::oracle::emitReport(
+    llvm::function_ref<void(llvm::raw_ostream &)> body) {
+  std::string buffer;
+  {
+    llvm::raw_string_ostream os(buffer);
+    body(os);
+  }
+  // stderr, NOT stdout: stdout carries ptoas's product (the emitted CCEC C++).
+  // Reports written there are spliced into the kernel source, which then
+  // stops compiling.
+  static llvm::sys::SmartMutex<true> mutex;
+  llvm::sys::SmartScopedLock<true> lock(mutex);
+  llvm::errs() << buffer;
+  llvm::errs().flush();
+}
+
+llvm::StringRef mlir::pto::oracle::pipelineTypeName(PipelineType pipe) {
+  switch (pipe) {
+  case PipelineType::PIPE_S:
+    return "S";
+  case PipelineType::PIPE_V:
+    return "V";
+  case PipelineType::PIPE_M:
+    return "M";
+  case PipelineType::PIPE_MTE1:
+    return "MTE1";
+  case PipelineType::PIPE_MTE2:
+    return "MTE2";
+  case PipelineType::PIPE_MTE3:
+    return "MTE3";
+  case PipelineType::PIPE_ALL:
+    return "ALL";
+  default:
+    return "?";
+  }
+}
+
+/// IR pipe enum -> the InsertSync PipelineType the gates reason about. Written
+/// as an explicit switch rather than a numeric cast: the two enums happen to
+/// agree today, and nothing enforces that they keep agreeing.
+static PipelineType toPipelineType(pto::PIPE pipe) {
+  switch (pipe) {
+  case pto::PIPE::PIPE_S:
+    return PipelineType::PIPE_S;
+  case pto::PIPE::PIPE_V:
+    return PipelineType::PIPE_V;
+  case pto::PIPE::PIPE_M:
+    return PipelineType::PIPE_M;
+  case pto::PIPE::PIPE_MTE1:
+    return PipelineType::PIPE_MTE1;
+  case pto::PIPE::PIPE_MTE2:
+    return PipelineType::PIPE_MTE2;
+  case pto::PIPE::PIPE_MTE3:
+    return PipelineType::PIPE_MTE3;
+  case pto::PIPE::PIPE_ALL:
+    return PipelineType::PIPE_ALL;
+  case pto::PIPE::PIPE_MTE4:
+    return PipelineType::PIPE_MTE4;
+  case pto::PIPE::PIPE_MTE5:
+    return PipelineType::PIPE_MTE5;
+  case pto::PIPE::PIPE_V2:
+    return PipelineType::PIPE_V2;
+  case pto::PIPE::PIPE_FIX:
+    return PipelineType::PIPE_FIX;
+  case pto::PIPE::VIRTUAL_PIPE_MTE2_L1A:
+    return PipelineType::VIRTUAL_PIPE_MTE2_L1A;
+  case pto::PIPE::VIRTUAL_PIPE_MTE2_L1B:
+    return PipelineType::VIRTUAL_PIPE_MTE2_L1B;
+  case pto::PIPE::PIPE_NUM:
+  case pto::PIPE::PIPE_UNASSIGNED:
+    return PipelineType::PIPE_UNASSIGNED;
+  }
+  return PipelineType::PIPE_UNASSIGNED;
+}
+
+/// get_buf/rls_buf name their pipe via `op_type`, which has TWO legal spellings.
+/// This mirrors `verifyBufSyncOp` (PTO.cpp): the attribute may be a plain
+/// PipeAttr, or a pipe_event_type/sync_op_type that must be mapped. Handling
+/// only the second (as this extractor originally did) silently decodes the pipe
+/// as UNASSIGNED for the first -- which quietly disables every pipe-keyed
+/// buffer-ID rule in G2.
+static pto::PIPE bufSyncPipe(mlir::Attribute opTypeAttr) {
+  if (!opTypeAttr)
+    return pto::PIPE::PIPE_UNASSIGNED;
+  if (auto pipeAttr = dyn_cast<pto::PipeAttr>(opTypeAttr))
+    return pipeAttr.getPipe();
+  auto opTypeOr = parseSyncOpTypeLikeAttr(opTypeAttr);
+  if (succeeded(opTypeOr))
+    return mapSyncOpTypeToPipe(*opTypeOr);
+  return pto::PIPE::PIPE_UNASSIGNED;
+}
+
+llvm::SmallVector<oracle::IRSyncRecord>
+mlir::pto::oracle::extractFromIR(func::FuncOp func) {
+  llvm::SmallVector<IRSyncRecord> records;
+
+  func.walk([&](Operation *op) {
+    IRSyncRecord rec;
+
+    auto setPipes = [&](pto::PIPE src, pto::PIPE dst) {
+      rec.srcPipe = stringifyPIPE(src).str();
+      rec.dstPipe = stringifyPIPE(dst).str();
+      rec.srcPipeType = toPipelineType(src);
+      rec.dstPipeType = toPipelineType(dst);
+    };
+
+    if (auto setFlag = dyn_cast<pto::SetFlagOp>(op)) {
+      rec.opName = "pto.set_flag";
+      setPipes(setFlag.getSrcPipeAttr().getPipe(),
+               setFlag.getDstPipeAttr().getPipe());
+      rec.eventId = static_cast<int64_t>(setFlag.getEventIdAttr().getEvent());
+    } else if (auto waitFlag = dyn_cast<pto::WaitFlagOp>(op)) {
+      rec.opName = "pto.wait_flag";
+      setPipes(waitFlag.getSrcPipeAttr().getPipe(),
+               waitFlag.getDstPipeAttr().getPipe());
+      rec.eventId = static_cast<int64_t>(waitFlag.getEventIdAttr().getEvent());
+    } else if (auto getBuf = dyn_cast<pto::GetBufOp>(op)) {
+      rec.opName = "pto.get_buf";
+      rec.bufId = static_cast<int64_t>(getBuf.getBufId());
+      rec.mode = static_cast<int64_t>(getBuf.getMode());
+      rec.block = op->getBlock();
+      pto::PIPE pipe = bufSyncPipe(getBuf.getOpTypeAttr());
+      setPipes(pipe, pipe);
+    } else if (auto rlsBuf = dyn_cast<pto::RlsBufOp>(op)) {
+      rec.opName = "pto.rls_buf";
+      rec.bufId = static_cast<int64_t>(rlsBuf.getBufId());
+      rec.mode = static_cast<int64_t>(rlsBuf.getMode());
+      rec.block = op->getBlock();
+      pto::PIPE pipe = bufSyncPipe(rlsBuf.getOpTypeAttr());
+      setPipes(pipe, pipe);
+    } else if (auto setDyn = dyn_cast<pto::SetFlagDynOp>(op)) {
+      // Rotating hazards emit these. They must be recorded, or a gate reading the
+      // emitted ops sees fewer sync ops than the kernel has.
+      //
+      // `eventId` stays -1 because the id is a RUNTIME value chosen by the selector
+      // chain rather than an attribute. THE ID ITSELF IS THEREFORE UNCHECKED: no gate
+      // here validates a rotating id, so a collision between two rotating hazards
+      // would not be reported. Recovering the ids statically is possible -- the
+      // selector is a chain of `arith.select` over constants -- and is not attempted.
+      rec.opName = "pto.set_flag_dyn";
+      setPipes(setDyn.getSrcPipeAttr().getPipe(),
+               setDyn.getDstPipeAttr().getPipe());
+    } else if (auto waitDyn = dyn_cast<pto::WaitFlagDynOp>(op)) {
+      rec.opName = "pto.wait_flag_dyn";
+      setPipes(waitDyn.getSrcPipeAttr().getPipe(),
+               waitDyn.getDstPipeAttr().getPipe());
+    } else if (auto barrier = dyn_cast<pto::BarrierOp>(op)) {
+      rec.opName = "pto.barrier";
+      pto::PIPE pipe = barrier.getPipeAttr().getPipe();
+      setPipes(pipe, pipe);
+    } else {
+      return WalkResult::advance();
+    }
+
+    rec.order = records.size();
+    records.push_back(std::move(rec));
+    return WalkResult::advance();
+  });
+
+  return records;
+}
+
+
+void mlir::pto::oracle::printIRRecords(llvm::raw_ostream &os,
+                                       llvm::StringRef funcName,
+                                       llvm::ArrayRef<IRSyncRecord> records) {
+  os << "[sync-extract:ir] func=" << funcName << " records=" << records.size()
+     << "\n";
+  for (const IRSyncRecord &rec : records) {
+    os << "  #" << rec.order << " " << rec.opName
+       << " src=" << (rec.srcPipe.empty() ? "-" : rec.srcPipe)
+       << " dst=" << (rec.dstPipe.empty() ? "-" : rec.dstPipe);
+    if (rec.eventId >= 0)
+      os << " event_id=" << rec.eventId;
+    if (rec.bufId >= 0)
+      os << " buf_id=" << rec.bufId;
+    os << "\n";
+  }
+}
+
+void mlir::pto::oracle::printSyncOpRecords(
+    llvm::raw_ostream &os, llvm::StringRef funcName,
+    llvm::ArrayRef<SyncOpRecord> records) {
+  os << "[sync-extract:syncops] func=" << funcName
+     << " records=" << records.size() << "\n";
+  for (const SyncOpRecord &rec : records) {
+    os << "  #" << rec.syncIndex << " " << rec.type
+       << " src="
+       << pipelineTypeName(static_cast<PipelineType>(rec.srcPipe))
+       << " dst=" << pipelineTypeName(static_cast<PipelineType>(rec.dstPipe))
+       << " irIdx=" << rec.irIndex << " event_ids=[";
+    for (size_t i = 0; i < rec.eventIds.size(); ++i) {
+      if (i)
+        os << ",";
+      os << rec.eventIds[i];
+    }
+    os << "]\n";
+  }
+}

--- a/lib/PTO/Transforms/InsertSync/SyncOracleExtract.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncOracleExtract.cpp
@@ -105,13 +105,10 @@ static PipelineType toPipelineType(pto::PIPE pipe) {
   return PipelineType::PIPE_UNASSIGNED;
 }
 
-/// get_buf/rls_buf name their pipe via `op_type`, which has TWO legal spellings.
-/// This mirrors `verifyBufSyncOp` (PTO.cpp): the attribute may be a plain
-/// PipeAttr, or a pipe_event_type/sync_op_type that must be mapped. Handling
-/// only the second (as this extractor originally did) silently decodes the pipe
-/// as UNASSIGNED for the first -- which quietly disables every pipe-keyed
-/// buffer-ID rule in G2.
-static pto::PIPE bufSyncPipe(mlir::Attribute opTypeAttr) {
+/// Mirrors `verifyBufSyncOp` (PTO.cpp): the attribute may be a plain PipeAttr, or a
+/// pipe_event_type/sync_op_type that must be mapped. Declared in the header because
+/// G1's coverage walk decodes the same attribute and must agree with this.
+pto::PIPE mlir::pto::oracle::bufSyncPipe(mlir::Attribute opTypeAttr) {
   if (!opTypeAttr)
     return pto::PIPE::PIPE_UNASSIGNED;
   if (auto pipeAttr = dyn_cast<pto::PipeAttr>(opTypeAttr))

--- a/lib/PTO/Transforms/InsertSync/SyncOracleExtract.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncOracleExtract.cpp
@@ -181,6 +181,7 @@ mlir::pto::oracle::extractFromIR(func::FuncOp func) {
       return WalkResult::advance();
     }
 
+    rec.op = op;
     rec.order = records.size();
     records.push_back(std::move(rec));
     return WalkResult::advance();

--- a/lib/PTO/Transforms/InsertSync/SyncOracleGates.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncOracleGates.cpp
@@ -1,0 +1,1712 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- SyncOracleGates.cpp - Oracle correctness gates ---------------------===//
+//
+// Implements G3 (device-id legality), G2 (non-interference), the happens-before
+// edge model, and G1-self (dependency coverage), plus the three read-only passes
+// that run them on a compiled function.
+//===----------------------------------------------------------------------===//
+
+#include "PTO/Transforms/InsertSync/SyncOracleGates.h"
+#include "PTO/Transforms/InsertSync/SyncMacroModel.h"
+#include "PTO/Transforms/Passes.h"
+#include "PTO/IR/PTO.h"
+#include "PTO/IR/PTOSyncUtils.h"
+#include "PTO/Transforms/InsertSync/MemoryDependentAnalyzer.h"
+#include "PTO/Transforms/InsertSync/PTOIRTranslator.h"
+#include "llvm/ADT/DenseMap.h"
+#include <tuple>
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/Support/Format.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include <map>
+#include <set>
+
+namespace mlir {
+namespace pto {
+namespace func = ::mlir::func;
+
+#define GEN_PASS_DEF_PTOCHECKSYNCIDS
+#define GEN_PASS_DEF_PTOCHECKSYNCSELFCOVERAGE
+#define GEN_PASS_DEF_PTOCHECKSYNCINTERFERENCE
+#include "PTO/Transforms/Passes.h.inc"
+
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::pto;
+using namespace mlir::pto::oracle;
+
+llvm::StringRef mlir::pto::oracle::idViolationKindName(IdViolationKind kind) {
+  switch (kind) {
+  case IdViolationKind::EventIdOutOfRange:
+    return "event-id-out-of-range";
+  case IdViolationKind::EventIdReservedForDirection:
+    return "event-id-reserved-for-direction";
+  case IdViolationKind::EventIdReservedForBlockAll:
+    return "event-id-reserved-for-block-all";
+  case IdViolationKind::BlockAllEventIdWrong:
+    return "block-all-event-id-wrong";
+  case IdViolationKind::BarrierCarriesEventId:
+    return "barrier-carries-event-id";
+  case IdViolationKind::BufIdOutOfRange:
+    return "buf-id-out-of-range";
+  case IdViolationKind::BufIdExceedsArchCapacity:
+    return "buf-id-exceeds-arch-capacity";
+  case IdViolationKind::EventIdCollidesWithMacroHidden:
+    return "event-id-collides-with-macro-hidden";
+  case IdViolationKind::EventSetWaitUnbalanced:
+    return "event-set-wait-unbalanced";
+  }
+  return "?";
+}
+
+namespace {
+
+std::string pipeDir(PipelineType src, PipelineType dst) {
+  return (oracle::pipelineTypeName(src) + "->" + oracle::pipelineTypeName(dst))
+      .str();
+}
+
+/// R1 + R2: an intra-core set/wait event id.
+void checkIntraCoreEventId(int64_t id, PipelineType src, PipelineType dst,
+                           unsigned poolSize, unsigned order,
+                           llvm::StringRef opName,
+                           llvm::SmallVectorImpl<IdViolation> &out) {
+  if (id < 0 || id >= static_cast<int64_t>(poolSize)) {
+    out.push_back({IdViolationKind::EventIdOutOfRange, order, opName.str(), id,
+                   ("intra-core event pool for " + pipeDir(src, dst) + " is [0, " +
+                    std::to_string(poolSize) + ")")});
+    return;
+  }
+  uint64_t reserved = SyncEventIdAllocation::GetReservedEventIdNum(src, dst);
+  if (reserved > 0 && id >= static_cast<int64_t>(poolSize - reserved)) {
+    out.push_back(
+        {IdViolationKind::EventIdReservedForDirection, order, opName.str(), id,
+         (pipeDir(src, dst) + " reserves its top " + std::to_string(reserved) +
+          " id(s); available is [0, " + std::to_string(poolSize - reserved) +
+          ")")});
+  }
+}
+
+/// R4 + R5: a buffer id.
+void checkBufId(int64_t id, unsigned order, llvm::StringRef opName,
+                const DeviceIdLimits &limits,
+                llvm::SmallVectorImpl<IdViolation> &out) {
+  if (id < 0 || id >= static_cast<int64_t>(limits.bufIdHwMax)) {
+    out.push_back({IdViolationKind::BufIdOutOfRange, order, opName.str(), id,
+                   ("hardware buf_id field is [0, " +
+                    std::to_string(limits.bufIdHwMax) + ")")});
+    return;
+  }
+  if (id >= static_cast<int64_t>(limits.bufIdCapacity)) {
+    out.push_back({IdViolationKind::BufIdExceedsArchCapacity, order,
+                   opName.str(), id,
+                   ("this compilation exposes K=" +
+                    std::to_string(limits.bufIdCapacity) +
+                    " buffer id(s); buffer-id sync needs K > 0 (A5)")});
+  }
+}
+
+} // namespace
+
+llvm::SmallVector<IdViolation>
+mlir::pto::oracle::checkDeviceIdLegality(llvm::ArrayRef<IRSyncRecord> records,
+                                         const DeviceIdLimits &limits) {
+  llvm::SmallVector<IdViolation> violations;
+
+  for (const IRSyncRecord &rec : records) {
+    if (rec.opName == "pto.set_flag" || rec.opName == "pto.wait_flag") {
+      checkIntraCoreEventId(rec.eventId, rec.srcPipeType, rec.dstPipeType,
+                            limits.intraCoreEventIdNum, rec.order, rec.opName,
+                            violations);
+    } else if (rec.opName == "pto.get_buf" || rec.opName == "pto.rls_buf") {
+      checkBufId(rec.bufId, rec.order, rec.opName, limits, violations);
+    } else if (rec.opName == "pto.barrier" && rec.eventId >= 0) {
+      violations.push_back({IdViolationKind::BarrierCarriesEventId, rec.order,
+                            rec.opName, rec.eventId,
+                            "a pipe barrier takes no event id"});
+    }
+  }
+
+  // Every (direction, id) must carry as many sets as waits. A shortfall either way
+  // is a hang: a wait with no set never retires, and a set with no wait leaves the
+  // flag raised for whoever takes the id next.
+  //
+  // Rotating pairs are excluded, not overlooked: `set_flag_dyn`/`wait_flag_dyn`
+    // choose their id at runtime and it is recorded as -1, so a rotating set cannot be
+    // paired with its wait. Nothing here checks a rotating id.
+  llvm::DenseMap<std::tuple<int, int, int64_t>, std::pair<unsigned, unsigned>> tally;
+  llvm::DenseMap<std::tuple<int, int, int64_t>, unsigned> firstOrder;
+  for (const IRSyncRecord &rec : records) {
+    bool isSet = rec.opName == "pto.set_flag";
+    bool isWait = rec.opName == "pto.wait_flag";
+    if ((!isSet && !isWait) || rec.eventId < 0)
+      continue;
+    auto key = std::make_tuple(static_cast<int>(rec.srcPipeType),
+                               static_cast<int>(rec.dstPipeType), rec.eventId);
+    auto &slot = tally[key];
+    (isSet ? slot.first : slot.second)++;
+    if (!firstOrder.count(key))
+      firstOrder[key] = rec.order;
+  }
+  llvm::SmallVector<std::tuple<int, int, int64_t>> keys;
+  for (const auto &kv : tally)
+    keys.push_back(kv.first);
+  llvm::sort(keys);
+  for (const auto &key : keys) {
+    auto [sets, waits] = tally[key];
+    if (sets == waits)
+      continue;
+    violations.push_back(
+        {IdViolationKind::EventSetWaitUnbalanced, firstOrder[key], "pto.set_flag",
+         static_cast<int>(std::get<2>(key)),
+         ("direction " + std::to_string(std::get<0>(key)) + "->" +
+          std::to_string(std::get<1>(key)) + " carries " + std::to_string(sets) +
+          " set_flag and " + std::to_string(waits) + " wait_flag")});
+  }
+
+  return violations;
+}
+
+llvm::SmallVector<IdViolation>
+mlir::pto::oracle::checkDeviceIdLegality(llvm::ArrayRef<SyncOpRecord> records,
+                                         const DeviceIdLimits &limits) {
+  using TYPE = SyncOperation::TYPE;
+  llvm::SmallVector<IdViolation> violations;
+
+  // The block-sync pool only shrinks when a SYNC_BLOCK_ALL is actually present;
+  // mirrors SyncEventIdAllocation::reserveBlockAllEventIds().
+  bool blockAllPresent = llvm::any_of(records, [](const SyncOpRecord &rec) {
+    return rec.typeCode == static_cast<int>(TYPE::SYNC_BLOCK_ALL);
+  });
+  const unsigned blockPool =
+      limits.blockSyncEventIdNum -
+      (blockAllPresent ? kReservedBlockSyncEventIdNum : 0u);
+
+  for (const SyncOpRecord &rec : records) {
+    auto src = static_cast<PipelineType>(rec.srcPipe);
+    auto dst = static_cast<PipelineType>(rec.dstPipe);
+
+    switch (static_cast<TYPE>(rec.typeCode)) {
+    case TYPE::SET_EVENT:
+    case TYPE::WAIT_EVENT:
+        // EVERY id a hazard holds is checked, not just the first. A rotating hazard
+        // carries several, and its emitted form (`set_flag_dyn`/`wait_flag_dyn`)
+        // resolves the id at runtime, so once emitted the id cannot be checked at
+        // all -- these pre-codegen records are the only place the full set is visible.
+      // Weakening or narrowing this loop --
+      // e.g. back to `eventIds[0]` -- would not fail any test: it would make that
+      // blind spot LIVE SILENTLY, because no other view can catch an illegal id
+      // on a rotating pair.
+      //
+        // Iterating the FULL set is the point: nothing else validates these ids, so
+        // narrowing it to `eventIds[0]` would silently stop checking the rest.
+      for (int id : rec.eventIds)
+        checkIntraCoreEventId(id, src, dst, limits.intraCoreEventIdNum,
+                              rec.syncIndex, rec.type, violations);
+      break;
+
+    case TYPE::SYNC_BLOCK_SET:
+    case TYPE::SYNC_BLOCK_WAIT:
+      for (int id : rec.eventIds) {
+        if (blockAllPresent && (id == static_cast<int>(kBlockSyncAllCubeEventId) ||
+                                id == static_cast<int>(kBlockSyncAllVectorEventId))) {
+          violations.push_back(
+              {IdViolationKind::EventIdReservedForBlockAll, rec.syncIndex,
+               rec.type, id,
+               ("ids " + std::to_string(kBlockSyncAllCubeEventId) + "/" +
+                std::to_string(kBlockSyncAllVectorEventId) +
+                " belong to sync_block_all while one is live")});
+          continue;
+        }
+        if (id < 0 || id >= static_cast<int64_t>(blockPool))
+          violations.push_back({IdViolationKind::EventIdOutOfRange,
+                                rec.syncIndex, rec.type, id,
+                                ("block-sync pool is [0, " +
+                                 std::to_string(blockPool) + ")")});
+      }
+      break;
+
+    case TYPE::SYNC_BLOCK_ALL:
+      for (int id : rec.eventIds)
+        if (id != static_cast<int>(kBlockSyncAllCubeEventId) &&
+            id != static_cast<int>(kBlockSyncAllVectorEventId))
+          violations.push_back(
+              {IdViolationKind::BlockAllEventIdWrong, rec.syncIndex, rec.type,
+               id,
+               ("sync_block_all must use " +
+                std::to_string(kBlockSyncAllCubeEventId) + " (cube) or " +
+                std::to_string(kBlockSyncAllVectorEventId) + " (vector)")});
+      break;
+
+    case TYPE::PIPE_BARRIER:
+    case TYPE::PIPE_BARRIER_CUBE:
+    case TYPE::PIPE_BARRIER_VECTOR:
+      for (int id : rec.eventIds)
+        violations.push_back({IdViolationKind::BarrierCarriesEventId,
+                              rec.syncIndex, rec.type, id,
+                              "a pipe barrier takes no event id"});
+      break;
+    }
+  }
+
+  return violations;
+}
+
+
+void mlir::pto::oracle::printIdViolations(llvm::raw_ostream &os,
+                                          llvm::StringRef funcName,
+                                          llvm::StringRef view,
+                                          size_t recordCount,
+                                          llvm::ArrayRef<IdViolation> violations) {
+  os << "[sync-gate:g3] func=" << funcName << " view=" << view
+     << " records=" << recordCount << " violations=" << violations.size()
+     << (violations.empty() ? " OK" : "") << "\n";
+  for (const IdViolation &v : violations) {
+    os << "  !! #" << v.order << " " << v.opName
+       << " kind=" << idViolationKindName(v.kind) << " id=" << v.id << " : "
+       << v.detail << "\n";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// G2: non-interference
+//===----------------------------------------------------------------------===//
+
+llvm::StringRef mlir::pto::oracle::interferenceKindName(InterferenceKind k) {
+  switch (k) {
+  case InterferenceKind::EventIdNested:
+    return "event-id-nested";
+  case InterferenceKind::EventIdWaitWithoutSet:
+    return "event-id-wait-without-set";
+  case InterferenceKind::EventIdUnclosed:
+    return "event-id-unclosed";
+  case InterferenceKind::BufIdNested:
+    return "buf-id-nested";
+  case InterferenceKind::BufIdReleaseWithoutAcquire:
+    return "buf-id-release-without-acquire";
+  case InterferenceKind::BufIdUnclosed:
+    return "buf-id-unclosed";
+  case InterferenceKind::BufIdPipeMismatch:
+    return "buf-id-pipe-mismatch";
+  case InterferenceKind::BufIdSinglePipe:
+    return "buf-id-single-pipe";
+  case InterferenceKind::BufIdTooManyPipes:
+    return "buf-id-spans-more-than-2-pipes";
+  case InterferenceKind::BufIdPairSplitAcrossBlocks:
+    return "buf-id-pair-split-across-blocks";
+  case InterferenceKind::BufIdDirectionalModeUnsupported:
+    return "buf-id-directional-mode-unsupported";
+  }
+  return "?";
+}
+
+llvm::StringRef mlir::pto::oracle::severityName(Severity s) {
+  return s == Severity::Warning ? "warning" : "error";
+}
+
+namespace {
+
+/// One live get_buf, remembered so its release can be checked against it: the
+/// release must be on the same pipe (B4) and in the same block (B7).
+struct BufOpen {
+  unsigned order;
+  PipelineType pipe;
+  mlir::Block *block;
+};
+
+/// One live interval stack per id key. `depth > 1` means two hazards hold the
+/// same id at once -- the bug G2 exists to find.
+/// An open interval owned by nothing in particular. The IR view has no notion of an
+/// owning hazard (a rotating pair's ops carry eventId = -1 there), so it passes this
+/// and every overlap conflicts, exactly as before.
+constexpr int kNoOwner = -1;
+
+struct LiveIntervals {
+  llvm::SmallVector<std::pair<unsigned, int>> opens; // (program order, owner)
+
+  /// Returns the order of an already-live interval that CONFLICTS with this open, or
+  /// -1 if this open is legal.
+  ///
+  /// Two opens with the same non-sentinel owner do NOT conflict: they are two halves
+  /// of ONE hazard -- the loop-carried compensation pair and the in-body pair it
+  /// primes, which share the rotating ids by construction (one stamp covers set,
+  /// wait, head and tail alike). Anything else still conflicts, INCLUDING a
+  /// compensation op against a different hazard, which is the whole point of keying on
+  /// the owner rather than just skipping compensation records.
+  int64_t open(unsigned order, int owner = kNoOwner) {
+    int64_t live = -1;
+    for (const auto &o : opens) {
+      if (owner != kNoOwner && o.second == owner)
+        continue; // same hazard: its own prime/drain, not a competing interval
+      live = int64_t(o.first);
+      break;
+    }
+    opens.push_back({order, owner});
+    return live;
+  }
+  bool close() {
+    if (opens.empty())
+      return false;
+    opens.pop_back();
+    return true;
+  }
+};
+
+std::string eventKeyName(PipelineType src, PipelineType dst, int64_t id) {
+  return (oracle::pipelineTypeName(src) + "->" + oracle::pipelineTypeName(dst) +
+          " id=" + llvm::Twine(id))
+      .str();
+}
+
+/// The shared scan. `Key` is whatever makes two intervals conflict.
+template <typename KeyT>
+void scanOpen(llvm::DenseMap<KeyT, LiveIntervals> &live, const KeyT &key,
+              unsigned order, llvm::StringRef opName, llvm::StringRef keyName,
+              InterferenceKind nestedKind,
+              llvm::SmallVectorImpl<InterferenceViolation> &out,
+              int owner = kNoOwner) {
+  int64_t alreadyLive = live[key].open(order, owner);
+  if (alreadyLive >= 0)
+    out.push_back({nestedKind, Severity::Error, order, unsigned(alreadyLive),
+                   opName.str(), keyName.str(),
+                   "this id is still live from the interval opened earlier; two "
+                   "overlapping hazards share it"});
+}
+
+template <typename KeyT>
+void scanClose(llvm::DenseMap<KeyT, LiveIntervals> &live, const KeyT &key,
+               unsigned order, llvm::StringRef opName, llvm::StringRef keyName,
+               InterferenceKind orphanKind,
+               llvm::SmallVectorImpl<InterferenceViolation> &out) {
+  if (!live[key].close())
+    out.push_back({orphanKind, Severity::Error, order, 0, opName.str(),
+                   keyName.str(), "closes an id that no earlier op opened"});
+}
+
+} // namespace
+
+llvm::SmallVector<InterferenceViolation>
+mlir::pto::oracle::checkNonInterference(llvm::ArrayRef<IRSyncRecord> records) {
+  llvm::SmallVector<InterferenceViolation> violations;
+
+  // Event ids are per-(src,dst) disjoint hardware; buffer ids are a global pool.
+  llvm::DenseMap<std::tuple<int, int, int64_t>, LiveIntervals> eventLive;
+  // Buffer ids need more than a depth counter: the release must match the
+  // acquire's pipe (B4) and block (B7), so remember both per open interval.
+  llvm::DenseMap<int64_t, llvm::SmallVector<BufOpen>> bufLive;
+  std::map<int64_t, std::set<int>> bufPipes; // ordered: deterministic reporting
+
+  for (const IRSyncRecord &rec : records) {
+      // set_flag_dyn / wait_flag_dyn carry a runtime id, recorded as -1, so they
+      // never reach this check and a rotating id is not validated here.
+
+    if (rec.opName == "pto.set_flag" || rec.opName == "pto.wait_flag") {
+      auto key = std::make_tuple(int(rec.srcPipeType), int(rec.dstPipeType),
+                                 rec.eventId);
+      std::string name = eventKeyName(rec.srcPipeType, rec.dstPipeType, rec.eventId);
+      if (rec.opName == "pto.set_flag")
+        scanOpen(eventLive, key, rec.order, rec.opName, name,
+                 InterferenceKind::EventIdNested, violations);
+      else
+        scanClose(eventLive, key, rec.order, rec.opName, name,
+                  InterferenceKind::EventIdWaitWithoutSet, violations);
+    } else if (rec.opName == "pto.get_buf" || rec.opName == "pto.rls_buf") {
+      // Buffer-ID legality. See SyncOracleGates.h for the rules, and
+      // docs/bufid_sync_a5_design.md "Correctness Invariants" for the protocol.
+      std::string key = ("buf_id=" + llvm::Twine(rec.bufId)).str();
+
+      // Track pipes-per-id (B5/B6) for the bidirectional token only: the
+      // directional mode has a different pipe discipline and is deferred.
+      if (rec.mode == 0)
+        bufPipes[rec.bufId].insert(int(rec.srcPipeType));
+
+      // The strict pairing discipline is defined for the bidirectional token
+      // (mode 0). The directional mode is explicitly freed from strict pairing
+      // by the spec and is a deferred mechanism -- report it, do not pair it.
+      if (rec.mode != 0) {
+        violations.push_back(
+            {InterferenceKind::BufIdDirectionalModeUnsupported, Severity::Error,
+             rec.order, 0, rec.opName, key,
+             "mode " + std::to_string(rec.mode) +
+                 " is the directional token (set_flagV2), a deferred mechanism "
+                 "this allocator does not emit"});
+        continue;
+      }
+
+      if (rec.opName == "pto.get_buf") {
+        // B1: re-acquiring a live id. Covers same-pipe nesting and
+        // cross-pipe interleave alike -- both are "opened twice".
+        auto &live = bufLive[rec.bufId];
+        if (!live.empty()) {
+          violations.push_back(
+              {InterferenceKind::BufIdNested, Severity::Error, rec.order,
+               live.front().order, rec.opName, key,
+               "this id is still live from the interval opened earlier; a "
+               "second acquire double-increments the counter and the get may "
+               "never pop"});
+        }
+        live.push_back({rec.order, rec.srcPipeType, rec.block});
+      } else {
+        auto &live = bufLive[rec.bufId];
+        if (live.empty()) {
+          // B2
+          violations.push_back(
+              {InterferenceKind::BufIdReleaseWithoutAcquire, Severity::Error,
+               rec.order, 0, rec.opName, key,
+               "closes an id that no earlier get_buf opened"});
+        } else {
+          BufOpen open = live.back();
+          live.pop_back();
+          // B4: the release must be on the same pipe as its acquire.
+          if (open.pipe != rec.srcPipeType) {
+            violations.push_back(
+                {InterferenceKind::BufIdPipeMismatch, Severity::Error,
+                 rec.order, open.order, rec.opName, key,
+                 "released on " +
+                     oracle::pipelineTypeName(rec.srcPipeType).str() +
+                     " but acquired on " +
+                     oracle::pipelineTypeName(open.pipe).str() +
+                     "; the token brackets one op on one pipe"});
+          }
+          // B7: the pair must sit in one block, or only one arm may execute.
+          if (open.block && rec.block && open.block != rec.block) {
+            violations.push_back(
+                {InterferenceKind::BufIdPairSplitAcrossBlocks, Severity::Error,
+                 rec.order, open.order, rec.opName, key,
+                 "get_buf and rls_buf are in different blocks; if they are in "
+                 "different control-flow arms only one executes and the id's "
+                 "counters desync"});
+          }
+        }
+      }
+    }
+  }
+
+  // B5 / B6: how many distinct pipes does each id span?
+  llvm::SmallVector<int64_t> ids;
+  for (const auto &entry : bufPipes)
+    ids.push_back(entry.first);
+  llvm::sort(ids);
+  for (int64_t id : ids) {
+    const auto &pipes = bufPipes[id];
+    std::string key = ("buf_id=" + llvm::Twine(id)).str();
+    if (pipes.size() == 1) {
+      violations.push_back(
+          {InterferenceKind::BufIdSinglePipe, Severity::Error, 0, 0,
+           "pto.get_buf", key,
+           "spans only 1 pipe (" +
+               oracle::pipelineTypeName(PipelineType(*pipes.begin())).str() +
+               "); buffer-ID is only for sync between TWO different pipes -- "
+               "same-pipe ordering needs bar.pipe"});
+    } else if (pipes.size() > 2) {
+      // Soft rule, not an illegality: this gate must accept an id that spans
+      // more than two pipes, so the case is reported rather than failed.
+      violations.push_back(
+          {InterferenceKind::BufIdTooManyPipes, Severity::Warning, 0, 0,
+           "pto.get_buf", key,
+           "spans " + std::to_string(pipes.size()) +
+               " pipes (>2 pipe-pairs on one id); the spec advises against "
+               "this -- it is the coalescing bound the allocator must decide"});
+    }
+  }
+
+  // A leaked id: opened, never closed. Deterministic order for diffability.
+  llvm::SmallVector<InterferenceViolation> leaks;
+  for (const auto &entry : eventLive)
+    for (const auto &open : entry.second.opens) {
+      unsigned order = open.first;
+      leaks.push_back({InterferenceKind::EventIdUnclosed, Severity::Error,
+                       order, order, "pto.set_flag",
+                       eventKeyName(PipelineType(std::get<0>(entry.first)),
+                                    PipelineType(std::get<1>(entry.first)),
+                                    std::get<2>(entry.first)),
+                       "opened but never waited: the id is leaked"});
+    }
+  for (const auto &entry : bufLive)
+    for (const BufOpen &open : entry.second)
+      leaks.push_back({InterferenceKind::BufIdUnclosed, Severity::Error,
+                       open.order, open.order, "pto.get_buf",
+                       ("buf_id=" + llvm::Twine(entry.first)).str(),
+                       "acquired but never released: the id's counters desync"});
+  llvm::sort(leaks, [](const InterferenceViolation &a,
+                       const InterferenceViolation &b) {
+    return a.order < b.order;
+  });
+  violations.append(leaks.begin(), leaks.end());
+
+  return violations;
+}
+
+unsigned mlir::pto::oracle::countErrors(
+    llvm::ArrayRef<InterferenceViolation> violations) {
+  return llvm::count_if(violations, [](const InterferenceViolation &v) {
+    return v.severity == Severity::Error;
+  });
+}
+
+void mlir::pto::oracle::printInterferenceViolations(
+    llvm::raw_ostream &os, llvm::StringRef funcName, llvm::StringRef view,
+    size_t recordCount, llvm::ArrayRef<InterferenceViolation> violations) {
+  unsigned errors = countErrors(violations);
+  unsigned warnings = violations.size() - errors;
+  os << "[sync-gate:g2] func=" << funcName << " view=" << view
+     << " records=" << recordCount << " errors=" << errors
+     << " warnings=" << warnings << (errors == 0 ? " OK" : "") << "\n";
+  for (const InterferenceViolation &v : violations) {
+    os << (v.severity == Severity::Warning ? "  ~~ " : "  !! ");
+    os << "#" << v.order << " " << v.opName
+       << " kind=" << interferenceKindName(v.kind) << " " << v.key;
+    if (v.kind == InterferenceKind::EventIdNested ||
+        v.kind == InterferenceKind::BufIdNested ||
+        v.kind == InterferenceKind::BufIdPipeMismatch ||
+        v.kind == InterferenceKind::BufIdPairSplitAcrossBlocks)
+      os << " live_since=#" << v.openedAt;
+    os << " : " << v.detail << "\n";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// The happens-before edge model, consumed by G1-self
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// An op that needs ordering: carries a pipe and touches memory. This is the
+/// same test InjectBarrierAllSync uses to decide where a barrier is required.
+bool isAnchor(Operation *op) {
+  if (isa<pto::SetFlagOp, pto::WaitFlagOp, pto::GetBufOp, pto::RlsBufOp,
+          pto::BarrierOp, pto::SetFlagDynOp, pto::WaitFlagDynOp>(op))
+    return false;
+  auto memEffect = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!memEffect || !(memEffect.hasEffect<MemoryEffects::Read>() ||
+                      memEffect.hasEffect<MemoryEffects::Write>()))
+    return false;
+  return isa<pto::OpPipeInterface>(op);
+}
+
+/// A sync op, positioned by how many anchors precede it.
+struct SyncEvent {
+  enum Kind {
+    BarrierAll, BarrierPipe, SetFlag, WaitFlag, GetBuf, RlsBuf,
+    SetFlagDyn, WaitFlagDyn
+  } kind;
+  unsigned slot;
+  pto::PIPE srcPipe;
+  pto::PIPE dstPipe;
+  int64_t id; // event id, or buf id
+  // The iteration dimension. `order` is the walk position, used only to say
+  // "before"/"after" in program order; `loop` is the NEAREST enclosing loop, or
+  // null at function level.
+  Operation *op = nullptr;
+  unsigned order = 0;
+  Operation *loop = nullptr;
+  /// Rotation depth N for a Dyn op: the ordering it establishes is at DISTANCE N,
+  /// not 1. 1 for every static op.
+  unsigned rotation = 1;
+};
+
+/// What one loop contributes to the iteration dimension: the anchor range of
+/// its body (inclusive) and the walk position of the earliest op inside it.
+///
+/// `firstOrder` is taken from the loop's CONTENTS, not from the loop op itself:
+/// `walk` is post-order, so the loop op is visited *after* its body, and using
+/// its own position would place the whole body "before" the loop.
+struct LoopSpan {
+  unsigned firstAnchor = std::numeric_limits<unsigned>::max();
+  unsigned lastAnchor = 0;
+  unsigned firstOrder = std::numeric_limits<unsigned>::max();
+  bool hasAnchors() const { return firstAnchor <= lastAnchor; }
+};
+
+/// Recover the rotation depth N from a `set_flag_dyn` / `wait_flag_dyn` id operand.
+///
+/// Codegen builds the id as `eventIds[slot % N]`: an `arith.remui <slot>, N`
+/// feeding a chain of `arith.select`s over N constants
+/// (`CreateSetWaitOpForMultiBuffer`). N is the modulus, so walking back from the
+/// operand to the nearest `RemUIOp` with a constant RHS recovers it exactly.
+///
+/// Returns 0 when N cannot be recovered. Callers treat that as "unknown depth"
+/// and credit NOTHING -- crediting an ordering whose distance cannot be named
+/// would be a false pass, and this model has no way to express "some distance".
+unsigned rotationDepthOf(Value eventId) {
+  llvm::SmallVector<Value, 8> work{eventId};
+  llvm::SmallPtrSet<Operation *, 8> seen;
+  while (!work.empty()) {
+    Value v = work.pop_back_val();
+    Operation *def = v.getDefiningOp();
+    if (!def || !seen.insert(def).second)
+      continue;
+    if (auto rem = dyn_cast<arith::RemUIOp>(def)) {
+      llvm::APInt n;
+      if (matchPattern(rem.getRhs(), m_ConstantInt(&n)) && n.getZExtValue() >= 2)
+        return unsigned(n.getZExtValue());
+    }
+    for (Value operand : def->getOperands())
+      work.push_back(operand);
+  }
+  return 0;
+}
+
+/// Is `op` nested anywhere inside `loop`?
+bool insideLoop(Operation *op, Operation *loop) {
+  for (Operation *p = op->getParentOp(); p; p = p->getParentOp())
+    if (p == loop)
+      return true;
+  return false;
+}
+
+/// The blocks on `loop`'s ancestor spine: the block holding `loop` itself, plus
+/// the block holding each of its ancestor ops, up to the function.
+///
+/// An op in one of these blocks and earlier in program order executes on EVERY
+/// path that reaches `loop` (structured control flow, single-block regions), so
+/// the spine is what "unconditionally before the loop" means concretely. An op
+/// in any other block sits inside a region the loop is not inside -- a
+/// conditional arm, or a sibling loop that may run zero times -- and may not
+/// execute at all. This is strictly stronger than "not inside the loop", and it
+/// has to be: see the P1' note in `isPrimed`.
+llvm::SmallPtrSet<Block *, 8> spineBlocks(Operation *loop) {
+  llvm::SmallPtrSet<Block *, 8> blocks;
+  for (Operation *p = loop; p; p = p->getParentOp())
+    if (Block *block = p->getBlock())
+      blocks.insert(block);
+  return blocks;
+}
+
+/// Does `op` execute exactly once per iteration of `loop`?
+///
+/// Only if it is a DIRECT child of the loop's body: an op one level deeper sits
+/// inside some other region -- an `scf.if` arm, or a nested loop that may run
+/// zero times -- and may be skipped on an iteration. A carried pair whose
+/// producer can be skipped establishes nothing on the iteration that skips it.
+bool executesEachIteration(Operation *op, Operation *loop) {
+  return op->getParentOp() == loop;
+}
+
+} // namespace
+
+CoverageProfile mlir::pto::oracle::computeCoverage(
+    func::FuncOp func, llvm::DenseMap<Operation *, unsigned> *anchorIndex) {
+  CoverageProfile profile;
+
+  llvm::SmallVector<pto::PIPE> anchorPipes;
+  llvm::SmallVector<SyncEvent> events;
+  std::string signatureText;
+  // Deterministic iteration order: the carried-edge scan walks these.
+  llvm::MapVector<Operation *, LoopSpan> loops;
+  unsigned walkOrder = 0;
+
+  // Enclosing loops of `op`, innermost first, stopping at the function.
+  auto enclosingLoops = [&](Operation *op) {
+    llvm::SmallVector<Operation *, 4> chain;
+    for (Operation *p = op->getParentOp(); p && p != func.getOperation();
+         p = p->getParentOp())
+      if (isa<LoopLikeOpInterface>(p))
+        chain.push_back(p);
+    return chain;
+  };
+
+  func.walk([&](Operation *op) {
+    unsigned order = walkOrder++;
+    llvm::SmallVector<Operation *, 4> chain = enclosingLoops(op);
+    for (Operation *loop : chain) {
+      LoopSpan &span = loops[loop];
+      span.firstOrder = std::min(span.firstOrder, order);
+    }
+
+    if (isAnchor(op)) {
+      pto::PIPE pipe = cast<pto::OpPipeInterface>(op).getPipe();
+      unsigned index = anchorPipes.size();
+      anchorPipes.push_back(pipe);
+      if (anchorIndex)
+        (*anchorIndex)[op] = index;
+      for (Operation *loop : chain) {
+        LoopSpan &span = loops[loop];
+        span.firstAnchor = std::min(span.firstAnchor, index);
+        span.lastAnchor = std::max(span.lastAnchor, index);
+      }
+      signatureText += op->getName().getStringRef().str();
+      signatureText += ':';
+      signatureText += stringifyPIPE(pipe).str();
+      // The carried-edge comparison presumes both runs agree on loop
+      // structure. The signature is where presumptions get checked rather than
+      // assumed, so the nest depth goes in it.
+      signatureText += "#";
+      signatureText += std::to_string(chain.size());
+      signatureText += ';';
+      return;
+    }
+    unsigned slot = anchorPipes.size();
+    Operation *nearest = chain.empty() ? nullptr : chain.front();
+    if (auto setFlag = dyn_cast<pto::SetFlagOp>(op)) {
+      events.push_back({SyncEvent::SetFlag, slot,
+                        setFlag.getSrcPipeAttr().getPipe(),
+                        setFlag.getDstPipeAttr().getPipe(),
+                        int64_t(setFlag.getEventIdAttr().getEvent()), op, order,
+                        nearest});
+    } else if (auto waitFlag = dyn_cast<pto::WaitFlagOp>(op)) {
+      events.push_back({SyncEvent::WaitFlag, slot,
+                        waitFlag.getSrcPipeAttr().getPipe(),
+                        waitFlag.getDstPipeAttr().getPipe(),
+                        int64_t(waitFlag.getEventIdAttr().getEvent()), op, order,
+                        nearest});
+    } else if (auto getBuf = dyn_cast<pto::GetBufOp>(op)) {
+      auto opTypeOr = parseSyncOpTypeLikeAttr(getBuf.getOpTypeAttr());
+      if (succeeded(opTypeOr)) {
+        pto::PIPE pipe = mapSyncOpTypeToPipe(*opTypeOr);
+        events.push_back({SyncEvent::GetBuf, slot, pipe, pipe,
+                          int64_t(getBuf.getBufId()), op, order, nearest});
+      }
+    } else if (auto rlsBuf = dyn_cast<pto::RlsBufOp>(op)) {
+      auto opTypeOr = parseSyncOpTypeLikeAttr(rlsBuf.getOpTypeAttr());
+      if (succeeded(opTypeOr)) {
+        pto::PIPE pipe = mapSyncOpTypeToPipe(*opTypeOr);
+        events.push_back({SyncEvent::RlsBuf, slot, pipe, pipe,
+                          int64_t(rlsBuf.getBufId()), op, order, nearest});
+      }
+    } else if (auto setDyn = dyn_cast<pto::SetFlagDynOp>(op)) {
+      // The rotating pair is what multi-buffering emits, and it was
+      // previously invisible: the type chain below had no Dyn case, so the op
+      // fell off the end and contributed NO edge. `id` is -1 because there is no
+      // static id -- the id is chosen at runtime -- so it cannot collide with a
+      // static key.
+      events.push_back({SyncEvent::SetFlagDyn, slot,
+                        setDyn.getSrcPipeAttr().getPipe(),
+                        setDyn.getDstPipeAttr().getPipe(), -1, op, order,
+                        nearest, rotationDepthOf(setDyn.getEventId())});
+    } else if (auto waitDyn = dyn_cast<pto::WaitFlagDynOp>(op)) {
+      events.push_back({SyncEvent::WaitFlagDyn, slot,
+                        waitDyn.getSrcPipeAttr().getPipe(),
+                        waitDyn.getDstPipeAttr().getPipe(), -1, op, order,
+                        nearest, rotationDepthOf(waitDyn.getEventId())});
+    } else if (auto barrier = dyn_cast<pto::BarrierOp>(op)) {
+      pto::PIPE pipe = barrier.getPipeAttr().getPipe();
+      events.push_back({pipe == pto::PIPE::PIPE_ALL ? SyncEvent::BarrierAll
+                                                    : SyncEvent::BarrierPipe,
+                        slot, pipe, pipe, -1, op, order, nearest});
+    }
+  });
+
+  profile.anchorCount = anchorPipes.size();
+
+  llvm::DenseSet<std::pair<unsigned, unsigned>> edges;
+  auto addEdges = [&](unsigned beforeSlot, pto::PIPE fromPipe,
+                      unsigned afterSlot, pto::PIPE toPipe, bool anyPipe) {
+    for (unsigned i = 0; i < beforeSlot; ++i) {
+      if (!anyPipe && anchorPipes[i] != fromPipe)
+        continue;
+      for (unsigned j = afterSlot; j < anchorPipes.size(); ++j) {
+        if (!anyPipe && anchorPipes[j] != toPipe)
+          continue;
+        if (i < j)
+          edges.insert({i, j});
+      }
+    }
+  };
+
+  for (size_t e = 0; e < events.size(); ++e) {
+    const SyncEvent &ev = events[e];
+    switch (ev.kind) {
+    case SyncEvent::BarrierAll:
+      addEdges(ev.slot, ev.srcPipe, ev.slot, ev.dstPipe, /*anyPipe=*/true);
+      break;
+    case SyncEvent::BarrierPipe:
+      addEdges(ev.slot, ev.srcPipe, ev.slot, ev.dstPipe, /*anyPipe=*/false);
+      break;
+    case SyncEvent::SetFlag:
+      // Pair with the next matching wait. G2 guarantees the interval discipline
+      // that makes "next" the right answer.
+      for (size_t w = e + 1; w < events.size(); ++w) {
+        const SyncEvent &wait = events[w];
+        if (wait.kind == SyncEvent::WaitFlag && wait.srcPipe == ev.srcPipe &&
+            wait.dstPipe == ev.dstPipe && wait.id == ev.id) {
+          addEdges(ev.slot, ev.srcPipe, wait.slot, wait.dstPipe, false);
+          break;
+        }
+      }
+      break;
+    case SyncEvent::RlsBuf:
+      // Buffer-token happens-before: get_buf acquires what the previous holder
+      // released, so rls precedes get for the same buffer id.
+      for (size_t g = e + 1; g < events.size(); ++g) {
+        const SyncEvent &get = events[g];
+        if (get.kind == SyncEvent::GetBuf && get.id == ev.id)
+          addEdges(ev.slot, ev.srcPipe, get.slot, get.dstPipe, false);
+      }
+      break;
+    case SyncEvent::WaitFlag:
+    case SyncEvent::GetBuf:
+      break;
+    case SyncEvent::SetFlagDyn:
+    case SyncEvent::WaitFlagDyn:
+      // Deliberately NO FORWARD EDGE. A rotating pair orders iteration j-N
+      // against iteration j; within ONE iteration it orders nothing, because the
+      // set and the wait in the same iteration touch DIFFERENT event ids
+      // (eventIds[j%N] is set at the bottom, and the wait at the top consumed
+      // whatever iteration j-N set). Crediting a same-iteration edge here would
+      // invent an ordering the hardware does not establish. Their contribution is
+      // the CARRIED edge at distance N, added by the carried scan below.
+      break;
+    }
+  }
+
+  profile.edges.assign(edges.begin(), edges.end());
+  llvm::sort(profile.edges);
+
+  //===--------------------------------------------------------------------===//
+  // The iteration dimension. Rules 1-3 (see SyncOracleGates.h).
+  //
+  // Deliberately a SECOND, INDEPENDENT scan. The forward pass above already
+  // consumes the head/tail compensation into two forward pairs, so bending it to
+  // pair backwards would change nothing -- which is precisely the measurement
+  // that motivated this. Nothing above this line is touched, so no existing
+  // forward edge can move.
+  //
+  // BARRIER-REALISED CARRIED ORDERINGS are handled here: a barrier
+  // are credited by the covering rule below. It was going to be deferred
+  // as untestable, but adversarial review showed it FIRES TODAY -- see the
+  // derivation at the covering loop.
+  //===--------------------------------------------------------------------===//
+
+  // (from, to, distance) -> the loop that carries it. Second insert from a
+  // DIFFERENT loop means one anchor pair is carried at two nest levels, which
+  // this flat key cannot tell apart. Measured empty on this corpus; the counter
+  // is the tripwire that keeps it that way.
+  std::map<std::tuple<unsigned, unsigned, unsigned>, Operation *> carriedOwner;
+  unsigned loopKeyCollisions = 0;
+
+  auto addCarried = [&](const SyncEvent &producer, const SyncEvent &consumer,
+                        Operation *loop, unsigned distance) {
+    const LoopSpan &span = loops[loop];
+    if (!span.hasAnchors())
+      return;
+    // Rule 2. Both endpoints restricted to the carrying loop's body: an anchor
+    // outside it has no iteration index, so a d=1 edge touching one would be
+    // meaningless.
+    for (unsigned x = span.firstAnchor;
+         x <= span.lastAnchor && x < producer.slot; ++x) {
+      if (anchorPipes[x] != producer.srcPipe)
+        continue;
+      for (unsigned y = std::max(span.firstAnchor, consumer.slot);
+           y <= span.lastAnchor; ++y) {
+        if (anchorPipes[y] != consumer.dstPipe)
+          continue;
+        auto key = std::make_tuple(x, y, distance);
+        auto it = carriedOwner.find(key);
+        if (it == carriedOwner.end())
+          carriedOwner[key] = loop;
+        else if (it->second != loop)
+          ++loopKeyCollisions;
+      }
+    }
+  };
+
+  // Rule 3: is this loop-carried EVENT pair primed by a set outside the loop?
+  //
+  // P1' IS A REACHABILITY TEST, NOT A NESTING TEST -- and that distinction was
+  // a REAL FALSE PASS, found by adversarial review and reproduced. The first
+  // version asked only `!insideLoop(head.op, loop)`, which credits a head that
+  // may never execute. Four deadlocking shapes were blessed `violations=0 OK`:
+  //   (a) `scf.if %c { set_flag }` before the loop  -- hangs when %c is false;
+  //   (b) `scf.if %c { set_flag } else { <the loop> }` -- prime and loop on
+  //       MUTUALLY EXCLUSIVE arms, so the prime provably never ran when the loop
+  //       runs: hangs for EVERY value of %c;
+  //   (c) the same with a guarded drain too, which balances G2's flat scan --
+  //       every gate reported OK on a certain hang;
+  //   (d) `scf.for %j = 0 to %n { set_flag }` before the loop -- a zero-trip
+  //       prime, on the very kernel named `test_dynamic_valid_shape`.
+  // `scf.if` is not a LoopLikeOpInterface, so nesting-only reasoning cannot see
+  // any of them. Blessing a hang is worse than having no iteration dimension at
+  // all, so P1' requires the head to be ON THE LOOP'S SPINE.
+  auto isPrimed = [&](const SyncEvent &producer, Operation *loop) {
+    unsigned entry = loops[loop].firstOrder;
+    llvm::SmallPtrSet<Block *, 8> spine = spineBlocks(loop);
+    for (const SyncEvent &head : events) {
+      if (head.kind != SyncEvent::SetFlag || head.id != producer.id ||
+          head.srcPipe != producer.srcPipe || head.dstPipe != producer.dstPipe)
+        continue;
+      // P1' -- unconditionally reached. Subsumes the old P1: a block inside the
+      // loop body is not on the spine either.
+      if (!spine.contains(head.op->getBlock()))
+        continue;
+      if (head.order >= entry) // P2
+        continue;
+      bool consumed = false; // P3: still live at loop entry?
+      for (const SyncEvent &wait : events) {
+        if (wait.kind != SyncEvent::WaitFlag || wait.id != producer.id ||
+            wait.srcPipe != producer.srcPipe || wait.dstPipe != producer.dstPipe)
+          continue;
+        if (insideLoop(wait.op, loop))
+          continue;
+        if (wait.order > head.order && wait.order < entry) {
+          consumed = true;
+          break;
+        }
+      }
+      if (!consumed)
+        return true;
+    }
+    return false;
+  };
+
+  for (const auto &entry : loops) {
+    Operation *loop = entry.first;
+
+    // Rule 1: match forward within THIS body only; the leftovers wrap.
+    // Key: (src, dst, id) for flags; the buffer rule keys on the buffer id
+    // alone, matching the forward rule above.
+    std::map<std::tuple<int, int, int64_t>, llvm::SmallVector<unsigned>>
+        openProducers, strandedConsumers;
+    auto flagKey = [](const SyncEvent &e) {
+      return std::make_tuple(int(e.srcPipe), int(e.dstPipe), e.id);
+    };
+    auto bufKey = [](const SyncEvent &e) {
+      return std::make_tuple(-1, -1, e.id);
+    };
+
+    for (unsigned i = 0; i < events.size(); ++i) {
+      const SyncEvent &ev = events[i];
+      if (ev.loop != loop)
+        continue;
+      // The mirror of P1' on the IN-BODY side, and a reproduced false pass in
+      // its own right: with an unconditional prime and drain but the in-body
+      // producer under `scf.if`, iterations 2..N have nothing to wait on and the
+      // kernel hangs -- yet G1 and G2 both reported OK. `ev.loop` is the NEAREST
+      // enclosing LOOP, so an op inside an `scf.if` inside the body still lands
+      // here; only a direct child of the body runs every iteration.
+      if (!executesEachIteration(ev.op, loop))
+        continue;
+      switch (ev.kind) {
+      case SyncEvent::SetFlag:
+      case SyncEvent::SetFlagDyn:
+        openProducers[flagKey(ev)].push_back(i);
+        break;
+      case SyncEvent::RlsBuf:
+        openProducers[bufKey(ev)].push_back(i);
+        break;
+      case SyncEvent::WaitFlag:
+      case SyncEvent::WaitFlagDyn:
+      case SyncEvent::GetBuf: {
+        auto key =
+            ev.kind == SyncEvent::GetBuf ? bufKey(ev) : flagKey(ev);
+        auto &open = openProducers[key];
+        if (!open.empty())
+          open.erase(open.begin()); // forward pair, consumed in this iteration
+        else
+          strandedConsumers[key].push_back(i);
+        break;
+      }
+      case SyncEvent::BarrierAll:
+      case SyncEvent::BarrierPipe:
+        break;
+      }
+    }
+
+    // Barrier-realised carried orderings fire on real kernels. A barrier in the
+    // body establishes carried orderings without any flag pair, so a candidate
+    // that serializes instead of pairing has nothing for Rule 1 to detect and
+    // was REJECTED for an ordering it does establish. That is a false failure,
+    // and it is reachable with an in-tree flag on an in-tree sample:
+    //   --enable-inject-barrier-all-sync on samples/Sync/test_dynamic_valid_shape.pto
+    // reported `!! missing-backward-ordering anchor#1 -> anchor#0 (d=1)` against
+    // the InsertSync reference. (The earlier "no corpus kernel emits that shape"
+    // reading was scoped to PINNED tests, which is not the same as reachable.)
+    //
+    // THE COVERING RULE. Unroll two iterations around a body barrier at slot s:
+    //     iter k:   a_0 .. a_{s-1}  BARRIER  a_s .. a_{n-1}
+    //     iter k+1: a_0 .. a_{s-1}  BARRIER  a_s .. a_{n-1}
+    // For the carried edge (from=x, to=y) -- "x in iter k before y in iter k+1":
+    //   x < s   => iter k's OWN barrier follows x and precedes all of iter k+1;
+    //   y >= s  => iter k+1's barrier precedes y and follows all of iter k.
+    // So it is covered iff (x < s || y >= s), i.e. UNCOVERED only in the wrap
+    // gap y < s <= x. A PIPE_ALL barrier covers any pipes; a per-pipe barrier
+    // covers only anchors on its own pipe, mirroring the forward rule.
+    //
+    // A barrier needs no priming -- it is unconditional hardware serialization,
+    // not a flag -- but it must still RUN every iteration, hence the
+    // `executesEachIteration` filter above applies to it as well.
+    for (const SyncEvent &ev : events) {
+      if (ev.loop != loop || !executesEachIteration(ev.op, loop))
+        continue;
+      if (ev.kind != SyncEvent::BarrierAll && ev.kind != SyncEvent::BarrierPipe)
+        continue;
+      const LoopSpan &span = loops[loop];
+      if (!span.hasAnchors())
+        continue;
+      bool anyPipe = ev.kind == SyncEvent::BarrierAll;
+      for (unsigned x = span.firstAnchor; x <= span.lastAnchor; ++x) {
+        if (!anyPipe && anchorPipes[x] != ev.srcPipe)
+          continue;
+        for (unsigned y = span.firstAnchor; y <= span.lastAnchor; ++y) {
+          if (!anyPipe && anchorPipes[y] != ev.dstPipe)
+            continue;
+          if (!(x < ev.slot || y >= ev.slot))
+            continue;
+          // A barrier drains the pipe, so it orders EVERY pair of adjacent
+          // iterations -- distance 1, and by transitive closure every larger
+          // distance too. It is the strongest carried ordering, so it is
+          // recorded at d=1 regardless of any rotation in the loop.
+          auto key = std::make_tuple(x, y, 1u);
+          if (!carriedOwner.count(key))
+            carriedOwner[key] = loop;
+        }
+      }
+    }
+
+    for (auto &open : openProducers) {
+      auto stranded = strandedConsumers.find(open.first);
+      if (stranded == strandedConsumers.end())
+        continue;
+      unsigned pairs = std::min(open.second.size(), stranded->second.size());
+      for (unsigned k = 0; k < pairs; ++k) {
+        const SyncEvent &producer = events[open.second[k]];
+        const SyncEvent &consumer = events[stranded->second[k]];
+        if (consumer.order >= producer.order)
+          continue; // not backward: nothing wraps
+        // Rule 3 applies to events only. A buffer token's ticket lock starts
+        // free, so iteration 1's get_buf needs no priming op -- there is no
+        // unprimed state to discriminate against.
+        // A DYN pair rotates: `wait_flag_dyn` in iteration j waits on
+        // eventIds[j % N] and `set_flag_dyn` in iteration k sets eventIds[k % N],
+        // so the wait at j is satisfied by the latest k < j with k%N == j%N --
+        // i.e. k = j - N. The ordering it establishes is at DISTANCE N, not 1.
+        // Derived from the emitted selector's modulus, not assumed.
+        bool isDyn = producer.kind == SyncEvent::SetFlagDyn ||
+                     consumer.kind == SyncEvent::WaitFlagDyn;
+        unsigned distance = 1;
+        if (isDyn) {
+          unsigned n = std::max(producer.rotation, consumer.rotation);
+          if (n < 2)
+            continue; // depth unrecoverable: credit nothing, never guess
+          distance = n;
+        }
+        // Rule 3 (priming) applies to the static event pair only. A rotating pair
+        // is primed by N static set_flags before the loop -- emitted through the
+        // compensation fan-out -- which the static scan below already sees as
+        // ordinary primes on the same (src,dst).
+        if (producer.kind == SyncEvent::SetFlag && !isPrimed(producer, loop))
+          continue;
+        addCarried(producer, consumer, loop, distance);
+      }
+    }
+  }
+
+  for (const auto &owned : carriedOwner)
+    profile.carriedEdges.push_back({std::get<0>(owned.first),
+                                    std::get<1>(owned.first),
+                                    std::get<2>(owned.first)});
+  llvm::sort(profile.carriedEdges);
+
+  // Through emitReport like every other oracle print: nested func passes run in
+  // PARALLEL and ptoas does not disable threading, so an unsynchronised write here
+  // can interleave with another function's report.
+  if (loopKeyCollisions)
+    oracle::emitReport([&](llvm::raw_ostream &os) {
+      os << "[sync-cov] !! carried-edge-loop-collision func=" << func.getName()
+         << " count=" << loopKeyCollisions
+         << " : one anchor pair is carried at two nest levels; the "
+            "(from,to,distance) key cannot tell them apart\n";
+    });
+
+  return profile;
+}
+
+//===----------------------------------------------------------------------===//
+// G1-self: absolute coverage against the dependency analysis
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// The anchor pipe of a compound's op. Taken from `OpPipeInterface` -- the same
+/// source `computeCoverage` keys its edge filtering on.
+std::optional<pto::PIPE> anchorPipe(Operation *op) {
+  if (auto pipeOp = dyn_cast<pto::OpPipeInterface>(op))
+    return pipeOp.getPipe();
+  return std::nullopt;
+}
+
+std::string anchorPipeName(Operation *op) {
+  if (auto pipe = anchorPipe(op))
+    return stringifyPIPE(*pipe).str();
+  return "?";
+}
+
+/// Can `a` and `b` both execute in one pass through the function?
+///
+/// FALSE only when they sit in DIFFERENT REGIONS of a common `scf.if`: the arms
+/// are mutually exclusive, so no ordering between them can ever be required and
+/// no sync can ever establish one. This is the same reasoning the carried rules apply to
+/// priming -- a set on the `then` arm cannot prime a loop on the `else` arm.
+///
+/// DELIBERATELY AS NARROW AS THE CORPUS ALLOWS. A too-broad exclusivity
+/// predicate silently EXCUSES real dependencies, and that failure is invisible in
+/// any "the number went down" check -- so this recognises `scf.if` and nothing
+/// else. Measured: `scf.if` is the ONLY mutually-exclusive-region op in the
+/// post-sync corpus IR (16 occurrences; zero `scf.index_switch`, zero `cf.cond_br`,
+/// zero `cf.switch`). If another one ever appears, this must be revisited
+/// explicitly rather than generalised on a hunch.
+///
+/// A one-armed `scf.if` is handled correctly by construction: if `b` is outside
+/// the `if` entirely, the `if` never appears as a common ancestor, so the pair is
+/// NOT excluded -- `b` always runs while `a` runs conditionally, and the ordering
+/// is still required.
+bool canBothExecute(Operation *a, Operation *b) {
+  llvm::SmallDenseMap<Operation *, Region *, 8> aRegionOf;
+  for (Operation *p = a; p && p->getParentOp(); p = p->getParentOp())
+    aRegionOf[p->getParentOp()] = p->getParentRegion();
+  for (Operation *p = b; p && p->getParentOp(); p = p->getParentOp()) {
+    auto it = aRegionOf.find(p->getParentOp());
+    if (it == aRegionOf.end() || it->second == p->getParentRegion())
+      continue;
+    if (isa<scf::IfOp>(p->getParentOp()))
+      return false;
+  }
+  return true;
+}
+
+/// The innermost loop enclosing `op`, or null.
+Operation *innermostLoop(Operation *op) {
+  for (Operation *p = op->getParentOp(); p; p = p->getParentOp())
+    if (isa<LoopLikeOpInterface>(p))
+      return p;
+  return nullptr;
+}
+
+} // namespace
+
+mlir::pto::oracle::SelfCoverageReport
+mlir::pto::oracle::computeSelfCoverage(func::FuncOp func) {
+  SelfCoverageReport report;
+
+  // --- The CANDIDATE side: what the emitted sync actually orders -------------
+  llvm::DenseMap<Operation *, unsigned> anchorIndex;
+  CoverageProfile profile = computeCoverage(func, &anchorIndex);
+  unsigned n = profile.anchorCount;
+
+  // Transitive closure with distances. reach[i][j] = 0 (same iteration), 1
+  // (loop-carried), or ABSENT. Happens-before is transitive and the raw edge set
+  // is not closed -- pipe filtering breaks chains across three pipes -- so
+  // closing it is required to avoid false "uncovered". 1+1 is dropped: distance 2
+  // is not represented, and dropping is the conservative direction.
+  // The closure is CAPPED, and the cap direction is load-bearing.
+  //
+  // `reach[i][j]` holds the SMALLEST distance at which emitted sync orders i
+  // before j. It used to be {0, 1, unreached}; rotation needs general N. The cap
+  // bounds the table, and ANYTHING ABOVE IT FALLS TO UNREACHED -- i.e. to
+  // UNCOVERED, never to covered. A cap that silently credited large N would be a
+  // false pass hiding in an implementation detail, which is the one direction
+  // that must not happen.
+  //
+  // 32 is chosen to exceed K (the 32-slot buffer-id pool) and every event pool
+  // (8 per direction), so no representable rotation depth can reach it. Measured:
+  // the deepest rotation anywhere in this repo's tests is N=6.
+  constexpr uint8_t kMaxDistance = 32;
+  constexpr uint8_t kUnreached = kMaxDistance + 1;
+  std::vector<uint8_t> reach(size_t(n) * n, kUnreached);
+  auto at = [&](unsigned i, unsigned j) -> uint8_t & {
+    return reach[size_t(i) * n + j];
+  };
+  for (const auto &e : profile.edges)
+    if (e.first < n && e.second < n)
+      at(e.first, e.second) = 0;
+  for (const CarriedEdge &e : profile.carriedEdges)
+    if (e.from < n && e.to < n && e.distance >= 1 &&
+        e.distance <= kMaxDistance)
+      at(e.from, e.to) =
+          std::min<uint8_t>(at(e.from, e.to), uint8_t(e.distance));
+  for (unsigned k = 0; k < n; ++k)
+    for (unsigned i = 0; i < n; ++i) {
+      uint8_t ik = at(i, k);
+      if (ik == kUnreached)
+        continue;
+      for (unsigned j = 0; j < n; ++j) {
+        uint8_t kj = at(k, j);
+        if (kj == kUnreached)
+          continue;
+        // Distances compose additively: i -before- k at d1 and k -before- j at
+        // d2 gives i -before- j at d1+d2. Above the cap the composition is
+        // DROPPED, which leaves the pair unreached -> uncovered. Conservative by
+        // construction.
+        unsigned sum = unsigned(ik) + unsigned(kj);
+        if (sum <= kMaxDistance)
+          at(i, j) = std::min<uint8_t>(at(i, j), uint8_t(sum));
+      }
+    }
+
+  // --- The EXPECTED side: the front-end dependency analysis, used DIRECTLY ---
+  // Nothing below reads InsertSync's decisions. `IsMemInfoHasDependency` is
+  // deliberately NOT called: it layers InsertSync's policy (the tload->tload WAW
+  // exemption, the ACC read/read case) on top of DepBetween, and policy is the
+  // thing under audit.
+  // The A5 PIPE_V intra-pipe guarantee. Read through the SAME predicate the
+  // codegen uses (`isTargetArchA5`, PTO/IR/PTO.h) rather than re-deriving it from
+  // the module attribute, so the oracle and the emitter cannot drift apart.
+  const bool isA5 = pto::isTargetArchA5(func.getOperation());
+
+  MemoryDependentAnalyzer memAnalyzer;
+  SyncIRs syncIR;
+  Buffer2MemInfoMap buffer2MemInfoMap;
+  PTOIRTranslator translator(syncIR, memAnalyzer, buffer2MemInfoMap, func,
+                             SyncAnalysisMode::NORMALSYNC);
+  translator.Build();
+
+  llvm::SmallVector<pto::CompoundInstanceElement *> compounds;
+  for (auto &element : syncIR)
+    if (auto *c = dyn_cast<pto::CompoundInstanceElement>(element.get()))
+      if (c->elementOp)
+        compounds.push_back(c);
+  report.compounds = compounds.size();
+
+  auto anchorOf = [&](pto::CompoundInstanceElement *c) -> int {
+    auto it = anchorIndex.find(c->elementOp);
+    return it == anchorIndex.end() ? -1 : int(it->second);
+  };
+
+  // One requirement per (pair, hazard class, distance).
+  auto record = [&](pto::CompoundInstanceElement *src,
+                    pto::CompoundInstanceElement *dst, llvm::StringRef hazard,
+                    unsigned distance) {
+    int as = anchorOf(src), ad = anchorOf(dst);
+    if (as < 0 || ad < 0) {
+      // NOT dropped -- counted. An endpoint with no anchor cannot be expressed
+      // in the coverage coordinate system at all.
+      ++report.unmappable;
+      return;
+    }
+    ++report.dependencies;
+    // Any distance >= 1 is loop-carried; 0 is same-iteration. Counting only
+    // d == 1 would hide rotating deps from the report once they carry
+    // their true distance.
+    if (distance >= 1)
+      ++report.carriedDeps;
+    bool covered = at(unsigned(as), unsigned(ad)) != kUnreached &&
+                   at(unsigned(as), unsigned(ad)) <= distance;
+    if (covered) {
+      ++report.covered;
+      if (distance >= 1)
+        ++report.carriedCovered;
+      return;
+    }
+    // (a2) Mutually exclusive arms. Counted, NOT silently dropped: `armExcluded`
+    // exists so the exclusion is auditable, and so that
+    // `uncovered + armExcluded` reproduces the pre-predicate uncovered count
+    // exactly. A predicate that quietly swallowed real dependencies would look
+    // identical to a correct one in any total-only check.
+    if (!canBothExecute(src->elementOp, dst->elementOp)) {
+      ++report.armExcluded;
+      return;
+    }
+    // A5 PIPE_V intra-pipe ordering is treated as a TARGET GUARANTEE. No sync is
+    // emitted for such a pair on A5 (`SyncCodegen`, `LoweringSyncToPipe`), so
+    // demanding one would make this gate report every such pair on every A5 kernel.
+    //
+    // NARROW ON PURPOSE -- this is NOT "A5 same-pipe is fine". The uncovered A5
+    // population is overwhelmingly V->V, but a residue is `MTE3->MTE3 waw/carried`
+    // and cross-pipe `MTE3->V war/carried`, which this test does not excuse.
+    // Widening it to "same pipe" would silence them -- re-blinding the gate in the
+    // same edit that fixes it.
+    //
+    // SCOPE, MEASURED. This test asks only whether both endpoints sit on PIPE_V; it
+    // does not distinguish a same-allocation pair from a cross-allocation one.
+    // Corpus-wide, of the pairs it excuses roughly three fifths are between ops on
+    // one allocation and two fifths span two distinct allocations that overlap in
+    // memory, which is how aliasing views are expressed once addresses are
+    // assigned. So the exemption is broader than a per-allocation test would be.
+    //
+      // It is not narrowed, for a measured reason: the sync pass treats every one of
+      // those cross-allocation pairs identically, excusing all of them and covering
+      // none. Narrowing it to one-allocation pairs would turn roughly a thousand
+      // corpus dependencies from excused to uncovered.
+    if (isA5) {
+      auto srcPipe = anchorPipe(src->elementOp);
+      auto dstPipe = anchorPipe(dst->elementOp);
+      if (srcPipe && dstPipe && *srcPipe == pto::PIPE::PIPE_V &&
+          *dstPipe == pto::PIPE::PIPE_V) {
+        ++report.archGuaranteed;
+        return;
+      }
+    }
+    if (anchorPipeName(src->elementOp) == anchorPipeName(dst->elementOp))
+      ++report.uncoveredSamePipe;
+    else
+      ++report.uncoveredCrossPipe;
+    report.violations.push_back({unsigned(as), unsigned(ad), distance,
+                                 hazard.str(),
+                                 src->opName.getStringRef().str(),
+                                 dst->opName.getStringRef().str(),
+                                 anchorPipeName(src->elementOp),
+                                 anchorPipeName(dst->elementOp)});
+  };
+
+  DepBaseMemInfoPairVec scratch;
+  // Accumulates the aliasing pairs across ALL hazard classes for one compound
+  // pair, because `scratch` is reset per call and the slot count below must see
+  // every pair, not just the last class tested.
+  DepBaseMemInfoPairVec allPairs;
+  auto dep = [&](pto::CompoundInstanceElement *a,
+                 pto::CompoundInstanceElement *b, bool aDef, bool bDef) {
+    scratch.clear();
+    bool found = memAnalyzer.DepBetween(aDef ? a->defVec : a->useVec,
+                                        bDef ? b->defVec : b->useVec, scratch);
+    if (found)
+      allPairs.append(scratch.begin(), scratch.end());
+    return found;
+  };
+
+  for (size_t i = 0; i < compounds.size(); ++i) {
+    for (size_t j = i + 1; j < compounds.size(); ++j) {
+      pto::CompoundInstanceElement *front = compounds[i];
+      pto::CompoundInstanceElement *now = compounds[j];
+
+      // Three hazard classes, front -> now, in the SAME iteration.
+      allPairs.clear();
+      bool raw = dep(front, now, /*aDef=*/true, /*bDef=*/false);  // W then R
+      bool war = dep(front, now, /*aDef=*/false, /*bDef=*/true);  // R then W
+      bool waw = dep(front, now, /*aDef=*/true, /*bDef=*/true);   // W then W
+      if (raw)
+        record(front, now, "raw", 0);
+      if (war)
+        record(front, now, "war", 0);
+      if (waw)
+        record(front, now, "waw", 0);
+
+      // The SAME alias relation also creates a LOOP-CARRIED requirement when
+      // both sit in one loop body: `now` in iteration k conflicts with `front` in
+      // iteration k+1, across the back edge. A forward RAW (front writes, now
+      // reads) is a carried WAR (now reads, then front writes next iteration),
+      // and so on -- which is exactly why the incumbent emits backward pairs at
+      // all. This is the requirement only carried edges can satisfy.
+      if (!(raw || war || waw))
+        continue;
+      Operation *loop = innermostLoop(front->elementOp);
+      if (!loop || loop != innermostLoop(now->elementOp))
+        continue;
+
+      // THE CARRIED DISTANCE IS THE SLOT COUNT, NOT ALWAYS 1.
+      //
+      // With N multi-buffer slots, iteration k touches slot k%N, so the next
+      // access that can CONFLICT is the one that reuses that slot -- iteration
+      // k+N. At N=1 this is 1 and nothing changes, which is the whole corpus.
+      //
+      // WIDEN, NEVER DROP. The forward precedent
+      // (`isForwardDepDroppableBySlotAffine`) DROPS a slot-disjoint dep, because
+      // forward it needs no sync at all. Mirroring that here would EXCUSE the
+      // dependency, and a kernel with NO ROTATION would then pass -- the
+      // false-pass direction. InsertSync's own comment guards exactly this:
+      // "Back-edge deps stay untouched -- they still need per-slot syncing
+      // through the dyn-event-id pipeline." The dep is real; only its DISTANCE
+      // moves. There is deliberately no skip/continue on this path.
+      //
+      // INDEPENDENCE: `baseAddresses` is front-end data, populated by the
+      // translator from the program's own `pto.multi_tile_get` slot structure. It
+      // is a fact about the PROGRAM, not about anything InsertSync decided.
+      unsigned slots = 1;
+      for (const auto &pair : allPairs) {
+        if (pair.first)
+          slots = std::max(slots, unsigned(pair.first->baseAddresses.size()));
+        if (pair.second)
+          slots = std::max(slots, unsigned(pair.second->baseAddresses.size()));
+      }
+      if (raw)
+        record(now, front, "war/carried", slots);
+      if (war)
+        record(now, front, "raw/carried", slots);
+      if (waw)
+        record(now, front, "waw/carried", slots);
+    }
+  }
+
+  // SELF-PAIRS: one compound against ITSELF across the back edge.
+  //
+  // The pair loop above starts at `j = i + 1`, so `x` in iteration k is never
+  // asked about against `x` in iteration k+1. That requirement is real -- an op
+  // that touches the same location on consecutive iterations must be ordered
+  // against its own previous execution -- and until it is enumerated here it sits
+  // in NO bucket: not `dependencies`, so not `covered`, `uncovered`, `armExcluded`
+  // or `archGuaranteed`. A gate that cannot see a requirement reports GREEN when
+  // the op realising it is deleted, which is indistinguishable from the
+  // requirement having never existed.
+  //
+  // The coverage side already answers these without change. A same-pipe body
+  // barrier records carried edges over every (x, y) anchor pair in its loop span
+  // subject to `x < slot || y >= slot`, which is trivially true when x == y, so
+  // the barrier contributes a carried SELF-edge at distance 1. Nothing seeds the
+  // closure diagonal otherwise -- the reach table starts every cell at
+  // `kUnreached` -- so a self-pair is covered exactly when some emitted op really
+  // does order the op against its own next execution.
+  //
+  // Only ops inside a loop are considered: without a back edge there is no second
+  // execution to conflict with.
+  for (size_t i = 0; i < compounds.size(); ++i) {
+    pto::CompoundInstanceElement *x = compounds[i];
+    if (!innermostLoop(x->elementOp))
+      continue;
+
+    allPairs.clear();
+    // Read against write in both orders: across the back edge "k writes then
+    // k+1 reads" and "k reads then k+1 writes" are two distinct orderings, and
+    // both have to hold. They are recorded separately for that reason, not by
+    // oversight.
+    bool waw = dep(x, x, /*aDef=*/true, /*bDef=*/true);
+    bool raw = dep(x, x, /*aDef=*/true, /*bDef=*/false);
+    bool war = dep(x, x, /*aDef=*/false, /*bDef=*/true);
+    if (!(waw || raw || war))
+      continue;
+
+    unsigned slots = 1;
+    for (const auto &pair : allPairs) {
+      if (pair.first)
+        slots = std::max(slots, unsigned(pair.first->baseAddresses.size()));
+      if (pair.second)
+        slots = std::max(slots, unsigned(pair.second->baseAddresses.size()));
+    }
+
+    if (waw)
+      record(x, x, "waw/carried-self", slots);
+    if (raw)
+      record(x, x, "raw/carried-self", slots);
+    if (war)
+      record(x, x, "war/carried-self", slots);
+  }
+
+  return report;
+}
+
+void mlir::pto::oracle::printSelfCoverage(llvm::raw_ostream &os,
+                                          llvm::StringRef funcName,
+                                          const SelfCoverageReport &report,
+                                          unsigned cap) {
+  unsigned uncovered = report.violations.size();
+  os << "[sync-gate:g1-self] func=" << funcName
+     << " compounds=" << report.compounds
+     << " deps=" << report.dependencies << " covered=" << report.covered
+     << " uncovered=" << uncovered << " (samepipe=" << report.uncoveredSamePipe
+     << " crosspipe=" << report.uncoveredCrossPipe << ")"
+     << " carried=" << report.carriedDeps << "/"
+     << report.carriedCovered << " arm_excluded=" << report.armExcluded
+     << " arch_guaranteed=" << report.archGuaranteed
+     << " unmappable=" << report.unmappable
+     << (uncovered == 0 ? " OK" : "") << "\n";
+  unsigned shown = 0;
+  for (const SelfCoverageViolation &v : report.violations) {
+    if (cap != 0 && shown >= cap) {
+      os << "  ... and " << (uncovered - shown) << " more\n";
+      break;
+    }
+    ++shown;
+    os << "  !! kind=uncovered-dependency " << v.hazard << " anchor#"
+       << v.srcAnchor << " (" << v.srcName << ") -> anchor#" << v.dstAnchor
+       << " (" << v.dstName << ")"
+       << " " << v.srcPipe << "->" << v.dstPipe;
+    if (v.distance == 1)
+      os << " (d=1)";
+    os << " : the dependency analysis reports this ordering; no emitted sync "
+          "establishes it\n";
+  }
+}
+
+namespace {
+
+/// Test-only synthetic faults for the classes the IR cannot spell.
+///
+/// The injection happens *after* extraction, into the gate's own record buffer.
+/// It never touches the IR and therefore cannot reach codegen. Its only purpose
+/// is to prove the gate rejects what it claims to reject.
+/// False when `kind` names no fault, which the caller must report: a silent no-op
+/// would leave the gate finding nothing and passing, so a misspelled selector would
+/// vacuously satisfy the very test that exists to prove the gate is not vacuous.
+bool injectFaultRecords(llvm::StringRef kind,
+                        llvm::SmallVectorImpl<IRSyncRecord> &irRecords,
+                        llvm::SmallVectorImpl<SyncOpRecord> &syncOpRecords) {
+  using TYPE = SyncOperation::TYPE;
+
+  if (kind == "event-oor") {
+    // An event id past the end of the intra-core pool. Unrepresentable in IR
+    // (`pto.set_flag`'s event_id enum stops at EVENT_ID7) but writable into
+    // SyncOperation::eventIds by any allocator.
+    SyncOpRecord rec;
+    rec.type = "set_event";
+    rec.typeCode = static_cast<int>(TYPE::SET_EVENT);
+    rec.srcPipe = static_cast<int>(PipelineType::PIPE_V);
+    rec.dstPipe = static_cast<int>(PipelineType::PIPE_MTE3);
+    rec.eventIds.push_back(9);
+    syncOpRecords.push_back(std::move(rec));
+    return true;
+  }
+
+  if (kind == "block-all-stomp") {
+    // A live sync_block_all owns id 14; a block set that also takes 14 stomps it.
+    SyncOpRecord all;
+    all.type = "sync_block_all";
+    all.typeCode = static_cast<int>(TYPE::SYNC_BLOCK_ALL);
+    all.srcPipe = static_cast<int>(PipelineType::PIPE_ALL);
+    all.dstPipe = static_cast<int>(PipelineType::PIPE_ALL);
+    all.eventIds.push_back(static_cast<int>(kBlockSyncAllCubeEventId));
+    syncOpRecords.push_back(std::move(all));
+
+    SyncOpRecord set;
+    set.type = "sync_block_set";
+    set.typeCode = static_cast<int>(TYPE::SYNC_BLOCK_SET);
+    set.srcPipe = static_cast<int>(PipelineType::PIPE_MTE3);
+    set.dstPipe = static_cast<int>(PipelineType::PIPE_V);
+    set.eventIds.push_back(static_cast<int>(kBlockSyncAllCubeEventId));
+    set.syncIndex = 1;
+    syncOpRecords.push_back(std::move(set));
+    return true;
+  }
+
+  if (kind == "bufid-oor") {
+    // Past the hardware buf_id field, which real IR cannot spell, so the fault is
+    // injected into the gate's record buffer instead.
+    IRSyncRecord rec;
+    rec.opName = "pto.get_buf";
+    rec.srcPipe = "PIPE_MTE2";
+    rec.dstPipe = "PIPE_MTE2";
+    rec.srcPipeType = PipelineType::PIPE_MTE2;
+    rec.dstPipeType = PipelineType::PIPE_MTE2;
+    rec.bufId = 64;
+    rec.order = irRecords.size();
+    irRecords.push_back(std::move(rec));
+    return true;
+  }
+
+  return false;
+}
+
+/// Runs G3 on a compiled function. Read-only apart from diagnostics.
+struct PTOCheckSyncIdsPass
+    : public mlir::pto::impl::PTOCheckSyncIdsBase<PTOCheckSyncIdsPass> {
+  unsigned bufidCapacity = 0;
+  std::string injectFault;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isDeclaration())
+      return;
+
+    DeviceIdLimits limits;
+    limits.bufIdCapacity = bufidCapacity;
+
+    llvm::SmallVector<IRSyncRecord> irRecords = oracle::extractFromIR(func);
+    llvm::SmallVector<SyncOpRecord> syncOpRecords;
+    if (!injectFault.empty() &&
+        !injectFaultRecords(injectFault, irRecords, syncOpRecords)) {
+      func.emitError() << "unknown --check-sync-ids-inject-fault selector '"
+                       << injectFault
+                       << "'; expected event-oor, block-all-stomp or bufid-oor";
+      signalPassFailure();
+      return;
+    }
+
+    auto irViolations = oracle::checkDeviceIdLegality(irRecords, limits);
+    llvm::SmallVector<IdViolation> syncOpViolations;
+    if (!syncOpRecords.empty())
+      syncOpViolations = oracle::checkDeviceIdLegality(syncOpRecords, limits);
+
+    oracle::emitReport([&](llvm::raw_ostream &os) {
+      oracle::printIdViolations(os, func.getSymName(), "ir", irRecords.size(),
+                                irViolations);
+      if (!syncOpRecords.empty())
+        oracle::printIdViolations(os, func.getSymName(), "syncops",
+                                  syncOpRecords.size(), syncOpViolations);
+    });
+
+    size_t total = irViolations.size() + syncOpViolations.size();
+    if (total > 0) {
+      func.emitError() << "G3 device-id legality: " << total
+                       << " illegal sync id(s)";
+      signalPassFailure();
+    }
+  }
+};
+
+/// G2: runs the non-interference check on a compiled function.
+struct PTOCheckSyncInterferencePass
+    : public mlir::pto::impl::PTOCheckSyncInterferenceBase<
+          PTOCheckSyncInterferencePass> {
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isDeclaration())
+      return;
+
+    auto records = oracle::extractFromIR(func);
+    auto violations = oracle::checkNonInterference(records);
+    oracle::emitReport([&](llvm::raw_ostream &os) {
+      oracle::printInterferenceViolations(os, func.getSymName(), "ir",
+                                          records.size(), violations);
+    });
+    // Warnings (a soft rule, such as an id spanning more than two pipes) are
+    // reported but do not fail the gate; only errors do.
+    if (unsigned errors = oracle::countErrors(violations)) {
+      func.emitError() << "G2 non-interference: " << errors
+                       << " illegal sync id use(s)";
+      signalPassFailure();
+    }
+  }
+};
+
+/// G1-self: ABSOLUTE, not differential. Asserts that every dependency the
+/// front-end analysis reports is ordered by emitted sync. No reference file --
+/// the expected set comes from `DepBetween`, so there is nothing to compare
+/// against and nothing inherited from InsertSync's choices.
+struct PTOCheckSyncSelfCoveragePass
+    : public mlir::pto::impl::PTOCheckSyncSelfCoverageBase<
+          PTOCheckSyncSelfCoveragePass> {
+  /// Violations printed per function; 0 = all. Threaded in from the driver rather
+  /// than read from a global, so nothing that links this library inherits a flag.
+  unsigned maxViolations = 8;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isDeclaration())
+      return;
+    auto report = oracle::computeSelfCoverage(func);
+    oracle::emitReport([&](llvm::raw_ostream &os) {
+      oracle::printSelfCoverage(os, func.getSymName(), report, maxViolations);
+    });
+    if (!report.violations.empty()) {
+      func.emitError() << "G1-self coverage: " << report.violations.size()
+                       << " dependency ordering(s) are not established by any "
+                          "emitted sync";
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass>
+mlir::pto::createPTOCheckSyncIdsPass(unsigned bufidCapacity,
+                                     llvm::StringRef injectFault) {
+  auto pass = std::make_unique<PTOCheckSyncIdsPass>();
+  pass->bufidCapacity = bufidCapacity;
+  pass->injectFault = injectFault.str();
+  return pass;
+}
+
+std::unique_ptr<Pass> mlir::pto::createPTOCheckSyncInterferencePass() {
+  return std::make_unique<PTOCheckSyncInterferencePass>();
+}
+
+std::unique_ptr<Pass>
+mlir::pto::createPTOCheckSyncSelfCoveragePass(unsigned maxViolations) {
+  auto pass = std::make_unique<PTOCheckSyncSelfCoveragePass>();
+  pass->maxViolations = maxViolations;
+  return pass;
+}
+

--- a/lib/PTO/Transforms/InsertSync/SyncOracleGates.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncOracleGates.cpp
@@ -766,19 +766,19 @@ CoverageProfile mlir::pto::oracle::computeCoverage(
                         int64_t(waitFlag.getEventIdAttr().getEvent()), op, order,
                         nearest});
     } else if (auto getBuf = dyn_cast<pto::GetBufOp>(op)) {
-      auto opTypeOr = parseSyncOpTypeLikeAttr(getBuf.getOpTypeAttr());
-      if (succeeded(opTypeOr)) {
-        pto::PIPE pipe = mapSyncOpTypeToPipe(*opTypeOr);
+      // A spelling this does not decode drops the event, and a dropped event is
+      // indistinguishable from an absent one: the ordering the token establishes
+      // then reads as uncovered. `isConcreteSyncPipe` mirrors `verifyBufSyncOp`,
+      // which rejects PIPE_ALL and PIPE_UNASSIGNED on these ops.
+      pto::PIPE pipe = oracle::bufSyncPipe(getBuf.getOpTypeAttr());
+      if (pto::isConcreteSyncPipe(pipe))
         events.push_back({SyncEvent::GetBuf, slot, pipe, pipe,
                           int64_t(getBuf.getBufId()), op, order, nearest});
-      }
     } else if (auto rlsBuf = dyn_cast<pto::RlsBufOp>(op)) {
-      auto opTypeOr = parseSyncOpTypeLikeAttr(rlsBuf.getOpTypeAttr());
-      if (succeeded(opTypeOr)) {
-        pto::PIPE pipe = mapSyncOpTypeToPipe(*opTypeOr);
+      pto::PIPE pipe = oracle::bufSyncPipe(rlsBuf.getOpTypeAttr());
+      if (pto::isConcreteSyncPipe(pipe))
         events.push_back({SyncEvent::RlsBuf, slot, pipe, pipe,
                           int64_t(rlsBuf.getBufId()), op, order, nearest});
-      }
     } else if (auto setDyn = dyn_cast<pto::SetFlagDynOp>(op)) {
       // The rotating pair is what multi-buffering emits, and it was
       // previously invisible: the type chain below had no Dyn case, so the op
@@ -1709,4 +1709,3 @@ mlir::pto::createPTOCheckSyncSelfCoveragePass(unsigned maxViolations) {
   pass->maxViolations = maxViolations;
   return pass;
 }
-

--- a/lib/PTO/Transforms/InsertSync/SyncOracleGates.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncOracleGates.cpp
@@ -1383,6 +1383,33 @@ mlir::pto::oracle::computeSelfCoverage(func::FuncOp func) {
         return;
       }
     }
+    // (a3) PIPE_S->PIPE_S, on every arch.
+    //
+    // THIS IS INFERENCE FROM COMPILER BEHAVIOUR, NOT AN ARCHITECTURAL FACT, and it is
+    // counted separately from `archGuaranteed` for that reason. No ISA or design
+    // document in this tree states the ordering the scalar pipe gives its own ops, and
+    // `pipe_barrier(PIPE_S)` is expressible and does reach the emitted code, so the
+    // omission below cannot be argued from the barrier being unavailable.
+    //
+    // What it does rest on is the same assumption encoded independently TWICE:
+    // `IsNoNeedToInsertSync` returns early for a same-pipe PIPE_S pair before any
+    // dependence analysis runs, deliberately -- the comment beside it declines to
+    // short-circuit same-pipe pairs in general -- and GraphSyncSolver's same-pipe
+    // barrier path (`SyncSolver.cpp`, guarded by `corePipeSrc == corePipeDst`) returns
+    // for PIPE_S unconditionally while gating PIPE_V and PIPE_M on `isRegBasedArch`.
+    // Two separate allocators decline to order this pair on every arch, so demanding
+    // it here would make the gate unsatisfiable rather than strict.
+    //
+    // Arch-independent, unlike (a1), because that is how both allocators key it.
+    {
+      auto srcPipe = anchorPipe(src->elementOp);
+      auto dstPipe = anchorPipe(dst->elementOp);
+      if (srcPipe && dstPipe && *srcPipe == pto::PIPE::PIPE_S &&
+          *dstPipe == pto::PIPE::PIPE_S) {
+        ++report.pipeSelfOrdered;
+        return;
+      }
+    }
     if (anchorPipeName(src->elementOp) == anchorPipeName(dst->elementOp))
       ++report.uncoveredSamePipe;
     else
@@ -1542,6 +1569,7 @@ void mlir::pto::oracle::printSelfCoverage(llvm::raw_ostream &os,
      << " carried=" << report.carriedDeps << "/"
      << report.carriedCovered << " arm_excluded=" << report.armExcluded
      << " arch_guaranteed=" << report.archGuaranteed
+     << " pipe_self_ordered=" << report.pipeSelfOrdered
      << " unmappable=" << report.unmappable
      << (uncovered == 0 ? " OK" : "") << "\n";
   unsigned shown = 0;

--- a/lib/PTO/Transforms/InsertSync/SyncOracleGates.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncOracleGates.cpp
@@ -747,6 +747,10 @@ CoverageProfile mlir::pto::oracle::computeCoverage(
   CoverageProfile profile;
 
   llvm::SmallVector<pto::PIPE> anchorPipes;
+  /// Parallel to `anchorPipes`, same index space, filled by the same walk. The edge
+  /// filter needs the op itself to ask whether a sync reaches it; building this list
+  /// in a second walk is what would let the two drift out of step.
+  llvm::SmallVector<Operation *> anchorOps;
   llvm::SmallVector<SyncEvent> events;
   std::string signatureText;
   // Deterministic iteration order: the carried-edge scan walks these.
@@ -775,6 +779,7 @@ CoverageProfile mlir::pto::oracle::computeCoverage(
       pto::PIPE pipe = cast<pto::OpPipeInterface>(op).getPipe();
       unsigned index = anchorPipes.size();
       anchorPipes.push_back(pipe);
+      anchorOps.push_back(op);
       if (anchorIndex)
         (*anchorIndex)[op] = index;
       for (Operation *loop : chain) {
@@ -847,14 +852,45 @@ CoverageProfile mlir::pto::oracle::computeCoverage(
   profile.anchorCount = anchorPipes.size();
 
   llvm::DenseSet<std::pair<unsigned, unsigned>> edges;
-  auto addEdges = [&](unsigned beforeSlot, pto::PIPE fromPipe,
-                      unsigned afterSlot, pto::PIPE toPipe, bool anyPipe) {
+  /// `reachedBy` is the op whose execution the edge depends on -- the CONSUMING end of
+  /// the mechanism: a barrier itself, the `wait_flag` of a flag pair, the `get_buf` of
+  /// a token pair. An edge is credited only when that op is reached on every path that
+  /// reaches the sink, because a sync the sink can skip establishes nothing.
+  ///
+  /// "Reached on every path" is tested as: the conditionals enclosing the sync must be
+  /// a PREFIX of those enclosing the sink. Enclosing LOOPS are not compared.
+  ///
+  /// NOT `DominanceInfo`, and the difference is not cosmetic. Structural dominance
+  /// says an op in a loop body never dominates an op after the loop, which withdraws
+  /// credit from a barrier inside a constant-trip-count loop -- it always executes, so
+  /// the ordering does hold. Measured: that rejection alone turns
+  /// `control_flow_nested_vec` from clean to three uncovered same-pipe dependencies.
+  /// A loop whose trip count can be zero is a real hole, and it is NOT covered here;
+  /// the carried rules test the loop spine for that case instead.
+  ///
+  /// Sink side only, deliberately. A sync inside an `scf.if` arm legitimately orders a
+  /// dependence whose sink is in that same arm -- every path reaching the sink passes
+  /// through it -- so also requiring the sync to be reached whenever the SOURCE is
+  /// would reject the shape the emitter produces most.
+  auto addEdges = [&](unsigned beforeSlot, pto::PIPE fromPipe, unsigned afterSlot,
+                      pto::PIPE toPipe, bool anyPipe, Operation *reachedBy) {
+    llvm::SmallVector<mlir::Region *, 4> syncGuards;
+    if (reachedBy)
+      syncGuards = conditionalGuards(reachedBy);
     for (unsigned i = 0; i < beforeSlot; ++i) {
       if (!anyPipe && anchorPipes[i] != fromPipe)
         continue;
       for (unsigned j = afterSlot; j < anchorPipes.size(); ++j) {
         if (!anyPipe && anchorPipes[j] != toPipe)
           continue;
+        if (reachedBy) {
+          llvm::SmallVector<mlir::Region *, 4> sinkGuards =
+              conditionalGuards(anchorOps[j]);
+          if (syncGuards.size() > sinkGuards.size() ||
+              !std::equal(syncGuards.begin(), syncGuards.end(),
+                          sinkGuards.begin()))
+            continue;
+        }
         if (i < j)
           edges.insert({i, j});
       }
@@ -865,10 +901,10 @@ CoverageProfile mlir::pto::oracle::computeCoverage(
     const SyncEvent &ev = events[e];
     switch (ev.kind) {
     case SyncEvent::BarrierAll:
-      addEdges(ev.slot, ev.srcPipe, ev.slot, ev.dstPipe, /*anyPipe=*/true);
+      addEdges(ev.slot, ev.srcPipe, ev.slot, ev.dstPipe, /*anyPipe=*/true, ev.op);
       break;
     case SyncEvent::BarrierPipe:
-      addEdges(ev.slot, ev.srcPipe, ev.slot, ev.dstPipe, /*anyPipe=*/false);
+      addEdges(ev.slot, ev.srcPipe, ev.slot, ev.dstPipe, /*anyPipe=*/false, ev.op);
       break;
     case SyncEvent::SetFlag:
       // Pair with the next matching wait. G2 guarantees the interval discipline
@@ -877,7 +913,8 @@ CoverageProfile mlir::pto::oracle::computeCoverage(
         const SyncEvent &wait = events[w];
         if (wait.kind == SyncEvent::WaitFlag && wait.srcPipe == ev.srcPipe &&
             wait.dstPipe == ev.dstPipe && wait.id == ev.id) {
-          addEdges(ev.slot, ev.srcPipe, wait.slot, wait.dstPipe, false);
+          // The WAIT is the consuming end: the sink is ordered only if the wait ran.
+          addEdges(ev.slot, ev.srcPipe, wait.slot, wait.dstPipe, false, wait.op);
           break;
         }
       }
@@ -888,7 +925,8 @@ CoverageProfile mlir::pto::oracle::computeCoverage(
       for (size_t g = e + 1; g < events.size(); ++g) {
         const SyncEvent &get = events[g];
         if (get.kind == SyncEvent::GetBuf && get.id == ev.id)
-          addEdges(ev.slot, ev.srcPipe, get.slot, get.dstPipe, false);
+          // The acquire is the consuming end, as the wait is for a flag pair.
+          addEdges(ev.slot, ev.srcPipe, get.slot, get.dstPipe, false, get.op);
       }
       break;
     case SyncEvent::WaitFlag:

--- a/lib/PTO/Transforms/InsertSync/SyncOracleGates.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncOracleGates.cpp
@@ -295,6 +295,8 @@ llvm::StringRef mlir::pto::oracle::interferenceKindName(InterferenceKind k) {
     return "event-id-wait-without-set";
   case InterferenceKind::EventIdUnclosed:
     return "event-id-unclosed";
+  case InterferenceKind::EventIdPairGuardMismatch:
+    return "event-id-pair-guard-mismatch";
   case InterferenceKind::BufIdNested:
     return "buf-id-nested";
   case InterferenceKind::BufIdReleaseWithoutAcquire:
@@ -336,8 +338,33 @@ struct BufOpen {
 /// and every overlap conflicts, exactly as before.
 constexpr int kNoOwner = -1;
 
+/// The `scf.if`/`scf.index_switch` REGIONS enclosing `op`, outermost first.
+///
+/// Loops are skipped on purpose. Two ops in different blocks of the same loop nest
+/// are still reached together whenever the loop body runs at all, and requiring the
+/// two halves of an event pair to share a block would reject the set-outside /
+/// wait-inside priming idiom, which is what the corpus overwhelmingly emits.
+llvm::SmallVector<mlir::Region *, 4> conditionalGuards(Operation *op) {
+  llvm::SmallVector<mlir::Region *, 4> guards;
+  for (Operation *p = op; p; p = p->getParentOp()) {
+    Operation *parent = p->getParentOp();
+    if (parent && isa<scf::IfOp, scf::IndexSwitchOp>(parent))
+      guards.push_back(p->getParentRegion());
+  }
+  std::reverse(guards.begin(), guards.end());
+  return guards;
+}
+
+/// One open interval. `op` is null in the pre-codegen record view, which carries no
+/// ops; a null disables only the checks that need a position in the IR.
+struct Open {
+  unsigned order;
+  int owner;
+  Operation *op;
+};
+
 struct LiveIntervals {
-  llvm::SmallVector<std::pair<unsigned, int>> opens; // (program order, owner)
+  llvm::SmallVector<Open> opens;
 
   /// Returns the order of an already-live interval that CONFLICTS with this open, or
   /// -1 if this open is legal.
@@ -348,22 +375,24 @@ struct LiveIntervals {
   /// wait, head and tail alike). Anything else still conflicts, INCLUDING a
   /// compensation op against a different hazard, which is the whole point of keying on
   /// the owner rather than just skipping compensation records.
-  int64_t open(unsigned order, int owner = kNoOwner) {
+  int64_t open(unsigned order, int owner = kNoOwner, Operation *op = nullptr) {
     int64_t live = -1;
     for (const auto &o : opens) {
-      if (owner != kNoOwner && o.second == owner)
+      if (owner != kNoOwner && o.owner == owner)
         continue; // same hazard: its own prime/drain, not a competing interval
-      live = int64_t(o.first);
+      live = int64_t(o.order);
       break;
     }
-    opens.push_back({order, owner});
+    opens.push_back({order, owner, op});
     return live;
   }
-  bool close() {
+  /// The interval this close pops, or nullopt when there is none to pop.
+  std::optional<Open> close() {
     if (opens.empty())
-      return false;
+      return std::nullopt;
+    Open top = opens.back();
     opens.pop_back();
-    return true;
+    return top;
   }
 };
 
@@ -379,8 +408,8 @@ void scanOpen(llvm::DenseMap<KeyT, LiveIntervals> &live, const KeyT &key,
               unsigned order, llvm::StringRef opName, llvm::StringRef keyName,
               InterferenceKind nestedKind,
               llvm::SmallVectorImpl<InterferenceViolation> &out,
-              int owner = kNoOwner) {
-  int64_t alreadyLive = live[key].open(order, owner);
+              int owner = kNoOwner, Operation *op = nullptr) {
+  int64_t alreadyLive = live[key].open(order, owner, op);
   if (alreadyLive >= 0)
     out.push_back({nestedKind, Severity::Error, order, unsigned(alreadyLive),
                    opName.str(), keyName.str(),
@@ -392,10 +421,23 @@ template <typename KeyT>
 void scanClose(llvm::DenseMap<KeyT, LiveIntervals> &live, const KeyT &key,
                unsigned order, llvm::StringRef opName, llvm::StringRef keyName,
                InterferenceKind orphanKind,
-               llvm::SmallVectorImpl<InterferenceViolation> &out) {
-  if (!live[key].close())
+               llvm::SmallVectorImpl<InterferenceViolation> &out,
+               Operation *op = nullptr) {
+  std::optional<Open> opened = live[key].close();
+  if (!opened) {
     out.push_back({orphanKind, Severity::Error, order, 0, opName.str(),
                    keyName.str(), "closes an id that no earlier op opened"});
+    return;
+  }
+  // The two halves must be equally guarded, or a path runs one without the other.
+  // A flattened scan cannot see this: the counts balance and the stack pairs them.
+  if (op && opened->op &&
+      conditionalGuards(opened->op) != conditionalGuards(op))
+    out.push_back({InterferenceKind::EventIdPairGuardMismatch, Severity::Error,
+                   order, opened->order, opName.str(), keyName.str(),
+                   "this op and the one that opened the id sit under different "
+                   "conditionals, so some path executes one without the other: a "
+                   "wait with no set hangs, a set with no wait leaks the id"});
 }
 
 } // namespace
@@ -421,10 +463,10 @@ mlir::pto::oracle::checkNonInterference(llvm::ArrayRef<IRSyncRecord> records) {
       std::string name = eventKeyName(rec.srcPipeType, rec.dstPipeType, rec.eventId);
       if (rec.opName == "pto.set_flag")
         scanOpen(eventLive, key, rec.order, rec.opName, name,
-                 InterferenceKind::EventIdNested, violations);
+                 InterferenceKind::EventIdNested, violations, kNoOwner, rec.op);
       else
         scanClose(eventLive, key, rec.order, rec.opName, name,
-                  InterferenceKind::EventIdWaitWithoutSet, violations);
+                  InterferenceKind::EventIdWaitWithoutSet, violations, rec.op);
     } else if (rec.opName == "pto.get_buf" || rec.opName == "pto.rls_buf") {
       // Buffer-ID legality. See SyncOracleGates.h for the rules, and
       // docs/bufid_sync_a5_design.md "Correctness Invariants" for the protocol.
@@ -529,7 +571,7 @@ mlir::pto::oracle::checkNonInterference(llvm::ArrayRef<IRSyncRecord> records) {
   llvm::SmallVector<InterferenceViolation> leaks;
   for (const auto &entry : eventLive)
     for (const auto &open : entry.second.opens) {
-      unsigned order = open.first;
+      unsigned order = open.order;
       leaks.push_back({InterferenceKind::EventIdUnclosed, Severity::Error,
                        order, order, "pto.set_flag",
                        eventKeyName(PipelineType(std::get<0>(entry.first)),

--- a/test/lit/pto/Inputs/oracle_buf_token_spellings.pto
+++ b/test/lit/pto/Inputs/oracle_buf_token_spellings.pto
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// One buffer-token chain, written twice in two of the spellings `PTO_PipeLikeAttr`
+// admits. Both name the same two pipes and establish the same ordering, so a gate
+// that decodes only one spelling reports different coverage for identical programs.
+// lit excludes this directory from discovery.
+
+module {
+  // The plain PipeAttr spelling.
+  func.func @buf_chain_pipe_attr(%a: !pto.partition_tensor_view<1x64xf32>,
+                                 %c: !pto.partition_tensor_view<1x64xf32>) {
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.get_buf "PIPE_MTE2", 0, 0
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    pto.rls_buf "PIPE_MTE2", 0, 0
+    pto.get_buf "PIPE_MTE3", 0, 0
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    pto.rls_buf "PIPE_MTE3", 0, 0
+    return
+  }
+
+  // The pipe_event_type spelling. TLOAD maps to MTE2 and TSTORE_VEC to MTE3, so this
+  // is the same chain over the same pipes as above.
+  func.func @buf_chain_event_type(%a: !pto.partition_tensor_view<1x64xf32>,
+                                  %c: !pto.partition_tensor_view<1x64xf32>) {
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.get_buf[#pto.pipe_event_type<TLOAD>, 0]
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    pto.rls_buf[#pto.pipe_event_type<TLOAD>, 0]
+    pto.get_buf[#pto.pipe_event_type<TSTORE_VEC>, 0]
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    pto.rls_buf[#pto.pipe_event_type<TSTORE_VEC>, 0]
+    return
+  }
+}

--- a/test/lit/pto/Inputs/oracle_event_pair_guards.pto
+++ b/test/lit/pto/Inputs/oracle_event_pair_guards.pto
@@ -15,14 +15,16 @@ module {
   // balance and a flattened scan pops this wait against this set.
   func.func @pair_split_across_arms(%a: !pto.partition_tensor_view<1x64xf32>,
                                     %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
-    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
-    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
-    scf.if %p {
-      pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-    } else {
-      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.section.vector {
+      %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+      pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+      scf.if %p {
+        pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      } else {
+        pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      }
+      pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     }
-    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     return
   }
 
@@ -30,26 +32,30 @@ module {
   // nothing to consume and the kernel hangs.
   func.func @guarded_set_plain_wait(%a: !pto.partition_tensor_view<1x64xf32>,
                                     %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
-    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
-    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
-    scf.if %p {
-      pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.section.vector {
+      %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+      pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+      scf.if %p {
+        pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      }
+      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     }
-    pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     return
   }
 
   // The mirror: an unguarded set with a guarded wait leaks the id on the false path.
   func.func @plain_set_guarded_wait(%a: !pto.partition_tensor_view<1x64xf32>,
                                     %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
-    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
-    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
-    pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-    scf.if %p {
-      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.section.vector {
+      %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+      pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+      pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      scf.if %p {
+        pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      }
+      pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     }
-    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     return
   }
 
@@ -57,13 +63,15 @@ module {
   // whole pair runs or neither half does.
   func.func @pair_on_one_arm(%a: !pto.partition_tensor_view<1x64xf32>,
                              %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
-    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
-    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
-    scf.if %p {
-      pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.section.vector {
+      %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+      pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+      scf.if %p {
+        pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+        pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      }
+      pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     }
-    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     return
   }
 
@@ -73,16 +81,18 @@ module {
   // comparing blocks rather than conditionals would reject it.
   func.func @set_outside_loop_wait_inside(%a: !pto.partition_tensor_view<1x64xf32>,
                                           %c: !pto.partition_tensor_view<1x64xf32>) {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c4 = arith.constant 4 : index
-    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
-    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
-    pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-    scf.for %i = %c0 to %c4 step %c1 {
-      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.section.vector {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+      pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+      pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      scf.for %i = %c0 to %c4 step %c1 {
+        pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      }
+      pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     }
-    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     return
   }
 }

--- a/test/lit/pto/Inputs/oracle_event_pair_guards.pto
+++ b/test/lit/pto/Inputs/oracle_event_pair_guards.pto
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// One event id, placed five ways. Three of them leave a runtime path that executes
+// one half of the pair without the other; two are legal and must stay silent.
+// lit excludes this directory from discovery.
+
+module {
+  // The set on one arm, the wait on the other. No path runs both, yet the counts
+  // balance and a flattened scan pops this wait against this set.
+  func.func @pair_split_across_arms(%a: !pto.partition_tensor_view<1x64xf32>,
+                                    %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    scf.if %p {
+      pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    } else {
+      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    }
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    return
+  }
+
+  // A guarded set with an unguarded wait: when the guard is false the wait has
+  // nothing to consume and the kernel hangs.
+  func.func @guarded_set_plain_wait(%a: !pto.partition_tensor_view<1x64xf32>,
+                                    %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    scf.if %p {
+      pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    }
+    pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    return
+  }
+
+  // The mirror: an unguarded set with a guarded wait leaks the id on the false path.
+  func.func @plain_set_guarded_wait(%a: !pto.partition_tensor_view<1x64xf32>,
+                                    %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    scf.if %p {
+      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    }
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    return
+  }
+
+  // LEGAL. Both halves on the same arm: the pair is equally guarded, so either the
+  // whole pair runs or neither half does.
+  func.func @pair_on_one_arm(%a: !pto.partition_tensor_view<1x64xf32>,
+                             %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    scf.if %p {
+      pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    }
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    return
+  }
+
+  // LEGAL, AND THE SHAPE THAT BOUNDS THE RULE. The set is outside the loop and the
+  // wait inside it, so the two sit in different BLOCKS while carrying the same
+  // conditional guards. This is what the emitter overwhelmingly produces, and a rule
+  // comparing blocks rather than conditionals would reject it.
+  func.func @set_outside_loop_wait_inside(%a: !pto.partition_tensor_view<1x64xf32>,
+                                          %c: !pto.partition_tensor_view<1x64xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    scf.for %i = %c0 to %c4 step %c1 {
+      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    }
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    return
+  }
+}

--- a/test/lit/pto/Inputs/oracle_gate_features.pto
+++ b/test/lit/pto/Inputs/oracle_gate_features.pto
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Two shapes G1-self treats specially, isolated so each can be pinned on its own.
+// lit excludes this directory from discovery.
+
+module {
+  // Two consecutive PIPE_V ops on one tile: a same-pipe read-after-write. A5
+  // guarantees intra-pipe ordering on that pipe and its backend rejects an
+  // explicit vector barrier, so the gate must credit the ordering there and must
+  // NOT credit it on A3.
+  func.func @same_pipe(%a: !pto.partition_tensor_view<1x64xf32>,
+                       %c: !pto.partition_tensor_view<1x64xf32>) {
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    %u = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    pto.tadd ins(%t, %t : !pto.tile_buf<vec, 1x64xf32>, !pto.tile_buf<vec, 1x64xf32>) outs(%u : !pto.tile_buf<vec, 1x64xf32>)
+    pto.tmul ins(%u, %u : !pto.tile_buf<vec, 1x64xf32>, !pto.tile_buf<vec, 1x64xf32>) outs(%u : !pto.tile_buf<vec, 1x64xf32>)
+    pto.tstore ins(%u : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    return
+  }
+
+  // The two arms of one `scf.if` can never both execute, so no ordering is owed
+  // between an op in each. Counted rather than dropped, so the bookkeeping identity
+  // still balances and a predicate that swallowed real dependencies would show up.
+  func.func @exclusive_arms(%a: !pto.partition_tensor_view<1x64xf32>,
+                            %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    %u = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    scf.if %p {
+      pto.tadd ins(%t, %t : !pto.tile_buf<vec, 1x64xf32>, !pto.tile_buf<vec, 1x64xf32>) outs(%u : !pto.tile_buf<vec, 1x64xf32>)
+    } else {
+      pto.tmul ins(%t, %t : !pto.tile_buf<vec, 1x64xf32>, !pto.tile_buf<vec, 1x64xf32>) outs(%u : !pto.tile_buf<vec, 1x64xf32>)
+    }
+    pto.tstore ins(%u : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    return
+  }
+}

--- a/test/lit/pto/Inputs/oracle_selfval_illegal_id.pto
+++ b/test/lit/pto/Inputs/oracle_selfval_illegal_id.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Oracle self-validation fixture: ONE fault, of G3's class only.
+// V->S reserves the top id of its pool, so EVENT_ID7 is illegal there. The
+// set/wait interval discipline is perfect, so G2 must stay silent.
+// Event-only on purpose: buffer-id sync is A5-only and this fixture is compiled for
+// a3, where the exposed capacity is zero, so a get_buf here would be rejected for the
+// arch rather than for the id under test.
+// Not a test: lives under Inputs/, which lit excludes from discovery.
+
+module attributes {pto.target_arch = "a3"} {
+  func.func @selfval_illegal_id() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    pto.set_flag["PIPE_V", "PIPE_S", "EVENT_ID7"]
+    pto.wait_flag["PIPE_V", "PIPE_S", "EVENT_ID7"]
+    return
+  }
+}

--- a/test/lit/pto/Inputs/oracle_selfval_nested_id.pto
+++ b/test/lit/pto/Inputs/oracle_selfval_nested_id.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Oracle self-validation fixture: ONE fault, of G2's class only.
+// Event id 0 on MTE2->V is opened twice before either close: two overlapping
+// hazards share it. Every id is inside its pool and its direction reserves
+// nothing, so G3 must stay silent.
+// Not a test: lives under Inputs/, which lit excludes from discovery.
+
+module attributes {pto.target_arch = "a3"} {
+  func.func @selfval_nested_id() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    return
+  }
+}

--- a/test/lit/pto/Inputs/oracle_sync_reachability.pto
+++ b/test/lit/pto/Inputs/oracle_sync_reachability.pto
@@ -15,15 +15,17 @@ module {
   // false path they execute back to back with nothing ordering them.
   func.func @sync_in_arm_outside_sink(%a: !pto.partition_tensor_view<1x64xf32>,
                                       %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
-    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
-    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
-    pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-    pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
-    scf.if %p {
-      pto.barrier <PIPE_MTE3>
+    pto.section.vector {
+      %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+      pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+      pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+      scf.if %p {
+        pto.barrier <PIPE_MTE3>
+      }
+      pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     }
-    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     return
   }
 
@@ -31,13 +33,15 @@ module {
   // and this one really is ordered.
   func.func @sync_hoisted_covers(%a: !pto.partition_tensor_view<1x64xf32>,
                                  %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
-    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
-    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
-    pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-    pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
-    pto.barrier <PIPE_MTE3>
-    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    pto.section.vector {
+      %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+      pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+      pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+      pto.barrier <PIPE_MTE3>
+      pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    }
     return
   }
 
@@ -46,14 +50,16 @@ module {
   // this is what a rule keyed on the source side as well would do.
   func.func @sync_and_sink_in_one_arm(%a: !pto.partition_tensor_view<1x64xf32>,
                                       %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
-    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
-    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
-    pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-    pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
-    scf.if %p {
-      pto.barrier <PIPE_MTE3>
+    pto.section.vector {
+      %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+      pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+      pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
       pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+      scf.if %p {
+        pto.barrier <PIPE_MTE3>
+        pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+      }
     }
     return
   }
@@ -65,18 +71,20 @@ module {
   // the false positive this line exists to catch.
   func.func @sync_in_loop_outside_sink(%a: !pto.partition_tensor_view<1x64xf32>,
                                        %c: !pto.partition_tensor_view<1x64xf32>) {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c3 = arith.constant 3 : index
-    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
-    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
-    pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-    pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
-    scf.for %i = %c0 to %c3 step %c1 {
+    pto.section.vector {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c3 = arith.constant 3 : index
+      %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+      pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+      pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+      scf.for %i = %c0 to %c3 step %c1 {
+        pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+        pto.barrier <PIPE_MTE3>
+      }
       pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
-      pto.barrier <PIPE_MTE3>
     }
-    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
     return
   }
 }

--- a/test/lit/pto/Inputs/oracle_sync_reachability.pto
+++ b/test/lit/pto/Inputs/oracle_sync_reachability.pto
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Four placements of one barrier, distinguishing "the sync sits before the sink in
+// program order" from "the sync is reached on every path that reaches the sink".
+// lit excludes this directory from discovery.
+
+module {
+  // The barrier runs only on the `then` path; both stores run regardless. On the
+  // false path they execute back to back with nothing ordering them.
+  func.func @sync_in_arm_outside_sink(%a: !pto.partition_tensor_view<1x64xf32>,
+                                      %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    scf.if %p {
+      pto.barrier <PIPE_MTE3>
+    }
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    return
+  }
+
+  // The same kernel with the barrier hoisted out of the `if`. Identical dependencies,
+  // and this one really is ordered.
+  func.func @sync_hoisted_covers(%a: !pto.partition_tensor_view<1x64xf32>,
+                                 %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    pto.barrier <PIPE_MTE3>
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    return
+  }
+
+  // LEGAL. Barrier and sink in the SAME arm: every path reaching the sink passes
+  // through the barrier, so the ordering holds and the edge must survive. Rejecting
+  // this is what a rule keyed on the source side as well would do.
+  func.func @sync_and_sink_in_one_arm(%a: !pto.partition_tensor_view<1x64xf32>,
+                                      %c: !pto.partition_tensor_view<1x64xf32>, %p: i1) {
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    scf.if %p {
+      pto.barrier <PIPE_MTE3>
+      pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    }
+    return
+  }
+
+  // LEGAL, AND THE BOUND ON THE RULE. The barrier is inside a loop whose trip count is
+  // a constant 3, and the sink follows the loop. The barrier therefore always runs and
+  // the ordering holds -- but STRUCTURAL DOMINANCE says a body op never dominates an
+  // op after the loop, so a dominance-keyed rule reports this as uncovered. That is
+  // the false positive this line exists to catch.
+  func.func @sync_in_loop_outside_sink(%a: !pto.partition_tensor_view<1x64xf32>,
+                                       %c: !pto.partition_tensor_view<1x64xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c3 = arith.constant 3 : index
+    %t = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>) outs(%t : !pto.tile_buf<vec, 1x64xf32>)
+    pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+    scf.for %i = %c0 to %c3 step %c1 {
+      pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+      pto.barrier <PIPE_MTE3>
+    }
+    pto.tstore ins(%t : !pto.tile_buf<vec, 1x64xf32>) outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    return
+  }
+}

--- a/test/lit/pto/Inputs/oracle_vadd.pto
+++ b/test/lit/pto/Inputs/oracle_vadd.pto
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Shared input for the oracle gate tests: two loads, one vector add, one store.
+// That is the smallest kernel carrying both a cross-pipe read-after-write
+// (MTE2 -> V) and a write-after-read the other way (V -> MTE3), so every gate has
+// something real to judge. lit excludes this directory from discovery.
+
+module {
+  func.func @oracle_vadd(%a: !pto.partition_tensor_view<1x64xf32>,
+                         %b: !pto.partition_tensor_view<1x64xf32>,
+                         %c: !pto.partition_tensor_view<1x64xf32>) {
+    %ta = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    %tb = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
+    pto.tload ins(%a : !pto.partition_tensor_view<1x64xf32>)
+              outs(%ta : !pto.tile_buf<vec, 1x64xf32>)
+    pto.tload ins(%b : !pto.partition_tensor_view<1x64xf32>)
+              outs(%tb : !pto.tile_buf<vec, 1x64xf32>)
+    pto.tadd ins(%ta, %tb : !pto.tile_buf<vec, 1x64xf32>,
+                            !pto.tile_buf<vec, 1x64xf32>)
+             outs(%ta : !pto.tile_buf<vec, 1x64xf32>)
+    pto.tstore ins(%ta : !pto.tile_buf<vec, 1x64xf32>)
+               outs(%c : !pto.partition_tensor_view<1x64xf32>)
+    return
+  }
+}

--- a/test/lit/pto/sync_gate_g1_buf_token_pipe.pto
+++ b/test/lit/pto/sync_gate_g1_buf_token_pipe.pto
@@ -20,12 +20,12 @@
 
 // The plain PipeAttr spelling.
 // RUN: ptoas --pto-arch=a5 --check-sync-self-coverage --emit-pto-ir %S/Inputs/oracle_buf_token_spellings.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=PIPEATTR
-// PIPEATTR: [sync-gate:g1-self] func=buf_chain_pipe_attr compounds=2 deps=1 covered=1 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0 OK
+// PIPEATTR: [sync-gate:g1-self] func=buf_chain_pipe_attr compounds=2 deps=1 covered=1 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0 OK
 
 // The pipe_event_type spelling, which decoded correctly already. Pinned so a
 // regression that broke this one instead would not go unnoticed.
 // RUN: ptoas --pto-arch=a5 --check-sync-self-coverage --emit-pto-ir %S/Inputs/oracle_buf_token_spellings.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=EVENTTYPE
-// EVENTTYPE: [sync-gate:g1-self] func=buf_chain_event_type compounds=2 deps=1 covered=1 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0 OK
+// EVENTTYPE: [sync-gate:g1-self] func=buf_chain_event_type compounds=2 deps=1 covered=1 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0 OK
 
 // G2 and G3 read the same ops through the extractor, which already decoded all three
 // spellings. Pinning them here records that the three gates agree on this input: a

--- a/test/lit/pto/sync_gate_g1_buf_token_pipe.pto
+++ b/test/lit/pto/sync_gate_g1_buf_token_pipe.pto
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A `get_buf`/`rls_buf` `op_type` has three legal spellings and G1-self must decode
+// every one: an undecoded spelling drops the op from the coverage walk, and a dropped
+// sync op is indistinguishable from an absent one, so the ordering the token
+// establishes is reported as an uncovered dependency.
+//
+// The two inputs are the same chain over the same two pipes, differing only in
+// spelling, so the pair is what makes the property testable -- either alone would
+// pass a gate that decoded only that one spelling.
+//
+// `--emit-pto-ir` stops before the backend on purpose. `pto.get_buf` in input IR does
+// not lower, and the property under test belongs to the gate, not to codegen.
+
+// The plain PipeAttr spelling.
+// RUN: ptoas --pto-arch=a5 --check-sync-self-coverage --emit-pto-ir %S/Inputs/oracle_buf_token_spellings.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=PIPEATTR
+// PIPEATTR: [sync-gate:g1-self] func=buf_chain_pipe_attr compounds=2 deps=1 covered=1 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0 OK
+
+// The pipe_event_type spelling, which decoded correctly already. Pinned so a
+// regression that broke this one instead would not go unnoticed.
+// RUN: ptoas --pto-arch=a5 --check-sync-self-coverage --emit-pto-ir %S/Inputs/oracle_buf_token_spellings.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=EVENTTYPE
+// EVENTTYPE: [sync-gate:g1-self] func=buf_chain_event_type compounds=2 deps=1 covered=1 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0 OK
+
+// G2 and G3 read the same ops through the extractor, which already decoded all three
+// spellings. Pinning them here records that the three gates agree on this input: a
+// decode gap in one gate alone shows up as two gates accepting what a third rejects.
+// RUN: ptoas --pto-arch=a5 --check-sync-interference --emit-pto-ir %S/Inputs/oracle_buf_token_spellings.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=G2
+// G2: [sync-gate:g2] func=buf_chain_pipe_attr view=ir records=4 errors=0 warnings=0 OK
+
+// RUN: ptoas --pto-arch=a5 --check-sync-ids --emit-pto-ir %S/Inputs/oracle_buf_token_spellings.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=G3
+// G3: [sync-gate:g3] func=buf_chain_pipe_attr view=ir records=4 violations=0 OK

--- a/test/lit/pto/sync_gate_g1_pipe_s_self_ordered.pto
+++ b/test/lit/pto/sync_gate_g1_pipe_s_self_ordered.pto
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// G1-self excuses a PIPE_S -> PIPE_S dependency, on every arch. Neither allocator in
+// this tree orders such a pair -- `IsNoNeedToInsertSync` returns before running the
+// dependence analysis, and GraphSyncSolver's same-pipe path returns for PIPE_S
+// unconditionally -- so requiring one here makes the gate unsatisfiable, not strict.
+// The exclusion is COUNTED in its own field rather than folded into
+// `arch_guaranteed`, because no hardware guarantee is claimed for it.
+//
+// The input is an existing kernel rather than a purpose-built one: this file's whole
+// reason to exist is that `scalar_gm_tstore_sync.pto` compiles and runs while G1
+// rejected it, so the property is worth pinning on the real thing.
+
+// The dependency is excused and the kernel is clean. `deps=3` is `covered=2` plus the
+// one excused pair, so the count still balances and nothing was dropped.
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-self-coverage %S/scalar_gm_tstore_sync.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=A3
+// A3: [sync-gate:g1-self] func=tstore_then_load_scalar_unknown_inttoptr compounds=4 deps=3 covered=2 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=1 unmappable=0 OK
+
+// THE SAME ON A5, which is the property that separates this exclusion from the
+// PIPE_V one. That is gated on A5 because only A5's codegen declines the barrier;
+// this is not gated, because both allocators decline PIPE_S on every arch.
+// RUN: ptoas --pto-arch=a5 --enable-insert-sync --check-sync-self-coverage %S/scalar_gm_tstore_sync.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=A5
+// A5: [sync-gate:g1-self] func=tstore_then_load_scalar_unknown_inttoptr compounds=4 deps=3 covered=2 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=1 unmappable=0 OK
+
+// NOT WIDENED TO "ANYTHING TOUCHING PIPE_S". A scalar op ordered against a tstore is
+// a cross-pipe pair, and it is still required and still covered by real sync --
+// `pipe_self_ordered=0` here is what shows the exclusion tests both endpoints.
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-self-coverage %S/scalar_gm_tstore_sync.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=CROSS
+// CROSS: [sync-gate:g1-self] func=store_scalar_then_tstore compounds=3 deps=2 covered=2 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0 OK

--- a/test/lit/pto/sync_gate_g1_self_coverage.pto
+++ b/test/lit/pto/sync_gate_g1_self_coverage.pto
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// G1-self asks whether every dependency the front-end analysis reports is ordered
+// by the emitted synchronization. It is ABSOLUTE: the expected set comes from
+// `MemoryDependentAnalyzer::DepBetween` over a freshly built SyncIR, so it reads
+// none of the sync allocator's decisions and there is no reference file.
+//
+// Two exemptions exist, and both are COUNTED rather than dropped, so that
+// covered + uncovered + arm_excluded + arch_guaranteed == deps holds exactly. A
+// predicate that quietly swallowed real dependencies would be indistinguishable
+// from a correct one in any total-only check.
+
+// ---------------------------------------------------------------------------
+// 1. Sound: every dependency ordered, on synchronization InsertSync produced.
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-self-coverage %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=COVERED
+// COVERED: [sync-gate:g1-self] func=oracle_vadd compounds=4 deps=5 covered=5 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0 OK
+
+// 2. Not vacuous: the same kernel with no sync pass at all still has the same five
+//    dependencies, and none of them is ordered. `deps` is identical to the run
+//    above, which is what shows the expected set does not move with the candidate.
+// RUN: not ptoas --pto-arch=a3 --check-sync-self-coverage %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=NOSYNC
+// NOSYNC: [sync-gate:g1-self] func=oracle_vadd compounds=4 deps=5 covered=0 uncovered=5 (samepipe=0 crosspipe=5) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0
+
+// ---------------------------------------------------------------------------
+// 3. THE A5 INTRA-PIPE GUARANTEE, and that it does not leak across arches.
+//
+//    A5 orders two consecutive PIPE_V ops on one tile in hardware, and its backend
+//    rejects an explicit vector barrier for such a pair, so demanding one would make
+//    the gate unsatisfiable rather than strict. The rule is applied at exactly the
+//    condition the codegen uses, so the two cannot drift.
+//
+//    On A5 the two same-pipe dependencies are credited to the target:
+// RUN: ptoas --pto-arch=a5 --enable-insert-sync --check-sync-self-coverage %S/Inputs/oracle_gate_features.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=A5GUAR
+// A5GUAR: [sync-gate:g1-self] func=same_pipe compounds=4 deps=5 covered=3 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=2 unmappable=0 OK
+
+//    On A3 the same analysis of the same kernel credits NOTHING to the target --
+//    `arch_guaranteed=0` is the property under test here, and it is what shows the
+//    A5 rule did not leak. A3 orders those dependencies with real sync instead.
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-self-coverage %S/Inputs/oracle_gate_features.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=A3NOGUAR
+// A3NOGUAR: [sync-gate:g1-self] func=same_pipe compounds=4 deps=5 covered=5 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0 OK
+
+// ---------------------------------------------------------------------------
+// 4. MUTUALLY EXCLUSIVE ARMS. Two ops in different arms of one `scf.if` can never
+//    both execute, so no ordering is missing between them. `scf.if` is the only
+//    mutually-exclusive-region op this recognises; the exclusion is counted so the
+//    identity above still balances (4 + 0 + 1 + 0 == 5).
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-self-coverage %S/Inputs/oracle_gate_features.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=ARMS
+// ARMS: [sync-gate:g1-self] func=exclusive_arms compounds=4 deps=5 covered=4 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=1 arch_guaranteed=0 unmappable=0 OK

--- a/test/lit/pto/sync_gate_g1_self_coverage.pto
+++ b/test/lit/pto/sync_gate_g1_self_coverage.pto
@@ -19,13 +19,13 @@
 // ---------------------------------------------------------------------------
 // 1. Sound: every dependency ordered, on synchronization InsertSync produced.
 // RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-self-coverage %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=COVERED
-// COVERED: [sync-gate:g1-self] func=oracle_vadd compounds=4 deps=5 covered=5 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0 OK
+// COVERED: [sync-gate:g1-self] func=oracle_vadd compounds=4 deps=5 covered=5 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0 OK
 
 // 2. Not vacuous: the same kernel with no sync pass at all still has the same five
 //    dependencies, and none of them is ordered. `deps` is identical to the run
 //    above, which is what shows the expected set does not move with the candidate.
 // RUN: not ptoas --pto-arch=a3 --check-sync-self-coverage %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=NOSYNC
-// NOSYNC: [sync-gate:g1-self] func=oracle_vadd compounds=4 deps=5 covered=0 uncovered=5 (samepipe=0 crosspipe=5) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0
+// NOSYNC: [sync-gate:g1-self] func=oracle_vadd compounds=4 deps=5 covered=0 uncovered=5 (samepipe=0 crosspipe=5) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0
 
 // ---------------------------------------------------------------------------
 // 3. THE A5 INTRA-PIPE GUARANTEE, and that it does not leak across arches.
@@ -37,13 +37,13 @@
 //
 //    On A5 the two same-pipe dependencies are credited to the target:
 // RUN: ptoas --pto-arch=a5 --enable-insert-sync --check-sync-self-coverage %S/Inputs/oracle_gate_features.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=A5GUAR
-// A5GUAR: [sync-gate:g1-self] func=same_pipe compounds=4 deps=5 covered=3 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=2 unmappable=0 OK
+// A5GUAR: [sync-gate:g1-self] func=same_pipe compounds=4 deps=5 covered=3 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=2 pipe_self_ordered=0 unmappable=0 OK
 
 //    On A3 the same analysis of the same kernel credits NOTHING to the target --
 //    `arch_guaranteed=0` is the property under test here, and it is what shows the
 //    A5 rule did not leak. A3 orders those dependencies with real sync instead.
 // RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-self-coverage %S/Inputs/oracle_gate_features.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=A3NOGUAR
-// A3NOGUAR: [sync-gate:g1-self] func=same_pipe compounds=4 deps=5 covered=5 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0 OK
+// A3NOGUAR: [sync-gate:g1-self] func=same_pipe compounds=4 deps=5 covered=5 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0 OK
 
 // ---------------------------------------------------------------------------
 // 4. MUTUALLY EXCLUSIVE ARMS. Two ops in different arms of one `scf.if` can never
@@ -51,4 +51,4 @@
 //    mutually-exclusive-region op this recognises; the exclusion is counted so the
 //    identity above still balances (4 + 0 + 1 + 0 == 5).
 // RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-self-coverage %S/Inputs/oracle_gate_features.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=ARMS
-// ARMS: [sync-gate:g1-self] func=exclusive_arms compounds=4 deps=5 covered=4 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=1 arch_guaranteed=0 unmappable=0 OK
+// ARMS: [sync-gate:g1-self] func=exclusive_arms compounds=4 deps=5 covered=4 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=1 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0 OK

--- a/test/lit/pto/sync_gate_g1_sync_reachability.pto
+++ b/test/lit/pto/sync_gate_g1_sync_reachability.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A sync op earns coverage credit only where it is reached on every path that reaches
+// the sink. Program order alone does not decide that, and neither does structural
+// dominance -- the four functions below pin both boundaries.
+//
+// Every run is `not`: one of the four is genuinely uncovered, so the gate fails the
+// pipeline. That also stops the three legal cases passing vacuously, because dropping
+// the rule entirely makes the run succeed and `not` fail.
+
+// THE DEFECT. The barrier is on the `then` arm and both stores are outside the `if`,
+// so the false path runs them back to back. Credit must NOT be given.
+// RUN: not ptoas --pto-arch=a3 --check-sync-self-coverage %S/Inputs/oracle_sync_reachability.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=ARM
+// ARM:      [sync-gate:g1-self] func=sync_in_arm_outside_sink compounds=3 deps=3 covered=2 uncovered=1 (samepipe=1 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0
+// ARM-NEXT:   !! kind=uncovered-dependency waw anchor#1 (pto.tstore) -> anchor#2 (pto.tstore) PIPE_MTE3->PIPE_MTE3
+
+// The same dependencies with the barrier hoisted out of the `if`. This one is ordered,
+// which is what shows the rule keys on reachability and not on the presence of an `if`.
+// RUN: not ptoas --pto-arch=a3 --check-sync-self-coverage %S/Inputs/oracle_sync_reachability.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=HOIST
+// HOIST: [sync-gate:g1-self] func=sync_hoisted_covers compounds=3 deps=3 covered=3 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0 OK
+
+// LEGAL. Barrier and sink in the same arm: every path reaching the sink passes through
+// the barrier. A rule that also required the sync to be reached whenever the SOURCE is
+// would reject this, and it is the shape the emitter produces most.
+// RUN: not ptoas --pto-arch=a3 --check-sync-self-coverage %S/Inputs/oracle_sync_reachability.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=ONEARM
+// ONEARM: [sync-gate:g1-self] func=sync_and_sink_in_one_arm compounds=3 deps=3 covered=3 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0 OK
+
+// LEGAL, AND THE BOUND ON THE RULE. The barrier is inside a constant-trip-count loop
+// and the sink follows the loop, so the barrier always runs. STRUCTURAL DOMINANCE
+// disagrees -- a body op does not dominate an op after the loop -- so a dominance-keyed
+// rule reports this uncovered. Enclosing loops are therefore not compared, and this is
+// the line that fails if they ever are.
+// RUN: not ptoas --pto-arch=a3 --check-sync-self-coverage %S/Inputs/oracle_sync_reachability.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=LOOP
+// LOOP: [sync-gate:g1-self] func=sync_in_loop_outside_sink compounds=3 deps=4 covered=4 uncovered=0 (samepipe=0 crosspipe=0) carried=1/1 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0 OK

--- a/test/lit/pto/sync_gate_g2_event_pair_guards.pto
+++ b/test/lit/pto/sync_gate_g2_event_pair_guards.pto
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// G2 pairs a set_flag with the wait_flag that closes its id. Program order alone
+// cannot decide whether the two halves belong together: a pair placed on opposite
+// arms of an `scf.if` balances the scan and its counts match, while no runtime path
+// executes both. The pair must be EQUALLY GUARDED.
+//
+// Every run below is `not`: three of the five functions are illegal, so the gate
+// fails the pipeline. That also makes the file self-guarding -- if the rule were
+// removed entirely the run would succeed and `not` would fail, so the legal cases
+// below cannot pass vacuously.
+
+// The set on one arm, the wait on the other.
+// RUN: not ptoas --pto-arch=a3 --check-sync-interference %S/Inputs/oracle_event_pair_guards.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=ARMS
+// ARMS:      [sync-gate:g2] func=pair_split_across_arms view=ir records=2 errors=1 warnings=0
+// ARMS-NEXT:   !! #1 pto.wait_flag kind=event-id-pair-guard-mismatch MTE2->MTE3 id=0
+
+// A guarded set with an unguarded wait. The wait outlives its producer on the false
+// path and the kernel hangs, which the arm case alone would not have caught.
+// RUN: not ptoas --pto-arch=a3 --check-sync-interference %S/Inputs/oracle_event_pair_guards.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=GSET
+// GSET:      [sync-gate:g2] func=guarded_set_plain_wait view=ir records=2 errors=1 warnings=0
+// GSET-NEXT:   !! #1 pto.wait_flag kind=event-id-pair-guard-mismatch MTE2->MTE3 id=0
+
+// The mirror: an unguarded set whose wait is guarded leaks the id.
+// RUN: not ptoas --pto-arch=a3 --check-sync-interference %S/Inputs/oracle_event_pair_guards.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=GWAIT
+// GWAIT:      [sync-gate:g2] func=plain_set_guarded_wait view=ir records=2 errors=1 warnings=0
+// GWAIT-NEXT:   !! #1 pto.wait_flag kind=event-id-pair-guard-mismatch MTE2->MTE3 id=0
+
+// LEGAL. Both halves under the same guard.
+// RUN: not ptoas --pto-arch=a3 --check-sync-interference %S/Inputs/oracle_event_pair_guards.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=ONEARM
+// ONEARM: [sync-gate:g2] func=pair_on_one_arm view=ir records=2 errors=0 warnings=0 OK
+
+// LEGAL, AND THE BOUND ON THE RULE. Set outside a loop, wait inside it: different
+// blocks, same guards. This is the shape the emitter produces most, so a rule keyed
+// on blocks rather than conditionals would reject working kernels -- this line is
+// what fails if the comparison is ever tightened that way.
+// RUN: not ptoas --pto-arch=a3 --check-sync-interference %S/Inputs/oracle_event_pair_guards.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=PRIME
+// PRIME: [sync-gate:g2] func=set_outside_loop_wait_inside view=ir records=2 errors=0 warnings=0 OK

--- a/test/lit/pto/sync_gate_g2_legal.pto
+++ b/test/lit/pto/sync_gate_g2_legal.pto
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// G2 passes synchronization the existing allocator produced, including the case
+// that would be a false positive under the wrong key: this kernel uses EVENT_ID0
+// in BOTH MTE2->V and V->MTE3 at once, which is legal because event flags are
+// per-direction disjoint hardware. Keying on the id alone would report it.
+
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-interference %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=LEGAL
+// LEGAL: [sync-gate:g2] func=oracle_vadd view=ir records=5 errors=0 warnings=0 OK
+
+// The two directions really do share id 0 here, so the check above is not vacuous.
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --emit-pto-ir %S/Inputs/oracle_vadd.pto | FileCheck %s --check-prefix=SHARED
+// SHARED-DAG: pto.set_flag[<PIPE_MTE2>, <PIPE_V>, <EVENT_ID0>]
+// SHARED-DAG: pto.set_flag[<PIPE_V>, <PIPE_MTE3>, <EVENT_ID0>]

--- a/test/lit/pto/sync_gate_g3_faults.pto
+++ b/test/lit/pto/sync_gate_g3_faults.pto
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// G3 rejects ids the target forbids. None of the three classes below can be written
+// as input IR: `pto.set_flag` spells its id as an EVENT_ID0..EVENT_ID7 enum, so 9 and
+// 14 are unrepresentable, and `pto.get_buf`'s buf_id is verified into [0, 31], so 64
+// is too. Each fault is appended to the gate's own record list after extraction,
+// never to the IR, so it cannot reach codegen. `--check-sync-ids-inject-fault` exists
+// for that and is hidden.
+
+// An event id past the end of the intra-core pool.
+// RUN: not ptoas --pto-arch=a3 --check-sync-ids --check-sync-ids-inject-fault=event-oor %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=OOR
+// OOR:      [sync-gate:g3] func=oracle_vadd view=syncops records=1 violations=1
+// OOR-NEXT:   !! #0 set_event kind=event-id-out-of-range id=9 : intra-core event pool for V->MTE3 is [0, 8)
+
+// An id that `sync_block_all` owns while one is live.
+// RUN: not ptoas --pto-arch=a3 --check-sync-ids --check-sync-ids-inject-fault=block-all-stomp %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=STOMP
+// STOMP:      [sync-gate:g3] func=oracle_vadd view=syncops records=2 violations=1
+// STOMP-NEXT:   !! #1 sync_block_set kind=event-id-reserved-for-block-all id=14 : ids 14/15 belong to sync_block_all while one is live
+
+// A buffer id past the hardware field. Checked on A5, where buffer-id sync exists.
+// RUN: not ptoas --pto-arch=a5 --check-sync-ids --check-sync-ids-inject-fault=bufid-oor %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=BUFOOR
+// BUFOOR:      [sync-gate:g3] func=oracle_vadd view=ir records=1 violations=1
+// BUFOOR-NEXT:   !! #0 pto.get_buf kind=buf-id-out-of-range id=64 : hardware buf_id field is [0, 32)
+
+// A SELECTOR THAT NAMES NO FAULT MUST FAIL LOUDLY. Injecting nothing would leave
+// the gate with nothing to find, so it would report clean and the three runs above
+// would pass while proving nothing -- a misspelling would vacuously satisfy the
+// tests that exist to show the gate is not vacuous.
+// RUN: not ptoas --pto-arch=a3 --check-sync-ids --check-sync-ids-inject-fault=typo-not-a-fault %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=BADSEL
+// BADSEL: error: unknown --check-sync-ids-inject-fault selector 'typo-not-a-fault'; expected event-oor, block-all-stomp or bufid-oor

--- a/test/lit/pto/sync_gate_g3_legal.pto
+++ b/test/lit/pto/sync_gate_g3_legal.pto
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// G3 passes synchronization the existing allocator produced. Paired with
+// sync_gate_g3_faults.pto: a gate that only ever passed would clear this file too.
+
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-ids %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=A3
+// A3: [sync-gate:g3] func=oracle_vadd view=ir records=5 violations=0 OK
+
+// The same kernel on A5. This kernel emits no buffer-id op, so the arch-capacity
+// rule is not exercised here; what the line pins is that changing the arch does not
+// change the verdict on event ids.
+// RUN: ptoas --pto-arch=a5 --enable-insert-sync --check-sync-ids %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=A5
+// A5: [sync-gate:g3] func=oracle_vadd view=ir records=5 violations=0 OK

--- a/test/lit/pto/sync_oracle_self_validation.pto
+++ b/test/lit/pto/sync_oracle_self_validation.pto
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Proves the three gates are neither unsound nor vacuous, which is the only basis
+// on which a green result from them means anything.
+//
+// Soundness: all three pass on synchronization InsertSync itself produced.
+// Non-vacuity: each of the three fault classes below is caught by exactly ONE gate
+// and is SILENT on the other two. Delete any one gate and a fault class escapes.
+//
+//   fault class                     G1-self   G2      G3
+//   ---------------------------------------------------------
+//   nothing ordered at all          CATCH     pass    pass
+//   two overlapping uses of one id  pass      CATCH   pass
+//   an id the target forbids        pass      pass    CATCH
+//
+// The inputs are hand-written modules rather than compiler output, so no gate's
+// verdict depends on another pass continuing to behave a particular way.
+
+// ---------------------------------------------------------------------------
+// ROW 0 -- SOUNDNESS. All three green on InsertSync's own output.
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-self-coverage %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=GOOD1
+// GOOD1: [sync-gate:g1-self] func=oracle_vadd compounds=4 deps=5 covered=5 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0 OK
+
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-interference %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=GOOD2
+// GOOD2: [sync-gate:g2] func=oracle_vadd view=ir records=5 errors=0 warnings=0 OK
+
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-ids %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=GOOD3
+// GOOD3: [sync-gate:g3] func=oracle_vadd view=ir records=5 violations=0 OK
+
+// ---------------------------------------------------------------------------
+// ROW 1 -- NOTHING ORDERED AT ALL. Only G1-self can see this.
+//
+// The fault is the ABSENCE of a sync pass, so the source is the whole truth and
+// this row cannot expire the way a stub-based injector would: it depends on no
+// pass's behaviour. G2 and G3 are silent because they judge the ids that ARE
+// present, and there are none -- which is exactly why a green G2/G3 is not a
+// correctness result on its own.
+// RUN: not ptoas --pto-arch=a3 --check-sync-self-coverage %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=EMPTY1
+// EMPTY1: [sync-gate:g1-self] func=oracle_vadd compounds=4 deps=5 covered=0 uncovered=5 (samepipe=0 crosspipe=5) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0
+
+// RUN: ptoas --pto-arch=a3 --check-sync-interference %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=EMPTY2
+// EMPTY2: [sync-gate:g2] func=oracle_vadd view=ir records=0 errors=0 warnings=0 OK
+
+// RUN: ptoas --pto-arch=a3 --check-sync-ids %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=EMPTY3
+// EMPTY3: [sync-gate:g3] func=oracle_vadd view=ir records=0 violations=0 OK
+
+// ---------------------------------------------------------------------------
+// ROW 2 -- TWO OVERLAPPING USES OF ONE ID. Only G2 can see this.
+//
+// One (src,dst,id) is acquired twice before either release. The op count is
+// unchanged and every ordering is still established, so neither a coverage gate
+// nor a count floor can distinguish it from correct code.
+// RUN: not ptoas --pto-arch=a3 --check-sync-interference %S/Inputs/oracle_selfval_nested_id.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=NEST1
+// NEST1: [sync-gate:g2] func=selfval_nested_id view=ir records=4 errors=1 warnings=0
+
+// RUN: ptoas --pto-arch=a3 --check-sync-ids %S/Inputs/oracle_selfval_nested_id.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=NEST2
+// NEST2: [sync-gate:g3] func=selfval_nested_id view=ir records=4 violations=0 OK
+
+// ---------------------------------------------------------------------------
+// ROW 3 -- AN ID THE TARGET FORBIDS. Only G3 can see this.
+//
+// A direction that reserves the tail of its pool, used with a reserved id. The
+// intervals are disjoint and every dependency is ordered, so G2 and G1-self are
+// both correct to stay quiet.
+// RUN: not ptoas --pto-arch=a3 --check-sync-ids %S/Inputs/oracle_selfval_illegal_id.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=ILL1
+// ILL1: [sync-gate:g3] func=selfval_illegal_id view=ir records=2 violations=2
+
+// RUN: ptoas --pto-arch=a3 --check-sync-interference %S/Inputs/oracle_selfval_illegal_id.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=ILL2
+// ILL2: [sync-gate:g2] func=selfval_illegal_id view=ir records=2 errors=0 warnings=0 OK

--- a/test/lit/pto/sync_oracle_self_validation.pto
+++ b/test/lit/pto/sync_oracle_self_validation.pto
@@ -25,7 +25,7 @@
 // ---------------------------------------------------------------------------
 // ROW 0 -- SOUNDNESS. All three green on InsertSync's own output.
 // RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-self-coverage %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=GOOD1
-// GOOD1: [sync-gate:g1-self] func=oracle_vadd compounds=4 deps=5 covered=5 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0 OK
+// GOOD1: [sync-gate:g1-self] func=oracle_vadd compounds=4 deps=5 covered=5 uncovered=0 (samepipe=0 crosspipe=0) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0 OK
 
 // RUN: ptoas --pto-arch=a3 --enable-insert-sync --check-sync-interference %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=GOOD2
 // GOOD2: [sync-gate:g2] func=oracle_vadd view=ir records=5 errors=0 warnings=0 OK
@@ -42,7 +42,7 @@
 // present, and there are none -- which is exactly why a green G2/G3 is not a
 // correctness result on its own.
 // RUN: not ptoas --pto-arch=a3 --check-sync-self-coverage %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=EMPTY1
-// EMPTY1: [sync-gate:g1-self] func=oracle_vadd compounds=4 deps=5 covered=0 uncovered=5 (samepipe=0 crosspipe=5) carried=0/0 arm_excluded=0 arch_guaranteed=0 unmappable=0
+// EMPTY1: [sync-gate:g1-self] func=oracle_vadd compounds=4 deps=5 covered=0 uncovered=5 (samepipe=0 crosspipe=5) carried=0/0 arm_excluded=0 arch_guaranteed=0 pipe_self_ordered=0 unmappable=0
 
 // RUN: ptoas --pto-arch=a3 --check-sync-interference %S/Inputs/oracle_vadd.pto 2>&1 >/dev/null | FileCheck %s --check-prefix=EMPTY2
 // EMPTY2: [sync-gate:g2] func=oracle_vadd view=ir records=0 errors=0 warnings=0 OK

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -397,6 +397,38 @@ static LogicalResult reorderEmitCFunctions(ModuleOp module) {
 // --------------------------------------------------------------------------
 // Command Line Options
 // --------------------------------------------------------------------------
+static llvm::cl::opt<bool> checkSyncIds(
+    "check-sync-ids",
+    llvm::cl::desc("Run oracle gate G3: verify every static emitted sync id is "
+                   "legal for its direction, op and arch. Rotating set_flag_dyn / "
+                   "wait_flag_dyn ids resolve at runtime and are not checked "
+                   "(fails on violation)"),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<std::string> checkSyncIdsInjectFault(
+    "check-sync-ids-inject-fault",
+    llvm::cl::desc("Gate self-test: feed G3 a synthetic illegal id "
+                   "(event-oor | block-all-stomp | bufid-oor). Appended to the "
+                   "gate's own record list after extraction, never to the IR, "
+                   "because an out-of-range event id is unrepresentable in IR"),
+    llvm::cl::init(""), llvm::cl::Hidden);
+
+static llvm::cl::opt<bool> checkSyncInterference(
+    "check-sync-interference",
+    llvm::cl::desc("Run oracle gate G2: assert no two overlapping intervals "
+                   "share a sync id (fails on nesting / leak)"),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<bool> checkSyncSelfCoverage(
+    "check-sync-self-coverage",
+    llvm::cl::desc("Run oracle gate G1-self: assert every dependency the "
+                   "front-end analysis (DepBetween) reports is ordered by the "
+                   "emitted sync, except pairs on mutually exclusive scf.if arms "
+                   "and, on A5, PIPE_V->PIPE_V pairs the target orders itself; "
+                   "both exclusions are counted and reported. ABSOLUTE -- no "
+                   "reference profile and nothing inherited from the sync pass"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<bool> enableInsertSync("enable-insert-sync",
                                             llvm::cl::desc("Enable automatic synchronization insertion pass"),
                                             llvm::cl::init(false));
@@ -3528,6 +3560,18 @@ int mlir::pto::compilePTOASModule(
 
   // Materialize each `pto.multi_tile_get` as an addressed `pto.alloc_tile`;
   // dynamic selections use an `arith.select` chain over planned addresses.
+  // Oracle gates. Read-only apart from diagnostics, and each fails the pipeline on
+  // a violation rather than reporting and continuing.
+  if (checkSyncIds)
+    pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOCheckSyncIdsPass(
+        arch == "a5" ? 32u : 0u, checkSyncIdsInjectFault));
+  if (checkSyncInterference)
+    pm.addNestedPass<mlir::func::FuncOp>(
+        pto::createPTOCheckSyncInterferencePass());
+  if (checkSyncSelfCoverage)
+    pm.addNestedPass<mlir::func::FuncOp>(
+        pto::createPTOCheckSyncSelfCoveragePass());
+
   pm.addPass(pto::createPTOResolveBufferSelectPass());
   if (effectiveBackend == PTOBackend::EmitC)
     pm.addPass(createNarrowUnusedMultiResultProvenancePass());


### PR DESCRIPTION
Three checks over the synchronization a compilation emits, each judging one run on its own rather than against a reference:

  G3       every static event and buffer id is one the target permits for that op, direction and arch, and set/wait stay balanced per direction. Rotating ids on set_flag_dyn / wait_flag_dyn resolve at runtime and are not checked.
  
  G2       for a given id key the live intervals are pairwise disjoint. Event ids are keyed by (srcPipe, dstPipe, id) because event flags are
per-direction disjoint hardware, so EVENT_ID0 may be live in MTE2->V and V->MTE3 at once; keying on the id alone would raise a false
     violation on correct code.
     
  G1-self  every dependence the front-end analysis reports is ordered by emitted sync, derived from DepBetween directly. Pairs on mutually exclusive scf.if arms, and on A5 PIPE_V pairs the target orders itself, areexcused -- both counted and reported .

All three are read-only apart from diagnostics and off by default. They run against the existing sync path and need no new allocator.

A self-validation fixture pins that each of three fault classes is caught by exactly one gate and is silent on the other two, so no gate is redundant and none is vacuous.

Outside the new files this adds one public accessor, SyncEventIdAllocation::GetReservedEventIdNum, so the gate reads the same per-direction reservation map the sync pass obeys instead of duplicating it.


Local verification: build clean; lit 1551/1556; licence-header check passes. The 5 failures are pre-existing on unmodified main -- all under test/lit/vpto/, none referencing any flag this change adds, and this change touches no file under vpto/.