### PR TITLE
lic: add upstream Apache-2.0 derivative notice to GraphSyncSolver

### DIFF
--- a/lib/PTO/Transforms/GraphSyncSolver/EventIdSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/EventIdSolver.cpp
@@ -5,6 +5,20 @@
 // THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
+//
+// This file is derived from the HIVM GraphSyncSolver in AscendNPU-IR/bishengir
+// (https://github.com/AscendNPU-IR/bishengir), licensed under the Apache
+// License, Version 2.0.  Upstream copyright and license notice:
+//   Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
 
 //===----------- EventIdSolver.cpp ---- Graph Sync Solver -----------------===//
 //===----------------------------------------------------------------------===//

--- a/lib/PTO/Transforms/GraphSyncSolver/GraphSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/GraphSolver.cpp
@@ -5,6 +5,20 @@
 // THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
+//
+// This file is derived from the HIVM GraphSyncSolver in AscendNPU-IR/bishengir
+// (https://github.com/AscendNPU-IR/bishengir), licensed under the Apache
+// License, Version 2.0.  Upstream copyright and license notice:
+//   Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
 
 //===----------- GraphSolver.cpp ---- Graph Sync Solver -------------------===//
 //===----------------------------------------------------------------------===//

--- a/lib/PTO/Transforms/GraphSyncSolver/MemInfo.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/MemInfo.cpp
@@ -5,6 +5,20 @@
 // THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
+//
+// This file is derived from the HIVM GraphSyncSolver in AscendNPU-IR/bishengir
+// (https://github.com/AscendNPU-IR/bishengir), licensed under the Apache
+// License, Version 2.0.  Upstream copyright and license notice:
+//   Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
 
 //===------------- MemInfo.cpp ---- Graph Sync Solver ---------------------===//
 //===----------------------------------------------------------------------===//

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
@@ -5,6 +5,20 @@
 // THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
+//
+// This file is derived from the HIVM GraphSyncSolver in AscendNPU-IR/bishengir
+// (https://github.com/AscendNPU-IR/bishengir), licensed under the Apache
+// License, Version 2.0.  Upstream copyright and license notice:
+//   Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
 
 //===--------- SyncSolver.cpp ------- Graph Sync Solver -------------------===//
 //===----------------------------------------------------------------------===//

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolverIR.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolverIR.cpp
@@ -5,6 +5,20 @@
 // THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
+//
+// This file is derived from the HIVM GraphSyncSolver in AscendNPU-IR/bishengir
+// (https://github.com/AscendNPU-IR/bishengir), licensed under the Apache
+// License, Version 2.0.  Upstream copyright and license notice:
+//   Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
 
 //===---------- SyncSolverIR.cpp ---- Graph Sync Solver -------------------===//
 //===----------------------------------------------------------------------===//

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolverIRTranslator.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolverIRTranslator.cpp
@@ -5,6 +5,20 @@
 // THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
+//
+// This file is derived from the HIVM GraphSyncSolver in AscendNPU-IR/bishengir
+// (https://github.com/AscendNPU-IR/bishengir), licensed under the Apache
+// License, Version 2.0.  Upstream copyright and license notice:
+//   Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
 
 //===--------- IRTranslator.cpp ------- Graph Sync Solver -------===//
 //===----------------------------------------------------------------------===//

--- a/lib/PTO/Transforms/GraphSyncSolver/Utility.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/Utility.cpp
@@ -5,6 +5,20 @@
 // THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
+//
+// This file is derived from the HIVM GraphSyncSolver in AscendNPU-IR/bishengir
+// (https://github.com/AscendNPU-IR/bishengir), licensed under the Apache
+// License, Version 2.0.  Upstream copyright and license notice:
+//   Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
 
 //===------------- Utility.cpp ---- Graph Sync Solver ---------------------===//
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary

The GraphSyncSolver sources under `lib/PTO/Transforms/GraphSyncSolver/` are derived from the HIVM GraphSyncSolver in [AscendNPU-IR/bishengir](https://github.com/AscendNPU-IR/bishengir), which is licensed under the Apache License 2.0.

Apache License 2.0 §4(b) requires derivative works to retain the upstream copyright notice and license. These files previously carried only the CANN 2.0 header and dropped the upstream Apache-2.0 notice.

## Changes

Add an upstream derivative notice to the 7 files that are direct copies of the upstream HIVM sources:

- `EventIdSolver.cpp`
- `GraphSolver.cpp`
- `MemInfo.cpp`
- `SyncSolver.cpp`
- `SyncSolverIR.cpp`
- `SyncSolverIRTranslator.cpp`
- `Utility.cpp`

Each notice preserves the upstream copyright `(c) Huawei Technologies Co., Ltd. 2025` and the full Apache-2.0 license text.

`PTOGraphSyncSolver.cpp` and `SyncSolverCodeGen.cpp` are substantially rewritten from upstream and are not treated as derivatives.