### PR TITLE
feat(sync): split cross and intra block interfaces

### DIFF
--- a/.codex/skills/rewrite-kernel-with-vmi/references/mi-dsl-spec.md
+++ b/.codex/skills/rewrite-kernel-with-vmi/references/mi-dsl-spec.md
@@ -137,8 +137,8 @@ Read `10-sync-ops.md` for:
 - `pto.pipe_barrier(pto.Pipe.ALL)`
 - `pto.mem_bar(pto.BarrierType.VV_ALL)` and other barrier types.
 - `pto.get_buf` / `pto.rls_buf` for double buffering.
-- `pto.set_cross_flag` / `pto.wait_cross_flag`.
-- `pto.set_intra_flag` / `pto.wait_intra_flag`.
+- `pto.set_cross_block` / `pto.wait_cross_block`.
+- `pto.set_intra_block` / `pto.wait_intra_block`.
 
 Common explicit-mode pairs:
 

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2846,9 +2846,9 @@ def SyncSetOp : PTO_Op<"sync.set"> {
   let summary = "Set a synchronization signal (trigger) between cube and vector.";
   let description = [{
     Sets a synchronization signal on the specified pipeline stage.
-    Corresponds to `ffts_cross_core_sync` (A3) or `set_intra_block` (A5).
-    On A3, the optional `ffts_mode` attribute selects the first argument passed
-    to `getFFTSMsg`; if omitted, the legacy `FFTS_MODE_VAL` path is preserved.
+    Corresponds to `ffts_cross_core_sync` on both A3 and A5.  The optional
+    `ffts_mode` selects FFTS mode 0 (inter), 1 (subblock), or 2 (block);
+    if omitted, block mode (2) is used for backward compatibility.
   }];
 
   let arguments = (ins
@@ -2866,15 +2866,59 @@ def SyncWaitOp : PTO_Op<"sync.wait"> {
   let summary = "Wait for a synchronization signal (barrier) between cube and vector.";
   let description = [{
     Waits for a synchronization signal on the specified pipeline stage.
-    Corresponds to `wait_flag_dev` (A3) or `wait_intra_block` (A5).
+    Corresponds to `wait_flag_dev` on both A3 and A5.  `ffts_mode` records
+    the matching set-side FFTS mode (0, 1, or 2).
   }];
 
   let arguments = (ins
     PTO_PipeAttr:$pipe,
     OptionalAttr<I32Attr>:$event_id,
+    OptionalAttr<I32Attr>:$ffts_mode,
     Optional<Index>:$event_id_dyn
   );
 
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+// Named cross-/intra-block synchronization operations.  Cross-core operations
+// are canonicalized to sync.set/sync.wait with FFTS mode 0 in the VPTO path;
+// intra-block operations lower directly to their CCE builtins.
+def SetCrossBlockOp : PTO_Op<"set_cross_block"> {
+  let summary = "Signal a cross-block synchronization flag";
+  let description = [{
+    Canonicalizes to `pto.sync.set` with FFTS mode 0.
+  }];
+  let arguments = (ins PTO_PipeAttr:$pipe, OptionalAttr<I32Attr>:$event_id,
+                       DefaultValuedAttr<I32Attr, "0">:$ffts_mode,
+                       Optional<Index>:$event_id_dyn);
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+def WaitCrossBlockOp : PTO_Op<"wait_cross_block"> {
+  let summary = "Wait for a cross-block synchronization flag";
+  let description = [{ Canonicalizes to `pto.sync.wait` with FFTS mode 0. }];
+  let arguments = (ins PTO_PipeAttr:$pipe, OptionalAttr<I32Attr>:$event_id,
+                       Optional<Index>:$event_id_dyn);
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+def SetIntraBlockOp : PTO_Op<"set_intra_block"> {
+  let summary = "Signal an intra-block synchronization flag";
+  let description = [{ Lowers to `__builtin_cce_set_intra_block`. }];
+  let arguments = (ins PTO_PipeAttr:$pipe, OptionalAttr<I32Attr>:$event_id,
+                       Optional<Index>:$event_id_dyn);
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+def WaitIntraBlockOp : PTO_Op<"wait_intra_block"> {
+  let summary = "Wait for an intra-block synchronization flag";
+  let description = [{ Lowers to `__builtin_cce_wait_intra_block`. }];
+  let arguments = (ins PTO_PipeAttr:$pipe, OptionalAttr<I32Attr>:$event_id,
+                       Optional<Index>:$event_id_dyn);
   let hasVerifier = 1;
   let hasCustomAssemblyFormat = 1;
 }

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2842,9 +2842,9 @@ def SyncSetOp : PTO_Op<"sync.set"> {
   let summary = "Set a synchronization signal (trigger) between cube and vector.";
   let description = [{
     Sets a synchronization signal on the specified pipeline stage.
-    Corresponds to `ffts_cross_core_sync` (A3) or `set_intra_block` (A5).
-    On A3, the optional `ffts_mode` attribute selects the first argument passed
-    to `getFFTSMsg`; if omitted, the legacy `FFTS_MODE_VAL` path is preserved.
+    Corresponds to `ffts_cross_core_sync` on both A3 and A5.  The optional
+    `ffts_mode` selects FFTS mode 0 (inter), 1 (subblock), or 2 (block);
+    if omitted, block mode (2) is used for backward compatibility.
   }];
 
   let arguments = (ins
@@ -2862,15 +2862,59 @@ def SyncWaitOp : PTO_Op<"sync.wait"> {
   let summary = "Wait for a synchronization signal (barrier) between cube and vector.";
   let description = [{
     Waits for a synchronization signal on the specified pipeline stage.
-    Corresponds to `wait_flag_dev` (A3) or `wait_intra_block` (A5).
+    Corresponds to `wait_flag_dev` on both A3 and A5.  `ffts_mode` records
+    the matching set-side FFTS mode (0, 1, or 2).
   }];
 
   let arguments = (ins
     PTO_PipeAttr:$pipe,
     OptionalAttr<I32Attr>:$event_id,
+    OptionalAttr<I32Attr>:$ffts_mode,
     Optional<Index>:$event_id_dyn
   );
 
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+// Named cross-/intra-block synchronization operations.  Cross-core operations
+// are canonicalized to sync.set/sync.wait with FFTS mode 0 in the VPTO path;
+// intra-block operations lower directly to their CCE builtins.
+def SetCrossBlockOp : PTO_Op<"set_cross_block"> {
+  let summary = "Signal a cross-block synchronization flag";
+  let description = [{
+    Canonicalizes to `pto.sync.set` with FFTS mode 0.
+  }];
+  let arguments = (ins PTO_PipeAttr:$pipe, OptionalAttr<I32Attr>:$event_id,
+                       DefaultValuedAttr<I32Attr, "0">:$ffts_mode,
+                       Optional<Index>:$event_id_dyn);
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+def WaitCrossBlockOp : PTO_Op<"wait_cross_block"> {
+  let summary = "Wait for a cross-block synchronization flag";
+  let description = [{ Canonicalizes to `pto.sync.wait` with FFTS mode 0. }];
+  let arguments = (ins PTO_PipeAttr:$pipe, OptionalAttr<I32Attr>:$event_id,
+                       Optional<Index>:$event_id_dyn);
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+def SetIntraBlockOp : PTO_Op<"set_intra_block"> {
+  let summary = "Signal an intra-block synchronization flag";
+  let description = [{ Lowers to `__builtin_cce_set_intra_block`. }];
+  let arguments = (ins PTO_PipeAttr:$pipe, OptionalAttr<I32Attr>:$event_id,
+                       Optional<Index>:$event_id_dyn);
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+def WaitIntraBlockOp : PTO_Op<"wait_intra_block"> {
+  let summary = "Wait for an intra-block synchronization flag";
+  let description = [{ Lowers to `__builtin_cce_wait_intra_block`. }];
+  let arguments = (ins PTO_PipeAttr:$pipe, OptionalAttr<I32Attr>:$event_id,
+                       Optional<Index>:$event_id_dyn);
   let hasVerifier = 1;
   let hasCustomAssemblyFormat = 1;
 }

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -4052,9 +4052,9 @@ LogicalResult mlir::pto::SyncSetOp::verify() {
   auto verifyA5 = [&]() -> LogicalResult {
     if (IntegerAttr eventIdAttr = getEventIdAttr()) {
       int64_t eventId = eventIdAttr.getInt();
-      if (eventId < 0 || eventId > 31) {
+      if (eventId < 0 || eventId > 15) {
         return emitOpError()
-               << "A5 sync.set expects static event_id in [0, 31], but got "
+               << "A5 sync.set expects static FFTS event_id in [0, 15], but got "
                << eventId;
       }
     }
@@ -4197,14 +4197,21 @@ LogicalResult mlir::pto::SyncWaitOp::verify() {
     return emitOpError()
            << "expects exactly one event-id form: static attr or dynamic index operand";
   }
+  if (IntegerAttr fftsModeAttr = getFftsModeAttr()) {
+    int64_t fftsMode = fftsModeAttr.getInt();
+    if (fftsMode < 0 || fftsMode > 2) {
+      return emitOpError() << "requires ffts_mode in range [0, 2], but got "
+                           << fftsMode;
+    }
+  }
 
   auto verifyA2A3 = [&]() -> LogicalResult { return success(); };
   auto verifyA5 = [&]() -> LogicalResult {
     if (IntegerAttr eventIdAttr = getEventIdAttr()) {
       int64_t eventId = eventIdAttr.getInt();
-      if (eventId < 0 || eventId > 31) {
+      if (eventId < 0 || eventId > 15) {
         return emitOpError()
-               << "A5 sync.wait expects static physical event_id in [0, 31], but got "
+               << "A5 sync.wait expects static FFTS event_id in [0, 15], but got "
                << eventId;
       }
     }
@@ -4220,6 +4227,126 @@ LogicalResult mlir::pto::SyncWaitOp::verify() {
                               "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, "
                               "<PIPE_MTE3>, <PIPE_V>";
     }
+  };
+  return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
+}
+
+static LogicalResult verifyNamedSyncEventOp(Operation *op, PipeAttr pipe,
+                                            IntegerAttr eventIdAttr,
+                                            Value eventIdDyn,
+                                            int64_t maxEventId,
+                                            StringRef opName) {
+  if ((eventIdAttr != nullptr) == static_cast<bool>(eventIdDyn))
+    return op->emitOpError()
+           << "expects exactly one event-id form: static attr or dynamic index operand";
+  if (eventIdAttr && (eventIdAttr.getInt() < 0 ||
+                      eventIdAttr.getInt() > maxEventId))
+    return op->emitOpError() << "expects static event_id in [0, " << maxEventId
+                             << "], but got " << eventIdAttr.getInt();
+  switch (pipe.getPipe()) {
+  case PIPE::PIPE_FIX:
+  case PIPE::PIPE_MTE1:
+  case PIPE::PIPE_MTE2:
+  case PIPE::PIPE_MTE3:
+  case PIPE::PIPE_V:
+    return success();
+  default:
+    return op->emitOpError() << opName << " expects pipe to be one of "
+                              << "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, "
+                              << "<PIPE_MTE3>, <PIPE_V>";
+  }
+}
+
+ParseResult mlir::pto::SetCrossBlockOp::parse(OpAsmParser &parser,
+                                              OperationState &result) {
+  return parseSyncEventOpCommon(parser, result,
+                                SetCrossBlockOp::getPipeAttrName(result.name),
+                                SetCrossBlockOp::getEventIdAttrName(result.name));
+}
+
+void mlir::pto::SetCrossBlockOp::print(OpAsmPrinter &p) {
+  printSyncEventOpCommon(p, getOperation(), getPipe(), getEventIdAttr(),
+                         getEventIdDyn(), getPipeAttrName().getValue(),
+                         getEventIdAttrName().getValue());
+}
+
+LogicalResult mlir::pto::SetCrossBlockOp::verify() {
+  if (IntegerAttr mode = getFftsModeAttr())
+    if (mode.getInt() != 0)
+      return emitOpError() << "requires ffts_mode 0, but got "
+                           << mode.getInt();
+  return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
+                                getEventIdDyn(), 15, "pto.set_cross_block");
+}
+
+ParseResult mlir::pto::WaitCrossBlockOp::parse(OpAsmParser &parser,
+                                             OperationState &result) {
+  return parseSyncEventOpCommon(parser, result,
+                                WaitCrossBlockOp::getPipeAttrName(result.name),
+                                WaitCrossBlockOp::getEventIdAttrName(result.name));
+}
+
+void mlir::pto::WaitCrossBlockOp::print(OpAsmPrinter &p) {
+  printSyncEventOpCommon(p, getOperation(), getPipe(), getEventIdAttr(),
+                         getEventIdDyn(), getPipeAttrName().getValue(),
+                         getEventIdAttrName().getValue());
+}
+
+LogicalResult mlir::pto::WaitCrossBlockOp::verify() {
+  return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
+                                getEventIdDyn(), 15, "pto.wait_cross_block");
+}
+
+ParseResult mlir::pto::SetIntraBlockOp::parse(OpAsmParser &parser,
+                                               OperationState &result) {
+  return parseSyncEventOpCommon(parser, result,
+                                SetIntraBlockOp::getPipeAttrName(result.name),
+                                SetIntraBlockOp::getEventIdAttrName(result.name));
+}
+
+void mlir::pto::SetIntraBlockOp::print(OpAsmPrinter &p) {
+  printSyncEventOpCommon(p, getOperation(), getPipe(), getEventIdAttr(),
+                         getEventIdDyn(), getPipeAttrName().getValue(),
+                         getEventIdAttrName().getValue());
+}
+
+LogicalResult mlir::pto::SetIntraBlockOp::verify() {
+  auto verifyA2A3 = [&]() -> LogicalResult {
+    return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
+                                  getEventIdDyn(), 15,
+                                  "pto.set_intra_block");
+  };
+  auto verifyA5 = [&]() -> LogicalResult {
+    return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
+                                  getEventIdDyn(), 31,
+                                  "pto.set_intra_block");
+  };
+  return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
+}
+
+ParseResult mlir::pto::WaitIntraBlockOp::parse(OpAsmParser &parser,
+                                               OperationState &result) {
+  return parseSyncEventOpCommon(parser, result,
+                                WaitIntraBlockOp::getPipeAttrName(result.name),
+                                WaitIntraBlockOp::getEventIdAttrName(result.name));
+}
+
+void mlir::pto::WaitIntraBlockOp::print(OpAsmPrinter &p) {
+  printSyncEventOpCommon(p, getOperation(), getPipe(), getEventIdAttr(),
+                         getEventIdDyn(), getPipeAttrName().getValue(),
+                         getEventIdAttrName().getValue());
+}
+
+LogicalResult mlir::pto::WaitIntraBlockOp::verify() {
+  auto verifyA2A3 = [&]() -> LogicalResult {
+    return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
+                                  getEventIdDyn(), 15,
+                                  "pto.wait_intra_block");
+  };
+  auto verifyA5 = [&]() -> LogicalResult {
+    return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
+                                  getEventIdDyn(), 31,
+                                  "pto.wait_intra_block");
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -4236,13 +4236,19 @@ static LogicalResult verifyNamedSyncEventOp(Operation *op, PipeAttr pipe,
                                             Value eventIdDyn,
                                             int64_t maxEventId,
                                             StringRef opName) {
-  if ((eventIdAttr != nullptr) == static_cast<bool>(eventIdDyn))
+  const bool hasStaticEventId = eventIdAttr != nullptr;
+  const bool hasDynamicEventId = static_cast<bool>(eventIdDyn);
+  if (hasStaticEventId == hasDynamicEventId) {
     return op->emitOpError()
            << "expects exactly one event-id form: static attr or dynamic index operand";
-  if (eventIdAttr && (eventIdAttr.getInt() < 0 ||
-                      eventIdAttr.getInt() > maxEventId))
+  }
+  const bool staticEventIdOutOfRange =
+      hasStaticEventId &&
+      (eventIdAttr.getInt() < 0 || eventIdAttr.getInt() > maxEventId);
+  if (staticEventIdOutOfRange) {
     return op->emitOpError() << "expects static event_id in [0, " << maxEventId
                              << "], but got " << eventIdAttr.getInt();
+  }
   switch (pipe.getPipe()) {
   case PIPE::PIPE_FIX:
   case PIPE::PIPE_MTE1:
@@ -4271,10 +4277,13 @@ void mlir::pto::SetCrossBlockOp::print(OpAsmPrinter &p) {
 }
 
 LogicalResult mlir::pto::SetCrossBlockOp::verify() {
-  if (IntegerAttr mode = getFftsModeAttr())
-    if (mode.getInt() != 0)
+  if (IntegerAttr mode = getFftsModeAttr()) {
+    int64_t modeValue = mode.getInt();
+    if (modeValue != 0) {
       return emitOpError() << "requires ffts_mode 0, but got "
-                           << mode.getInt();
+                           << modeValue;
+    }
+  }
   return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
                                 getEventIdDyn(), 15, "pto.set_cross_block");
 }

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3580,9 +3580,9 @@ LogicalResult mlir::pto::SyncSetOp::verify() {
   auto verifyA5 = [&]() -> LogicalResult {
     if (IntegerAttr eventIdAttr = getEventIdAttr()) {
       int64_t eventId = eventIdAttr.getInt();
-      if (eventId < 0 || eventId > 31) {
+      if (eventId < 0 || eventId > 15) {
         return emitOpError()
-               << "A5 sync.set expects static event_id in [0, 31], but got "
+               << "A5 sync.set expects static FFTS event_id in [0, 15], but got "
                << eventId;
       }
     }
@@ -3711,14 +3711,20 @@ LogicalResult mlir::pto::SyncWaitOp::verify() {
   if (hasStatic == hasDynamic)
     return emitOpError()
            << "expects exactly one event-id form: static attr or dynamic index operand";
+  if (IntegerAttr fftsModeAttr = getFftsModeAttr()) {
+    int64_t fftsMode = fftsModeAttr.getInt();
+    if (fftsMode < 0 || fftsMode > 2)
+      return emitOpError() << "requires ffts_mode in range [0, 2], but got "
+                           << fftsMode;
+  }
 
   auto verifyA2A3 = [&]() -> LogicalResult { return success(); };
   auto verifyA5 = [&]() -> LogicalResult {
     if (IntegerAttr eventIdAttr = getEventIdAttr()) {
       int64_t eventId = eventIdAttr.getInt();
-      if (eventId < 0 || eventId > 31)
+      if (eventId < 0 || eventId > 15)
         return emitOpError()
-               << "A5 sync.wait expects static physical event_id in [0, 31], but got "
+               << "A5 sync.wait expects static FFTS event_id in [0, 15], but got "
                << eventId;
     }
     switch (getPipe().getPipe()) {
@@ -3733,6 +3739,126 @@ LogicalResult mlir::pto::SyncWaitOp::verify() {
                               "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, "
                               "<PIPE_MTE3>, <PIPE_V>";
     }
+  };
+  return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
+}
+
+static LogicalResult verifyNamedSyncEventOp(Operation *op, PipeAttr pipe,
+                                            IntegerAttr eventIdAttr,
+                                            Value eventIdDyn,
+                                            int64_t maxEventId,
+                                            StringRef opName) {
+  if ((eventIdAttr != nullptr) == static_cast<bool>(eventIdDyn))
+    return op->emitOpError()
+           << "expects exactly one event-id form: static attr or dynamic index operand";
+  if (eventIdAttr && (eventIdAttr.getInt() < 0 ||
+                      eventIdAttr.getInt() > maxEventId))
+    return op->emitOpError() << "expects static event_id in [0, " << maxEventId
+                             << "], but got " << eventIdAttr.getInt();
+  switch (pipe.getPipe()) {
+  case PIPE::PIPE_FIX:
+  case PIPE::PIPE_MTE1:
+  case PIPE::PIPE_MTE2:
+  case PIPE::PIPE_MTE3:
+  case PIPE::PIPE_V:
+    return success();
+  default:
+    return op->emitOpError() << opName << " expects pipe to be one of "
+                              << "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, "
+                              << "<PIPE_MTE3>, <PIPE_V>";
+  }
+}
+
+ParseResult mlir::pto::SetCrossBlockOp::parse(OpAsmParser &parser,
+                                              OperationState &result) {
+  return parseSyncEventOpCommon(parser, result,
+                                SetCrossBlockOp::getPipeAttrName(result.name),
+                                SetCrossBlockOp::getEventIdAttrName(result.name));
+}
+
+void mlir::pto::SetCrossBlockOp::print(OpAsmPrinter &p) {
+  printSyncEventOpCommon(p, getOperation(), getPipe(), getEventIdAttr(),
+                         getEventIdDyn(), getPipeAttrName().getValue(),
+                         getEventIdAttrName().getValue());
+}
+
+LogicalResult mlir::pto::SetCrossBlockOp::verify() {
+  if (IntegerAttr mode = getFftsModeAttr())
+    if (mode.getInt() != 0)
+      return emitOpError() << "requires ffts_mode 0, but got "
+                           << mode.getInt();
+  return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
+                                getEventIdDyn(), 15, "pto.set_cross_block");
+}
+
+ParseResult mlir::pto::WaitCrossBlockOp::parse(OpAsmParser &parser,
+                                             OperationState &result) {
+  return parseSyncEventOpCommon(parser, result,
+                                WaitCrossBlockOp::getPipeAttrName(result.name),
+                                WaitCrossBlockOp::getEventIdAttrName(result.name));
+}
+
+void mlir::pto::WaitCrossBlockOp::print(OpAsmPrinter &p) {
+  printSyncEventOpCommon(p, getOperation(), getPipe(), getEventIdAttr(),
+                         getEventIdDyn(), getPipeAttrName().getValue(),
+                         getEventIdAttrName().getValue());
+}
+
+LogicalResult mlir::pto::WaitCrossBlockOp::verify() {
+  return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
+                                getEventIdDyn(), 15, "pto.wait_cross_block");
+}
+
+ParseResult mlir::pto::SetIntraBlockOp::parse(OpAsmParser &parser,
+                                               OperationState &result) {
+  return parseSyncEventOpCommon(parser, result,
+                                SetIntraBlockOp::getPipeAttrName(result.name),
+                                SetIntraBlockOp::getEventIdAttrName(result.name));
+}
+
+void mlir::pto::SetIntraBlockOp::print(OpAsmPrinter &p) {
+  printSyncEventOpCommon(p, getOperation(), getPipe(), getEventIdAttr(),
+                         getEventIdDyn(), getPipeAttrName().getValue(),
+                         getEventIdAttrName().getValue());
+}
+
+LogicalResult mlir::pto::SetIntraBlockOp::verify() {
+  auto verifyA2A3 = [&]() -> LogicalResult {
+    return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
+                                  getEventIdDyn(), 15,
+                                  "pto.set_intra_block");
+  };
+  auto verifyA5 = [&]() -> LogicalResult {
+    return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
+                                  getEventIdDyn(), 31,
+                                  "pto.set_intra_block");
+  };
+  return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
+}
+
+ParseResult mlir::pto::WaitIntraBlockOp::parse(OpAsmParser &parser,
+                                               OperationState &result) {
+  return parseSyncEventOpCommon(parser, result,
+                                WaitIntraBlockOp::getPipeAttrName(result.name),
+                                WaitIntraBlockOp::getEventIdAttrName(result.name));
+}
+
+void mlir::pto::WaitIntraBlockOp::print(OpAsmPrinter &p) {
+  printSyncEventOpCommon(p, getOperation(), getPipe(), getEventIdAttr(),
+                         getEventIdDyn(), getPipeAttrName().getValue(),
+                         getEventIdAttrName().getValue());
+}
+
+LogicalResult mlir::pto::WaitIntraBlockOp::verify() {
+  auto verifyA2A3 = [&]() -> LogicalResult {
+    return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
+                                  getEventIdDyn(), 15,
+                                  "pto.wait_intra_block");
+  };
+  auto verifyA5 = [&]() -> LogicalResult {
+    return verifyNamedSyncEventOp(getOperation(), getPipe(), getEventIdAttr(),
+                                  getEventIdDyn(), 31,
+                                  "pto.wait_intra_block");
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }

--- a/lib/PTO/Transforms/PTOCanonicalizeIR.cpp
+++ b/lib/PTO/Transforms/PTOCanonicalizeIR.cpp
@@ -391,6 +391,42 @@ struct PTOCanonicalizeIRPass
       }
     }
 
+    // VPTO consumes the shared FFTS sync representation.  Normalize named
+    // cross-block ops to mode 0 and A2/A3 intra-block ops to mode 2; A5 keeps
+    // named intra ops for dedicated lowering.
+    SmallVector<SetCrossBlockOp> crossSets;
+    SmallVector<WaitCrossBlockOp> crossWaits;
+    SmallVector<SetIntraBlockOp> intraSets;
+    SmallVector<WaitIntraBlockOp> intraWaits;
+    func.walk([&](SetCrossBlockOp op) { crossSets.push_back(op); });
+    func.walk([&](WaitCrossBlockOp op) { crossWaits.push_back(op); });
+    if (getTargetArch(func) != PTOArch::A5) {
+      func.walk([&](SetIntraBlockOp op) { intraSets.push_back(op); });
+      func.walk([&](WaitIntraBlockOp op) { intraWaits.push_back(op); });
+    }
+    auto mode0 = IntegerAttr::get(IntegerType::get(func.getContext(), 32), 0);
+    auto mode2 = IntegerAttr::get(IntegerType::get(func.getContext(), 32), 2);
+    for (SetCrossBlockOp op : crossSets) {
+      rewriter.setInsertionPoint(op);
+      rewriter.replaceOpWithNewOp<SyncSetOp>(
+          op, op.getPipe(), op.getEventIdAttr(), mode0, op.getEventIdDyn());
+    }
+    for (WaitCrossBlockOp op : crossWaits) {
+      rewriter.setInsertionPoint(op);
+      rewriter.replaceOpWithNewOp<SyncWaitOp>(
+          op, op.getPipe(), op.getEventIdAttr(), mode0, op.getEventIdDyn());
+    }
+    for (SetIntraBlockOp op : intraSets) {
+      rewriter.setInsertionPoint(op);
+      rewriter.replaceOpWithNewOp<SyncSetOp>(
+          op, op.getPipe(), op.getEventIdAttr(), mode2, op.getEventIdDyn());
+    }
+    for (WaitIntraBlockOp op : intraWaits) {
+      rewriter.setInsertionPoint(op);
+      rewriter.replaceOpWithNewOp<SyncWaitOp>(
+          op, op.getPipe(), op.getEventIdAttr(), mode2, op.getEventIdDyn());
+    }
+
     // Post-canonicalization verification: ensure no low-rank view types
     // survived. If any do, it means an op with rank-dependent operands
     // was not given a structural rewrite.

--- a/lib/PTO/Transforms/PTOCanonicalizeIR.cpp
+++ b/lib/PTO/Transforms/PTOCanonicalizeIR.cpp
@@ -400,7 +400,8 @@ struct PTOCanonicalizeIRPass
     SmallVector<WaitIntraBlockOp> intraWaits;
     func.walk([&](SetCrossBlockOp op) { crossSets.push_back(op); });
     func.walk([&](WaitCrossBlockOp op) { crossWaits.push_back(op); });
-    if (getTargetArch(func) != PTOArch::A5) {
+    PTOArch targetArch = getTargetArch(func);
+    if (targetArch != PTOArch::A5) {
       func.walk([&](SetIntraBlockOp op) { intraSets.push_back(op); });
       func.walk([&](WaitIntraBlockOp op) { intraWaits.push_back(op); });
     }

--- a/lib/PTO/Transforms/PTOCanonicalizeIR.cpp
+++ b/lib/PTO/Transforms/PTOCanonicalizeIR.cpp
@@ -372,6 +372,42 @@ struct PTOCanonicalizeIRPass
       }
     }
 
+    // VPTO consumes the shared FFTS sync representation.  Normalize named
+    // cross-block ops to mode 0 and A2/A3 intra-block ops to mode 2; A5 keeps
+    // named intra ops for dedicated lowering.
+    SmallVector<SetCrossBlockOp> crossSets;
+    SmallVector<WaitCrossBlockOp> crossWaits;
+    SmallVector<SetIntraBlockOp> intraSets;
+    SmallVector<WaitIntraBlockOp> intraWaits;
+    func.walk([&](SetCrossBlockOp op) { crossSets.push_back(op); });
+    func.walk([&](WaitCrossBlockOp op) { crossWaits.push_back(op); });
+    if (getTargetArch(func) != PTOArch::A5) {
+      func.walk([&](SetIntraBlockOp op) { intraSets.push_back(op); });
+      func.walk([&](WaitIntraBlockOp op) { intraWaits.push_back(op); });
+    }
+    auto mode0 = IntegerAttr::get(IntegerType::get(func.getContext(), 32), 0);
+    auto mode2 = IntegerAttr::get(IntegerType::get(func.getContext(), 32), 2);
+    for (SetCrossBlockOp op : crossSets) {
+      rewriter.setInsertionPoint(op);
+      rewriter.replaceOpWithNewOp<SyncSetOp>(
+          op, op.getPipe(), op.getEventIdAttr(), mode0, op.getEventIdDyn());
+    }
+    for (WaitCrossBlockOp op : crossWaits) {
+      rewriter.setInsertionPoint(op);
+      rewriter.replaceOpWithNewOp<SyncWaitOp>(
+          op, op.getPipe(), op.getEventIdAttr(), mode0, op.getEventIdDyn());
+    }
+    for (SetIntraBlockOp op : intraSets) {
+      rewriter.setInsertionPoint(op);
+      rewriter.replaceOpWithNewOp<SyncSetOp>(
+          op, op.getPipe(), op.getEventIdAttr(), mode2, op.getEventIdDyn());
+    }
+    for (WaitIntraBlockOp op : intraWaits) {
+      rewriter.setInsertionPoint(op);
+      rewriter.replaceOpWithNewOp<SyncWaitOp>(
+          op, op.getPipe(), op.getEventIdAttr(), mode2, op.getEventIdDyn());
+    }
+
     // Post-canonicalization verification: ensure no low-rank view types
     // survived. If any do, it means an op with rank-dependent operands
     // was not given a structural rewrite.

--- a/lib/PTO/Transforms/PTOMaterializeTileOpSections.cpp
+++ b/lib/PTO/Transforms/PTOMaterializeTileOpSections.cpp
@@ -67,7 +67,8 @@ static bool isForbiddenPipeOperation(Operation *op) {
              AivInitializePipeOp, InitializeL2G2LPipeOp, InitializeL2LPipeOp,
              DeclareEventIdArrayOp, EventIdArrayGetOp, EventIdArraySetOp,
              SetFlagOp, WaitFlagOp, SetFlagDynOp, WaitFlagDynOp, GetBufOp,
-             RlsBufOp, SyncSetOp, SyncWaitOp, BarrierOp, FenceBarrierAllOp,
+             RlsBufOp, SyncSetOp, SyncWaitOp, SetCrossBlockOp, WaitCrossBlockOp,
+             SetIntraBlockOp, WaitIntraBlockOp, BarrierOp, FenceBarrierAllOp,
              TSyncOp, SyncAllOp, DsbOp>(op);
 }
 

--- a/lib/PTO/Transforms/PTONormalizeUncoveredTileSections.cpp
+++ b/lib/PTO/Transforms/PTONormalizeUncoveredTileSections.cpp
@@ -86,7 +86,8 @@ static bool isRawSectionCarrierOp(Operation *op) {
   }
   return op &&
          isa<VectorMicroOpInterface, CubeMicroOpInterface, MteOpInterface,
-             SetFlagOp, WaitFlagOp, SyncSetOp, SyncWaitOp>(op);
+             SetFlagOp, WaitFlagOp, SyncSetOp, SyncWaitOp, SetCrossBlockOp,
+             WaitCrossBlockOp, SetIntraBlockOp, WaitIntraBlockOp>(op);
 }
 
 static std::optional<InferredSectionKind>
@@ -198,6 +199,18 @@ classifyRawSectionCarrierOp(Operation *op) {
   }
   if (auto syncWait = dyn_cast<SyncWaitOp>(op)) {
     return classifySyncPipe(syncWait.getPipe().getPipe());
+  }
+  if (auto crossSet = dyn_cast<SetCrossBlockOp>(op)) {
+    return classifySyncPipe(crossSet.getPipe().getPipe());
+  }
+  if (auto crossWait = dyn_cast<WaitCrossBlockOp>(op)) {
+    return classifySyncPipe(crossWait.getPipe().getPipe());
+  }
+  if (auto intraSet = dyn_cast<SetIntraBlockOp>(op)) {
+    return classifySyncPipe(intraSet.getPipe().getPipe());
+  }
+  if (auto intraWait = dyn_cast<WaitIntraBlockOp>(op)) {
+    return classifySyncPipe(intraWait.getPipe().getPipe());
   }
   return std::nullopt;
 }

--- a/lib/PTO/Transforms/PTONormalizeUncoveredTileSections.cpp
+++ b/lib/PTO/Transforms/PTONormalizeUncoveredTileSections.cpp
@@ -77,7 +77,8 @@ static bool isRawSectionCarrierOp(Operation *op) {
     return false;
   return op &&
          isa<VectorMicroOpInterface, CubeMicroOpInterface, MteOpInterface,
-             SetFlagOp, WaitFlagOp, SyncSetOp, SyncWaitOp>(op);
+             SetFlagOp, WaitFlagOp, SyncSetOp, SyncWaitOp, SetCrossBlockOp,
+             WaitCrossBlockOp, SetIntraBlockOp, WaitIntraBlockOp>(op);
 }
 
 static std::optional<InferredSectionKind>
@@ -174,6 +175,14 @@ classifyRawSectionCarrierOp(Operation *op) {
     return classifySyncPipe(syncSet.getPipe().getPipe());
   if (auto syncWait = dyn_cast<SyncWaitOp>(op))
     return classifySyncPipe(syncWait.getPipe().getPipe());
+  if (auto crossSet = dyn_cast<SetCrossBlockOp>(op))
+    return classifySyncPipe(crossSet.getPipe().getPipe());
+  if (auto crossWait = dyn_cast<WaitCrossBlockOp>(op))
+    return classifySyncPipe(crossWait.getPipe().getPipe());
+  if (auto intraSet = dyn_cast<SetIntraBlockOp>(op))
+    return classifySyncPipe(intraSet.getPipe().getPipe());
+  if (auto intraWait = dyn_cast<WaitIntraBlockOp>(op))
+    return classifySyncPipe(intraWait.getPipe().getPipe());
   return std::nullopt;
 }
 

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6059,9 +6059,12 @@ struct PTOSyncSetToEmitC : public OpConversionPattern<mlir::pto::SyncSetOp> {
     if (IntegerAttr fftsModeAttr = op.getFftsModeAttr())
       fftsMode = getIntegerAttrSignedValue(fftsModeAttr);
 
-    if ((eventIdAttr != nullptr) == static_cast<bool>(eventIdDyn))
+    const bool hasStaticEventId = eventIdAttr != nullptr;
+    const bool hasDynamicEventId = static_cast<bool>(eventIdDyn);
+    if (hasStaticEventId == hasDynamicEventId) {
       return rewriter.notifyMatchFailure(
           op, "expects exactly one of static event_id attr or dynamic event_id operand");
+    }
 
     InterCoreSyncCallDesc desc;
     if (eventIdAttr) {
@@ -6131,9 +6134,12 @@ struct PTONamedIntraSyncToEmitC : public OpConversionPattern<SyncOp> {
     auto loc = op->getLoc();
     IntegerAttr eventIdAttr = op.getEventIdAttr();
     Value eventIdDyn = adaptor.getEventIdDyn();
-    if ((eventIdAttr != nullptr) == static_cast<bool>(eventIdDyn))
+    const bool hasStaticEventId = eventIdAttr != nullptr;
+    const bool hasDynamicEventId = static_cast<bool>(eventIdDyn);
+    if (hasStaticEventId == hasDynamicEventId) {
       return rewriter.notifyMatchFailure(
           op, "expects exactly one of static event_id attr or dynamic event_id operand");
+    }
 
     if (targetArch != PTOArch::A5) {
       InterCoreSyncCallDesc desc;
@@ -6158,14 +6164,16 @@ struct PTONamedIntraSyncToEmitC : public OpConversionPattern<SyncOp> {
     auto *ctx = rewriter.getContext();
     std::string pipeTok = pipeTokFromPipeAttr(op.getPipe());
     Value eventValue;
-    if (eventIdDyn)
+    if (eventIdDyn) {
       eventValue = castInterCoreEventIdToI32(rewriter, loc, eventIdDyn);
+    }
 
     StringRef callee;
-    if constexpr (std::is_same_v<SyncOp, mlir::pto::SetIntraBlockOp>)
+    if constexpr (std::is_same_v<SyncOp, mlir::pto::SetIntraBlockOp>) {
       callee = "__builtin_cce_set_intra_block";
-    else
+    } else {
       callee = "__builtin_cce_wait_intra_block";
+    }
 
     auto args = rewriter.getArrayAttr({
         emitc::OpaqueAttr::get(ctx, pipeTok),

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -1645,27 +1645,19 @@ static InterCoreSyncCallDesc buildInterCoreSyncSetCall(
   auto *ctx = rewriter.getContext();
   std::string pipeTok = pipeTokFromPipeAttr(pipeAttr);
 
-  if (targetArch == PTOArch::A3) {
-    auto indexTy = emitc::OpaqueType::get(ctx, "int64_t");
-    Value eventVal =
-        makeEmitCIntConstant(rewriter, loc, indexTy,
-                             getIntegerAttrSignedValue(eventIdAttr));
-    Value msgVal = createFFTSMsg(rewriter, loc, eventVal, fftsMode);
-
-    InterCoreSyncCallDesc desc;
-    desc.callee = "ffts_cross_core_sync";
-    desc.args = rewriter.getArrayAttr({
-        emitc::OpaqueAttr::get(ctx, pipeTok),
-        IntegerAttr::get(IndexType::get(ctx), 0),
-    });
-    desc.operands.push_back(msgVal);
-    return desc;
-  }
-
+  (void)targetArch;
+  auto indexTy = emitc::OpaqueType::get(ctx, "int64_t");
+  Value eventVal =
+      makeEmitCIntConstant(rewriter, loc, indexTy,
+                           getIntegerAttrSignedValue(eventIdAttr));
+  Value msgVal = createFFTSMsg(rewriter, loc, eventVal, fftsMode);
   InterCoreSyncCallDesc desc;
-  desc.callee = "set_intra_block";
-  desc.args = rewriter.getArrayAttr(
-      {emitc::OpaqueAttr::get(ctx, pipeTok), eventIdAttr});
+  desc.callee = "__builtin_cce_ffts_cross_core_sync";
+  desc.args = rewriter.getArrayAttr({
+      emitc::OpaqueAttr::get(ctx, pipeTok),
+      IntegerAttr::get(IndexType::get(ctx), 0),
+  });
+  desc.operands.push_back(msgVal);
   return desc;
 }
 
@@ -1675,46 +1667,28 @@ static InterCoreSyncCallDesc buildInterCoreSyncSetCallDyn(
   auto *ctx = rewriter.getContext();
   std::string pipeTok = pipeTokFromPipeAttr(pipeAttr);
 
-  if (targetArch == PTOArch::A3) {
-    Value msgVal = createFFTSMsg(rewriter, loc, eventIdVal, fftsMode);
-
-    InterCoreSyncCallDesc desc;
-    desc.callee = "ffts_cross_core_sync";
-    desc.args = rewriter.getArrayAttr({
-        emitc::OpaqueAttr::get(ctx, pipeTok),
-        IntegerAttr::get(IndexType::get(ctx), 0),
-    });
-    desc.operands.push_back(msgVal);
-    return desc;
-  }
-
-  Value eventI32 = castInterCoreEventIdToI32(rewriter, loc, eventIdVal);
+  (void)targetArch;
+  Value msgVal = createFFTSMsg(rewriter, loc, eventIdVal, fftsMode);
   InterCoreSyncCallDesc desc;
-  desc.callee = "set_intra_block";
+  desc.callee = "__builtin_cce_ffts_cross_core_sync";
   desc.args = rewriter.getArrayAttr({
       emitc::OpaqueAttr::get(ctx, pipeTok),
       IntegerAttr::get(IndexType::get(ctx), 0),
   });
-  desc.operands.push_back(eventI32);
+  desc.operands.push_back(msgVal);
   return desc;
 }
 
 static InterCoreSyncCallDesc buildInterCoreSyncWaitCall(
     ConversionPatternRewriter &rewriter, PTOArch targetArch,
     pto::PipeAttr pipeAttr, IntegerAttr eventIdAttr) {
-  auto *ctx = rewriter.getContext();
   std::string pipeTok = pipeTokFromPipeAttr(pipeAttr);
 
   InterCoreSyncCallDesc desc;
-  if (targetArch == PTOArch::A3) {
-    desc.callee = "wait_flag_dev";
-    desc.args = rewriter.getArrayAttr({eventIdAttr});
-    return desc;
-  }
-
-  desc.callee = "wait_intra_block";
-  desc.args = rewriter.getArrayAttr(
-      {emitc::OpaqueAttr::get(ctx, pipeTok), eventIdAttr});
+  (void)targetArch;
+  (void)pipeTok;
+  desc.callee = "__builtin_cce_wait_flag_dev";
+  desc.args = rewriter.getArrayAttr({eventIdAttr});
   return desc;
 }
 
@@ -1723,29 +1697,21 @@ static InterCoreSyncCallDesc buildInterCoreSyncWaitCallDyn(
     pto::PipeAttr pipeAttr, Value eventIdVal) {
   auto *ctx = rewriter.getContext();
   std::string pipeTok = pipeTokFromPipeAttr(pipeAttr);
-  Value eventI32 = castInterCoreEventIdToI32(rewriter, loc, eventIdVal);
-
   InterCoreSyncCallDesc desc;
-  if (targetArch == PTOArch::A3) {
-    desc.callee = "wait_flag_dev";
-    desc.args = rewriter.getArrayAttr({IntegerAttr::get(IndexType::get(ctx), 0)});
-    desc.operands.push_back(eventI32);
-    return desc;
-  }
-
-  desc.callee = "wait_intra_block";
-  desc.args = rewriter.getArrayAttr({
-      emitc::OpaqueAttr::get(ctx, pipeTok),
-      IntegerAttr::get(IndexType::get(ctx), 0),
-  });
-  desc.operands.push_back(eventI32);
+  (void)targetArch;
+  (void)pipeTok;
+  desc.callee = "__builtin_cce_wait_flag_dev";
+  desc.args = rewriter.getArrayAttr({IntegerAttr::get(IndexType::get(ctx), 0)});
+  desc.operands.push_back(castInterCoreEventIdToI32(rewriter, loc, eventIdVal));
   return desc;
 }
 
 static bool hasInterCoreSyncOp(func::FuncOp func) {
   bool found = false;
   func.walk([&](Operation *op) {
-    if (isa<pto::SyncSetOp, pto::SyncWaitOp>(op)) {
+    if (isa<pto::SyncSetOp, pto::SyncWaitOp, pto::SetCrossBlockOp,
+            pto::WaitCrossBlockOp, pto::SetIntraBlockOp,
+            pto::WaitIntraBlockOp>(op)) {
       found = true;
       return WalkResult::interrupt();
     }
@@ -6087,7 +6053,6 @@ struct PTOSyncSetToEmitC : public OpConversionPattern<mlir::pto::SyncSetOp> {
   matchAndRewrite(mlir::pto::SyncSetOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op->getLoc();
-    auto *ctx = rewriter.getContext();
     IntegerAttr eventIdAttr = op.getEventIdAttr();
     Value eventIdDyn = adaptor.getEventIdDyn();
     int64_t fftsMode = 2;
@@ -6097,44 +6062,6 @@ struct PTOSyncSetToEmitC : public OpConversionPattern<mlir::pto::SyncSetOp> {
     if ((eventIdAttr != nullptr) == static_cast<bool>(eventIdDyn))
       return rewriter.notifyMatchFailure(
           op, "expects exactly one of static event_id attr or dynamic event_id operand");
-
-    // A5 sync uses physical semaphore IDs. Emit exactly the ID authored in IR;
-    // callers that need to notify both AIV subblocks must emit both IDs.
-    if (targetArch == PTOArch::A5) {
-      std::string pipeTok = pipeTokFromPipeAttr(op.getPipe());
-      auto emitSet = [&](Value eventOperand, IntegerAttr eventLiteral,
-                         bool isDynamic) {
-        if (isDynamic) {
-          auto args = rewriter.getArrayAttr({
-              emitc::OpaqueAttr::get(ctx, pipeTok),
-              IntegerAttr::get(IndexType::get(ctx), 0),
-          });
-          rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "set_intra_block",
-                                               /*args=*/args,
-                                               /*templateArgs=*/ArrayAttr{},
-                                               /*operands=*/ValueRange{eventOperand});
-          return;
-        }
-        auto args = rewriter.getArrayAttr({
-            emitc::OpaqueAttr::get(ctx, pipeTok),
-            eventLiteral,
-        });
-        rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "set_intra_block",
-                                             /*args=*/args,
-                                             /*templateArgs=*/ArrayAttr{},
-                                             /*operands=*/ValueRange{});
-      };
-
-      if (eventIdAttr) {
-        emitSet(Value{}, eventIdAttr, /*isDynamic=*/false);
-      } else {
-        Value eventI32 = castInterCoreEventIdToI32(rewriter, loc, eventIdDyn);
-        emitSet(eventI32, IntegerAttr{}, /*isDynamic=*/true);
-      }
-
-      rewriter.eraseOp(op);
-      return success();
-    }
 
     InterCoreSyncCallDesc desc;
     if (eventIdAttr) {
@@ -6189,6 +6116,83 @@ struct PTOSyncWaitToEmitC : public OpConversionPattern<mlir::pto::SyncWaitOp> {
   }
 
   PTOArch targetArch;
+};
+
+template <typename SyncOp>
+struct PTONamedIntraSyncToEmitC : public OpConversionPattern<SyncOp> {
+  PTONamedIntraSyncToEmitC(TypeConverter &typeConverter, MLIRContext *ctx,
+                           PTOArch targetArch)
+      : OpConversionPattern<SyncOp>(typeConverter, ctx),
+        targetArch(targetArch) {}
+
+  LogicalResult
+  matchAndRewrite(SyncOp op, typename SyncOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op->getLoc();
+    IntegerAttr eventIdAttr = op.getEventIdAttr();
+    Value eventIdDyn = adaptor.getEventIdDyn();
+    if ((eventIdAttr != nullptr) == static_cast<bool>(eventIdDyn))
+      return rewriter.notifyMatchFailure(
+          op, "expects exactly one of static event_id attr or dynamic event_id operand");
+
+    if (targetArch != PTOArch::A5) {
+      InterCoreSyncCallDesc desc;
+      if constexpr (std::is_same_v<SyncOp, mlir::pto::SetIntraBlockOp>) {
+        desc = eventIdAttr
+                   ? buildInterCoreSyncSetCall(rewriter, loc, targetArch,
+                                               op.getPipe(), eventIdAttr, 2)
+                   : buildInterCoreSyncSetCallDyn(rewriter, loc, targetArch,
+                                                  op.getPipe(), eventIdDyn, 2);
+      } else {
+        desc = eventIdAttr
+                   ? buildInterCoreSyncWaitCall(rewriter, targetArch,
+                                                op.getPipe(), eventIdAttr)
+                   : buildInterCoreSyncWaitCallDyn(rewriter, loc, targetArch,
+                                                   op.getPipe(), eventIdDyn);
+      }
+      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+          op, TypeRange{}, desc.callee, desc.args, ArrayAttr{}, desc.operands);
+      return success();
+    }
+
+    auto *ctx = rewriter.getContext();
+    std::string pipeTok = pipeTokFromPipeAttr(op.getPipe());
+    Value eventValue;
+    if (eventIdDyn)
+      eventValue = castInterCoreEventIdToI32(rewriter, loc, eventIdDyn);
+
+    StringRef callee;
+    if constexpr (std::is_same_v<SyncOp, mlir::pto::SetIntraBlockOp>)
+      callee = "__builtin_cce_set_intra_block";
+    else
+      callee = "__builtin_cce_wait_intra_block";
+
+    auto args = rewriter.getArrayAttr({
+        emitc::OpaqueAttr::get(ctx, pipeTok),
+        eventIdAttr ? eventIdAttr : IntegerAttr::get(IndexType::get(ctx), 0),
+    });
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, TypeRange{}, callee, args, ArrayAttr{},
+        eventValue ? ValueRange{eventValue} : ValueRange{});
+    return success();
+  }
+
+  PTOArch targetArch;
+};
+
+template <typename CrossOp, typename SyncOp>
+struct PTOCrossSyncToSync : public OpConversionPattern<CrossOp> {
+  PTOCrossSyncToSync(TypeConverter &typeConverter, MLIRContext *ctx)
+      : OpConversionPattern<CrossOp>(typeConverter, ctx) {}
+
+  LogicalResult
+  matchAndRewrite(CrossOp op, typename CrossOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto mode0 = IntegerAttr::get(rewriter.getI32Type(), 0);
+    rewriter.replaceOpWithNewOp<SyncOp>(op, op.getPipe(), op.getEventIdAttr(),
+                                        mode0, adaptor.getEventIdDyn());
+    return success();
+  }
 };
 
 // GetBlockIdxOp Lowering (pto.get_block_idx -> get_block_idx())
@@ -13640,6 +13644,12 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOTFreeToEmitC>(typeConverter, ctx, targetArch);
   patterns.add<PTOSyncSetToEmitC>(typeConverter, ctx, targetArch);
   patterns.add<PTOSyncWaitToEmitC>(typeConverter, ctx, targetArch);
+  patterns.add<PTOCrossSyncToSync<pto::SetCrossBlockOp, pto::SyncSetOp>,
+               PTOCrossSyncToSync<pto::WaitCrossBlockOp, pto::SyncWaitOp>>(
+      typeConverter, ctx);
+  patterns.add<PTONamedIntraSyncToEmitC<pto::SetIntraBlockOp>,
+               PTONamedIntraSyncToEmitC<pto::WaitIntraBlockOp>>(typeConverter,
+                                                               ctx, targetArch);
   patterns.add<SectionToEmitC<pto::SectionCubeOp>>(typeConverter, ctx);
   patterns.add<SectionToEmitC<pto::SectionVectorOp>>(typeConverter, ctx);
   patterns.add<PTOGetBlockIdxToEmitC>(typeConverter, ctx);

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -1609,27 +1609,19 @@ static InterCoreSyncCallDesc buildInterCoreSyncSetCall(
   auto *ctx = rewriter.getContext();
   std::string pipeTok = pipeTokFromPipeAttr(pipeAttr);
 
-  if (targetArch == PTOArch::A3) {
-    auto indexTy = emitc::OpaqueType::get(ctx, "int64_t");
-    Value eventVal =
-        makeEmitCIntConstant(rewriter, loc, indexTy,
-                             getIntegerAttrSignedValue(eventIdAttr));
-    Value msgVal = createFFTSMsg(rewriter, loc, eventVal, fftsMode);
-
-    InterCoreSyncCallDesc desc;
-    desc.callee = "ffts_cross_core_sync";
-    desc.args = rewriter.getArrayAttr({
-        emitc::OpaqueAttr::get(ctx, pipeTok),
-        IntegerAttr::get(IndexType::get(ctx), 0),
-    });
-    desc.operands.push_back(msgVal);
-    return desc;
-  }
-
+  (void)targetArch;
+  auto indexTy = emitc::OpaqueType::get(ctx, "int64_t");
+  Value eventVal =
+      makeEmitCIntConstant(rewriter, loc, indexTy,
+                           getIntegerAttrSignedValue(eventIdAttr));
+  Value msgVal = createFFTSMsg(rewriter, loc, eventVal, fftsMode);
   InterCoreSyncCallDesc desc;
-  desc.callee = "set_intra_block";
-  desc.args = rewriter.getArrayAttr(
-      {emitc::OpaqueAttr::get(ctx, pipeTok), eventIdAttr});
+  desc.callee = "__builtin_cce_ffts_cross_core_sync";
+  desc.args = rewriter.getArrayAttr({
+      emitc::OpaqueAttr::get(ctx, pipeTok),
+      IntegerAttr::get(IndexType::get(ctx), 0),
+  });
+  desc.operands.push_back(msgVal);
   return desc;
 }
 
@@ -1639,46 +1631,28 @@ static InterCoreSyncCallDesc buildInterCoreSyncSetCallDyn(
   auto *ctx = rewriter.getContext();
   std::string pipeTok = pipeTokFromPipeAttr(pipeAttr);
 
-  if (targetArch == PTOArch::A3) {
-    Value msgVal = createFFTSMsg(rewriter, loc, eventIdVal, fftsMode);
-
-    InterCoreSyncCallDesc desc;
-    desc.callee = "ffts_cross_core_sync";
-    desc.args = rewriter.getArrayAttr({
-        emitc::OpaqueAttr::get(ctx, pipeTok),
-        IntegerAttr::get(IndexType::get(ctx), 0),
-    });
-    desc.operands.push_back(msgVal);
-    return desc;
-  }
-
-  Value eventI32 = castInterCoreEventIdToI32(rewriter, loc, eventIdVal);
+  (void)targetArch;
+  Value msgVal = createFFTSMsg(rewriter, loc, eventIdVal, fftsMode);
   InterCoreSyncCallDesc desc;
-  desc.callee = "set_intra_block";
+  desc.callee = "__builtin_cce_ffts_cross_core_sync";
   desc.args = rewriter.getArrayAttr({
       emitc::OpaqueAttr::get(ctx, pipeTok),
       IntegerAttr::get(IndexType::get(ctx), 0),
   });
-  desc.operands.push_back(eventI32);
+  desc.operands.push_back(msgVal);
   return desc;
 }
 
 static InterCoreSyncCallDesc buildInterCoreSyncWaitCall(
     ConversionPatternRewriter &rewriter, PTOArch targetArch,
     pto::PipeAttr pipeAttr, IntegerAttr eventIdAttr) {
-  auto *ctx = rewriter.getContext();
   std::string pipeTok = pipeTokFromPipeAttr(pipeAttr);
 
   InterCoreSyncCallDesc desc;
-  if (targetArch == PTOArch::A3) {
-    desc.callee = "wait_flag_dev";
-    desc.args = rewriter.getArrayAttr({eventIdAttr});
-    return desc;
-  }
-
-  desc.callee = "wait_intra_block";
-  desc.args = rewriter.getArrayAttr(
-      {emitc::OpaqueAttr::get(ctx, pipeTok), eventIdAttr});
+  (void)targetArch;
+  (void)pipeTok;
+  desc.callee = "__builtin_cce_wait_flag_dev";
+  desc.args = rewriter.getArrayAttr({eventIdAttr});
   return desc;
 }
 
@@ -1687,29 +1661,21 @@ static InterCoreSyncCallDesc buildInterCoreSyncWaitCallDyn(
     pto::PipeAttr pipeAttr, Value eventIdVal) {
   auto *ctx = rewriter.getContext();
   std::string pipeTok = pipeTokFromPipeAttr(pipeAttr);
-  Value eventI32 = castInterCoreEventIdToI32(rewriter, loc, eventIdVal);
-
   InterCoreSyncCallDesc desc;
-  if (targetArch == PTOArch::A3) {
-    desc.callee = "wait_flag_dev";
-    desc.args = rewriter.getArrayAttr({IntegerAttr::get(IndexType::get(ctx), 0)});
-    desc.operands.push_back(eventI32);
-    return desc;
-  }
-
-  desc.callee = "wait_intra_block";
-  desc.args = rewriter.getArrayAttr({
-      emitc::OpaqueAttr::get(ctx, pipeTok),
-      IntegerAttr::get(IndexType::get(ctx), 0),
-  });
-  desc.operands.push_back(eventI32);
+  (void)targetArch;
+  (void)pipeTok;
+  desc.callee = "__builtin_cce_wait_flag_dev";
+  desc.args = rewriter.getArrayAttr({IntegerAttr::get(IndexType::get(ctx), 0)});
+  desc.operands.push_back(castInterCoreEventIdToI32(rewriter, loc, eventIdVal));
   return desc;
 }
 
 static bool hasInterCoreSyncOp(func::FuncOp func) {
   bool found = false;
   func.walk([&](Operation *op) {
-    if (isa<pto::SyncSetOp, pto::SyncWaitOp>(op)) {
+    if (isa<pto::SyncSetOp, pto::SyncWaitOp, pto::SetCrossBlockOp,
+            pto::WaitCrossBlockOp, pto::SetIntraBlockOp,
+            pto::WaitIntraBlockOp>(op)) {
       found = true;
       return WalkResult::interrupt();
     }
@@ -6027,7 +5993,6 @@ struct PTOSyncSetToEmitC : public OpConversionPattern<mlir::pto::SyncSetOp> {
   matchAndRewrite(mlir::pto::SyncSetOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op->getLoc();
-    auto *ctx = rewriter.getContext();
     IntegerAttr eventIdAttr = op.getEventIdAttr();
     Value eventIdDyn = adaptor.getEventIdDyn();
     int64_t fftsMode = 2;
@@ -6037,44 +6002,6 @@ struct PTOSyncSetToEmitC : public OpConversionPattern<mlir::pto::SyncSetOp> {
     if ((eventIdAttr != nullptr) == static_cast<bool>(eventIdDyn))
       return rewriter.notifyMatchFailure(
           op, "expects exactly one of static event_id attr or dynamic event_id operand");
-
-    // A5 sync uses physical semaphore IDs. Emit exactly the ID authored in IR;
-    // callers that need to notify both AIV subblocks must emit both IDs.
-    if (targetArch == PTOArch::A5) {
-      std::string pipeTok = pipeTokFromPipeAttr(op.getPipe());
-      auto emitSet = [&](Value eventOperand, IntegerAttr eventLiteral,
-                         bool isDynamic) {
-        if (isDynamic) {
-          auto args = rewriter.getArrayAttr({
-              emitc::OpaqueAttr::get(ctx, pipeTok),
-              IntegerAttr::get(IndexType::get(ctx), 0),
-          });
-          rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "set_intra_block",
-                                               /*args=*/args,
-                                               /*templateArgs=*/ArrayAttr{},
-                                               /*operands=*/ValueRange{eventOperand});
-          return;
-        }
-        auto args = rewriter.getArrayAttr({
-            emitc::OpaqueAttr::get(ctx, pipeTok),
-            eventLiteral,
-        });
-        rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "set_intra_block",
-                                             /*args=*/args,
-                                             /*templateArgs=*/ArrayAttr{},
-                                             /*operands=*/ValueRange{});
-      };
-
-      if (eventIdAttr) {
-        emitSet(Value{}, eventIdAttr, /*isDynamic=*/false);
-      } else {
-        Value eventI32 = castInterCoreEventIdToI32(rewriter, loc, eventIdDyn);
-        emitSet(eventI32, IntegerAttr{}, /*isDynamic=*/true);
-      }
-
-      rewriter.eraseOp(op);
-      return success();
-    }
 
     InterCoreSyncCallDesc desc;
     if (eventIdAttr) {
@@ -6129,6 +6056,83 @@ struct PTOSyncWaitToEmitC : public OpConversionPattern<mlir::pto::SyncWaitOp> {
   }
 
   PTOArch targetArch;
+};
+
+template <typename SyncOp>
+struct PTONamedIntraSyncToEmitC : public OpConversionPattern<SyncOp> {
+  PTONamedIntraSyncToEmitC(TypeConverter &typeConverter, MLIRContext *ctx,
+                           PTOArch targetArch)
+      : OpConversionPattern<SyncOp>(typeConverter, ctx),
+        targetArch(targetArch) {}
+
+  LogicalResult
+  matchAndRewrite(SyncOp op, typename SyncOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op->getLoc();
+    IntegerAttr eventIdAttr = op.getEventIdAttr();
+    Value eventIdDyn = adaptor.getEventIdDyn();
+    if ((eventIdAttr != nullptr) == static_cast<bool>(eventIdDyn))
+      return rewriter.notifyMatchFailure(
+          op, "expects exactly one of static event_id attr or dynamic event_id operand");
+
+    if (targetArch != PTOArch::A5) {
+      InterCoreSyncCallDesc desc;
+      if constexpr (std::is_same_v<SyncOp, mlir::pto::SetIntraBlockOp>) {
+        desc = eventIdAttr
+                   ? buildInterCoreSyncSetCall(rewriter, loc, targetArch,
+                                               op.getPipe(), eventIdAttr, 2)
+                   : buildInterCoreSyncSetCallDyn(rewriter, loc, targetArch,
+                                                  op.getPipe(), eventIdDyn, 2);
+      } else {
+        desc = eventIdAttr
+                   ? buildInterCoreSyncWaitCall(rewriter, targetArch,
+                                                op.getPipe(), eventIdAttr)
+                   : buildInterCoreSyncWaitCallDyn(rewriter, loc, targetArch,
+                                                   op.getPipe(), eventIdDyn);
+      }
+      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+          op, TypeRange{}, desc.callee, desc.args, ArrayAttr{}, desc.operands);
+      return success();
+    }
+
+    auto *ctx = rewriter.getContext();
+    std::string pipeTok = pipeTokFromPipeAttr(op.getPipe());
+    Value eventValue;
+    if (eventIdDyn)
+      eventValue = castInterCoreEventIdToI32(rewriter, loc, eventIdDyn);
+
+    StringRef callee;
+    if constexpr (std::is_same_v<SyncOp, mlir::pto::SetIntraBlockOp>)
+      callee = "__builtin_cce_set_intra_block";
+    else
+      callee = "__builtin_cce_wait_intra_block";
+
+    auto args = rewriter.getArrayAttr({
+        emitc::OpaqueAttr::get(ctx, pipeTok),
+        eventIdAttr ? eventIdAttr : IntegerAttr::get(IndexType::get(ctx), 0),
+    });
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, TypeRange{}, callee, args, ArrayAttr{},
+        eventValue ? ValueRange{eventValue} : ValueRange{});
+    return success();
+  }
+
+  PTOArch targetArch;
+};
+
+template <typename CrossOp, typename SyncOp>
+struct PTOCrossSyncToSync : public OpConversionPattern<CrossOp> {
+  PTOCrossSyncToSync(TypeConverter &typeConverter, MLIRContext *ctx)
+      : OpConversionPattern<CrossOp>(typeConverter, ctx) {}
+
+  LogicalResult
+  matchAndRewrite(CrossOp op, typename CrossOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto mode0 = IntegerAttr::get(rewriter.getI32Type(), 0);
+    rewriter.replaceOpWithNewOp<SyncOp>(op, op.getPipe(), op.getEventIdAttr(),
+                                        mode0, adaptor.getEventIdDyn());
+    return success();
+  }
 };
 
 // GetBlockIdxOp Lowering (pto.get_block_idx -> get_block_idx())
@@ -13508,6 +13512,12 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOTFreeToEmitC>(typeConverter, ctx, targetArch);
   patterns.add<PTOSyncSetToEmitC>(typeConverter, ctx, targetArch);
   patterns.add<PTOSyncWaitToEmitC>(typeConverter, ctx, targetArch);
+  patterns.add<PTOCrossSyncToSync<pto::SetCrossBlockOp, pto::SyncSetOp>,
+               PTOCrossSyncToSync<pto::WaitCrossBlockOp, pto::SyncWaitOp>>(
+      typeConverter, ctx);
+  patterns.add<PTONamedIntraSyncToEmitC<pto::SetIntraBlockOp>,
+               PTONamedIntraSyncToEmitC<pto::WaitIntraBlockOp>>(typeConverter,
+                                                               ctx, targetArch);
   patterns.add<SectionToEmitC<pto::SectionCubeOp>>(typeConverter, ctx);
   patterns.add<SectionToEmitC<pto::SectionVectorOp>>(typeConverter, ctx);
   patterns.add<PTOGetBlockIdxToEmitC>(typeConverter, ctx);

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -4412,11 +4412,21 @@ StringRef buildSyncCallee<pto::BarrierOp>(MLIRContext *context) {
 
 template <>
 StringRef buildSyncCallee<pto::SyncSetOp>(MLIRContext *context) {
-  return StringAttr::get(context, "llvm.hivm.SET.INTRA.BLOCK.mode").getValue();
+  return StringAttr::get(context, "llvm.hivm.SET.CROSS.CORE").getValue();
 }
 
 template <>
 StringRef buildSyncCallee<pto::SyncWaitOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.WAIT.FLAG.DEV.REG").getValue();
+}
+
+template <>
+StringRef buildSyncCallee<pto::SetIntraBlockOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.SET.INTRA.BLOCK.mode").getValue();
+}
+
+template <>
+StringRef buildSyncCallee<pto::WaitIntraBlockOp>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.WAIT.INTRA.BLOCK.mode").getValue();
 }
 
@@ -9239,15 +9249,77 @@ public:
     }
 
     StringRef calleeName = buildSyncCallee<SyncOp>(op.getContext());
+    SmallVector<Value> args{pipeValue, eventValue};
+    if constexpr (std::is_same_v<SyncOp, pto::SyncSetOp>) {
+      int64_t mode = 2;
+      if (IntegerAttr attr = op.getFftsModeAttr()) mode = attr.getInt();
+      Value modeValue = getI64Constant(rewriter, op.getLoc(), mode);
+      Value one = getI64Constant(rewriter, op.getLoc(), 1);
+      Value modeMask = getI64Constant(rewriter, op.getLoc(), 0x3);
+      Value eventMask = getI64Constant(rewriter, op.getLoc(), 0xf);
+      modeValue = rewriter.create<arith::AndIOp>(op.getLoc(), modeValue,
+                                                  modeMask);
+      eventValue = rewriter.create<arith::AndIOp>(op.getLoc(), eventValue,
+                                                   eventMask);
+      Value modeShift = rewriter.create<arith::ShLIOp>(op.getLoc(), modeValue,
+          getI64Constant(rewriter, op.getLoc(), 4));
+      Value eventShift = rewriter.create<arith::ShLIOp>(op.getLoc(), eventValue,
+          getI64Constant(rewriter, op.getLoc(), 8));
+      Value msg = rewriter.create<arith::OrIOp>(op.getLoc(), one, modeShift);
+      msg = rewriter.create<arith::OrIOp>(op.getLoc(), msg, eventShift);
+      args = {pipeValue, msg};
+    } else if constexpr (std::is_same_v<SyncOp, pto::SyncWaitOp>) {
+      calleeName = op.getEventIdAttr()
+                       ? StringAttr::get(op.getContext(),
+                                         "llvm.hivm.WAIT.FLAG.DEV.PIPE.IMM")
+                             .getValue()
+                       : StringAttr::get(op.getContext(),
+                                         "llvm.hivm.WAIT.FLAG.DEV.PIPE.REG")
+                             .getValue();
+    }
     auto funcType = rewriter.getFunctionType(
-        TypeRange{rewriter.getI64Type(), rewriter.getI64Type()}, TypeRange{});
-    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{},
-                                  ValueRange{pipeValue, eventValue});
+        TypeRange{args[0].getType(), args[1].getType()}, TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{}, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
     rewriter.eraseOp(op);
     return success();
   }
 
+private:
+  LoweringState &state;
+};
+
+template <typename SyncOp>
+class LowerNamedSyncOpPattern final : public OpConversionPattern<SyncOp> {
+public:
+  explicit LowerNamedSyncOpPattern(TypeConverter &tc, MLIRContext *ctx,
+                                   LoweringState &state)
+      : OpConversionPattern<SyncOp>(tc, ctx), state(state) {}
+  LogicalResult matchAndRewrite(
+      SyncOp op, typename SyncOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto pipe = parsePipeImmediate(stringifyPIPE(op.getPipe().getPipe()));
+    if (!pipe)
+      return rewriter.notifyMatchFailure(op, "unsupported sync pipe");
+    Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipe);
+    Value eventValue;
+    if (IntegerAttr attr = op.getEventIdAttr())
+      eventValue = getI64Constant(rewriter, op.getLoc(), attr.getInt());
+    else {
+      eventValue = castIntegerLikeTo(op, adaptor.getEventIdDyn(),
+                                     rewriter.getI64Type());
+      if (!eventValue)
+        return rewriter.notifyMatchFailure(op, "missing event-id operand");
+    }
+    StringRef callee = buildSyncCallee<SyncOp>(op.getContext());
+    auto fnTy = rewriter.getFunctionType(
+        TypeRange{rewriter.getI64Type(), rewriter.getI64Type()}, TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), callee, TypeRange{},
+                                  ValueRange{pipeValue, eventValue});
+    state.plannedDecls.push_back(PlannedDecl{callee.str(), fnTy});
+    rewriter.eraseOp(op);
+    return success();
+  }
 private:
   LoweringState &state;
 };
@@ -11213,6 +11285,8 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerPstuOpPattern, LowerVstusOpPattern, LowerVsturOpPattern,
                LowerInterCoreSyncOpPattern<pto::SyncSetOp>,
                LowerInterCoreSyncOpPattern<pto::SyncWaitOp>,
+               LowerNamedSyncOpPattern<pto::SetIntraBlockOp>,
+               LowerNamedSyncOpPattern<pto::WaitIntraBlockOp>,
                LowerCopyGmToCbufOpPattern, LowerLoadCbufToCaOpPattern,
                LowerLoadCbufToCbOpPattern,
                LowerLoadCbufToS4OpPattern<pto::LoadCbufToCaS4Op>,
@@ -11246,7 +11320,8 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                          func::FuncDialect, scf::SCFDialect>();
   target.addLegalOp<UnrealizedConversionCastOp>();
   target.addIllegalOp<pto::SetFlagOp, pto::WaitFlagOp, pto::SetFlagDynOp, pto::WaitFlagDynOp, pto::SyncSetOp,
-                      pto::SyncWaitOp, pto::BarrierOp, pto::MemBarOp,
+                      pto::SyncWaitOp, pto::SetIntraBlockOp, pto::WaitIntraBlockOp,
+                      pto::BarrierOp, pto::MemBarOp,
                       pto::CmoCacheInvalidOp, pto::FenceBarrierAllOp,
                       pto::DsbOp, pto::DcciOp,
                       pto::GetBufOp, pto::RlsBufOp,

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -9252,7 +9252,9 @@ public:
     SmallVector<Value> args{pipeValue, eventValue};
     if constexpr (std::is_same_v<SyncOp, pto::SyncSetOp>) {
       int64_t mode = 2;
-      if (IntegerAttr attr = op.getFftsModeAttr()) mode = attr.getInt();
+      if (IntegerAttr attr = op.getFftsModeAttr()) {
+        mode = attr.getInt();
+      }
       Value modeValue = getI64Constant(rewriter, op.getLoc(), mode);
       Value one = getI64Constant(rewriter, op.getLoc(), 1);
       Value modeMask = getI64Constant(rewriter, op.getLoc(), 0x3);
@@ -9299,17 +9301,19 @@ public:
       SyncOp op, typename SyncOp::Adaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     auto pipe = parsePipeImmediate(stringifyPIPE(op.getPipe().getPipe()));
-    if (!pipe)
+    if (!pipe) {
       return rewriter.notifyMatchFailure(op, "unsupported sync pipe");
+    }
     Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipe);
     Value eventValue;
-    if (IntegerAttr attr = op.getEventIdAttr())
+    if (IntegerAttr attr = op.getEventIdAttr()) {
       eventValue = getI64Constant(rewriter, op.getLoc(), attr.getInt());
-    else {
+    } else {
       eventValue = castIntegerLikeTo(op, adaptor.getEventIdDyn(),
                                      rewriter.getI64Type());
-      if (!eventValue)
+      if (!eventValue) {
         return rewriter.notifyMatchFailure(op, "missing event-id operand");
+      }
     }
     StringRef callee = buildSyncCallee<SyncOp>(op.getContext());
     auto fnTy = rewriter.getFunctionType(

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -4307,11 +4307,21 @@ StringRef buildSyncCallee<pto::BarrierOp>(MLIRContext *context) {
 
 template <>
 StringRef buildSyncCallee<pto::SyncSetOp>(MLIRContext *context) {
-  return StringAttr::get(context, "llvm.hivm.SET.INTRA.BLOCK.mode").getValue();
+  return StringAttr::get(context, "llvm.hivm.SET.CROSS.CORE").getValue();
 }
 
 template <>
 StringRef buildSyncCallee<pto::SyncWaitOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.WAIT.FLAG.DEV.REG").getValue();
+}
+
+template <>
+StringRef buildSyncCallee<pto::SetIntraBlockOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.SET.INTRA.BLOCK.mode").getValue();
+}
+
+template <>
+StringRef buildSyncCallee<pto::WaitIntraBlockOp>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.WAIT.INTRA.BLOCK.mode").getValue();
 }
 
@@ -9038,15 +9048,77 @@ public:
     }
 
     StringRef calleeName = buildSyncCallee<SyncOp>(op.getContext());
+    SmallVector<Value> args{pipeValue, eventValue};
+    if constexpr (std::is_same_v<SyncOp, pto::SyncSetOp>) {
+      int64_t mode = 2;
+      if (IntegerAttr attr = op.getFftsModeAttr()) mode = attr.getInt();
+      Value modeValue = getI64Constant(rewriter, op.getLoc(), mode);
+      Value one = getI64Constant(rewriter, op.getLoc(), 1);
+      Value modeMask = getI64Constant(rewriter, op.getLoc(), 0x3);
+      Value eventMask = getI64Constant(rewriter, op.getLoc(), 0xf);
+      modeValue = rewriter.create<arith::AndIOp>(op.getLoc(), modeValue,
+                                                  modeMask);
+      eventValue = rewriter.create<arith::AndIOp>(op.getLoc(), eventValue,
+                                                   eventMask);
+      Value modeShift = rewriter.create<arith::ShLIOp>(op.getLoc(), modeValue,
+          getI64Constant(rewriter, op.getLoc(), 4));
+      Value eventShift = rewriter.create<arith::ShLIOp>(op.getLoc(), eventValue,
+          getI64Constant(rewriter, op.getLoc(), 8));
+      Value msg = rewriter.create<arith::OrIOp>(op.getLoc(), one, modeShift);
+      msg = rewriter.create<arith::OrIOp>(op.getLoc(), msg, eventShift);
+      args = {pipeValue, msg};
+    } else if constexpr (std::is_same_v<SyncOp, pto::SyncWaitOp>) {
+      calleeName = op.getEventIdAttr()
+                       ? StringAttr::get(op.getContext(),
+                                         "llvm.hivm.WAIT.FLAG.DEV.PIPE.IMM")
+                             .getValue()
+                       : StringAttr::get(op.getContext(),
+                                         "llvm.hivm.WAIT.FLAG.DEV.PIPE.REG")
+                             .getValue();
+    }
     auto funcType = rewriter.getFunctionType(
-        TypeRange{rewriter.getI64Type(), rewriter.getI64Type()}, TypeRange{});
-    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{},
-                                  ValueRange{pipeValue, eventValue});
+        TypeRange{args[0].getType(), args[1].getType()}, TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{}, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
     rewriter.eraseOp(op);
     return success();
   }
 
+private:
+  LoweringState &state;
+};
+
+template <typename SyncOp>
+class LowerNamedSyncOpPattern final : public OpConversionPattern<SyncOp> {
+public:
+  explicit LowerNamedSyncOpPattern(TypeConverter &tc, MLIRContext *ctx,
+                                   LoweringState &state)
+      : OpConversionPattern<SyncOp>(tc, ctx), state(state) {}
+  LogicalResult matchAndRewrite(
+      SyncOp op, typename SyncOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto pipe = parsePipeImmediate(stringifyPIPE(op.getPipe().getPipe()));
+    if (!pipe)
+      return rewriter.notifyMatchFailure(op, "unsupported sync pipe");
+    Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipe);
+    Value eventValue;
+    if (IntegerAttr attr = op.getEventIdAttr())
+      eventValue = getI64Constant(rewriter, op.getLoc(), attr.getInt());
+    else {
+      eventValue = castIntegerLikeTo(op, adaptor.getEventIdDyn(),
+                                     rewriter.getI64Type());
+      if (!eventValue)
+        return rewriter.notifyMatchFailure(op, "missing event-id operand");
+    }
+    StringRef callee = buildSyncCallee<SyncOp>(op.getContext());
+    auto fnTy = rewriter.getFunctionType(
+        TypeRange{rewriter.getI64Type(), rewriter.getI64Type()}, TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), callee, TypeRange{},
+                                  ValueRange{pipeValue, eventValue});
+    state.plannedDecls.push_back(PlannedDecl{callee.str(), fnTy});
+    rewriter.eraseOp(op);
+    return success();
+  }
 private:
   LoweringState &state;
 };
@@ -11015,6 +11087,8 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerPstuOpPattern, LowerVstusOpPattern, LowerVsturOpPattern,
                LowerInterCoreSyncOpPattern<pto::SyncSetOp>,
                LowerInterCoreSyncOpPattern<pto::SyncWaitOp>,
+               LowerNamedSyncOpPattern<pto::SetIntraBlockOp>,
+               LowerNamedSyncOpPattern<pto::WaitIntraBlockOp>,
                LowerCopyGmToCbufOpPattern, LowerLoadCbufToCaOpPattern,
                LowerLoadCbufToCbOpPattern,
                LowerLoadCbufToS4OpPattern<pto::LoadCbufToCaS4Op>,
@@ -11047,7 +11121,8 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                          func::FuncDialect, scf::SCFDialect>();
   target.addLegalOp<UnrealizedConversionCastOp>();
   target.addIllegalOp<pto::SetFlagOp, pto::WaitFlagOp, pto::SetFlagDynOp, pto::WaitFlagDynOp, pto::SyncSetOp,
-                      pto::SyncWaitOp, pto::BarrierOp, pto::MemBarOp,
+                      pto::SyncWaitOp, pto::SetIntraBlockOp, pto::WaitIntraBlockOp,
+                      pto::BarrierOp, pto::MemBarOp,
                       pto::CmoCacheInvalidOp, pto::FenceBarrierAllOp,
                       pto::DsbOp, pto::DcciOp,
                       pto::GetBufOp, pto::RlsBufOp,

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -11151,17 +11151,19 @@ public:
       SyncOp op, typename SyncOp::Adaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     auto pipe = parsePipeImmediate(stringifyPIPE(op.getPipe().getPipe()));
-    if (!pipe)
+    if (!pipe) {
       return rewriter.notifyMatchFailure(op, "unsupported sync pipe");
+    }
     Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipe);
     Value eventValue;
-    if (IntegerAttr attr = op.getEventIdAttr())
+    if (IntegerAttr attr = op.getEventIdAttr()) {
       eventValue = getI64Constant(rewriter, op.getLoc(), attr.getInt());
-    else {
+    } else {
       eventValue = castIntegerLikeTo(op, adaptor.getEventIdDyn(),
                                      rewriter.getI64Type());
-      if (!eventValue)
+      if (!eventValue) {
         return rewriter.notifyMatchFailure(op, "missing event-id operand");
+      }
     }
     StringRef callee = buildSyncCallee<SyncOp>(op.getContext());
     auto fnTy = rewriter.getFunctionType(
@@ -11283,7 +11285,9 @@ public:
     SmallVector<Value> args{pipeValue, eventValue};
     if constexpr (std::is_same_v<SyncOp, pto::SyncSetOp>) {
       int64_t mode = 2;
-      if (IntegerAttr attr = op.getFftsModeAttr()) mode = attr.getInt();
+      if (IntegerAttr attr = op.getFftsModeAttr()) {
+        mode = attr.getInt();
+      }
       Value modeValue = getI64Constant(rewriter, op.getLoc(), mode);
       Value one = getI64Constant(rewriter, op.getLoc(), 1);
       Value modeMask = getI64Constant(rewriter, op.getLoc(), 0x3);

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -5329,11 +5329,21 @@ StringRef buildSyncCallee<pto::BarrierOp>(MLIRContext *context) {
 
 template <>
 StringRef buildSyncCallee<pto::SyncSetOp>(MLIRContext *context) {
-  return StringAttr::get(context, "llvm.hivm.SET.INTRA.BLOCK.mode").getValue();
+  return StringAttr::get(context, "llvm.hivm.SET.CROSS.CORE").getValue();
 }
 
 template <>
 StringRef buildSyncCallee<pto::SyncWaitOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.WAIT.FLAG.DEV.REG").getValue();
+}
+
+template <>
+StringRef buildSyncCallee<pto::SetIntraBlockOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.SET.INTRA.BLOCK.mode").getValue();
+}
+
+template <>
+StringRef buildSyncCallee<pto::WaitIntraBlockOp>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.WAIT.INTRA.BLOCK.mode").getValue();
 }
 
@@ -11132,6 +11142,41 @@ private:
 };
 
 template <typename SyncOp>
+class LowerNamedSyncOpPattern final : public OpConversionPattern<SyncOp> {
+public:
+  explicit LowerNamedSyncOpPattern(TypeConverter &tc, MLIRContext *ctx,
+                                   LoweringState &state)
+      : OpConversionPattern<SyncOp>(tc, ctx), state(state) {}
+  LogicalResult matchAndRewrite(
+      SyncOp op, typename SyncOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto pipe = parsePipeImmediate(stringifyPIPE(op.getPipe().getPipe()));
+    if (!pipe)
+      return rewriter.notifyMatchFailure(op, "unsupported sync pipe");
+    Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipe);
+    Value eventValue;
+    if (IntegerAttr attr = op.getEventIdAttr())
+      eventValue = getI64Constant(rewriter, op.getLoc(), attr.getInt());
+    else {
+      eventValue = castIntegerLikeTo(op, adaptor.getEventIdDyn(),
+                                     rewriter.getI64Type());
+      if (!eventValue)
+        return rewriter.notifyMatchFailure(op, "missing event-id operand");
+    }
+    StringRef callee = buildSyncCallee<SyncOp>(op.getContext());
+    auto fnTy = rewriter.getFunctionType(
+        TypeRange{rewriter.getI64Type(), rewriter.getI64Type()}, TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), callee, TypeRange{},
+                                  ValueRange{pipeValue, eventValue});
+    state.plannedDecls.push_back(PlannedDecl{callee.str(), fnTy});
+    rewriter.eraseOp(op);
+    return success();
+  }
+private:
+  LoweringState &state;
+};
+
+template <typename SyncOp>
 class LowerPipeEventDynSyncOpPattern final : public OpConversionPattern<SyncOp> {
 public:
   explicit LowerPipeEventDynSyncOpPattern(TypeConverter &typeConverter,
@@ -11235,10 +11280,37 @@ public:
     }
 
     StringRef calleeName = buildSyncCallee<SyncOp>(op.getContext());
+    SmallVector<Value> args{pipeValue, eventValue};
+    if constexpr (std::is_same_v<SyncOp, pto::SyncSetOp>) {
+      int64_t mode = 2;
+      if (IntegerAttr attr = op.getFftsModeAttr()) mode = attr.getInt();
+      Value modeValue = getI64Constant(rewriter, op.getLoc(), mode);
+      Value one = getI64Constant(rewriter, op.getLoc(), 1);
+      Value modeMask = getI64Constant(rewriter, op.getLoc(), 0x3);
+      Value eventMask = getI64Constant(rewriter, op.getLoc(), 0xf);
+      modeValue = rewriter.create<arith::AndIOp>(op.getLoc(), modeValue,
+                                                  modeMask);
+      eventValue = rewriter.create<arith::AndIOp>(op.getLoc(), eventValue,
+                                                   eventMask);
+      Value modeShift = rewriter.create<arith::ShLIOp>(op.getLoc(), modeValue,
+          getI64Constant(rewriter, op.getLoc(), 4));
+      Value eventShift = rewriter.create<arith::ShLIOp>(op.getLoc(), eventValue,
+          getI64Constant(rewriter, op.getLoc(), 8));
+      Value msg = rewriter.create<arith::OrIOp>(op.getLoc(), one, modeShift);
+      msg = rewriter.create<arith::OrIOp>(op.getLoc(), msg, eventShift);
+      args = {pipeValue, msg};
+    } else if constexpr (std::is_same_v<SyncOp, pto::SyncWaitOp>) {
+      calleeName = op.getEventIdAttr()
+                       ? StringAttr::get(op.getContext(),
+                                         "llvm.hivm.WAIT.FLAG.DEV.PIPE.IMM")
+                             .getValue()
+                       : StringAttr::get(op.getContext(),
+                                         "llvm.hivm.WAIT.FLAG.DEV.PIPE.REG")
+                             .getValue();
+    }
     auto funcType = rewriter.getFunctionType(
-        TypeRange{rewriter.getI64Type(), rewriter.getI64Type()}, TypeRange{});
-    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{},
-                                  ValueRange{pipeValue, eventValue});
+        TypeRange{args[0].getType(), args[1].getType()}, TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{}, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
     rewriter.eraseOp(op);
     return success();
@@ -13294,6 +13366,8 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerPstuOpPattern, LowerVstusOpPattern, LowerVsturOpPattern,
                LowerInterCoreSyncOpPattern<pto::SyncSetOp>,
                LowerInterCoreSyncOpPattern<pto::SyncWaitOp>,
+               LowerNamedSyncOpPattern<pto::SetIntraBlockOp>,
+               LowerNamedSyncOpPattern<pto::WaitIntraBlockOp>,
                LowerCopyGmToCbufOpPattern, LowerLoadCbufToCaOpPattern,
                LowerLoadCbufToCbOpPattern,
                LowerLoadCbufToS4OpPattern<pto::LoadCbufToCaS4Op>,
@@ -13393,7 +13467,8 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                !hasVPTOConvertibleType(op->getResultTypes());
       });
   target.addIllegalOp<pto::SetFlagOp, pto::WaitFlagOp, pto::SetFlagDynOp, pto::WaitFlagDynOp, pto::SyncSetOp,
-                      pto::SyncWaitOp, pto::BarrierOp, pto::MemBarOp,
+                      pto::SyncWaitOp, pto::SetIntraBlockOp, pto::WaitIntraBlockOp,
+                      pto::BarrierOp, pto::MemBarOp,
                       pto::CmoCacheInvalidOp, pto::FenceBarrierAllOp,
                       pto::DsbOp, pto::DcciOp,
                       pto::GetBufOp, pto::RlsBufOp,

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -4352,11 +4352,21 @@ StringRef buildSyncCallee<pto::BarrierOp>(MLIRContext *context) {
 
 template <>
 StringRef buildSyncCallee<pto::SyncSetOp>(MLIRContext *context) {
-  return StringAttr::get(context, "llvm.hivm.SET.INTRA.BLOCK.mode").getValue();
+  return StringAttr::get(context, "llvm.hivm.SET.CROSS.CORE").getValue();
 }
 
 template <>
 StringRef buildSyncCallee<pto::SyncWaitOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.WAIT.FLAG.DEV.REG").getValue();
+}
+
+template <>
+StringRef buildSyncCallee<pto::SetIntraBlockOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.SET.INTRA.BLOCK.mode").getValue();
+}
+
+template <>
+StringRef buildSyncCallee<pto::WaitIntraBlockOp>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.WAIT.INTRA.BLOCK.mode").getValue();
 }
 
@@ -9558,6 +9568,41 @@ private:
 };
 
 template <typename SyncOp>
+class LowerNamedSyncOpPattern final : public OpConversionPattern<SyncOp> {
+public:
+  explicit LowerNamedSyncOpPattern(TypeConverter &tc, MLIRContext *ctx,
+                                   LoweringState &state)
+      : OpConversionPattern<SyncOp>(tc, ctx), state(state) {}
+  LogicalResult matchAndRewrite(
+      SyncOp op, typename SyncOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto pipe = parsePipeImmediate(stringifyPIPE(op.getPipe().getPipe()));
+    if (!pipe)
+      return rewriter.notifyMatchFailure(op, "unsupported sync pipe");
+    Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipe);
+    Value eventValue;
+    if (IntegerAttr attr = op.getEventIdAttr())
+      eventValue = getI64Constant(rewriter, op.getLoc(), attr.getInt());
+    else {
+      eventValue = castIntegerLikeTo(op, adaptor.getEventIdDyn(),
+                                     rewriter.getI64Type());
+      if (!eventValue)
+        return rewriter.notifyMatchFailure(op, "missing event-id operand");
+    }
+    StringRef callee = buildSyncCallee<SyncOp>(op.getContext());
+    auto fnTy = rewriter.getFunctionType(
+        TypeRange{rewriter.getI64Type(), rewriter.getI64Type()}, TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), callee, TypeRange{},
+                                  ValueRange{pipeValue, eventValue});
+    state.plannedDecls.push_back(PlannedDecl{callee.str(), fnTy});
+    rewriter.eraseOp(op);
+    return success();
+  }
+private:
+  LoweringState &state;
+};
+
+template <typename SyncOp>
 class LowerPipeEventDynSyncOpPattern final : public OpConversionPattern<SyncOp> {
 public:
   explicit LowerPipeEventDynSyncOpPattern(TypeConverter &typeConverter,
@@ -9652,10 +9697,37 @@ public:
     }
 
     StringRef calleeName = buildSyncCallee<SyncOp>(op.getContext());
+    SmallVector<Value> args{pipeValue, eventValue};
+    if constexpr (std::is_same_v<SyncOp, pto::SyncSetOp>) {
+      int64_t mode = 2;
+      if (IntegerAttr attr = op.getFftsModeAttr()) mode = attr.getInt();
+      Value modeValue = getI64Constant(rewriter, op.getLoc(), mode);
+      Value one = getI64Constant(rewriter, op.getLoc(), 1);
+      Value modeMask = getI64Constant(rewriter, op.getLoc(), 0x3);
+      Value eventMask = getI64Constant(rewriter, op.getLoc(), 0xf);
+      modeValue = rewriter.create<arith::AndIOp>(op.getLoc(), modeValue,
+                                                  modeMask);
+      eventValue = rewriter.create<arith::AndIOp>(op.getLoc(), eventValue,
+                                                   eventMask);
+      Value modeShift = rewriter.create<arith::ShLIOp>(op.getLoc(), modeValue,
+          getI64Constant(rewriter, op.getLoc(), 4));
+      Value eventShift = rewriter.create<arith::ShLIOp>(op.getLoc(), eventValue,
+          getI64Constant(rewriter, op.getLoc(), 8));
+      Value msg = rewriter.create<arith::OrIOp>(op.getLoc(), one, modeShift);
+      msg = rewriter.create<arith::OrIOp>(op.getLoc(), msg, eventShift);
+      args = {pipeValue, msg};
+    } else if constexpr (std::is_same_v<SyncOp, pto::SyncWaitOp>) {
+      calleeName = op.getEventIdAttr()
+                       ? StringAttr::get(op.getContext(),
+                                         "llvm.hivm.WAIT.FLAG.DEV.PIPE.IMM")
+                             .getValue()
+                       : StringAttr::get(op.getContext(),
+                                         "llvm.hivm.WAIT.FLAG.DEV.PIPE.REG")
+                             .getValue();
+    }
     auto funcType = rewriter.getFunctionType(
-        TypeRange{rewriter.getI64Type(), rewriter.getI64Type()}, TypeRange{});
-    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{},
-                                  ValueRange{pipeValue, eventValue});
+        TypeRange{args[0].getType(), args[1].getType()}, TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{}, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
     rewriter.eraseOp(op);
     return success();
@@ -11539,6 +11611,8 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerPstuOpPattern, LowerVstusOpPattern, LowerVsturOpPattern,
                LowerInterCoreSyncOpPattern<pto::SyncSetOp>,
                LowerInterCoreSyncOpPattern<pto::SyncWaitOp>,
+               LowerNamedSyncOpPattern<pto::SetIntraBlockOp>,
+               LowerNamedSyncOpPattern<pto::WaitIntraBlockOp>,
                LowerCopyGmToCbufOpPattern, LowerLoadCbufToCaOpPattern,
                LowerLoadCbufToCbOpPattern,
                LowerLoadCbufToS4OpPattern<pto::LoadCbufToCaS4Op>,
@@ -11637,7 +11711,8 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                !hasVPTOConvertibleType(op->getResultTypes());
       });
   target.addIllegalOp<pto::SetFlagOp, pto::WaitFlagOp, pto::SetFlagDynOp, pto::WaitFlagDynOp, pto::SyncSetOp,
-                      pto::SyncWaitOp, pto::BarrierOp, pto::MemBarOp,
+                      pto::SyncWaitOp, pto::SetIntraBlockOp, pto::WaitIntraBlockOp,
+                      pto::BarrierOp, pto::MemBarOp,
                       pto::CmoCacheInvalidOp, pto::FenceBarrierAllOp,
                       pto::DsbOp, pto::DcciOp,
                       pto::GetBufOp, pto::RlsBufOp,

--- a/ptodsl/docs/user_guide/10-sync-ops.md
+++ b/ptodsl/docs/user_guide/10-sync-ops.md
@@ -361,13 +361,13 @@ These are core-level (SU) operations — `wait_cross_block` stalls the entire co
 
 #### `pto.set_cross_block(pipe, event_id)`
 
-**Description**: Signal an FFTS cross-block event on a synchronization endpoint. The DSL lowers to `pto.set_cross_block`, which is normalized to `pto.sync.set` with `ffts_mode = 0` for the VPTO path.
+**Description**: Signal a cross-block event on a synchronization endpoint.
 
 **Parameters**:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `pipe` | `Pipe` | Producing endpoint for the synchronization event. The public DSL accepts `Pipe.FIX` here. |
+| `pipe` | `Pipe` | Producing endpoint: `Pipe.FIX`, `Pipe.MTE1`, `Pipe.MTE2`, `Pipe.MTE3`, or `Pipe.V`. |
 | `event_id` | `int` | Cross-core event identifier (`0`–`15`) |
 
 **Returns**: None (side-effect operation).
@@ -382,13 +382,13 @@ pto.set_cross_block(pto.Pipe.FIX, 0)
 
 #### `pto.wait_cross_block(pipe, event_id)`
 
-**Description**: Wait for an FFTS cross-block event. The DSL lowers to `pto.wait_cross_block`, which is normalized to `pto.sync.wait` with `ffts_mode = 0` for the VPTO path.
+**Description**: Wait for a cross-block event.
 
 **Parameters**:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `pipe` | `Pipe` | Waiting endpoint for the synchronization event. The public DSL accepts `Pipe.FIX` here. |
+| `pipe` | `Pipe` | Waiting endpoint: `Pipe.FIX`, `Pipe.MTE1`, `Pipe.MTE2`, `Pipe.MTE3`, or `Pipe.V`. |
 | `event_id` | `int` | Event identifier to wait on (`0`–`15`) |
 
 **Returns**: None (side-effect operation).
@@ -405,8 +405,8 @@ pto.wait_cross_block(pto.Pipe.FIX, 0)
 
 The intra-block sync channel is separate from the standard pipe-flag mechanism used by cross-core sync. `set_intra_block` and `wait_intra_block` synchronize the relevant producer/consumer pipes within the same block, ensuring that shared UB tile data is not accessed before the producer finishes.
 
-Cross-core flags use the public `0`-`7` event range. A5 intra-block sync uses a separate
-physical event range, described below.
+Cross-block event IDs use the public `0`-`15` range. Static intra-block event IDs use
+`0`-`31` on A5 and `0`-`15` on A2 and A3.
 
 Unlike `wait_cross_block`, `wait_intra_block` only stalls the specified pipeline — the SU and other pipelines continue executing.
 

--- a/ptodsl/docs/user_guide/10-sync-ops.md
+++ b/ptodsl/docs/user_guide/10-sync-ops.md
@@ -353,22 +353,22 @@ def flash_attention_block(
 
 Section 10.2 covers the general pipe-to-pipe sync mechanism (`set_flag`/`wait_flag`). This section covers two additional sync domains that the pipe-flag mechanism does not address: **cross-core** communication between separate NPU cores, and **intra-block** synchronization between the Cube and Vector units within a block.
 
-### 10.5.1 Cross-core sync: `set_cross_flag`, `wait_cross_flag`
+### 10.5.1 Cross-core sync: `set_cross_block`, `wait_cross_block`
 
-When a kernel spans multiple cores, cores need to coordinate through shared resources. `set_cross_flag` sends a signal to another core; `wait_cross_flag` blocks the calling core until the expected signal arrives.
+When a kernel spans multiple cores, cores need to coordinate through shared resources. `set_cross_block` sends a signal to another core; `wait_cross_block` blocks the calling core until the expected signal arrives.
 
-These are core-level (SU) operations — `wait_cross_flag` stalls the entire core, not just a single pipeline. Use them sparingly: splitting work so that each core operates independently for as long as possible minimises cross-core sync overhead.
+These are core-level (SU) operations — `wait_cross_block` stalls the entire core, not just a single pipeline. Use them sparingly: splitting work so that each core operates independently for as long as possible minimises cross-core sync overhead.
 
-#### `pto.set_cross_flag(pipe, event_id)`
+#### `pto.set_cross_block(pipe, event_id)`
 
-**Description**: Signal an event on a synchronization endpoint. In the current PTODSL surface this is authored with a `Pipe`; the backend maps it to the architecture-specific cross-core / intra-block builtin during lowering.
+**Description**: Signal an FFTS cross-block event on a synchronization endpoint. The DSL lowers to `pto.set_cross_block`, which is normalized to `pto.sync.set` with `ffts_mode = 0` for the VPTO path.
 
 **Parameters**:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `pipe` | `Pipe` | Producing endpoint for the synchronization event. The public DSL accepts `Pipe.FIX` here. |
-| `event_id` | `int` | Cross-core event identifier (`0`–`7`) |
+| `event_id` | `int` | Cross-core event identifier (`0`–`15`) |
 
 **Returns**: None (side-effect operation).
 
@@ -377,19 +377,19 @@ These are core-level (SU) operations — `wait_cross_flag` stalls the entire cor
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"sync_ops.basic","symbol":"sync_ops_basic_probe","compile":{}} -->
 ```python
 # Signal from the FIX/Cube-side endpoint
-pto.set_cross_flag(pto.Pipe.FIX, 0)
+pto.set_cross_block(pto.Pipe.FIX, 0)
 ```
 
-#### `pto.wait_cross_flag(pipe, event_id)`
+#### `pto.wait_cross_block(pipe, event_id)`
 
-**Description**: Wait for an event on a synchronization endpoint. On architectures that lower this surface to the backend `sync.wait` primitive, the wait is core-level (SU) blocking.
+**Description**: Wait for an FFTS cross-block event. The DSL lowers to `pto.wait_cross_block`, which is normalized to `pto.sync.wait` with `ffts_mode = 0` for the VPTO path.
 
 **Parameters**:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `pipe` | `Pipe` | Waiting endpoint for the synchronization event. The public DSL accepts `Pipe.FIX` here. |
-| `event_id` | `int` | Event identifier to wait on (`0`–`7`) |
+| `event_id` | `int` | Event identifier to wait on (`0`–`15`) |
 
 **Returns**: None (side-effect operation).
 
@@ -398,19 +398,19 @@ pto.set_cross_flag(pto.Pipe.FIX, 0)
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"sync_ops.basic","symbol":"sync_ops_basic_probe","compile":{}} -->
 ```python
 # Wait on the FIX/Cube-side endpoint
-pto.wait_cross_flag(pto.Pipe.FIX, 0)
+pto.wait_cross_block(pto.Pipe.FIX, 0)
 ```
 
-### 10.5.2 Intra-block sync: `set_intra_flag`, `wait_intra_flag`
+### 10.5.2 Intra-block sync: `set_intra_block`, `wait_intra_block`
 
-The intra-block sync channel is separate from the standard pipe-flag mechanism used by cross-core sync. `set_intra_flag` and `wait_intra_flag` synchronize the relevant producer/consumer pipes within the same block, ensuring that shared UB tile data is not accessed before the producer finishes.
+The intra-block sync channel is separate from the standard pipe-flag mechanism used by cross-core sync. `set_intra_block` and `wait_intra_block` synchronize the relevant producer/consumer pipes within the same block, ensuring that shared UB tile data is not accessed before the producer finishes.
 
 Cross-core flags use the public `0`-`7` event range. A5 intra-block sync uses a separate
 physical event range, described below.
 
-Unlike `wait_cross_flag`, `wait_intra_flag` only stalls the specified pipeline — the SU and other pipelines continue executing.
+Unlike `wait_cross_block`, `wait_intra_block` only stalls the specified pipeline — the SU and other pipelines continue executing.
 
-#### `pto.set_intra_flag(pipe, event_id)`
+#### `pto.set_intra_block(pipe, event_id)`
 
 **Description**: Signal a synchronization event within a block. The current PTODSL surface authors the trigger endpoint explicitly as a `Pipe`.
 
@@ -431,10 +431,10 @@ explicitly: one for the base event ID and one for `base_id + 16`.
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"sync_ops.basic","symbol":"sync_ops_basic_probe","compile":{}} -->
 ```python
 # Signal event ID0 from the MTE3-side endpoint.
-pto.set_intra_flag(pto.Pipe.MTE3, 0)
+pto.set_intra_block(pto.Pipe.MTE3, 0)
 ```
 
-#### `pto.wait_intra_flag(pipe, event_id)`
+#### `pto.wait_intra_block(pipe, event_id)`
 
 **Description**: Wait for an intra-block event. Only the specified pipeline stalls — the SU and other pipelines continue executing independently.
 
@@ -456,7 +456,7 @@ the base event ID and `base_id + 16`.
 ```python
 # MTE3 waits for the Cube-to-UB handoff for each AIV subblock.
 with pto.for_(0, 2, step=1) as sid:
-    pto.wait_intra_flag(pto.Pipe.MTE3, sid * 16 + 6)
+    pto.wait_intra_block(pto.Pipe.MTE3, sid * 16 + 6)
 ```
 
 ## 10.6 Synchronization in the authoring model
@@ -488,7 +488,7 @@ In auto mode, users can still write sync operations directly — `set_flag`/`wai
 | Full pipeline sync point | `pipe_barrier(Pipe.ALL)` |
 | Double-buffer handoff (compute → DMA) | `rls_buf(V, id)` + `get_buf(MTE2, id)` |
 | Double-buffer handoff (DMA → compute) | `rls_buf(MTE2, id)` + `get_buf(V, id)` |
-| Core A notifies core B | `set_cross_flag(B, id)` + `wait_cross_flag(A, id)` |
+| Core A notifies core B | `set_cross_block(B, id)` + `wait_cross_block(A, id)` |
 
 ## 10.7 Device-side trap
 

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -6710,7 +6710,7 @@ def _flag_event_id_operand(event_id, *, context: str):
     return _coerce_index(event_id, context=context), False
 
 
-def set_cross_block(pipe, event_id, *, ffts_mode=0):
+def set_cross_block(pipe, event_id):
     """``pto.set_cross_block(pipe, event_id)`` – emits ``pto.set_cross_block``."""
     _validate_sync_pipe(
         pipe,
@@ -6720,7 +6720,7 @@ def set_cross_block(pipe, event_id, *, ffts_mode=0):
     event_operand = _sync_event_id_operand_in_range(
         event_id, context="set_cross_block(..., event_id=...)", lo=0, hi=15
     )
-    _pto.set_cross_block(_pipe_attr(pipe), event_operand, ffts_mode=ffts_mode)
+    _pto.set_cross_block(_pipe_attr(pipe), event_operand)
 
 
 def wait_cross_block(pipe, event_id):

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -6710,52 +6710,64 @@ def _flag_event_id_operand(event_id, *, context: str):
     return _coerce_index(event_id, context=context), False
 
 
-def set_cross_flag(pipe, event_id):
-    """``pto.set_cross_flag(pipe, event_id)`` – cross-core sync facade for ``pto.sync.set``."""
-    _validate_sync_pipe(pipe, context="set_cross_flag(pipe, event_id)", allowed=("PIPE_FIX",))
-    event_operand = _sync_event_id_operand(event_id, context="set_cross_flag(..., event_id=...)")
-    _pto.sync_set(_pipe_attr(pipe), event_operand)
-
-
-def wait_cross_flag(pipe, event_id):
-    """``pto.wait_cross_flag(pipe, event_id)`` – cross-core sync facade for ``pto.sync.wait``."""
-    _validate_sync_pipe(pipe, context="wait_cross_flag(pipe, event_id)", allowed=("PIPE_FIX",))
-    event_operand = _sync_event_id_operand(event_id, context="wait_cross_flag(..., event_id=...)")
-    _pto.sync_wait(_pipe_attr(pipe), event_operand)
-
-
-def set_intra_flag(pipe, event_id):
-    """``pto.set_intra_flag(pipe, event_id)`` – intra-block sync facade for ``pto.sync.set``."""
+def set_cross_block(pipe, event_id, *, ffts_mode=0):
+    """``pto.set_cross_block(pipe, event_id)`` – emits ``pto.set_cross_block``."""
     _validate_sync_pipe(
         pipe,
-        context="set_intra_flag(pipe, event_id)",
+        context="set_cross_block(pipe, event_id)",
+        allowed=("PIPE_FIX", "PIPE_MTE1", "PIPE_MTE2", "PIPE_MTE3", "PIPE_V"),
+    )
+    event_operand = _sync_event_id_operand_in_range(
+        event_id, context="set_cross_block(..., event_id=...)", lo=0, hi=15
+    )
+    _pto.set_cross_block(_pipe_attr(pipe), event_operand, ffts_mode=ffts_mode)
+
+
+def wait_cross_block(pipe, event_id):
+    """``pto.wait_cross_block(pipe, event_id)`` – emits ``pto.wait_cross_block``."""
+    _validate_sync_pipe(
+        pipe,
+        context="wait_cross_block(pipe, event_id)",
+        allowed=("PIPE_FIX", "PIPE_MTE1", "PIPE_MTE2", "PIPE_MTE3", "PIPE_V"),
+    )
+    event_operand = _sync_event_id_operand_in_range(
+        event_id, context="wait_cross_block(..., event_id=...)", lo=0, hi=15
+    )
+    _pto.wait_cross_block(_pipe_attr(pipe), event_operand)
+
+
+def set_intra_block(pipe, event_id):
+    """``pto.set_intra_block(pipe, event_id)`` – emits ``pto.set_intra_block``."""
+    _validate_sync_pipe(
+        pipe,
+        context="set_intra_block(pipe, event_id)",
         allowed=("PIPE_FIX", "PIPE_MTE1", "PIPE_MTE2", "PIPE_MTE3", "PIPE_V"),
     )
     event_operand = _sync_event_id_operand_in_range(
         event_id,
-        context="set_intra_flag(..., event_id=...)",
+        context="set_intra_block(..., event_id=...)",
         lo=0,
         hi=31,
         meaning="physical event_id",
     )
-    _pto.sync_set(_pipe_attr(pipe), event_operand)
+    _pto.set_intra_block(_pipe_attr(pipe), event_operand)
 
 
-def wait_intra_flag(pipe, event_id):
-    """``pto.wait_intra_flag(pipe, event_id)`` – intra-block sync facade for ``pto.sync.wait``."""
+def wait_intra_block(pipe, event_id):
+    """``pto.wait_intra_block(pipe, event_id)`` – emits ``pto.wait_intra_block``."""
     _validate_sync_pipe(
         pipe,
-        context="wait_intra_flag(pipe, event_id)",
+        context="wait_intra_block(pipe, event_id)",
         allowed=("PIPE_FIX", "PIPE_MTE1", "PIPE_MTE2", "PIPE_MTE3", "PIPE_V"),
     )
     event_operand = _sync_event_id_operand_in_range(
         event_id,
-        context="wait_intra_flag(..., event_id=...)",
+        context="wait_intra_block(..., event_id=...)",
         lo=0,
         hi=31,
         meaning="physical event_id",
     )
-    _pto.sync_wait(_pipe_attr(pipe), event_operand)
+    _pto.wait_intra_block(_pipe_attr(pipe), event_operand)
 
 
 def set_flag(src: str, dst: str, *, event_id: int = 0):
@@ -6904,7 +6916,7 @@ __all__ = [
     "fmin", "fmax", "fma", "convert",
     "syncthreads", "threadfence", "threadfence_block", "trap", "keep", "resume",
     "pipe_barrier", "get_buf", "rls_buf",
-    "set_cross_flag", "wait_cross_flag", "set_intra_flag", "wait_intra_flag",
+    "set_cross_block", "wait_cross_block", "set_intra_block", "wait_intra_block",
     "set_flag", "wait_flag",
     "reserve_buffer", "import_reserved_buffer",
 ]

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -6592,52 +6592,64 @@ def _flag_event_id_operand(event_id, *, context: str):
     return _coerce_index(event_id, context=context), False
 
 
-def set_cross_flag(pipe, event_id):
-    """``pto.set_cross_flag(pipe, event_id)`` – cross-core sync facade for ``pto.sync.set``."""
-    _validate_sync_pipe(pipe, context="set_cross_flag(pipe, event_id)", allowed=("PIPE_FIX",))
-    event_operand = _sync_event_id_operand(event_id, context="set_cross_flag(..., event_id=...)")
-    _pto.sync_set(_pipe_attr(pipe), event_operand)
-
-
-def wait_cross_flag(pipe, event_id):
-    """``pto.wait_cross_flag(pipe, event_id)`` – cross-core sync facade for ``pto.sync.wait``."""
-    _validate_sync_pipe(pipe, context="wait_cross_flag(pipe, event_id)", allowed=("PIPE_FIX",))
-    event_operand = _sync_event_id_operand(event_id, context="wait_cross_flag(..., event_id=...)")
-    _pto.sync_wait(_pipe_attr(pipe), event_operand)
-
-
-def set_intra_flag(pipe, event_id):
-    """``pto.set_intra_flag(pipe, event_id)`` – intra-block sync facade for ``pto.sync.set``."""
+def set_cross_block(pipe, event_id, *, ffts_mode=0):
+    """``pto.set_cross_block(pipe, event_id)`` – emits ``pto.set_cross_block``."""
     _validate_sync_pipe(
         pipe,
-        context="set_intra_flag(pipe, event_id)",
+        context="set_cross_block(pipe, event_id)",
+        allowed=("PIPE_FIX", "PIPE_MTE1", "PIPE_MTE2", "PIPE_MTE3", "PIPE_V"),
+    )
+    event_operand = _sync_event_id_operand_in_range(
+        event_id, context="set_cross_block(..., event_id=...)", lo=0, hi=15
+    )
+    _pto.set_cross_block(_pipe_attr(pipe), event_operand, ffts_mode=ffts_mode)
+
+
+def wait_cross_block(pipe, event_id):
+    """``pto.wait_cross_block(pipe, event_id)`` – emits ``pto.wait_cross_block``."""
+    _validate_sync_pipe(
+        pipe,
+        context="wait_cross_block(pipe, event_id)",
+        allowed=("PIPE_FIX", "PIPE_MTE1", "PIPE_MTE2", "PIPE_MTE3", "PIPE_V"),
+    )
+    event_operand = _sync_event_id_operand_in_range(
+        event_id, context="wait_cross_block(..., event_id=...)", lo=0, hi=15
+    )
+    _pto.wait_cross_block(_pipe_attr(pipe), event_operand)
+
+
+def set_intra_block(pipe, event_id):
+    """``pto.set_intra_block(pipe, event_id)`` – emits ``pto.set_intra_block``."""
+    _validate_sync_pipe(
+        pipe,
+        context="set_intra_block(pipe, event_id)",
         allowed=("PIPE_FIX", "PIPE_MTE1", "PIPE_MTE2", "PIPE_MTE3", "PIPE_V"),
     )
     event_operand = _sync_event_id_operand_in_range(
         event_id,
-        context="set_intra_flag(..., event_id=...)",
+        context="set_intra_block(..., event_id=...)",
         lo=0,
         hi=31,
         meaning="physical event_id",
     )
-    _pto.sync_set(_pipe_attr(pipe), event_operand)
+    _pto.set_intra_block(_pipe_attr(pipe), event_operand)
 
 
-def wait_intra_flag(pipe, event_id):
-    """``pto.wait_intra_flag(pipe, event_id)`` – intra-block sync facade for ``pto.sync.wait``."""
+def wait_intra_block(pipe, event_id):
+    """``pto.wait_intra_block(pipe, event_id)`` – emits ``pto.wait_intra_block``."""
     _validate_sync_pipe(
         pipe,
-        context="wait_intra_flag(pipe, event_id)",
+        context="wait_intra_block(pipe, event_id)",
         allowed=("PIPE_FIX", "PIPE_MTE1", "PIPE_MTE2", "PIPE_MTE3", "PIPE_V"),
     )
     event_operand = _sync_event_id_operand_in_range(
         event_id,
-        context="wait_intra_flag(..., event_id=...)",
+        context="wait_intra_block(..., event_id=...)",
         lo=0,
         hi=31,
         meaning="physical event_id",
     )
-    _pto.sync_wait(_pipe_attr(pipe), event_operand)
+    _pto.wait_intra_block(_pipe_attr(pipe), event_operand)
 
 
 def set_flag(src: str, dst: str, *, event_id: int = 0):
@@ -6788,7 +6800,7 @@ __all__ = [
     "fmin", "fmax", "fma", "convert",
     "syncthreads", "threadfence", "threadfence_block", "trap", "keep", "resume",
     "pipe_barrier", "get_buf", "rls_buf",
-    "set_cross_flag", "wait_cross_flag", "set_intra_flag", "wait_intra_flag",
+    "set_cross_block", "wait_cross_block", "set_intra_block", "wait_intra_block",
     "set_flag", "wait_flag",
     "reserve_buffer", "import_reserved_buffer",
 ]

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -151,7 +151,7 @@ from ._ops import (             # noqa: F401
     syncthreads, threadfence, threadfence_block, trap, keep, resume,
     pipe_barrier,
     get_buf, rls_buf,
-    set_cross_flag, wait_cross_flag, set_intra_flag, wait_intra_flag,
+    set_cross_block, wait_cross_block, set_intra_block, wait_intra_block,
     set_flag, wait_flag,
     reserve_buffer, import_reserved_buffer,
 )

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -3563,14 +3563,14 @@ def public_sync_surface_probe():
     pto.wait_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=0)
     pto.set_flag(pto.Pipe.V, pto.Pipe.MTE3, event_id=dynamic_event)
     pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE3, event_id=dynamic_event)
-    pto.set_cross_flag(pto.Pipe.FIX, 0)
-    pto.set_intra_flag(pto.Pipe.MTE3, dynamic_event)
-    pto.set_intra_flag(pto.Pipe.FIX, 4)
-    pto.wait_cross_flag(pto.Pipe.FIX, 0)
-    pto.wait_intra_flag(pto.Pipe.V, dynamic_event)
-    pto.wait_intra_flag(pto.Pipe.FIX, 20)
-    pto.wait_intra_flag(pto.Pipe.MTE3, dynamic_event)
-    pto.wait_intra_flag(pto.Pipe.MTE3, 31)
+    pto.set_cross_block(pto.Pipe.FIX, 0)
+    pto.set_intra_block(pto.Pipe.MTE3, dynamic_event)
+    pto.set_intra_block(pto.Pipe.FIX, 4)
+    pto.wait_cross_block(pto.Pipe.FIX, 0)
+    pto.wait_intra_block(pto.Pipe.V, dynamic_event)
+    pto.wait_intra_block(pto.Pipe.FIX, 20)
+    pto.wait_intra_block(pto.Pipe.MTE3, dynamic_event)
+    pto.wait_intra_block(pto.Pipe.MTE3, 31)
 
 
 @pto.jit(target="a5")
@@ -4241,10 +4241,10 @@ def main() -> None:
         "pipe_barrier",
         "get_buf",
         "rls_buf",
-        "set_cross_flag",
-        "wait_cross_flag",
-        "set_intra_flag",
-        "wait_intra_flag",
+        "set_cross_block",
+        "wait_cross_block",
+        "set_intra_block",
+        "wait_intra_block",
         "mte_gm_ub",
         "mte_ub_gm",
         "mte_ub_ub",
@@ -7595,14 +7595,14 @@ def main() -> None:
         ast_runtime_index_bitwise_event_text.count("pto.wait_flag_dyn") == 1,
         "AST rewritten range loop index bitwise event id should lower to pto.wait_flag_dyn",
     )
-    expect("pto.sync.set <PIPE_FIX>, 0" in sync_surface_text, "set_cross_flag(Pipe.FIX, 0) should lower to pto.sync.set")
-    expect("pto.sync.wait <PIPE_FIX>, 0" in sync_surface_text, "wait_cross_flag(Pipe.FIX, 0) should lower to pto.sync.wait")
-    expect("pto.sync.set <PIPE_MTE3>, %c3" in sync_surface_text, "set_intra_flag(Pipe.MTE3, dynamic_event) should lower dynamic event ids through pto.sync.set")
-    expect("pto.sync.set <PIPE_FIX>, 4" in sync_surface_text, "set_intra_flag(Pipe.FIX, 4) should lower physical event ids through pto.sync.set")
-    expect("pto.sync.wait <PIPE_V>, %c3" in sync_surface_text, "wait_intra_flag(Pipe.V, dynamic_event) should lower dynamic event ids through pto.sync.wait")
-    expect("pto.sync.wait <PIPE_FIX>, 20" in sync_surface_text, "wait_intra_flag(Pipe.FIX, 20) should lower physical event ids through pto.sync.wait")
-    expect("pto.sync.wait <PIPE_MTE3>, %c3" in sync_surface_text, "wait_intra_flag(Pipe.MTE3, dynamic_event) should lower dynamic event ids through pto.sync.wait")
-    expect("pto.sync.wait <PIPE_MTE3>, 31" in sync_surface_text, "wait_intra_flag(Pipe.MTE3, 31) should lower the static physical event id through pto.sync.wait")
+    expect("pto.set_cross_block <PIPE_FIX>, 0" in sync_surface_text, "set_cross_block(Pipe.FIX, 0) should lower to pto.set_cross_block")
+    expect("pto.wait_cross_block <PIPE_FIX>, 0" in sync_surface_text, "wait_cross_block(Pipe.FIX, 0) should lower to pto.wait_cross_block")
+    expect("pto.set_intra_block <PIPE_MTE3>, %c3" in sync_surface_text, "set_intra_block(Pipe.MTE3, dynamic_event) should lower to pto.set_intra_block")
+    expect("pto.set_intra_block <PIPE_FIX>, 4" in sync_surface_text, "set_intra_block(Pipe.FIX, 4) should preserve physical event ids")
+    expect("pto.wait_intra_block <PIPE_V>, %c3" in sync_surface_text, "wait_intra_block(Pipe.V, dynamic_event) should lower to pto.wait_intra_block")
+    expect("pto.wait_intra_block <PIPE_FIX>, 20" in sync_surface_text, "wait_intra_block(Pipe.FIX, 20) should preserve physical event ids")
+    expect("pto.wait_intra_block <PIPE_MTE3>, %c3" in sync_surface_text, "wait_intra_block(Pipe.MTE3, dynamic_event) should lower to pto.wait_intra_block")
+    expect("pto.wait_intra_block <PIPE_MTE3>, 31" in sync_surface_text, "wait_intra_block(Pipe.MTE3, 31) should preserve static physical event ids")
     expect(data_movement_surface_text.count("pto.mte_gm_ub") == 2, "public grouped GM->UB wrappers should lower to pto.mte_gm_ub")
     expect("pto.mte_ub_gm" in data_movement_surface_text, "public grouped UB->GM wrapper should lower to pto.mte_ub_gm")
     expect(

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -7590,19 +7590,46 @@ def main() -> None:
         explicit_runtime_index_integer_bitwise_event_text.count("pto.set_flag_dyn") == 1,
         "index/integer bitwise event ids should lower sets to pto.set_flag_dyn",
     )
-    expect("arith.andi" in ast_runtime_index_bitwise_event_text, "AST rewritten range loop index & event id should lower to arith.andi")
+    expect(
+        "arith.andi" in ast_runtime_index_bitwise_event_text,
+        "AST rewritten range loop index & event id should lower to arith.andi",
+    )
     expect(
         ast_runtime_index_bitwise_event_text.count("pto.wait_flag_dyn") == 1,
         "AST rewritten range loop index bitwise event id should lower to pto.wait_flag_dyn",
     )
-    expect("pto.set_cross_block <PIPE_FIX>, 0" in sync_surface_text, "set_cross_block(Pipe.FIX, 0) should lower to pto.set_cross_block")
-    expect("pto.wait_cross_block <PIPE_FIX>, 0" in sync_surface_text, "wait_cross_block(Pipe.FIX, 0) should lower to pto.wait_cross_block")
-    expect("pto.set_intra_block <PIPE_MTE3>, %c3" in sync_surface_text, "set_intra_block(Pipe.MTE3, dynamic_event) should lower to pto.set_intra_block")
-    expect("pto.set_intra_block <PIPE_FIX>, 4" in sync_surface_text, "set_intra_block(Pipe.FIX, 4) should preserve physical event ids")
-    expect("pto.wait_intra_block <PIPE_V>, %c3" in sync_surface_text, "wait_intra_block(Pipe.V, dynamic_event) should lower to pto.wait_intra_block")
-    expect("pto.wait_intra_block <PIPE_FIX>, 20" in sync_surface_text, "wait_intra_block(Pipe.FIX, 20) should preserve physical event ids")
-    expect("pto.wait_intra_block <PIPE_MTE3>, %c3" in sync_surface_text, "wait_intra_block(Pipe.MTE3, dynamic_event) should lower to pto.wait_intra_block")
-    expect("pto.wait_intra_block <PIPE_MTE3>, 31" in sync_surface_text, "wait_intra_block(Pipe.MTE3, 31) should preserve static physical event ids")
+    expect(
+        "pto.set_cross_block <PIPE_FIX>, 0" in sync_surface_text,
+        "set_cross_block(Pipe.FIX, 0) should lower to pto.set_cross_block",
+    )
+    expect(
+        "pto.wait_cross_block <PIPE_FIX>, 0" in sync_surface_text,
+        "wait_cross_block(Pipe.FIX, 0) should lower to pto.wait_cross_block",
+    )
+    expect(
+        "pto.set_intra_block <PIPE_MTE3>, %c3" in sync_surface_text,
+        "set_intra_block(Pipe.MTE3, dynamic_event) should lower to pto.set_intra_block",
+    )
+    expect(
+        "pto.set_intra_block <PIPE_FIX>, 4" in sync_surface_text,
+        "set_intra_block(Pipe.FIX, 4) should preserve physical event ids",
+    )
+    expect(
+        "pto.wait_intra_block <PIPE_V>, %c3" in sync_surface_text,
+        "wait_intra_block(Pipe.V, dynamic_event) should lower to pto.wait_intra_block",
+    )
+    expect(
+        "pto.wait_intra_block <PIPE_FIX>, 20" in sync_surface_text,
+        "wait_intra_block(Pipe.FIX, 20) should preserve physical event ids",
+    )
+    expect(
+        "pto.wait_intra_block <PIPE_MTE3>, %c3" in sync_surface_text,
+        "wait_intra_block(Pipe.MTE3, dynamic_event) should lower to pto.wait_intra_block",
+    )
+    expect(
+        "pto.wait_intra_block <PIPE_MTE3>, 31" in sync_surface_text,
+        "wait_intra_block(Pipe.MTE3, 31) should preserve static physical event ids",
+    )
     expect(data_movement_surface_text.count("pto.mte_gm_ub") == 2, "public grouped GM->UB wrappers should lower to pto.mte_gm_ub")
     expect("pto.mte_ub_gm" in data_movement_surface_text, "public grouped UB->GM wrapper should lower to pto.mte_ub_gm")
     expect(

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -3150,14 +3150,14 @@ def public_sync_surface_probe():
     pto.wait_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=0)
     pto.set_flag(pto.Pipe.V, pto.Pipe.MTE3, event_id=dynamic_event)
     pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE3, event_id=dynamic_event)
-    pto.set_cross_flag(pto.Pipe.FIX, 0)
-    pto.set_intra_flag(pto.Pipe.MTE3, dynamic_event)
-    pto.set_intra_flag(pto.Pipe.FIX, 4)
-    pto.wait_cross_flag(pto.Pipe.FIX, 0)
-    pto.wait_intra_flag(pto.Pipe.V, dynamic_event)
-    pto.wait_intra_flag(pto.Pipe.FIX, 20)
-    pto.wait_intra_flag(pto.Pipe.MTE3, dynamic_event)
-    pto.wait_intra_flag(pto.Pipe.MTE3, 31)
+    pto.set_cross_block(pto.Pipe.FIX, 0)
+    pto.set_intra_block(pto.Pipe.MTE3, dynamic_event)
+    pto.set_intra_block(pto.Pipe.FIX, 4)
+    pto.wait_cross_block(pto.Pipe.FIX, 0)
+    pto.wait_intra_block(pto.Pipe.V, dynamic_event)
+    pto.wait_intra_block(pto.Pipe.FIX, 20)
+    pto.wait_intra_block(pto.Pipe.MTE3, dynamic_event)
+    pto.wait_intra_block(pto.Pipe.MTE3, 31)
 
 
 @pto.jit(target="a5")
@@ -3799,10 +3799,10 @@ def main() -> None:
         "pipe_barrier",
         "get_buf",
         "rls_buf",
-        "set_cross_flag",
-        "wait_cross_flag",
-        "set_intra_flag",
-        "wait_intra_flag",
+        "set_cross_block",
+        "wait_cross_block",
+        "set_intra_block",
+        "wait_intra_block",
         "mte_gm_ub",
         "mte_ub_gm",
         "mte_ub_ub",
@@ -6800,14 +6800,14 @@ def main() -> None:
         ast_runtime_index_bitwise_event_text.count("pto.wait_flag_dyn") == 1,
         "AST rewritten range loop index bitwise event id should lower to pto.wait_flag_dyn",
     )
-    expect("pto.sync.set <PIPE_FIX>, 0" in sync_surface_text, "set_cross_flag(Pipe.FIX, 0) should lower to pto.sync.set")
-    expect("pto.sync.wait <PIPE_FIX>, 0" in sync_surface_text, "wait_cross_flag(Pipe.FIX, 0) should lower to pto.sync.wait")
-    expect("pto.sync.set <PIPE_MTE3>, %c3" in sync_surface_text, "set_intra_flag(Pipe.MTE3, dynamic_event) should lower dynamic event ids through pto.sync.set")
-    expect("pto.sync.set <PIPE_FIX>, 4" in sync_surface_text, "set_intra_flag(Pipe.FIX, 4) should lower physical event ids through pto.sync.set")
-    expect("pto.sync.wait <PIPE_V>, %c3" in sync_surface_text, "wait_intra_flag(Pipe.V, dynamic_event) should lower dynamic event ids through pto.sync.wait")
-    expect("pto.sync.wait <PIPE_FIX>, 20" in sync_surface_text, "wait_intra_flag(Pipe.FIX, 20) should lower physical event ids through pto.sync.wait")
-    expect("pto.sync.wait <PIPE_MTE3>, %c3" in sync_surface_text, "wait_intra_flag(Pipe.MTE3, dynamic_event) should lower dynamic event ids through pto.sync.wait")
-    expect("pto.sync.wait <PIPE_MTE3>, 31" in sync_surface_text, "wait_intra_flag(Pipe.MTE3, 31) should lower the static physical event id through pto.sync.wait")
+    expect("pto.set_cross_block <PIPE_FIX>, 0" in sync_surface_text, "set_cross_block(Pipe.FIX, 0) should lower to pto.set_cross_block")
+    expect("pto.wait_cross_block <PIPE_FIX>, 0" in sync_surface_text, "wait_cross_block(Pipe.FIX, 0) should lower to pto.wait_cross_block")
+    expect("pto.set_intra_block <PIPE_MTE3>, %c3" in sync_surface_text, "set_intra_block(Pipe.MTE3, dynamic_event) should lower to pto.set_intra_block")
+    expect("pto.set_intra_block <PIPE_FIX>, 4" in sync_surface_text, "set_intra_block(Pipe.FIX, 4) should preserve physical event ids")
+    expect("pto.wait_intra_block <PIPE_V>, %c3" in sync_surface_text, "wait_intra_block(Pipe.V, dynamic_event) should lower to pto.wait_intra_block")
+    expect("pto.wait_intra_block <PIPE_FIX>, 20" in sync_surface_text, "wait_intra_block(Pipe.FIX, 20) should preserve physical event ids")
+    expect("pto.wait_intra_block <PIPE_MTE3>, %c3" in sync_surface_text, "wait_intra_block(Pipe.MTE3, dynamic_event) should lower to pto.wait_intra_block")
+    expect("pto.wait_intra_block <PIPE_MTE3>, 31" in sync_surface_text, "wait_intra_block(Pipe.MTE3, 31) should preserve static physical event ids")
     expect(data_movement_surface_text.count("pto.mte_gm_ub") == 2, "public grouped GM->UB wrappers should lower to pto.mte_gm_ub")
     expect("pto.mte_ub_gm" in data_movement_surface_text, "public grouped UB->GM wrapper should lower to pto.mte_ub_gm")
     expect(

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -1302,10 +1302,34 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
     def test_sync_facades_reject_illegal_pipe_endpoints(self):
         cases = [
-            (_ops.set_cross_block, ("M", 0), "set_cross_block(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
-            (_ops.wait_cross_block, (pto.Pipe.M, 0), "wait_cross_block(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
-            (_ops.set_intra_block, ("M", 0), "set_intra_block(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
-            (_ops.wait_intra_block, (pto.Pipe.M, 0), "wait_intra_block(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
+            (
+                _ops.set_cross_block,
+                ("M", 0),
+                "set_cross_block(pipe, event_id)",
+                "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>",
+                "<PIPE_M>",
+            ),
+            (
+                _ops.wait_cross_block,
+                (pto.Pipe.M, 0),
+                "wait_cross_block(pipe, event_id)",
+                "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>",
+                "<PIPE_M>",
+            ),
+            (
+                _ops.set_intra_block,
+                ("M", 0),
+                "set_intra_block(pipe, event_id)",
+                "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>",
+                "<PIPE_M>",
+            ),
+            (
+                _ops.wait_intra_block,
+                (pto.Pipe.M, 0),
+                "wait_intra_block(pipe, event_id)",
+                "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>",
+                "<PIPE_M>",
+            ),
         ]
 
         with patch.object(_ops._pto, "sync_set") as sync_set_op, \

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -386,12 +386,12 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
     def test_sync_flag_names_are_exposed_without_legacy_aliases(self):
         preferred_names = [
-            "set_cross_flag", "wait_cross_flag",
-            "set_intra_flag", "wait_intra_flag",
+            "set_cross_block", "wait_cross_block",
+            "set_intra_block", "wait_intra_block",
         ]
         legacy_names = [
-            "set_cross_core", "wait_flag_dev",
-            "set_intra_block", "wait_intra_core",
+            "set_cross_flag", "wait_cross_flag",
+            "set_intra_flag", "wait_intra_flag",
         ]
 
         for name in preferred_names:
@@ -1265,13 +1265,13 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         cases = [
             (_ops.set_flag, ("MTE2", "V"), {"event_id": 8}, "set_flag(..., event_id=...)"),
             (_ops.wait_flag, ("MTE2", "V"), {"event_id": -1}, "wait_flag(..., event_id=...)"),
-            (_ops.set_cross_flag, (pto.Pipe.FIX, 8), {}, "set_cross_flag(..., event_id=...)"),
-            (_ops.wait_cross_flag, (pto.Pipe.FIX, -1), {}, "wait_cross_flag(..., event_id=...)"),
-            (_ops.set_intra_flag, (pto.Pipe.FIX, 32), {}, "set_intra_flag(..., event_id=...)", "[0, 31]"),
-            (_ops.set_intra_flag, (pto.Pipe.MTE3, 32), {}, "set_intra_flag(..., event_id=...)", "[0, 31]"),
-            (_ops.wait_intra_flag, (pto.Pipe.V, -2), {}, "wait_intra_flag(..., event_id=...)", "[0, 31]"),
-            (_ops.wait_intra_flag, (pto.Pipe.FIX, 32), {}, "wait_intra_flag(..., event_id=...)", "[0, 31]"),
-            (_ops.wait_intra_flag, (pto.Pipe.MTE3, 32), {}, "wait_intra_flag(..., event_id=...)", "[0, 31]"),
+            (_ops.set_cross_block, (pto.Pipe.FIX, 16), {}, "set_cross_block(..., event_id=...)", "[0, 15]"),
+            (_ops.wait_cross_block, (pto.Pipe.FIX, -1), {}, "wait_cross_block(..., event_id=...)", "[0, 15]"),
+            (_ops.set_intra_block, (pto.Pipe.FIX, 32), {}, "set_intra_block(..., event_id=...)", "[0, 31]"),
+            (_ops.set_intra_block, (pto.Pipe.MTE3, 32), {}, "set_intra_block(..., event_id=...)", "[0, 31]"),
+            (_ops.wait_intra_block, (pto.Pipe.V, -2), {}, "wait_intra_block(..., event_id=...)", "[0, 31]"),
+            (_ops.wait_intra_block, (pto.Pipe.FIX, 32), {}, "wait_intra_block(..., event_id=...)", "[0, 31]"),
+            (_ops.wait_intra_block, (pto.Pipe.MTE3, 32), {}, "wait_intra_block(..., event_id=...)", "[0, 31]"),
         ]
 
         with patch.object(_ops._pto, "set_flag") as set_flag_op, \
@@ -1298,10 +1298,10 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
     def test_sync_facades_reject_illegal_pipe_endpoints(self):
         cases = [
-            (_ops.set_cross_flag, (pto.Pipe.V, 0), "set_cross_flag(pipe, event_id)", "<PIPE_FIX>", "<PIPE_V>"),
-            (_ops.wait_cross_flag, (pto.Pipe.MTE3, 0), "wait_cross_flag(pipe, event_id)", "<PIPE_FIX>", "<PIPE_MTE3>"),
-            (_ops.set_intra_flag, ("M", 0), "set_intra_flag(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
-            (_ops.wait_intra_flag, (pto.Pipe.M, 0), "wait_intra_flag(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
+            (_ops.set_cross_block, ("M", 0), "set_cross_block(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
+            (_ops.wait_cross_block, (pto.Pipe.M, 0), "wait_cross_block(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
+            (_ops.set_intra_block, ("M", 0), "set_intra_block(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
+            (_ops.wait_intra_block, (pto.Pipe.M, 0), "wait_intra_block(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
         ]
 
         with patch.object(_ops._pto, "sync_set") as sync_set_op, \
@@ -1323,18 +1323,18 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         dynamic_event_operand = object()
         with patch.object(_ops, "_pipe_attr", side_effect=lambda pipe: f"pipe:{pipe}") as pipe_attr, \
              patch.object(_ops, "unwrap_surface_value", return_value=dynamic_event_operand) as unwrap_surface_value, \
-             patch.object(_ops._pto, "sync_set") as sync_set_op, \
-             patch.object(_ops._pto, "sync_wait") as sync_wait_op:
-            _ops.set_intra_flag(pto.Pipe.FIX, 31)
-            _ops.set_intra_flag(pto.Pipe.MTE3, 31)
-            _ops.wait_intra_flag(pto.Pipe.FIX, 16)
-            _ops.wait_intra_flag(pto.Pipe.V, 31)
-            _ops.wait_intra_flag(pto.Pipe.MTE3, 31)
-            _ops.wait_intra_flag(pto.Pipe.MTE3, dynamic_event)
+             patch.object(_ops._pto, "set_intra_block") as set_intra_block_op, \
+             patch.object(_ops._pto, "wait_intra_block") as wait_intra_block_op:
+            _ops.set_intra_block(pto.Pipe.FIX, 31)
+            _ops.set_intra_block(pto.Pipe.MTE3, 31)
+            _ops.wait_intra_block(pto.Pipe.FIX, 16)
+            _ops.wait_intra_block(pto.Pipe.V, 31)
+            _ops.wait_intra_block(pto.Pipe.MTE3, 31)
+            _ops.wait_intra_block(pto.Pipe.MTE3, dynamic_event)
 
         self.assertEqual(pipe_attr.call_count, 6)
-        self.assertEqual(sync_set_op.call_count, 2)
-        sync_wait_op.assert_has_calls([
+        self.assertEqual(set_intra_block_op.call_count, 2)
+        wait_intra_block_op.assert_has_calls([
             call(f"pipe:{pto.Pipe.FIX}", 16),
             call(f"pipe:{pto.Pipe.V}", 31),
             call(f"pipe:{pto.Pipe.MTE3}", 31),

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -402,6 +402,10 @@ class VectorCubeSurfaceTest(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertFalse(hasattr(pto, name), name)
 
+    def test_cross_block_sync_rejects_ffts_mode(self):
+        with self.assertRaises(TypeError):
+            _ops.set_cross_block(pto.Pipe.FIX, 0, ffts_mode=2)
+
     def test_direct_vector_wrappers_dispatch_to_generated_ops(self):
         lhs = SimpleNamespace(type="vec_ty")
         rhs = SimpleNamespace(type="vec_ty")

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -295,12 +295,12 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
     def test_sync_flag_names_are_exposed_without_legacy_aliases(self):
         preferred_names = [
-            "set_cross_flag", "wait_cross_flag",
-            "set_intra_flag", "wait_intra_flag",
+            "set_cross_block", "wait_cross_block",
+            "set_intra_block", "wait_intra_block",
         ]
         legacy_names = [
-            "set_cross_core", "wait_flag_dev",
-            "set_intra_block", "wait_intra_core",
+            "set_cross_flag", "wait_cross_flag",
+            "set_intra_flag", "wait_intra_flag",
         ]
 
         for name in preferred_names:
@@ -1036,13 +1036,13 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         cases = [
             (_ops.set_flag, ("MTE2", "V"), {"event_id": 8}, "set_flag(..., event_id=...)"),
             (_ops.wait_flag, ("MTE2", "V"), {"event_id": -1}, "wait_flag(..., event_id=...)"),
-            (_ops.set_cross_flag, (pto.Pipe.FIX, 8), {}, "set_cross_flag(..., event_id=...)"),
-            (_ops.wait_cross_flag, (pto.Pipe.FIX, -1), {}, "wait_cross_flag(..., event_id=...)"),
-            (_ops.set_intra_flag, (pto.Pipe.FIX, 32), {}, "set_intra_flag(..., event_id=...)", "[0, 31]"),
-            (_ops.set_intra_flag, (pto.Pipe.MTE3, 32), {}, "set_intra_flag(..., event_id=...)", "[0, 31]"),
-            (_ops.wait_intra_flag, (pto.Pipe.V, -2), {}, "wait_intra_flag(..., event_id=...)", "[0, 31]"),
-            (_ops.wait_intra_flag, (pto.Pipe.FIX, 32), {}, "wait_intra_flag(..., event_id=...)", "[0, 31]"),
-            (_ops.wait_intra_flag, (pto.Pipe.MTE3, 32), {}, "wait_intra_flag(..., event_id=...)", "[0, 31]"),
+            (_ops.set_cross_block, (pto.Pipe.FIX, 16), {}, "set_cross_block(..., event_id=...)", "[0, 15]"),
+            (_ops.wait_cross_block, (pto.Pipe.FIX, -1), {}, "wait_cross_block(..., event_id=...)", "[0, 15]"),
+            (_ops.set_intra_block, (pto.Pipe.FIX, 32), {}, "set_intra_block(..., event_id=...)", "[0, 31]"),
+            (_ops.set_intra_block, (pto.Pipe.MTE3, 32), {}, "set_intra_block(..., event_id=...)", "[0, 31]"),
+            (_ops.wait_intra_block, (pto.Pipe.V, -2), {}, "wait_intra_block(..., event_id=...)", "[0, 31]"),
+            (_ops.wait_intra_block, (pto.Pipe.FIX, 32), {}, "wait_intra_block(..., event_id=...)", "[0, 31]"),
+            (_ops.wait_intra_block, (pto.Pipe.MTE3, 32), {}, "wait_intra_block(..., event_id=...)", "[0, 31]"),
         ]
 
         with patch.object(_ops._pto, "set_flag") as set_flag_op, \
@@ -1069,10 +1069,10 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
     def test_sync_facades_reject_illegal_pipe_endpoints(self):
         cases = [
-            (_ops.set_cross_flag, (pto.Pipe.V, 0), "set_cross_flag(pipe, event_id)", "<PIPE_FIX>", "<PIPE_V>"),
-            (_ops.wait_cross_flag, (pto.Pipe.MTE3, 0), "wait_cross_flag(pipe, event_id)", "<PIPE_FIX>", "<PIPE_MTE3>"),
-            (_ops.set_intra_flag, ("M", 0), "set_intra_flag(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
-            (_ops.wait_intra_flag, (pto.Pipe.M, 0), "wait_intra_flag(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
+            (_ops.set_cross_block, ("M", 0), "set_cross_block(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
+            (_ops.wait_cross_block, (pto.Pipe.M, 0), "wait_cross_block(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
+            (_ops.set_intra_block, ("M", 0), "set_intra_block(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
+            (_ops.wait_intra_block, (pto.Pipe.M, 0), "wait_intra_block(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE1>, <PIPE_MTE2>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_M>"),
         ]
 
         with patch.object(_ops._pto, "sync_set") as sync_set_op, \
@@ -1094,18 +1094,18 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         dynamic_event_operand = object()
         with patch.object(_ops, "_pipe_attr", side_effect=lambda pipe: f"pipe:{pipe}") as pipe_attr, \
              patch.object(_ops, "unwrap_surface_value", return_value=dynamic_event_operand) as unwrap_surface_value, \
-             patch.object(_ops._pto, "sync_set") as sync_set_op, \
-             patch.object(_ops._pto, "sync_wait") as sync_wait_op:
-            _ops.set_intra_flag(pto.Pipe.FIX, 31)
-            _ops.set_intra_flag(pto.Pipe.MTE3, 31)
-            _ops.wait_intra_flag(pto.Pipe.FIX, 16)
-            _ops.wait_intra_flag(pto.Pipe.V, 31)
-            _ops.wait_intra_flag(pto.Pipe.MTE3, 31)
-            _ops.wait_intra_flag(pto.Pipe.MTE3, dynamic_event)
+             patch.object(_ops._pto, "set_intra_block") as set_intra_block_op, \
+             patch.object(_ops._pto, "wait_intra_block") as wait_intra_block_op:
+            _ops.set_intra_block(pto.Pipe.FIX, 31)
+            _ops.set_intra_block(pto.Pipe.MTE3, 31)
+            _ops.wait_intra_block(pto.Pipe.FIX, 16)
+            _ops.wait_intra_block(pto.Pipe.V, 31)
+            _ops.wait_intra_block(pto.Pipe.MTE3, 31)
+            _ops.wait_intra_block(pto.Pipe.MTE3, dynamic_event)
 
         self.assertEqual(pipe_attr.call_count, 6)
-        self.assertEqual(sync_set_op.call_count, 2)
-        sync_wait_op.assert_has_calls([
+        self.assertEqual(set_intra_block_op.call_count, 2)
+        wait_intra_block_op.assert_has_calls([
             call(f"pipe:{pto.Pipe.FIX}", 16),
             call(f"pipe:{pto.Pipe.V}", 31),
             call(f"pipe:{pto.Pipe.MTE3}", 31),

--- a/python/pto/dialects/pto.py
+++ b/python/pto/dialects/pto.py
@@ -651,12 +651,10 @@ def sync_wait(pipe, event_id, ffts_mode=2, *, loc=None, ip=None):
 # Named cross-/intra-block synchronization instructions.
 # -----------------------------------------------------------------------------
 
-def _named_sync_event_op(name, pipe, event_id, *, ffts_mode=None, loc=None, ip=None):
+def _named_sync_event_op(name, pipe, event_id, *, loc=None, ip=None):
     ctx = loc.context if loc else _ods_ir.Context.current
     pipe_attr = _ensure_pipe_attr(pipe, ctx)
     attrs = {"pipe": pipe_attr}
-    if ffts_mode is not None and ffts_mode != 2:
-        attrs["ffts_mode"] = _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)
     if _is_static_i32_event_id(event_id):
         attrs["event_id"] = _ensure_i32_attr(event_id, "event_id", ctx)
         return _ods_ir.Operation.create(name, attributes=attrs, loc=loc, ip=ip)
@@ -665,11 +663,9 @@ def _named_sync_event_op(name, pipe, event_id, *, ffts_mode=None, loc=None, ip=N
     )
 
 
-def set_cross_block(pipe, event_id, ffts_mode=0, *, loc=None, ip=None):
+def set_cross_block(pipe, event_id, *, loc=None, ip=None):
     """Emit ``pto.set_cross_block`` (FFTS cross-block signal)."""
-    return _named_sync_event_op(
-        "pto.set_cross_block", pipe, event_id, ffts_mode=ffts_mode, loc=loc, ip=ip
-    )
+    return _named_sync_event_op("pto.set_cross_block", pipe, event_id, loc=loc, ip=ip)
 
 
 def wait_cross_block(pipe, event_id, *, loc=None, ip=None):

--- a/python/pto/dialects/pto.py
+++ b/python/pto/dialects/pto.py
@@ -639,8 +639,15 @@ def sync_wait(pipe, event_id, ffts_mode=2, *, loc=None, ip=None):
         except TypeError:
             return _ods_ir.Operation.create(
                 "pto.sync.wait",
-                attributes={"pipe": pipe_attr, "event_id": event_attr,
-                            **({} if ffts_mode == 2 else {"ffts_mode": _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)}),},
+                attributes={
+                    "pipe": pipe_attr,
+                    "event_id": event_attr,
+                    **(
+                        {}
+                        if ffts_mode == 2
+                        else {"ffts_mode": _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)}
+                    ),
+                },
                 loc=loc,
                 ip=ip,
             )

--- a/python/pto/dialects/pto.py
+++ b/python/pto/dialects/pto.py
@@ -611,13 +611,14 @@ def sync_set(pipe, event_id, ffts_mode=2, *, loc=None, ip=None):
     return sync_set_dyn(pipe_attr, event_id, ffts_mode=ffts_mode, loc=loc, ip=ip)
 
 
-def sync_wait_dyn(pipe, event_id, *, loc=None, ip=None):
+def sync_wait_dyn(pipe, event_id, ffts_mode=2, *, loc=None, ip=None):
     ctx = loc.context if loc else _ods_ir.Context.current
     pipe_attr = _ensure_pipe_attr(pipe, ctx)
     event_val = get_op_result_or_value(event_id)
     try:
+        mode_attr = None if ffts_mode == 2 else _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)
         return _pto_ops_gen.sync_wait(
-            pipe_attr, event_id=None, event_id_dyn=event_val, loc=loc, ip=ip
+            pipe_attr, event_id=None, ffts_mode=mode_attr, event_id_dyn=event_val, loc=loc, ip=ip
         )
     except TypeError:
         if hasattr(_pto_ops_gen, "sync_wait_dyn"):
@@ -625,23 +626,65 @@ def sync_wait_dyn(pipe, event_id, *, loc=None, ip=None):
         raise
 
 
-def sync_wait(pipe, event_id, *, loc=None, ip=None):
+def sync_wait(pipe, event_id, ffts_mode=2, *, loc=None, ip=None):
     ctx = loc.context if loc else _ods_ir.Context.current
     pipe_attr = _ensure_pipe_attr(pipe, ctx)
     if _is_static_i32_event_id(event_id):
         event_attr = _ensure_i32_attr(event_id, "event_id", ctx)
         try:
+            mode_attr = None if ffts_mode == 2 else _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)
             return _pto_ops_gen.sync_wait(
-                pipe_attr, event_id=event_attr, event_id_dyn=None, loc=loc, ip=ip
+                pipe_attr, event_id=event_attr, ffts_mode=mode_attr, event_id_dyn=None, loc=loc, ip=ip
             )
         except TypeError:
             return _ods_ir.Operation.create(
                 "pto.sync.wait",
-                attributes={"pipe": pipe_attr, "event_id": event_attr},
+                attributes={"pipe": pipe_attr, "event_id": event_attr,
+                            **({} if ffts_mode == 2 else {"ffts_mode": _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)}),},
                 loc=loc,
                 ip=ip,
             )
-    return sync_wait_dyn(pipe_attr, event_id, loc=loc, ip=ip)
+    return sync_wait_dyn(pipe_attr, event_id, ffts_mode=ffts_mode, loc=loc, ip=ip)
+
+
+# -----------------------------------------------------------------------------
+# Named cross-/intra-block synchronization instructions.
+# -----------------------------------------------------------------------------
+
+def _named_sync_event_op(name, pipe, event_id, *, ffts_mode=None, loc=None, ip=None):
+    ctx = loc.context if loc else _ods_ir.Context.current
+    pipe_attr = _ensure_pipe_attr(pipe, ctx)
+    attrs = {"pipe": pipe_attr}
+    if ffts_mode is not None and ffts_mode != 2:
+        attrs["ffts_mode"] = _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)
+    if _is_static_i32_event_id(event_id):
+        attrs["event_id"] = _ensure_i32_attr(event_id, "event_id", ctx)
+        return _ods_ir.Operation.create(name, attributes=attrs, loc=loc, ip=ip)
+    return _ods_ir.Operation.create(
+        name, attributes=attrs, operands=[get_op_result_or_value(event_id)], loc=loc, ip=ip
+    )
+
+
+def set_cross_block(pipe, event_id, ffts_mode=0, *, loc=None, ip=None):
+    """Emit ``pto.set_cross_block`` (FFTS cross-block signal)."""
+    return _named_sync_event_op(
+        "pto.set_cross_block", pipe, event_id, ffts_mode=ffts_mode, loc=loc, ip=ip
+    )
+
+
+def wait_cross_block(pipe, event_id, *, loc=None, ip=None):
+    """Emit ``pto.wait_cross_block`` (FFTS cross-block wait)."""
+    return _named_sync_event_op("pto.wait_cross_block", pipe, event_id, loc=loc, ip=ip)
+
+
+def set_intra_block(pipe, event_id, *, loc=None, ip=None):
+    """Emit ``pto.set_intra_block`` (intra-block signal)."""
+    return _named_sync_event_op("pto.set_intra_block", pipe, event_id, loc=loc, ip=ip)
+
+
+def wait_intra_block(pipe, event_id, *, loc=None, ip=None):
+    """Emit ``pto.wait_intra_block`` (intra-block wait)."""
+    return _named_sync_event_op("pto.wait_intra_block", pipe, event_id, loc=loc, ip=ip)
 
 
 def set_ffts(ffts, *, loc=None, ip=None):

--- a/python/pto/dialects/pto.py
+++ b/python/pto/dialects/pto.py
@@ -605,13 +605,14 @@ def sync_set(pipe, event_id, ffts_mode=2, *, loc=None, ip=None):
     return sync_set_dyn(pipe_attr, event_id, ffts_mode=ffts_mode, loc=loc, ip=ip)
 
 
-def sync_wait_dyn(pipe, event_id, *, loc=None, ip=None):
+def sync_wait_dyn(pipe, event_id, ffts_mode=2, *, loc=None, ip=None):
     ctx = loc.context if loc else _ods_ir.Context.current
     pipe_attr = _ensure_pipe_attr(pipe, ctx)
     event_val = get_op_result_or_value(event_id)
     try:
+        mode_attr = None if ffts_mode == 2 else _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)
         return _pto_ops_gen.sync_wait(
-            pipe_attr, event_id=None, event_id_dyn=event_val, loc=loc, ip=ip
+            pipe_attr, event_id=None, ffts_mode=mode_attr, event_id_dyn=event_val, loc=loc, ip=ip
         )
     except TypeError:
         if hasattr(_pto_ops_gen, "sync_wait_dyn"):
@@ -619,23 +620,65 @@ def sync_wait_dyn(pipe, event_id, *, loc=None, ip=None):
         raise
 
 
-def sync_wait(pipe, event_id, *, loc=None, ip=None):
+def sync_wait(pipe, event_id, ffts_mode=2, *, loc=None, ip=None):
     ctx = loc.context if loc else _ods_ir.Context.current
     pipe_attr = _ensure_pipe_attr(pipe, ctx)
     if _is_static_i32_event_id(event_id):
         event_attr = _ensure_i32_attr(event_id, "event_id", ctx)
         try:
+            mode_attr = None if ffts_mode == 2 else _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)
             return _pto_ops_gen.sync_wait(
-                pipe_attr, event_id=event_attr, event_id_dyn=None, loc=loc, ip=ip
+                pipe_attr, event_id=event_attr, ffts_mode=mode_attr, event_id_dyn=None, loc=loc, ip=ip
             )
         except TypeError:
             return _ods_ir.Operation.create(
                 "pto.sync.wait",
-                attributes={"pipe": pipe_attr, "event_id": event_attr},
+                attributes={"pipe": pipe_attr, "event_id": event_attr,
+                            **({} if ffts_mode == 2 else {"ffts_mode": _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)}),},
                 loc=loc,
                 ip=ip,
             )
-    return sync_wait_dyn(pipe_attr, event_id, loc=loc, ip=ip)
+    return sync_wait_dyn(pipe_attr, event_id, ffts_mode=ffts_mode, loc=loc, ip=ip)
+
+
+# -----------------------------------------------------------------------------
+# Named cross-/intra-block synchronization instructions.
+# -----------------------------------------------------------------------------
+
+def _named_sync_event_op(name, pipe, event_id, *, ffts_mode=None, loc=None, ip=None):
+    ctx = loc.context if loc else _ods_ir.Context.current
+    pipe_attr = _ensure_pipe_attr(pipe, ctx)
+    attrs = {"pipe": pipe_attr}
+    if ffts_mode is not None and ffts_mode != 2:
+        attrs["ffts_mode"] = _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)
+    if _is_static_i32_event_id(event_id):
+        attrs["event_id"] = _ensure_i32_attr(event_id, "event_id", ctx)
+        return _ods_ir.Operation.create(name, attributes=attrs, loc=loc, ip=ip)
+    return _ods_ir.Operation.create(
+        name, attributes=attrs, operands=[get_op_result_or_value(event_id)], loc=loc, ip=ip
+    )
+
+
+def set_cross_block(pipe, event_id, ffts_mode=0, *, loc=None, ip=None):
+    """Emit ``pto.set_cross_block`` (FFTS cross-block signal)."""
+    return _named_sync_event_op(
+        "pto.set_cross_block", pipe, event_id, ffts_mode=ffts_mode, loc=loc, ip=ip
+    )
+
+
+def wait_cross_block(pipe, event_id, *, loc=None, ip=None):
+    """Emit ``pto.wait_cross_block`` (FFTS cross-block wait)."""
+    return _named_sync_event_op("pto.wait_cross_block", pipe, event_id, loc=loc, ip=ip)
+
+
+def set_intra_block(pipe, event_id, *, loc=None, ip=None):
+    """Emit ``pto.set_intra_block`` (intra-block signal)."""
+    return _named_sync_event_op("pto.set_intra_block", pipe, event_id, loc=loc, ip=ip)
+
+
+def wait_intra_block(pipe, event_id, *, loc=None, ip=None):
+    """Emit ``pto.wait_intra_block`` (intra-block wait)."""
+    return _named_sync_event_op("pto.wait_intra_block", pipe, event_id, loc=loc, ip=ip)
 
 
 def set_ffts(ffts, *, loc=None, ip=None):

--- a/test/lit/pto/named_intra_a3_emitc.pto
+++ b/test/lit/pto/named_intra_a3_emitc.pto
@@ -20,7 +20,7 @@ module attributes {
   }
 }
 
-// CHECK-LABEL: AICORE void named_intra_a3_emitc()
+// CHECK-LABEL: extern "C" __global__ AICORE void named_intra_a3_emitc({{.*}}) {
 // CHECK: getFFTSMsg(FFTS_MODE_VAL, {{.*}})
 // CHECK-NEXT: __builtin_cce_ffts_cross_core_sync(PIPE_MTE1, {{.*}});
 // CHECK-NEXT: __builtin_cce_wait_flag_dev(15);

--- a/test/lit/pto/named_intra_a3_emitc.pto
+++ b/test/lit/pto/named_intra_a3_emitc.pto
@@ -6,27 +6,23 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
 
 module attributes {
   pto.kernel_kind = #pto.kernel_kind<vector>,
-  pto.target_arch = "a5"
+  pto.target_arch = "a3"
 } {
-  func.func @sync_set_a5_emitc_ffts_modes() attributes {pto.kernel} {
-    pto.sync.set <PIPE_FIX>, 0 {ffts_mode = 0 : i32}
-    pto.sync.set <PIPE_MTE1>, 1 {ffts_mode = 1 : i32}
-    pto.sync.set <PIPE_MTE2>, 2 {ffts_mode = 2 : i32}
-    pto.sync.wait <PIPE_V>, 2 {ffts_mode = 2 : i32}
+  func.func @named_intra_a3_emitc(%ffts : !pto.ptr<i64>) attributes {pto.kernel} {
+    pto.set_ffts %ffts : !pto.ptr<i64>
+    pto.set_intra_block <PIPE_MTE1>, 15
+    pto.wait_intra_block <PIPE_V>, 15
     return
   }
 }
 
-// CHECK-LABEL: AICORE void sync_set_a5_emitc_ffts_modes()
-// CHECK: getFFTSMsg(0, {{.*}})
-// CHECK: __builtin_cce_ffts_cross_core_sync(PIPE_FIX, {{.*}});
-// CHECK: getFFTSMsg(1, {{.*}})
-// CHECK: __builtin_cce_ffts_cross_core_sync(PIPE_MTE1, {{.*}});
+// CHECK-LABEL: AICORE void named_intra_a3_emitc()
 // CHECK: getFFTSMsg(FFTS_MODE_VAL, {{.*}})
-// CHECK: __builtin_cce_ffts_cross_core_sync(PIPE_MTE2, {{.*}});
-// CHECK: __builtin_cce_wait_cross_block(2);
+// CHECK-NEXT: __builtin_cce_ffts_cross_core_sync(PIPE_MTE1, {{.*}});
+// CHECK-NEXT: __builtin_cce_wait_flag_dev(15);
 // CHECK-NOT: __builtin_cce_set_intra_block
+// CHECK-NOT: __builtin_cce_wait_intra_block

--- a/test/lit/pto/named_sync_a5_emitc.pto
+++ b/test/lit/pto/named_sync_a5_emitc.pto
@@ -12,21 +12,18 @@ module attributes {
   pto.kernel_kind = #pto.kernel_kind<vector>,
   pto.target_arch = "a5"
 } {
-  func.func @sync_set_a5_emitc_ffts_modes() attributes {pto.kernel} {
-    pto.sync.set <PIPE_FIX>, 0 {ffts_mode = 0 : i32}
-    pto.sync.set <PIPE_MTE1>, 1 {ffts_mode = 1 : i32}
-    pto.sync.set <PIPE_MTE2>, 2 {ffts_mode = 2 : i32}
-    pto.sync.wait <PIPE_V>, 2 {ffts_mode = 2 : i32}
+  func.func @named_sync_a5_emitc() attributes {pto.kernel} {
+    pto.set_cross_block <PIPE_FIX>, 0
+    pto.wait_cross_block <PIPE_MTE3>, 0
+    pto.set_intra_block <PIPE_MTE1>, 17
+    pto.wait_intra_block <PIPE_V>, 17
     return
   }
 }
 
-// CHECK-LABEL: AICORE void sync_set_a5_emitc_ffts_modes()
+// CHECK-LABEL: AICORE void named_sync_a5_emitc()
 // CHECK: getFFTSMsg(0, {{.*}})
 // CHECK: __builtin_cce_ffts_cross_core_sync(PIPE_FIX, {{.*}});
-// CHECK: getFFTSMsg(1, {{.*}})
-// CHECK: __builtin_cce_ffts_cross_core_sync(PIPE_MTE1, {{.*}});
-// CHECK: getFFTSMsg(FFTS_MODE_VAL, {{.*}})
-// CHECK: __builtin_cce_ffts_cross_core_sync(PIPE_MTE2, {{.*}});
-// CHECK: __builtin_cce_wait_cross_block(2);
-// CHECK-NOT: __builtin_cce_set_intra_block
+// CHECK-NEXT: __builtin_cce_wait_cross_block(0);
+// CHECK-NEXT: __builtin_cce_set_intra_block(PIPE_MTE1, 17);
+// CHECK-NEXT: __builtin_cce_wait_intra_block(PIPE_V, 17);

--- a/test/lit/pto/named_sync_a5_emitc.pto
+++ b/test/lit/pto/named_sync_a5_emitc.pto
@@ -21,9 +21,9 @@ module attributes {
   }
 }
 
-// CHECK-LABEL: AICORE void named_sync_a5_emitc()
+// CHECK-LABEL: extern "C" __global__ AICORE void named_sync_a5_emitc() {
 // CHECK: getFFTSMsg(0, {{.*}})
 // CHECK: __builtin_cce_ffts_cross_core_sync(PIPE_FIX, {{.*}});
-// CHECK-NEXT: __builtin_cce_wait_cross_block(0);
+// CHECK-NEXT: __builtin_cce_wait_flag_dev(0);
 // CHECK-NEXT: __builtin_cce_set_intra_block(PIPE_MTE1, 17);
 // CHECK-NEXT: __builtin_cce_wait_intra_block(PIPE_V, 17);

--- a/test/lit/pto/scf_while_generic_domains_emitc.pto
+++ b/test/lit/pto/scf_while_generic_domains_emitc.pto
@@ -61,5 +61,7 @@ module attributes {pto.target_arch = "a5"} {
 // CHECK: goto [[CUBE_HEADER:label[0-9]+]];
 // CHECK: [[CUBE_HEADER]]:
 // CHECK: [[CUBE_BODY:label[0-9]+]]:
-// CHECK: set_intra_block(PIPE_MTE1, 0);
+// CHECK: getFFTSMsg(FFTS_MODE_VAL, {{.*}})
+// CHECK-NEXT: __builtin_cce_ffts_cross_core_sync(PIPE_MTE1, {{.*}});
+// CHECK-NOT: __builtin_cce_set_intra_block
 // CHECK: goto [[CUBE_HEADER]];

--- a/test/lit/pto/sync_set_a5_emitc_physical_ids.pto
+++ b/test/lit/pto/sync_set_a5_emitc_physical_ids.pto
@@ -21,12 +21,12 @@ module attributes {
   }
 }
 
-// CHECK-LABEL: AICORE void sync_set_a5_emitc_ffts_modes()
+// CHECK-LABEL: extern "C" __global__ AICORE void sync_set_a5_emitc_ffts_modes() {
 // CHECK: getFFTSMsg(0, {{.*}})
 // CHECK: __builtin_cce_ffts_cross_core_sync(PIPE_FIX, {{.*}});
 // CHECK: getFFTSMsg(1, {{.*}})
 // CHECK: __builtin_cce_ffts_cross_core_sync(PIPE_MTE1, {{.*}});
 // CHECK: getFFTSMsg(FFTS_MODE_VAL, {{.*}})
 // CHECK: __builtin_cce_ffts_cross_core_sync(PIPE_MTE2, {{.*}});
-// CHECK: __builtin_cce_wait_cross_block(2);
+// CHECK: __builtin_cce_wait_flag_dev(2);
 // CHECK-NOT: __builtin_cce_set_intra_block

--- a/test/lit/vpto/intra_block_sync_vpto_llvm.pto
+++ b/test/lit/vpto/intra_block_sync_vpto_llvm.pto
@@ -9,29 +9,30 @@
 // RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
-  func.func @intra_block_sync_static_dynamic(%event_id: index) attributes {pto.kernel} {
-    pto.sync.set <PIPE_FIX>, 0
-    pto.sync.wait <PIPE_MTE3>, 0
-    pto.sync.set <PIPE_FIX>, %event_id
-    pto.sync.wait <PIPE_MTE3>, %event_id
+  func.func @sync_static_dynamic(%event_id: index) attributes {pto.kernel} {
+    pto.sync.set <PIPE_FIX>, 0 {ffts_mode = 0 : i32}
+    pto.sync.wait <PIPE_MTE3>, 0 {ffts_mode = 0 : i32}
+    pto.sync.set <PIPE_FIX>, %event_id {ffts_mode = 1 : i32}
+    pto.sync.wait <PIPE_MTE3>, %event_id {ffts_mode = 1 : i32}
     return
   }
 
   func.func @intra_block_sync_mte_pipes() attributes {pto.kernel} {
-    pto.sync.set <PIPE_MTE1>, 17
-    pto.sync.wait <PIPE_MTE2>, 17
+    pto.set_intra_block <PIPE_MTE1>, 17
+    pto.wait_intra_block <PIPE_MTE2>, 17
     return
   }
 
   func.func @intra_block_sync_v_dynamic(%event_id: index) attributes {pto.kernel} {
-    pto.sync.set <PIPE_V>, %event_id
+    pto.set_intra_block <PIPE_V>, %event_id
     return
   }
 }
 
-// CHECK-LABEL: llvm.func @intra_block_sync_static_dynamic_mix_aiv
-// CHECK: llvm.call @llvm.hivm.SET.INTRA.BLOCK.mode
-// CHECK: llvm.call @llvm.hivm.WAIT.INTRA.BLOCK.mode
+// CHECK-LABEL: llvm.func @sync_static_dynamic_mix_aiv
+// CHECK: llvm.call @llvm.hivm.SET.CROSS.CORE
+// CHECK: llvm.call @llvm.hivm.WAIT.FLAG.DEV.PIPE.IMM
+// CHECK: llvm.call @llvm.hivm.WAIT.FLAG.DEV.PIPE.REG
 
 // CHECK-LABEL: llvm.func @intra_block_sync_mte_pipes_mix_aiv
 // CHECK: llvm.mlir.constant(3 : i64) : i64

--- a/test/samples/Complex/mix_kernel.pto
+++ b/test/samples/Complex/mix_kernel.pto
@@ -1,4 +1,4 @@
-module {
+module attributes {pto.target_arch = "a5"} {
   func.func @vector_cube_mixed_kernel(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -37,11 +37,10 @@ module {
     pto.tmov ins(%17 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=1>) outs(%19 : !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=1>)
     pto.tmatmul ins(%18, %19 : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=1>, !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=1>) outs(%20 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=1>)
     pto.tmov ins(%20 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=1>) outs(%21 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>)
-    pto.sync.set <PIPE_FIX>, 0
-    pto.sync.set <PIPE_FIX>, 16
-    pto.sync.wait <PIPE_V>, 0
+    pto.set_intra_block <PIPE_FIX>, 0
+    pto.set_intra_block <PIPE_FIX>, 16
+    pto.wait_intra_block <PIPE_V>, 0
     pto.trowmax ins(%21 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>) outs(%22 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=1>)
     return
   }
 }
-

--- a/test/samples/Sync/test_intercore_sync_a5.py
+++ b/test/samples/Sync/test_intercore_sync_a5.py
@@ -15,6 +15,7 @@ from ptoas.mlir.ir import (
     InsertionPoint,
     Location,
     Module,
+    StringAttr,
 )
 from ptoas.mlir.dialects import arith, func, pto
 
@@ -24,6 +25,7 @@ def build():
         pto.register_dialect(ctx, load=True)
         with Location.unknown(ctx):
             module = Module.create()
+            module.operation.attributes["pto.target_arch"] = StringAttr.get("a5")
             f32 = F32Type.get(ctx)
             idx = IndexType.get(ctx)
             ptr_f32 = pto.PtrType.get(f32, ctx)
@@ -47,12 +49,12 @@ def build():
 
                 sec_cube = pto.SectionCubeOp()
                 with InsertionPoint(sec_cube.body.blocks.append()):
-                    pto.sync_set(pipe_fix, evt)
-                    pto.sync_set(pipe_fix, evt + 16)
+                    pto.set_intra_block(pipe_fix, evt)
+                    pto.set_intra_block(pipe_fix, evt + 16)
 
                 sec_vec = pto.SectionVectorOp()
                 with InsertionPoint(sec_vec.body.blocks.append()):
-                    pto.sync_wait(pipe_mte3, evt)
+                    pto.wait_intra_block(pipe_mte3, evt)
                     pto.store_scalar(out, c0, two)
 
                 func.ReturnOp([])

--- a/test/samples/Sync/test_intercore_sync_a5_dyn.py
+++ b/test/samples/Sync/test_intercore_sync_a5_dyn.py
@@ -7,7 +7,16 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from ptoas.mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module, UnitAttr
+from ptoas.mlir.ir import (
+    Context,
+    F32Type,
+    IndexType,
+    InsertionPoint,
+    Location,
+    Module,
+    StringAttr,
+    UnitAttr,
+)
 from ptoas.mlir.dialects import arith, func, pto
 
 
@@ -16,6 +25,7 @@ def build():
         pto.register_dialect(ctx, load=True)
         with Location.unknown(ctx):
             module = Module.create()
+            module.operation.attributes["pto.target_arch"] = StringAttr.get("a5")
             f32 = F32Type.get(ctx)
             idx = IndexType.get(ctx)
             ptr_f32 = pto.PtrType.get(f32, ctx)
@@ -38,12 +48,12 @@ def build():
 
                 sec_cube = pto.SectionCubeOp()
                 with InsertionPoint(sec_cube.body.blocks.append()):
-                    pto.sync_set(pipe_fix, c0_evt)
-                    pto.sync_set(pipe_fix, c16_evt_pair)
+                    pto.set_intra_block(pipe_fix, c0_evt)
+                    pto.set_intra_block(pipe_fix, c16_evt_pair)
 
                 sec_vec = pto.SectionVectorOp()
                 with InsertionPoint(sec_vec.body.blocks.append()):
-                    pto.sync_wait(pipe_mte3, c0_evt)
+                    pto.wait_intra_block(pipe_mte3, c0_evt)
                     pto.store_scalar(out, c0, two)
                 func.ReturnOp([])
 

--- a/test/samples/Sync/test_intercore_sync_a5_functional.py
+++ b/test/samples/Sync/test_intercore_sync_a5_functional.py
@@ -7,7 +7,16 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from ptoas.mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module, UnitAttr
+from ptoas.mlir.ir import (
+    Context,
+    F32Type,
+    IndexType,
+    InsertionPoint,
+    Location,
+    Module,
+    StringAttr,
+    UnitAttr,
+)
 from ptoas.mlir.dialects import arith, func, pto
 
 
@@ -16,6 +25,7 @@ def build():
         pto.register_dialect(ctx, load=True)
         with Location.unknown(ctx):
             module = Module.create()
+            module.operation.attributes["pto.target_arch"] = StringAttr.get("a5")
 
             f32 = F32Type.get(ctx)
             idx = IndexType.get(ctx)
@@ -42,12 +52,12 @@ def build():
 
                 sec_cube = pto.SectionCubeOp()
                 with InsertionPoint(sec_cube.body.blocks.append()):
-                    pto.sync_set(pipe_fix, evt)
-                    pto.sync_set(pipe_fix, evt + 16)
+                    pto.set_intra_block(pipe_fix, evt)
+                    pto.set_intra_block(pipe_fix, evt + 16)
 
                 sec_vec = pto.SectionVectorOp()
                 with InsertionPoint(sec_vec.body.blocks.append()):
-                    pto.sync_wait(pipe_mte3, evt)
+                    pto.wait_intra_block(pipe_mte3, evt)
                     pto.store_scalar(out, c0_idx, c2)
                     pto.store_scalar(out, c1_idx, c2)
 

--- a/test/samples/Sync/test_intercore_sync_a5_ptoisa_vec.py
+++ b/test/samples/Sync/test_intercore_sync_a5_ptoisa_vec.py
@@ -7,7 +7,16 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from ptoas.mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module, UnitAttr
+from ptoas.mlir.ir import (
+    Context,
+    F32Type,
+    IndexType,
+    InsertionPoint,
+    Location,
+    Module,
+    StringAttr,
+    UnitAttr,
+)
 from ptoas.mlir.dialects import arith, func, pto
 
 
@@ -16,6 +25,7 @@ def build():
         pto.register_dialect(ctx, load=True)
         with Location.unknown(ctx):
             module = Module.create()
+            module.operation.attributes["pto.target_arch"] = StringAttr.get("a5")
 
             f32 = F32Type.get(ctx)
             idx = IndexType.get(ctx)
@@ -42,12 +52,12 @@ def build():
 
                 sec_cube = pto.SectionCubeOp()
                 with InsertionPoint(sec_cube.body.blocks.append()):
-                    pto.sync_set(pipe_fix, sync_id)
-                    pto.sync_set(pipe_fix, sync_id + 16)
+                    pto.set_intra_block(pipe_fix, sync_id)
+                    pto.set_intra_block(pipe_fix, sync_id + 16)
 
                 sec_vec = pto.SectionVectorOp()
                 with InsertionPoint(sec_vec.body.blocks.append()):
-                    pto.sync_wait(pipe_mte3, sync_id)
+                    pto.wait_intra_block(pipe_mte3, sync_id)
                     pto.store_scalar(out, c0_idx, c2)
                     pto.store_scalar(out, c1_idx, c2)
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tinsert_acc2vec/tinsert_acc2vec.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tinsert_acc2vec/tinsert_acc2vec.pto
@@ -61,14 +61,14 @@ module attributes {pto.target_arch = "a5"} {
       pto.tinsert ins(%l0c_tile, %c0_idx, %c0_idx : !pto.tile_buf<acc, 16x16xf32, blayout=col_major, slayout=row_major, fractal=1024>, index, index)
                     outs(%dst_ub_tile : !pto.tile_buf<vec, 16x16xf16, blayout=row_major, slayout=none_box, fractal=512>)
 
-      pto.sync.set <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 1
     }
 
     pto.section.vector {
       %subblock = pto.get_subblock_idx
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %dst_ub, %out_gm, %c32_i64
           nburst(%c16_i64, %c32_i64, %c32_i64)
           : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64
@@ -127,14 +127,14 @@ module attributes {pto.target_arch = "a5"} {
       pto.tinsert ins(%l0c_tile, %c0_idx, %c0_idx : !pto.tile_buf<acc, 16x16xf32, blayout=col_major, slayout=row_major, fractal=1024>, index, index)
                     outs(%dst_ub_tile : !pto.tile_buf<vec, 16x16xf32, blayout=row_major, slayout=none_box, fractal=1024>)
 
-      pto.sync.set <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 1
     }
 
     pto.section.vector {
       %subblock = pto.get_subblock_idx
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %dst_ub, %out_gm, %c64_i64
           nburst(%c16_i64, %c64_i64, %c64_i64)
           : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
@@ -193,14 +193,14 @@ module attributes {pto.target_arch = "a5"} {
       pto.tinsert ins(%l0c_tile, %c0_idx, %c0_idx : !pto.tile_buf<acc, 16x16xf32, blayout=col_major, slayout=row_major, fractal=1024>, index, index)
                     outs(%dst_ub_tile : !pto.tile_buf<vec, 16x16xf32, blayout=col_major, slayout=row_major, fractal=512>)
 
-      pto.sync.set <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 1
     }
 
     pto.section.vector {
       %subblock = pto.get_subblock_idx
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %dst_ub, %out_gm, %c64_i64
           nburst(%c16_i64, %c64_i64, %c64_i64)
           : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/cube-matmul/fixpipe-cc-gm/kernel.pto
+++ b/test/vpto/cases/micro-op/cube-matmul/fixpipe-cc-gm/kernel.pto
@@ -11,7 +11,7 @@
 // family: cube-matmul
 // target_ops: pto.mte_gm_l1_frac, pto.mte_l1_l0a, pto.mte_l1_l0b, pto.mad,
 //   pto.mte_l0c_gm, pto.mte_l0c_l1, pto.mte_l1_ub, pto.mte_ub_gm,
-//   pto.sync.set, pto.sync.wait
+//   pto.set_intra_block, pto.wait_intra_block
 // scenarios: fixpipe, cc-to-gm, acc-to-cbuf-to-ub-to-gm, strict-matmul-golden
 // -----------------------------------------------------------------------------
 
@@ -97,8 +97,8 @@ module attributes {pto.target_arch = "a5"} {
 
       pto.set_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
-      pto.sync.set <PIPE_FIX>, 1
-      pto.sync.set <PIPE_FIX>, 17
+      pto.set_intra_block <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 17
     }
 
     pto.section.vector {
@@ -106,7 +106,7 @@ module attributes {pto.target_arch = "a5"} {
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
 
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %ub_out, %out_cbuf_gm, %c256_i64
           nburst(%c40_i64, %c256_i64, %c256_i64)
           : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-atomic-f32-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-atomic-f32-cv/kernel.pto
@@ -10,7 +10,7 @@
 // case: micro-op/cv-mixed/fixpipe-acc-store-atomic-f32-cv
 // family: cv-mixed
 // target_ops: pto.mte_gm_l1_frac, pto.mte_l1_l0a, pto.mte_l1_l0b, pto.mad,
-//   pto.mte_l0c_gm, pto.sync.set, pto.sync.wait
+//   pto.mte_l0c_gm, pto.set_intra_block, pto.wait_intra_block
 // scenarios: acc-store-gm-atomic-add-max-min, f32, nz2nd, strict-matmul-golden
 // -----------------------------------------------------------------------------
 

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv/kernel.pto
@@ -10,7 +10,7 @@
 // case: micro-op/cv-mixed/fixpipe-acc-store-dual-ub-cv
 // family: cv-mixed
 // target_ops: pto.mte_gm_l1_frac, pto.mte_l1_l0a, pto.mte_l1_l0b, pto.mad,
-//   pto.mte_l0c_ub, pto.mte_ub_gm, pto.sync.set, pto.sync.wait
+//   pto.mte_l0c_ub, pto.mte_ub_gm, pto.set_intra_block, pto.wait_intra_block
 // scenarios: nd2nz-functional-load, mte_l0c_ub split-M, mte_l0c_ub split-N,
 //   per-subblock UB writeback
 // -----------------------------------------------------------------------------
@@ -92,8 +92,8 @@ module attributes {pto.target_arch = "a5"} {
         sat
         : !pto.ptr<f32, l0c>, !pto.ptr<f32, ub>, i64, i64, i64, i64
 
-      pto.sync.set <PIPE_FIX>, 1
-      pto.sync.set <PIPE_FIX>, 17
+      pto.set_intra_block <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 17
     }
 
     pto.section.vector {
@@ -102,7 +102,7 @@ module attributes {pto.target_arch = "a5"} {
       %is_subblock1 = arith.cmpi eq, %subblock, %c1_i64 : i64
 
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %ub_split_m, %out_split_m0_gm, %c256_i64
           nburst(%c20_i64, %c256_i64, %c256_i64)
           : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
@@ -111,7 +111,7 @@ module attributes {pto.target_arch = "a5"} {
           : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
       }
       scf.if %is_subblock1 {
-        pto.sync.wait <PIPE_MTE3>, 17
+        pto.wait_intra_block <PIPE_MTE3>, 17
         pto.mte_ub_gm %ub_split_m, %out_split_m1_gm, %c256_i64
           nburst(%c20_i64, %c256_i64, %c256_i64)
           : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-sat-f16-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-store-sat-f16-cv/kernel.pto
@@ -12,7 +12,7 @@
 // target_ops: pto.mte_gm_l1_frac, pto.mte_l1_l0a, pto.mte_l1_l0b, pto.mad,
 //   pto.mte_gm_l1, pto.mte_l1_fb, pto.mte_l0c_ub, pto.mte_l0c_gm, pto.mte_l0c_l1,
 //   pto.mte_l1_ub, pto.mte_ub_gm, pto.get_ctrl, pto.sbitset1, pto.set_ctrl,
-//   pto.sync.set, pto.sync.wait
+//   pto.set_intra_block, pto.wait_intra_block
 // scenarios: acc-store-ub-gm-l1, sat-ab, qf322f16, ctrl48-restore, ub-to-gm, l1-to-ub
 // -----------------------------------------------------------------------------
 
@@ -163,8 +163,8 @@ module attributes {pto.target_arch = "a5"} {
 
       pto.set_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
-      pto.sync.set <PIPE_FIX>, 1
-      pto.sync.set <PIPE_FIX>, 17
+      pto.set_intra_block <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 17
     }
 
     pto.section.vector {
@@ -172,7 +172,7 @@ module attributes {pto.target_arch = "a5"} {
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
 
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %ub_sat, %out_ub_sat_gm, %c128_i64
           nburst(%c40_i64, %c128_i64, %c128_i64)
           : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-acc-ub-cv/kernel.pto
@@ -10,7 +10,7 @@
 // case: micro-op/cv-mixed/fixpipe-acc-ub-cv
 // family: cv-mixed
 // target_ops: pto.mte_gm_l1_frac, pto.mte_l1_l0a, pto.mte_l1_l0b, pto.mad,
-//   pto.mte_l0c_ub, pto.mte_ub_gm, pto.sync.set, pto.sync.wait
+//   pto.mte_l0c_ub, pto.mte_ub_gm, pto.set_intra_block, pto.wait_intra_block
 // scenarios: nd2nz-functional-load, cc-to-ub, ub-to-gm
 // -----------------------------------------------------------------------------
 
@@ -83,8 +83,8 @@ module attributes {pto.target_arch = "a5"} {
         sat
         : !pto.ptr<f32, l0c>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64, i64
 
-      pto.sync.set <PIPE_FIX>, 1
-      pto.sync.set <PIPE_FIX>, 17
+      pto.set_intra_block <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 17
     }
 
     pto.section.vector {
@@ -92,7 +92,7 @@ module attributes {pto.target_arch = "a5"} {
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
 
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %ub_out, %out_gm, %c256_i64
           nburst(%c40_i64, %c256_i64, %c256_i64)
           : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-clip-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-clip-ub-cv/kernel.pto
@@ -11,7 +11,7 @@
 // family: cv-mixed
 // target_ops: pto.mte_gm_l1_frac, pto.mte_l1_l0a, pto.mte_l1_l0b, pto.mad,
 //   pto.mte_l0c_ub, pto.mte_l0c_gm, pto.mte_l0c_l1, pto.mte_l1_ub,
-//   pto.mte_ub_gm, pto.sync.set, pto.sync.wait
+//   pto.mte_ub_gm, pto.set_intra_block, pto.wait_intra_block
 // scenarios: nd2nz-functional-load, cc-store-ub-gm-l1, standalone-clip, ub-to-gm
 // -----------------------------------------------------------------------------
 
@@ -114,7 +114,7 @@ module attributes {pto.target_arch = "a5"} {
 
       pto.set_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
-      pto.sync.set <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 1
     }
 
     pto.section.vector {
@@ -122,7 +122,7 @@ module attributes {pto.target_arch = "a5"} {
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
 
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %ub_clip, %out_ub_clip_gm, %c128_i64
           nburst(%c40_i64, %c128_i64, %c128_i64)
           : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-clip-f16-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-clip-f16-ub-cv/kernel.pto
@@ -11,7 +11,7 @@
 // family: cv-mixed
 // target_ops: pto.mte_gm_l1_frac, pto.mte_l1_l0a, pto.mte_l1_l0b, pto.mad,
 //   pto.mte_l1_fb, pto.mte_l0c_ub, pto.mte_l0c_gm, pto.mte_l0c_l1,
-//   pto.mte_l1_ub, pto.mte_ub_gm, pto.sync.set, pto.sync.wait
+//   pto.mte_l1_ub, pto.mte_ub_gm, pto.set_intra_block, pto.wait_intra_block
 // scenarios: split-compile, cube-producer, vector-consumer, fixpipe-vector-qf322f16,
 //   standalone-clip-on-f16, fp-load, strict-matmul-golden, cc-store-ub-gm-l1
 // -----------------------------------------------------------------------------
@@ -157,8 +157,8 @@ module attributes {pto.target_arch = "a5"} {
 
       pto.set_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
-      pto.sync.set <PIPE_FIX>, 1
-      pto.sync.set <PIPE_FIX>, 17
+      pto.set_intra_block <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 17
     }
 
     pto.section.vector {
@@ -166,7 +166,7 @@ module attributes {pto.target_arch = "a5"} {
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
 
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %ub_quant, %out_ub_quant_gm, %c128_i64
           nburst(%c40_i64, %c128_i64, %c128_i64)
           : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-normal-relu-clip-f16-scalar-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-normal-relu-clip-f16-scalar-ub-cv/kernel.pto
@@ -11,7 +11,7 @@
 // family: cv-mixed
 // target_ops: pto.mte_gm_l1_frac, pto.mte_l1_l0a, pto.mte_l1_l0b, pto.mad,
 //   pto.mte_l0c_ub, pto.mte_l0c_gm, pto.mte_l0c_l1, pto.mte_l1_ub,
-//   pto.mte_ub_gm, pto.sync.set, pto.sync.wait
+//   pto.mte_ub_gm, pto.set_intra_block, pto.wait_intra_block
 // scenarios: split-compile, cube-producer, vector-consumer, fixpipe-qf322f16-scalar,
 //   normal-relu, clip-relu-pre, strict-matmul-golden, cc-store-ub-gm-l1
 // -----------------------------------------------------------------------------
@@ -148,8 +148,8 @@ module attributes {pto.target_arch = "a5"} {
 
       pto.set_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
-      pto.sync.set <PIPE_FIX>, 1
-      pto.sync.set <PIPE_FIX>, 17
+      pto.set_intra_block <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 17
     }
 
     pto.section.vector {
@@ -157,7 +157,7 @@ module attributes {pto.target_arch = "a5"} {
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
 
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %ub_relu, %out_ub_relu_gm, %c128_i64
           nburst(%c40_i64, %c128_i64, %c128_i64)
           : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-relu-clip-f16-scalar-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-relu-clip-f16-scalar-ub-cv/kernel.pto
@@ -11,7 +11,7 @@
 // family: cv-mixed
 // target_ops: pto.mte_gm_l1_frac, pto.mte_l1_l0a, pto.mte_l1_l0b, pto.mad,
 //   pto.mte_l0c_ub, pto.mte_l0c_gm, pto.mte_l0c_l1, pto.mte_l1_ub,
-//   pto.mte_ub_gm, pto.sync.set, pto.sync.wait
+//   pto.mte_ub_gm, pto.set_intra_block, pto.wait_intra_block
 // scenarios: split-compile, cube-producer, vector-consumer, fixpipe-qf322f16-scalar,
 //   scalar-relu, clip-relu-pre, strict-matmul-golden, cc-store-ub-gm-l1
 // -----------------------------------------------------------------------------
@@ -149,8 +149,8 @@ module attributes {pto.target_arch = "a5"} {
 
       pto.set_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
-      pto.sync.set <PIPE_FIX>, 1
-      pto.sync.set <PIPE_FIX>, 17
+      pto.set_intra_block <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 17
     }
 
     pto.section.vector {
@@ -158,7 +158,7 @@ module attributes {pto.target_arch = "a5"} {
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
 
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %ub_relu, %out_ub_relu_gm, %c128_i64
           nburst(%c40_i64, %c128_i64, %c128_i64)
           : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-relu-float-payload-f16-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-relu-float-payload-f16-ub-cv/kernel.pto
@@ -11,7 +11,7 @@
 // family: cv-mixed
 // target_ops: pto.mte_gm_l1_frac, pto.mte_l1_l0a, pto.mte_l1_l0b, pto.mad,
 //   pto.mte_l0c_ub, pto.mte_l0c_gm, pto.mte_l0c_l1, pto.mte_l1_ub,
-//   pto.mte_ub_gm, pto.sync.set, pto.sync.wait
+//   pto.mte_ub_gm, pto.set_intra_block, pto.wait_intra_block
 // scenarios: split-compile, cube-producer, vector-consumer,
 //   fixpipe-qf322f16-scalar-float-payload, scalar-relu-float-payload,
 //   f32-f16-bf16-payload-ab, cc-store-ub-gm-l1
@@ -121,8 +121,8 @@ module attributes {pto.target_arch = "a5"} {
 
       pto.set_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
-      pto.sync.set <PIPE_FIX>, 1
-      pto.sync.set <PIPE_FIX>, 17
+      pto.set_intra_block <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 17
     }
 
     pto.section.vector {
@@ -130,7 +130,7 @@ module attributes {pto.target_arch = "a5"} {
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
 
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %ub_out, %out_ub_gm, %c128_i64
           nburst(%c40_i64, %c128_i64, %c128_i64)
           : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-quant-ub-cv/kernel.pto
@@ -11,7 +11,7 @@
 // family: cv-mixed
 // target_ops: pto.mte_gm_l1_frac, pto.mte_l1_l0a, pto.mte_l1_l0b, pto.mad,
 //   pto.mte_l1_fb, pto.mte_l0c_ub, pto.mte_l0c_gm, pto.mte_l0c_l1,
-//   pto.mte_l1_ub, pto.mte_ub_gm, pto.sync.set, pto.sync.wait
+//   pto.mte_l1_ub, pto.mte_ub_gm, pto.set_intra_block, pto.wait_intra_block
 // scenarios: split-compile, cube-producer, vector-consumer, fixpipe-vector-qf322f16,
 //   fp-load, strict-matmul-golden, cc-store-ub-gm-l1
 // -----------------------------------------------------------------------------
@@ -122,8 +122,8 @@ module attributes {pto.target_arch = "a5"} {
 
       pto.set_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
-      pto.sync.set <PIPE_FIX>, 1
-      pto.sync.set <PIPE_FIX>, 17
+      pto.set_intra_block <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 17
     }
 
     pto.section.vector {
@@ -131,7 +131,7 @@ module attributes {pto.target_arch = "a5"} {
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
 
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %ub_out, %out_ub_gm, %c128_i64
           nburst(%c40_i64, %c128_i64, %c128_i64)
           : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-relu-scalar-vector-f16-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-relu-scalar-vector-f16-cv/kernel.pto
@@ -11,7 +11,7 @@
 // family: cv-mixed
 // target_ops: pto.mte_gm_l1_frac, pto.mte_gm_l1, pto.mte_l1_l0a, pto.mte_l1_l0b,
 //   pto.mad, pto.mte_l1_fb, pto.mte_l0c_ub, pto.mte_l0c_gm, pto.mte_l0c_l1,
-//   pto.mte_l1_ub, pto.mte_ub_gm, pto.sync.set, pto.sync.wait
+//   pto.mte_l1_ub, pto.mte_ub_gm, pto.set_intra_block, pto.wait_intra_block
 // scenarios: split-compile, cube-producer, vector-consumer, fixpipe-qf322f16-scalar,
 //   scalar-relu, vector-relu, strict-matmul-golden, cc-store-ub-gm-l1
 // -----------------------------------------------------------------------------
@@ -162,8 +162,8 @@ module attributes {pto.target_arch = "a5"} {
 
       pto.set_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
-      pto.sync.set <PIPE_FIX>, 1
-      pto.sync.set <PIPE_FIX>, 17
+      pto.set_intra_block <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 17
     }
 
     pto.section.vector {
@@ -171,7 +171,7 @@ module attributes {pto.target_arch = "a5"} {
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
 
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %ub_scalar, %out_ub_scalar_gm, %c128_i64
           nburst(%c40_i64, %c128_i64, %c128_i64)
           : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/cv-mixed/fixpipe-relu-ub-cv/kernel.pto
+++ b/test/vpto/cases/micro-op/cv-mixed/fixpipe-relu-ub-cv/kernel.pto
@@ -11,7 +11,7 @@
 // family: cv-mixed
 // target_ops: pto.mte_gm_l1_frac, pto.mte_l1_l0a, pto.mte_l1_l0b, pto.mad,
 //   pto.mte_l0c_ub, pto.mte_l0c_gm, pto.mte_l0c_l1, pto.mte_l1_ub,
-//   pto.mte_ub_gm, pto.sync.set, pto.sync.wait
+//   pto.mte_ub_gm, pto.set_intra_block, pto.wait_intra_block
 // scenarios: nd2nz-functional-load, cc-store-ub-gm-l1, normal-relu, standalone-clip, ub-to-gm
 // -----------------------------------------------------------------------------
 
@@ -146,8 +146,8 @@ module attributes {pto.target_arch = "a5"} {
 
       pto.set_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
       pto.wait_flag["PIPE_MTE1", "PIPE_FIX", "EVENT_ID0"]
-      pto.sync.set <PIPE_FIX>, 1
-      pto.sync.set <PIPE_FIX>, 17
+      pto.set_intra_block <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 17
     }
 
     pto.section.vector {
@@ -155,7 +155,7 @@ module attributes {pto.target_arch = "a5"} {
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
 
       scf.if %is_subblock0 {
-        pto.sync.wait <PIPE_MTE3>, 1
+        pto.wait_intra_block <PIPE_MTE3>, 1
         pto.mte_ub_gm %ub_relu, %out_ub_relu_gm, %c128_i64
           nburst(%c40_i64, %c128_i64, %c128_i64)
           : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64

--- a/test/vpto/cases/micro-op/vector-load-store/cbuf-ubuf-roundtrip-mixed/kernel.pto
+++ b/test/vpto/cases/micro-op/vector-load-store/cbuf-ubuf-roundtrip-mixed/kernel.pto
@@ -34,9 +34,9 @@ module attributes {pto.target_arch = "a5"} {
       pto.copy_ubuf_to_cbuf %ub0, %l1_rt, %c1_i64, %c1_i64, %c16_i64, %c0_i64, %c0_i64
         : !pto.ptr<i16, ub>, !pto.ptr<i16, l1>, i64, i64, i64, i64, i64
 
-      pto.sync.set <PIPE_MTE3>, 0
+      pto.set_intra_block <PIPE_MTE3>, 0
 
-      pto.sync.wait <PIPE_MTE3>, 1
+      pto.wait_intra_block <PIPE_MTE3>, 1
 
       %subblock = pto.get_subblock_idx
       %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
@@ -52,8 +52,8 @@ module attributes {pto.target_arch = "a5"} {
     pto.section.cube {
       // Follow the working PTO-ISA tmov_ub2l1 handoff:
       // vec produces L1, cube waits on MTE1 before reading cbuf.
-      pto.sync.wait <PIPE_MTE1>, 0
-      pto.sync.wait <PIPE_MTE1>, 16
+      pto.wait_intra_block <PIPE_MTE1>, 0
+      pto.wait_intra_block <PIPE_MTE1>, 16
 
       pto.copy_cbuf_to_ubuf %l1_rt, %ub1, %c0_i64, %c1_i64, %c16_i64, %c0_i64, %c0_i64
         : !pto.ptr<i16, l1>, !pto.ptr<i16, ub>, i64, i64, i64, i64, i64
@@ -61,8 +61,8 @@ module attributes {pto.target_arch = "a5"} {
         : !pto.ptr<i16, l1>, !pto.ptr<i16, ub>, i64, i64, i64, i64, i64
 
       // cube produces UB, vec waits on MTE3 for the return handoff.
-      pto.sync.set <PIPE_FIX>, 1
-      pto.sync.set <PIPE_FIX>, 17
+      pto.set_intra_block <PIPE_FIX>, 1
+      pto.set_intra_block <PIPE_FIX>, 17
     }
     return
   }

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -3232,6 +3232,8 @@ static LogicalResult runVPTOBackendPipeline(OwningOpRef<ModuleOp> &module,
                                             bool hasTileOpsToExpand) {
   PassManager pm(module->getContext());
   pm.enableVerifier();
+  if (!hasTileOpsToExpand)
+    pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOCanonicalizeIRPass());
   pm.addPass(pto::createVPTOSplitCVModulePass());
   pm.addPass(pto::createVPTONormalizeContainerPass());
   if (hasTileOpsToExpand) {

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -3232,8 +3232,9 @@ static LogicalResult runVPTOBackendPipeline(OwningOpRef<ModuleOp> &module,
                                             bool hasTileOpsToExpand) {
   PassManager pm(module->getContext());
   pm.enableVerifier();
-  if (!hasTileOpsToExpand)
+  if (!hasTileOpsToExpand) {
     pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOCanonicalizeIRPass());
+  }
   pm.addPass(pto::createVPTOSplitCVModulePass());
   pm.addPass(pto::createVPTONormalizeContainerPass());
   if (hasTileOpsToExpand) {

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -2902,6 +2902,8 @@ static LogicalResult runVPTOBackendPipeline(OwningOpRef<ModuleOp> &module,
                                             bool hasTileOpsToExpand) {
   PassManager pm(module->getContext());
   pm.enableVerifier();
+  if (!hasTileOpsToExpand)
+    pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOCanonicalizeIRPass());
   pm.addPass(pto::createVPTOSplitCVModulePass());
   pm.addPass(pto::createVPTONormalizeContainerPass());
   if (hasTileOpsToExpand)


### PR DESCRIPTION
## Summary

- Align the named PTO IR synchronization interfaces with PTODSL: `pto.set_cross_block`, `pto.wait_cross_block`, `pto.set_intra_block`, and `pto.wait_intra_block`.
- Keep `pto.sync.set/wait` limited to FFTS modes `0/1/2`.

## Lowering

- Cross-block: named IR ops canonicalize to `pto.sync.set/wait` with mode `0`.
- A5 intra-block: named IR ops lower directly to `__builtin_cce_set_intra_block` / `__builtin_cce_wait_intra_block`.
- A2/A3 intra-block: named IR ops fall back to `ffts_cross_core_sync` / `wait_flag_dev` using CANN 9.1 `FFTS_MODE_VAL` (mode `2`); static IDs are `[0,15]`.
- VPTO applies the same normalization, including its no-tile-op fast path.

## Rebase

- Rebased onto current `official/main` (`e0647ffa`).
- Dropped `a1d0f724938283c8a65679cacc8a640b68fa6522`: its ptobc test-data fix is already on main.

## Validation

- `ninja -C build PTOASCompiler`
- `PYTHONPATH=build/python:ptodsl python3 -m unittest discover -s ptodsl/tests -p test_vector_cube_ops.py`
- A5 EmitC smoke: cross-block lowers to FFTS and intra-block to dedicated builtins.
- A3 EmitC smoke: intra-block lowers to mode-2 FFTS and never to A5 builtins.
