### PR TITLE
[VMI] Cover generalized group-slot integer extensions

### DIFF
--- a/test/lit/vmi_new/vmi_to_vpto_group_slot_integer_extension_invalid.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_slot_integer_extension_invalid.pto
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under
+// the terms and conditions of CANN Open Software License Agreement Version 2.0
+// (the "License"). Please refer to the License for details. You may not use
+// this file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON
+// AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// RUN: not pto-test-opt %s -split-input-file -vmi-to-vpto 2>&1 | FileCheck %s
+
+module {
+  func.func @extui_rejects_signed(
+      %src: !pto.vmi.vreg<1xsi8, #pto.vmi.layout<num_groups = 1, slots = 1>>) {
+    %wide = pto.vmi.extui %src
+        : !pto.vmi.vreg<1xsi8, #pto.vmi.layout<num_groups = 1, slots = 1>>
+        -> !pto.vmi.vreg<1xsi16, #pto.vmi.layout<num_groups = 1, slots = 1>>
+    return
+  }
+}
+
+// CHECK: error: 'pto.vmi.extui' op requires unsigned integer source and result element types
+
+// -----
+
+module {
+  func.func @extui_rejects_signless(
+      %src: !pto.vmi.vreg<1xi8, #pto.vmi.layout<num_groups = 1, slots = 1>>) {
+    %wide = pto.vmi.extui %src
+        : !pto.vmi.vreg<1xi8, #pto.vmi.layout<num_groups = 1, slots = 1>>
+        -> !pto.vmi.vreg<1xi16, #pto.vmi.layout<num_groups = 1, slots = 1>>
+    return
+  }
+}
+
+// CHECK: error: 'pto.vmi.extui' op requires unsigned integer source and result element types
+
+// -----
+
+module {
+  func.func @extsi_rejects_unsigned(
+      %src: !pto.vmi.vreg<1xui8, #pto.vmi.layout<num_groups = 1, slots = 1>>) {
+    %wide = pto.vmi.extsi %src
+        : !pto.vmi.vreg<1xui8, #pto.vmi.layout<num_groups = 1, slots = 1>>
+        -> !pto.vmi.vreg<1xui16, #pto.vmi.layout<num_groups = 1, slots = 1>>
+    return
+  }
+}
+
+// CHECK: error: 'pto.vmi.extsi' op requires signed or signless integer source and result element types
+
+// -----
+
+module {
+  func.func @slots8_requires_natural_stride(
+      %src: !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>) {
+    %wide = pto.vmi.extui %src
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>
+        -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>
+    return
+  }
+}
+
+// CHECK: error: VMI-UNSUPPORTED: pto.vmi.extui
+// CHECK-SAME: requires a legal cast relation for the source layout
+
+// -----
+
+module {
+  func.func @slots8_rejects_wrong_stride(
+      %src: !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>) {
+    %wide = pto.vmi.extui %src
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>
+        -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>
+    return
+  }
+}
+
+// CHECK: error: VMI-UNSUPPORTED: pto.vmi.extui
+// CHECK-SAME: requires a legal cast relation for the source layout

--- a/test/lit/vmi_new/vmi_to_vpto_group_slot_integer_extension_matrix.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_slot_integer_extension_matrix.pto
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under
+// the terms and conditions of CANN Open Software License Agreement Version 2.0
+// (the "License"). Please refer to the License for details. You may not use
+// this file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON
+// AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-to-vpto | FileCheck %s
+
+// G=1 covers the complete width and signedness cross product for both layout
+// families.  G=2/4/8 vary num_groups orthogonally, while G=16/32 cross the
+// eight-groups-per-carrier boundary for all three widening relations.
+
+!g1s1u8 = !pto.vmi.vreg<1xui8, #pto.vmi.layout<num_groups = 1, slots = 1>>
+!g1s1u16 = !pto.vmi.vreg<1xui16, #pto.vmi.layout<num_groups = 1, slots = 1>>
+!g1s1u32 = !pto.vmi.vreg<1xui32, #pto.vmi.layout<num_groups = 1, slots = 1>>
+!g1s1s8 = !pto.vmi.vreg<1xsi8, #pto.vmi.layout<num_groups = 1, slots = 1>>
+!g1s1s16 = !pto.vmi.vreg<1xsi16, #pto.vmi.layout<num_groups = 1, slots = 1>>
+!g1s1s32 = !pto.vmi.vreg<1xsi32, #pto.vmi.layout<num_groups = 1, slots = 1>>
+!g1s1i8 = !pto.vmi.vreg<1xi8, #pto.vmi.layout<num_groups = 1, slots = 1>>
+!g1s1i16 = !pto.vmi.vreg<1xi16, #pto.vmi.layout<num_groups = 1, slots = 1>>
+!g1s1i32 = !pto.vmi.vreg<1xi32, #pto.vmi.layout<num_groups = 1, slots = 1>>
+
+!g1s8u8x2 = !pto.vmi.vreg<1xui8, #pto.vmi.layout<num_groups = 1, slots = 8, lane_stride = 2>>
+!g1s8u8x4 = !pto.vmi.vreg<1xui8, #pto.vmi.layout<num_groups = 1, slots = 8, lane_stride = 4>>
+!g1s8u16x2 = !pto.vmi.vreg<1xui16, #pto.vmi.layout<num_groups = 1, slots = 8, lane_stride = 2>>
+!g1s8u16 = !pto.vmi.vreg<1xui16, #pto.vmi.layout<num_groups = 1, slots = 8>>
+!g1s8u32 = !pto.vmi.vreg<1xui32, #pto.vmi.layout<num_groups = 1, slots = 8>>
+!g1s8s8x2 = !pto.vmi.vreg<1xsi8, #pto.vmi.layout<num_groups = 1, slots = 8, lane_stride = 2>>
+!g1s8s8x4 = !pto.vmi.vreg<1xsi8, #pto.vmi.layout<num_groups = 1, slots = 8, lane_stride = 4>>
+!g1s8s16x2 = !pto.vmi.vreg<1xsi16, #pto.vmi.layout<num_groups = 1, slots = 8, lane_stride = 2>>
+!g1s8s16 = !pto.vmi.vreg<1xsi16, #pto.vmi.layout<num_groups = 1, slots = 8>>
+!g1s8s32 = !pto.vmi.vreg<1xsi32, #pto.vmi.layout<num_groups = 1, slots = 8>>
+!g1s8i8x2 = !pto.vmi.vreg<1xi8, #pto.vmi.layout<num_groups = 1, slots = 8, lane_stride = 2>>
+!g1s8i8x4 = !pto.vmi.vreg<1xi8, #pto.vmi.layout<num_groups = 1, slots = 8, lane_stride = 4>>
+!g1s8i16x2 = !pto.vmi.vreg<1xi16, #pto.vmi.layout<num_groups = 1, slots = 8, lane_stride = 2>>
+!g1s8i16 = !pto.vmi.vreg<1xi16, #pto.vmi.layout<num_groups = 1, slots = 8>>
+!g1s8i32 = !pto.vmi.vreg<1xi32, #pto.vmi.layout<num_groups = 1, slots = 8>>
+
+module {
+  func.func @group_slot_ext_slots1_g1(
+      %u8: !g1s1u8, %u16: !g1s1u16, %s8: !g1s1s8,
+      %s16: !g1s1s16, %i8: !g1s1i8, %i16: !g1s1i16) {
+    %u8u16 = pto.vmi.extui %u8 : !g1s1u8 -> !g1s1u16
+    %u16u32 = pto.vmi.extui %u16 : !g1s1u16 -> !g1s1u32
+    %u8u32 = pto.vmi.extui %u8 : !g1s1u8 -> !g1s1u32
+    %s8s16 = pto.vmi.extsi %s8 : !g1s1s8 -> !g1s1s16
+    %s16s32 = pto.vmi.extsi %s16 : !g1s1s16 -> !g1s1s32
+    %s8s32 = pto.vmi.extsi %s8 : !g1s1s8 -> !g1s1s32
+    %i8i16 = pto.vmi.extsi %i8 : !g1s1i8 -> !g1s1i16
+    %i16i32 = pto.vmi.extsi %i16 : !g1s1i16 -> !g1s1i32
+    %i8i32 = pto.vmi.extsi %i8 : !g1s1i8 -> !g1s1i32
+    %s8i16 = pto.vmi.extsi %s8 : !g1s1s8 -> !g1s1i16
+    %s16i32 = pto.vmi.extsi %s16 : !g1s1s16 -> !g1s1i32
+    %s8i32 = pto.vmi.extsi %s8 : !g1s1s8 -> !g1s1i32
+    %i8s16 = pto.vmi.extsi %i8 : !g1s1i8 -> !g1s1s16
+    %i16s32 = pto.vmi.extsi %i16 : !g1s1i16 -> !g1s1s32
+    %i8s32 = pto.vmi.extsi %i8 : !g1s1i8 -> !g1s1s32
+    return
+  }
+
+  func.func @group_slot_ext_slots1_g2(
+      %src: !pto.vmi.vreg<2xui8, #pto.vmi.layout<num_groups = 2, slots = 1>>) {
+    %wide = pto.vmi.extui %src
+        : !pto.vmi.vreg<2xui8, #pto.vmi.layout<num_groups = 2, slots = 1>>
+        -> !pto.vmi.vreg<2xui16, #pto.vmi.layout<num_groups = 2, slots = 1>>
+    return
+  }
+
+  func.func @group_slot_ext_slots1_g4(
+      %src: !pto.vmi.vreg<4xsi16, #pto.vmi.layout<num_groups = 4, slots = 1>>) {
+    %wide = pto.vmi.extsi %src
+        : !pto.vmi.vreg<4xsi16, #pto.vmi.layout<num_groups = 4, slots = 1>>
+        -> !pto.vmi.vreg<4xsi32, #pto.vmi.layout<num_groups = 4, slots = 1>>
+    return
+  }
+
+  func.func @group_slot_ext_slots1_g8(
+      %src: !pto.vmi.vreg<8xi8, #pto.vmi.layout<num_groups = 8, slots = 1>>) {
+    %wide = pto.vmi.extsi %src
+        : !pto.vmi.vreg<8xi8, #pto.vmi.layout<num_groups = 8, slots = 1>>
+        -> !pto.vmi.vreg<8xi32, #pto.vmi.layout<num_groups = 8, slots = 1>>
+    return
+  }
+
+  func.func @group_slot_ext_slots8_g1(
+      %u8x2: !g1s8u8x2, %u8x4: !g1s8u8x4, %u16x2: !g1s8u16x2,
+      %s8x2: !g1s8s8x2, %s8x4: !g1s8s8x4, %s16x2: !g1s8s16x2,
+      %i8x2: !g1s8i8x2, %i8x4: !g1s8i8x4, %i16x2: !g1s8i16x2) {
+    %u8u16 = pto.vmi.extui %u8x2 : !g1s8u8x2 -> !g1s8u16
+    %u16u32 = pto.vmi.extui %u16x2 : !g1s8u16x2 -> !g1s8u32
+    %u8u32 = pto.vmi.extui %u8x4 : !g1s8u8x4 -> !g1s8u32
+    %s8s16 = pto.vmi.extsi %s8x2 : !g1s8s8x2 -> !g1s8s16
+    %s16s32 = pto.vmi.extsi %s16x2 : !g1s8s16x2 -> !g1s8s32
+    %s8s32 = pto.vmi.extsi %s8x4 : !g1s8s8x4 -> !g1s8s32
+    %i8i16 = pto.vmi.extsi %i8x2 : !g1s8i8x2 -> !g1s8i16
+    %i16i32 = pto.vmi.extsi %i16x2 : !g1s8i16x2 -> !g1s8i32
+    %i8i32 = pto.vmi.extsi %i8x4 : !g1s8i8x4 -> !g1s8i32
+    %s8i16 = pto.vmi.extsi %s8x2 : !g1s8s8x2 -> !g1s8i16
+    %s16i32 = pto.vmi.extsi %s16x2 : !g1s8s16x2 -> !g1s8i32
+    %s8i32 = pto.vmi.extsi %s8x4 : !g1s8s8x4 -> !g1s8i32
+    %i8s16 = pto.vmi.extsi %i8x2 : !g1s8i8x2 -> !g1s8s16
+    %i16s32 = pto.vmi.extsi %i16x2 : !g1s8i16x2 -> !g1s8s32
+    %i8s32 = pto.vmi.extsi %i8x4 : !g1s8i8x4 -> !g1s8s32
+    return
+  }
+
+  func.func @group_slot_ext_slots8_g2(
+      %src: !pto.vmi.vreg<2xui8, #pto.vmi.layout<num_groups = 2, slots = 8, lane_stride = 2>>) {
+    %wide = pto.vmi.extui %src
+        : !pto.vmi.vreg<2xui8, #pto.vmi.layout<num_groups = 2, slots = 8, lane_stride = 2>>
+        -> !pto.vmi.vreg<2xui16, #pto.vmi.layout<num_groups = 2, slots = 8>>
+    return
+  }
+
+  func.func @group_slot_ext_slots8_g4(
+      %src: !pto.vmi.vreg<4xsi16, #pto.vmi.layout<num_groups = 4, slots = 8, lane_stride = 2>>) {
+    %wide = pto.vmi.extsi %src
+        : !pto.vmi.vreg<4xsi16, #pto.vmi.layout<num_groups = 4, slots = 8, lane_stride = 2>>
+        -> !pto.vmi.vreg<4xsi32, #pto.vmi.layout<num_groups = 4, slots = 8>>
+    return
+  }
+
+  func.func @group_slot_ext_slots8_g8(
+      %src: !pto.vmi.vreg<8xi8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>) {
+    %wide = pto.vmi.extsi %src
+        : !pto.vmi.vreg<8xi8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>
+        -> !pto.vmi.vreg<8xi32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+    return
+  }
+
+  func.func @group_slot_ext_slots8_g16(
+      %u8x2: !pto.vmi.vreg<16xui8, #pto.vmi.layout<num_groups = 16, slots = 8, lane_stride = 2>>,
+      %s16x2: !pto.vmi.vreg<16xsi16, #pto.vmi.layout<num_groups = 16, slots = 8, lane_stride = 2>>,
+      %i8x4: !pto.vmi.vreg<16xi8, #pto.vmi.layout<num_groups = 16, slots = 8, lane_stride = 4>>) {
+    %u16 = pto.vmi.extui %u8x2
+        : !pto.vmi.vreg<16xui8, #pto.vmi.layout<num_groups = 16, slots = 8, lane_stride = 2>>
+        -> !pto.vmi.vreg<16xui16, #pto.vmi.layout<num_groups = 16, slots = 8>>
+    %s32 = pto.vmi.extsi %s16x2
+        : !pto.vmi.vreg<16xsi16, #pto.vmi.layout<num_groups = 16, slots = 8, lane_stride = 2>>
+        -> !pto.vmi.vreg<16xsi32, #pto.vmi.layout<num_groups = 16, slots = 8>>
+    %i32 = pto.vmi.extsi %i8x4
+        : !pto.vmi.vreg<16xi8, #pto.vmi.layout<num_groups = 16, slots = 8, lane_stride = 4>>
+        -> !pto.vmi.vreg<16xi32, #pto.vmi.layout<num_groups = 16, slots = 8>>
+    return
+  }
+
+  func.func @group_slot_ext_slots8_g32(
+      %u8x2: !pto.vmi.vreg<32xui8, #pto.vmi.layout<num_groups = 32, slots = 8, lane_stride = 2>>,
+      %s16x2: !pto.vmi.vreg<32xsi16, #pto.vmi.layout<num_groups = 32, slots = 8, lane_stride = 2>>,
+      %i8x4: !pto.vmi.vreg<32xi8, #pto.vmi.layout<num_groups = 32, slots = 8, lane_stride = 4>>) {
+    %u16 = pto.vmi.extui %u8x2
+        : !pto.vmi.vreg<32xui8, #pto.vmi.layout<num_groups = 32, slots = 8, lane_stride = 2>>
+        -> !pto.vmi.vreg<32xui16, #pto.vmi.layout<num_groups = 32, slots = 8>>
+    %s32 = pto.vmi.extsi %s16x2
+        : !pto.vmi.vreg<32xsi16, #pto.vmi.layout<num_groups = 32, slots = 8, lane_stride = 2>>
+        -> !pto.vmi.vreg<32xsi32, #pto.vmi.layout<num_groups = 32, slots = 8>>
+    %i32 = pto.vmi.extsi %i8x4
+        : !pto.vmi.vreg<32xi8, #pto.vmi.layout<num_groups = 32, slots = 8, lane_stride = 4>>
+        -> !pto.vmi.vreg<32xi32, #pto.vmi.layout<num_groups = 32, slots = 8>>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @group_slot_ext_slots1_g1(
+// CHECK-COUNT-15: pto.vcvt
+// CHECK-NOT: pto.vmi.
+// CHECK-LABEL: func.func @group_slot_ext_slots1_g2(
+// CHECK-COUNT-2: pto.vcvt
+// CHECK-LABEL: func.func @group_slot_ext_slots1_g4(
+// CHECK-COUNT-4: pto.vcvt
+// CHECK-LABEL: func.func @group_slot_ext_slots1_g8(
+// CHECK-COUNT-8: pto.vcvt
+// CHECK-LABEL: func.func @group_slot_ext_slots8_g1(
+// CHECK-COUNT-15: pto.vcvt
+// CHECK-LABEL: func.func @group_slot_ext_slots8_g2(
+// CHECK-COUNT-1: pto.vcvt
+// CHECK-LABEL: func.func @group_slot_ext_slots8_g4(
+// CHECK-COUNT-1: pto.vcvt
+// CHECK-LABEL: func.func @group_slot_ext_slots8_g8(
+// CHECK-COUNT-1: pto.vcvt
+// CHECK-LABEL: func.func @group_slot_ext_slots8_g16(
+// CHECK-COUNT-6: pto.vcvt
+// CHECK-LABEL: func.func @group_slot_ext_slots8_g32(
+// CHECK-COUNT-12: pto.vcvt
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_group_slot_load.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_slot_load.pto
@@ -107,6 +107,39 @@ module {
           !pto.ptr<ui32, ub>
     return
   }
+
+  func.func @vmi_to_vpto_group_slot_load_extui_u8_u16_slots8(
+      %src: !pto.ptr<ui8, ub>, %dst: !pto.ptr<ui16, ub>, %off: index) {
+    %c1 = arith.constant 1 : index
+    %narrow = pto.vmi.vload %src[%off], %c1 {group = 8}
+        : !pto.ptr<ui8, ub>
+        -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>
+    %strided = pto.vmi.ensure_layout %narrow
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>
+        -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
+    %wide = pto.vmi.extui %strided
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
+        -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>
+    pto.vmi.vstore %wide, %dst[%off], %c1 {group = 8}
+        : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>,
+          !pto.ptr<ui16, ub>
+    return
+  }
+
+  func.func @vmi_to_vpto_group_slot_load_extui_u8_u16_slots1(
+      %src: !pto.ptr<ui8, ub>, %dst: !pto.ptr<ui16, ub>, %off: index) {
+    %c32 = arith.constant 32 : index
+    %narrow = pto.vmi.vload %src[%off], %c32 {group = 8}
+        : !pto.ptr<ui8, ub>
+        -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 1>>
+    %wide = pto.vmi.extui %narrow
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 1>>
+        -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>
+    pto.vmi.vstore %wide, %dst[%off], %c32 {group = 8}
+        : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>,
+          !pto.ptr<ui16, ub>
+    return
+  }
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_load_slots8(
@@ -151,6 +184,22 @@ module {
 // CHECK: pto.pge_b16 "PAT_VL16" : !pto.mask<b16>
 // CHECK: pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
 // CHECK: pto.vsts {{.*}} : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast
+
+// CHECK-LABEL: func.func @vmi_to_vpto_group_slot_load_extui_u8_u16_slots8(
+// CHECK: %[[LOAD:.*]] = pto.vsldb {{.*}} : !pto.ptr<ui8, ub>, i16, i16, !pto.mask<b8> -> !pto.vreg<256xui8>
+// CHECK: %[[UNPACK:.*]] = pto.vzunpack %[[LOAD]]
+// CHECK: %[[WIDE:.*]] = pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<128xui16>
+// CHECK: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_group_slot_load_extui_u8_u16_slots1(
+// CHECK-COUNT-8: pto.vsldb
+// CHECK-COUNT-8: pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<128xui16>
+// CHECK-COUNT-8: pto.vsts {{.*}} {dist = "1PT_B16"}
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast


### PR DESCRIPTION
## 背景

主线已经具备 group-slot 整数扩宽 lowering，但已有回归主要集中在 `num_groups=8` 的少数组合，无法系统证明 `ui8 -> ui16` 属于完整的通用能力，而不是单一 dtype 特判。

## 改动

- 新增正交能力矩阵，覆盖：
  - `extui` 的 unsigned 类型与 `extsi` 的 signed/signless 类型，包括 mixed `si/i` 结果；
  - `8 -> 16`、`16 -> 32`、`8 -> 32` 三种扩宽关系；
  - `slots=1` 同布局，以及 `slots=8` 的自然 `lane_stride=2/4` 输入；
  - `num_groups=1/2/4/8`，并用 `16/32` 验证跨越单个物理 carrier 后的 2-part/4-part lowering。
- 在现有 group-slot load 测试中补充 pointer-ABI 的 `ui8 -> ui16` 链路：
  - compact `slots=8` load 先通过 `ensure_layout` 形成自然 `lane_stride=2`，再扩宽并 group store；
  - `slots=1` load、扩宽和 group store 的完整链路。
- 新增负向边界，明确拒绝错误 signedness、缺少自然 stride 的 compact 直接扩宽，以及与扩宽倍数不一致的 stride。

本 PR 只补齐主线现有通用能力的回归覆盖，不重复修改 lowering。compact `slots=8` 数据需要先物化为自然 lane stride；未指定布局的整图 seed phase 优化由 #1114 处理。

## 验证

- `cmake --build build -j64`
- 定向 lit：3/3 passed
- `vmi_new` lit：452/452 passed

关联 #1024

关联 learning-chip/vmi-demo#30
