### PR TITLE
feat(ptodsl): support struct member access (named fields)

### DIFF
--- a/docs/designs/ptodsl-struct-member-access-design.md
+++ b/docs/designs/ptodsl-struct-member-access-design.md
@@ -10,7 +10,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 
 # PTODSL Struct 成员访问表层设计
 
-**状态：** 设计稿 v4（Issue #1129，已按三轮 Codex review 修订）
+**状态：** 设计稿 v5（Issue #1129，已按三轮 Codex review + 一轮 maintainer review 修订）
 
 > 修订说明：v2 将字段名→位置 path 的解析**完全移到 AST 重写期**并直接发射
 > canonical `struct_get` / `struct_set`，消除运行时私有 helper、descriptor→value
@@ -35,6 +35,28 @@ See LICENSE in the root of the software repository for the full text of the Lice
 >   `struct_type` 字段规则一致）；选项门控统一为公开的 `ast_rewrite` /
 >   `frontend_options["ast_rewrite"]`，并明确 `rewrite_part` 只接受
 >   `{"control_flow"}`；补 `AnnAssign` 注解的丢弃 / 一致性校验 / 重写期错误。
+>
+> v5（本轮，针对 maintainer review）：
+> - **新增 `@pto.struct` class 声明形式**（supersede §5.2 的拒绝决定）：构造
+>   `Point(...)` 走运行时 `__call__`（trace 时执行 declare + 逐字段 struct_set，
+>   无需 AST 重写），成员访问仍走 AST 重写；§5.2 当初的顾虑（与运行时
+>   `_SurfaceValue` 语义耦合）因这一分工不成立。类体仅允许裸注解：默认值、
+>   方法、继承在装饰期拒绝。
+> - **健全性修复**：`for`/`while` 循环体内删除或改动的 struct 绑定不再泄漏到
+>   循环之后；`state += ...` 取消 struct 身份；AnnAssign 声明
+>   （`S: T = pto.struct({...})`）与赋值建立相同绑定；多段点名字段类型
+>   （`a.b.c`）不再使重写器抛出内部 AttributeError（按不可解析处理）。
+>
+> v6（本轮，PR review 自查）：
+> - **全 Name 多目标赋值传播绑定**：`a = b = Point(...)` / `a = b =
+>   pto.declare_struct(S)` / `A = B = S` 此前仅单目标赋值建立 struct 类型/值
+>   绑定，链式赋值后成员访问未被重写、并误报"需要 AST 重写"；现按 RHS 分类
+>   （`_classify_struct_binding`）将绑定传播到每个 Name 目标。本地名字优先于
+>   `static_env` 中的同名 descriptor。
+> - **补 PEP 563 回归测试**：`rewrite_jit_function` 的 future-flag 修复
+>   （`dont_inherit=True` + 保留 kernel 自身的 future flags）此前无回归覆盖；
+>   新增 kernel 内局部 dtype 别名注解（`T = pto.i32; v: T`）用例锁定该行为，
+>   以及字符串注解经 `from_class` 在定义模块命名空间解析的用例。
 
 **范围：** PTODSL Python 前端（`_types.py` / `_ops.py` / `_surface_values.py`）、
 AST 重写、用户手册与回归测试
@@ -228,20 +250,40 @@ def kernel():
 - 非标识符 dict 键（如 `"a-b"`）在声明期即报错，避免产生无法通过 `state.a-b`
   访问的名字。
 
-### 5.2 Python class 声明方式（备选，均不采用）
+### 5.2 Python class 声明方式（v5 起采用，见下）
 
-被拒绝的备选：
+**v5 更新：maintainer review 明确要求 class 形式，本节原拒绝决定被 supersede。**
+关键认识变化：构造 `Point(...)` 走**运行时 `__call__`**（trace 时执行
+`declare_struct` + 逐字段 `struct_set`），不需要 AST 重写；只有成员访问需要 AST
+重写。当初担心的"class 语句创建真正的 Python 类型、与 `_SurfaceValue` 运行时语义
+耦合"因此不成立——装饰器返回的是 `_StructDescriptor` 实例而不是类型对象，类体被
+限制为纯注解声明（无默认值 / 方法 / 继承），dict 保序问题由 `__annotations__`
+的插入序（Python 3.7+）解决。
 
-- **`class` + `__annotations__`**：PTODSL 的 dtype descriptor 用作注解类型并非
-  真正的 Python 类型，`__annotations__` 在 `@pto.jit` 前即可读取，但 `class` 语句
-  会创建真正的 Python 类型对象，与运行时 `_SurfaceValue` 语义耦合，且 dict 保序
-  与继承/`__slots__` 语义带来额外复杂度。本设计不引入新的 Python 类型层次。
+现采用的形式：
+
+```python
+@pto.struct
+class Point:
+    x: pto.i32
+    y: pto.f32
+
+state = Point(x, y)   # declare + 全字段初始化（all-or-none）
+state = Point()       # 仅声明
+```
+
+- `pto.struct` 按参数类型双用法分发：`dict` → 既有 dict 形式；`type` → 类装饰。
+- `__call__` 实现于 `_StructDescriptor`：named descriptor 均可调用（dict 形式构造的
+  描述符同样可调用，行为一致）；positional 描述符调用即报错。
+- PEP 563 字符串注解在定义模块的命名空间内解析（与 dataclasses 同一惯例）。
+- dict 形式保留为程序化构造途径（字段集合由代码计算而非字面写出时）。
+
+仍被拒绝的备选：
+
 - **dataclass**：引入 dataclass + 字段映射的完整对象模型，超出"薄、无损"目标。
 - **`pto.struct_type` + 独立 names 参数**：`struct_type(pto.i32, pto.f32,
   names=("n","sum"))` 可用，但把名字与位置分离，嵌套时容易错位；`pto.struct({...})`
   把名字与类型绑在一起，更不易错。
-
-因此选择 `pto.struct({...})` 这种"名字与类型同处"的声明式 dict 形式。
 
 ## 6. 前端实现
 
@@ -377,6 +419,11 @@ AST 重写发生在函数执行前，此时局部 `S` **尚未构造**，重写�
 
 - `type_bindings: var_name -> _DescriptorMetadata`（来自 `S = pto.struct(...)`）。
 - `value_bindings: var_name -> _DescriptorMetadata`（来自 `state = declare_struct(S)`）。
+
+全 Name 多目标赋值（`a = b = rhs`）按 `_classify_struct_binding(rhs)` 的分类把
+类型/值绑定传播到**每个**目标（RHS 只求值一次，两个名字别名同一个 descriptor /
+struct 值）；含成员写目标的混合链式赋值（如 `state.x = a = rhs`）不在此列，走
+成员写路径。
 
 `declare_struct(...)` 的实参既可以是直接 `S`，也可以是内联
 `pto.declare_struct(pto.struct({...}))`（后者建立 `state -> 内联 metadata` 绑定）。

--- a/docs/designs/ptodsl-struct-member-access-design.md
+++ b/docs/designs/ptodsl-struct-member-access-design.md
@@ -1,0 +1,617 @@
+<!--
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+-->
+
+# PTODSL Struct 成员访问表层设计
+
+**状态：** 设计稿 v4（Issue #1129，已按三轮 Codex review 修订）
+
+> 修订说明：v2 将字段名→位置 path 的解析**完全移到 AST 重写期**并直接发射
+> canonical `struct_get` / `struct_set`，消除运行时私有 helper、descriptor→value
+> 传播、source-less 静默失效等 P1 问题。
+>
+> v3（本轮，针对第二轮 review）：
+> - **P1 #1**：新增局部 descriptor 的**白名单静态求值**机制（不对任意 AST 用
+>   `eval()`），并删除"全局需源码可定位"的错误约束（直接查 `static_env`）。
+> - **P1 #2**：混合规则改为——进入 positional 层后整条成员表达式非法，须改写为完整
+>   canonical path。
+> - **P1 #3**：`_StructMemberRewriter` 与 `_ControlFlowRewriter` 同受
+>   `rewrite_control_flow` 门控，并同步 `ast_rewrite` 选项文档。
+> - **P1 #4**：EmitC 验收改为断言位置字段访问 `.f0` / `.f1.f0`，不期待源字段名。
+> - **P2**：签名固定 `dict[str, FieldType]`；修正 rebinding 继承、`state.field: T`
+>   写入语义、多目标赋值临时变量；删除非 struct base 的普遍诊断承诺；补充公开导出
+>   与 path 断言方式。
+>
+> v4（本轮，针对第三轮 review）：
+> - **P1**：修正多目标赋值顺序——按 `node.targets` 源码顺序从左到右逐个执行目标，
+>   RHS 只求值一次；补充 `state.x = a = rhs` 与多个成员目标的反例。
+> - **P2**：静态求值白名单覆盖 `static_env` 中的合法 MLIR scalar `Type`（与
+>   `struct_type` 字段规则一致）；选项门控统一为公开的 `ast_rewrite` /
+>   `frontend_options["ast_rewrite"]`，并明确 `rewrite_part` 只接受
+>   `{"control_flow"}`；补 `AnnAssign` 注解的丢弃 / 一致性校验 / 重写期错误。
+
+**范围：** PTODSL Python 前端（`_types.py` / `_ops.py` / `_surface_values.py`）、
+AST 重写、用户手册与回归测试
+
+**依赖：** 已合并的 `ptodsl-struct-frontend-design.md`（Issue #1104）中定义的
+`!pto.struct`、`pto.struct_type`、`pto.declare_struct`、`pto.struct_get` 与
+`pto.struct_set` canonical API。
+
+## 1. 背景与动机
+
+PR #1104 引入了与 PTO IR 对齐的 canonical struct API：用位置 path
+`pto.struct_get(state, (1, 0))` 与 `pto.struct_set(state, (1, 0), value)` 读写
+`pto.declare_struct(...)` 声明的栈上异构聚合 `!pto.struct<...>`。该 API 最贴近 IR
+形态，但 review 指出其易用性不足：
+
+> 希望 DSL 能够直接提供一个类似 class 的抽象，用户可以像访问 class 成员一样访问
+> struct 成员，不用 `struct_set` / `struct_get`。
+
+本设计为 PTODSL 增加一个"命名字段 + Python 成员访问"的表层，作为 canonical
+path API 之上的薄、无损包装，并保留 canonical API 作为底层实现。
+
+### 核心矛盾
+
+- Python 的 `obj.field` 由 `__getattr__` / `__setattr__` 在运行时解析，天然支持
+  任意字段名，且无法在调用 `__setattr__` 前天然区分"写入整块 struct"与"写入成员"。
+- PTO IR 的字段身份是**位置**（`DenseI64ArrayAttr` path），不是名字。
+- `!pto.struct` 的字段类型是**位置顺序**的；若支持任意命名，必须把名字可靠地映射
+  回位置，且不能依赖 Python 运行时把字符串当作 IR path。
+
+因此本设计引入**显式命名字段声明**（`pto.struct({...})`），由前端在 tracing 前把
+名字静态解析为位置 path，再复用现有 `struct_get` / `struct_set` 的 path 检查和
+lowering。字段名是编译期常量，不进入 IR。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+- 提供可声明命名字段的 PTODSL struct 表层。
+- 支持成员读取 `state.field`、写入 `state.field = value` 与嵌套成员访问
+  `state.inner.field`。
+- 成员访问无损 lower 到现有 `pto.struct_get` / `pto.struct_set`，生成与显式 path
+  API **逐位等价**的 PTO IR。
+- 保持显式 path API 可用，作为底层 canonical API。
+- 明确字段命名、Python class 声明方式、字面量 materialization 与诊断规则。
+
+### 2.2 非目标
+
+- 不改变 `!pto.struct` 的存储模型、ABI、生命周期或后端 lowering。
+- 不支持动态字段名（`getattr(state, name)` / `state.__dict__` 注入）、动态索引。
+- 不将 struct 用作函数 ABI（`@pto.jit` entry / `entry=False` module、
+  `@pto.tileop` / `@pto.simt` 参数）。
+- 不引入通用 `pto.f64` surface、Tile/TensorView/ptr 容器字段（沿用既有类型约束）。
+- 不修改 canonical path API 的签名或语义。
+
+## 3. 用户 API
+
+### 3.1 类型构造：`pto.struct({...})`
+
+用命名字段构造与 `pto.struct_type(...)` 等价的惰性描述符：
+
+```python
+Point = pto.struct({"x": pto.i32, "y": pto.f32})
+Nested = pto.struct({
+    "id": pto.i32,
+    "point": pto.struct({"x": pto.i32, "y": pto.f32}),
+})
+```
+
+公开签名为（**固定为 `dict[str, FieldType]` 单参数**，不接受位置列表、不接受
+`*args`、不接受裸描述符）：
+
+```python
+pto.struct(fields: dict[str, FieldType]) -> _StructDescriptor
+```
+
+- `fields` 必须为 `dict[str, field_type]`（Python 3.7+ 保序）。字段类型规则与
+  `pto.struct_type(...)` 完全一致：PTODSL 标量 dtype、已 materialize 的 MLIR
+  scalar type，或另一个 `pto.struct({...})` / `pto.struct_type(...)` 描述符。
+- 返回一个新的 `_StructDescriptor`，其字段顺序即 dict 插入顺序。因此由
+  `pto.struct({...})` 构造的描述符与等价的 `pto.struct_type(...)` 解析为**同一个**
+  `!pto.struct<...>` 文本表示。
+- 名字是**编译期常量**，仅由前端 / AST 重写器用来把成员访问映射为位置 path；名字
+  本身不进入 IR 文本、不参与 lowering。
+- 空 dict、非 dict 参数、非法字段类型沿用既有 `struct_type` 诊断并补充 struct
+  专属上下文。
+
+**重名键诊断的边界**：普通 Python `dict` 在求值前就丢失重复键
+（`{"x": i32, "x": f32}` 只剩一个），因此**不能承诺在运行时检测重名键**。重复键
+检测只在 AST 重写期对源码中的字面量 `{...}` AST 节点进行（见 §6.4）；运行时传入
+已构造 dict 的重复键无法且不检测。文档与诊断表相应改为"仅 AST 字面量 dict 检测
+重名键"。
+
+**混用规则（明确，P1 #2 修订）**：成员访问要求整条字段名链上的**每一层**都是
+`pto.struct({...})` 命名的。规则如下：
+
+- **一旦路径进入 positional struct（`pto.struct_type(...)` 层），整条成员表达式
+  不合法**，用户必须改写为到达标量叶子的完整 canonical path。因为
+  `struct_get` / `struct_set` 只允许 path 到达标量叶子，不能返回或写入整个嵌套
+  struct；`state.pt` 本身也不是 IR 值（见 §4）。
+- 因此 `state.inner.x` 只有在 `inner` 及其祖先都是 named 时才可解析；若 `inner` 是
+  positional，`state.inner` 与 `state.inner.x` **都**在重写期报错，用户应改写为
+  `pto.struct_get(state, (1, 0))` 这类完整标量 path。
+- 允许 named 与 positional 混用，但混用只影响"能够用成员访问到达多深"，不改变
+  `!pto.struct<...>` 的表示。
+
+### 3.2 声明与成员访问
+
+```python
+@pto.jit(target="a5", mode="explicit")
+def accumulate(x: pto.i32, y: pto.f32):
+    S = pto.struct({"n": pto.i32, "sum": pto.f32})
+    state = pto.declare_struct(S)
+
+    state.n = x            # -> pto.struct_set(state, 0, x)
+    state.sum = y          # -> pto.struct_set(state, 1, y)
+    count = state.n        # -> pto.struct_get(state, 0)
+    total = state.sum      # -> pto.struct_get(state, 1)
+    _ = count, total
+```
+
+嵌套成员访问：
+
+```python
+P = pto.struct({
+    "id": pto.i32,
+    "pt": pto.struct({"x": pto.i32, "y": pto.f32}),
+})
+
+@pto.jit(target="a5", mode="explicit")
+def kernel():
+    s = pto.declare_struct(P)
+    s.pt.x = 1            # -> pto.struct_set(s, (1, 0), 1)
+    v = s.pt.y            # -> pto.struct_get(s, (1, 1))
+```
+
+### 3.3 与 canonical API 的关系
+
+`state.field` 仅是 `pto.struct_get(state, path)` / `pto.struct_set(state, path, v)`
+的语法糖，其中 `path` 由字段名静态解析。两者可混写；`struct_get` / `struct_set`
+保持可用并作为唯一 canonical 底层。
+
+## 4. 关键设计决策
+
+1. **字段名是编译期常量，由结构性（structural）类型携带，不进入 IR。**
+   名字存储于 `_StructDescriptor` 的字段元数据中；`!pto.struct` 本身仍是位置聚合。
+   这保证了与既有 PTO IR / VPTO / EmitC lowering 的零改动。
+
+2. **成员访问通过 AST 重写实现，且字段名→位置 path 在重写期完全解析并直接发射
+   canonical `struct_get` / `struct_set`。**
+   原因：
+   - `state.field = value` 在 Python 里必然先触发 `__setattr__`，无法在求值前把
+     字段名转成位置 path 并让 `state.field`（读）与 `state.field = v`（写）共享同一
+     套解析逻辑。
+   - 运行时 `__getattr__` 返回的标量 SSA value 无法携带"来自哪个 struct 的哪个
+     成员"这一信息，无法在 `state.pt.x = v` 时把 `state.pt` 中间结果当作可写
+     handle 再回填。
+   - PTODSL 已有 `@pto.jit(ast_rewrite=True)` 的 source-to-source 重写基础设施
+     （`_ast_rewrite.py`），可把 `attribute` 节点静态替换为对 `pto.struct_get` /
+     `pto.struct_set` 的调用。
+   - **重写器在重写期用 `field_index(name)` 把名字链解析为整数 tuple**，生成的
+     代码是 `pto.struct_set(state, (0,), value)` / `pto.struct_get(state, (0,))`，
+     **不含任何运行时私有 helper、不携带 descriptor 到 value**。这样：
+     - 不需要 `state -> descriptor` 的运行时绑定（P1 #1 消除）；
+     - 不需要注入/引用私有 helper（P1 #2 消除）；
+     - 生成的代码直接落在 canonical surface 上，可追踪、可验证、与手写 path 一致。
+
+3. **标量成员就是 `struct_get` 的标量 result，不引入新的值类别。**
+   因此 `state.field` 可直接参与 arith 运算、作为 `if_` 条件等，与
+   `pto.struct_get(state, path)` 的返回值完全等价。
+
+4. **嵌套 struct 成员（`state.pt`）在前端 typing 期就解析为位置 path，不产生
+   IR。** 它只在「基 struct + path 前缀」的意义上存在，用于把 `state.pt.x`
+   折叠为 `struct_get(state, (1, 0))`。对 `state.pt` 本身求值（非继续访问标量）在
+   重写期报错，因为它不是 IR 值；用户必须给出到达标量叶子的完整 path。
+
+## 5. 命名与语法分歧点
+
+### 5.1 字段命名规则
+
+字段名必须同时满足以下条件，否则在 `pto.struct(...)` 声明期报错：
+
+- **合法 Python 标识符**（`str.isidentifier()`），且**不是 Python 关键字**
+  （`keyword.iskeyword(name)`）。`isidentifier()` 会接受 `class`、`await` 等关键字，
+  但 `state.class` / `state.await` 不是合法 Python 语法；因此必须额外排除关键字。
+- **不以 `_` 开头**（避免与内部属性冲突，预留扩展）。
+- **不在实现维护的保留集合内**。保留集合由 `_StructDescriptor` / struct surface 的
+  内部属性名决定，是可执行的、需随实现维护的常量集合，至少包含：
+  `value`、`type`、`surface_metadata`、`field_descriptors`、`field_names`、
+  `field_index`、`resolve`、`declared_value` 以及所有 `_SurfaceValue` 的既有属性。
+  保留集合应在 `_types.py` 中定义为模块级 frozenset，并在测试中逐一断言冲突报错。
+- 非标识符 dict 键（如 `"a-b"`）在声明期即报错，避免产生无法通过 `state.a-b`
+  访问的名字。
+
+### 5.2 Python class 声明方式（备选，均不采用）
+
+被拒绝的备选：
+
+- **`class` + `__annotations__`**：PTODSL 的 dtype descriptor 用作注解类型并非
+  真正的 Python 类型，`__annotations__` 在 `@pto.jit` 前即可读取，但 `class` 语句
+  会创建真正的 Python 类型对象，与运行时 `_SurfaceValue` 语义耦合，且 dict 保序
+  与继承/`__slots__` 语义带来额外复杂度。本设计不引入新的 Python 类型层次。
+- **dataclass**：引入 dataclass + 字段映射的完整对象模型，超出"薄、无损"目标。
+- **`pto.struct_type` + 独立 names 参数**：`struct_type(pto.i32, pto.f32,
+  names=("n","sum"))` 可用，但把名字与位置分离，嵌套时容易错位；`pto.struct({...})`
+  把名字与类型绑在一起，更不易错。
+
+因此选择 `pto.struct({...})` 这种"名字与类型同处"的声明式 dict 形式。
+
+## 6. 前端实现
+
+### 6.1 类型层（`_types.py`）
+
+扩展 `_StructDescriptor`，使其同时支持两种构造路径：
+
+- positional 构造（`pto.struct_type(...)`）：`field_descriptors` 保序，无名字。
+- named 构造（`pto.struct({...})`）：保存 `_field_names: tuple[str, ...]` 与
+  `_name_to_index: dict[str, int]`，`field_descriptors` 仍为保序字段类型。
+
+新增公开 `struct(fields)`，**固定单参数**：
+
+```python
+def struct(fields: dict[str, FieldType]) -> _StructDescriptor:
+    if not isinstance(fields, dict):
+        raise TypeError("pto.struct(...): expected a dict[str, field_type]")
+    return _StructDescriptor.from_named(fields)
+```
+
+不接受位置列表、`*args` 或裸描述符；这些误用报错并提示用 `struct_type` 或 dict。
+**签名固定为 `dict[str, FieldType]`（与伪实现一致），不是 `Mapping`**：字段顺序取自
+`dict` 的插入序，且 `Mapping` 的迭代序未定义、普通 `dict` 之外的其他 `Mapping` 子类
+不在支持范围内。文档统一使用 `dict[str, FieldType]`。
+
+`_StructDescriptor` 增加：
+
+- `field_names` property（positional 构造返回 `None`）。
+- `field_index(name) -> int`：查 `_name_to_index`，未知名报错。
+- `field_descriptor_at(i) -> (name, type)`：返回第 `i` 个字段的名字（可能为 `None`）
+  与类型，供 AST 重写器逐层解析嵌套。
+- `resolve()` / `field_descriptors` 保持与 positional 构造完全一致，保证生成相同
+  `!pto.struct<...>`。
+
+### 6.2 成员访问解析（全部在 AST 重写期，无运行时 helper）
+
+**不引入 `_StructMemberRef` 或任何运行时私有 helper。** 字段名→位置 path 的解析
+完全发生在 §6.4 的 AST 重写器内：
+
+- 重写器持有 `state -> _StructDescriptor` 的静态绑定（见 §6.4）。
+- 对 `state.a.b`，重写器用 `field_index` / `field_descriptor_at` 逐层把名字解析为
+  整数 tuple `indices`。
+- **直接发射** `pto.struct_get(state, indices)` 或 `pto.struct_set(state, indices,
+  rhs)`——即 canonical API 本身，路径已预解析好。
+
+因此 `_ops.py` 无需新增任何可被源码引用的名称；生成的代码只引用 `pto.struct_get` /
+`pto.struct_set`（已在 `pto` 命名空间及 `exec` 的 globals 中可用）。这消除了 P1 #1
+的 descriptor→value 传播与 P1 #2 的 helper 注入/命名冲突问题。
+
+### 6.3 运行时 surface 与 source-less fallback（`_surface_values.py`）
+
+不新增公开的 struct surface 类。`declare_struct` 返回值保持现有 `_SurfaceValue`
+包装。
+
+**source-less / 未重写路径的策略（明确，非静默）**：成员语法依赖 AST 源码可获取。
+当 `inspect.getsource()` 失败（exec / REPL / notebook）或 `ast_rewrite=False` 时，
+`_ast_rewrite.py` 现有逻辑返回原函数（[`_ast_rewrite.py:49`](file:///Users/jimmychou/work/ptoas/PTOAS/ptodsl/ptodsl/_ast_rewrite.py)）。
+此时 `state.field = value` 会退化为普通 Python 实例属性赋值（不会生成 `struct_set`），
+读取则得到 `AttributeError`——这比显式失败更危险。
+
+因此给 `_SurfaceValue` 增加 `__getattr__` / `__setattr__`，**仅用于诊断**：
+
+- 当对象是 `declare_struct` 的返回值（通过一个私有标记 `_is_struct_value` 标识）且
+  访问了非内部属性时，抛出明确错误：内容为"struct 成员访问需要 AST 源码重写
+  （默认开启）；请保留 `@pto.jit` 的源码可获取性，或改用
+  `pto.struct_get` / `pto.struct_set`"。
+- **绝不**通过这些魔术方法静默生成 IR。
+- 普通 `_SurfaceValue`（非 struct）不额外拦截，保持既有行为。
+
+这样三条路径都有确定行为：AST 重写成功（推荐）、明确报错（source-less /
+`ast_rewrite=False`）、显式 canonical path API（始终可用）。
+
+### 6.4 AST 重写（`_ast_rewrite.py`）
+
+在 `rewrite_jit_function` 的 transformer 中新增 `_StructMemberRewriter`。它需要精确的
+**符号环境**与 **rebinding 规则**，以免误重写普通 Python 属性。
+
+#### 局部 descriptor 的静态求值（P1 #1 核心）
+
+AST 重写发生在函数执行前，此时局部 `S` **尚未构造**，重写器不能调用
+`S.field_index()`。因此重写器必须把 `pto.struct({...})` / `pto.struct_type(...)`
+的赋值**静态求值**为独立的 descriptor metadata，而不是直接对任意 AST 用 `eval()`。
+
+**静态求值机制（限定可解析语法，逐层安全求值）**：
+
+重写器解析 `pto.struct({...})` 的 AST，为每个字段名递归求值其类型，得到元数据
+`{name -> resolved_field_metadata}`。可解析的值集合（白名单）为：
+
+- `pto.struct({...})` 字面量：字段名是字符串字面量，字段类型递归用白名单求值。
+- `pto.struct_type(...)` 字面量：位置字段，无名字（`field_names is None`）。
+- `pto.*` 标量 dtype：`pto.i32`、`pto.f32` 等**常量属性**——通过
+  `static_env` 中已有的 `pto` + 属性名常量解析，不执行任意代码。
+- 已存在于 `static_env` 的 descriptor 名（全局 / closure 中已构造的 `P`）。
+- 已存在于 `static_env` 的 **合法 MLIR scalar `Type`**（P2 修订）：命名 `pto.struct`
+  承诺与 `struct_type` 完全相同的字段类型规则，而 §3.1 允许字段是"已 materialize
+  的 MLIR scalar type"。因此白名单必须覆盖 `static_env` 中 `ptoas.mlir.ir.Type` 的
+  合法标量实例（如 `IntegerType.get_signless(32)`），与 `_resolve_struct_field_type`
+  的既有校验一致；不支持的 MLIR 类型照旧报错。
+- 局部 type 别名：`T = pto.struct({...})` 后 `T` 可被引用（重写器在同函数内
+  AST 前瞻解析）。
+
+**不支持**的表达式（动态表达式、函数调用返回值、下标、运算、非 `pto.*` 名称、
+非 `static_env` 中已知的 MLIR `Type`）在重写期报错，提示用字面量形式或
+`static_env` 中的名 descriptor / 名 MLIR Type。重写器**不**对任意 AST 调用
+`eval()`——只对白名单形式做结构化求值，避免执行任意代码。
+
+这一步产出重写器内部的 `descriptors: {name -> _DescriptorMetadata}`，其中
+`_DescriptorMetadata` 是纯数据（字段名列表 + 每层类型），与运行时 `_StructDescriptor`
+结构一致，但可在无 context、函数未执行时构造。
+
+#### 全局 / closure descriptor（P1 #1 修正）
+
+全局 / closure 的 `P = pto.struct(...)` **不需要源码可定位到赋值**。`static_env`
+（`fn.__globals__` + `nonlocals`）已经包含实际的 `P` descriptor 对象，重写器直接
+检查 `static_env[name]` 是否为 `_StructDescriptor` 即可。因此文档第 3.2 节的全局
+`P` 示例可正常解析。上一版"源码可定位到赋值"的限制删除。
+
+#### 符号环境（struct 绑定来源）
+
+- **函数局部**：`pto.struct({...})` / `pto.struct_type(...)` 的赋值 /
+  `AnnAssign`，经上面的静态求值产出 `var_name -> _DescriptorMetadata`。
+- **全局 / closure**：`static_env[name]` 是 `_StructDescriptor` 则直接使用（见上）。
+- **不支持**在分支/循环内**合并** descriptor 绑定（即不同分支赋不同 struct 类型给
+  同名变量）；这类情形重写器报错，提示将 struct 类型在函数入口统一声明，或用
+  canonical path。
+
+**结构性绑定 vs 值绑定**：`state = pto.declare_struct(S)` 建立 `state` 的"struct
+值"身份，指向 `S` 的 descriptor。重写器维护两类映射：
+
+- `type_bindings: var_name -> _DescriptorMetadata`（来自 `S = pto.struct(...)`）。
+- `value_bindings: var_name -> _DescriptorMetadata`（来自 `state = declare_struct(S)`）。
+
+`declare_struct(...)` 的实参既可以是直接 `S`，也可以是内联
+`pto.declare_struct(pto.struct({...}))`（后者建立 `state -> 内联 metadata` 绑定）。
+`declare_struct` 的其他实参（非 struct 类型）不应建立 value binding。
+
+**Rebinding 与取消身份（精确规则，P2 修订）**：
+
+- 变量被重新赋值（`state = other`、`state = some_value`、`state += ...`）后，其
+  struct 值身份**取消**；后续 `state.field` 不再按 struct 重写。重写器在赋值点更
+  `value_bindings`：若 `other` **是 struct value binding**（即 `other` 本身在
+  `value_bindings` 中）则继承其绑定，否则移除 `state` 的绑定。
+- 对 `state.field += x`、链式赋值（`a = b = state.field`）、`AnnAssign`、`del
+  state.field`（P2 修订）：
+  - `state.field += x`：重写为 `tmp = pto.struct_get(state, path); new = tmp + x;
+    pto.struct_set(state, path, new)`（读→运算→写）。
+  - `state.field: T = value`（带值的注解赋值）是**写入**，lower 为
+    `pto.struct_set(state, path, value)`。
+  - `state.field: T`（无值注解）**不支持**，明确拒绝或定义为无操作（不做
+    `struct_get`）；文档选择**拒绝**，避免无端读取。
+  - **`AnnAssign` 注解处理（P2 增补）**：成员注解只允许**静态、可忽略的类型标注**。
+    实现重写为 `struct_set` 时**不保留 annotation**（丢弃 `node.annotation`）。
+    注解表达式须为静态形式（`pto.*` dtype 或 `static_env` 中已知 type dispatch）；
+    动态注解表达式在重写期报错。若注解与字段实际类型不一致（如
+    `state.field: pto.i32 = ...` 而字段是 `f32`），在**重写期**给出明确错误，而非
+    仅当语法检查通过。无值注解 `state.field: T` 的重写期拒绝同时覆盖：注解即使合法
+    也不产生读取。
+  - `del state.field`：不支持，报错（struct 无字段删除语义）。
+  - **多目标赋值（P1 修订）**：对 `Assign`（如 `a = state.x = rhs`），RHS **只求值
+    一次**到临时变量，然后**按 `node.targets` 的源码顺序从左到右**逐个执行目标
+    赋值。对 struct 成员目标生成 `struct_set`，对普通名称目标生成普通赋值。因此
+    `a = state.x = rhs` 的正确顺序是：
+    ```python
+    _tmp = rhs        # RHS 求值一次
+    a = _tmp          # 目标 a（源码顺序在前）
+    pto.struct_set(state, path, _tmp)   # 目标 state.x
+    ```
+    而 `state.x = a = rhs` 的顺序是：
+    ```python
+    _tmp = rhs
+    pto.struct_set(state, path, _tmp)   # 目标 state.x（源码顺序在前）
+    a = _tmp
+    ```
+    多个成员目标同样按 `node.targets` 顺序逐个生成 `struct_set`。普通名称目标（包括
+    其值等于 RHS 的临时变量）照常赋 `_tmp`。成员写入不产生可赋给其他目标的新值，
+    所有普通目标统一取 `_tmp`。
+
+**避免误重写普通属性（P2 修订）**：只有当 `base` 是 `value_bindings` 中的已知
+struct 值变量，且整条字段名链都能解析时才重写。`pto.for_`、`loop.state`、第三方
+对象属性等**不**在 `value_bindings` 中，保持原样。**不做**对任意 `obj.field` 的
+猜测重写。
+
+**非 struct base 的普遍诊断不承诺**：当 `state` 被 rebinding 出 `value_bindings`
+（如 `state = pto.i32(1)` 后 `state.field = 2`），AST 不会重写，普通非 struct
+`_SurfaceValue` 也不拦截，可能只是设置 Python 实例属性。因此**不承诺**在
+`value_bindings` 之外对"成员访问但 base 非 struct"普遍报错。诊断只覆盖**已知为
+struct value binding** 时的未知字段等情形；对已脱离 struct 身份的 base，行为与普通
+Python 属性一致（不重写、不报错）。可选增强（不承诺）：若前端能跟踪"某变量曾是
+struct value binding 但被重赋值"，可对后续成员访问给出提示，但这是非阻塞增强。
+
+**实际重写产出**（P1 #1/#2 的闭合方案）：
+
+- 读 `x = state.a.b` → `x = pto.struct_get(state, (1, 0))`（重写器已把 `["a","b"]`
+  解析为整数 tuple）。
+- 写 `state.a.b = v` → `pto.struct_set(state, (1, 0), v)`。
+- 生成的代码只引用 `pto.struct_get` / `pto.struct_set`，二者已在 `pto` 命名空间，
+  且 `exec` 的 globals 已含 `pto`；无需注入私有 helper。
+
+**AST 字面量 dict 的重名键检测**：对 `pto.struct({...})` 的字面量 `{...}` 节点，若
+其中出现重复键，在重写期报错（运行时 dict 无法检测，见 §3.1）。
+
+**错误处理**：
+
+- 未知字段名：抛 `PTODSLAstRewriteError`，信息含 struct 上下文与合法字段名列表。
+- `state.pt` 单独求值（非成员，且 `pt` 是嵌套 named struct）：报错，提示继续访问
+  到标量叶子或用 `pto.struct_get` / canonical path。
+- 链上某层是 positional（`field_names is None`）却继续访问成员：报错，提示该层
+  用 canonical path。
+
+**选项门控（P2 修订，对齐公开 API 名称）**：公开 `@pto.jit` 选项没有
+`rewrite_control_flow` 参数；实际 API 是 `ast_rewrite=...` 与
+`frontend_options={"ast_rewrite": ...}`。`_StructMemberRewriter` **不引入新的公开
+选项名**，而是与 `_ControlFlowRewriter` 同受 `ast_rewrite` /
+`frontend_options["ast_rewrite"]` 门控，因为成员赋值重写依赖 control-flow 重写对
+`state.field += x` 等生成的临时变量与 SSA 语义保持一致：
+
+```python
+if ast_rewrite:   # 即 frontend_options.get("ast_rewrite", True)
+    function_def = _StructMemberRewriter(...).visit(function_def)
+    rewriter = _ControlFlowRewriter(...)
+    function_def.body = rewriter.rewrite_block(...)
+```
+
+当 `ast_rewrite=False` 时，`_StructMemberRewriter` **不运行**，成员访问不重写，落入
+§6.3 的 `_SurfaceValue` 诊断路径。这与"`ast_rewrite=False` 下成员访问必须走诊断"
+的设计一致。
+
+**`rewrite_part` 的语义**：`frontend_options["rewrite_part"]` 当前只接受
+`{"control_flow"}`，用于在 control-flow 重写内细分。成员重写不单独暴露 rewrite
+part；若未来要独立控制成员重写，应另行设计新的 rewrite part 名，而不是复用未公开
+名称。**公开文档更新**：`ast_rewrite` / `frontend_options["ast_rewrite"]` 不再只
+控制 control flow，还控制 struct 成员访问重写；需在 `@pto.jit` 选项文档注明该语义
+扩展。
+
+重写发生在 `_ControlFlowRewriter` 之前，保证成员赋值不会被后续控制流重写误判。
+重写后的函数体即 canonical `struct_get` / `struct_set`，因此既有 path 验证、字面量
+materialization 与诊断全部复用。
+
+### 6.5 字面量 materialization
+
+`state.n = 7` 复用 `struct_set` 的 `_materialize_struct_value`：整型字面量写整型
+字段、也可 materialize 为浮点字段；`float` 仅可写浮点字段；`bool` / 字符串 /
+typed-SSA 精确匹配规则全部沿用。AST 重写只负责把 `state.n` 变成
+`struct_set(state, path, rhs)`，不额外引入类型转换。
+
+### 6.6 诊断规则
+
+| 场景 | 诊断 |
+|---|---|
+| `pto.struct({})` 空 dict | 至少需要一个字段 |
+| `pto.struct([...])` 位置列表 / 非 dict | 提示用 `pto.struct_type(...)` 或 dict |
+| 字段名非标识符 / 是 Python 关键字 / 以 `_` 开头 / 保留名 | 声明期报错，列出合法形式 |
+| 重名键 | 仅对 AST 字面量 `{...}` 在重写期报错；运行时 dict 无法检测 |
+| 访问未知字段 | 报字段名 + 合法字段名列表 |
+| 链上某层是 positional nested 却继续访问成员 | 提示改写为到达标量叶子的完整 canonical path |
+| `state.pt` 求值（非继续访问标量） | 提示继续访问到标量或用完整 canonical path |
+| 分支/循环内合并 struct 类型绑定 | 报错，提示入口统一声明或用 canonical path |
+| `del state.field` | 不支持，报错（struct 无字段删除语义） |
+| `state.field: T`（无值注解） | 不支持，拒绝（不做 `struct_get`） |
+| 成员访问但 base 已脱离 struct 身份 | **不承诺普遍报错**（见 §6.4 避免误重写）；与普通属性一致 |
+| 写入类型不匹配 | 复用 `struct_set` 现有诊断 |
+| struct 作 ABI / carry state | 复用既有拒绝逻辑 |
+| source-less / `ast_rewrite=False` 下访问成员 | 明确报错，提示保留源码或用 canonical path |
+
+## 7. 兼容性与后端
+
+- 由 `pto.struct({...})` 构造的描述符与等价 `pto.struct_type(...)` 解析为同一个
+  `!pto.struct<...>`，因此对 EmitC / VPTO LLVM lowering **零改动**。
+- 既有 `struct_type` / `declare_struct` / `struct_get` / `struct_set` 签名与语义
+  不变；`pto.struct` 是新增命名空间符号。
+- 现有 `test_struct.py` 全部保持通过；新增用例只覆盖命名与成员访问表层。
+
+**公开导出（P2 增补）**：新增 `pto.struct` 需同步三处导出，并加测试：
+
+- `ptodsl/ptodsl/_types.py`：将 `struct` 加入 `__all__`。
+- `ptodsl/ptodsl/pto.py`：从 `._types` 显式 import 并导出 `struct`（沿用现有
+  named-import 风格，见 `pto.py` 中 `struct_type` 的导入）。
+- 新增 public namespace export 测试：断言 `hasattr(pto, "struct")` 且
+  `"struct" in _types.__all__`（与现有 `test_struct.py::test_public_namespace_exports_struct_surface`
+  的 `struct_type` 断言并列）。
+
+**命名冲突的申明（supersede #1104 决定）**：Issue #1104 的设计文档曾以"避免与
+Python `struct` 标准库和未来结构化 value helper 混淆"为由选择 `struct_type` 而非
+`struct`。本设计新增 `pto.struct` 是**有意的需求演进**，在此明确 supersede 该命名
+决定的一部分：
+
+- `pto.struct_type` **保留**并继续作为 positional canonical 构造器（`#1104` 的
+  既定 API 不变）。
+- `pto.struct` **新增**作为 field mapping 构造器，用于成员访问表层。
+- 二者在 `pto` 命名空间下靠 `_` 与参数形态区分，Python 用户经 `pto.` 前缀调用，
+  不会与标准库 `struct` 模块（需 `import struct`）冲突。
+- 若后续需要，`pto.struct` 也可作为未来结构化 value helper 的命名空间入口，这
+  与它承担"命名字段构造器"的角色不冲突。
+
+一句话：`struct_type` 的"避免与 `struct` 混淆"约束针对的是**不使用 `pto.` 前缀的
+裸名**；在 `pto.` 命名空间内新增 `struct` 不产生该混淆，且 `struct_type` 仍保留。
+
+## 8. 文档与测试
+
+### 8.1 用户手册
+
+在 `ptodsl/docs/user_guide/04-type-system-and-buffer.md` 的 Struct 小节增加"命名字段
+与成员访问"小节：`pto.struct({...})` 声明、读 / 写 / 嵌套示例、与 canonical path
+API 的关系、字段名与保留字规则、AST 重写开启要求。示例纳入
+`docs_fragment_fixtures.py` docs-as-tests。
+
+### 8.2 回归测试
+
+`ptodsl/tests/test_struct.py` 新增：
+
+- `pto.struct({...})` 与 `pto.struct_type(...)` 解析为同一 `!pto.struct` 文本；
+- **AST 重写**：`state.field` 读 / 写被重写为 `pto.struct_get(state, (0,))` /
+  `pto.struct_set(state, (0,), v)`，断言生成的 canonical op 的 **path 属性**
+  与手写等价，并用 path 属性值相等而非整段 MLIR 文本比较（避免 SSA 名 / location
+  差异）。path 从 op 的 `DenseI64ArrayAttr` 读取：`op.operation.attributes["path"]`
+  （仓库无 `CompositeType`，不引用它）；
+- 嵌套成员访问（≥ 2 层）生成 `[1, 0]` / `[1, 1]` 形式 path；
+- 成员访问与显式 path API 混写；
+- 字段名不入 IR：断言生成的 canonical op 的 path 是整数、且 `!pto.struct` 类型文本
+  不含字段名字符串；
+- 未知字段、非标识符/关键字/保留名、`state.pt` 单独求值、positional-nested 继续
+  访问、`del state.field`、分支合并类型绑定等在重写期报错；
+- rebinding 后 `state.field` 不再按 struct 重写；
+- 与现有 `--emit-pto-ir` frontend verification 一起通过。
+
+**EmitC / VPTO 端到端编译（新增，证明重写确实工作）**：
+
+- 一个使用 `pto.struct({...})` + `state.field` 的 `backend="emitc"` 嵌套例子：
+  parse + verify，并断言生成的 C++ 包含 **EmitC 按位置生成的字段访问 `.f0` /
+  `.f1.f0`**（见 `test/lit/pto/struct_nested_emitc.pto`）。字段名不进入 IR，因此
+  **不**期待源字段名 `n` / `pt.x` 出现在 C++ 中——只检查位置成员访问；
+- 一个使用默认 VPTO backend 的等同例子：parse + verify，并断言 `pto.struct_get` /
+  `pto.struct_set` 在 VPTO LLVM lowering 后变为 GEP/load/store；
+- 与手写 `struct_get` / `struct_set` 的等价例子对比，确认两者生成**相同**的
+  field-path / 类型 / lowering 结果。
+
+## 9. 验收矩阵
+
+| 层级 | 验收内容 |
+|---|---|
+| Python 单测 | 命名 / 成员访问在重写期映射为等价 canonical path，字段名不入 IR |
+| AST 重写 | 重写产物只含 `pto.struct_get` / `pto.struct_set`，无私有 helper |
+| 文档 | 用户示例在 docs-as-tests 中编译 |
+| PTOAS frontend | 生成 module 在 `--emit-pto-ir` 下验证通过 |
+| EmitC | 嵌套成员例子 parse/verify，C++ 输出含位置字段访问 `.f0` / `.f1.f0`（非源字段名） |
+| VPTO | 嵌套成员例子 parse/verify，get/set lower 为 GEP/load/store，与手写 path 一致 |
+
+## 10. 需要保持的决定
+
+- 字段名是编译期常量，由描述符携带，不进入 IR。
+- 字段名→位置 path 的解析**完全在 AST 重写期**完成，重写产物直接是
+  `pto.struct_get` / `pto.struct_set`，无运行时私有 helper、无 descriptor→value
+  传播。
+- 局部 descriptor 在重写期经**白名单静态求值**（字面量 `pto.struct(...)` /
+  `pto.struct_type(...)` / `pto.*` dtype / `static_env` 中的 descriptor / 合法 MLIR
+  scalar `Type` / 局部别名），不对任意 AST 调 `eval()`。
+- 全局 / closure descriptor 直接查 `static_env`，不要求源码可定位到赋值。
+- 成员访问通过 AST 重写实现，受公开选项 `ast_rewrite` /
+  `frontend_options["ast_rewrite"]` 门控（不引入 `rewrite_control_flow` 等未公开
+  名称；`rewrite_part` 只接受 `{"control_flow"}`）；`ast_rewrite=False` 时不重写、
+  落入 `_SurfaceValue` 明确诊断。`_SurfaceValue` 的 `__getattr__` / `__setattr__`
+  仅用于诊断，绝不静默生成 IR。
+- 多目标赋值按 `node.targets` **源码顺序从左到右**逐个执行目标，RHS 只求值一次；
+  成员目标生成 `struct_set`，普通目标赋 RHS 临时值。
+- 成员 `AnnAssign` 注解只允许静态可忽略标注，重写为 `struct_set` 时不保留 annotation，
+  注解与字段类型不一致或无值注解在重写期报错。
+- 嵌套成员在前端即折叠为位置 path，`state.pt` 本身不是 IR 值；一旦进入 positional
+  层，整条成员表达式不合法，须改写为完整 canonical path。
+- `pto.struct({...})` 与 `pto.struct_type(...)` 解析为同一 `!pto.struct`；成员访问
+  要求链上每层都是 named。
+- 标量成员即 `struct_get` 的标量 result，无新值类别。
+- EmitC 生成位置字段访问（`.f0` / `.f1.f0`），**不**含源字段名；验收按此断言。
+- struct 生命周期与 ABI 约束沿用既有规则，本设计不改变。

--- a/docs/designs/ptodsl-struct-member-access-design.md
+++ b/docs/designs/ptodsl-struct-member-access-design.md
@@ -293,23 +293,27 @@ def struct(fields: dict[str, FieldType]) -> _StructDescriptor:
 
 ### 6.3 运行时 surface 与 source-less fallback（`_surface_values.py`）
 
-不新增公开的 struct surface 类。`declare_struct` 返回值保持现有 `_SurfaceValue`
-包装。
+不新增**公开**的 struct surface 符号；`declare_struct` 返回内部
+`StructValue`（`RuntimeValue` 子类，仍属 `_SurfaceValue` 体系）。
 
 **source-less / 未重写路径的策略（明确，非静默）**：成员语法依赖 AST 源码可获取。
 当 `inspect.getsource()` 失败（exec / REPL / notebook）或 `ast_rewrite=False` 时，
-`_ast_rewrite.py` 现有逻辑返回原函数（[`_ast_rewrite.py:49`](file:///Users/jimmychou/work/ptoas/PTOAS/ptodsl/ptodsl/_ast_rewrite.py)）。
-此时 `state.field = value` 会退化为普通 Python 实例属性赋值（不会生成 `struct_set`），
-读取则得到 `AttributeError`——这比显式失败更危险。
+`_ast_rewrite.py` 现有逻辑返回原函数（见 `rewrite_jit_function` 的 source-less
+fallback）。此时 `state.field = value` 会退化为普通 Python 实例属性赋值（不会生成
+`struct_set`），读取则得到 `AttributeError`——这比显式失败更危险。
 
-因此给 `_SurfaceValue` 增加 `__getattr__` / `__setattr__`，**仅用于诊断**：
+因此实现引入 `StructValue(RuntimeValue)`（`_surface_values.py`），作为
+`declare_struct` 的返回类型；其 `__getattr__` / `__setattr__` **仅用于诊断**：
 
-- 当对象是 `declare_struct` 的返回值（通过一个私有标记 `_is_struct_value` 标识）且
-  访问了非内部属性时，抛出明确错误：内容为"struct 成员访问需要 AST 源码重写
+- 访问非内部属性时抛出明确错误：内容为"struct 成员访问需要 AST 源码重写
   （默认开启）；请保留 `@pto.jit` 的源码可获取性，或改用
   `pto.struct_get` / `pto.struct_set`"。
 - **绝不**通过这些魔术方法静默生成 IR。
 - 普通 `_SurfaceValue`（非 struct）不额外拦截，保持既有行为。
+
+> 注：v4 之前的草稿曾计划"不新增 surface 类、用 `_is_struct_value` 私有标记
+> 挂在 `_SurfaceValue` 上"；最终实现改用 `StructValue` 子类，诊断面相同、
+> 类型边界更清晰。
 
 这样三条路径都有确定行为：AST 重写成功（推荐）、明确报错（source-less /
 `ast_rewrite=False`）、显式 canonical path API（始终可用）。

--- a/ptodsl/docs/user_guide/04-type-system-and-buffer.md
+++ b/ptodsl/docs/user_guide/04-type-system-and-buffer.md
@@ -115,6 +115,44 @@ Python `int` literals can initialize integer and floating-point fields; Python `
 
 Structs cannot be used as `@pto.jit`, `@pto.tileop`, or `@pto.simt` parameters, or as `pto.for_(...).carry(...)` state. A struct declared outside an ordinary `pto.for_` may be read and mutated inside that loop. Struct values also cannot be returned, yielded, or passed as function arguments from their declaring scope.
 
+### Named fields and member access
+
+`pto.struct({...})` describes the same `!pto.struct<...>` as `pto.struct_type(...)`, but with named fields. Field names are compile-time constants that let you read and write members with Python attribute syntax; the member access lowers losslessly to the canonical `pto.struct_get` / `pto.struct_set` positional-path operations.
+
+```python
+pto.struct(fields: dict[str, FieldType]) -> StructTypeDescriptor
+```
+
+```text
+state.field             # pto.struct_get(state, [index])
+state.field = value     # pto.struct_set(state, [index], value)
+state.inner.field       # pto.struct_get(state, [i, j])
+```
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"type_system.struct_member","symbol":"type_system_struct_member_probe","compile":{}} -->
+```python
+Point = pto.struct({"x": pto.i32, "y": pto.f32})
+state = pto.declare_struct(Point)
+state.x = 1
+state.y = 2.5
+count = state.x
+scale = state.y
+```
+
+Nested named structs are accessed with chained members:
+
+```python
+Nested = pto.struct({
+    "id": pto.i32,
+    "pt": pto.struct({"x": pto.i32, "y": pto.f32}),
+})
+s = pto.declare_struct(Nested)
+s.pt.x = 1              # pto.struct_set(s, (1, 0), 1)
+v = s.pt.y              # pto.struct_get(s, (1, 1))
+```
+
+Field names must be valid Python identifiers that are not keywords, not start with an underscore, and not in the reserved set (`value`, `type`, `surface_metadata`, `field_*`, `resolve`, `declared_value`, `field_map`). Member access requires the AST source rewrite (the default `@pto.jit` mode); if source is unavailable or `ast_rewrite=False`, member access raises a clear error instead of silently creating a Python attribute. Use the canonical `pto.struct_get` / `pto.struct_set` with positional paths whenever member syntax is not available.
+
 ## 4.2 Vector register type
 
 Vector registers hold a fixed 256-byte payload. `pto.vreg(dtype)` infers the element count automatically:

--- a/ptodsl/docs/user_guide/04-type-system-and-buffer.md
+++ b/ptodsl/docs/user_guide/04-type-system-and-buffer.md
@@ -153,6 +153,16 @@ v = s.pt.y              # pto.struct_get(s, (1, 1))
 
 Field names must be valid Python identifiers that are not keywords, not start with an underscore, and not in the reserved set (`value`, `type`, `surface_metadata`, `field_*`, `resolve`, `declared_value`, `field_map`). Member access requires the AST source rewrite (the default `@pto.jit` mode); if source is unavailable or `ast_rewrite=False`, member access raises a clear error instead of silently creating a Python attribute. Use the canonical `pto.struct_get` / `pto.struct_set` with positional paths whenever member syntax is not available.
 
+Member access rules and diagnostics:
+
+- `state.field += value` (and other augmented assignments) lower to a read-modify-write sequence: `tmp = pto.struct_get(state, path)`, `tmp += value`, `pto.struct_set(state, path, tmp)`.
+- `state.field: T = value` is a write (`pto.struct_set`); the annotation must be a static dtype (e.g. `pto.i32`) matching the field type, and is not kept. `state.field: T` without a value is rejected.
+- `del state.field` is not supported; structs have no field-deletion semantics.
+- Every layer of the access chain must be named. Once the chain enters a positional `pto.struct_type(...)` layer, the whole member expression is rejected at rewrite time; rewrite it as a full canonical path to a scalar leaf, e.g. `pto.struct_get(state, (1, 0))`. Reading a nested struct member itself (`v = state.pt`) is likewise rejected — nested structs are not IR values; continue to a scalar leaf.
+- Rebinding the variable (`state = other`, `state += ...`) cancels its struct identity: later `state.field` is no longer rewritten and behaves like a plain Python attribute. Rebinding inside a loop body cancels the identity after the loop.
+- A struct type must not be bound to incompatible types in different branches of one `if`; declare it once at function entry or use the canonical path API.
+- Field names are compile-time constants: they never appear in the generated IR, and `pto.struct({...})` resolves to the same `!pto.struct<...>` as the equivalent positional `pto.struct_type(...)`.
+
 ## 4.2 Vector register type
 
 Vector registers hold a fixed 256-byte payload. `pto.vreg(dtype)` infers the element count automatically:

--- a/ptodsl/docs/user_guide/04-type-system-and-buffer.md
+++ b/ptodsl/docs/user_guide/04-type-system-and-buffer.md
@@ -117,7 +117,25 @@ Structs cannot be used as `@pto.jit`, `@pto.tileop`, or `@pto.simt` parameters, 
 
 ### Named fields and member access
 
-`pto.struct({...})` describes the same `!pto.struct<...>` as `pto.struct_type(...)`, but with named fields. Field names are compile-time constants that let you read and write members with Python attribute syntax; the member access lowers losslessly to the canonical `pto.struct_get` / `pto.struct_set` positional-path operations.
+`@pto.struct` describes the same `!pto.struct<...>` as `pto.struct_type(...)`, but with named fields. Field names are compile-time constants that let you read and write members with Python attribute syntax; the member access lowers losslessly to the canonical `pto.struct_get` / `pto.struct_set` positional-path operations.
+
+The idiomatic declaration is a class whose body only lists field annotations:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"type_system.struct_member","symbol":"type_system_struct_member_probe","compile":{}} -->
+```python
+@pto.struct
+class Point:
+    x: pto.i32
+    y: pto.f32
+
+state = Point(1, 2.5)   # declare + initialize all fields
+count = state.x         # pto.struct_get(state, [0])
+state.y = 3.5           # pto.struct_set(state, [1], 3.5)
+```
+
+`Point(...)` runs at trace time: it is `pto.declare_struct(Point)` plus one `pto.struct_set` per given field, in declaration order. Fields may be given positionally (declaration order) or by name, all-or-none — `Point()` declares without initializing, partial initialization is rejected. The decorated class body may only contain `name: field_type` annotations: default values, methods, and base classes are rejected at decoration time. `declare_struct(Point)` remains available when no initialization is wanted.
+
+The equivalent programmatic spelling takes an order-preserving dict — useful when the field set is computed rather than written literally:
 
 ```python
 pto.struct(fields: dict[str, FieldType]) -> StructTypeDescriptor
@@ -139,7 +157,7 @@ count = state.x
 scale = state.y
 ```
 
-Nested named structs are accessed with chained members:
+Nested named structs are accessed with chained members — both spellings nest (`inner: ClassInner` in class form, `"inner": pto.struct({...})` in dict form):
 
 ```python
 Nested = pto.struct({
@@ -156,6 +174,7 @@ Field names must be valid Python identifiers that are not keywords, not start wi
 Member access rules and diagnostics:
 
 - `state.field += value` (and other augmented assignments) lower to a read-modify-write sequence: `tmp = pto.struct_get(state, path)`, `tmp += value`, `pto.struct_set(state, path, tmp)`.
+- Chained assignment binds every name: `a = b = Point(...)` / `a = b = pto.declare_struct(S)` evaluates the right-hand side once, so both names alias the same struct value and both support member access.
 - `state.field: T = value` is a write (`pto.struct_set`); the annotation must be a static dtype (e.g. `pto.i32`) matching the field type, and is not kept. `state.field: T` without a value is rejected.
 - `del state.field` is not supported; structs have no field-deletion semantics.
 - Every layer of the access chain must be named. Once the chain enters a positional `pto.struct_type(...)` layer, the whole member expression is rejected at rewrite time; rewrite it as a full canonical path to a scalar leaf, e.g. `pto.struct_get(state, (1, 0))`. Reading a nested struct member itself (`v = state.pt`) is likewise rejected — nested structs are not IR values; continue to a scalar leaf.

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -1498,10 +1498,21 @@ def _reject_control_flow_exits(stmts, context: str, *, reject_bare_returns: bool
             )
 
 
-# Sentinel marking a scalar leaf field in a statically-evaluated struct type.
-_SCALAR_FIELD = object()
 # Sentinel marking a struct field type that cannot be statically evaluated.
 _UNRESOLVABLE_FIELD = object()
+
+
+@dataclass(frozen=True)
+class _ScalarField:
+    """A scalar leaf field in a statically-evaluated struct type.
+
+    Carries an optional ``type_key`` (e.g. ``"pto.f32"``) so the member
+    rewriter can validate an assignment annotation against the field's actual
+    scalar type.  ``type_key`` is ``None`` when the type is not statically
+    known.
+    """
+
+    type_key: object = None
 
 
 @dataclass(frozen=True)
@@ -1531,6 +1542,17 @@ class _StructTypeMeta:
             return self.field_names.index(name)
         except ValueError:
             raise ValueError(f"unknown struct field {name!r}")
+
+
+def _normalize_type_key(key) -> str:
+    """Normalize a scalar type key for comparison.
+
+    Strips a leading ``pto.`` prefix so ``"pto.i32"`` and ``"i32"`` compare
+    equal.  Returns the key unchanged when it is not a string.
+    """
+    if isinstance(key, str):
+        return key[len("pto."):] if key.startswith("pto.") else key
+    return key
 
 
 def _duck_struct_descriptor(obj) -> bool:
@@ -1692,6 +1714,13 @@ class _StructMemberRewriter:
                 self._type_bindings[name] = meta
                 self._value_bindings.pop(name, None)
                 return [node]
+            # Assignment-form local type alias: Alias = Inner where Inner is a
+            # locally-bound struct type.  The alias inherits the descriptor so
+            # it can be reused in a nested pto.struct({...}) field.
+            if isinstance(node.value, ast.Name) and node.value.id in self._type_bindings:
+                self._type_bindings[name] = self._type_bindings[node.value.id]
+                self._value_bindings.pop(name, None)
+                return [node]
             if _is_pto_attr_call(node.value, "declare_struct"):
                 arg = node.value.args[0] if node.value.args else None
                 arg_meta = self._resolve_struct_arg(arg)
@@ -1714,7 +1743,7 @@ class _StructMemberRewriter:
         if any(m is not None for m in member_targets):
             if len(node.targets) == 1:
                 base, path, leaf = member_targets[0]
-                if leaf is not _SCALAR_FIELD:
+                if not isinstance(leaf, _ScalarField):
                     raise PTODSLAstRewriteError(
                         "ast_rewrite=True cannot write a whole nested struct member; "
                         "continue to a scalar leaf or use a full canonical "
@@ -1726,7 +1755,7 @@ class _StructMemberRewriter:
             for t, m in zip(node.targets, member_targets):
                 if m is not None:
                     base, path, leaf = m
-                    if leaf is not _SCALAR_FIELD:
+                    if not isinstance(leaf, _ScalarField):
                         raise PTODSLAstRewriteError(
                             "ast_rewrite=True cannot write a whole nested struct member"
                         )
@@ -1747,7 +1776,7 @@ class _StructMemberRewriter:
             resolved = self._resolve_member(node.target)
             if resolved is not None:
                 base, path, leaf = resolved
-                if leaf is not _SCALAR_FIELD:
+                if not isinstance(leaf, _ScalarField):
                     raise PTODSLAstRewriteError(
                         "ast_rewrite=True annotated struct member must reach a scalar "
                         "leaf; use a full canonical pto.struct_set(...) path"
@@ -1757,8 +1786,19 @@ class _StructMemberRewriter:
                 # to a known descriptor / MLIR Type.  A bare Name that is not a
                 # known static type (e.g. a function parameter) is treated as
                 # dynamic and rejected so the annotation is not silently dropped.
+                # When the field's scalar type is statically known, the
+                # annotation must match it.
                 if node.annotation is not None:
-                    self._require_static_annotation(node.annotation)
+                    ann_key = self._require_static_annotation(node.annotation)
+                    if (
+                        leaf.type_key is not None
+                        and ann_key is not None
+                        and _normalize_type_key(ann_key) != _normalize_type_key(leaf.type_key)
+                    ):
+                        raise PTODSLAstRewriteError(
+                            f"ast_rewrite=True struct member annotation {ann_key!r} "
+                            f"does not match field type {leaf.type_key!r}"
+                        )
                 if node.value is None:
                     raise PTODSLAstRewriteError(
                         "ast_rewrite=True does not support value-less annotated struct "
@@ -1775,7 +1815,7 @@ class _StructMemberRewriter:
             resolved = self._resolve_member(node.target)
             if resolved is not None:
                 base, path, leaf = resolved
-                if leaf is not _SCALAR_FIELD:
+                if not isinstance(leaf, _ScalarField):
                     raise PTODSLAstRewriteError(
                         "ast_rewrite=True augmented assignment must reach a scalar leaf"
                     )
@@ -1815,7 +1855,7 @@ class _StructMemberRewriter:
             resolved = self._resolve_member(node)
             if resolved is not None:
                 base, path, leaf = resolved
-                if leaf is _SCALAR_FIELD:
+                if isinstance(leaf, _ScalarField):
                     return self._struct_get_call(base, path, node)
                 raise PTODSLAstRewriteError(
                     "ast_rewrite=True cannot read a nested struct member as a value; "
@@ -1849,7 +1889,7 @@ class _StructMemberRewriter:
             return None
         path = []
         for attr in reversed(chain):
-            if meta is _SCALAR_FIELD:
+            if isinstance(meta, _ScalarField):
                 raise PTODSLAstRewriteError(
                     f"ast_rewrite=True struct member access descends into a scalar "
                     f"field; cannot read {attr!r} on a scalar member"
@@ -1958,7 +1998,12 @@ class _StructMemberRewriter:
             return _UNRESOLVABLE_FIELD
         if isinstance(node, ast.Attribute):
             if isinstance(node.value, ast.Name) and node.value.id == "pto":
-                return _SCALAR_FIELD
+                return _ScalarField(node.attr)
+            obj = self._static_env.get(node.value.id)
+            if _duck_struct_descriptor(obj):
+                # A member of a known descriptor (e.g. a static dtype attribute)
+                # is treated as a scalar leaf whose type key is the attribute.
+                return _ScalarField(node.attr)
             return _UNRESOLVABLE_FIELD
         if isinstance(node, ast.Name):
             # Local type aliases (e.g. Inner = pto.struct(...)) take precedence
@@ -1970,7 +2015,8 @@ class _StructMemberRewriter:
             obj = self._static_env.get(node.id)
             if _duck_struct_descriptor(obj):
                 return self._meta_from_descriptor(obj)
-            return _SCALAR_FIELD
+            # An unknown name is a scalar leaf of unknown type.
+            return _ScalarField(None)
         return _UNRESOLVABLE_FIELD
 
     def _require_static_annotation(self, node):
@@ -1984,7 +2030,7 @@ class _StructMemberRewriter:
         """
         if isinstance(node, ast.Attribute):
             if isinstance(node.value, ast.Name) and node.value.id == "pto":
-                return  # pto.i32 etc.
+                return node.attr  # pto.i32 -> "i32"
             raise PTODSLAstRewriteError(
                 "ast_rewrite=True struct member annotation must be a static dtype "
                 "annotation (e.g. pto.i32); got a dynamic annotation"
@@ -1992,10 +2038,10 @@ class _StructMemberRewriter:
         if isinstance(node, ast.Name):
             local = self._type_bindings.get(node.id)
             if local is not None:
-                return
+                return None
             obj = self._static_env.get(node.id)
             if _duck_struct_descriptor(obj):
-                return
+                return None
             raise PTODSLAstRewriteError(
                 f"ast_rewrite=True struct member annotation references unknown name "
                 f"{node.id!r}; only static pto.* dtype annotations are supported"
@@ -2015,7 +2061,7 @@ class _StructMemberRewriter:
             if _duck_struct_descriptor(fd):
                 types.append(self._meta_from_descriptor(fd))
             else:
-                types.append(_SCALAR_FIELD)
+                types.append(_ScalarField(None))
         return _StructTypeMeta(tuple(names), tuple(types))
 
 

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -20,6 +20,16 @@ class PTODSLAstRewriteError(SyntaxError):
     """Raised when AST rewrite sees unsupported Python control flow."""
 
 
+# Future flags worth preserving when recompiling the rewritten tree.  Without
+# this, compile() would inherit the flags of *this* module — which sets
+# ``from __future__ import annotations`` — and class-body annotations inside
+# rewritten kernels (e.g. ``@pto.struct`` classes) would be stringified.
+_PRESERVED_FUTURE_FLAGS = 0
+for _flag_name in ("CO_FUTURE_ANNOTATIONS", "CO_FUTURE_GENERATOR_STOP"):
+    _PRESERVED_FUTURE_FLAGS |= getattr(inspect, _flag_name, 0)
+del _flag_name
+
+
 def rewrite_jit_function(
     fn,
     *,
@@ -103,7 +113,13 @@ def rewrite_jit_function(
         source_file = inspect.getsourcefile(fn)
     except (OSError, TypeError):
         source_file = None
-    code = compile(tree, source_file or "<ptodsl-ast-rewrite>", "exec")
+    code = compile(
+        tree,
+        source_file or "<ptodsl-ast-rewrite>",
+        "exec",
+        flags=fn.__code__.co_flags & _PRESERVED_FUTURE_FLAGS,
+        dont_inherit=True,
+    )
     globals_ns = fn.__globals__
     restored_globals = _temporarily_bind_globals(globals_ns, closure_vars.nonlocals)
     try:
@@ -1614,9 +1630,18 @@ class _StructMemberRewriter:
             return [self._rewrite_try(stmt)]
         if hasattr(ast, "TryStar") and isinstance(stmt, ast.TryStar):
             return [self._rewrite_try(stmt)]
+        if isinstance(stmt, ast.ClassDef):
+            # An ``@pto.struct`` class declaration binds its struct type for
+            # later member-access resolution; the statement itself stays so
+            # the decorator still runs at trace time.
+            meta = self._eval_struct_class_meta(stmt)
+            if meta is not None:
+                self._type_bindings[stmt.name] = meta
+                self._value_bindings.pop(stmt.name, None)
+            return [stmt]
         if isinstance(
             stmt,
-            (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef),
+            (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda),
         ):
             return [stmt]
         self._rewrite_expr_in_stmt(stmt)
@@ -1718,37 +1743,69 @@ class _StructMemberRewriter:
                 )
         return merged
 
+    def _classify_struct_binding(self, value):
+        """Classify an (already rewritten) assignment RHS for binding purposes.
+
+        Returns ``("type", meta)`` for struct *type* expressions — a
+        ``pto.struct({...})`` / ``pto.struct_type(...)`` literal or a name
+        bound to one (a local alias can be reused as a nested field type) —
+        and ``("value", meta)`` for struct *value* expressions —
+        ``pto.declare_struct(...)`` / ``Point(...)`` construction calls or a
+        name bound to one.  ``None`` means the RHS carries no struct binding.
+        Locally bound names shadow same-named descriptors in ``static_env``.
+        """
+        if isinstance(value, ast.Name):
+            local_type = self._type_bindings.get(value.id)
+            if local_type is not None:
+                return "type", local_type
+            local_value = self._value_bindings.get(value.id)
+            if local_value is not None:
+                return "value", local_value
+            static_meta = self._eval_struct_meta(value)
+            if static_meta is not None:
+                return "type", static_meta
+            return None
+        meta = self._eval_struct_meta(value)
+        if meta is not None:
+            return "type", meta
+        if isinstance(value, ast.Call):
+            if _is_pto_attr_call(value, "declare_struct"):
+                arg = value.args[0] if value.args else None
+                arg_meta = self._resolve_struct_arg(arg)
+                if arg_meta is not None:
+                    return "value", arg_meta
+                return None
+            # Struct construction: state = Point(...) where Point is a known
+            # @pto.struct class / named descriptor.  The call stays: at trace
+            # time the descriptor's __call__ emits declare_struct plus one
+            # struct_set per initialized field.
+            ctor_meta = self._resolve_struct_constructor(value.func)
+            if ctor_meta is not None:
+                return "value", ctor_meta
+        return None
+
     def _rewrite_assign(self, node):
         node.value = self._rewrite_expr(node.value)
 
-        if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
-            name = node.targets[0].id
-            meta = self._eval_struct_meta(node.value)
-            if meta is not None:
-                self._type_bindings[name] = meta
-                self._value_bindings.pop(name, None)
+        if all(isinstance(t, ast.Name) for t in node.targets):
+            # A plain name assignment — single or chained (``a = b = rhs``) —
+            # evaluates the RHS once, so every target aliases the same struct
+            # type descriptor / struct value; establish the binding for all
+            # of them, not only the single-target form.
+            classified = self._classify_struct_binding(node.value)
+            if classified is not None:
+                kind, meta = classified
+                for t in node.targets:
+                    if kind == "type":
+                        self._type_bindings[t.id] = meta
+                        self._value_bindings.pop(t.id, None)
+                    else:
+                        self._value_bindings[t.id] = meta
+                        self._type_bindings.pop(t.id, None)
                 return [node]
-            # Assignment-form local type alias: Alias = Inner where Inner is a
-            # locally-bound struct type.  The alias inherits the descriptor so
-            # it can be reused in a nested pto.struct({...}) field.
-            if isinstance(node.value, ast.Name) and node.value.id in self._type_bindings:
-                self._type_bindings[name] = self._type_bindings[node.value.id]
-                self._value_bindings.pop(name, None)
-                return [node]
-            if _is_pto_attr_call(node.value, "declare_struct"):
-                arg = node.value.args[0] if node.value.args else None
-                arg_meta = self._resolve_struct_arg(arg)
-                if arg_meta is not None:
-                    self._value_bindings[name] = arg_meta
-                    return [node]
-                self._value_bindings.pop(name, None)
-                self._type_bindings.pop(name, None)
-                return [node]
-            if isinstance(node.value, ast.Name) and node.value.id in self._value_bindings:
-                self._value_bindings[name] = self._value_bindings[node.value.id]
-                return [node]
-            self._value_bindings.pop(name, None)
-            self._type_bindings.pop(name, None)
+            for t in node.targets:
+                self._cancel_binding(t)
+            return [node]
 
         member_targets = [
             self._resolve_member(t) if isinstance(t, ast.Attribute) else None
@@ -1837,6 +1894,12 @@ class _StructMemberRewriter:
                 arg_meta = self._resolve_struct_arg(arg)
                 if arg_meta is not None:
                     self._value_bindings[name] = arg_meta
+                    self._type_bindings.pop(name, None)
+                    return [node]
+            if isinstance(node.value, ast.Call):
+                ctor_meta = self._resolve_struct_constructor(node.value.func)
+                if ctor_meta is not None:
+                    self._value_bindings[name] = ctor_meta
                     self._type_bindings.pop(name, None)
                     return [node]
             if node.value is not None:
@@ -1987,6 +2050,54 @@ class _StructMemberRewriter:
             if _duck_struct_descriptor(obj):
                 return self._meta_from_descriptor(obj)
         return None
+
+    def _resolve_struct_constructor(self, func):
+        """Resolve ``Point`` in a ``Point(...)`` call to struct metadata."""
+        if not isinstance(func, ast.Name):
+            return None
+        meta = self._type_bindings.get(func.id)
+        if meta is not None:
+            return meta
+        obj = self._static_env.get(func.id)
+        if _duck_struct_descriptor(obj):
+            return self._meta_from_descriptor(obj)
+        return None
+
+    def _eval_struct_class_meta(self, stmt):
+        """Statically evaluate an ``@pto.struct`` class declaration.
+
+        Returns ``_StructTypeMeta`` when the class body is a pure annotation
+        list (the only supported form; the runtime decorator rejects anything
+        else), or ``None`` when the class is not a struct declaration.
+        """
+        if len(stmt.decorator_list) != 1:
+            return None
+        decorator = stmt.decorator_list[0]
+        if not (
+            isinstance(decorator, ast.Attribute)
+            and decorator.attr == "struct"
+            and isinstance(decorator.value, ast.Name)
+            and decorator.value.id == "pto"
+        ):
+            return None
+        names, types = [], []
+        for sub in stmt.body:
+            if isinstance(sub, ast.Expr) and isinstance(sub.value, ast.Constant):
+                continue  # docstring
+            if not (
+                isinstance(sub, ast.AnnAssign)
+                and sub.value is None
+                and isinstance(sub.target, ast.Name)
+            ):
+                return None
+            field_type = self._eval_field_type(sub.annotation)
+            if field_type is _UNRESOLVABLE_FIELD:
+                return None
+            names.append(sub.target.id)
+            types.append(field_type)
+        if not names:
+            return None
+        return _StructTypeMeta(tuple(names), tuple(types))
 
     def _eval_struct_meta(self, node):
         if isinstance(node, ast.Call):

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -76,6 +76,8 @@ def rewrite_jit_function(
     section_rewriter = _SectionLexicalRewriter()
     function_def = section_rewriter.visit(function_def)
     if rewrite_control_flow:
+        member_rewriter = _StructMemberRewriter(static_env)
+        function_def.body = member_rewriter.rewrite_block(function_def.body)
         rewriter = _ControlFlowRewriter(
             static_env,
             section_uninitialized_aliases=section_rewriter.section_uninitialized_aliases,
@@ -1494,6 +1496,476 @@ def _reject_control_flow_exits(stmts, context: str, *, reject_bare_returns: bool
                 f"ast_rewrite=True does not support return/yield inside rewritten {context}; "
                 "assign values to locals and return after the rewritten control flow"
             )
+
+
+# Sentinel marking a scalar leaf field in a statically-evaluated struct type.
+_SCALAR_FIELD = object()
+# Sentinel marking a struct field type that cannot be statically evaluated.
+_UNRESOLVABLE_FIELD = object()
+
+
+@dataclass(frozen=True)
+class _StructTypeMeta:
+    """Static, pure-Python description of a ``pto.struct`` descriptor.
+
+    Built at rewrite time from ``pto.struct({...})`` / ``pto.struct_type(...)``
+    literals or from a descriptor found in ``static_env``.  It carries only the
+    field names and nesting needed to resolve member access ``state.a.b`` to an
+    integer path; the actual scalar leaf types are validated later by the
+    canonical ``pto.struct_get`` / ``pto.struct_set`` ops.
+    """
+
+    field_names: tuple
+    field_types: tuple
+
+    @property
+    def is_named(self) -> bool:
+        return self.field_names is not None and all(
+            n is not None for n in self.field_names
+        )
+
+    def field_index(self, name: str) -> int:
+        if self.field_names is None:
+            raise ValueError("positional struct has no field names")
+        try:
+            return self.field_names.index(name)
+        except ValueError:
+            raise ValueError(f"unknown struct field {name!r}")
+
+
+def _duck_struct_descriptor(obj) -> bool:
+    return (
+        obj is not None
+        and hasattr(obj, "field_names")
+        and hasattr(obj, "field_descriptors")
+        and hasattr(obj, "field_index")
+    )
+
+
+class _StructMemberRewriter:
+    """Rewrite ``state.field`` member access into canonical get/set calls.
+
+    Field names are resolved to integer paths entirely at rewrite time: the
+    rewriter statically evaluates ``pto.struct({...})`` / ``pto.struct_type(...)``
+    literals (and descriptors already in ``static_env``) into ``_StructTypeMeta``
+    metadata, tracks ``type_bindings`` / ``value_bindings`` across the function
+    body, and rewrites member reads/writes into ``pto.struct_get`` /
+    ``pto.struct_set`` with the integer path baked in.  No runtime helper and no
+    descriptor->value propagation is needed.
+    """
+
+    def __init__(self, static_env=None):
+        self._static_env = dict(static_env or {})
+        self._type_bindings = {}
+        self._value_bindings = {}
+        self._counter = 0
+
+    def _fresh(self, prefix: str) -> str:
+        value = f"__pto_struct_{prefix}_{self._counter}"
+        self._counter += 1
+        return value
+
+    def rewrite_block(self, stmts):
+        out = []
+        for stmt in stmts:
+            out.extend(self._rewrite_stmt(stmt))
+        return out
+
+    def _rewrite_stmt(self, stmt):
+        if isinstance(stmt, ast.Assign):
+            return self._rewrite_assign(stmt)
+        if isinstance(stmt, ast.AnnAssign):
+            return self._rewrite_annassign(stmt)
+        if isinstance(stmt, ast.AugAssign):
+            return self._rewrite_augassign(stmt)
+        if isinstance(stmt, ast.Delete):
+            return self._rewrite_delete(stmt)
+        if isinstance(stmt, ast.If):
+            return [self._rewrite_if(stmt)]
+        if isinstance(stmt, ast.For):
+            return [self._rewrite_for(stmt)]
+        if isinstance(stmt, ast.While):
+            return [self._rewrite_while(stmt)]
+        if isinstance(stmt, (ast.With, ast.AsyncWith)):
+            return [self._rewrite_with(stmt)]
+        if isinstance(stmt, ast.Try):
+            return [self._rewrite_try(stmt)]
+        if hasattr(ast, "TryStar") and isinstance(stmt, ast.TryStar):
+            return [self._rewrite_try(stmt)]
+        if isinstance(
+            stmt,
+            (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef),
+        ):
+            return [stmt]
+        self._rewrite_expr_in_stmt(stmt)
+        return [stmt]
+
+    def _rewrite_expr_in_stmt(self, stmt):
+        for field, value in ast.iter_fields(stmt):
+            if isinstance(value, ast.AST):
+                setattr(stmt, field, self._rewrite_expr(value))
+            elif isinstance(value, list):
+                setattr(
+                    stmt,
+                    field,
+                    [self._rewrite_expr(v) if isinstance(v, ast.AST) else v for v in value],
+                )
+        return stmt
+
+    def _rewrite_if(self, stmt):
+        stmt.test = self._rewrite_expr(stmt.test)
+        saved_t, saved_v = dict(self._type_bindings), dict(self._value_bindings)
+        stmt.body = self.rewrite_block(stmt.body)
+        body_t, body_v = dict(self._type_bindings), dict(self._value_bindings)
+        self._type_bindings, self._value_bindings = dict(saved_t), dict(saved_v)
+        stmt.orelse = self.rewrite_block(stmt.orelse)
+        else_t, else_v = dict(self._type_bindings), dict(self._value_bindings)
+        self._type_bindings = self._merge_bindings(saved_t, body_t, else_t, "type")
+        self._value_bindings = self._merge_bindings(saved_v, body_v, else_v, "value")
+        return stmt
+
+    def _rewrite_for(self, stmt):
+        stmt.iter = self._rewrite_expr(stmt.iter)
+        saved_t, saved_v = dict(self._type_bindings), dict(self._value_bindings)
+        for n in _target_stores(stmt.target):
+            self._value_bindings.pop(n, None)
+            self._type_bindings.pop(n, None)
+        stmt.body = self.rewrite_block(stmt.body)
+        self._type_bindings, self._value_bindings = saved_t, saved_v
+        if stmt.orelse:
+            stmt.orelse = self.rewrite_block(stmt.orelse)
+        return stmt
+
+    def _rewrite_while(self, stmt):
+        stmt.test = self._rewrite_expr(stmt.test)
+        saved_t, saved_v = dict(self._type_bindings), dict(self._value_bindings)
+        stmt.body = self.rewrite_block(stmt.body)
+        self._type_bindings, self._value_bindings = saved_t, saved_v
+        if stmt.orelse:
+            stmt.orelse = self.rewrite_block(stmt.orelse)
+        return stmt
+
+    def _rewrite_with(self, stmt):
+        for item in stmt.items:
+            item.context_expr = self._rewrite_expr(item.context_expr)
+            if item.optional_vars is not None:
+                for n in _target_stores(item.optional_vars):
+                    self._value_bindings.pop(n, None)
+                    self._type_bindings.pop(n, None)
+        stmt.body = self.rewrite_block(stmt.body)
+        return stmt
+
+    def _rewrite_try(self, stmt):
+        stmt.body = self.rewrite_block(stmt.body)
+        for handler in stmt.handlers:
+            handler.body = self.rewrite_block(handler.body)
+        if stmt.orelse:
+            stmt.orelse = self.rewrite_block(stmt.orelse)
+        if stmt.finalbody:
+            stmt.finalbody = self.rewrite_block(stmt.finalbody)
+        return stmt
+
+    def _merge_bindings(self, base, a, b, kind):
+        merged = dict(base)
+        for name in set(a) | set(b):
+            va = a.get(name)
+            vb = b.get(name)
+            if name in merged:
+                if va == merged.get(name) and vb == merged.get(name):
+                    continue
+                merged.pop(name, None)
+            elif va is not None and vb is not None and va != vb:
+                raise PTODSLAstRewriteError(
+                    f"ast_rewrite=True struct {kind} binding for {name!r} is assigned "
+                    "incompatible struct types in different branches; declare it once "
+                    "before the conditional or use canonical pto.struct_get/set"
+                )
+        return merged
+
+    def _rewrite_assign(self, node):
+        node.value = self._rewrite_expr(node.value)
+
+        if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            name = node.targets[0].id
+            meta = self._eval_struct_meta(node.value)
+            if meta is not None:
+                self._type_bindings[name] = meta
+                self._value_bindings.pop(name, None)
+                return [node]
+            if _is_pto_attr_call(node.value, "declare_struct"):
+                arg = node.value.args[0] if node.value.args else None
+                arg_meta = self._resolve_struct_arg(arg)
+                if arg_meta is not None:
+                    self._value_bindings[name] = arg_meta
+                    return [node]
+                self._value_bindings.pop(name, None)
+                self._type_bindings.pop(name, None)
+                return [node]
+            if isinstance(node.value, ast.Name) and node.value.id in self._value_bindings:
+                self._value_bindings[name] = self._value_bindings[node.value.id]
+                return [node]
+            self._value_bindings.pop(name, None)
+            self._type_bindings.pop(name, None)
+
+        member_targets = [
+            self._resolve_member(t) if isinstance(t, ast.Attribute) else None
+            for t in node.targets
+        ]
+        if any(m is not None for m in member_targets):
+            if len(node.targets) == 1:
+                base, path, leaf = member_targets[0]
+                if leaf is not _SCALAR_FIELD:
+                    raise PTODSLAstRewriteError(
+                        "ast_rewrite=True cannot write a whole nested struct member; "
+                        "continue to a scalar leaf or use a full canonical "
+                        "pto.struct_set(...) path"
+                    )
+                return [self._struct_set_stmt(base, path, node.value)]
+            tmp = self._fresh("tmp")
+            out = [ast.Assign(targets=[ast.Name(tmp, ast.Store())], value=node.value)]
+            for t, m in zip(node.targets, member_targets):
+                if m is not None:
+                    base, path, leaf = m
+                    if leaf is not _SCALAR_FIELD:
+                        raise PTODSLAstRewriteError(
+                            "ast_rewrite=True cannot write a whole nested struct member"
+                        )
+                    out.append(
+                        self._struct_set_stmt(base, path, ast.Name(tmp, ast.Load()))
+                    )
+                else:
+                    out.append(ast.Assign(targets=[t], value=ast.Name(tmp, ast.Load())))
+                    self._cancel_binding(t)
+            return out
+
+        for t in node.targets:
+            self._cancel_binding(t)
+        return [node]
+
+    def _rewrite_annassign(self, node):
+        if isinstance(node.target, ast.Attribute):
+            resolved = self._resolve_member(node.target)
+            if resolved is not None:
+                base, path, leaf = resolved
+                if leaf is not _SCALAR_FIELD:
+                    raise PTODSLAstRewriteError(
+                        "ast_rewrite=True annotated struct member must reach a scalar "
+                        "leaf; use a full canonical pto.struct_set(...) path"
+                    )
+                if node.value is None:
+                    raise PTODSLAstRewriteError(
+                        "ast_rewrite=True does not support value-less annotated struct "
+                        "member access"
+                    )
+                node.value = self._rewrite_expr(node.value)
+                return [self._struct_set_stmt(base, path, node.value)]
+        if node.value is not None:
+            node.value = self._rewrite_expr(node.value)
+        return [node]
+
+    def _rewrite_augassign(self, node):
+        if isinstance(node.target, ast.Attribute):
+            resolved = self._resolve_member(node.target)
+            if resolved is not None:
+                base, path, leaf = resolved
+                if leaf is not _SCALAR_FIELD:
+                    raise PTODSLAstRewriteError(
+                        "ast_rewrite=True augmented assignment must reach a scalar leaf"
+                    )
+                node.value = self._rewrite_expr(node.value)
+                tmp = self._fresh("tmp")
+                read = ast.Assign(
+                    targets=[ast.Name(tmp, ast.Store())],
+                    value=self._struct_get_call(base, path, node.target),
+                )
+                aug = ast.AugAssign(
+                    target=ast.Name(tmp, ast.Load()),
+                    op=node.op,
+                    value=node.value,
+                )
+                set_stmt = self._struct_set_stmt(
+                    base, path, ast.Name(tmp, ast.Load())
+                )
+                return [read, aug, set_stmt]
+        node.value = self._rewrite_expr(node.value)
+        return [node]
+
+    def _rewrite_delete(self, node):
+        for t in node.targets:
+            if isinstance(t, ast.Attribute) and self._resolve_member(t) is not None:
+                raise PTODSLAstRewriteError(
+                    "ast_rewrite=True does not support del on struct fields"
+                )
+        return [node]
+
+    def _cancel_binding(self, t):
+        if isinstance(t, ast.Name):
+            self._value_bindings.pop(t.id, None)
+            self._type_bindings.pop(t.id, None)
+
+    def _rewrite_expr(self, node):
+        if isinstance(node, ast.Attribute):
+            resolved = self._resolve_member(node)
+            if resolved is not None:
+                base, path, leaf = resolved
+                if leaf is _SCALAR_FIELD:
+                    return self._struct_get_call(base, path, node)
+                raise PTODSLAstRewriteError(
+                    "ast_rewrite=True cannot read a nested struct member as a value; "
+                    "continue to a scalar leaf (e.g. state.pt.x) or use a full "
+                    "canonical pto.struct_get(...) path"
+                )
+            node.value = self._rewrite_expr(node.value)
+            return node
+        for field, value in ast.iter_fields(node):
+            if isinstance(value, ast.AST):
+                setattr(node, field, self._rewrite_expr(value))
+            elif isinstance(value, list):
+                setattr(
+                    node,
+                    field,
+                    [self._rewrite_expr(v) if isinstance(v, ast.AST) else v for v in value],
+                )
+        return node
+
+    def _resolve_member(self, node):
+        chain = []
+        cur = node
+        while isinstance(cur, ast.Attribute):
+            chain.append(cur.attr)
+            cur = cur.value
+        if not isinstance(cur, ast.Name):
+            return None
+        base = cur.id
+        meta = self._value_bindings.get(base)
+        if meta is None:
+            return None
+        path = []
+        for attr in reversed(chain):
+            if meta is _SCALAR_FIELD:
+                raise PTODSLAstRewriteError(
+                    f"ast_rewrite=True struct member access descends into a scalar "
+                    f"field; cannot read {attr!r} on a scalar member"
+                )
+            if not isinstance(meta, _StructTypeMeta):
+                raise PTODSLAstRewriteError(
+                    f"ast_rewrite=True struct member access descends into a "
+                    f"non-struct field; cannot read {attr!r}"
+                )
+            if not meta.is_named:
+                raise PTODSLAstRewriteError(
+                    "ast_rewrite=True struct member access cannot descend into a "
+                    "positional (pto.struct_type) layer; use a full canonical "
+                    "pto.struct_get(...) path"
+                )
+            try:
+                idx = meta.field_index(attr)
+            except ValueError:
+                raise PTODSLAstRewriteError(
+                    f"ast_rewrite=True unknown struct field {attr!r}; expected one of "
+                    f"{[n for n in meta.field_names]}"
+                )
+            path.append(idx)
+            meta = meta.field_types[idx]
+        return base, tuple(path), meta
+
+    def _struct_get_call(self, base, path, node):
+        call = ast.Call(
+            func=_pto_attr("struct_get"),
+            args=[_name(base), self._path_tuple(path)],
+            keywords=[],
+        )
+        return ast.copy_location(call, node)
+
+    def _struct_set_stmt(self, base, path, value):
+        call = ast.Call(
+            func=_pto_attr("struct_set"),
+            args=[_name(base), self._path_tuple(path), value],
+            keywords=[],
+        )
+        return ast.Expr(value=call)
+
+    @staticmethod
+    def _path_tuple(path):
+        return ast.Tuple(elts=[ast.Constant(i) for i in path], ctx=ast.Load())
+
+    def _resolve_struct_arg(self, arg):
+        if arg is None:
+            return None
+        meta = self._eval_struct_meta(arg)
+        if meta is not None:
+            return meta
+        if isinstance(arg, ast.Name):
+            meta = self._type_bindings.get(arg.id)
+            if meta is not None:
+                return meta
+            obj = self._static_env.get(arg.id)
+            if _duck_struct_descriptor(obj):
+                return self._meta_from_descriptor(obj)
+        return None
+
+    def _eval_struct_meta(self, node):
+        if isinstance(node, ast.Call):
+            if _is_pto_attr_call(node, "struct"):
+                if len(node.args) != 1 or not isinstance(node.args[0], ast.Dict):
+                    return None
+                d = node.args[0]
+                names, types = [], []
+                for k, v in zip(d.keys, d.values):
+                    if not (isinstance(k, ast.Constant) and isinstance(k.value, str)):
+                        return None
+                    sub = self._eval_field_type(v)
+                    if sub is _UNRESOLVABLE_FIELD:
+                        return None
+                    names.append(k.value)
+                    types.append(sub)
+                return _StructTypeMeta(tuple(names), tuple(types))
+            if _is_pto_attr_call(node, "struct_type"):
+                names, types = [], []
+                for a in node.args:
+                    sub = self._eval_field_type(a)
+                    if sub is _UNRESOLVABLE_FIELD:
+                        return None
+                    names.append(None)
+                    types.append(sub)
+                return _StructTypeMeta(tuple(names), tuple(types))
+            return None
+        if isinstance(node, ast.Name):
+            obj = self._static_env.get(node.id)
+            if _duck_struct_descriptor(obj):
+                return self._meta_from_descriptor(obj)
+            return None
+        return None
+
+    def _eval_field_type(self, node):
+        if isinstance(node, ast.Call):
+            sub = self._eval_struct_meta(node)
+            if sub is not None:
+                return sub
+            return _UNRESOLVABLE_FIELD
+        if isinstance(node, ast.Attribute):
+            if isinstance(node.value, ast.Name) and node.value.id == "pto":
+                return _SCALAR_FIELD
+            return _UNRESOLVABLE_FIELD
+        if isinstance(node, ast.Name):
+            obj = self._static_env.get(node.id)
+            if _duck_struct_descriptor(obj):
+                return self._meta_from_descriptor(obj)
+            return _SCALAR_FIELD
+        return _UNRESOLVABLE_FIELD
+
+    def _meta_from_descriptor(self, obj):
+        field_names = getattr(obj, "field_names", None)
+        field_descriptors = getattr(obj, "field_descriptors", ())
+        names, types = [], []
+        for i, fd in enumerate(field_descriptors):
+            name = None if field_names is None else field_names[i]
+            names.append(name)
+            if _duck_struct_descriptor(fd):
+                types.append(self._meta_from_descriptor(fd))
+            else:
+                types.append(_SCALAR_FIELD)
+        return _StructTypeMeta(tuple(names), tuple(types))
 
 
 class _ControlFlowRewriter:

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -1752,6 +1752,13 @@ class _StructMemberRewriter:
                         "ast_rewrite=True annotated struct member must reach a scalar "
                         "leaf; use a full canonical pto.struct_set(...) path"
                     )
+                # The annotation must be a static, ignorable type annotation:
+                # a pto.* dtype (pto.i32) or a name in static_env that resolves
+                # to a known descriptor / MLIR Type.  A bare Name that is not a
+                # known static type (e.g. a function parameter) is treated as
+                # dynamic and rejected so the annotation is not silently dropped.
+                if node.annotation is not None:
+                    self._require_static_annotation(node.annotation)
                 if node.value is None:
                     raise PTODSLAstRewriteError(
                         "ast_rewrite=True does not support value-less annotated struct "
@@ -1779,7 +1786,7 @@ class _StructMemberRewriter:
                     value=self._struct_get_call(base, path, node.target),
                 )
                 aug = ast.AugAssign(
-                    target=ast.Name(tmp, ast.Load()),
+                    target=ast.Name(tmp, ast.Store()),
                     op=node.op,
                     value=node.value,
                 )
@@ -1910,10 +1917,16 @@ class _StructMemberRewriter:
                 if len(node.args) != 1 or not isinstance(node.args[0], ast.Dict):
                     return None
                 d = node.args[0]
-                names, types = [], []
+                names, types, seen = [], [], set()
                 for k, v in zip(d.keys, d.values):
                     if not (isinstance(k, ast.Constant) and isinstance(k.value, str)):
                         return None
+                    if k.value in seen:
+                        raise PTODSLAstRewriteError(
+                            f"ast_rewrite=True pto.struct(...) has a duplicate field "
+                            f"name {k.value!r}; field names must be unique"
+                        )
+                    seen.add(k.value)
                     sub = self._eval_field_type(v)
                     if sub is _UNRESOLVABLE_FIELD:
                         return None
@@ -1948,11 +1961,49 @@ class _StructMemberRewriter:
                 return _SCALAR_FIELD
             return _UNRESOLVABLE_FIELD
         if isinstance(node, ast.Name):
+            # Local type aliases (e.g. Inner = pto.struct(...)) take precedence
+            # over static_env so nested named descriptors defined in the same
+            # function can be reused.
+            local = self._type_bindings.get(node.id)
+            if local is not None:
+                return local
             obj = self._static_env.get(node.id)
             if _duck_struct_descriptor(obj):
                 return self._meta_from_descriptor(obj)
             return _SCALAR_FIELD
         return _UNRESOLVABLE_FIELD
+
+    def _require_static_annotation(self, node):
+        """Require a struct-member annotation to be a static, ignorable type.
+
+        A member annotation must be a ``pto.*`` dtype attribute or a name in
+        ``static_env`` that resolves to a known descriptor / MLIR Type.  Any
+        other expression (a bare Name that is a function parameter or a local,
+        a call, a subscript, ...) is a dynamic annotation and is rejected so it
+        is not silently dropped.
+        """
+        if isinstance(node, ast.Attribute):
+            if isinstance(node.value, ast.Name) and node.value.id == "pto":
+                return  # pto.i32 etc.
+            raise PTODSLAstRewriteError(
+                "ast_rewrite=True struct member annotation must be a static dtype "
+                "annotation (e.g. pto.i32); got a dynamic annotation"
+            )
+        if isinstance(node, ast.Name):
+            local = self._type_bindings.get(node.id)
+            if local is not None:
+                return
+            obj = self._static_env.get(node.id)
+            if _duck_struct_descriptor(obj):
+                return
+            raise PTODSLAstRewriteError(
+                f"ast_rewrite=True struct member annotation references unknown name "
+                f"{node.id!r}; only static pto.* dtype annotations are supported"
+            )
+        raise PTODSLAstRewriteError(
+            "ast_rewrite=True struct member annotation must be a static dtype "
+            "annotation (e.g. pto.i32); got a dynamic annotation"
+        )
 
     def _meta_from_descriptor(self, obj):
         field_names = getattr(obj, "field_names", None)

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -1653,7 +1653,11 @@ class _StructMemberRewriter:
             self._value_bindings.pop(n, None)
             self._type_bindings.pop(n, None)
         stmt.body = self.rewrite_block(stmt.body)
-        self._type_bindings, self._value_bindings = saved_t, saved_v
+        # The body may execute zero times, so bindings made only inside it do
+        # not survive; conversely the body may have run, so a binding it
+        # removed or changed can no longer be trusted after the loop.
+        self._type_bindings = self._restore_unchanged(saved_t, self._type_bindings)
+        self._value_bindings = self._restore_unchanged(saved_v, self._value_bindings)
         if stmt.orelse:
             stmt.orelse = self.rewrite_block(stmt.orelse)
         return stmt
@@ -1662,10 +1666,20 @@ class _StructMemberRewriter:
         stmt.test = self._rewrite_expr(stmt.test)
         saved_t, saved_v = dict(self._type_bindings), dict(self._value_bindings)
         stmt.body = self.rewrite_block(stmt.body)
-        self._type_bindings, self._value_bindings = saved_t, saved_v
+        self._type_bindings = self._restore_unchanged(saved_t, self._type_bindings)
+        self._value_bindings = self._restore_unchanged(saved_v, self._value_bindings)
         if stmt.orelse:
             stmt.orelse = self.rewrite_block(stmt.orelse)
         return stmt
+
+    @staticmethod
+    def _restore_unchanged(saved, after_body):
+        """Keep only pre-loop bindings the loop body left untouched."""
+        return {
+            name: meta
+            for name, meta in saved.items()
+            if name in after_body and after_body[name] == meta
+        }
 
     def _rewrite_with(self, stmt):
         for item in stmt.items:
@@ -1808,6 +1822,25 @@ class _StructMemberRewriter:
                 return [self._struct_set_stmt(base, path, node.value)]
         if node.value is not None:
             node.value = self._rewrite_expr(node.value)
+        if isinstance(node.target, ast.Name):
+            # Annotated declarations establish the same bindings as plain
+            # assignments: ``S: T = pto.struct({...})`` binds a struct type,
+            # ``state: T = pto.declare_struct(S)`` binds a struct value.
+            name = node.target.id
+            meta = self._eval_struct_meta(node.value) if node.value is not None else None
+            if meta is not None:
+                self._type_bindings[name] = meta
+                self._value_bindings.pop(name, None)
+                return [node]
+            if node.value is not None and _is_pto_attr_call(node.value, "declare_struct"):
+                arg = node.value.args[0] if node.value.args else None
+                arg_meta = self._resolve_struct_arg(arg)
+                if arg_meta is not None:
+                    self._value_bindings[name] = arg_meta
+                    self._type_bindings.pop(name, None)
+                    return [node]
+            if node.value is not None:
+                self._cancel_binding(node.target)
         return [node]
 
     def _rewrite_augassign(self, node):
@@ -1835,6 +1868,10 @@ class _StructMemberRewriter:
                 )
                 return [read, aug, set_stmt]
         node.value = self._rewrite_expr(node.value)
+        if isinstance(node.target, ast.Name):
+            # ``state += ...`` rebinds the name to a non-struct value, so its
+            # struct identity is cancelled (same rule as plain assignment).
+            self._cancel_binding(node.target)
         return [node]
 
     def _rewrite_delete(self, node):
@@ -1999,6 +2036,9 @@ class _StructMemberRewriter:
         if isinstance(node, ast.Attribute):
             if isinstance(node.value, ast.Name) and node.value.id == "pto":
                 return _ScalarField(node.attr)
+            if not isinstance(node.value, ast.Name):
+                # Multi-segment dotted names (e.g. a.b.c) are not resolvable.
+                return _UNRESOLVABLE_FIELD
             obj = self._static_env.get(node.value.id)
             if _duck_struct_descriptor(obj):
                 # A member of a known descriptor (e.g. a static dtype attribute)

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -42,6 +42,7 @@ from ._surface_values import (
     AllocatedBufferValue,
     MaskResultValue,
     PartitionTensorViewValue,
+    StructValue,
     TensorViewValue,
     TileSliceValue,
     TileValue,

--- a/ptodsl/ptodsl/_ops_core.py
+++ b/ptodsl/ptodsl/_ops_core.py
@@ -29,6 +29,7 @@ from ._surface_values import (
     AllocatedBufferValue,
     MaskResultValue,
     PartitionTensorViewValue,
+    StructValue,
     TensorViewValue,
     TileSliceValue,
     TileValue,
@@ -186,7 +187,7 @@ def declare_struct(struct_type):
             "pto.declare_struct(...): expected a pto.struct_type(...) descriptor or !pto.struct type, "
             f"got {resolved_type}"
         )
-    return wrap_surface_value(_pto.DeclareStructOp(resolved_type).s)
+    return StructValue(_pto.DeclareStructOp(resolved_type).s)
 
 
 def struct_get(struct, path):

--- a/ptodsl/ptodsl/_surface_values.py
+++ b/ptodsl/ptodsl/_surface_values.py
@@ -327,6 +327,37 @@ class RuntimeValue(_SurfaceValue):
         return wrap_surface_value(emit_runtime_bitwise_op("xor", unwrap_surface_value(other), self.value))
 
 
+class StructValue(RuntimeValue):
+    """Stack-local ``!pto.struct`` value backing ``pto.declare_struct(...)``.
+
+    Member access (``state.field``) is handled by the ``@pto.jit`` AST rewriter
+    when source is available; this class only provides a *diagnostic* fallback
+    so that member access on an un-rewritten function (source-less/REPL, or
+    ``ast_rewrite=False``) fails loudly instead of silently creating a plain
+    Python attribute or raising ``AttributeError``.
+    """
+
+    def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        raise AttributeError(
+            "struct member access requires @pto.jit AST rewriting (default on); "
+            "keep the function source retrievable or use pto.struct_get / "
+            f"pto.struct_set instead. Attempted to read member {name!r}."
+        )
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            # Internal attributes (e.g. _value) are set by __init__ and helpers.
+            object.__setattr__(self, name, value)
+            return
+        raise AttributeError(
+            "struct member access requires @pto.jit AST rewriting (default on); "
+            "keep the function source retrievable or use pto.struct_get / "
+            f"pto.struct_set instead. Attempted to write member {name!r}."
+        )
+
+
 class VecValue(_SurfaceValue):
     """Author-facing builtin vector value backed by an MLIR vector SSA value."""
 

--- a/ptodsl/ptodsl/_types.py
+++ b/ptodsl/ptodsl/_types.py
@@ -164,7 +164,7 @@ class _MaskDescriptor(_DType):
 _STRUCT_RESERVED_FIELD_NAMES = frozenset({
     "value", "type", "surface_metadata", "field_descriptors", "field_names",
     "field_index", "field_descriptor_at", "resolve", "declared_value",
-    "field_map", "__getattr__", "__setattr__",
+    "field_map",
 })
 
 
@@ -704,7 +704,7 @@ def struct(fields: dict) -> _StructDescriptor:
 
     ``fields`` is an order-preserving ``dict[str, field_type]`` whose field names
     become the struct member-access surface: ``state.field`` lowers to
-    ``pto.struct_set/get(state, [index], ...)``.``
+    ``pto.struct_set/get(state, [index], ...)``.
     """
     return _StructDescriptor.from_named(fields)
 

--- a/ptodsl/ptodsl/_types.py
+++ b/ptodsl/ptodsl/_types.py
@@ -20,6 +20,7 @@ the actual type is materialised later by the ``@pto.jit`` decorator.
 """
 
 import keyword
+import sys
 
 from ptoas.mlir.dialects import pto as _pto
 from ptoas.mlir.dialects import arith
@@ -197,13 +198,19 @@ class _StructDescriptor(_DType):
 
     - positional (``pto.struct_type(...)``): ``field_descriptors`` is order-
       preserving, ``field_names`` is ``None``.
-    - named (``pto.struct({...})``): ``field_names`` holds the field names, and
-      ``field_index(name)`` maps a member name to its integer position.  The
-      resolved ``!pto.struct<...>`` is identical to the positional form.
+    - named (``pto.struct({...})`` or ``@pto.struct`` on a class):
+      ``field_names`` holds the field names, and ``field_index(name)`` maps a
+      member name to its integer position.  The resolved ``!pto.struct<...>``
+      is identical to the positional form.
+
+    A named descriptor is also *callable*: ``Point(x, y)`` declares a struct
+    value at trace time and initializes the given fields (all-or-none);
+    ``Point()`` declares without initializing.
     """
 
     def __init__(self, field_descriptors, field_names=None):
         self._field_descriptors = tuple(field_descriptors)
+        self._class_qualname = None
         if field_names is None:
             self._field_names = None
             self._name_to_index = None
@@ -229,6 +236,110 @@ class _StructDescriptor(_DType):
             _validate_struct_field_name(name, context="pto.struct(...)")
             names.append(name)
         return cls(tuple(fields.values()), field_names=tuple(names))
+
+    # Class-body attributes every plain class carries; anything else must be a
+    # field annotation.
+    _CLASS_NOISE_ATTRS = frozenset({
+        "__module__", "__qualname__", "__annotations__", "__dict__",
+        "__weakref__", "__doc__",
+    })
+
+    @classmethod
+    def from_class(cls, py_cls) -> "_StructDescriptor":
+        """Build a named struct descriptor from an ``@pto.struct`` class.
+
+        The class body may only contain ``name: field_type`` annotations
+        (plus an optional docstring); default values, methods, and non-object
+        bases are rejected so the class stays a pure field declaration.
+        Field-type legality is validated lazily by ``resolve()``, exactly
+        like the dict form.
+        """
+        display = f"@pto.struct class {getattr(py_cls, '__qualname__', py_cls)}"
+        if py_cls.__bases__ != (object,):
+            raise TypeError(
+                f"{display}: struct classes do not support inheritance; "
+                "declare fields without base classes"
+            )
+        annotations = dict(getattr(py_cls, "__annotations__", None) or {})
+        if not annotations:
+            raise ValueError(
+                f"{display}: declare at least one 'name: pto.<dtype>' field"
+            )
+        for attr_name in vars(py_cls):
+            if attr_name in cls._CLASS_NOISE_ATTRS:
+                continue
+            if attr_name in annotations:
+                raise TypeError(
+                    f"{display}: field {attr_name!r} has a default value; struct "
+                    "fields do not support defaults, pass values to the "
+                    "constructor instead"
+                )
+            raise TypeError(
+                f"{display}: unsupported class attribute {attr_name!r}; struct "
+                "classes may only contain 'name: pto.<dtype>' annotations "
+                "(no methods or defaults)"
+            )
+        module = sys.modules.get(py_cls.__module__)
+        module_globals = vars(module) if module is not None else {}
+        names, fields = [], []
+        for name, ann in annotations.items():
+            _validate_struct_field_name(name, context=display)
+            if isinstance(ann, str):
+                # PEP 563 (from __future__ import annotations): resolve the
+                # stringified annotation in the defining module's namespace.
+                try:
+                    ann = eval(ann, dict(module_globals))
+                except Exception as exc:
+                    raise TypeError(
+                        f"{display}: cannot resolve annotation {ann!r} for field "
+                        f"{name!r}; annotate with pto.* dtypes or struct "
+                        "descriptors"
+                    ) from exc
+            names.append(name)
+            fields.append(ann)
+        descriptor = cls(tuple(fields), field_names=tuple(names))
+        descriptor._class_qualname = getattr(py_cls, "__qualname__", None)
+        return descriptor
+
+    def __call__(self, *args, **kwargs):
+        """Declare and initialize a struct value at trace time.
+
+        ``Point(x, y)`` is sugar for ``declare_struct`` plus one
+        ``struct_set`` per field, in declaration order; ``Point()`` declares
+        without initializing.  Fields may be given positionally (declaration
+        order) or by name, all-or-none.
+        """
+        display = self._class_qualname or "pto.struct(...)"
+        if self._field_names is None:
+            raise TypeError(
+                "positional pto.struct_type(...) descriptors are not callable; "
+                "use pto.declare_struct(...)"
+            )
+        if len(args) > len(self._field_names):
+            raise TypeError(
+                f"{display}(...) takes at most {len(self._field_names)} "
+                f"positional field values ({len(args)} given)"
+            )
+        values = dict(zip(self._field_names, args))
+        for key, val in kwargs.items():
+            if key not in self._name_to_index:
+                raise TypeError(f"{display}(...) got an unexpected field name {key!r}")
+            if key in values:
+                raise TypeError(f"{display}(...) got multiple values for field {key!r}")
+            values[key] = val
+        missing = [n for n in self._field_names if n not in values]
+        if values and missing:
+            raise TypeError(
+                f"{display}(...) missing field values for {missing}; "
+                "pass all fields or none"
+            )
+        from . import _ops  # lazy: _ops imports _types
+
+        state = _ops.declare_struct(self)
+        for name in self._field_names:
+            if name in values:
+                _ops.struct_set(state, [self.field_index(name)], values[name])
+        return state
 
     @property
     def field_descriptors(self):
@@ -699,13 +810,22 @@ def struct_type(*field_types) -> _StructDescriptor:
     return _StructDescriptor(field_types)
 
 
-def struct(fields: dict) -> _StructDescriptor:
+def struct(fields) -> _StructDescriptor:
     """Return a named lazy descriptor for ``!pto.struct<...>``.
 
-    ``fields`` is an order-preserving ``dict[str, field_type]`` whose field names
-    become the struct member-access surface: ``state.field`` lowers to
-    ``pto.struct_set/get(state, [index], ...)``.
+    Two spellings dispatch on the argument type:
+
+    - ``pto.struct({"x": pto.i32, ...})`` — an order-preserving
+      ``dict[str, field_type]``;
+    - ``@pto.struct class Point: ...`` — a class whose body only contains
+      ``name: field_type`` annotations.
+
+    The field names become the struct member-access surface: ``state.field``
+    lowers to ``pto.struct_set/get(state, [index], ...)``.  A named descriptor
+    is callable: ``Point(x, y)`` declares and initializes a struct value.
     """
+    if isinstance(fields, type):
+        return _StructDescriptor.from_class(fields)
     return _StructDescriptor.from_named(fields)
 
 

--- a/ptodsl/ptodsl/_types.py
+++ b/ptodsl/ptodsl/_types.py
@@ -19,6 +19,8 @@ where the annotation is evaluated at *import* time (no active context), and
 the actual type is materialised later by the ``@pto.jit`` decorator.
 """
 
+import keyword
+
 from ptoas.mlir.dialects import pto as _pto
 from ptoas.mlir.dialects import arith
 from ptoas.mlir.dialects.builtin import UnrealizedConversionCastOp
@@ -156,17 +158,110 @@ class _MaskDescriptor(_DType):
     def __repr__(self):
         return f"<pto.mask {self._bits}>"
 
-class _StructDescriptor(_DType):
-    """Deferred ``!pto.struct<...>`` type assembled from scalar fields."""
+# Names used by the struct surface / _SurfaceValue that are reserved and cannot
+# be used as pto.struct({...}) field names.  Kept as a module-level frozenset so
+# tests can assert the exact conflict set.
+_STRUCT_RESERVED_FIELD_NAMES = frozenset({
+    "value", "type", "surface_metadata", "field_descriptors", "field_names",
+    "field_index", "field_descriptor_at", "resolve", "declared_value",
+    "field_map", "__getattr__", "__setattr__",
+})
 
-    def __init__(self, field_descriptors):
+
+def _validate_struct_field_name(name: str, *, context: str) -> None:
+    """Validate one named struct field name against the public naming rules."""
+    if not isinstance(name, str) or not name.isidentifier():
+        raise ValueError(
+            f"{context} field names must be valid Python identifiers; got {name!r}"
+        )
+    if keyword.iskeyword(name):
+        raise ValueError(
+            f"{context} field name {name!r} is a Python keyword and cannot be used "
+            "as a struct member"
+        )
+    if name.startswith("_"):
+        raise ValueError(
+            f"{context} field name {name!r} must not start with an underscore"
+        )
+    if name in _STRUCT_RESERVED_FIELD_NAMES:
+        raise ValueError(
+            f"{context} field name {name!r} is reserved and cannot be used as a "
+            "struct member"
+        )
+
+
+class _StructDescriptor(_DType):
+    """Deferred ``!pto.struct<...>`` type assembled from scalar fields.
+
+    Supports two construction paths:
+
+    - positional (``pto.struct_type(...)``): ``field_descriptors`` is order-
+      preserving, ``field_names`` is ``None``.
+    - named (``pto.struct({...})``): ``field_names`` holds the field names, and
+      ``field_index(name)`` maps a member name to its integer position.  The
+      resolved ``!pto.struct<...>`` is identical to the positional form.
+    """
+
+    def __init__(self, field_descriptors, field_names=None):
         self._field_descriptors = tuple(field_descriptors)
+        if field_names is None:
+            self._field_names = None
+            self._name_to_index = None
+        else:
+            if len(field_names) != len(self._field_descriptors):
+                raise ValueError(
+                    "struct field names must have the same length as field types"
+                )
+            self._field_names = tuple(field_names)
+            self._name_to_index = {name: i for i, name in enumerate(self._field_names)}
+
+    @classmethod
+    def from_named(cls, fields: dict) -> "_StructDescriptor":
+        """Build a named struct descriptor from a ``dict[str, field_type]``."""
+        if not isinstance(fields, dict):
+            raise TypeError(
+                "pto.struct(...): expected a dict[str, field_type]"
+            )
+        if not fields:
+            raise ValueError("pto.struct(...) requires at least one field")
+        names = []
+        for name, _field_type in fields.items():
+            _validate_struct_field_name(name, context="pto.struct(...)")
+            names.append(name)
+        return cls(tuple(fields.values()), field_names=tuple(names))
 
     @property
     def field_descriptors(self):
         return self._field_descriptors
 
-    def resolve(self) -> Type:
+    @property
+    def field_names(self):
+        """Return the ordered field names, or ``None`` for positional structs."""
+        return self._field_names
+
+    @property
+    def is_named(self) -> bool:
+        return self._field_names is not None
+
+    def field_index(self, name: str) -> int:
+        """Return the positional index of a named field."""
+        if self._name_to_index is None:
+            raise ValueError(
+                f"positional struct has no field names; cannot resolve {name!r}"
+            )
+        if name not in self._name_to_index:
+            raise ValueError(
+                f"unknown struct field {name!r}; expected one of "
+                f"{', '.join(repr(n) for n in self._field_names)}"
+            )
+        return self._name_to_index[name]
+
+    def field_descriptor_at(self, i: int):
+        """Return ``(name, descriptor)`` for field ``i`` (name may be ``None``)."""
+        name = None if self._field_names is None else self._field_names[i]
+        return name, self._field_descriptors[i]
+
+    def resolve(self, *, context: str = "pto.struct_type(...)") -> Type:
         struct_type_cls = getattr(_pto, "StructType", None)
         if struct_type_cls is None:
             raise TypeError(
@@ -174,14 +269,20 @@ class _StructDescriptor(_DType):
                 "Rebuild the PTO Python extension before using pto.struct_type(...)."
             )
         field_types = [
-            _resolve_struct_field_type(field, context="pto.struct_type(...)")
+            _resolve_struct_field_type(field, context=context)
             for field in self._field_descriptors
         ]
         return struct_type_cls.get(field_types)
 
     def __repr__(self):
-        fields = ", ".join(repr(field) for field in self._field_descriptors)
-        return f"<pto.struct {fields}>"
+        if self._field_names is None:
+            fields = ", ".join(repr(field) for field in self._field_descriptors)
+            return f"<pto.struct {fields}>"
+        fields = ", ".join(
+            f"{name}={repr(field)}"
+            for name, field in zip(self._field_names, self._field_descriptors)
+        )
+        return f"<pto.struct{{{fields}}}>"
 
 # Legal logical lane counts for VMI vreg/mask types on the formal PTODSL
 # surface: compact/group-slot flows use the first four values, full logical
@@ -598,6 +699,16 @@ def struct_type(*field_types) -> _StructDescriptor:
     return _StructDescriptor(field_types)
 
 
+def struct(fields: dict) -> _StructDescriptor:
+    """Return a named lazy descriptor for ``!pto.struct<...>``.
+
+    ``fields`` is an order-preserving ``dict[str, field_type]`` whose field names
+    become the struct member-access surface: ``state.field`` lowers to
+    ``pto.struct_set/get(state, [index], ...)``.``
+    """
+    return _StructDescriptor.from_named(fields)
+
+
 def vmi_vreg_type(lanes: int, elem) -> _VMIVRegDescriptor:
     """Return a lazy descriptor for ``!pto.vmi.vreg<lanesxelem>``."""
     return _VMIVRegDescriptor(lanes, elem)
@@ -714,7 +825,7 @@ __all__ = [
     "si8", "si16", "si32", "si64",
     "ui8", "ui16", "ui32", "ui64",
     "index",
-    "ptr", "vreg_type", "vec_type", "mask_type", "struct_type",
+    "ptr", "vreg_type", "vec_type", "mask_type", "struct_type", "struct",
     "vmi_vreg_type", "vmi_mask_type",
     "tile_buf_type", "tensor_view_type", "tensor_view_type_from_dims",
     "part_tensor_view_type", "part_tensor_view_type_from_dims",

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -34,7 +34,7 @@ from ._types import (           # noqa: F401
     si8, si16, si32, si64,
     ui8, ui16, ui32, ui64,
     index,
-    ptr, vreg_type, vec_type, mask_type, struct_type,
+    ptr, vreg_type, vec_type, mask_type, struct_type, struct,
     _resolve,
 )
 from ._builtin_vector import Vec  # noqa: F401

--- a/ptodsl/tests/support/docs_fragment_fixtures.py
+++ b/ptodsl/tests/support/docs_fragment_fixtures.py
@@ -68,6 +68,13 @@ FRAGMENT_FIXTURES = {
             {SNIPPET_PLACEHOLDER}
         """
     ),
+    "type_system.struct_member": _fixture(
+        f"""
+        @pto.jit(target="a5")
+        def type_system_struct_member_probe():
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
     "type_system.low_precision_types": _fixture(
         f"""
         @pto.jit(target="a5")

--- a/ptodsl/tests/test_ptoas_frontend_verify.py
+++ b/ptodsl/tests/test_ptoas_frontend_verify.py
@@ -348,6 +348,16 @@ def struct_member_frontend_verify_probe():
     _ = state.x
 
 
+@pto.jit(target="a5", backend="vpto", mode="explicit", kernel_kind="vector")
+def struct_member_vpto_probe(x: pto.i32):
+    Inner = pto.struct({"x": pto.i32, "y": pto.f32})
+    Alias = Inner
+    Outer = pto.struct({"id": pto.i32, "inner": Alias})
+    s = pto.declare_struct(Outer)
+    s.inner.x += x
+    _ = s.inner.y
+
+
 @pto.simt
 def vec_value_arith_simt_body(
     A_ptr: pto.ptr(pto.f32, "gm"),
@@ -472,6 +482,42 @@ def main() -> None:
     expect(
         ".f0" in joined_struct_member_emitc_cpp,
         "EmitC should lower named-member writes/reads to positional field access",
+    )
+
+    # Default (VPTO) backend named-member surface: local descriptor alias,
+    # nested member access, and += must all lower through the same canonical
+    # get/set ops into the VPTO child module.
+    struct_member_vpto_text = struct_member_vpto_probe.compile().mlir_text()
+    expect(
+        "pto.declare_struct" in struct_member_vpto_text
+        and "pto.struct_set" in struct_member_vpto_text
+        and "pto.struct_get" in struct_member_vpto_text,
+        "struct_member_vpto probe source MLIR should contain canonical struct ops after AST rewrite",
+    )
+    struct_member_vpto_frontend_texts = run_ptoas_frontend_verify(
+        ptoas_bin,
+        struct_member_vpto_text,
+        "struct_member_vpto_probe PTODSL artifact",
+    )
+    expect(
+        len(struct_member_vpto_frontend_texts) == 1,
+        "struct_member_vpto probe should lower to exactly one backend child module",
+    )
+    # The VPTO fast path lowers the (already canonical) struct ops to LLVM
+    # alloca/GEP/load/store, so the frontend output may be empty (object-output
+    # fallback) rather than retaining pto.struct_get/set.  The important
+    # contract is that the AST-rewritten named-member surface survives PTODSL
+    # compile -> PTOAS frontend without error.
+    struct_member_vpto_frontend_text = struct_member_vpto_frontend_texts[0]
+    expect(
+        struct_member_vpto_frontend_text == ""
+        or (
+            "pto.declare_struct" in struct_member_vpto_frontend_text
+            and "pto.struct_set" in struct_member_vpto_frontend_text
+            and "pto.struct_get" in struct_member_vpto_frontend_text
+        ),
+        "struct_member_vpto probe should lower through the VPTO frontend "
+        "(struct ops are lowered to object code or kept as IR)",
     )
 
     simt_gm_memory_text = simt_gm_memory_core_kernel.compile().mlir_text()

--- a/ptodsl/tests/test_ptoas_frontend_verify.py
+++ b/ptodsl/tests/test_ptoas_frontend_verify.py
@@ -348,6 +348,17 @@ def struct_member_frontend_verify_probe():
     _ = state.x
 
 
+@pto.jit(target="a5", backend="emitc")
+def struct_class_frontend_verify_probe():
+    @pto.struct
+    class Point:
+        x: pto.i32
+        y: pto.f32
+
+    state = Point(1, 3.5)
+    _ = state.x
+
+
 @pto.jit(target="a5", backend="vpto", mode="explicit", kernel_kind="vector")
 def struct_member_vpto_probe(x: pto.i32):
     Inner = pto.struct({"x": pto.i32, "y": pto.f32})
@@ -482,6 +493,39 @@ def main() -> None:
     expect(
         ".f0" in joined_struct_member_emitc_cpp,
         "EmitC should lower named-member writes/reads to positional field access",
+    )
+
+    # @pto.struct class form: declaration + Point(...) construction + member
+    # access must reach the same canonical ops and EmitC field access.
+    struct_class_text = struct_class_frontend_verify_probe.compile().mlir_text()
+    expect(
+        "pto.declare_struct" in struct_class_text
+        and "pto.struct_set" in struct_class_text
+        and "pto.struct_get" in struct_class_text,
+        "struct_class probe source MLIR should contain the canonical struct ops after AST rewrite",
+    )
+    struct_class_frontend_texts = run_ptoas_frontend_verify(
+        ptoas_bin,
+        struct_class_text,
+        "struct_class_frontend_verify_probe PTODSL artifact",
+    )
+    expect(
+        len(struct_class_frontend_texts) == 1,
+        "struct_class probe should lower to exactly one backend child module",
+    )
+    struct_class_emitc_cpp_texts = run_ptoas_emitc(
+        ptoas_bin,
+        struct_class_text,
+        "struct_class_frontend_verify_probe PTODSL EmitC artifact",
+    )
+    expect(
+        len(struct_class_emitc_cpp_texts) == 1,
+        "struct_class probe should materialize one EmitC module",
+    )
+    joined_struct_class_emitc_cpp = "\n".join(struct_class_emitc_cpp_texts)
+    expect(
+        ".f0" in joined_struct_class_emitc_cpp,
+        "EmitC should lower class-form construction/member access to positional field access",
     )
 
     # Default (VPTO) backend named-member surface: local descriptor alias,

--- a/ptodsl/tests/test_ptoas_frontend_verify.py
+++ b/ptodsl/tests/test_ptoas_frontend_verify.py
@@ -339,6 +339,15 @@ def struct_frontend_verify_probe():
     _ = pto.struct_get(state, (1, 0))
 
 
+@pto.jit(target="a5", backend="emitc")
+def struct_member_frontend_verify_probe():
+    Point = pto.struct({"x": pto.i32, "y": pto.f32})
+    state = pto.declare_struct(Point)
+    state.x = 1
+    state.y = 3.5
+    _ = state.x
+
+
 @pto.simt
 def vec_value_arith_simt_body(
     A_ptr: pto.ptr(pto.f32, "gm"),
@@ -430,6 +439,39 @@ def main() -> None:
     expect(
         ".f0" in joined_struct_emitc_cpp and ".f1.f0" in joined_struct_emitc_cpp,
         "EmitC should lower PTODSL struct writes and nested reads to direct field access",
+    )
+
+    # Named-member surface (pto.struct({...}) + state.field) must go through the
+    # same AST rewrite -> canonical get/set -> EmitC field-access path.
+    struct_member_text = struct_member_frontend_verify_probe.compile().mlir_text()
+    expect(
+        "pto.declare_struct" in struct_member_text
+        and "pto.struct_set" in struct_member_text
+        and "pto.struct_get" in struct_member_text,
+        "struct_member probe source MLIR should contain the canonical struct ops after AST rewrite",
+    )
+    struct_member_frontend_texts = run_ptoas_frontend_verify(
+        ptoas_bin,
+        struct_member_text,
+        "struct_member_frontend_verify_probe PTODSL artifact",
+    )
+    expect(
+        len(struct_member_frontend_texts) == 1,
+        "struct_member probe should lower to exactly one backend child module",
+    )
+    struct_member_emitc_cpp_texts = run_ptoas_emitc(
+        ptoas_bin,
+        struct_member_text,
+        "struct_member_frontend_verify_probe PTODSL EmitC artifact",
+    )
+    expect(
+        len(struct_member_emitc_cpp_texts) == 1,
+        "struct_member probe should materialize one EmitC module",
+    )
+    joined_struct_member_emitc_cpp = "\n".join(struct_member_emitc_cpp_texts)
+    expect(
+        ".f0" in joined_struct_member_emitc_cpp,
+        "EmitC should lower named-member writes/reads to positional field access",
     )
 
     simt_gm_memory_text = simt_gm_memory_core_kernel.compile().mlir_text()

--- a/ptodsl/tests/test_struct.py
+++ b/ptodsl/tests/test_struct.py
@@ -292,6 +292,25 @@ def named_static_loop_rebind_kernel(x: pto.i32):
 
 
 @pto.jit(target="a5")
+def named_multi_target_kernel(x: pto.i32, y: pto.f32):
+    a = b = pto.declare_struct(NAMED_STRUCT)
+    a.n = x
+    b.sum = y
+    _ = a.n
+    _ = b.sum
+
+
+@pto.jit(target="a5")
+def named_multi_target_alias_kernel():
+    Inner = pto.struct({"x": pto.i32})
+    A = B = Inner
+    s = pto.declare_struct(A)
+    s.x = 1
+    t = pto.declare_struct(B)
+    t.x = 2
+
+
+@pto.jit(target="a5")
 def named_annassign_decl_kernel():
     S: object = pto.struct({"x": pto.i32, "y": pto.f32})
     state = pto.declare_struct(S)
@@ -304,6 +323,96 @@ def named_annassign_decl_kernel():
 def named_member_no_rewrite_kernel():
     state = pto.declare_struct(NAMED_STRUCT)
     state.n = 1
+
+
+@pto.struct
+class ClassPoint:
+    x: pto.i32
+    y: pto.f32
+
+
+@pto.struct
+class ClassInner:
+    x: pto.i32
+    y: pto.f32
+
+
+@pto.struct
+class ClassOuter:
+    id: pto.i32
+    inner: ClassInner
+
+
+@pto.jit(target="a5")
+def class_member_kernel(x: pto.i32, y: pto.f32):
+    state = ClassPoint(x, y)
+    count = state.x
+    total = state.y
+    _ = count
+    _ = total
+
+
+@pto.jit(target="a5")
+def class_kwargs_kernel(x: pto.i32):
+    state = ClassPoint(y=2.5, x=x)
+    _ = state.x
+
+
+@pto.jit(target="a5")
+def class_declare_only_kernel():
+    state = ClassPoint()
+    state.x = 1
+    _ = state.x
+
+
+@pto.jit(target="a5")
+def class_nested_kernel():
+    s = ClassOuter()
+    s.inner.x = 1
+    v = s.inner.y
+    _ = v
+
+
+@pto.jit(target="a5")
+def class_local_kernel(x: pto.i32):
+    @pto.struct
+    class Local:
+        x: pto.i32
+        y: pto.f32
+
+    s = Local(x, 2.5)
+    v = s.y
+    _ = v
+
+
+@pto.jit(target="a5")
+def class_multi_target_kernel(x: pto.i32, y: pto.f32):
+    a = b = ClassPoint(x, y)
+    _ = a.x
+    b.y = y
+
+
+# Regression for the future-flag fix in rewrite_jit_function: the rewritten
+# module must compile with the kernel's own future flags (dont_inherit=True).
+# If compile() inherited ``from __future__ import annotations`` from
+# _ast_rewrite, ``v: T`` below would stringify and from_class could not
+# resolve the kernel-local name ``T`` in module globals.
+@pto.jit(target="a5")
+def class_local_dtype_alias_kernel(x: pto.i32):
+    T = pto.i32
+
+    @pto.struct
+    class Local:
+        v: T
+
+    s = Local(x)
+    _ = s.v
+
+
+@pto.jit(target="a5", ast_rewrite=False)
+def class_no_rewrite_kernel(x: pto.i32, y: pto.f32):
+    state = ClassPoint(x, y)
+    state.x = 1
 
 
 class NamedStructMemberAccessTest(unittest.TestCase):
@@ -426,6 +535,23 @@ class NamedStructMemberAccessTest(unittest.TestCase):
         self.assertIn("pto.struct_set", text)
         self.assertIn("pto.struct_get", text)
 
+    def test_multi_target_assignment_binds_all_names(self):
+        # ``a = b = declare_struct(...)`` evaluates the RHS once; both names
+        # alias the same struct value and their member access is rewritten.
+        text = named_multi_target_kernel.compile().mlir_text()
+        self.assertEqual(text.count("pto.declare_struct"), 1)
+        self.assertIn("pto.struct_set", text)
+        self.assertIn("pto.struct_get", text)
+        self.assertIn("[0]", text)
+        self.assertIn("[1]", text)
+
+    def test_multi_target_assignment_binds_type_aliases(self):
+        # ``A = B = Inner`` binds the struct type on both names so each can
+        # back a declare_struct(...) call.
+        text = named_multi_target_alias_kernel.compile().mlir_text()
+        self.assertEqual(text.count("pto.declare_struct"), 2)
+        self.assertEqual(text.count("pto.struct_set"), 2)
+
     def test_ast_rewrite_disabled_member_access_diagnostic(self):
         with self.assertRaisesRegex(AttributeError, "AST rewriting"):
             named_member_no_rewrite_kernel.compile()
@@ -446,6 +572,139 @@ class NamedStructMemberAccessTest(unittest.TestCase):
         # Unresolvable field types must leave the statements unrewritten
         # instead of crashing with a raw AttributeError.
         rewriter.rewrite_block(fn.body)
+
+
+class StructClassFormTest(unittest.TestCase):
+    def test_class_form_resolves_same_type_as_dict(self):
+        with make_context() as ctx, Location.unknown(ctx):
+            self.assertEqual(
+                str(ClassPoint.resolve()),
+                str(pto.struct({"x": pto.i32, "y": pto.f32}).resolve()),
+            )
+
+    def test_class_form_field_metadata(self):
+        self.assertEqual(ClassPoint.field_names, ("x", "y"))
+        self.assertTrue(ClassPoint.is_named)
+        self.assertEqual(ClassPoint.field_index("y"), 1)
+        self.assertEqual(ClassPoint.field_descriptor_at(0)[0], "x")
+
+    def test_class_form_ctor_validation(self):
+        with self.assertRaisesRegex(TypeError, "positional"):
+            ClassPoint(1, 2, 3)
+        with self.assertRaisesRegex(TypeError, "unexpected field"):
+            ClassPoint(x=1, z=2)
+        with self.assertRaisesRegex(TypeError, "multiple values"):
+            ClassPoint(1, x=2)
+        with self.assertRaisesRegex(TypeError, "missing"):
+            ClassPoint(1)
+
+    def test_class_form_declaration_errors(self):
+        with self.assertRaisesRegex(TypeError, "default value"):
+            @pto.struct
+            class _WithDefault:
+                x: pto.i32 = 0
+
+        with self.assertRaisesRegex(TypeError, "unsupported class attribute"):
+            @pto.struct
+            class _WithMethod:
+                x: pto.i32
+
+                def foo(self):
+                    pass
+
+        with self.assertRaisesRegex(ValueError, "underscore"):
+            @pto.struct
+            class _WithUnderscore:
+                _x: pto.i32
+
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            @pto.struct
+            class _Empty:
+                pass
+
+    def test_class_form_rejects_inheritance(self):
+        class _PlainBase:
+            pass
+
+        with self.assertRaisesRegex(TypeError, "inheritance"):
+            @pto.struct
+            class _Sub(_PlainBase):
+                x: pto.i32
+
+    def test_positional_descriptor_not_callable(self):
+        with self.assertRaisesRegex(TypeError, "not callable"):
+            pto.struct_type(pto.i32, pto.f32)(1, 2)
+
+    def test_class_member_access_rewrites_to_canonical_ops(self):
+        text = class_member_kernel.compile().mlir_text()
+        self.assertIn("pto.declare_struct", text)
+        # Constructor initializes both fields; reads become struct_get.
+        self.assertEqual(text.count("pto.struct_set"), 2)
+        self.assertEqual(text.count("pto.struct_get"), 2)
+        self.assertNotIn("ClassPoint", text)
+
+    def test_class_kwargs_ctor(self):
+        text = class_kwargs_kernel.compile().mlir_text()
+        self.assertEqual(text.count("pto.struct_set"), 2)
+        self.assertIn("pto.struct_get", text)
+
+    def test_class_declare_only_ctor(self):
+        text = class_declare_only_kernel.compile().mlir_text()
+        # Point() declares without initializing; only the explicit member
+        # write produces struct_set.
+        self.assertEqual(text.count("pto.struct_set"), 1)
+        self.assertIn("pto.struct_get", text)
+
+    def test_class_nested_member_access(self):
+        text = class_nested_kernel.compile().mlir_text()
+        self.assertIn("[1, 0]", text)
+        self.assertIn("[1, 1]", text)
+
+    def test_class_form_function_local(self):
+        text = class_local_kernel.compile().mlir_text()
+        self.assertEqual(text.count("pto.struct_set"), 2)
+        self.assertIn("pto.struct_get", text)
+
+    def test_class_form_construction_without_ast_rewrite(self):
+        # Construction itself needs no AST rewrite (the descriptor __call__
+        # emits declare+set at trace time); only member access does.
+        with self.assertRaisesRegex(AttributeError, "AST rewriting"):
+            class_no_rewrite_kernel.compile()
+
+    def test_class_multi_target_assignment_binds_all_names(self):
+        # ``a = b = ClassPoint(...)`` evaluates the constructor once; both
+        # names alias the same struct value and support member access.  The
+        # constructor initializes both fields (2 struct_set) and the explicit
+        # member write adds a third.
+        text = class_multi_target_kernel.compile().mlir_text()
+        self.assertEqual(text.count("pto.declare_struct"), 1)
+        self.assertEqual(text.count("pto.struct_set"), 3)
+        self.assertIn("pto.struct_get", text)
+
+    def test_class_form_local_dtype_alias_annotation(self):
+        # Regression for the future-flag fix in rewrite_jit_function: the
+        # rewritten module must compile with the kernel's own future flags.
+        # If compile() inherited ``from __future__ import annotations`` from
+        # _ast_rewrite, ``v: T`` would stringify and from_class could not
+        # resolve the kernel-local name ``T`` in module globals.
+        text = class_local_dtype_alias_kernel.compile().mlir_text()
+        self.assertIn("pto.declare_struct", text)
+        self.assertIn("pto.struct_set", text)
+        self.assertIn("pto.struct_get", text)
+
+    def test_class_form_resolves_string_annotations(self):
+        # PEP 563 stringifies class-body annotations; from_class resolves
+        # them in the defining module's namespace (here this test module).
+        @pto.struct
+        class _StringAnnotated:
+            x: "pto.i32"
+            y: "pto.f32"
+
+        with make_context() as ctx, Location.unknown(ctx):
+            self.assertEqual(
+                str(_StringAnnotated.resolve()),
+                str(pto.struct({"x": pto.i32, "y": pto.f32}).resolve()),
+            )
 
 
 if __name__ == "__main__":

--- a/ptodsl/tests/test_struct.py
+++ b/ptodsl/tests/test_struct.py
@@ -231,6 +231,81 @@ def named_dup_key_kernel():
     _ = state.x
 
 
+@pto.jit(target="a5")
+def named_unknown_field_kernel():
+    state = pto.declare_struct(NAMED_STRUCT)
+    state.missing = 1
+
+
+@pto.jit(target="a5")
+def named_positional_layer_kernel():
+    S = pto.struct({"pt": pto.struct_type(pto.i32, pto.f32)})
+    state = pto.declare_struct(S)
+    state.pt.x = 1
+
+
+@pto.jit(target="a5")
+def named_nested_bare_read_kernel():
+    s = pto.declare_struct(NAMED_NESTED)
+    v = s.pt
+    _ = v
+
+
+@pto.jit(target="a5")
+def named_del_field_kernel():
+    state = pto.declare_struct(NAMED_STRUCT)
+    del state.n
+
+
+@pto.jit(target="a5")
+def named_branch_conflict_kernel(x: pto.i32):
+    if x > 0:
+        S = pto.struct({"a": pto.i32})
+    else:
+        S = pto.struct({"b": pto.i32})
+
+
+@pto.jit(target="a5")
+def named_rebind_kernel(x: pto.i32):
+    state = pto.declare_struct(NAMED_STRUCT)
+    state.n = 1
+    state = x
+    state.n = 2
+
+
+@pto.jit(target="a5")
+def named_static_loop_member_kernel():
+    state = pto.declare_struct(NAMED_STRUCT)
+    for i in pto.static_range(2):
+        state.n = i
+    v = state.n
+    _ = v
+
+
+@pto.jit(target="a5")
+def named_static_loop_rebind_kernel(x: pto.i32):
+    state = pto.declare_struct(NAMED_STRUCT)
+    state.n = 1
+    for i in pto.static_range(2):
+        state = x
+    state.n = 2
+
+
+@pto.jit(target="a5")
+def named_annassign_decl_kernel():
+    S: object = pto.struct({"x": pto.i32, "y": pto.f32})
+    state = pto.declare_struct(S)
+    state.x = 1
+    v = state.y
+    _ = v
+
+
+@pto.jit(target="a5", ast_rewrite=False)
+def named_member_no_rewrite_kernel():
+    state = pto.declare_struct(NAMED_STRUCT)
+    state.n = 1
+
+
 class NamedStructMemberAccessTest(unittest.TestCase):
     def test_named_descriptor_exposes_fields(self):
         descriptor = pto.struct({"n": pto.i32, "sum": pto.f32})
@@ -301,6 +376,76 @@ class NamedStructMemberAccessTest(unittest.TestCase):
     def test_duplicate_literal_key_rejected(self):
         with self.assertRaisesRegex(SyntaxError, "duplicate field name"):
             named_dup_key_kernel.compile()
+
+    def test_reserved_field_name_set_rejected(self):
+        for name in sorted(_types._STRUCT_RESERVED_FIELD_NAMES):
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, "reserved"):
+                    pto.struct({name: pto.i32})
+
+    def test_unknown_field_rejected(self):
+        with self.assertRaisesRegex(SyntaxError, "unknown struct field 'missing'"):
+            named_unknown_field_kernel.compile()
+
+    def test_positional_layer_member_access_rejected(self):
+        with self.assertRaisesRegex(SyntaxError, "positional"):
+            named_positional_layer_kernel.compile()
+
+    def test_nested_struct_bare_read_rejected(self):
+        with self.assertRaisesRegex(SyntaxError, "nested struct member as a value"):
+            named_nested_bare_read_kernel.compile()
+
+    def test_del_field_rejected(self):
+        with self.assertRaisesRegex(SyntaxError, "does not support del"):
+            named_del_field_kernel.compile()
+
+    def test_branch_merge_conflicting_types_rejected(self):
+        with self.assertRaisesRegex(SyntaxError, "incompatible struct types"):
+            named_branch_conflict_kernel.compile()
+
+    def test_rebinding_cancels_struct_identity(self):
+        # After ``state = x`` the name is no longer a struct value, so the
+        # second member write is not rewritten (documented plain-Python
+        # attribute behavior); only the first write reaches the IR.
+        text = named_rebind_kernel.compile().mlir_text()
+        self.assertEqual(text.count("pto.struct_set"), 1)
+
+    def test_static_loop_member_access_survives(self):
+        text = named_static_loop_member_kernel.compile().mlir_text()
+        self.assertIn("pto.struct_set", text)
+        self.assertIn("pto.struct_get", text)
+
+    def test_static_loop_rebinding_cancels_struct_identity(self):
+        # The loop body rebinds ``state`` to a scalar, so the member write
+        # after the loop must not be rewritten to struct_set.
+        text = named_static_loop_rebind_kernel.compile().mlir_text()
+        self.assertEqual(text.count("pto.struct_set"), 1)
+
+    def test_annassign_declaration_binds_struct_type(self):
+        text = named_annassign_decl_kernel.compile().mlir_text()
+        self.assertIn("pto.struct_set", text)
+        self.assertIn("pto.struct_get", text)
+
+    def test_ast_rewrite_disabled_member_access_diagnostic(self):
+        with self.assertRaisesRegex(AttributeError, "AST rewriting"):
+            named_member_no_rewrite_kernel.compile()
+
+    def test_unresolvable_dotted_field_type_does_not_crash(self):
+        import ast as _ast
+
+        from ptodsl import _ast_rewrite
+
+        src = (
+            "def k():\n"
+            "    S = pto.struct({'x': a.b.c})\n"
+            "    state = pto.declare_struct(S)\n"
+            "    state.x = 1\n"
+        )
+        fn = _ast.parse(src).body[0]
+        rewriter = _ast_rewrite._StructMemberRewriter(static_env={})
+        # Unresolvable field types must leave the statements unrewritten
+        # instead of crashing with a raw AttributeError.
+        rewriter.rewrite_block(fn.body)
 
 
 if __name__ == "__main__":

--- a/ptodsl/tests/test_struct.py
+++ b/ptodsl/tests/test_struct.py
@@ -46,10 +46,11 @@ def struct_carry_kernel():
 
 class StructSurfaceTest(unittest.TestCase):
     def test_public_namespace_exports_struct_surface(self):
-        for name in ("struct_type", "declare_struct", "struct_get", "struct_set"):
+        for name in ("struct_type", "struct", "declare_struct", "struct_get", "struct_set"):
             with self.subTest(name=name):
                 self.assertTrue(hasattr(pto, name), name)
         self.assertIn("struct_type", _types.__all__)
+        self.assertIn("struct", _types.__all__)
 
     def test_struct_type_is_lazy_and_exposes_fields(self):
         descriptor = pto.struct_type(pto.i32, pto.struct_type(pto.f32, pto.i16))
@@ -168,6 +169,81 @@ class StructSurfaceTest(unittest.TestCase):
 
         with self.assertRaisesRegex(TypeError, "does not accept pto.struct_type"):
             pto.for_(0, 2, step=1).carry(state=STRUCT_TYPE)
+
+
+NAMED_STRUCT = pto.struct({"n": pto.i32, "sum": pto.f32})
+NAMED_NESTED = pto.struct({
+    "id": pto.i32,
+    "pt": pto.struct({"x": pto.i32, "y": pto.f32}),
+})
+
+
+@pto.jit(target="a5")
+def named_member_kernel(x: pto.i32, y: pto.f32):
+    state = pto.declare_struct(NAMED_STRUCT)
+    state.n = x
+    state.sum = y
+    count = state.n
+    total = state.sum
+    _ = count
+    _ = total
+
+
+@pto.jit(target="a5")
+def named_nested_kernel():
+    s = pto.declare_struct(NAMED_NESTED)
+    s.pt.x = 1
+    v = s.pt.y
+    _ = v
+
+
+class NamedStructMemberAccessTest(unittest.TestCase):
+    def test_named_descriptor_exposes_fields(self):
+        descriptor = pto.struct({"n": pto.i32, "sum": pto.f32})
+        self.assertEqual(descriptor.field_names, ("n", "sum"))
+        self.assertTrue(descriptor.is_named)
+        self.assertEqual(descriptor.field_index("n"), 0)
+        self.assertEqual(descriptor.field_index("sum"), 1)
+        self.assertEqual(descriptor.field_descriptor_at(1)[0], "sum")
+
+    def test_named_and_positional_resolve_to_same_type(self):
+        named = pto.struct({"n": pto.i32, "sum": pto.f32})
+        positional = pto.struct_type(pto.i32, pto.f32)
+        with make_context() as ctx, Location.unknown(ctx):
+            self.assertEqual(
+                str(named.resolve()),
+                str(positional.resolve()),
+            )
+
+    def test_named_field_rules(self):
+        with self.assertRaisesRegex(ValueError, "valid Python identifiers"):
+            pto.struct({"a-b": pto.i32})
+        with self.assertRaisesRegex(ValueError, "Python keyword"):
+            pto.struct({"class": pto.i32})
+        with self.assertRaisesRegex(ValueError, "underscore"):
+            pto.struct({"_x": pto.i32})
+        with self.assertRaisesRegex(ValueError, "reserved"):
+            pto.struct({"value": pto.i32})
+        with self.assertRaisesRegex(TypeError, "dict"):
+            pto.struct([pto.i32, pto.f32])
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            pto.struct({})
+
+    def test_member_access_rewrites_to_canonical_ops(self):
+        text = named_member_kernel.compile().mlir_text()
+        self.assertIn("pto.struct_set", text)
+        self.assertIn("pto.struct_get", text)
+        # Field names ("n", "sum") must not leak into the IR.
+        for name in ("n", "sum"):
+            self.assertNotRegex(text, rf"\b{name}\b")
+
+    def test_nested_member_access_rewrites_to_path(self):
+        text = named_nested_kernel.compile().mlir_text()
+        self.assertIn("pto.struct_set", text)
+        self.assertIn("pto.struct_get", text)
+        # Nested member access resolves to position path [1, 0] / [1, 1].
+        self.assertIn("[1, 0]", text)
+        self.assertIn("[1, 1]", text)
 
 
 if __name__ == "__main__":

--- a/ptodsl/tests/test_struct.py
+++ b/ptodsl/tests/test_struct.py
@@ -197,6 +197,40 @@ def named_nested_kernel():
     _ = v
 
 
+@pto.jit(target="a5")
+def named_augassign_kernel(x: pto.i32):
+    state = pto.declare_struct(NAMED_STRUCT)
+    state.n += x
+    _ = state.n
+
+
+@pto.jit(target="a5")
+def named_local_alias_kernel():
+    Inner = pto.struct({"x": pto.i32, "y": pto.f32})
+    Alias = Inner
+    Outer = pto.struct({"id": pto.i32, "inner": Alias})
+    s = pto.declare_struct(Outer)
+    s.inner.x = 1
+    v = s.inner.y
+    _ = v
+
+
+@pto.jit(target="a5")
+def named_ann_mismatch_kernel():
+    S = pto.struct({"x": pto.f32})
+    state = pto.declare_struct(S)
+    state.x: pto.i32 = 1
+    _ = state.x
+
+
+@pto.jit(target="a5")
+def named_dup_key_kernel():
+    S = pto.struct({"x": pto.i32, "x": pto.f32})
+    state = pto.declare_struct(S)
+    state.x = 1
+    _ = state.x
+
+
 class NamedStructMemberAccessTest(unittest.TestCase):
     def test_named_descriptor_exposes_fields(self):
         descriptor = pto.struct({"n": pto.i32, "sum": pto.f32})
@@ -244,6 +278,29 @@ class NamedStructMemberAccessTest(unittest.TestCase):
         # Nested member access resolves to position path [1, 0] / [1, 1].
         self.assertIn("[1, 0]", text)
         self.assertIn("[1, 1]", text)
+
+    def test_augassign_member_rewrites_to_read_write(self):
+        text = named_augassign_kernel.compile().mlir_text()
+        self.assertIn("pto.struct_get", text)
+        self.assertIn("pto.struct_set", text)
+        self.assertLess(
+            text.index("pto.struct_get"),
+            text.index("pto.struct_set"),
+            "state.n += x should read then write",
+        )
+
+    def test_local_descriptor_alias_nesting(self):
+        text = named_local_alias_kernel.compile().mlir_text()
+        self.assertIn("[1, 0]", text)  # s.inner.x -> path [1, 0]
+        self.assertIn("[1, 1]", text)  # s.inner.y -> path [1, 1]
+
+    def test_annassign_type_mismatch_rejected(self):
+        with self.assertRaisesRegex(SyntaxError, "does not match field type"):
+            named_ann_mismatch_kernel.compile()
+
+    def test_duplicate_literal_key_rejected(self):
+        with self.assertRaisesRegex(SyntaxError, "duplicate field name"):
+            named_dup_key_kernel.compile()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add a **named-field struct surface** to PTODSL on top of the canonical
`pto.struct_type` / `pto.declare_struct` / `pto.struct_get` / `pto.struct_set`
API (introduced in #1104). Enables Python member syntax:

```python
Point = pto.struct({"x": pto.i32, "y": pto.f32})
state = pto.declare_struct(Point)
state.x = 1            # -> pto.struct_set(state, [0], 1)
state.y = 2.5          # -> pto.struct_set(state, [1], 2.5)
count = state.x        # -> pto.struct_get(state, [0])
```

Nested member access works too: `s.pt.x = 1` lowers to
`pto.struct_set(s, [1, 0], 1)`.

## Design

Full design doc: `docs/designs/ptodsl-struct-member-access-design.md` (four
rounds of review).

Key decisions:
- Field names are **compile-time constants** carried by the descriptor; they
  never enter the IR. `!pto.struct<...>` stays positional.
- Field-name → positional-path resolution happens **entirely at AST-rewrite
  time**. The rewriter statically evaluates `pto.struct({...})` /
  `pto.struct_type(...)` literals and emits `pto.struct_get` / `pto.struct_set`
  with baked integer paths. No runtime helper, no descriptor→value propagation.
- `_StructMemberRewriter` handles rebinding, multi-target assignment order,
  `+=`, annotated assignment, `del`, positional-layer rejection, and
  branch-merge conflicts. Gated by `ast_rewrite`.
- `declare_struct` returns a `StructValue` whose `__getattr__`/`__setattr__`
  are diagnostic-only (clear error when source is unavailable / `ast_rewrite=False`).
- Round-3 hardening: struct bindings changed inside a loop body no longer
  leak past the loop; AnnAssign declarations bind struct types/values like
  plain assignments; unresolvable dotted field types no longer crash the
  rewriter.

## Tests

- `test_struct.py`: 30 tests pass (21 `NamedStructMemberAccessTest`, incl.
  error paths: unknown field, positional-layer descent, nested bare read,
  `del`, branch-merge conflict, rebinding, `ast_rewrite=False` diagnostic).
- Full PTODSL ctest suite: 40/40 on dev-481211 (rebased onto main @ 893a66fc7).
- `test_ptoas_frontend_verify.py`: PASS (EmitC `.f0` positional field access
  + VPTO probe for the named-member surface).
- `test_docs_as_test.py` / `test_ast_rewrite_example_ir.py`: PASS.

## Related

- Issue #1129
- PR #1104 (base struct surface)

Closes #1129
