### PR TITLE
[VMI] Optimize layout and predicate lowering for widen workloads

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -107,6 +107,7 @@ std::unique_ptr<Pass> createPTOFlattenFusionRegionPass();
 std::unique_ptr<Pass> createVPTOPtrNormalizePass();
 std::unique_ptr<Pass> createVPTOPtrCastCleanupPass();
 std::unique_ptr<Pass> createVPTOOptimizeVcvtPass();
+std::unique_ptr<Pass> createVPTOMaskSimplifyPass();
 LogicalResult validateVPTOAuthoringIR(ModuleOp module,
                                       llvm::raw_ostream *diagOS = nullptr);
 LogicalResult validateVPTOEmissionIR(ModuleOp module,

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -971,9 +971,10 @@ def VMIPreAssignmentCombine
     still exposing direct semantic operations to the later layout and lowering
     passes.
 
-    The pass currently rewrites the semantic pattern
-    `group_broadcast(group_slot_load(...))` into the equivalent
-    `group_broadcast_load` operation.
+    The pass rewrites a `group_load` whose constant row stride equals its
+    logical group size into an ordinary contiguous `load`. It also rewrites
+    the semantic pattern `group_broadcast(group_slot_load(...))` into the
+    equivalent `group_broadcast_load` operation.
   }];
   let constructor = "mlir::pto::createVMIPreAssignmentCombinePass()";
   let dependentDialects = ["mlir::func::FuncDialect",

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -1361,4 +1361,18 @@ def VPTOOptimizeVcvt
   let dependentDialects = ["mlir::pto::PTODialect"];
 }
 
+def VPTOMaskSimplify
+    : Pass<"vpto-mask-simplify", "ModuleOp"> {
+  let summary = "Simplify provably redundant VPTO mask transformations";
+  let description = [{
+    Replaces the two results of `pto.pintlv_b*` and `pto.pdintlv_b*` with
+    their inputs when both inputs are masks produced with the `PAT_ALL`
+    pattern. Interleaving or deinterleaving an all-true predicate cannot change
+    its value, so this removes redundant predicate values before backend
+    emission. Non-uniform masks are intentionally left unchanged.
+  }];
+  let constructor = "mlir::pto::createVPTOMaskSimplifyPass()";
+  let dependentDialects = ["mlir::pto::PTODialect"];
+}
+
 #endif // MLIR_DIALECT_PTO_PASSES

--- a/include/PTO/Transforms/VMILayoutSupport.h
+++ b/include/PTO/Transforms/VMILayoutSupport.h
@@ -68,6 +68,7 @@ enum class VMICastLayoutPort {
 enum class VMICastLayoutPriority {
   Normal,
   High,
+  LaneStrideNarrowing,
 };
 
 enum class VMIInterleaveLayoutPort {

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -44,6 +44,7 @@ add_mlir_dialect_library(PTOTransforms
   VPTOPtrNormalize.cpp
   VPTOPtrCastCleanup.cpp
   VPTOOptimizeVcvt.cpp
+  VPTOMaskSimplify.cpp
   VPTOExpandWrapperOps.cpp
   VPTOSoftPostUpdate.cpp
   PTOVPTOPtrBoundary.cpp

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -64,6 +64,7 @@ enum class DataLayoutSeedPhase {
   GroupBroadcastLoad,
   CompactCast,
   GroupStore,
+  LaneStrideNarrowCast,
   Cast,
   WeakReduce,
   Store,
@@ -265,9 +266,11 @@ struct LayoutSolver {
   }
 
   DataLayoutSeedPhase getCastSeedPhase(const VMICastLayoutFact &fact) {
-    return fact.priority == VMICastLayoutPriority::High
-               ? DataLayoutSeedPhase::CompactCast
-               : DataLayoutSeedPhase::Cast;
+    if (fact.priority == VMICastLayoutPriority::High)
+      return DataLayoutSeedPhase::CompactCast;
+    if (fact.priority == VMICastLayoutPriority::LaneStrideNarrowing)
+      return DataLayoutSeedPhase::LaneStrideNarrowCast;
+    return DataLayoutSeedPhase::Cast;
   }
 
   VMILayoutAttr getPreferredDenseStoreLayout(VMIVRegType type) {

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -1531,7 +1531,8 @@ makeMaskGranularityCastLayoutFact(int64_t sourceBits, int64_t resultBits,
 
 static FailureOr<VMICastLayoutFact> getPreferredCastLayoutFactImpl(
     ArrayRef<PreferredCastLayoutPattern> patterns, VMIVRegType sourceType,
-    VMIVRegType resultType, StringRef tableName, std::string *reason) {
+    VMIVRegType resultType, StringRef tableName, std::string *reason,
+    VMICastLayoutPriority priority = VMICastLayoutPriority::Normal) {
   auto [sourceBits, resultBits] = getCastElementBits(sourceType, resultType);
 
   const PreferredCastLayoutPattern *selected = nullptr;
@@ -1568,7 +1569,8 @@ static FailureOr<VMICastLayoutFact> getPreferredCastLayoutFactImpl(
                             materializeLayoutPattern(ctx,
                                                      selected->sourceLayout),
                             materializeLayoutPattern(ctx,
-                                                     selected->resultLayout));
+                                                     selected->resultLayout),
+                            priority);
 }
 
 static FailureOr<VMICastLayoutFact>
@@ -1577,7 +1579,8 @@ getPreferredLaneStrideNarrowCastLayoutFactImpl(VMIVRegType sourceType,
                                                std::string *reason) {
   return getPreferredCastLayoutFactImpl(
       kPreferredLaneStrideNarrowCastLayoutPatterns, sourceType, resultType,
-      "preferred lane-stride narrow cast layout table", reason);
+      "preferred lane-stride narrow cast layout table", reason,
+      VMICastLayoutPriority::LaneStrideNarrowing);
 }
 
 FailureOr<VMICastLayoutFact> VMILayoutSupport::getPreferredCastLayoutFact(

--- a/lib/PTO/Transforms/VMIPreAssignmentCombine.cpp
+++ b/lib/PTO/Transforms/VMIPreAssignmentCombine.cpp
@@ -12,11 +12,14 @@
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/SmallVector.h"
+
+#include <optional>
 
 namespace mlir {
 namespace pto {
@@ -29,6 +32,45 @@ using namespace mlir;
 using namespace mlir::pto;
 
 namespace {
+
+static std::optional<int64_t> getConstantIndexValue(Value value) {
+  if (auto constant = value.getDefiningOp<arith::ConstantIndexOp>())
+    return constant.value();
+  if (auto constant = value.getDefiningOp<arith::ConstantOp>())
+    if (auto integerAttr = dyn_cast<IntegerAttr>(constant.getValue()))
+      return integerAttr.getInt();
+  return std::nullopt;
+}
+
+static LogicalResult canonicalizeContiguousGroupLoads(ModuleOp module) {
+  SmallVector<VMIGroupLoadOp> loads;
+  module.walk([&](VMIGroupLoadOp load) {
+    auto resultType = dyn_cast<VMIVRegType>(load.getResult().getType());
+    if (!resultType)
+      return;
+
+    int64_t numGroups = load.getNumGroupsAttr().getInt();
+    int64_t laneCount = resultType.getElementCount();
+    if (numGroups <= 0 || laneCount % numGroups != 0)
+      return;
+
+    std::optional<int64_t> rowStride =
+        getConstantIndexValue(load.getRowStride());
+    if (rowStride && *rowStride == laneCount / numGroups)
+      loads.push_back(load);
+  });
+
+  OpBuilder builder(module.getContext());
+  for (VMIGroupLoadOp load : loads) {
+    builder.setInsertionPoint(load);
+    auto replacement = builder.create<VMILoadOp>(
+        load.getLoc(), load.getResult().getType(), load.getSource(),
+        load.getOffset());
+    load.getResult().replaceAllUsesWith(replacement.getResult());
+    load.erase();
+  }
+  return success();
+}
 
 static LogicalResult fuseGroupSlotBroadcastLoads(ModuleOp module) {
   SmallVector<VMIGroupBroadcastOp> broadcasts;
@@ -67,7 +109,8 @@ static LogicalResult fuseGroupSlotBroadcastLoads(ModuleOp module) {
 struct VMIPreAssignmentCombinePass
     : pto::impl::VMIPreAssignmentCombineBase<VMIPreAssignmentCombinePass> {
   void runOnOperation() override {
-    if (failed(fuseGroupSlotBroadcastLoads(getOperation())))
+    if (failed(canonicalizeContiguousGroupLoads(getOperation())) ||
+        failed(fuseGroupSlotBroadcastLoads(getOperation())))
       signalPassFailure();
   }
 };

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -540,18 +540,23 @@ FailureOr<Value> createPatternMask(Location loc, MaskType maskType,
 FailureOr<Value> createPrefixMask(Location loc, MaskType maskType,
                                   StringRef pattern,
                                   PatternRewriter &rewriter) {
+  // A prefix mask with a compile-time PAT_* pattern is represented by the
+  // modern A5 pset builtin.  The legacy pge builtin accepts the same static
+  // pattern set, but has a different LLVM ABI and is deprecated after V210;
+  // keeping it here would prevent the normal VPTO CSE from merging identical
+  // static masks produced through createAllTrueMask/createPatternMask.
   StringAttr patternAttr = rewriter.getStringAttr(pattern);
   MLIRContext *ctx = rewriter.getContext();
   if (maskType.isB8())
-    return rewriter.create<PgeB8Op>(loc, MaskType::get(ctx, "b8"), patternAttr)
+    return rewriter.create<PsetB8Op>(loc, MaskType::get(ctx, "b8"), patternAttr)
         .getResult();
   if (maskType.isB16())
     return rewriter
-        .create<PgeB16Op>(loc, MaskType::get(ctx, "b16"), patternAttr)
+        .create<PsetB16Op>(loc, MaskType::get(ctx, "b16"), patternAttr)
         .getResult();
   if (maskType.isB32())
     return rewriter
-        .create<PgeB32Op>(loc, MaskType::get(ctx, "b32"), patternAttr)
+        .create<PsetB32Op>(loc, MaskType::get(ctx, "b32"), patternAttr)
         .getResult();
   return failure();
 }

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -1422,6 +1422,17 @@ static std::optional<uint64_t> parseStoreDistImmediate(StringRef dist,
   return std::nullopt;
 }
 
+static bool isOnePointStoreDist(StringRef dist) {
+  return dist == "1PT_B8" || dist == "1PT_B16" || dist == "1PT_B32";
+}
+
+static bool isMaskOnlyUsedByOnePointStores(Value mask) {
+  return !mask.use_empty() && llvm::all_of(mask.getUsers(), [](Operation *user) {
+    auto store = dyn_cast<pto::VstsOp>(user);
+    return store && store.getDist() && isOnePointStoreDist(*store.getDist());
+  });
+}
+
 static std::optional<uint64_t> parseStoreX2DistImmediate(StringRef dist,
                                                          Type elementType) {
   auto width = getDistElementWidth(elementType);
@@ -6607,6 +6618,12 @@ public:
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes)))
       return rewriter.notifyMatchFailure(op, "failed to convert pset result types");
 
+    if (isMaskOnlyUsedByOnePointStores(op.getResult())) {
+      auto undef = rewriter.create<LLVM::UndefOp>(op.getLoc(), resultTypes.front());
+      rewriter.replaceOp(op, undef.getResult());
+      return success();
+    }
+
     StringRef calleeName = buildPsetCallee<PsetOp>(op.getContext());
     Value patternValue = rewriter.create<arith::ConstantOp>(
         op.getLoc(), rewriter.getI32IntegerAttr(*pattern));
@@ -6641,6 +6658,12 @@ public:
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes)))
       return rewriter.notifyMatchFailure(op, "failed to convert pge result types");
+
+    if (isMaskOnlyUsedByOnePointStores(op.getResult())) {
+      auto undef = rewriter.create<LLVM::UndefOp>(op.getLoc(), resultTypes.front());
+      rewriter.replaceOp(op, undef.getResult());
+      return success();
+    }
 
     StringRef calleeName = buildPgeCallee<PgeOp>(op.getContext());
     Value patternValue = rewriter.create<arith::ConstantOp>(
@@ -7066,12 +7089,19 @@ public:
                                                         usePostIntrinsic ? 1 : 0));
     Value value = castToPayloadABI(
         op.getLoc(), adaptor.getValue(), op.getValue().getType(), rewriter);
-    SmallVector<Value> args{value, adaptor.getDestination(),
-                            *offsetBytes, distValue, zero, adaptor.getMask()};
+    Value mask = adaptor.getMask();
+    // The 1PT store forms keep a mask operand in the LLVM ABI, but the
+    // hardware ignores it.  Do not materialize a pset/pge mask solely for
+    // this dead operand; an LLVM undef is sufficient at this boundary.
+    StringRef distToken = op.getDist().value_or("");
+    if (isOnePointStoreDist(distToken))
+      mask = rewriter.create<LLVM::UndefOp>(op.getLoc(), mask.getType());
+    SmallVector<Value> args{value, adaptor.getDestination(), *offsetBytes,
+                            distValue, zero, mask};
     auto funcType = rewriter.getFunctionType(
         TypeRange{value.getType(), adaptor.getDestination().getType(),
                   rewriter.getI32Type(), rewriter.getI32Type(),
-                  rewriter.getI32Type(), adaptor.getMask().getType()},
+                  rewriter.getI32Type(), mask.getType()},
         resultTypes);
     auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
                                               resultTypes, args);

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -1391,6 +1391,17 @@ static std::optional<uint64_t> parseStoreDistImmediate(StringRef dist,
   return std::nullopt;
 }
 
+static bool isOnePointStoreDist(StringRef dist) {
+  return dist == "1PT_B8" || dist == "1PT_B16" || dist == "1PT_B32";
+}
+
+static bool isMaskOnlyUsedByOnePointStores(Value mask) {
+  return !mask.use_empty() && llvm::all_of(mask.getUsers(), [](Operation *user) {
+    auto store = dyn_cast<pto::VstsOp>(user);
+    return store && store.getDist() && isOnePointStoreDist(*store.getDist());
+  });
+}
+
 static std::optional<uint64_t> parseStoreX2DistImmediate(StringRef dist,
                                                          Type elementType) {
   auto width = getDistElementWidth(elementType);
@@ -7204,6 +7215,12 @@ public:
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes)))
       return rewriter.notifyMatchFailure(op, "failed to convert pset result types");
 
+    if (isMaskOnlyUsedByOnePointStores(op.getResult())) {
+      auto undef = rewriter.create<LLVM::UndefOp>(op.getLoc(), resultTypes.front());
+      rewriter.replaceOp(op, undef.getResult());
+      return success();
+    }
+
     StringRef calleeName = buildPsetCallee<PsetOp>(op.getContext());
     Value patternValue = rewriter.create<arith::ConstantOp>(
         op.getLoc(), rewriter.getI32IntegerAttr(*pattern));
@@ -7238,6 +7255,12 @@ public:
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes)))
       return rewriter.notifyMatchFailure(op, "failed to convert pge result types");
+
+    if (isMaskOnlyUsedByOnePointStores(op.getResult())) {
+      auto undef = rewriter.create<LLVM::UndefOp>(op.getLoc(), resultTypes.front());
+      rewriter.replaceOp(op, undef.getResult());
+      return success();
+    }
 
     StringRef calleeName = buildPgeCallee<PgeOp>(op.getContext());
     Value patternValue = rewriter.create<arith::ConstantOp>(
@@ -7665,12 +7688,19 @@ public:
                                                         usePostIntrinsic ? 1 : 0));
     Value value = castToPayloadABI(
         op.getLoc(), adaptor.getValue(), op.getValue().getType(), rewriter);
+    Value mask = adaptor.getMask();
+    // The 1PT store forms keep a mask operand in the LLVM ABI, but the
+    // hardware ignores it.  Do not materialize a pset/pge mask solely for
+    // this dead operand; an LLVM undef is sufficient at this boundary.
+    StringRef distToken = op.getDist().value_or("");
+    if (isOnePointStoreDist(distToken))
+      mask = rewriter.create<LLVM::UndefOp>(op.getLoc(), mask.getType());
     SmallVector<Value> args{value, adaptor.getDestination(), *offsetBytes,
-                            distValue, zero, adaptor.getMask()};
+                            distValue, zero, mask};
     auto funcType = rewriter.getFunctionType(
         TypeRange{value.getType(), adaptor.getDestination().getType(),
                   rewriter.getI32Type(), rewriter.getI32Type(),
-                  rewriter.getI32Type(), adaptor.getMask().getType()},
+                  rewriter.getI32Type(), mask.getType()},
         resultTypes);
     auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
                                               resultTypes, args);

--- a/lib/PTO/Transforms/VPTOMaskSimplify.cpp
+++ b/lib/PTO/Transforms/VPTOMaskSimplify.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_VPTOMASKSIMPLIFY
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::pto;
+
+namespace {
+
+template <typename OpTy> static bool isAllTrueMaskFrom(Value mask) {
+  auto op = mask.getDefiningOp<OpTy>();
+  return op && op.getPattern() == "PAT_ALL";
+}
+
+static bool isAllTrueMask(Value mask) {
+  return isAllTrueMaskFrom<PsetB8Op>(mask) ||
+         isAllTrueMaskFrom<PsetB16Op>(mask) ||
+         isAllTrueMaskFrom<PsetB32Op>(mask) ||
+         isAllTrueMaskFrom<PgeB8Op>(mask) ||
+         isAllTrueMaskFrom<PgeB16Op>(mask) || isAllTrueMaskFrom<PgeB32Op>(mask);
+}
+
+template <typename OpTy>
+struct SimplifyAllTruePredicateReorder : public OpRewritePattern<OpTy> {
+  using OpRewritePattern<OpTy>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const override {
+    if (!isAllTrueMask(op.getLhs()) || !isAllTrueMask(op.getRhs()))
+      return failure();
+
+    rewriter.replaceOp(op, {op.getLhs(), op.getRhs()});
+    return success();
+  }
+};
+
+struct VPTOMaskSimplifyPass
+    : public pto::impl::VPTOMaskSimplifyBase<VPTOMaskSimplifyPass> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<SimplifyAllTruePredicateReorder<PintlvB8Op>,
+                 SimplifyAllTruePredicateReorder<PintlvB16Op>,
+                 SimplifyAllTruePredicateReorder<PintlvB32Op>,
+                 SimplifyAllTruePredicateReorder<PdintlvB8Op>,
+                 SimplifyAllTruePredicateReorder<PdintlvB16Op>,
+                 SimplifyAllTruePredicateReorder<PdintlvB32Op>>(&getContext());
+
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createVPTOMaskSimplifyPass() {
+  return std::make_unique<VPTOMaskSimplifyPass>();
+}

--- a/test/lit/vmi_new/opt/compute_single_row_vf_vmi_opt.pto
+++ b/test/lit/vmi_new/opt/compute_single_row_vf_vmi_opt.pto
@@ -10,10 +10,12 @@
 // RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s | FileCheck %s --check-prefix=VPTO --implicit-check-not=pto.vmi. --implicit-check-not='!pto.vmi' --implicit-check-not=pto.vcgmax --implicit-check-not=pto.vselr
 
 // Optimization guard for the ComputeSingleRowVF block-quant path.
-// The 128xf32 -> 128xf8 truncf should use a contiguous f32 source and a
-// lane_stride=4 fp8 result. Each physical f32 source part should lower through
-// P0 independently, and the masked_store should preserve lane_stride and lower
-// to two PK4_B32 stores without vor/vpack assembly.
+// The 128xf16 input should split into two UNPK_B16 loads whose f16 -> f32
+// conversions both consume the EVEN lanes. The 128xf32 -> 128xf8 truncf should
+// use a contiguous f32 source and a lane_stride=4 fp8 result. Each physical f32
+// source part should lower through P0 independently, and the masked_store
+// should preserve lane_stride and lower to two PK4_B32 stores without
+// vor/vpack assembly.
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @ComputeSingleRowVF_fp16_vmi_opt(
@@ -90,8 +92,10 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 // ASSIGN: pto.vmi.masked_store %[[Q8]], {{.*}}, %[[MASK]]
 
 // VPTO-LABEL: func.func @ComputeSingleRowVF_fp16_vmi_opt(
-// VPTO: pto.vcvt {{.*}} {part = "EVEN"}
-// VPTO: pto.vcvt {{.*}} {part = "ODD"}
+// VPTO: %[[INPUT_LOW:.*]] = pto.vlds {{.*}} {dist = "UNPK_B16"}
+// VPTO: %[[INPUT_HIGH:.*]] = pto.vlds {{.*}} {dist = "UNPK_B16"}
+// VPTO: pto.vcvt %[[INPUT_LOW]], {{.*}} {part = "EVEN"}
+// VPTO: pto.vcvt %[[INPUT_HIGH]], {{.*}} {part = "EVEN"}
 // VPTO: pto.vcmax
 // VPTO-NOT: part = "P1"
 // VPTO-NOT: part = "P3"

--- a/test/lit/vmi_new/opt/fused_quant_dequant_vmi_opt.pto
+++ b/test/lit/vmi_new/opt/fused_quant_dequant_vmi_opt.pto
@@ -1,0 +1,391 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s | FileCheck %s --check-prefix=VPTO --implicit-check-not=pto.vmi. --implicit-check-not='!pto.vmi' --implicit-check-not=pto.pge_ --implicit-check-not=pto.pintlv --implicit-check-not=pto.pdintlv --implicit-check-not=pto.vintlv --implicit-check-not=pto.vdintlv --implicit-check-not=pto.mem_bar --implicit-check-not=E2B_B16
+
+// Optimization guard for the fused quant-to-FP8 and dequant-to-BF16 VMI demo.
+// This is the dynamic two-slot kernel derived from learning-chip/vmi-demo
+// quant/quant_dequant. Keep the row body as scf.for so it remains eligible for
+// hardware-loop lowering. The intended VPTO shape is:
+// - the reduction input becomes a direct DINTLV_B16 load, while the contiguous
+//   quant input becomes four UNPK_B16 loads;
+// - the eight reciprocal BF16 slots broadcast directly in registers, without
+//   a UB store/reload or VST_VLD barrier, then split into four data paths with
+//   bitcast + vzunpack;
+// - static predicates canonicalize to pset without predicate reorder ops;
+// - the FP8 roundtrip needs no standalone vector-interleave materialization.
+
+// VPTO-LABEL: func.func @fused_qd_vmi_current
+// VPTO: scf.for
+// VPTO: scf.if
+// VPTO: pto.vecscope
+// VPTO: pto.pset_b16 "PAT_ALL"
+// VPTO: pto.pset_b16 "PAT_VL8"
+// VPTO: pto.pset_b32 "PAT_VL1"
+// VPTO: scf.for
+// VPTO: %[[REDUCE_LOW:.*]], %[[REDUCE_HIGH:.*]] = pto.vldsx2 {{.*}}, "DINTLV_B16"
+// VPTO: pto.vcgmax
+// VPTO: pto.vcvt {{.*}} {part = "EVEN", sat = "SAT"}
+// VPTO: pto.vsts {{.*}} {dist = "1PT_B32"}
+// VPTO: %[[RECIP_LOW:.*]] = pto.vselr {{.*}} : !pto.vreg<128xbf16>, !pto.vreg<128xui16> -> !pto.vreg<128xbf16>
+// VPTO: %[[RECIP_HIGH:.*]] = pto.vselr {{.*}} : !pto.vreg<128xbf16>, !pto.vreg<128xui16> -> !pto.vreg<128xbf16>
+// VPTO: %[[QUANT_0:.*]] = pto.vlds {{.*}} {dist = "UNPK_B16"}
+// VPTO: %[[QUANT_1:.*]] = pto.vlds {{.*}} {dist = "UNPK_B16"}
+// VPTO: %[[QUANT_2:.*]] = pto.vlds {{.*}} {dist = "UNPK_B16"}
+// VPTO: %[[QUANT_3:.*]] = pto.vlds {{.*}} {dist = "UNPK_B16"}
+// VPTO: %[[RECIP_LOW_BITS:.*]] = pto.vbitcast %[[RECIP_LOW]]
+// VPTO: %[[RECIP_0_WORDS:.*]] = pto.vzunpack %[[RECIP_LOW_BITS]], {{.*}}
+// VPTO: %[[RECIP_0:.*]] = pto.vbitcast %[[RECIP_0_WORDS]]
+// VPTO: %[[RECIP_1_WORDS:.*]] = pto.vzunpack %[[RECIP_LOW_BITS]], {{.*}}
+// VPTO: %[[RECIP_1:.*]] = pto.vbitcast %[[RECIP_1_WORDS]]
+// VPTO: %[[RECIP_HIGH_BITS:.*]] = pto.vbitcast %[[RECIP_HIGH]]
+// VPTO: %[[RECIP_2_WORDS:.*]] = pto.vzunpack %[[RECIP_HIGH_BITS]], {{.*}}
+// VPTO: %[[RECIP_2:.*]] = pto.vbitcast %[[RECIP_2_WORDS]]
+// VPTO: %[[RECIP_3_WORDS:.*]] = pto.vzunpack %[[RECIP_HIGH_BITS]], {{.*}}
+// VPTO: %[[RECIP_3:.*]] = pto.vbitcast %[[RECIP_3_WORDS]]
+// VPTO: pto.vmul %[[QUANT_0]], %[[RECIP_0]]
+// VPTO: pto.vmul %[[QUANT_1]], %[[RECIP_1]]
+// VPTO: pto.vmul %[[QUANT_2]], %[[RECIP_2]]
+// VPTO: pto.vmul %[[QUANT_3]], %[[RECIP_3]]
+// VPTO: %[[QUANT_FP8_0:.*]] = pto.vcvt {{.*}} {part = "P0", rnd = "R", sat = "SAT"}
+// VPTO: %[[QUANT_FP8_1:.*]] = pto.vcvt {{.*}} {part = "P0", rnd = "R", sat = "SAT"}
+// VPTO: %[[QUANT_FP8_2:.*]] = pto.vcvt {{.*}} {part = "P0", rnd = "R", sat = "SAT"}
+// VPTO: %[[QUANT_FP8_3:.*]] = pto.vcvt {{.*}} {part = "P0", rnd = "R", sat = "SAT"}
+// VPTO: %[[DEQUANT_SCALE_LOW:.*]] = pto.vselr {{.*}} : !pto.vreg<128xbf16>, !pto.vreg<128xui16> -> !pto.vreg<128xbf16>
+// VPTO: %[[DEQUANT_SCALE_HIGH:.*]] = pto.vselr {{.*}} : !pto.vreg<128xbf16>, !pto.vreg<128xui16> -> !pto.vreg<128xbf16>
+// VPTO: %[[DEQUANT_0:.*]] = pto.vcvt %[[QUANT_FP8_0]], {{.*}} {part = "P0"}
+// VPTO: %[[DEQUANT_1:.*]] = pto.vcvt %[[QUANT_FP8_1]], {{.*}} {part = "P0"}
+// VPTO: %[[DEQUANT_2:.*]] = pto.vcvt %[[QUANT_FP8_2]], {{.*}} {part = "P0"}
+// VPTO: %[[DEQUANT_3:.*]] = pto.vcvt %[[QUANT_FP8_3]], {{.*}} {part = "P0"}
+// VPTO: %[[DEQUANT_SCALE_LOW_BITS:.*]] = pto.vbitcast %[[DEQUANT_SCALE_LOW]]
+// VPTO: %[[DEQUANT_SCALE_0_WORDS:.*]] = pto.vzunpack %[[DEQUANT_SCALE_LOW_BITS]], {{.*}}
+// VPTO: %[[DEQUANT_SCALE_0:.*]] = pto.vbitcast %[[DEQUANT_SCALE_0_WORDS]]
+// VPTO: %[[DEQUANT_SCALE_1_WORDS:.*]] = pto.vzunpack %[[DEQUANT_SCALE_LOW_BITS]], {{.*}}
+// VPTO: %[[DEQUANT_SCALE_1:.*]] = pto.vbitcast %[[DEQUANT_SCALE_1_WORDS]]
+// VPTO: %[[DEQUANT_SCALE_HIGH_BITS:.*]] = pto.vbitcast %[[DEQUANT_SCALE_HIGH]]
+// VPTO: %[[DEQUANT_SCALE_2_WORDS:.*]] = pto.vzunpack %[[DEQUANT_SCALE_HIGH_BITS]], {{.*}}
+// VPTO: %[[DEQUANT_SCALE_2:.*]] = pto.vbitcast %[[DEQUANT_SCALE_2_WORDS]]
+// VPTO: %[[DEQUANT_SCALE_3_WORDS:.*]] = pto.vzunpack %[[DEQUANT_SCALE_HIGH_BITS]], {{.*}}
+// VPTO: %[[DEQUANT_SCALE_3:.*]] = pto.vbitcast %[[DEQUANT_SCALE_3_WORDS]]
+// VPTO: %[[DEQUANT_SCALE_F32_0:.*]] = pto.vcvt %[[DEQUANT_SCALE_0]], {{.*}} {part = "EVEN"}
+// VPTO: %[[DEQUANT_SCALE_F32_1:.*]] = pto.vcvt %[[DEQUANT_SCALE_1]], {{.*}} {part = "EVEN"}
+// VPTO: %[[DEQUANT_SCALE_F32_2:.*]] = pto.vcvt %[[DEQUANT_SCALE_2]], {{.*}} {part = "EVEN"}
+// VPTO: %[[DEQUANT_SCALE_F32_3:.*]] = pto.vcvt %[[DEQUANT_SCALE_3]], {{.*}} {part = "EVEN"}
+// VPTO: %[[DEQUANT_OUT_0:.*]] = pto.vmul %[[DEQUANT_0]], %[[DEQUANT_SCALE_F32_0]]
+// VPTO: %[[DEQUANT_OUT_1:.*]] = pto.vmul %[[DEQUANT_1]], %[[DEQUANT_SCALE_F32_1]]
+// VPTO: %[[DEQUANT_OUT_2:.*]] = pto.vmul %[[DEQUANT_2]], %[[DEQUANT_SCALE_F32_2]]
+// VPTO: %[[DEQUANT_OUT_3:.*]] = pto.vmul %[[DEQUANT_3]], %[[DEQUANT_SCALE_F32_3]]
+// VPTO: %[[DEQUANT_BF16_0:.*]] = pto.vcvt %[[DEQUANT_OUT_0]], {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"}
+// VPTO: %[[DEQUANT_BF16_1:.*]] = pto.vcvt %[[DEQUANT_OUT_1]], {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"}
+// VPTO: %[[DEQUANT_BF16_2:.*]] = pto.vcvt %[[DEQUANT_OUT_2]], {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"}
+// VPTO: %[[DEQUANT_BF16_3:.*]] = pto.vcvt %[[DEQUANT_OUT_3]], {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"}
+// VPTO: pto.vsts %[[DEQUANT_BF16_0]], {{.*}} {dist = "PK_B32"}
+// VPTO: pto.vsts %[[DEQUANT_BF16_1]], {{.*}} {dist = "PK_B32"}
+// VPTO: pto.vsts %[[DEQUANT_BF16_2]], {{.*}} {dist = "PK_B32"}
+// VPTO: pto.vsts %[[DEQUANT_BF16_3]], {{.*}} {dist = "PK_B32"}
+
+module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.backend = "vpto", pto.kernel_kind = #pto.kernel_kind<vector>, pto.target_arch = "a5"} {
+    func.func @fused_qd_vmi_current(%arg0: !pto.ptr<bf16, gm>, %arg1: i32, %arg2: i32) attributes {pto.entry, pto.kernel_kind = #pto.kernel_kind<vector>} {
+      %0 = pto.get_block_idx
+      %1 = pto.get_block_num
+      %c4_i32 = arith.constant 4 : i32
+      %2 = arith.addi %arg1, %c4_i32 : i32
+      %c1_i32 = arith.constant 1 : i32
+      %3 = arith.subi %2, %c1_i32 : i32
+      %c4_i32_0 = arith.constant 4 : i32
+      %4 = arith.floordivsi %3, %c4_i32_0 : i32
+      %c256_i32 = arith.constant 256 : i32
+      %5 = arith.floordivsi %arg2, %c256_i32 : i32
+      %6 = arith.muli %4, %5 : i32
+      %c0_i64 = arith.constant 0 : i64
+      %7 = builtin.unrealized_conversion_cast %c0_i64 : i64 to ui64
+      %8 = pto.castptr %7 : ui64 -> !pto.ptr<bf16, ub>
+      %c2048_i64 = arith.constant 2048 : i64
+      %9 = builtin.unrealized_conversion_cast %c2048_i64 : i64 to ui64
+      %10 = pto.castptr %9 : ui64 -> !pto.ptr<bf16, ub>
+      %c4096_i64 = arith.constant 4096 : i64
+      %11 = builtin.unrealized_conversion_cast %c4096_i64 : i64 to ui64
+      %12 = pto.castptr %11 : ui64 -> !pto.ptr<f8E4M3FN, ub>
+      %c5120_i64 = arith.constant 5120 : i64
+      %13 = builtin.unrealized_conversion_cast %c5120_i64 : i64 to ui64
+      %14 = pto.castptr %13 : ui64 -> !pto.ptr<ui8, ub>
+      %c5152_i64 = arith.constant 5152 : i64
+      %15 = builtin.unrealized_conversion_cast %c5152_i64 : i64 to ui64
+      %16 = pto.castptr %15 : ui64 -> !pto.ptr<bf16, ub>
+      %c5472_i64 = arith.constant 5472 : i64
+      %17 = builtin.unrealized_conversion_cast %c5472_i64 : i64 to ui64
+      %18 = pto.castptr %17 : ui64 -> !pto.ptr<bf16, ub>
+      %c7520_i64 = arith.constant 7520 : i64
+      %19 = builtin.unrealized_conversion_cast %c7520_i64 : i64 to ui64
+      %20 = pto.castptr %19 : ui64 -> !pto.ptr<bf16, ub>
+      %c9568_i64 = arith.constant 9568 : i64
+      %21 = builtin.unrealized_conversion_cast %c9568_i64 : i64 to ui64
+      %22 = pto.castptr %21 : ui64 -> !pto.ptr<f8E4M3FN, ub>
+      %c10592_i64 = arith.constant 10592 : i64
+      %23 = builtin.unrealized_conversion_cast %c10592_i64 : i64 to ui64
+      %24 = pto.castptr %23 : ui64 -> !pto.ptr<ui8, ub>
+      %c10624_i64 = arith.constant 10624 : i64
+      %25 = builtin.unrealized_conversion_cast %c10624_i64 : i64 to ui64
+      %26 = pto.castptr %25 : ui64 -> !pto.ptr<bf16, ub>
+      pto.set_flag[<PIPE_MTE3>, <PIPE_V>, <EVENT_ID0>]
+      pto.set_flag[<PIPE_MTE3>, <PIPE_V>, <EVENT_ID1>]
+      pto.set_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID0>]
+      pto.set_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID1>]
+      %27 = arith.index_cast %0 : i64 to index
+      %28 = arith.index_cast %6 : i32 to index
+      %29 = arith.index_cast %1 : i64 to index
+      scf.for %arg3 = %27 to %28 step %29 {
+        %30 = arith.index_cast %5 : i32 to index
+        %31 = arith.floordivsi %arg3, %30 : index
+        %32 = arith.index_cast %5 : i32 to index
+        %33 = arith.remsi %arg3, %32 : index
+        %c2 = arith.constant 2 : index
+        %34 = arith.remsi %arg3, %c2 : index
+        %c4 = arith.constant 4 : index
+        %35 = arith.muli %31, %c4 : index
+        %c256 = arith.constant 256 : index
+        %36 = arith.muli %33, %c256 : index
+        %37 = arith.index_cast %arg2 : i32 to index
+        %38 = arith.muli %35, %37 : index
+        %39 = arith.addi %38, %36 : index
+        %40 = pto.addptr %arg0, %39 : <bf16, gm> -> <bf16, gm>
+        %c0 = arith.constant 0 : index
+        %41 = arith.cmpi eq, %34, %c0 : index
+        scf.if %41 {
+          pto.wait_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID0>]
+          %c2_i32 = arith.constant 2 : i32
+          %42 = arith.muli %arg2, %c2_i32 : i32
+          %c4_i64 = arith.constant 4 : i64
+          %43 = arith.extsi %42 : i32 to i64
+          %c512_i64 = arith.constant 512 : i64
+          %c0_i64_1 = arith.constant 0 : i64
+          %c512_i64_2 = arith.constant 512 : i64
+          pto.mte_gm_ub %40, %8, %c0_i64_1, %c512_i64_2 nburst(%c4_i64, %43, %c512_i64) {operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0>} : !pto.ptr<bf16, gm>, !pto.ptr<bf16, ub>, i64, i64, i64, i64, i64
+          pto.set_flag[<PIPE_MTE2>, <PIPE_V>, <EVENT_ID0>]
+          pto.wait_flag[<PIPE_MTE2>, <PIPE_V>, <EVENT_ID0>]
+          pto.wait_flag[<PIPE_MTE3>, <PIPE_V>, <EVENT_ID0>]
+          %c256_3 = arith.constant 256 : index
+          %44 = pto.vmi.create_mask %c256_3 : index -> !pto.vmi.mask<256xpred>
+          %c8 = arith.constant 8 : index
+          %45 = pto.vmi.create_mask %c8 : index -> !pto.vmi.mask<8xpred>
+          %c32640_i16 = arith.constant 32640 : i16
+          %46 = builtin.unrealized_conversion_cast %c32640_i16 : i16 to ui16
+          %47 = pto.vmi.vbrc %46 : ui16 -> !pto.vmi.vreg<256xui16>
+          %c1024_i16 = arith.constant 1024 : i16
+          %48 = builtin.unrealized_conversion_cast %c1024_i16 : i16 to ui16
+          %49 = pto.vmi.vbrc %48 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c255_i16 = arith.constant 255 : i16
+          %50 = builtin.unrealized_conversion_cast %c255_i16 : i16 to ui16
+          %51 = pto.vmi.vbrc %50 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c0_i16 = arith.constant 0 : i16
+          %52 = builtin.unrealized_conversion_cast %c0_i16 : i16 to ui16
+          %53 = pto.vmi.vbrc %52 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c32512_i16 = arith.constant 32512 : i16
+          %54 = builtin.unrealized_conversion_cast %c32512_i16 : i16 to ui16
+          %55 = pto.vmi.vbrc %54 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c32641_i16 = arith.constant 32641 : i16
+          %56 = builtin.unrealized_conversion_cast %c32641_i16 : i16 to ui16
+          %57 = pto.vmi.vbrc %56 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c64_i16 = arith.constant 64 : i16
+          %58 = builtin.unrealized_conversion_cast %c64_i16 : i16 to ui16
+          %59 = pto.vmi.vbrc %58 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c32704_i16 = arith.constant 32704 : i16
+          %60 = builtin.unrealized_conversion_cast %c32704_i16 : i16 to ui16
+          %61 = pto.vmi.vbrc %60 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c0_4 = arith.constant 0 : index
+          %c4_5 = arith.constant 4 : index
+          %c1 = arith.constant 1 : index
+          scf.for %arg4 = %c0_4 to %c4_5 step %c1 {
+            %c256_11 = arith.constant 256 : index
+            %64 = arith.muli %arg4, %c256_11 : index
+            %c32 = arith.constant 32 : index
+            %65 = pto.vmi.vload %8[%64], %c32 {group = 8 : i64} : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+            %66 = pto.vmi.vinterpret_cast %65 : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xui16>
+            %67 = pto.vmi.vand %66, %47, %44 : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<256xui16>, !pto.vmi.mask<256xpred> -> !pto.vmi.vreg<256xui16>
+            %68 = pto.vmi.vcmax %67, %44 {group = 8 : i64} : !pto.vmi.vreg<256xui16>, !pto.vmi.mask<256xpred> -> !pto.vmi.vreg<8xui16>
+            %c32640_i16_12 = arith.constant 32640 : i16
+            %69 = builtin.unrealized_conversion_cast %c32640_i16_12 : i16 to ui16
+            %70 = pto.vmi.vcmps %68, %69, %45 {cmp = "ne"} : !pto.vmi.vreg<8xui16>, ui16, !pto.vmi.mask<8xpred> -> !pto.vmi.mask<8xpred>
+            %c0_i16_13 = arith.constant 0 : i16
+            %71 = builtin.unrealized_conversion_cast %c0_i16_13 : i16 to ui16
+            %72 = pto.vmi.vcmps %68, %71, %45 {cmp = "ne"} : !pto.vmi.vreg<8xui16>, ui16, !pto.vmi.mask<8xpred> -> !pto.vmi.mask<8xpred>
+            %c1024_i16_14 = arith.constant 1024 : i16
+            %73 = builtin.unrealized_conversion_cast %c1024_i16_14 : i16 to ui16
+            %74 = pto.vmi.vcmps %68, %73, %45 {cmp = "le"} : !pto.vmi.vreg<8xui16>, ui16, !pto.vmi.mask<8xpred> -> !pto.vmi.mask<8xpred>
+            %75 = pto.vmi.vsel %74, %49, %68 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %76 = pto.vmi.vsub %75, %49, %45 : !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16>, !pto.vmi.mask<8xpred> -> !pto.vmi.vreg<8xui16>
+            %c7_i16 = arith.constant 7 : i16
+            %77 = pto.vmi.vshrs %76, %c7_i16, %45 : !pto.vmi.vreg<8xui16>, i16, !pto.vmi.mask<8xpred> -> !pto.vmi.vreg<8xui16>
+            %78 = pto.vmi.vsel %70, %77, %51 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %79 = pto.vmi.vsel %72, %78, %53 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %80 = pto.vmi.vcvt %79 {saturate = "SAT"} : !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui8>
+            %c32512_i16_15 = arith.constant 32512 : i16
+            %81 = builtin.unrealized_conversion_cast %c32512_i16_15 : i16 to ui16
+            %82 = pto.vmi.vcmps %76, %81, %45 {cmp = "eq"} : !pto.vmi.vreg<8xui16>, ui16, !pto.vmi.mask<8xpred> -> !pto.vmi.mask<8xpred>
+            %83 = pto.vmi.vsub %55, %76, %45 : !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16>, !pto.vmi.mask<8xpred> -> !pto.vmi.vreg<8xui16>
+            %84 = pto.vmi.vsel %70, %83, %57 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %85 = pto.vmi.vsel %72, %84, %53 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %86 = pto.vmi.vsel %82, %59, %85 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %87 = pto.vmi.vinterpret_cast %86 : !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xbf16>
+            %c8_16 = arith.constant 8 : index
+            %88 = arith.muli %arg4, %c8_16 : index
+            %c1_17 = arith.constant 1 : index
+            pto.vmi.vstore %80, %14[%88], %c1_17 {group = 8 : i64} : !pto.vmi.vreg<8xui8>, !pto.ptr<ui8, ub>
+            %c7_i16_18 = arith.constant 7 : i16
+            %89 = pto.vmi.vshls %79, %c7_i16_18, %45 : !pto.vmi.vreg<8xui16>, i16, !pto.vmi.mask<8xpred> -> !pto.vmi.vreg<8xui16>
+            %c32640_i16_19 = arith.constant 32640 : i16
+            %90 = builtin.unrealized_conversion_cast %c32640_i16_19 : i16 to ui16
+            %91 = pto.vmi.vcmps %89, %90, %45 {cmp = "eq"} : !pto.vmi.vreg<8xui16>, ui16, !pto.vmi.mask<8xpred> -> !pto.vmi.mask<8xpred>
+            %92 = pto.vmi.vsel %91, %61, %89 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %93 = pto.vmi.vinterpret_cast %92 : !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xbf16>
+            %96 = pto.vmi.vbrc %87 {group = 8 : i64} : !pto.vmi.vreg<8xbf16> -> !pto.vmi.vreg<256xbf16>
+            %97 = pto.vmi.vload %8[%64] : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+            %98 = pto.vmi.vmul %97, %96, %44 : !pto.vmi.vreg<256xbf16>, !pto.vmi.vreg<256xbf16>, !pto.vmi.mask<256xpred> -> !pto.vmi.vreg<256xbf16>
+            %99 = pto.vmi.vcvt %98 : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xf32>
+            %100 = pto.vmi.vcvt %99 {rounding = "R", saturate = "SAT"} : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
+            %101 = pto.vmi.vbrc %93 {group = 8 : i64} : !pto.vmi.vreg<8xbf16> -> !pto.vmi.vreg<256xbf16>
+            %102 = pto.vmi.vcvt %100 : !pto.vmi.vreg<256xf8E4M3FN> -> !pto.vmi.vreg<256xf32>
+            %103 = pto.vmi.vcvt %101 : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xf32>
+            %104 = pto.vmi.vmul %102, %103, %44 : !pto.vmi.vreg<256xf32>, !pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred> -> !pto.vmi.vreg<256xf32>
+            %105 = pto.vmi.vcvt %104 {saturate = "SAT"} : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xbf16>
+            pto.vmi.vstore %105, %10[%64], %44 : !pto.vmi.vreg<256xbf16>, !pto.ptr<bf16, ub>, !pto.vmi.mask<256xpred>
+          }
+          pto.set_flag[<PIPE_V>, <PIPE_MTE3>, <EVENT_ID0>]
+          pto.set_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID0>]
+          pto.wait_flag[<PIPE_V>, <PIPE_MTE3>, <EVENT_ID0>]
+          %c2_i32_6 = arith.constant 2 : i32
+          %62 = arith.muli %arg2, %c2_i32_6 : i32
+          %c4_i64_7 = arith.constant 4 : i64
+          %c512_i64_8 = arith.constant 512 : i64
+          %63 = arith.extsi %62 : i32 to i64
+          %c512_i64_9 = arith.constant 512 : i64
+          %c4_i64_10 = arith.constant 4 : i64
+          pto.mte_ub_gm %10, %40, %c512_i64_9 nburst(%c4_i64_7, %c512_i64_8, %63) l2_cache_ctl(%c4_i64_10) {operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1, 1, 0, 0, 0>} : !pto.ptr<bf16, ub>, !pto.ptr<bf16, gm>, i64, i64, i64, i64, i64
+          pto.set_flag[<PIPE_MTE3>, <PIPE_V>, <EVENT_ID0>]
+        } else {
+          pto.wait_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID1>]
+          %c2_i32 = arith.constant 2 : i32
+          %42 = arith.muli %arg2, %c2_i32 : i32
+          %c4_i64 = arith.constant 4 : i64
+          %43 = arith.extsi %42 : i32 to i64
+          %c512_i64 = arith.constant 512 : i64
+          %c0_i64_1 = arith.constant 0 : i64
+          %c512_i64_2 = arith.constant 512 : i64
+          pto.mte_gm_ub %40, %18, %c0_i64_1, %c512_i64_2 nburst(%c4_i64, %43, %c512_i64) {operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0>} : !pto.ptr<bf16, gm>, !pto.ptr<bf16, ub>, i64, i64, i64, i64, i64
+          pto.set_flag[<PIPE_MTE2>, <PIPE_V>, <EVENT_ID1>]
+          pto.wait_flag[<PIPE_MTE2>, <PIPE_V>, <EVENT_ID1>]
+          pto.wait_flag[<PIPE_MTE3>, <PIPE_V>, <EVENT_ID1>]
+          %c256_3 = arith.constant 256 : index
+          %44 = pto.vmi.create_mask %c256_3 : index -> !pto.vmi.mask<256xpred>
+          %c8 = arith.constant 8 : index
+          %45 = pto.vmi.create_mask %c8 : index -> !pto.vmi.mask<8xpred>
+          %c32640_i16 = arith.constant 32640 : i16
+          %46 = builtin.unrealized_conversion_cast %c32640_i16 : i16 to ui16
+          %47 = pto.vmi.vbrc %46 : ui16 -> !pto.vmi.vreg<256xui16>
+          %c1024_i16 = arith.constant 1024 : i16
+          %48 = builtin.unrealized_conversion_cast %c1024_i16 : i16 to ui16
+          %49 = pto.vmi.vbrc %48 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c255_i16 = arith.constant 255 : i16
+          %50 = builtin.unrealized_conversion_cast %c255_i16 : i16 to ui16
+          %51 = pto.vmi.vbrc %50 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c0_i16 = arith.constant 0 : i16
+          %52 = builtin.unrealized_conversion_cast %c0_i16 : i16 to ui16
+          %53 = pto.vmi.vbrc %52 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c32512_i16 = arith.constant 32512 : i16
+          %54 = builtin.unrealized_conversion_cast %c32512_i16 : i16 to ui16
+          %55 = pto.vmi.vbrc %54 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c32641_i16 = arith.constant 32641 : i16
+          %56 = builtin.unrealized_conversion_cast %c32641_i16 : i16 to ui16
+          %57 = pto.vmi.vbrc %56 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c64_i16 = arith.constant 64 : i16
+          %58 = builtin.unrealized_conversion_cast %c64_i16 : i16 to ui16
+          %59 = pto.vmi.vbrc %58 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c32704_i16 = arith.constant 32704 : i16
+          %60 = builtin.unrealized_conversion_cast %c32704_i16 : i16 to ui16
+          %61 = pto.vmi.vbrc %60 : ui16 -> !pto.vmi.vreg<8xui16>
+          %c0_4 = arith.constant 0 : index
+          %c4_5 = arith.constant 4 : index
+          %c1 = arith.constant 1 : index
+          scf.for %arg4 = %c0_4 to %c4_5 step %c1 {
+            %c256_11 = arith.constant 256 : index
+            %64 = arith.muli %arg4, %c256_11 : index
+            %c32 = arith.constant 32 : index
+            %65 = pto.vmi.vload %18[%64], %c32 {group = 8 : i64} : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+            %66 = pto.vmi.vinterpret_cast %65 : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xui16>
+            %67 = pto.vmi.vand %66, %47, %44 : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<256xui16>, !pto.vmi.mask<256xpred> -> !pto.vmi.vreg<256xui16>
+            %68 = pto.vmi.vcmax %67, %44 {group = 8 : i64} : !pto.vmi.vreg<256xui16>, !pto.vmi.mask<256xpred> -> !pto.vmi.vreg<8xui16>
+            %c32640_i16_12 = arith.constant 32640 : i16
+            %69 = builtin.unrealized_conversion_cast %c32640_i16_12 : i16 to ui16
+            %70 = pto.vmi.vcmps %68, %69, %45 {cmp = "ne"} : !pto.vmi.vreg<8xui16>, ui16, !pto.vmi.mask<8xpred> -> !pto.vmi.mask<8xpred>
+            %c0_i16_13 = arith.constant 0 : i16
+            %71 = builtin.unrealized_conversion_cast %c0_i16_13 : i16 to ui16
+            %72 = pto.vmi.vcmps %68, %71, %45 {cmp = "ne"} : !pto.vmi.vreg<8xui16>, ui16, !pto.vmi.mask<8xpred> -> !pto.vmi.mask<8xpred>
+            %c1024_i16_14 = arith.constant 1024 : i16
+            %73 = builtin.unrealized_conversion_cast %c1024_i16_14 : i16 to ui16
+            %74 = pto.vmi.vcmps %68, %73, %45 {cmp = "le"} : !pto.vmi.vreg<8xui16>, ui16, !pto.vmi.mask<8xpred> -> !pto.vmi.mask<8xpred>
+            %75 = pto.vmi.vsel %74, %49, %68 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %76 = pto.vmi.vsub %75, %49, %45 : !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16>, !pto.vmi.mask<8xpred> -> !pto.vmi.vreg<8xui16>
+            %c7_i16 = arith.constant 7 : i16
+            %77 = pto.vmi.vshrs %76, %c7_i16, %45 : !pto.vmi.vreg<8xui16>, i16, !pto.vmi.mask<8xpred> -> !pto.vmi.vreg<8xui16>
+            %78 = pto.vmi.vsel %70, %77, %51 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %79 = pto.vmi.vsel %72, %78, %53 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %80 = pto.vmi.vcvt %79 {saturate = "SAT"} : !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui8>
+            %c32512_i16_15 = arith.constant 32512 : i16
+            %81 = builtin.unrealized_conversion_cast %c32512_i16_15 : i16 to ui16
+            %82 = pto.vmi.vcmps %76, %81, %45 {cmp = "eq"} : !pto.vmi.vreg<8xui16>, ui16, !pto.vmi.mask<8xpred> -> !pto.vmi.mask<8xpred>
+            %83 = pto.vmi.vsub %55, %76, %45 : !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16>, !pto.vmi.mask<8xpred> -> !pto.vmi.vreg<8xui16>
+            %84 = pto.vmi.vsel %70, %83, %57 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %85 = pto.vmi.vsel %72, %84, %53 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %86 = pto.vmi.vsel %82, %59, %85 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %87 = pto.vmi.vinterpret_cast %86 : !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xbf16>
+            %c8_16 = arith.constant 8 : index
+            %88 = arith.muli %arg4, %c8_16 : index
+            %c1_17 = arith.constant 1 : index
+            pto.vmi.vstore %80, %24[%88], %c1_17 {group = 8 : i64} : !pto.vmi.vreg<8xui8>, !pto.ptr<ui8, ub>
+            %c7_i16_18 = arith.constant 7 : i16
+            %89 = pto.vmi.vshls %79, %c7_i16_18, %45 : !pto.vmi.vreg<8xui16>, i16, !pto.vmi.mask<8xpred> -> !pto.vmi.vreg<8xui16>
+            %c32640_i16_19 = arith.constant 32640 : i16
+            %90 = builtin.unrealized_conversion_cast %c32640_i16_19 : i16 to ui16
+            %91 = pto.vmi.vcmps %89, %90, %45 {cmp = "eq"} : !pto.vmi.vreg<8xui16>, ui16, !pto.vmi.mask<8xpred> -> !pto.vmi.mask<8xpred>
+            %92 = pto.vmi.vsel %91, %61, %89 : !pto.vmi.mask<8xpred>, !pto.vmi.vreg<8xui16>, !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xui16>
+            %93 = pto.vmi.vinterpret_cast %92 : !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xbf16>
+            %96 = pto.vmi.vbrc %87 {group = 8 : i64} : !pto.vmi.vreg<8xbf16> -> !pto.vmi.vreg<256xbf16>
+            %97 = pto.vmi.vload %18[%64] : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+            %98 = pto.vmi.vmul %97, %96, %44 : !pto.vmi.vreg<256xbf16>, !pto.vmi.vreg<256xbf16>, !pto.vmi.mask<256xpred> -> !pto.vmi.vreg<256xbf16>
+            %99 = pto.vmi.vcvt %98 : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xf32>
+            %100 = pto.vmi.vcvt %99 {rounding = "R", saturate = "SAT"} : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
+            %101 = pto.vmi.vbrc %93 {group = 8 : i64} : !pto.vmi.vreg<8xbf16> -> !pto.vmi.vreg<256xbf16>
+            %102 = pto.vmi.vcvt %100 : !pto.vmi.vreg<256xf8E4M3FN> -> !pto.vmi.vreg<256xf32>
+            %103 = pto.vmi.vcvt %101 : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xf32>
+            %104 = pto.vmi.vmul %102, %103, %44 : !pto.vmi.vreg<256xf32>, !pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred> -> !pto.vmi.vreg<256xf32>
+            %105 = pto.vmi.vcvt %104 {saturate = "SAT"} : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xbf16>
+            pto.vmi.vstore %105, %20[%64], %44 : !pto.vmi.vreg<256xbf16>, !pto.ptr<bf16, ub>, !pto.vmi.mask<256xpred>
+          }
+          pto.set_flag[<PIPE_V>, <PIPE_MTE3>, <EVENT_ID1>]
+          pto.set_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID1>]
+          pto.wait_flag[<PIPE_V>, <PIPE_MTE3>, <EVENT_ID1>]
+          %c2_i32_6 = arith.constant 2 : i32
+          %62 = arith.muli %arg2, %c2_i32_6 : i32
+          %c4_i64_7 = arith.constant 4 : i64
+          %c512_i64_8 = arith.constant 512 : i64
+          %63 = arith.extsi %62 : i32 to i64
+          %c512_i64_9 = arith.constant 512 : i64
+          %c4_i64_10 = arith.constant 4 : i64
+          pto.mte_ub_gm %20, %40, %c512_i64_9 nburst(%c4_i64_7, %c512_i64_8, %63) l2_cache_ctl(%c4_i64_10) {operandSegmentSizes = array<i32: 1, 1, 1, 1, 1, 1, 1, 0, 0, 0>} : !pto.ptr<bf16, ub>, !pto.ptr<bf16, gm>, i64, i64, i64, i64, i64
+          pto.set_flag[<PIPE_MTE3>, <PIPE_V>, <EVENT_ID1>]
+        }
+      }
+      pto.wait_flag[<PIPE_MTE3>, <PIPE_V>, <EVENT_ID0>]
+      pto.wait_flag[<PIPE_MTE3>, <PIPE_V>, <EVENT_ID1>]
+      pto.wait_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID0>]
+      pto.wait_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID1>]
+      return
+    }
+  }
+}

--- a/test/lit/vmi_new/vmi_compact_load_store_group_alias.pto
+++ b/test/lit/vmi_new/vmi_compact_load_store_group_alias.pto
@@ -96,26 +96,26 @@ module {
 // LEGACY-SAME: {num_groups = 1 : i64}
 
 // LOWER-LABEL: func.func @compact_1(
-// LOWER: pto.pge_b32 "PAT_VL1"
+// LOWER: pto.pset_b32 "PAT_VL1"
 // LOWER: pto.vsldb
 // LOWER: pto.vsts
 // LOWER-NOT: pto.vmi.
 
 
 // LOWER-LABEL: func.func @compact_2(
-// LOWER: pto.pge_b32 "PAT_VL2"
+// LOWER: pto.pset_b32 "PAT_VL2"
 // LOWER: pto.vsldb
 // LOWER: pto.vsts
 // LOWER-NOT: pto.vmi.
 
 // LOWER-LABEL: func.func @compact_4(
-// LOWER: pto.pge_b32 "PAT_VL4"
+// LOWER: pto.pset_b32 "PAT_VL4"
 // LOWER: pto.vsldb
 // LOWER: pto.vsts
 // LOWER-NOT: pto.vmi.
 
 // LOWER-LABEL: func.func @compact_8(
-// LOWER: pto.pge_b32 "PAT_VL8"
+// LOWER: pto.pset_b32 "PAT_VL8"
 // LOWER: pto.vsldb
 // LOWER: pto.vsts
 // LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_cast_roundtrip.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_cast_roundtrip.pto
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER --implicit-check-not=pto.vor
+
+module {
+  func.func @f32_fp8_f32_roundtrip(
+      %src: !pto.ptr<bf16, ub>,
+      %scale: bf16,
+      %dst: !pto.ptr<bf16, ub>) {
+    %c0 = arith.constant 0 : index
+    %c256 = arith.constant 256 : index
+    %mask = pto.vmi.create_mask %c256
+        : index -> !pto.vmi.mask<256xpred>
+    %input = pto.vmi.vload %src[%c0]
+        : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+    %wide = pto.vmi.vcvt %input
+        : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xf32>
+    %quantized = pto.vmi.vcvt %wide {saturate = "SAT"}
+        : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
+    %restored = pto.vmi.vcvt %quantized
+        : !pto.vmi.vreg<256xf8E4M3FN> -> !pto.vmi.vreg<256xf32>
+    %scale_bf16 = pto.vmi.vbrc %scale
+        : bf16 -> !pto.vmi.vreg<256xbf16>
+    %scale_f32 = pto.vmi.vcvt %scale_bf16
+        : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xf32>
+    %scaled = pto.vmi.vmul %restored, %scale_f32
+        : !pto.vmi.vreg<256xf32>, !pto.vmi.vreg<256xf32>
+        -> !pto.vmi.vreg<256xf32>
+    %output = pto.vmi.vcvt %scaled {saturate = "SAT"}
+        : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xbf16>
+    pto.vmi.vstore %output, %dst[%c0], %mask
+        : !pto.vmi.vreg<256xbf16>, !pto.ptr<bf16, ub>,
+          !pto.vmi.mask<256xpred>
+    return
+  }
+
+  func.func @f32_f16_f32_roundtrip(
+      %src: !pto.ptr<f32, ub>,
+      %dst16: !pto.ptr<f16, ub>,
+      %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %mask = pto.vmi.create_mask %c128
+        : index -> !pto.vmi.mask<128xpred>
+    %input = pto.vmi.vload %src[%c0]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
+    %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf16>
+    %restored = pto.vmi.vcvt %narrow
+        : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
+    pto.vmi.vstore %narrow, %dst16[%c0]
+        : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>
+    pto.vmi.vstore %restored, %dst[%c0], %mask
+        : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>,
+          !pto.vmi.mask<128xpred>
+    return
+  }
+
+  func.func @si32_si16_si32_roundtrip(
+      %src: !pto.ptr<si32, ub>,
+      %dst: !pto.ptr<si32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %mask = pto.vmi.create_mask %c64
+        : index -> !pto.vmi.mask<64xpred>
+    %input = pto.vmi.vload %src[%c0]
+        : !pto.ptr<si32, ub> -> !pto.vmi.vreg<64xsi32>
+    %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<64xsi32> -> !pto.vmi.vreg<64xsi16>
+    %restored = pto.vmi.vcvt %narrow
+        : !pto.vmi.vreg<64xsi16> -> !pto.vmi.vreg<64xsi32>
+    pto.vmi.vstore %restored, %dst[%c0], %mask
+        : !pto.vmi.vreg<64xsi32>, !pto.ptr<si32, ub>,
+          !pto.vmi.mask<64xpred>
+    return
+  }
+
+  func.func @ui32_ui8_ui32_roundtrip(
+      %src: !pto.ptr<ui32, ub>,
+      %dst8: !pto.ptr<ui8, ub>,
+      %dst: !pto.ptr<ui32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %mask = pto.vmi.create_mask %c64
+        : index -> !pto.vmi.mask<64xpred>
+    %input = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui32, ub> -> !pto.vmi.vreg<64xui32>
+    %narrow = pto.vmi.vcvt %input {saturate = "NOSAT"}
+        : !pto.vmi.vreg<64xui32> -> !pto.vmi.vreg<64xui8>
+    %restored = pto.vmi.vcvt %narrow
+        : !pto.vmi.vreg<64xui8> -> !pto.vmi.vreg<64xui32>
+    pto.vmi.vstore %narrow, %dst8[%c0]
+        : !pto.vmi.vreg<64xui8>, !pto.ptr<ui8, ub>
+    pto.vmi.vstore %restored, %dst[%c0], %mask
+        : !pto.vmi.vreg<64xui32>, !pto.ptr<ui32, ub>,
+          !pto.vmi.mask<64xpred>
+    return
+  }
+}
+
+// ASSIGN-LABEL: func.func @f32_fp8_f32_roundtrip(
+// ASSIGN: %[[INPUT:.*]] = pto.vmi.load
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<contiguous, lane_stride = 2>>
+// ASSIGN: %[[WIDE:.*]] = pto.vmi.extf %[[INPUT]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
+// ASSIGN-NOT: pto.vmi.ensure_layout %[[WIDE]]
+// ASSIGN: %[[QUANTIZED:.*]] = pto.vmi.truncf %[[WIDE]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous, lane_stride = 4>>
+// ASSIGN: %[[RESTORED:.*]] = pto.vmi.extf %[[QUANTIZED]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
+// ASSIGN-NOT: pto.vmi.ensure_layout %[[QUANTIZED]]
+
+// ASSIGN-LABEL: func.func @f32_f16_f32_roundtrip(
+// ASSIGN: %[[F16:.*]] = pto.vmi.truncf
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous, lane_stride = 2>>
+// ASSIGN: %[[F32:.*]] = pto.vmi.extf %[[F16]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
+// ASSIGN-NOT: pto.vmi.ensure_layout %[[F16]]
+// ASSIGN: pto.vmi.store %[[F16]]
+
+// ASSIGN-LABEL: func.func @si32_si16_si32_roundtrip(
+// ASSIGN: %[[SI16:.*]] = pto.vmi.trunci
+// ASSIGN-SAME: -> !pto.vmi.vreg<64xsi16, #pto.vmi.layout<contiguous, lane_stride = 2>>
+// ASSIGN: %[[SI32:.*]] = pto.vmi.extsi %[[SI16]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<64xsi32, #pto.vmi.layout<contiguous>>
+// ASSIGN-NOT: pto.vmi.ensure_layout %[[SI16]]
+
+// ASSIGN-LABEL: func.func @ui32_ui8_ui32_roundtrip(
+// ASSIGN: %[[UI8:.*]] = pto.vmi.trunci
+// ASSIGN-SAME: -> !pto.vmi.vreg<64xui8, #pto.vmi.layout<contiguous, lane_stride = 4>>
+// ASSIGN: %[[UI32:.*]] = pto.vmi.extui %[[UI8]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<64xui32, #pto.vmi.layout<contiguous>>
+// ASSIGN-NOT: pto.vmi.ensure_layout %[[UI8]]
+// ASSIGN: pto.vmi.store %[[UI8]]
+
+// LOWER-LABEL: func.func @f32_fp8_f32_roundtrip(
+// LOWER-COUNT-4: pto.vcvt {{.*}} {part = "P0", rnd = "R", sat = "SAT"}
+// LOWER-NOT: part = "P1", rnd = "R", sat = "SAT"
+// LOWER-NOT: part = "P2", rnd = "R", sat = "SAT"
+// LOWER-NOT: part = "P3", rnd = "R", sat = "SAT"

--- a/test/lit/vmi_new/vmi_layout_assignment_f8_compute_f8.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_f8_compute_f8.pto
@@ -7,7 +7,7 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
-// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER --implicit-check-not=pto.vintlv
 
 module {
   func.func @vmi_layout_assignment_f8_compute_f8(
@@ -34,24 +34,22 @@ module {
 
 // ASSIGN-LABEL: func.func @vmi_layout_assignment_f8_compute_f8(
 // ASSIGN: %[[X8:.*]] = pto.vmi.load
-// ASSIGN-SAME: -> !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous>>
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous, lane_stride = 4>>
 // ASSIGN: %[[X32:.*]] = pto.vmi.extf %[[X8]]
-// ASSIGN-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
 // ASSIGN: %[[SCALE:.*]] = pto.vmi.broadcast
 // ASSIGN-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
-// ASSIGN: %[[X32_C:.*]] = pto.vmi.ensure_layout %[[X32]]
-// ASSIGN-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
-// ASSIGN: %[[Y32:.*]] = pto.vmi.mulf %[[X32_C]], %[[SCALE]]
+// ASSIGN-NOT: pto.vmi.ensure_layout %[[X32]]
+// ASSIGN: %[[Y32:.*]] = pto.vmi.mulf %[[X32]], %[[SCALE]]
 // ASSIGN-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
 // ASSIGN: %[[Y8:.*]] = pto.vmi.truncf %[[Y32]]
 // ASSIGN-SAME: -> !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous, lane_stride = 4>>
 // ASSIGN: pto.vmi.store %[[Y8]]
 
 // LOWER-LABEL: func.func @vmi_layout_assignment_f8_compute_f8(
-// LOWER: pto.vlds
-// LOWER-COUNT-4: pto.vcvt {{.*}} {part = "P{{[0-3]}}"}
+// LOWER-COUNT-4: pto.vlds {{.*}} {dist = "UNPK4"}
+// LOWER-COUNT-4: pto.vcvt {{.*}} {part = "P0"}
 // LOWER-COUNT-4: pto.vdup
-// LOWER: pto.vintlv
 // LOWER-COUNT-4: pto.vmul
 // LOWER-COUNT-4: pto.vcvt {{.*}} {part = "P0", rnd = "R", sat = "SAT"}
 // LOWER-NOT: part = "P1"

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s16_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s16_store.pto
@@ -41,11 +41,11 @@ module {
 // LOWER-LABEL: func.func @vmi_layout_assignment_group_reduce_s16_store(
 // LOWER: %[[LO:.*]], %[[HI:.*]] = pto.vdintlv
 // LOWER: %[[MLO:.*]], %[[MHI:.*]] = pto.pdintlv_b32
-// LOWER: %[[VL8:.*]] = pto.pge_b32 "PAT_VL8" : !pto.mask<b32>
+// LOWER: %[[VL8:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // LOWER: %[[SLO:.*]] = pto.vcgadd %[[LO]], %[[MLO]]
 // LOWER: %[[SHI:.*]] = pto.vcgadd %[[HI]], %[[MHI]]
 // LOWER: %[[SUM:.*]] = pto.vadd %[[SLO]], %[[SHI]], %[[VL8]]
-// LOWER: %[[STORE_MASK:.*]] = pto.pge_b32 "PAT_VL8" : !pto.mask<b32>
+// LOWER: %[[STORE_MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // LOWER: pto.vsts %[[SUM]], %arg4[%arg5], %[[STORE_MASK]]
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s32_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s32_store.pto
@@ -41,10 +41,10 @@ module {
 // LOWER-LABEL: func.func @vmi_layout_assignment_group_reduce_s32_store(
 // LOWER-COUNT-4: pto.vdintlv
 // LOWER-COUNT-4: pto.pdintlv_b32
-// LOWER: %[[VL8:.*]] = pto.pge_b32 "PAT_VL8" : !pto.mask<b32>
+// LOWER: %[[VL8:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // LOWER-COUNT-4: pto.vcgadd
 // LOWER-COUNT-3: pto.vadd {{.*}}, {{.*}}, %[[VL8]]
-// LOWER: %[[STORE_MASK:.*]] = pto.pge_b32 "PAT_VL8" : !pto.mask<b32>
+// LOWER: %[[STORE_MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // LOWER: pto.vsts {{.*}}, %arg8[%arg9], %[[STORE_MASK]]
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s64_truncf.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s64_truncf.pto
@@ -41,7 +41,7 @@ module {
 // LOWER-COUNT-8: pto.vcadd
 // LOWER-NOT: pto.vsel
 // LOWER: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
-// LOWER: pto.pge_b16 "PAT_VL1"
+// LOWER: pto.pset_b16 "PAT_VL1"
 // LOWER: pto.vsts {{.*}} : !pto.vreg<128xf16>, {{(!pto\.ptr)?<f16, ub>}}, !pto.mask<b16>
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_slots8_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_slots8_store.pto
@@ -36,7 +36,7 @@ module {
 
 // LOWER-LABEL: func.func @vmi_layout_assignment_group_reduce_slots8_store(
 // LOWER: %[[SUM:.*]] = pto.vcgadd %arg0, %arg1 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-// LOWER: %[[STORE_MASK:.*]] = pto.pge_b32 "PAT_VL8" : !pto.mask<b32>
+// LOWER: %[[STORE_MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // LOWER: pto.vsts %[[SUM]], %arg2[%arg3], %[[STORE_MASK]] : !pto.vreg<64xf32>, {{(!pto\.ptr)?<f32, ub>}}, !pto.mask<b32>
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_group_slot_broadcast_partial_packet.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_slot_broadcast_partial_packet.pto
@@ -42,14 +42,14 @@ module {
 // CHECK-NOT: pto.vmi.
 
 // CHECK-LABEL: func.func @partial_group_slots_2(
-// CHECK: pto.pge_b32 "PAT_VL2"
+// CHECK: pto.pset_b32 "PAT_VL2"
 // CHECK: pto.vsldb
 // CHECK: pto.vshrs
 // CHECK: pto.vselr
 // CHECK-NOT: pto.vmi.
 
 // CHECK-LABEL: func.func @partial_group_slots_4(
-// CHECK: pto.pge_b32 "PAT_VL4"
+// CHECK: pto.pset_b32 "PAT_VL4"
 // CHECK: pto.vsldb
 // CHECK: pto.vshrs
 // CHECK: pto.vselr

--- a/test/lit/vmi_new/vmi_layout_assignment_group_slot_load_dual_layout.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_slot_load_dual_layout.pto
@@ -63,7 +63,7 @@ module {
 // ASSIGN-SAME: -> !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 1>>
 
 // LOWER-LABEL: func.func @vmi_layout_assignment_group_slot_load_dual_layout(
-// LOWER: pto.pge_b32 "PAT_VL8"
+// LOWER: pto.pset_b32 "PAT_VL8"
 // LOWER: pto.vsldb
 // LOWER: pto.vsts {{.*}}, %arg21[%arg23], {{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
 // LOWER-COUNT-8: pto.vsldb

--- a/test/lit/vmi_new/vmi_layout_assignment_group_store_slots1_unit_stride.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_store_slots1_unit_stride.pto
@@ -27,7 +27,7 @@ module {
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_store_slots1_unit_stride(
 // CHECK-COUNT-8: pto.vcadd
-// CHECK: pto.pge_b32 "PAT_VL1" : !pto.mask<b32>
+// CHECK: pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK-COUNT-8: pto.vsts {{.*}} {dist = "1PT_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_intlv_mask_f16.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_intlv_mask_f16.pto
@@ -39,10 +39,10 @@ module {
 // ASSIGN-SAME: !pto.vmi.mask<64xb16, #pto.vmi.layout<contiguous>>
 
 // LOWER-LABEL: func.func @vmi_layout_assignment_intlv_mask_f16(
-// LOWER: pto.pge_b32 "PAT_ALL"
-// LOWER: pto.pge_b16 "PAT_VL64"
+// LOWER: pto.pset_b32 "PAT_ALL"
+// LOWER: pto.pset_b16 "PAT_VL64"
 // LOWER: pto.vdintlv
-// LOWER: pto.pge_b16 "PAT_VL64"
+// LOWER: pto.pset_b16 "PAT_VL64"
 // LOWER: pto.vintlv
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_non_load_s32_reduce.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_non_load_s32_reduce.pto
@@ -53,7 +53,7 @@ module {
 // LOWER-COUNT-4: pto.vdup %arg1
 // LOWER-COUNT-7: pto.vadd {{.*}}, {{.*}}, {{.*}} : !pto.vreg<64xf32>
 // LOWER: pto.vcgadd
-// LOWER: %[[VL8:.*]] = pto.pge_b32 "PAT_VL8" : !pto.mask<b32>
+// LOWER: %[[VL8:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // LOWER: pto.vsts {{.*}}, %arg2[%arg3], {{.*}} : !pto.vreg<64xf32>, {{(!pto\.ptr)?<f32, ub>}}, !pto.mask<b32>
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_widen_reduce_priority.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_widen_reduce_priority.pto
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under
+// the terms and conditions of CANN Open Software License Agreement Version 2.0
+// (the "License"). Please refer to the License for details. You may not use
+// this file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON
+// AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER --implicit-check-not=pto.vintlv
+
+module {
+  func.func @vmi_layout_assignment_widen_reduce_priority(
+      %input: !pto.vmi.vreg<256xsi16>,
+      %mask: !pto.vmi.mask<256xpred>) -> !pto.vmi.vreg<8xsi32> {
+    %wide = pto.vmi.extsi %input
+        : !pto.vmi.vreg<256xsi16> -> !pto.vmi.vreg<256xsi32>
+    %sum = pto.vmi.group_reduce_addi %wide, %mask
+        {num_groups = 8 : i64, reassoc}
+        : !pto.vmi.vreg<256xsi32>, !pto.vmi.mask<256xpred>
+        -> !pto.vmi.vreg<8xsi32>
+    return %sum : !pto.vmi.vreg<8xsi32>
+  }
+}
+
+// ASSIGN-LABEL: func.func @vmi_layout_assignment_widen_reduce_priority(
+// ASSIGN: %[[INPUT:.*]] = pto.vmi.ensure_layout %arg0
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xsi16, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[WIDE:.*]] = pto.vmi.extsi %[[INPUT]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xsi32, #pto.vmi.layout<deinterleaved = 4>>
+// ASSIGN-NOT: pto.vmi.ensure_layout %[[WIDE]]
+// ASSIGN: pto.vmi.group_reduce_addi %[[WIDE]]
+
+// LOWER-LABEL: func.func @vmi_layout_assignment_widen_reduce_priority(
+// LOWER: pto.vdintlv
+// LOWER-NOT: pto.vdintlv
+// LOWER-COUNT-4: pto.vcvt
+// LOWER-NOT: pto.vdintlv
+// LOWER: pto.vcgadd
+// LOWER-NOT: pto.vmi.
+// LOWER-NOT: !pto.vmi.
+// LOWER-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_pre_assignment_combine_contiguous_group_load.pto
+++ b/test/lit/vmi_new/vmi_pre_assignment_combine_contiguous_group_load.pto
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-pre-assignment-combine | FileCheck %s --check-prefix=COMBINE
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-pre-assignment-combine -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER
+
+module {
+  func.func @contiguous_bf16_group_load(
+      %src: !pto.ptr<bf16, ub>,
+      %off: index) -> !pto.vmi.vreg<8xui16> {
+    %c256 = arith.constant 256 : index
+    %mask = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xpred>
+    %c32640_i16 = arith.constant 32640 : i16
+    %c32640_ui16 = builtin.unrealized_conversion_cast %c32640_i16
+        : i16 to ui16
+    %exp_mask = pto.vmi.vbrc %c32640_ui16
+        : ui16 -> !pto.vmi.vreg<256xui16>
+    %c32 = arith.constant 32 : index
+    %x = pto.vmi.vload %src[%off], %c32 {group = 8}
+        : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+    %bits = pto.vmi.vinterpret_cast %x
+        : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xui16>
+    %exp = pto.vmi.vand %bits, %exp_mask, %mask
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<256xui16>,
+          !pto.vmi.mask<256xpred> -> !pto.vmi.vreg<256xui16>
+    %max = pto.vmi.vcmax %exp, %mask {group = 8}
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.mask<256xpred>
+          -> !pto.vmi.vreg<8xui16>
+    return %max : !pto.vmi.vreg<8xui16>
+  }
+
+  func.func @contiguous_ui8_group_load(
+      %src: !pto.ptr<ui8, ub>,
+      %off: index) -> !pto.vmi.vreg<64xui8> {
+    %c16 = arith.constant 16 : index
+    %value = pto.vmi.vload %src[%off], %c16 {group = 4}
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<64xui8>
+    return %value : !pto.vmi.vreg<64xui8>
+  }
+
+  func.func @contiguous_f32_group_load(
+      %src: !pto.ptr<f32, ub>,
+      %off: index) -> !pto.vmi.vreg<128xf32> {
+    %c8 = arith.constant 8 : index
+    %value = pto.vmi.vload %src[%off], %c8 {group = 16}
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
+    return %value : !pto.vmi.vreg<128xf32>
+  }
+
+  func.func @contiguous_si16_group_load(
+      %src: !pto.ptr<si16, ub>,
+      %off: index) -> !pto.vmi.vreg<128xsi16> {
+    %c16 = arith.constant 16 : index
+    %value = pto.vmi.vload %src[%off], %c16 {group = 8}
+        : !pto.ptr<si16, ub> -> !pto.vmi.vreg<128xsi16>
+    return %value : !pto.vmi.vreg<128xsi16>
+  }
+}
+
+// COMBINE-LABEL: func.func @contiguous_bf16_group_load
+// COMBINE: %[[LOAD:.*]] = pto.vmi.load
+// COMBINE-NOT: pto.vmi.group_load
+// COMBINE: pto.vmi.bitcast %[[LOAD]]
+
+// COMBINE-LABEL: func.func @contiguous_ui8_group_load
+// COMBINE: pto.vmi.load
+// COMBINE-NOT: pto.vmi.group_load
+
+// COMBINE-LABEL: func.func @contiguous_f32_group_load
+// COMBINE: pto.vmi.load
+// COMBINE-NOT: pto.vmi.group_load
+
+// COMBINE-LABEL: func.func @contiguous_si16_group_load
+// COMBINE: pto.vmi.load
+// COMBINE-NOT: pto.vmi.group_load
+
+// LOWER-LABEL: func.func @contiguous_bf16_group_load
+// LOWER: %[[LOW:.*]], %[[HIGH:.*]] = pto.vldsx2 {{.*}}, "DINTLV_B16" : !pto.ptr<bf16, ub>, index -> !pto.vreg<128xbf16>, !pto.vreg<128xbf16>
+// LOWER-NEXT: %{{.*}} = pto.vbitcast %[[LOW]]
+// LOWER-NEXT: %{{.*}} = pto.vbitcast %[[HIGH]]
+// LOWER: pto.vmax
+// LOWER-NEXT: pto.vcgmax

--- a/test/lit/vmi_new/vmi_pre_assignment_combine_noncontiguous_group_load.pto
+++ b/test/lit/vmi_new/vmi_pre_assignment_combine_noncontiguous_group_load.pto
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-pre-assignment-combine | FileCheck %s
+
+module {
+  func.func @strided_bf16_group_load(
+      %src: !pto.ptr<bf16, ub>, %off: index) -> !pto.vmi.vreg<256xbf16> {
+    %c40 = arith.constant 40 : index
+    %x = pto.vmi.vload %src[%off], %c40 {group = 8}
+        : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+    return %x : !pto.vmi.vreg<256xbf16>
+  }
+
+  func.func @dynamic_stride_bf16_group_load(
+      %src: !pto.ptr<bf16, ub>, %off: index, %stride: index)
+      -> !pto.vmi.vreg<256xbf16> {
+    %x = pto.vmi.vload %src[%off], %stride {group = 8}
+        : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+    return %x : !pto.vmi.vreg<256xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @strided_bf16_group_load
+// CHECK: pto.vmi.group_load
+
+// CHECK-LABEL: func.func @dynamic_stride_bf16_group_load
+// CHECK: pto.vmi.group_load

--- a/test/lit/vmi_new/vmi_to_vpto_create_mask.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_create_mask.pto
@@ -55,32 +55,32 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_create_mask_contiguous
-// CHECK: %[[M0:.*]] = pto.pge_b32 "PAT_ALL" : !pto.mask<b32>
-// CHECK: %[[M1:.*]] = pto.pge_b32 "PAT_VL32" : !pto.mask<b32>
+// CHECK: %[[M0:.*]] = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+// CHECK: %[[M1:.*]] = pto.pset_b32 "PAT_VL32" : !pto.mask<b32>
 // CHECK: return %[[M0]], %[[M1]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_create_mask_deint2
-// CHECK: %[[P0:.*]] = pto.pge_b32 "PAT_VL32" : !pto.mask<b32>
-// CHECK: %[[P1:.*]] = pto.pge_b32 "PAT_VL32" : !pto.mask<b32>
+// CHECK: %[[P0:.*]] = pto.pset_b32 "PAT_VL32" : !pto.mask<b32>
+// CHECK: %[[P1:.*]] = pto.pset_b32 "PAT_VL32" : !pto.mask<b32>
 // CHECK: return %[[P0]], %[[P1]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_create_mask_b8_contiguous
-// CHECK: %[[B8_0:.*]] = pto.pge_b8 "PAT_ALL" : !pto.mask<b8>
-// CHECK: %[[B8_1:.*]] = pto.pge_b8 "PAT_VL64" : !pto.mask<b8>
+// CHECK: %[[B8_0:.*]] = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+// CHECK: %[[B8_1:.*]] = pto.pset_b8 "PAT_VL64" : !pto.mask<b8>
 // CHECK: return %[[B8_0]], %[[B8_1]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_create_mask_b16_deint2
-// CHECK: %[[B16_0:.*]] = pto.pge_b16 "PAT_VL32" : !pto.mask<b16>
-// CHECK: %[[B16_1:.*]] = pto.pge_b16 "PAT_VL32" : !pto.mask<b16>
+// CHECK: %[[B16_0:.*]] = pto.pset_b16 "PAT_VL32" : !pto.mask<b16>
+// CHECK: %[[B16_1:.*]] = pto.pset_b16 "PAT_VL32" : !pto.mask<b16>
 // CHECK: return %[[B16_0]], %[[B16_1]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_group_reduce_partial_slots8.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_reduce_partial_slots8.pto
@@ -59,7 +59,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_reduce_f16_s64_g4(
-// CHECK-DAG: %[[SLOT4:.*]] = pto.pge_b16 "PAT_VL4" : !pto.mask<b16>
+// CHECK-DAG: %[[SLOT4:.*]] = pto.pset_b16 "PAT_VL4" : !pto.mask<b16>
 // CHECK-COUNT-4: pto.vcgadd
 // CHECK-COUNT-3: pto.vadd {{.*}}, {{.*}}, %[[SLOT4]]
 // CHECK: %[[WORDS4:.*]] = pto.vbitcast {{.*}} : !pto.vreg<128xf16> -> !pto.vreg<64xui32>
@@ -69,7 +69,7 @@ module {
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_reduce_f16_s64_g8(
-// CHECK-DAG: %[[SLOT8:.*]] = pto.pge_b16 "PAT_VL8" : !pto.mask<b16>
+// CHECK-DAG: %[[SLOT8:.*]] = pto.pset_b16 "PAT_VL8" : !pto.mask<b16>
 // CHECK-COUNT-4: pto.vcgadd
 // CHECK-COUNT-3: pto.vadd {{.*}}, {{.*}}, %[[SLOT8]]
 // CHECK: %[[WORDS8:.*]] = pto.vbitcast {{.*}} : !pto.vreg<128xf16> -> !pto.vreg<64xui32>
@@ -79,15 +79,15 @@ module {
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_reduce_f16_s64_g12(
-// CHECK: %[[SLOT8_12:.*]] = pto.pge_b16 "PAT_VL8" : !pto.mask<b16>
+// CHECK: %[[SLOT8_12:.*]] = pto.pset_b16 "PAT_VL8" : !pto.mask<b16>
 // CHECK-COUNT-4: pto.vcgadd
 // CHECK-COUNT-3: pto.vadd {{.*}}, {{.*}}, %[[SLOT8_12]]
-// CHECK: %[[SLOT4_12:.*]] = pto.pge_b16 "PAT_VL4" : !pto.mask<b16>
+// CHECK: %[[SLOT4_12:.*]] = pto.pset_b16 "PAT_VL4" : !pto.mask<b16>
 // CHECK-COUNT-4: pto.vcgadd
 // CHECK-COUNT-3: pto.vadd {{.*}}, {{.*}}, %[[SLOT4_12]]
-// CHECK: %[[STORE8_12:.*]] = pto.pge_b16 "PAT_VL8" : !pto.mask<b16>
+// CHECK: %[[STORE8_12:.*]] = pto.pset_b16 "PAT_VL8" : !pto.mask<b16>
 // CHECK: pto.vsts {{.*}}, {{.*}}, %[[STORE8_12]]
-// CHECK: %[[STORE4_12:.*]] = pto.pge_b16 "PAT_VL4" : !pto.mask<b16>
+// CHECK: %[[STORE4_12:.*]] = pto.pset_b16 "PAT_VL4" : !pto.mask<b16>
 // CHECK: pto.vsts {{.*}}, {{.*}}, %[[STORE4_12]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_group_reduce_typed.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_reduce_typed.pto
@@ -70,7 +70,7 @@ module {
 // CHECK: return %[[SUM]]
 
 // CHECK-LABEL: func.func @vmi_group_reduce_addi_i32_two_vlane(
-// CHECK: %[[MASK:.*]] = pto.pge_b32 "PAT_VL8" : !pto.mask<b32>
+// CHECK: %[[MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // CHECK: %[[SLO:.*]] = pto.vcgadd %arg0, %arg2
 // CHECK: %[[SHI:.*]] = pto.vcgadd %arg1, %arg3
 // CHECK: %[[SUM:.*]] = pto.vadd %[[SLO]], %[[SHI]], %[[MASK]]

--- a/test/lit/vmi_new/vmi_to_vpto_group_slot_load.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_slot_load.pto
@@ -143,7 +143,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_load_slots8(
-// CHECK: %[[MASK:.*]] = pto.pge_b32 "PAT_VL8" : !pto.mask<b32>
+// CHECK: %[[MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // CHECK: %[[BASE:.*]] = pto.addptr %arg0, %arg1 : <f32, ub> -> <f32, ub>
 // CHECK: %[[OUT:.*]] = pto.vsldb %[[BASE]], {{.*}}, {{.*}}, %[[MASK]] : !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: return %[[OUT]]
@@ -152,22 +152,22 @@ module {
 // CHECK-COUNT-8: pto.vsldb
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_load_slots8_store(
-// CHECK: %[[LOAD_MASK:.*]] = pto.pge_b32 "PAT_VL8" : !pto.mask<b32>
+// CHECK: %[[LOAD_MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // CHECK: %[[BASE:.*]] = pto.addptr %arg0, %arg2 : <f32, ub> -> <f32, ub>
 // CHECK: %[[OUT:.*]] = pto.vsldb %[[BASE]], {{.*}}, {{.*}}, %[[LOAD_MASK]]
-// CHECK: %[[STORE_MASK:.*]] = pto.pge_b32 "PAT_VL8" : !pto.mask<b32>
+// CHECK: %[[STORE_MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // CHECK: pto.vsts %[[OUT]], %arg1[%arg2], %[[STORE_MASK]] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_load_u8_scale_broadcast(
-// CHECK: pto.pge_b8 "PAT_VL8" : !pto.mask<b8>
+// CHECK: pto.pset_b8 "PAT_VL8" : !pto.mask<b8>
 // CHECK: %[[U8:.*]] = pto.vsldb {{.*}} : !pto.ptr<ui8, ub>, i16, i16, !pto.mask<b8> -> !pto.vreg<256xui8>
 // CHECK: %[[U16:.*]] = pto.vzunpack %[[U8]]
 // CHECK: %[[U32:.*]] = pto.vzunpack %[[U16]]
 // CHECK: pto.vbitcast %[[U32]] : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
-// CHECK: pto.pge_b8 "PAT_VL32" : !pto.mask<b8>
+// CHECK: pto.pset_b8 "PAT_VL32" : !pto.mask<b8>
 // CHECK: pto.vcvt {{.*}} {part = "P0"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
 // CHECK: pto.vshl
 // CHECK: pto.vselr
@@ -177,11 +177,11 @@ module {
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_load_u16_broadcast(
-// CHECK: pto.pge_b16 "PAT_VL8" : !pto.mask<b16>
+// CHECK: pto.pset_b16 "PAT_VL8" : !pto.mask<b16>
 // CHECK: %[[U16:.*]] = pto.vsldb {{.*}} : !pto.ptr<ui16, ub>, i16, i16, !pto.mask<b16> -> !pto.vreg<128xui16>
 // CHECK: %[[U32:.*]] = pto.vzunpack %[[U16]]
 // CHECK: pto.vbitcast %[[U32]] : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
-// CHECK: pto.pge_b16 "PAT_VL16" : !pto.mask<b16>
+// CHECK: pto.pset_b16 "PAT_VL16" : !pto.mask<b16>
 // CHECK: pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
 // CHECK: pto.vsts {{.*}} : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
 // CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_group_slot_load_support.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_slot_load_support.pto
@@ -23,7 +23,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_load_support(
-// CHECK: pto.pge_b32 "PAT_VL8"
+// CHECK: pto.pset_b32 "PAT_VL8"
 // CHECK: pto.vsldb
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_group_slot_truncf_slots1.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_slot_truncf_slots1.pto
@@ -30,7 +30,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_truncf_slots1(
-// CHECK-DAG: %[[VL1:.*]] = pto.pge_b32 "PAT_VL1"
+// CHECK-DAG: %[[VL1:.*]] = pto.pset_b32 "PAT_VL1"
 // CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1]] {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
 // CHECK: return {{.*}} : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.vreg<128xf16>
 // CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_group_slot_truncf_slots8.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_slot_truncf_slots8.pto
@@ -29,7 +29,7 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_truncf_slots8(
 // CHECK: %[[SRC:.*]] = pto.vsldb
-// CHECK: %[[MASK:.*]] = pto.pge_b32 "PAT_VL8" : !pto.mask<b32>
+// CHECK: %[[MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // CHECK: %[[OUT:.*]] = pto.vcvt %[[SRC]], %[[MASK]] {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
 // CHECK: return %[[OUT]]
 // CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_group_store_compact_small.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_store_compact_small.pto
@@ -172,7 +172,7 @@ module {
 // LOWER-NOT: dist = "PK_B16"
 // LOWER-NOT: dist = "PK4_B32"
 // LOWER-LABEL: func.func @aligned_compact_group_store_bf16(
-// LOWER: %[[MASK:.*]] = pto.pge_b16 "PAT_VL8" : !pto.mask<b16>
+// LOWER: %[[MASK:.*]] = pto.pset_b16 "PAT_VL8" : !pto.mask<b16>
 // LOWER: pto.vsts %arg0, %{{.*}}[%{{.*}}], %[[MASK]] {dist = "NORM_B16"} : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.mask<b16>
 // LOWER-NOT: dist = "1PT_B32"
 // LOWER-LABEL: func.func @aligned_compact_group_store_bf16_across_addptr(

--- a/test/lit/vmi_new/vmi_to_vpto_integer_casts.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_integer_casts.pto
@@ -337,49 +337,49 @@ module {
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extui_slots1_ui8_to_ui16(
-// CHECK: %[[VL1:.*]] = pto.pge_b8 "PAT_VL1" : !pto.mask<b8>
+// CHECK: %[[VL1:.*]] = pto.pset_b8 "PAT_VL1" : !pto.mask<b8>
 // CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1]] {part = "EVEN"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<128xui16>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extui_slots1_ui8_to_ui32(
-// CHECK: %[[VL1U8:.*]] = pto.pge_b8 "PAT_VL1" : !pto.mask<b8>
+// CHECK: %[[VL1U8:.*]] = pto.pset_b8 "PAT_VL1" : !pto.mask<b8>
 // CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1U8]] {part = "P0"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extui_slots1_ui16_to_ui32(
-// CHECK: %[[VL1U16EXT:.*]] = pto.pge_b16 "PAT_VL1" : !pto.mask<b16>
+// CHECK: %[[VL1U16EXT:.*]] = pto.pset_b16 "PAT_VL1" : !pto.mask<b16>
 // CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1U16EXT]] {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extui_slots8_ui8_to_ui16(
-// CHECK: %[[VL16:.*]] = pto.pge_b8 "PAT_VL16" : !pto.mask<b8>
+// CHECK: %[[VL16:.*]] = pto.pset_b8 "PAT_VL16" : !pto.mask<b8>
 // CHECK: pto.vcvt {{.*}}, %[[VL16]] {part = "EVEN"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<128xui16>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extui_slots8_ui8_to_ui32(
-// CHECK: %[[VL32:.*]] = pto.pge_b8 "PAT_VL32" : !pto.mask<b8>
+// CHECK: %[[VL32:.*]] = pto.pset_b8 "PAT_VL32" : !pto.mask<b8>
 // CHECK: pto.vcvt {{.*}}, %[[VL32]] {part = "P0"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extsi_slots8_si16_to_si32(
-// CHECK: %[[VL16S:.*]] = pto.pge_b16 "PAT_VL16" : !pto.mask<b16>
+// CHECK: %[[VL16S:.*]] = pto.pset_b16 "PAT_VL16" : !pto.mask<b16>
 // CHECK: pto.vcvt {{.*}}, %[[VL16S]] {part = "EVEN"} : !pto.vreg<128xsi16>, !pto.mask<b16> -> !pto.vreg<64xsi32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_trunci_slots1_ui16_to_ui8(
-// CHECK: %[[VL1U16:.*]] = pto.pge_b16 "PAT_VL1" : !pto.mask<b16>
+// CHECK: %[[VL1U16:.*]] = pto.pset_b16 "PAT_VL1" : !pto.mask<b16>
 // CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1U16]] {part = "EVEN", sat = "SAT"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<256xui8>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_trunci_slots1_ui32_to_ui16(
-// CHECK: %[[VL1U32:.*]] = pto.pge_b32 "PAT_VL1" : !pto.mask<b32>
+// CHECK: %[[VL1U32:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1U32]] {part = "EVEN", sat = "SAT"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<128xui16>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_integer_casts.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_integer_casts.pto
@@ -329,7 +329,7 @@ module {
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_trunci_slots8_i32_to_ui8(
-// CHECK: pto.pge_b32 "PAT_VL8"
+// CHECK: pto.pset_b32 "PAT_VL8"
 // CHECK: pto.vcvt {{.*}} {part = "P0", sat = "SAT"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<256xui8>
 // CHECK: pto.vsts
 // CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addf.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addf.pto
@@ -25,7 +25,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_addf(
-// CHECK: %[[FIRST:.*]] = pto.pge_b32 "PAT_VL1" : !pto.mask<b32>
+// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[REDUCED:.*]] = pto.vcadd %arg0, %arg1 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: pto.vadd %[[REDUCED]], {{.*}}, %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addf_f16.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addf_f16.pto
@@ -25,7 +25,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_addf_f16(
-// CHECK: %[[LANE0:.*]] = pto.pge_b16 "PAT_VL1" : !pto.mask<b16>
+// CHECK: %[[LANE0:.*]] = pto.pset_b16 "PAT_VL1" : !pto.mask<b16>
 // CHECK: %[[REDUCED:.*]] = pto.vcadd %arg0, %arg1
 // CHECK-SAME: !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
 // CHECK: pto.vadd %[[REDUCED]], {{.*}}, %[[LANE0]]

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addf_multichunk.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addf_multichunk.pto
@@ -41,7 +41,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_addf_multichunk(
-// CHECK: %[[FIRST:.*]] = pto.pge_b32 "PAT_VL1" : !pto.mask<b32>
+// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[RED0:.*]] = pto.vcadd %arg0, %arg2 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: pto.vadd %[[RED0]], {{.*}}, %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: %[[RED1:.*]] = pto.vcadd %arg1, %arg3 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addf_store.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addf_store.pto
@@ -60,8 +60,8 @@ module {
 // LOWER-SAME: %[[DST_BF16:[^,]+]]: !pto.ptr<bf16, ub>
 // LOWER-SAME: %[[DST:[^,]+]]: !pto.ptr<f32, ub>
 // LOWER-SAME: %[[OFF:[^)]+]]: index
-// LOWER: %[[REDUCE_MASK:.*]] = pto.pge_b32 "PAT_ALL"
-// LOWER: %[[STORE_MASK:.*]] = pto.pge_b32 "PAT_VL1"
+// LOWER: %[[REDUCE_MASK:.*]] = pto.pset_b32 "PAT_ALL"
+// LOWER: %[[STORE_MASK:.*]] = pto.pset_b32 "PAT_VL1"
 // LOWER: %[[ALL:.*]] = pto.pset_b32 "PAT_ALL"
 // LOWER: %[[SUM:.*]] = pto.vadd %[[SRC]], %[[RHS]], %[[ALL]]
 // LOWER: pto.vsts {{.*}}, %[[DST_BF16]][%[[OFF]]], {{.*}} {dist = "PK_B32"}

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addi.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addi.pto
@@ -25,7 +25,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_addi(
-// CHECK: %[[FIRST:.*]] = pto.pge_b32 "PAT_VL1" : !pto.mask<b32>
+// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[REDUCED:.*]] = pto.vcadd %arg0, %arg1 : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
 // CHECK: pto.vadd %[[REDUCED]], {{.*}}, %[[FIRST]] : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
 // CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addi_multichunk.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addi_multichunk.pto
@@ -41,7 +41,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_addi_multichunk(
-// CHECK: %[[FIRST:.*]] = pto.pge_b32 "PAT_VL1" : !pto.mask<b32>
+// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[RED0:.*]] = pto.vcadd %arg0, %arg2 : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
 // CHECK: pto.vadd %[[RED0]], {{.*}}, %[[FIRST]] : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
 // CHECK: %[[RED1:.*]] = pto.vcadd %arg1, %arg3 : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_maxf_multichunk.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_maxf_multichunk.pto
@@ -55,7 +55,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_maxf_multichunk(
-// CHECK: %[[FIRST:.*]] = pto.pge_b32 "PAT_VL1" : !pto.mask<b32>
+// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[RED0:.*]] = pto.vcmax %arg0, %arg2 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: pto.vmax %[[RED0]], {{.*}}, %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: %[[RED1:.*]] = pto.vcmax %arg1, %arg3 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
@@ -65,7 +65,7 @@ module {
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_minf_multichunk(
-// CHECK: %[[FIRST:.*]] = pto.pge_b32 "PAT_VL1" : !pto.mask<b32>
+// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[RED0:.*]] = pto.vcmin %arg0, %arg2 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: pto.vmin %[[RED0]], {{.*}}, %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: %[[RED1:.*]] = pto.vcmin %arg1, %arg3 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_minf.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_minf.pto
@@ -25,7 +25,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_minf(
-// CHECK: %[[FIRST:.*]] = pto.pge_b16 "PAT_VL1" : !pto.mask<b16>
+// CHECK: %[[FIRST:.*]] = pto.pset_b16 "PAT_VL1" : !pto.mask<b16>
 // CHECK: %[[REDUCED:.*]] = pto.vcmin %arg0, %arg1 : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
 // CHECK: %[[OUT:.*]] = pto.vmin %[[REDUCED]], {{.*}}, %[[FIRST]] : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
 // CHECK: return %[[OUT]]

--- a/test/lit/vpto/vpto_mask_simplify.pto
+++ b/test/lit/vpto/vpto_mask_simplify.pto
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vpto-mask-simplify | FileCheck %s
+
+module {
+  func.func @pintlv_b8_pset() -> (!pto.mask<b8>, !pto.mask<b8>) {
+    %lhs = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+    %rhs = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+    %low, %high = pto.pintlv_b8 %lhs, %rhs
+        : !pto.mask<b8>, !pto.mask<b8> -> !pto.mask<b8>, !pto.mask<b8>
+    return %low, %high : !pto.mask<b8>, !pto.mask<b8>
+  }
+
+  func.func @pintlv_b16_pge() -> (!pto.mask<b16>, !pto.mask<b16>) {
+    %lhs = pto.pge_b16 "PAT_ALL" : !pto.mask<b16>
+    %rhs = pto.pge_b16 "PAT_ALL" : !pto.mask<b16>
+    %low, %high = pto.pintlv_b16 %lhs, %rhs
+        : !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>, !pto.mask<b16>
+    return %low, %high : !pto.mask<b16>, !pto.mask<b16>
+  }
+
+  func.func @pintlv_b32_mixed() -> (!pto.mask<b32>, !pto.mask<b32>) {
+    %lhs = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %rhs = pto.pge_b32 "PAT_ALL" : !pto.mask<b32>
+    %low, %high = pto.pintlv_b32 %lhs, %rhs
+        : !pto.mask<b32>, !pto.mask<b32> -> !pto.mask<b32>, !pto.mask<b32>
+    return %low, %high : !pto.mask<b32>, !pto.mask<b32>
+  }
+
+  func.func @pdintlv_b8_pge() -> (!pto.mask<b8>, !pto.mask<b8>) {
+    %lhs = pto.pge_b8 "PAT_ALL" : !pto.mask<b8>
+    %rhs = pto.pge_b8 "PAT_ALL" : !pto.mask<b8>
+    %low, %high = pto.pdintlv_b8 %lhs, %rhs
+        : !pto.mask<b8>, !pto.mask<b8> -> !pto.mask<b8>, !pto.mask<b8>
+    return %low, %high : !pto.mask<b8>, !pto.mask<b8>
+  }
+
+  func.func @pdintlv_b16_mixed() -> (!pto.mask<b16>, !pto.mask<b16>) {
+    %lhs = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+    %rhs = pto.pge_b16 "PAT_ALL" : !pto.mask<b16>
+    %low, %high = pto.pdintlv_b16 %lhs, %rhs
+        : !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>, !pto.mask<b16>
+    return %low, %high : !pto.mask<b16>, !pto.mask<b16>
+  }
+
+  func.func @pdintlv_b32_pset() -> (!pto.mask<b32>, !pto.mask<b32>) {
+    %lhs = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %rhs = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %low, %high = pto.pdintlv_b32 %lhs, %rhs
+        : !pto.mask<b32>, !pto.mask<b32> -> !pto.mask<b32>, !pto.mask<b32>
+    return %low, %high : !pto.mask<b32>, !pto.mask<b32>
+  }
+
+  func.func @nonuniform_pintlv_is_preserved()
+      -> (!pto.mask<b16>, !pto.mask<b16>) {
+    %lhs = pto.pge_b16 "PAT_ALL" : !pto.mask<b16>
+    %rhs = pto.pge_b16 "PAT_VL8" : !pto.mask<b16>
+    %low, %high = pto.pintlv_b16 %lhs, %rhs
+        : !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>, !pto.mask<b16>
+    return %low, %high : !pto.mask<b16>, !pto.mask<b16>
+  }
+
+  func.func @identical_nonuniform_pdintlv_is_preserved()
+      -> (!pto.mask<b32>, !pto.mask<b32>) {
+    %mask = pto.pge_b32 "PAT_VL1" : !pto.mask<b32>
+    %low, %high = pto.pdintlv_b32 %mask, %mask
+        : !pto.mask<b32>, !pto.mask<b32> -> !pto.mask<b32>, !pto.mask<b32>
+    return %low, %high : !pto.mask<b32>, !pto.mask<b32>
+  }
+
+  func.func @all_true_reorder_preserves_external_uses()
+      -> (!pto.mask<b16>, !pto.mask<b16>, !pto.mask<b16>, !pto.mask<b16>) {
+    %lhs = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+    %rhs = pto.pge_b16 "PAT_ALL" : !pto.mask<b16>
+    %low, %high = pto.pintlv_b16 %lhs, %rhs
+        : !pto.mask<b16>, !pto.mask<b16> -> !pto.mask<b16>, !pto.mask<b16>
+    return %low, %high, %lhs, %rhs
+        : !pto.mask<b16>, !pto.mask<b16>, !pto.mask<b16>, !pto.mask<b16>
+  }
+}
+
+// CHECK-LABEL: func.func @pintlv_b8_pset
+// CHECK: %[[LHS:.*]] = pto.pset_b8 "PAT_ALL"
+// CHECK: %[[RHS:.*]] = pto.pset_b8 "PAT_ALL"
+// CHECK-NOT: pto.pintlv_b8
+// CHECK: return %[[LHS]], %[[RHS]]
+
+// CHECK-LABEL: func.func @pintlv_b16_pge
+// CHECK-NOT: pto.pintlv_b16
+// CHECK: return %[[LHS:.*]], %[[RHS:.*]]
+
+// CHECK-LABEL: func.func @pintlv_b32_mixed
+// CHECK-NOT: pto.pintlv_b32
+// CHECK: return %[[LHS:.*]], %[[RHS:.*]]
+
+// CHECK-LABEL: func.func @pdintlv_b8_pge
+// CHECK-NOT: pto.pdintlv_b8
+// CHECK: return %[[LHS:.*]], %[[RHS:.*]]
+
+// CHECK-LABEL: func.func @pdintlv_b16_mixed
+// CHECK-NOT: pto.pdintlv_b16
+// CHECK: return %[[LHS:.*]], %[[RHS:.*]]
+
+// CHECK-LABEL: func.func @pdintlv_b32_pset
+// CHECK-NOT: pto.pdintlv_b32
+// CHECK: return %[[LHS:.*]], %[[RHS:.*]]
+
+// CHECK-LABEL: func.func @nonuniform_pintlv_is_preserved
+// CHECK: pto.pintlv_b16
+
+// CHECK-LABEL: func.func @identical_nonuniform_pdintlv_is_preserved
+// CHECK: pto.pdintlv_b32
+
+// CHECK-LABEL: func.func @all_true_reorder_preserves_external_uses
+// CHECK: %[[LHS:.*]] = pto.pset_b16 "PAT_ALL"
+// CHECK: %[[RHS:.*]] = pto.pge_b16 "PAT_ALL"
+// CHECK-NOT: pto.pintlv_b16
+// CHECK: return %[[LHS]], %[[RHS]], %[[LHS]], %[[RHS]]

--- a/test/lit/vpto/vsts_1pt_mask_vpto_llvm.pto
+++ b/test/lit/vpto/vsts_1pt_mask_vpto_llvm.pto
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+// RUN: ptoas --cann-output-version=9.0.0-beta.1 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @one_point_only(
+      %src8: !pto.ptr<ui8, ub>,
+      %src16: !pto.ptr<ui16, ub>,
+      %src32: !pto.ptr<ui32, ub>,
+      %dst8: !pto.ptr<ui8, ub>,
+      %dst16: !pto.ptr<ui16, ub>,
+      %dst32: !pto.ptr<ui32, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %value8 = pto.vlds %src8[%c0]
+          : !pto.ptr<ui8, ub> -> !pto.vreg<256xui8>
+      %value16 = pto.vlds %src16[%c0]
+          : !pto.ptr<ui16, ub> -> !pto.vreg<128xui16>
+      %value32 = pto.vlds %src32[%c0]
+          : !pto.ptr<ui32, ub> -> !pto.vreg<64xui32>
+      %mask8 = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %mask16 = pto.pge_b16 "PAT_ALL" : !pto.mask<b16>
+      %mask32 = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      pto.vsts %value8, %dst8[%c0], %mask8 {dist = "1PT_B8"}
+          : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b8>
+      pto.vsts %value16, %dst16[%c0], %mask16 {dist = "1PT_B16"}
+          : !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
+      pto.vsts %value32, %dst32[%c0], %mask32 {dist = "1PT_B32"}
+          : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
+    }
+    return
+  }
+
+  func.func @mixed_one_point_and_normal(
+      %src: !pto.ptr<ui32, ub>,
+      %dst: !pto.ptr<ui32, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %value = pto.vlds %src[%c0]
+          : !pto.ptr<ui32, ub> -> !pto.vreg<64xui32>
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      pto.vsts %value, %dst[%c0], %mask {dist = "1PT_B32"}
+          : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
+      pto.vsts %value, %dst[%c0], %mask {dist = "NORM_B32"}
+          : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: define {{.*}}@one_point_only_mix_aiv
+// CHECK-NOT: call {{.*}}@llvm.hivm.pset
+// CHECK-NOT: call {{.*}}@llvm.hivm.pge
+// CHECK-COUNT-3: call void @llvm.hivm.vstsx1
+// CHECK-SAME: undef)
+
+// CHECK-LABEL: define {{.*}}@mixed_one_point_and_normal_mix_aiv
+// CHECK: %[[MASK:.*]] = call {{.*}}@llvm.hivm.pset
+// CHECK: call void @llvm.hivm.vstsx1{{.*}}undef)
+// CHECK: call void @llvm.hivm.vstsx1{{.*}}%[[MASK]])

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -2871,6 +2871,7 @@ static void prepareVPTOForEmission(PassManager &pm) {
   kernelModulePM.addPass(pto::createVPTOPtrNormalizePass());
   kernelModulePM.addPass(pto::createVPTOPtrCastCleanupPass());
   kernelModulePM.addPass(pto::createVPTOOptimizeVcvtPass());
+  kernelModulePM.addPass(pto::createVPTOMaskSimplifyPass());
   kernelModulePM.addPass(createReconcileUnrealizedCastsPass());
   kernelModulePM.addNestedPass<func::FuncOp>(
       createVPTOExpandWrapperOpsPass());


### PR DESCRIPTION
## 背景

VMI widen 类 workload 中存在几类相互叠加的冗余：逻辑上连续的 group load 在 layout assignment 前仍保留分组语义；静态前缀 mask 同时生成 `pge` 和 `pset`，阻碍 CSE；1PT store 携带硬件不读取的 predicate；全真 predicate 的 interleave/deinterleave 产生多余指令；窄化后立即扩展的 cast 链也可能被较弱的 layout seed 拆开并插入额外 layout materialization。

## 关联问题

- Related to https://github.com/hw-native-sys/PTOAS/issues/1024
- 端到端复现：https://github.com/learning-chip/vmi-demo/pull/30
- 原始问题说明：https://github.com/learning-chip/vmi-demo/blob/widen_issue/quant/quant_dequant/PTOAS_ASKS.md

## 修改

- 在 VMI layout assignment 前将满足 `row_stride == lane_count / group_count` 的连续 group load 规范化为普通 load，同时保留动态或非连续 stride 的 group load。
- 将 VMI lowering 生成的静态前缀 mask 统一为 `pset`，使等价静态 mask 可以被后续 CSE 合并。
- 在 CANN 9.0.0 及 beta.1 LLVM emitter 中，将 `1PT_B8/B16/B32` store 的无效 mask operand 替换为 `undef`；仅供 1PT store 使用的 `pset/pge` producer 不再生成 intrinsic，混合 NORM use 仍保留真实 mask。
- 新增 `vpto-mask-simplify`，消除输入均为 `PAT_ALL` 的 `pintlv/pdintlv`，覆盖 B8/B16/B32 以及 `pset/pge` 组合，并保留非全真重排。
- 按 layout fact 为多 chunk 的 lane-stride narrowing 分类赋予独立 cast seed phase，并沿合法 cast relation 自然传播；普通 widening 不设全局 anchor，`Reduce` 等更高优先级消费者仍可直接决定 widen 结果布局。

## 回归覆盖

- `f32 -> f16/f8 -> f32`、signed/unsigned integer 2x/4x roundtrip 不再在窄化与扩展之间插入 `ensure_layout`。
- `i16 -> i32 -> group_reduce(group=8)` 直接生成消费者需要的 `deinterleaved=4` widen 结果，不再在 widen 后生成 `vintlv/vdintlv`。
- f8 compute 路径采用 `UNPK4 + P0 vcvt`，不再生成 `vintlv`。
- 连续 group load 覆盖 bf16、ui8、si16、f32，64/128/256 lanes 和 group 4/8/16，并包含动态及非连续负例。
- mask 覆盖两套 LLVM emitter、B8/B16/B32、纯 1PT 与 1PT/NORM 混合 use、全真与非全真重排。
- 新增完整动态双缓冲 fused quant-dequant 优化守护，覆盖 `DINTLV_B16` 连续 group load、8-slot reciprocal 的直接寄存器 group broadcast、无 `VST_VLD`/`E2B_B16` 的 quant/dequant FP8 roundtrip，以及 `pset` mask canonicalization。

## 测试

- 增量构建：`pto-test-opt`、`PTOASCompiler` 通过。
- 定向 layout/pass/emitter lit：6/6 通过。
- `vmi_new/opt` lit：7/7 通过。
- 完整 `vmi_new/` lit：457/457 通过。
- 完整 `vpto/` lit：442/448 通过。6 个失败分别为缺少 `pto-vfsimt-size-patcher-test`、4 个 TileLib 常量 SSA 顺序 FileCheck、1 个 soft-postupdate 算术顺序 FileCheck，均不经过本 PR 修改路径。
- CANN 9.0.0 和 9.0.0-beta.1 的 1PT B8/B16/B32 LLVM IR 此前均已使用 Bisheng 编译为无残留 `llvm.hivm.*` 符号的 AICore relocatable object。
- `git diff --check origin/main...HEAD` 通过。
