### PR TITLE
[Bug reproducer] VMI compact f32 store device error

### DIFF
--- a/docs/repro/compact_f32_store/.gitignore
+++ b/docs/repro/compact_f32_store/.gitignore
@@ -1,0 +1,3 @@
+outputs/
+__pycache__/
+*.pyc

--- a/docs/repro/compact_f32_store/FEATURE_REQUEST.md
+++ b/docs/repro/compact_f32_store/FEATURE_REQUEST.md
@@ -1,0 +1,85 @@
+# Feature request: reliable compact f32 group-store on device
+
+Audience: PTOAS/VMI maintainers.
+
+## Requested contract
+
+A f32 VMI value whose logical layout contains one group/slot should support:
+
+```python
+pto.vmi.vstore(value, dst, offset, group=1, stride=1)
+```
+
+at every naturally aligned f32 destination. It should have the same observable
+result as native ASC/CCE `vsts(value, dst, 0, ONEPT_B32, mask)`: lane 0 is
+written and adjacent elements are unchanged.
+
+## Observed mislowering
+
+The desired fixture enters layout assignment with a contiguous 64-lane result:
+
+```text
+pto.vmi.group_broadcast_load ... ->
+  !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+pto.vmi.group_store ... {num_groups = 1}
+```
+
+The emitted VPTO incorrectly contains:
+
+```text
+%value = pto.vlds ... {dist = "BRC_B32"}
+...
+pto.vsts %value, %compact_destination[%zero], %all_mask
+```
+
+There is no `dist = "1PT_B32"`. The `group=1` store constraint did not force a
+compact group-slot representation or point-store lowering, so a dense store is
+issued at each 4-byte destination.
+
+## Why existing compile-only coverage is insufficient
+
+`test/lit/vmi_new/vmi_to_vpto_group_store_compact_small.pto` verifies
+`1PT_B32` for inputs already typed with a compact group-slot layout. It does
+not cover a full broadcast vector feeding `group_store(num_groups=1)`. Native
+compilation therefore succeeds even though the emitted store is unsafe. The
+consequence appears when synchronizing the launched kernel:
+
+```text
+RuntimeError: npuSynchronizeDevice: ... NPU function error:
+device error type 3, error code is 507035
+ERR00100 PTA call acl api failed
+```
+
+Both a focused layout/lowering test for the broadcast-to-compact transition and
+an on-device regression are needed.
+
+## Acceptance criteria
+
+1. `scripts/check_compile.sh` builds the native baseline and lowers both VMI
+   variants through PTOAS.
+2. Emitted VPTO for the desired case contains `BRC_B32` for its loads and
+   `1PT_B32` for each logical scalar store; it must not emit a dense full-mask
+   store into the compact destination.
+3. `scripts/run_device.sh DEVICE` reports a numeric pass for the native
+   baseline.
+4. The desired compact VMI fixture reports a numeric pass and never emits
+   507035.
+5. The padded workaround also passes, demonstrating parity of the surrounding
+   broadcast/multiply/add computation.
+6. The device test is retained in PTOAS CI so a compile-success/device-fault
+   regression cannot recur.
+
+## Related fix boundary
+
+Commit `823ec908` fixed a closely related but earlier failure: a logical
+one-slot VMI load lowered to `vsldb`, which required 32-byte source alignment.
+It now lowers to a scalar broadcast load. This fixture already emits
+`BRC_B32`; its separate defect is the missing layout conversion/point-store
+lowering at the following `group=1` store.
+
+## Non-goals
+
+- Exercising a frontend outside this repository.
+- Reproducing an end-to-end application kernel.
+- Treating the 64× UB allocation and SIMT extraction as an acceptable final
+  implementation.

--- a/docs/repro/compact_f32_store/README.md
+++ b/docs/repro/compact_f32_store/README.md
@@ -1,0 +1,80 @@
+# Compact f32 group-store device reproducer
+
+This package isolates a PTOAS layout/lowering defect: a logical scalar carried
+in a 64-lane broadcast f32 vector is not converted to compact group-slot layout
+before a `group=1` store.
+
+The intended operation is:
+
+```python
+pto.vmi.vstore(value, destination, offset, group=1, stride=1)
+```
+
+The equivalent native ASC/CCE instruction is `vsts(..., ONEPT_B32, ...)`.
+Both should write lane 0 to one f32 element. Current PTOAS instead keeps the
+broadcast result in contiguous layout and emits a dense, full-mask `vsts`
+without `1PT_B32`; launching that code raises device error 507035.
+
+## Algorithm
+
+All three fixtures implement the same neutral computation for 24 values:
+
+```text
+for i in 0..23:
+    lanes = broadcast(input[i])
+    result = lanes * 1.25 + 1.0
+    output[i] = result[0]
+```
+
+They run as independent processes because a vector-core fault can poison the
+current device context.
+
+| Fixture | Purpose | Expected result |
+|---|---|---|
+| `fixtures/reference_compact_store.asc` | Native ASC/CCE `ONEPT_B32` baseline | Numeric pass |
+| `fixtures/desired_compact_store.py` | Direct VMI `group=1, stride=1` after broadcast arithmetic | Currently mislowers to dense `vsts` and faults with 507035 |
+| `fixtures/workaround_padded_store.py` | 64-lane VMI stores followed by scalar extraction | Numeric pass, but non-optimal |
+
+The workaround allocates 24 × 64 f32 values (6144 bytes) instead of 24 f32
+values (96 bytes), then launches a separate SIMT extraction phase. It is proof
+that broadcast arithmetic and normal vector stores work, not a suitable
+replacement for compact group-store support.
+
+## Run
+
+The scripts default to CANN 9.1.0.beta3 and the `cann91_dev` conda environment.
+They use only local source/build artifacts.
+
+```bash
+cd docs/repro/compact_f32_store
+./scripts/check_compile.sh
+./scripts/run_device.sh 0
+```
+
+`run_device.sh` uses `task-submit --device` when available. Generated objects,
+MLIR and logs are written below the gitignored `outputs/` directory. The
+compile check records the dense-store mislowering in emitted VPTO. The device
+case is classified as a reproduced bug only when its isolated log contains
+`507035`; any other failure is reported as unexpected. A numeric pass is
+reported honestly as a fixed issue.
+
+If this worktree has not been built in place, point `PTOAS_BIN` at a PTOAS
+binary built from the same commit. The Python path is intentionally rooted at
+this source worktree so the fixture itself remains PTODSL/PTOAS-only.
+
+## Relationship to nearby reports
+
+- `narrow_lane_store` is directly related but not identical. Its fault was on
+  a one-slot load lowered to a 32-byte-aligned block load. Commit `823ec908`
+  changed that load to `BRC_B32`, and this branch contains the fix. Here the
+  load is already explicitly `BRC_B32`; the remaining defect is propagation
+  from a contiguous broadcast result into a compact `group=1` store.
+- `pad_brc` concerns legalization of grouped broadcast values in registers.
+  The desired fixture here already lowers; its decisive test is device launch.
+- `quant_vf_parity` covers quantization/vector-fusion parity and does not
+  report this compact f32 store pattern.
+- `l8_widen` covers widening/layout behavior and is not the same operation.
+
+See [`FEATURE_REQUEST.md`](FEATURE_REQUEST.md) for the precise acceptance
+criteria and [`recorded/DEVICE_RESULTS.md`](recorded/DEVICE_RESULTS.md) for the
+result recorded on the development host.

--- a/docs/repro/compact_f32_store/fixtures/desired_compact_store.py
+++ b/docs/repro/compact_f32_store/fixtures/desired_compact_store.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Desired VMI form: compute 24 broadcast values and store them compactly."""
+
+import argparse
+import os
+
+import numpy as np
+
+from ptodsl import pto
+
+
+WIDTH = 24
+VL = 64
+SCALE = 1.25
+BIAS = 1.0
+_BYTES = WIDTH * 4
+
+
+@pto.jit(
+    name="compact_f32_store_desired",
+    kernel_kind="vector",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+)
+def compact_f32_store_desired(
+    input_gm: pto.ptr(pto.f32, "gm"),
+    output_gm: pto.ptr(pto.f32, "gm"),
+):
+    zero = pto.const(0, dtype=pto.i64)
+    input_ub = pto.castptr(zero, pto.ptr(pto.f32, "ub"))
+    output_ub = pto.addptr(input_ub, WIDTH)
+    offset0 = pto.const(0, dtype=pto.index)
+    stride1 = pto.const(1, dtype=pto.index)
+    mask = pto.vmi.create_mask(VL, size=VL)
+
+    pto.mte_gm_ub(input_gm, input_ub, 0, _BYTES, nburst=(1, _BYTES, _BYTES))
+    pto.set_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=0)
+    pto.wait_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=0)
+
+    for index in range(WIDTH):
+        value = pto.vmi.vload(
+            pto.addptr(input_ub, index),
+            offset0,
+            size=VL,
+            dist_mode="brc",
+        )
+        value = pto.vmi.vmuls(value, SCALE, mask)
+        value = pto.vmi.vadds(value, BIAS, mask)
+        pto.vmi.vstore(
+            value,
+            pto.addptr(output_ub, index),
+            offset0,
+            group=1,
+            stride=stride1,
+        )
+
+    pto.set_flag(pto.Pipe.V, pto.Pipe.MTE3, event_id=0)
+    pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE3, event_id=0)
+    pto.mte_ub_gm(output_ub, output_gm, _BYTES, nburst=(1, _BYTES, _BYTES))
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+
+def compile_kernel():
+    return compact_f32_store_desired.compile()
+
+
+def _init_runtime(device: str):
+    import torch
+    import torch_npu  # noqa: F401
+
+    torch.npu.config.allow_internal_format = False
+    torch_npu.npu.set_compile_mode(jit_compile=False)
+    torch.npu.set_device(device)
+    return torch
+
+
+def run(device: str) -> None:
+    torch = _init_runtime(device)
+    host_input = np.linspace(-3.0, 4.0, WIDTH, dtype=np.float32)
+    expected = host_input * np.float32(SCALE) + np.float32(BIAS)
+    input_tensor = torch.from_numpy(host_input).to(device)
+    output_tensor = torch.full((WIDTH,), float("nan"), dtype=torch.float32, device=device)
+    stream = torch.npu.current_stream()._as_parameter_  # noqa: SLF001
+    compiled = compile_kernel()
+    compiled[1, stream](input_tensor.data_ptr(), output_tensor.data_ptr())
+    torch.npu.synchronize()
+    actual = output_tensor.cpu().numpy()
+    np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+    print("PASS desired compact VMI numeric check")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--compile-only", action="store_true")
+    parser.add_argument("--emit-mlir", action="store_true")
+    parser.add_argument("--device", default=os.environ.get("NPU_TEST_DEVICE", "npu:0"))
+    args = parser.parse_args()
+    if args.compile_only or args.emit_mlir:
+        text = compile_kernel().mlir_text()
+        if args.emit_mlir:
+            print(text)
+        else:
+            assert "pto.vmi.vstore" in text and "group = 1" in text
+            print(f"COMPILE PASS desired compact VMI ({len(text)} bytes MLIR)")
+        return 0
+    run(args.device)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/repro/compact_f32_store/fixtures/reference_compact_store.asc
+++ b/docs/repro/compact_f32_store/fixtures/reference_compact_store.asc
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "kernel_operator.h"
+
+namespace {
+constexpr int kWidth = 24;
+constexpr int kBytes = kWidth * sizeof(float);
+constexpr float kScale = 1.25f;
+constexpr float kBias = 1.0f;
+
+__simd_vf__ inline void ComputeCompact(__ubuf__ float *input,
+                                       __ubuf__ float *output) {
+  vector_bool all = pset_b32(PAT_ALL);
+  for (int index = 0; index < kWidth; ++index) {
+    vector_f32 value;
+    vector_f32 scaled;
+    vector_f32 result;
+    vlds(value, input + index, 0, BRC_B32);
+    vmuls(scaled, value, kScale, all, MODE_ZEROING);
+    vadds(result, scaled, kBias, all, MODE_ZEROING);
+    vsts(result, output + index, 0, ONEPT_B32, all);
+  }
+}
+}  // namespace
+
+extern "C" __global__ __vector__ void reference_compact_f32_store(
+    __gm__ float *input_gm,
+    __gm__ float *output_gm) {
+  AscendC::InitSocState();
+  __ubuf__ float *input = (__ubuf__ float *)0;
+  __ubuf__ float *output = input + kWidth;
+
+  copy_gm_to_ubuf_align_v2(
+      (__ubuf__ uint8_t *)input, (__gm__ uint8_t *)input_gm,
+      0, 1, kBytes, 0, 0, false, 0, kBytes, kBytes);
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+  ComputeCompact(input, output);
+
+  set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  copy_ubuf_to_gm_align_v2(
+      (__gm__ void *)output_gm, (__ubuf__ void *)output,
+      0, 1, kBytes, 0, kBytes, kBytes);
+  pipe_barrier(PIPE_ALL);
+}

--- a/docs/repro/compact_f32_store/fixtures/reference_compact_store.cpp
+++ b/docs/repro/compact_f32_store/fixtures/reference_compact_store.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "reference_compact_store.asc"
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+extern "C" void launch_reference_compact_f32_store(
+    void *stream,
+    void *input,
+    void *output) {
+  reference_compact_f32_store<<<1, nullptr, stream>>>(
+      (__gm__ float *)input,
+      (__gm__ float *)output);
+}

--- a/docs/repro/compact_f32_store/fixtures/run_reference.py
+++ b/docs/repro/compact_f32_store/fixtures/run_reference.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Launch the native ASC/CCE reference shared library and check its output."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import os
+from pathlib import Path
+
+import numpy as np
+
+
+WIDTH = 24
+SCALE = 1.25
+BIAS = 1.0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--library", type=Path, required=True)
+    parser.add_argument("--device", default=os.environ.get("NPU_TEST_DEVICE", "npu:0"))
+    args = parser.parse_args()
+
+    import torch
+    import torch_npu  # noqa: F401
+
+    torch.npu.config.allow_internal_format = False
+    torch_npu.npu.set_compile_mode(jit_compile=False)
+    torch.npu.set_device(args.device)
+    host_input = np.linspace(-3.0, 4.0, WIDTH, dtype=np.float32)
+    expected = host_input * np.float32(SCALE) + np.float32(BIAS)
+    input_tensor = torch.from_numpy(host_input).to(args.device)
+    output_tensor = torch.full((WIDTH,), float("nan"), dtype=torch.float32, device=args.device)
+
+    library = ctypes.CDLL(str(args.library.resolve()))
+    launch = library.launch_reference_compact_f32_store
+    launch.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
+    launch.restype = None
+    stream = torch.npu.current_stream()._as_parameter_  # noqa: SLF001
+    launch(
+        ctypes.c_void_p(int(getattr(stream, "value", stream))),
+        ctypes.c_void_p(input_tensor.data_ptr()),
+        ctypes.c_void_p(output_tensor.data_ptr()),
+    )
+    torch.npu.synchronize()
+    actual = output_tensor.cpu().numpy()
+    np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+    print("PASS native ASC/CCE compact-store numeric check")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/repro/compact_f32_store/fixtures/workaround_padded_store.py
+++ b/docs/repro/compact_f32_store/fixtures/workaround_padded_store.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Working VMI fallback: 64-lane stores plus a scalar extraction phase."""
+
+import argparse
+import os
+
+import numpy as np
+
+from ptodsl import pto, scalar
+
+
+WIDTH = 24
+VL = 64
+SCALE = 1.25
+BIAS = 1.0
+_INPUT_BYTES = WIDTH * 4
+_PADDED_BYTES = WIDTH * VL * 4
+
+
+@pto.simt
+def extract_first_lane(
+    padded_ub: pto.ptr(pto.f32, "ub"),
+    compact_ub: pto.ptr(pto.f32, "ub"),
+):
+    index = pto.get_tid_x()
+    value = scalar.load(padded_ub, scalar.index_cast(index * VL))
+    scalar.store(value, compact_ub, scalar.index_cast(index))
+
+
+@pto.jit(
+    name="compact_f32_store_workaround",
+    kernel_kind="vector",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+)
+def compact_f32_store_workaround(
+    input_gm: pto.ptr(pto.f32, "gm"),
+    output_gm: pto.ptr(pto.f32, "gm"),
+):
+    zero = pto.const(0, dtype=pto.i64)
+    input_ub = pto.castptr(zero, pto.ptr(pto.f32, "ub"))
+    padded_ub = pto.addptr(input_ub, WIDTH)
+    compact_ub = pto.addptr(padded_ub, WIDTH * VL)
+    offset0 = pto.const(0, dtype=pto.index)
+    mask = pto.vmi.create_mask(VL, size=VL)
+
+    pto.mte_gm_ub(
+        input_gm,
+        input_ub,
+        0,
+        _INPUT_BYTES,
+        nburst=(1, _INPUT_BYTES, _INPUT_BYTES),
+    )
+    pto.set_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=0)
+    pto.wait_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=0)
+
+    for index in range(WIDTH):
+        value = pto.vmi.vload(
+            pto.addptr(input_ub, index),
+            offset0,
+            size=VL,
+            dist_mode="brc",
+        )
+        value = pto.vmi.vmuls(value, SCALE, mask)
+        value = pto.vmi.vadds(value, BIAS, mask)
+        pto.vmi.vstore(value, pto.addptr(padded_ub, index * VL), offset0, mask)
+
+    pto.pipe_barrier(pto.Pipe.ALL)
+    extract_first_lane[WIDTH, 1, 1](padded_ub, compact_ub)
+    pto.pipe_barrier(pto.Pipe.ALL)
+    pto.mte_ub_gm(
+        compact_ub,
+        output_gm,
+        _INPUT_BYTES,
+        nburst=(1, _INPUT_BYTES, _INPUT_BYTES),
+    )
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+
+def compile_kernel():
+    return compact_f32_store_workaround.compile()
+
+
+def _init_runtime(device: str):
+    import torch
+    import torch_npu  # noqa: F401
+
+    torch.npu.config.allow_internal_format = False
+    torch_npu.npu.set_compile_mode(jit_compile=False)
+    torch.npu.set_device(device)
+    return torch
+
+
+def run(device: str) -> None:
+    torch = _init_runtime(device)
+    host_input = np.linspace(-3.0, 4.0, WIDTH, dtype=np.float32)
+    expected = host_input * np.float32(SCALE) + np.float32(BIAS)
+    input_tensor = torch.from_numpy(host_input).to(device)
+    output_tensor = torch.full((WIDTH,), float("nan"), dtype=torch.float32, device=device)
+    stream = torch.npu.current_stream()._as_parameter_  # noqa: SLF001
+    compiled = compile_kernel()
+    compiled[1, stream](input_tensor.data_ptr(), output_tensor.data_ptr())
+    torch.npu.synchronize()
+    actual = output_tensor.cpu().numpy()
+    np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+    print("PASS padded VMI workaround numeric check")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--compile-only", action="store_true")
+    parser.add_argument("--emit-mlir", action="store_true")
+    parser.add_argument("--device", default=os.environ.get("NPU_TEST_DEVICE", "npu:0"))
+    args = parser.parse_args()
+    if args.compile_only or args.emit_mlir:
+        text = compile_kernel().mlir_text()
+        if args.emit_mlir:
+            print(text)
+        else:
+            assert "pto.vmi.vstore" in text and "pto.simt_launch" in text
+            print(f"COMPILE PASS padded VMI workaround ({len(text)} bytes MLIR)")
+        return 0
+    run(args.device)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/repro/compact_f32_store/recorded/DEVICE_RESULTS.md
+++ b/docs/repro/compact_f32_store/recorded/DEVICE_RESULTS.md
@@ -1,0 +1,53 @@
+# Recorded device results
+
+- PTOAS source commit: `e1c4fd9a`
+- Includes related load-side fix: `823ec908`
+- CANN: `9.1.0.beta3`
+- Python environment: `cann91_dev`
+- Device: Ascend 950DT, device 0
+- Date: 2026-08-08 (Asia/Shanghai)
+
+Run commands:
+
+```bash
+./scripts/check_compile.sh
+./scripts/run_device.sh 0
+```
+
+## Compile results
+
+All compile checks passed:
+
+- Native ASC/CCE source and launch wrapper built and linked into a shared
+  library with Bisheng.
+- Desired compact VMI fixture emitted PTODSL MLIR and lowered through PTOAS to
+  an object.
+- Padded VMI workaround emitted PTODSL MLIR and lowered through PTOAS to an
+  object.
+- Emitted VPTO reproduces the compile-side defect: the explicit scalar load is
+  `BRC_B32`, but `group=1` lowers to a dense `pto.vsts` with the all-lanes mask
+  and no `1PT_B32` distribution.
+
+The VMI device launch used the installed editable package/build for the same
+source commit (`e1c4fd9a`).
+
+## Isolated device results
+
+| Process | Result |
+|---|---|
+| Native ASC/CCE baseline | **PASS**, output matches `input * 1.25 + 1.0` |
+| Desired VMI `group=1, stride=1` | **FAIL**, exact device error `507035` at `torch.npu.synchronize()` |
+| 64-lane padded VMI + SIMT extraction | **PASS**, output matches reference |
+
+Exact desired-case error:
+
+```text
+RuntimeError: npuSynchronizeDevice: ... NPU function error:
+device error type 3, error code is 507035
+[ERROR] ... ERR00100 PTA call acl api failed
+```
+
+This confirms that commit `823ec908` fixes the related one-slot load-side
+alignment issue but not the broadcast-result-to-compact-store layout
+transition. The dense-store mislowering explains the device fault. The
+arithmetic and regular 64-lane store path are healthy.

--- a/docs/repro/compact_f32_store/scripts/build_reference.sh
+++ b/docs/repro/compact_f32_store/scripts/build_reference.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/env.sh"
+
+OUTPUT_DIR="${REPRO_ROOT}/outputs/reference_build"
+FIXTURES="${REPRO_ROOT}/fixtures"
+mkdir -p "${OUTPUT_DIR}"
+
+if [ -z "${BISHENG}" ] || [ ! -x "${BISHENG}" ]; then
+  echo "bisheng was not found after sourcing ${CANN_ENV}" >&2
+  exit 1
+fi
+
+COMMON=(
+  -O3 -std=gnu++17 -fPIC -Wno-macro-redefined
+  -Wno-ignored-attributes -Wno-unknown-attributes
+  --cce-aicore-arch=dav-c310-vec
+)
+
+"${BISHENG}" "${COMMON[@]}" -xcce \
+  -Xhost-start -Xhost-end \
+  -c "${FIXTURES}/reference_compact_store.cpp" \
+  -o "${OUTPUT_DIR}/reference_compact_store.o" \
+  -I"${ASCEND_HOME_PATH}/include" \
+  -I"${FIXTURES}" \
+  -I"${ASCEND_HOME_PATH}/aarch64-linux/asc/include" \
+  -I"${ASCEND_HOME_PATH}/aarch64-linux/asc/include/basic_api" \
+  -I"${ASCEND_HOME_PATH}/aarch64-linux/asc/include/interface" \
+  -I"${ASCEND_HOME_PATH}/aarch64-linux/asc" \
+  -I"${ASCEND_HOME_PATH}/aarch64-linux/asc/impl/basic_api" \
+  -I"${ASCEND_HOME_PATH}/aarch64-linux/asc/impl" \
+  >"${OUTPUT_DIR}/reference_compact_store.cpp.log" 2>&1
+
+"${BISHENG}" --cce-fatobj-link -shared -fPIC \
+  -Wl,--no-undefined \
+  "${OUTPUT_DIR}/reference_compact_store.o" \
+  -L"${ASCEND_HOME_PATH}/lib64" \
+  -Wl,-rpath,"${ASCEND_HOME_PATH}/lib64" \
+  -Wl,--no-as-needed -lruntime \
+  -o "${OUTPUT_DIR}/libreference_compact_store.so" \
+  >"${OUTPUT_DIR}/reference_compact_store.link.log" 2>&1
+
+echo "${OUTPUT_DIR}/libreference_compact_store.so"

--- a/docs/repro/compact_f32_store/scripts/check_compile.sh
+++ b/docs/repro/compact_f32_store/scripts/check_compile.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/env.sh"
+
+OUT="${REPRO_ROOT}/outputs/compile"
+mkdir -p "${OUT}"
+RESULTS="${OUT}/results.txt"
+: >"${RESULTS}"
+
+echo "PTOAS commit: $(git -C "${PTOAS_ROOT}" rev-parse HEAD)" | tee -a "${RESULTS}"
+echo "CANN env: ${CANN_ENV}" | tee -a "${RESULTS}"
+echo "Python: ${PYTHON_BIN}" | tee -a "${RESULTS}"
+echo "PTOAS binary: ${PTOAS_BIN:-MISSING}" | tee -a "${RESULTS}"
+
+reference_lib="$("${SCRIPT_DIR}/build_reference.sh")"
+test -s "${reference_lib}"
+echo "PASS native ASC/CCE reference build" | tee -a "${RESULTS}"
+
+compile_vmi() {
+  local fixture="$1"
+  local stem="${fixture%.py}"
+  "${PYTHON_BIN}" "${REPRO_ROOT}/fixtures/${fixture}" --compile-only \
+    >"${OUT}/${stem}.log" 2>&1
+  "${PYTHON_BIN}" "${REPRO_ROOT}/fixtures/${fixture}" --emit-mlir \
+    >"${OUT}/${stem}.mlir" 2>>"${OUT}/${stem}.log"
+  grep -q "pto.vmi.vstore" "${OUT}/${stem}.mlir"
+  echo "PASS ${fixture} frontend compile" | tee -a "${RESULTS}"
+}
+
+compile_vmi desired_compact_store.py
+compile_vmi workaround_padded_store.py
+
+test -n "${PTOAS_BIN}" && test -x "${PTOAS_BIN}"
+for stem in desired_compact_store workaround_padded_store; do
+  "${PTOAS_BIN}" --pto-arch=a5 --pto-backend=vpto --pto-level=level3 \
+    --enable-tile-op-expand "${OUT}/${stem}.mlir" -o "${OUT}/${stem}.o" \
+    >"${OUT}/${stem}.ptoas.log" 2>&1
+  test -s "${OUT}/${stem}.o"
+done
+echo "PASS both VMI fixtures lower through PTOAS native compilation" | tee -a "${RESULTS}"
+
+"${PTOAS_BIN}" --pto-arch=a5 --pto-backend=vpto --pto-level=level3 \
+  --enable-tile-op-expand --emit-vpto "${OUT}/desired_compact_store.mlir" \
+  -o "${OUT}/desired_compact_store.vpto" \
+  >"${OUT}/desired_compact_store.emit-vpto.log" 2>&1
+"${PYTHON_BIN}" - "${OUT}/desired_compact_store.vpto" <<'PY'
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+if 'dist = "BRC_B32"' not in text:
+    raise SystemExit("expected the explicit scalar broadcast load in emitted VPTO")
+store_lines = [line.strip() for line in text.splitlines() if "pto.vsts" in line]
+if not store_lines:
+    raise SystemExit("expected a lowered pto.vsts in emitted VPTO")
+if any('dist = "1PT_B32"' in line for line in store_lines):
+    raise SystemExit("compiler behavior changed: desired store now lowers to 1PT_B32; rerun device test")
+if not any("{dist =" not in line for line in store_lines):
+    raise SystemExit("unexpected desired-store lowering; inspect emitted VPTO")
+print("KNOWN BUG: group=1 broadcast result lowered to dense vsts, not 1PT_B32")
+PY
+echo "REPRODUCED compile-side dense-store mislowering" | tee -a "${RESULTS}"
+
+echo "Compile checks passed. Logs: ${OUT}" | tee -a "${RESULTS}"

--- a/docs/repro/compact_f32_store/scripts/env.sh
+++ b/docs/repro/compact_f32_store/scripts/env.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# Shared environment for the compact f32 store reproducer.
+
+set -euo pipefail
+
+REPRO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PTOAS_ROOT="$(cd "${REPRO_ROOT}/../../.." && pwd)"
+CANN_ENV="${CANN_ENV:-/home/jzhuang/cann_installed/9.1.0-beta.3/cann/set_env.sh}"
+CONDA_ENV="${CONDA_ENV:-cann91_dev}"
+
+if [ ! -f "${CANN_ENV}" ]; then
+  echo "CANN environment script not found: ${CANN_ENV}" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# The toolkit script reads these variables while `set -u` is active.
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+export PYTHONPATH="${PYTHONPATH:-}"
+export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:-}"
+# shellcheck disable=SC1090
+source "${CANN_ENV}"
+
+PYTHON_BIN="${PYTHON_BIN:-$(conda run -n "${CONDA_ENV}" which python)}"
+export PATH="$(dirname "${PYTHON_BIN}"):${PATH}"
+BISHENG="${BISHENG:-$(command -v bisheng || true)}"
+PTOAS_BIN="${PTOAS_BIN:-${PTOAS_ROOT}/build/tools/ptoas/ptoas}"
+
+if [ ! -x "${PTOAS_BIN}" ]; then
+  # The source worktree may intentionally share a verified build from a sibling
+  # checkout. Override PTOAS_BIN explicitly when using such a build.
+  PTOAS_BIN="$(command -v ptoas || true)"
+fi
+
+export REPRO_ROOT PTOAS_ROOT CANN_ENV CONDA_ENV PYTHON_BIN BISHENG PTOAS_BIN
+export PYTHONPATH="${PTOAS_ROOT}/build/python:${PTOAS_ROOT}/build/ptodsl:${PTOAS_ROOT}/ptodsl:${PTOAS_ROOT}/build/lib:${PYTHONPATH:-}"
+export PTOAS_BIN

--- a/docs/repro/compact_f32_store/scripts/run_device.sh
+++ b/docs/repro/compact_f32_store/scripts/run_device.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+DEVICE="${1:-0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/env.sh"
+
+OUT="${REPRO_ROOT}/outputs/device"
+mkdir -p "${OUT}"
+RESULTS="${OUT}/results.txt"
+: >"${RESULTS}"
+
+reference_lib="$("${SCRIPT_DIR}/build_reference.sh")"
+
+run_isolated() {
+  local name="$1"
+  local command="$2"
+  local log="${OUT}/${name}.log"
+  local status_file="${OUT}/${name}.status"
+  local wrapped
+  wrapped="source '${CANN_ENV}' >/dev/null 2>&1 && export PYTHONPATH='${PYTHONPATH}' PTOAS_BIN='${PTOAS_BIN}' NPU_TEST_DEVICE='npu:${DEVICE}' && ${command}"
+  set +e
+  if command -v task-submit >/dev/null 2>&1; then
+    task-submit --device "${DEVICE}" --max-time 1200 --run "${wrapped}" >"${log}" 2>&1 &
+  else
+    bash -lc "${wrapped}" >"${log}" 2>&1 &
+  fi
+  local job_pid=$!
+  while kill -0 "${job_pid}" 2>/dev/null; do
+    sleep 5
+  done
+  wait "${job_pid}"
+  local rc=$?
+  set -e
+  echo "${rc}" >"${status_file}"
+}
+
+run_isolated reference "'${PYTHON_BIN}' '${REPRO_ROOT}/fixtures/run_reference.py' --library '${reference_lib}' --device 'npu:${DEVICE}'"
+ref_rc="$(<"${OUT}/reference.status")"
+if [ "${ref_rc}" -ne 0 ] || ! grep -q "PASS native ASC/CCE" "${OUT}/reference.log"; then
+  echo "FAIL native ASC/CCE reference (rc=${ref_rc})" | tee -a "${RESULTS}"
+  tail -80 "${OUT}/reference.log" | tee -a "${RESULTS}"
+  exit 1
+fi
+echo "PASS native ASC/CCE reference" | tee -a "${RESULTS}"
+
+run_isolated desired "'${PYTHON_BIN}' '${REPRO_ROOT}/fixtures/desired_compact_store.py' --device 'npu:${DEVICE}'"
+desired_rc="$(<"${OUT}/desired.status")"
+if [ "${desired_rc}" -eq 0 ] && grep -q "PASS desired compact VMI" "${OUT}/desired.log"; then
+  echo "PASS desired compact VMI (issue is fixed)" | tee -a "${RESULTS}"
+elif grep -q "507035" "${OUT}/desired.log"; then
+  echo "REPRODUCED desired compact VMI device fault 507035" | tee -a "${RESULTS}"
+else
+  echo "FAIL desired compact VMI with an unexpected result (rc=${desired_rc})" | tee -a "${RESULTS}"
+  tail -100 "${OUT}/desired.log" | tee -a "${RESULTS}"
+  exit 1
+fi
+
+run_isolated workaround "'${PYTHON_BIN}' '${REPRO_ROOT}/fixtures/workaround_padded_store.py' --device 'npu:${DEVICE}'"
+workaround_rc="$(<"${OUT}/workaround.status")"
+if [ "${workaround_rc}" -ne 0 ] || ! grep -q "PASS padded VMI workaround" "${OUT}/workaround.log"; then
+  echo "FAIL padded VMI workaround (rc=${workaround_rc})" | tee -a "${RESULTS}"
+  tail -100 "${OUT}/workaround.log" | tee -a "${RESULTS}"
+  exit 1
+fi
+echo "PASS padded VMI workaround" | tee -a "${RESULTS}"
+
+echo "Device checks completed in independent processes. Logs: ${OUT}" | tee -a "${RESULTS}"


### PR DESCRIPTION
- See `docs/repro/compact_f32_store/README.md` to reproduce bug (CCE runs, VMI compiles but crashes on-device)
- See `docs/repro/compact_f32_store/FEATURE_REQUEST.md` for the full story.
- This is a similar but different bug vs https://github.com/hw-native-sys/PTOAS/commit/823ec908