### PR TITLE
fix(ptodsl): isolate bindings across physical sections

### DIFF
--- a/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
+++ b/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
@@ -675,6 +675,11 @@ inference. Sections cannot be nested, each kind may appear at most once per
 function, and `pto.section()` cannot be combined with an explicit
 `@pto.jit(kernel_kind=...)` contract. The context manager is only a placement
 scope and does not expose the underlying IR operation through an `as` binding.
+Runtime scalar assignments inside a section are local to that physical region;
+after the section closes, AST rewrite restores the incoming Python bindings so
+a sibling section cannot capture SSA values defined in the previous region.
+Communicate between cube and vector sections through memory and synchronization
+operations rather than Python scalar assignments.
 
 The richer type surface also applies to sub-kernels: in auto mode, a
 sub-kernel's parameters are restricted to `Tile` and PTO scalar types; in

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -705,6 +705,14 @@ def _is_pto_attr_call(node, name: str) -> bool:
     )
 
 
+def _is_pto_section_with(node) -> bool:
+    return (
+        isinstance(node, ast.With)
+        and len(node.items) == 1
+        and _is_pto_attr_call(node.items[0].context_expr, "section")
+    )
+
+
 def _is_range_call(node) -> bool:
     return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "range"
 
@@ -824,6 +832,14 @@ class _ControlFlowRewriter:
     def rewrite_stmt(self, stmt, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None):
         live_after_slots = set(live_after_slots or ())
         static_iters = dict(static_iters or {})
+        if _is_pto_section_with(stmt):
+            return self._rewrite_section(
+                stmt,
+                live_after=live_after,
+                live_after_slots=live_after_slots,
+                allow_loop_control=allow_loop_control,
+                static_iters=static_iters,
+            )
         if isinstance(stmt, ast.If):
             return self._rewrite_if(
                 stmt,
@@ -853,6 +869,54 @@ class _ControlFlowRewriter:
                 static_iters=static_iters,
             )
         ]
+
+    def _rewrite_section(
+        self,
+        stmt,
+        *,
+        live_after,
+        live_after_slots=None,
+        allow_loop_control=False,
+        static_iters=None,
+    ):
+        """Keep Python bindings assigned in one physical section region-local.
+
+        ``pto.section`` operations are sibling MLIR regions and have no SSA
+        results.  Without restoring the incoming Python bindings, tracing a
+        later section can accidentally capture values produced by an earlier
+        sibling region, yielding invalid cross-region SSA uses.
+        """
+        live_after_slots = set(live_after_slots or ())
+        static_iters = dict(static_iters or {})
+        restore_names = tuple(sorted(set(live_after) & _name_info(stmt.body).stores))
+        saved_names = {
+            name: self._fresh(f"section_old_{name}")
+            for name in restore_names
+        }
+
+        stmt.body = self.rewrite_block(
+            stmt.body,
+            live_after=set(live_after),
+            live_after_slots=live_after_slots,
+            allow_loop_control=allow_loop_control,
+            static_iters=static_iters,
+        )
+
+        saves = [
+            ast.Assign(
+                targets=[_name(saved_name, ast.Store())],
+                value=_name(name),
+            )
+            for name, saved_name in saved_names.items()
+        ]
+        restores = [
+            ast.Assign(
+                targets=[_name(name, ast.Store())],
+                value=_name(saved_name),
+            )
+            for name, saved_name in saved_names.items()
+        ]
+        return [*saves, stmt, *restores]
 
     def _rewrite_nested(self, stmt, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None):
         live_after_slots = set(live_after_slots or ())

--- a/ptodsl/tests/test_section.py
+++ b/ptodsl/tests/test_section.py
@@ -26,6 +26,26 @@ def explicit_sections_probe():
         pto.set_flag("S", "MTE2", event_id=event_id)
 
 
+@pto.jit(target="a5", mode="explicit")
+def sibling_section_branch_binding_probe():
+    m_tile = pto.const(0, dtype=pto.i64)
+    n_tile = pto.const(0, dtype=pto.i64)
+
+    with pto.section("cube"):
+        if pto.get_block_idx() < 16:
+            m_tile = pto.get_block_idx() & 3
+            n_tile = pto.get_block_idx() // 4
+        _ = m_tile
+        _ = n_tile
+
+    with pto.section("vector"):
+        if pto.get_block_idx() < 16:
+            m_tile = pto.get_block_idx() & 3
+            n_tile = pto.get_block_idx() // 4
+        _ = m_tile
+        _ = n_tile
+
+
 @pto.jit(target="a5", mode="explicit", ast_rewrite=False)
 def duplicate_section_probe():
     with pto.section("cube"):
@@ -128,6 +148,14 @@ def main() -> None:
     assert "pto.set_flag_dyn[<PIPE_S>, <PIPE_MTE2>" in text
     with make_context() as context:
         module = Module.parse(text, context)
+        module.operation.verify()
+
+    sibling_text = sibling_section_branch_binding_probe.compile().mlir_text()
+    assert sibling_text.count("pto.section.cube {") == 1
+    assert sibling_text.count("pto.section.vector {") == 1
+    assert sibling_text.count("scf.if") == 2
+    with make_context() as context:
+        module = Module.parse(sibling_text, context)
         module.operation.verify()
 
     recovered_text = recovered_section_probe.compile().mlir_text()


### PR DESCRIPTION
## 修改原因

`pto.section("cube")` 和 `pto.section("vector")` 会生成两个 sibling MLIR region。AST rewrite 后，Python 局部变量可能仍绑定到前一个 section 内产生的 SSA 值，并被后一个 section 使用：

```python
m_tile = pto.const(0, dtype=pto.i64)

with pto.section("cube"):
    if cond:
        m_tile = ...

with pto.section("vector"):
    if cond:
        m_tile = ...
```

第一个动态 `if` 会生成 `scf.if`，其结果属于 cube region。离开 cube section 后，Python 变量 `m_tile` 仍可能指向这个结果。vector section 再使用它时，就形成 sibling region 间的非法 SSA 引用，导致：

```text
operand does not dominate this use
```

## 修改方式

AST rewrite 现在把 `pto.section()` 视为变量生命周期边界：

```python
saved_m_tile = m_tile

with pto.section("cube"):
    # section 内可以临时重新绑定 m_tile
    ...

m_tile = saved_m_tile
```

只保存同时满足以下条件的变量：

- section 内被赋值；
- section 结束后仍然活跃。

这样既保留 section 内原有的 `if`/`for` 改写，又防止内部 SSA 值逃逸到 sibling section。

## 影响范围

仅影响以下组合：

- `@pto.jit(mode="explicit")`
- 使用 `pto.section()`
- 开启默认的 `ast_rewrite=True`
- section 内重新绑定了后续仍会使用的 Python 标量

不影响：

- `ast_rewrite=False`
- 不使用 `pto.section()` 的 kernel
- section 内仅有同步或数据搬运操作
- PTO IR、lowering 和 ABI

语义上，cube/vector section 之间不能通过 Python scalar 传值，应使用内存和同步操作通信。

新增测试生成两个 physical section 和两个 `scf.if`，并运行 MLIR verifier，确保不再出现跨 region dominance 错误。