### PR TITLE
docs: preserve v0.5 release note in spec generator

### DIFF
--- a/.codex/skills/generate-vpto-release-doc/scripts/generate_release_vpto_spec.py
+++ b/.codex/skills/generate-vpto-release-doc/scripts/generate_release_vpto_spec.py
@@ -77,6 +77,7 @@ VERSION_NOTES = {
         "0.2": "Update micro Instruction latency and throughput",
         "0.3": "Add runtime block query and vector-interval legality notes; Normalize load/store distribution families; Update get_buf/rls_buf details",
         "0.4": "Update DMA instruction docs and add PTO Tile Instruction SPEC",
+        "0.5": "Add CUBE instruction docs; Rename MTE instruction and address space",
     },
     TILEOP_TARGET: {
         "0.4": "Initial PTO Tile Instruction SPEC covering core TileOps",
@@ -86,6 +87,7 @@ VERSION_NOTES = {
         "0.2": "Update micro Instruction latency and throughput",
         "0.3": "Add runtime block query and vector-interval legality notes; Normalize load/store distribution families; Update get_buf/rls_buf details",
         "0.4": "Update DMA instruction docs and add PTO Tile Instruction SPEC",
+        "0.5": "Add CUBE instruction docs; Rename MTE instruction and address space",
     },
 }
 


### PR DESCRIPTION
## 概述

补齐 release-doc 生成器中的 v0.5 微指令手册发布记录，避免生成 v0.6 或后续版本时丢失已经发布的 v0.5 changelog。

## 变更

- 为 micro bundle 增加现有 v0.5 release note
- 为 legacy merged bundle 增加相同的 v0.5 release note

## 验证

- `quick_validate.py .codex/skills/generate-vpto-release-doc`
- 使用生成器生成 v0.6 micro bundle，确认版本列表完整保留 v0.1-v0.6
- `git diff --check`

该修复支持 PTO-ISA/PTO-Gym#20 的手册同步，不改变 PTO/VPTO IR 或 lowering 行为。
