### PR TITLE
(VMI issue) lit-test reproducer for prefix-sum "expert-cursor" scf.while pattern.

### DIFF
--- a/test/lit/pto/ISSUE_psum_expert_cursor.md
+++ b/test/lit/pto/ISSUE_psum_expert_cursor.md
@@ -1,0 +1,69 @@
+# Issue: PTOAS cannot lower psum expert-cursor `scf.while` pattern
+
+## In plain language
+
+Packed per-group token layouts need a tiny device loop:
+
+1. Walk tokens in order.
+2. Advance a monotonic **group cursor** with a **data-dependent `while`**
+   against an aligned prefix-sum threshold (`psum`).
+3. Compute a **boolean `valid`** (real token vs pad).
+4. Conditionally store a result.
+
+**What works today (related samples):**
+
+- Top-level `scf.while` with an `i1` alive flag (`test/samples/SCF/scf_while_break.pto`)
+- `scf.for` carrying an index + nested `scf.while` with a **simple** condition
+  (no `scf.if` inside the while condition)
+
+**What fails (this repro):**
+
+- Full algorithm in `psum_expert_cursor_while.pto`:
+  `error: Unsupported SCF op remained after pre-lowering`
+- Reduced trigger in `psum_for_while_if_condition.pto`:
+  `scf.for` + nested `scf.while` whose condition contains `scf.if`
+  → pinned `ptoas` **segfaults** (SIGSEGV) or fails SCF pre-lowering
+
+## Out of scope
+
+- Host layout generators
+- Any compute beyond the keep-mask / store
+
+## How to run
+
+Use a working `ptoas` (pin tip `8a3e3def` or equivalent). Avoid shadowing
+`PYTHONPATH` with an incomplete build tree (that can break `import ptoas._core`).
+
+```bash
+# Full expert-cursor algorithm (expects the Unsupported SCF diagnostic)
+ptoas --pto-arch=a5 test/lit/pto/psum_expert_cursor_while.pto -o -
+
+# Reduced for+while+if-in-condition trigger
+ptoas --pto-arch=a5 test/lit/pto/psum_for_while_if_condition.pto -o -
+```
+
+Or via lit (FileCheck expects the failure until fixed):
+
+```bash
+# from a configured ptoas build / lit setup
+llvm-lit test/lit/pto/psum_expert_cursor_while.pto
+```
+
+## Observed results (2026-08-06)
+
+```
+# psum_expert_cursor_while.pto
+loc("eid_after"(...psum_expert_cursor_while.pto":40:20)): \
+  error: Unsupported SCF op remained after pre-lowering
+Error: Pass execution failed.
+
+# psum_for_while_if_condition.pto (same machine)
+Segmentation fault (exit 139)
+```
+
+Control: `test/samples/SCF/scf_while_break.pto` still lowers to EmitC.
+
+## Desired fix
+
+Lower (or rewrite during pre-lowering) nested `scf.while` with `scf.if` in the
+condition / body so the expert-cursor pattern emits valid vector-kernel CCE.

--- a/test/lit/pto/psum_expert_cursor_while.pto
+++ b/test/lit/pto/psum_expert_cursor_while.pto
@@ -1,0 +1,82 @@
+// Minimal PTOAS repro: prefix-sum expert-cursor keep-mask.
+//
+// Algorithm:
+//   for token_id in 0..N-1:                 // carry expert_id
+//     while expert_id < E and token_id >= align(psum[expert_id]):
+//       expert_id += 1
+//     valid = expert_id < E and token_id < psum[expert_id]
+//     out[token_id] = valid ? 1 : 0
+//
+// Nested scf.if avoids evaluating psum[expert_id] when expert_id == E
+// (MLIR arith.andi does not short-circuit).
+//
+// Observed failure:
+//   error: Unsupported SCF op remained after pre-lowering
+// Reduced cousin (for + while + scf.if in while condition, no GM load)
+// also crashes the compiler (SIGSEGV) — see psum_for_while_if_condition.pto.
+//
+// RUN: not ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @psum_expert_cursor(
+      %psum: !pto.ptr<i32, gm>,
+      %out: !pto.ptr<i32, gm>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c16 = arith.constant 16 : index
+    %c7 = arith.constant 7 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %false = arith.constant false
+
+    // Carry expert_id across the token loop (monotonic cursor).
+    %final_eid = scf.for %token_id = %c0 to %c16 step %c1
+        iter_args(%expert_id = %c0) -> (index) {
+      // while expert_id < 2 and token_id >= align8(psum[expert_id]): expert_id++
+      %eid_after = scf.while (%eid = %expert_id) : (index) -> index {
+        %lt_e = arith.cmpi slt, %eid, %c2 : index
+        %go = scf.if %lt_e -> (i1) {
+          %thr_i32 = pto.load_scalar %psum[%eid] : !pto.ptr<i32, gm> -> i32
+          %thr = arith.index_cast %thr_i32 : i32 to index
+          // align8(x) = ((x + 7) / 8) * 8
+          %thr_plus = arith.addi %thr, %c7 : index
+          %thr_div = arith.divui %thr_plus, %c8 : index
+          %aligned = arith.muli %thr_div, %c8 : index
+          %ge_thr = arith.cmpi uge, %token_id, %aligned : index
+          scf.yield %ge_thr : i1
+        } else {
+          scf.yield %false : i1
+        }
+        scf.condition(%go) %eid : index
+      } do {
+      ^bb0(%eid2: index):
+        %next = arith.addi %eid2, %c1 : index
+        scf.yield %next : index
+      }
+
+      %lt_e2 = arith.cmpi slt, %eid_after, %c2 : index
+      %valid = scf.if %lt_e2 -> (i1) {
+        %end_i32 = pto.load_scalar %psum[%eid_after] : !pto.ptr<i32, gm> -> i32
+        %end = arith.index_cast %end_i32 : i32 to index
+        %lt_tok = arith.cmpi ult, %token_id, %end : index
+        scf.yield %lt_tok : i1
+      } else {
+        scf.yield %false : i1
+      }
+
+      %val = scf.if %valid -> (i32) {
+        scf.yield %c1_i32 : i32
+      } else {
+        scf.yield %c0_i32 : i32
+      }
+      pto.store_scalar %val, %out[%token_id] : !pto.ptr<i32, gm>, i32
+      scf.yield %eid_after : index
+    }
+    return
+  }
+}
+
+// CHECK: Unsupported SCF op remained after pre-lowering

--- a/test/lit/pto/psum_for_while_if_condition.pto
+++ b/test/lit/pto/psum_for_while_if_condition.pto
@@ -1,0 +1,51 @@
+// Reduced cousin of psum_expert_cursor_while.pto.
+//
+// Isolates: scf.for (carry) + nested scf.while whose condition uses scf.if.
+// No GM load / align math. Plain for+while without the inner if lowers
+// successfully; adding scf.if in the while condition crashes pinned ptoas
+// (SIGSEGV) or fails SCF pre-lowering. See ISSUE_psum_expert_cursor.md.
+//
+// Lit only asserts non-zero exit today (crash or diagnostic). When fixed,
+// replace with a positive EmitC FileCheck like scf_while_break.pto.
+//
+// RUN: not ptoas --pto-arch=a5 %s -o /dev/null
+
+module {
+  func.func @for_while_if_cond(%out: !pto.ptr<i32, gm>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %false = arith.constant false
+
+    %final = scf.for %t = %c0 to %c8 step %c1
+        iter_args(%eid = %c0) -> (index) {
+      %eid2 = scf.while (%e = %eid) : (index) -> index {
+        %lt = arith.cmpi slt, %e, %c2 : index
+        // THIS nested if-in-while-condition is the reduced trigger.
+        %go = scf.if %lt -> (i1) {
+          %ge = arith.cmpi uge, %t, %c8 : index
+          scf.yield %ge : i1
+        } else {
+          scf.yield %false : i1
+        }
+        scf.condition(%go) %e : index
+      } do {
+      ^bb0(%e2: index):
+        %n = arith.addi %e2, %c1 : index
+        scf.yield %n : index
+      }
+      %val = scf.if %false -> (i32) {
+        scf.yield %c1_i32 : i32
+      } else {
+        scf.yield %c0_i32 : i32
+      }
+      pto.store_scalar %val, %out[%t] : !pto.ptr<i32, gm>, i32
+      scf.yield %eid2 : index
+    }
+    return
+  }
+}


### PR DESCRIPTION
See `test/lit/pto/ISSUE_psum_expert_cursor.md` for the current bug. 

Reproducer: Minimal for/while/if keep-mask that hits Unsupported SCF pre-lowering (and a reduced if-in-while-condition crash), without higher-level stacks.

Note: This bug not about SIMD VF itself, but about the scalar-side control flow code that is used together with a VF later. The bug reproducer doesn't need SIMD VF part. 