### PR TITLE
fix: guard co-live multi-tile slots in InsertSync

### DIFF
--- a/include/PTO/Transforms/InsertSync/SyncCommon.h
+++ b/include/PTO/Transforms/InsertSync/SyncCommon.h
@@ -248,15 +248,24 @@ canonicalizeSyncDepRoots(const SmallVector<Value> &roots);
 
 bool hasSameSyncDepRoots(const SyncOperation *lhs, const SyncOperation *rhs);
 
-/// True when `sync` lowers to `pto.set_flag_dyn` / `pto.wait_flag_dyn`, i.e. a
-/// back-edge pair whose rendezvous is keyed on the runtime slot index.
+/// True when `sync` lowers to `pto.set_flag_dyn` / `pto.wait_flag_dyn`, i.e.
+/// its rendezvous is keyed on the runtime slot index rather than on a fixed
+/// event id.
 ///
-/// Such a pair orders ONLY the accesses that resolve to its own event lane
+/// Such a sync orders ONLY the accesses that resolve to its own event lane
 /// (`slotSSAExpr % slotCount`); it does not serialize its (src, dst) pipe pair
 /// the way a static flag does. Every place that reasons about one sync
 /// "covering" another must therefore exclude it, or a second access through a
 /// different slot is left unguarded (issue #1118).
-inline bool isLaneKeyedBackEdgeSync(const SyncOperation *sync) {
+///
+/// `slotSSAExpr` is the discriminator, NOT `GetForEndIndex()`. Slot keying is
+/// only ever established for a back-edge dependency (InsertSyncOperation), so
+/// it may be tempting to test for one -- but the synthetic prologue-prime and
+/// epilogue-drain pairs that SyncEventIdAllocation::UpdateBackwardMatchSync
+/// derives from such a pair inherit both `forEndIndex` and `eventIdNum` while
+/// deliberately carrying no slot, and they lower to STATIC flags. Keying off
+/// the back edge would misclassify exactly those.
+inline bool isSlotKeyedSync(const SyncOperation *sync) {
   return sync && sync->eventIdNum > 1 && sync->slotSSAExpr;
 }
  

--- a/include/PTO/Transforms/InsertSync/SyncCommon.h
+++ b/include/PTO/Transforms/InsertSync/SyncCommon.h
@@ -247,6 +247,18 @@ SmallVector<const void *>
 canonicalizeSyncDepRoots(const SmallVector<Value> &roots);
 
 bool hasSameSyncDepRoots(const SyncOperation *lhs, const SyncOperation *rhs);
+
+/// True when `sync` lowers to `pto.set_flag_dyn` / `pto.wait_flag_dyn`, i.e. a
+/// back-edge pair whose rendezvous is keyed on the runtime slot index.
+///
+/// Such a pair orders ONLY the accesses that resolve to its own event lane
+/// (`slotSSAExpr % slotCount`); it does not serialize its (src, dst) pipe pair
+/// the way a static flag does. Every place that reasons about one sync
+/// "covering" another must therefore exclude it, or a second access through a
+/// different slot is left unguarded (issue #1118).
+inline bool isLaneKeyedBackEdgeSync(const SyncOperation *sync) {
+  return sync && sync->eventIdNum > 1 && sync->slotSSAExpr;
+}
  
 using SyncOps = std::deque<SyncOperation *>;
  

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -659,7 +659,7 @@ void InsertSyncAnalysis::UpdateAlreadySync(const SyncOps &syncVector,
   for (auto *sync : syncVector) {
     // A slot-keyed event orders only the selected physical slot. It must not
     // make later accesses through another slot look globally synchronized.
-    if (isLaneKeyedBackEdgeSync(sync)) continue;
+    if (isSlotKeyedSync(sync)) continue;
     for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
       UpdateSyncRecord(sync, syncRecordList[bufferIdx], nowPipeValue);
     }
@@ -721,7 +721,7 @@ void InsertSyncAnalysis::UpdateSyncRecordInfo(
   auto *newSync = syncPair[0].get();
   // Dynamic event IDs cover one runtime-selected slot, not the complete pipe
   // dependency represented by this record.
-  if (isLaneKeyedBackEdgeSync(newSync)) return;
+  if (isSlotKeyedSync(newSync)) return;
   for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
     if (!isValidPipeIndex(newSync->GetSrcPipe())) continue;
     syncRecordList[bufferIdx]

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -659,7 +659,7 @@ void InsertSyncAnalysis::UpdateAlreadySync(const SyncOps &syncVector,
   for (auto *sync : syncVector) {
     // A slot-keyed event orders only the selected physical slot. It must not
     // make later accesses through another slot look globally synchronized.
-    if (sync->eventIdNum > 1 && sync->slotSSAExpr) continue;
+    if (isLaneKeyedBackEdgeSync(sync)) continue;
     for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
       UpdateSyncRecord(sync, syncRecordList[bufferIdx], nowPipeValue);
     }
@@ -721,7 +721,7 @@ void InsertSyncAnalysis::UpdateSyncRecordInfo(
   auto *newSync = syncPair[0].get();
   // Dynamic event IDs cover one runtime-selected slot, not the complete pipe
   // dependency represented by this record.
-  if (newSync->eventIdNum > 1 && newSync->slotSSAExpr) return;
+  if (isLaneKeyedBackEdgeSync(newSync)) return;
   for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
     if (!isValidPipeIndex(newSync->GetSrcPipe())) continue;
     syncRecordList[bufferIdx]

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -581,21 +581,38 @@ void InsertSyncAnalysis::InsertSyncOperation(
       if (eventIdNum > 1) {
         // Each dep pair has (now=consumer, front=producer). The producer's
         // slot SSA gates the `set_flag_dyn`; the consumer's gates the
-        // `wait_flag_dyn`. Walk the first viable dep pair to extract them.
+        // `wait_flag_dyn`. A single dynamic event pair can represent only one
+        // slot expression on each side. If the dependency group contains
+        // multiple expressions, fall back to a static event that guards the
+        // whole group instead of silently synchronizing just the first one.
         Value producerSlot;
         Value consumerSlot;
+        bool hasAmbiguousSlot = false;
         for (auto &pair : depBaseMemInfosVec) {
-          if (pair.second && pair.second->baseBuffer)
-            producerSlot = findMultiTileSlotExpr(pair.second->baseBuffer);
-          if (pair.first && pair.first->baseBuffer)
-            consumerSlot = findMultiTileSlotExpr(pair.first->baseBuffer);
-          if (producerSlot && consumerSlot)
+          Value pairProducerSlot;
+          Value pairConsumerSlot;
+          if (pair.second && pair.second->baseBuffer) {
+            pairProducerSlot = findMultiTileSlotExpr(pair.second->baseBuffer);
+          }
+          if (pair.first && pair.first->baseBuffer) {
+            pairConsumerSlot = findMultiTileSlotExpr(pair.first->baseBuffer);
+          }
+          if (!pairProducerSlot || !pairConsumerSlot) {
+            hasAmbiguousSlot = true;
             break;
+          }
+          if ((producerSlot && producerSlot != pairProducerSlot) ||
+              (consumerSlot && consumerSlot != pairConsumerSlot)) {
+            hasAmbiguousSlot = true;
+            break;
+          }
+          producerSlot = pairProducerSlot;
+          consumerSlot = pairConsumerSlot;
         }
-        if (!producerSlot || !consumerSlot) {
-          // No slot SSA threaded through -- fall back to single event id.
-          // This keeps non-multi-buffer codepaths untouched even if their
-          // baseAddresses happen to have multiple entries for another reason.
+        if (hasAmbiguousSlot || !producerSlot || !consumerSlot) {
+          // Missing or ambiguous slot SSA -- fall back to a single event id.
+          // This also keeps non-multi-buffer codepaths untouched if their
+          // baseAddresses have multiple entries for another reason.
           eventIdNum = 1;
         } else {
           setOp->slotSSAExpr = producerSlot;
@@ -640,11 +657,10 @@ void InsertSyncAnalysis::UpdateAlreadySync(const SyncOps &syncVector,
                                            SyncRecordList &syncRecordList,
                                            const PipelineType nowPipeValue) {
   for (auto *sync : syncVector) {
+    // A slot-keyed event orders only the selected physical slot. It must not
+    // make later accesses through another slot look globally synchronized.
+    if (sync->eventIdNum > 1 && sync->slotSSAExpr) continue;
     for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
-      if (bufferIdx == 0 && sync->eventIdNum > 1 &&
-          sync->GetForEndIndex().has_value()) {
-        continue;
-      }
       UpdateSyncRecord(sync, syncRecordList[bufferIdx], nowPipeValue);
     }
   }
@@ -703,10 +719,10 @@ void InsertSyncAnalysis::UpdateSyncRecordInfo(
   assert(!syncPair.empty());
 
   auto *newSync = syncPair[0].get();
+  // Dynamic event IDs cover one runtime-selected slot, not the complete pipe
+  // dependency represented by this record.
+  if (newSync->eventIdNum > 1 && newSync->slotSSAExpr) return;
   for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
-    if (bufferIdx == 0 && newSync->eventIdNum > 1) {
-      continue;
-    }
     if (!isValidPipeIndex(newSync->GetSrcPipe())) continue;
     syncRecordList[bufferIdx]
         .alreadySync[static_cast<unsigned>(newSync->GetSrcPipe())] = true;

--- a/lib/PTO/Transforms/InsertSync/RemoveRedundantSync.cpp
+++ b/lib/PTO/Transforms/InsertSync/RemoveRedundantSync.cpp
@@ -236,7 +236,7 @@ bool RemoveRedundantSync::CanMatchedSync(SmallVector<bool> &syncFinder,
   // whole-pipe pair -- which is strictly stronger -- but it may never PROVIDE
   // coverage for another pair. Letting it do so drops the guard on every access
   // that resolves to a different slot (issue #1118).
-  if (isLaneKeyedBackEdgeSync(relatedSync)) return false;
+  if (isSlotKeyedSync(relatedSync)) return false;
 
   bool isWait = (relatedSync->GetType() == SyncOperation::TYPE::WAIT_EVENT);
   bool isSet = (relatedSync->GetType() == SyncOperation::TYPE::SET_EVENT);

--- a/lib/PTO/Transforms/InsertSync/RemoveRedundantSync.cpp
+++ b/lib/PTO/Transforms/InsertSync/RemoveRedundantSync.cpp
@@ -226,9 +226,17 @@ bool RemoveRedundantSync::CheckLoopBetween(LoopInstanceElement *loopElement,
 bool RemoveRedundantSync::CanMatchedSync(SmallVector<bool> &syncFinder,
                                          SyncOperation *relatedSync,
                                          SyncOperation *setFlag) {
-  // Set/wait flags serialize a pipe pair, not a particular root buffer.  A
-  // complete inner pair on the same pipe pair can cover an outer pair even when
-  // the memory dependency roots differ.
+  // STATIC set/wait flags serialize a pipe pair, not a particular root buffer.
+  // A complete inner pair on the same pipe pair can cover an outer pair even
+  // when the memory dependency roots differ.
+  //
+  // A slot-keyed pair (set_flag_dyn / wait_flag_dyn) is the exception: it
+  // rendezvouses on the event lane `slotSSAExpr % slotCount`, so it orders only
+  // the accesses that land on that lane. It may therefore BE covered by a
+  // whole-pipe pair -- which is strictly stronger -- but it may never PROVIDE
+  // coverage for another pair. Letting it do so drops the guard on every access
+  // that resolves to a different slot (issue #1118).
+  if (isLaneKeyedBackEdgeSync(relatedSync)) return false;
 
   bool isWait = (relatedSync->GetType() == SyncOperation::TYPE::WAIT_EVENT);
   bool isSet = (relatedSync->GetType() == SyncOperation::TYPE::SET_EVENT);

--- a/test/lit/pto/multi_tile_same_region_two_gets_sync.pto
+++ b/test/lit/pto/multi_tile_same_region_two_gets_sync.pto
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --enable-insert-sync --pto-level=level2 --pto-arch=a3 --emit-pto-ir --mlir-print-ir-after=pto-insert-sync %s -o /dev/null 2>&1 1>/dev/null | FileCheck %s --implicit-check-not=pto.wait_flag_dyn --implicit-check-not=pto.set_flag_dyn
+
+// Two dynamic views of the same multi-tile buffer remain live until one vector
+// operation consumes both. A single slot-keyed back-edge event cannot cover the
+// two distinct slot expressions. InsertSync must conservatively synchronize the
+// complete MTE2 group before either load, then release it after the vector use.
+
+module {
+  func.func @two_gets_same_multi_tile(
+      %a : !pto.partition_tensor_view<64x64xf32>,
+      %b : !pto.partition_tensor_view<64x64xf32>,
+      %out : !pto.partition_tensor_view<64x64xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+
+    %mb = pto.alloc_multi_tile
+        : !pto.multi_tile_buf<vec, 64x64xf32, count=2>
+    %sum = pto.alloc_tile : !pto.tile_buf<vec, 64x64xf32>
+
+    scf.for %i = %c0 to %c4 step %c1 {
+      %lo_idx = arith.remsi %i, %c2 : index
+      %lo = pto.multi_tile_get %mb[%lo_idx]
+          : !pto.multi_tile_buf<vec, 64x64xf32, count=2>
+         -> !pto.tile_buf<vec, 64x64xf32>
+      pto.tload ins(%a : !pto.partition_tensor_view<64x64xf32>)
+                outs(%lo : !pto.tile_buf<vec, 64x64xf32>)
+
+      %next = arith.addi %i, %c1 : index
+      %hi_idx = arith.remsi %next, %c2 : index
+      %hi = pto.multi_tile_get %mb[%hi_idx]
+          : !pto.multi_tile_buf<vec, 64x64xf32, count=2>
+         -> !pto.tile_buf<vec, 64x64xf32>
+      pto.tload ins(%b : !pto.partition_tensor_view<64x64xf32>)
+                outs(%hi : !pto.tile_buf<vec, 64x64xf32>)
+
+      pto.tadd ins(%lo, %hi : !pto.tile_buf<vec, 64x64xf32>,
+                                    !pto.tile_buf<vec, 64x64xf32>)
+               outs(%sum : !pto.tile_buf<vec, 64x64xf32>)
+      pto.tstore ins(%sum : !pto.tile_buf<vec, 64x64xf32>)
+                 outs(%out : !pto.partition_tensor_view<64x64xf32>)
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @two_gets_same_multi_tile
+// CHECK: pto.set_flag[<PIPE_V>, <PIPE_MTE2>, [[WAR_EVENT:<EVENT_ID[0-9]+>]]]
+// CHECK: scf.for
+// CHECK: pto.wait_flag[<PIPE_V>, <PIPE_MTE2>, [[WAR_EVENT]]]
+// CHECK: pto.tload
+// CHECK: pto.tload
+// CHECK: pto.tadd
+// CHECK: pto.set_flag[<PIPE_V>, <PIPE_MTE2>, [[WAR_EVENT]]]

--- a/test/lit/pto/multi_tile_two_regions_two_gets_sync.pto
+++ b/test/lit/pto/multi_tile_two_regions_two_gets_sync.pto
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --enable-insert-sync --pto-level=level2 --pto-arch a3 --mlir-print-ir-after=pto-insert-sync %s 2>&1 1>/dev/null | FileCheck %s
+
+// Companion to multi_tile_same_region_two_gets_sync.pto, covering the other
+// half of the issue #1118 blast radius: TWO DISTINCT `pto.alloc_multi_tile`
+// regions, one dynamic-slot get each, both consumed by one vector op.
+//
+// Each region's back edge is unambiguous on its own (the tload's slot and the
+// tadd's read of that same slot are the same SSA value), so each keeps its
+// per-slot dyn event pair -- both regions stay double-buffered. The two pairs
+// are independent: they guard different memory and different event lanes.
+//
+// The bug this pins: a slot-keyed pair rendezvouses per event lane, so it does
+// NOT serialize its (src, dst) pipe pair. Before the fix, region A's pair was
+// treated as whole-pipe coverage for region B's -- by the `alreadySync`
+// transitive elimination in InsertSyncAnalysis, and then by
+// RemoveRedundantSync::CanMatchedSync -- and region B's tload shipped with no
+// WAR guard at all against the previous iteration's tadd.
+
+module {
+  func.func @two_regions_two_gets(
+      %a : !pto.partition_tensor_view<64x64xf32>,
+      %b : !pto.partition_tensor_view<64x64xf32>,
+      %out : !pto.partition_tensor_view<64x64xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+
+    %mbA = pto.alloc_multi_tile
+        : !pto.multi_tile_buf<vec, 64x64xf32, count=2>
+    %mbB = pto.alloc_multi_tile
+        : !pto.multi_tile_buf<vec, 64x64xf32, count=2>
+    %sum = pto.alloc_tile : !pto.tile_buf<vec, 64x64xf32>
+
+    scf.for %i = %c0 to %c4 step %c1 {
+      %lo_idx = arith.remsi %i, %c2 : index
+      %lo = pto.multi_tile_get %mbA[%lo_idx]
+          : !pto.multi_tile_buf<vec, 64x64xf32, count=2>
+         -> !pto.tile_buf<vec, 64x64xf32>
+      pto.tload ins(%a : !pto.partition_tensor_view<64x64xf32>)
+                outs(%lo : !pto.tile_buf<vec, 64x64xf32>)
+
+      %next = arith.addi %i, %c1 : index
+      %hi_idx = arith.remsi %next, %c2 : index
+      %hi = pto.multi_tile_get %mbB[%hi_idx]
+          : !pto.multi_tile_buf<vec, 64x64xf32, count=2>
+         -> !pto.tile_buf<vec, 64x64xf32>
+      pto.tload ins(%b : !pto.partition_tensor_view<64x64xf32>)
+                outs(%hi : !pto.tile_buf<vec, 64x64xf32>)
+
+      pto.tadd ins(%lo, %hi : !pto.tile_buf<vec, 64x64xf32>,
+                              !pto.tile_buf<vec, 64x64xf32>)
+               outs(%sum : !pto.tile_buf<vec, 64x64xf32>)
+      pto.tstore ins(%sum : !pto.tile_buf<vec, 64x64xf32>)
+                 outs(%out : !pto.partition_tensor_view<64x64xf32>)
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @two_regions_two_gets
+// Two independent lane groups are primed before the loop: 2 event ids per
+// region. EVENT_ID2/EVENT_ID3 only exist if the second region kept its own
+// dyn pair instead of being folded into the first one's.
+// CHECK: pto.set_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID0>]
+// CHECK: pto.set_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID1>]
+// CHECK: pto.set_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID2>]
+// CHECK: pto.set_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID3>]
+// CHECK: scf.for
+//
+// Region A: the wait is keyed on region A's own slot value.
+// CHECK: %[[A_SLOT:[0-9a-zA-Z_]+]] = arith.remsi %arg3, %c2
+// CHECK: pto.multi_tile_get %[[MB_A:[0-9a-zA-Z_]+]][%[[A_SLOT]]]
+// CHECK: arith.remui %[[A_SLOT]],
+// CHECK: %[[A_LANE:[0-9a-zA-Z_]+]] = arith.select
+// CHECK: pto.wait_flag_dyn[<PIPE_V>, <PIPE_MTE2>, %[[A_LANE]]]
+// CHECK: pto.tload
+//
+// Region B must get its OWN guard before its OWN tload -- this is the edge the
+// bug dropped. Anchoring the lane on region B's slot means a missing pair, or a
+// pair mis-keyed to region A's slot, fails here.
+// CHECK: %[[NEXT:[0-9a-zA-Z_]+]] = arith.addi %arg3, %c1
+// CHECK: %[[B_SLOT:[0-9a-zA-Z_]+]] = arith.remsi %[[NEXT]], %c2
+// CHECK: pto.multi_tile_get %[[MB_B:[0-9a-zA-Z_]+]][%[[B_SLOT]]]
+// CHECK: arith.remui %[[B_SLOT]],
+// CHECK: %[[B_LANE:[0-9a-zA-Z_]+]] = arith.select
+// CHECK: pto.wait_flag_dyn[<PIPE_V>, <PIPE_MTE2>, %[[B_LANE]]]
+// CHECK: pto.tload
+//
+// CHECK: pto.tadd
+// Both releases land after the shared consumer, one per region.
+// CHECK: pto.set_flag_dyn[<PIPE_V>, <PIPE_MTE2>,
+// CHECK: pto.set_flag_dyn[<PIPE_V>, <PIPE_MTE2>,
+// Post-loop drains both lane groups.
+// CHECK: pto.wait_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID0>]
+// CHECK: pto.wait_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID1>]
+// CHECK: pto.wait_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID2>]
+// CHECK: pto.wait_flag[<PIPE_V>, <PIPE_MTE2>, <EVENT_ID3>]


### PR DESCRIPTION
## Summary

- Reject ambiguous multi-slot dependency groups for dynamic event IDs and conservatively fall back to one static event for the complete pipe group.
- Stop treating slot-keyed dynamic events as whole-pipe synchronization records.
- Add a level2 regression with two co-live `multi_tile_get` results consumed by one vector operation.

## Root cause

Legacy InsertSync selected the first viable producer/consumer slot expression when creating a multi-event back-edge sync. It then recorded that slot-keyed event as though the complete source pipe were synchronized. With two co-live dynamic slots, this could leave the second access unguarded.

## Validation

- Built `PTOASPythonPackage` against LLVM 21.1.8 in WSL with `-j1` (360/360 initial build; 6/6 final incremental build).
- Ran all `multi_tile_` lit tests: 26/26 passed.
- Ran the new reproducer through the complete default code-generation pipeline successfully.
- Verified the corrected order is a static `V -> MTE2` wait, both TLOADs, TADD, then the matching static set; unambiguous single-slot cases still use dynamic event IDs.

Closes #1118
