### PR TITLE
fix(vmi): lower scalar stores as point stores

### DIFF
--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7234,40 +7234,6 @@ struct OneToNVMIStoreOpPattern : OpConversionPattern<VMIStoreOp> {
       return failure();
 
     ValueRange valueParts = adaptor.getValue();
-    // A one-lane VMI value is a scalar memory operation. Although its
-    // physical carrier is a full vreg, a regular vsts still requires a
-    // 32-byte-aligned address even with a PAT_VL1 mask. Select the ISA
-    // point-store form so adjacent scalar elements can be addressed normally.
-    if (valueVMIType.getElementCount() == 1) {
-      if (valueParts.size() != 1)
-        return rewriter.notifyMatchFailure(
-            op, "scalar store requires one physical value part");
-      auto valueType = dyn_cast<VRegType>(valueParts.front().getType());
-      if (!valueType)
-        return rewriter.notifyMatchFailure(op,
-                                           "scalar store value must be vreg");
-      std::optional<std::string> pointDist =
-          getPointStoreDistToken(valueVMIType.getElementType());
-      if (!pointDist)
-        return rewriter.notifyMatchFailure(
-            op, "scalar store requires 1PT_B8/B16/B32 store support");
-      FailureOr<MaskType> maskType =
-          getMaskTypeForVReg(valueType, rewriter.getContext());
-      if (failed(maskType))
-        return rewriter.notifyMatchFailure(
-            op, "unsupported element type for scalar store mask");
-      FailureOr<Value> mask =
-          createPrefixMask(op.getLoc(), *maskType, "PAT_VL1", rewriter);
-      if (failed(mask))
-        return rewriter.notifyMatchFailure(
-            op, "failed to create scalar store mask");
-      rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{},
-                              valueParts.front(), *destination, *offset,
-                              rewriter.getStringAttr(*pointDist), *mask);
-      rewriter.eraseOp(op);
-      return success();
-    }
-
     if (std::optional<std::string> dist =
             getDenseLaneStrideStoreDistToken(valueVMIType)) {
       std::optional<StringRef> maskGranularity =
@@ -7489,6 +7455,44 @@ struct OneToNVMIGroupStoreOpPattern
     bool compactSmallGroupStore = isCompactSmallGroupStore(
         layout, valueVMIType, op.getNumGroupsAttr().getInt(),
         getConstantIndexValue(op.getRowStride()));
+
+    // Unified scalar vstore is lowered to group_store(num_groups=1) before
+    // layout assignment.  The producer may therefore carry the slots=8
+    // layout selected by group_slot_load, even though the logical operation
+    // still writes one scalar.  Preserve the scalar memory semantics here;
+    // a masked ordinary vsts would require a 32-byte-aligned destination.
+    if (op.getNumGroupsAttr().getInt() == 1 &&
+        valueVMIType.getElementCount() == 1) {
+      ValueRange valueParts = adaptor.getValue();
+      if (valueParts.size() != 1)
+        return rewriter.notifyMatchFailure(
+            op, "scalar group_store requires one physical value part");
+      auto valueType = dyn_cast<VRegType>(valueParts.front().getType());
+      if (!valueType)
+        return rewriter.notifyMatchFailure(
+            op, "scalar group_store value must be vreg");
+      std::optional<std::string> pointDist =
+          getPointStoreDistToken(valueVMIType.getElementType());
+      if (!pointDist)
+        return rewriter.notifyMatchFailure(
+            op, "scalar group_store requires point-store support");
+      FailureOr<MaskType> maskType =
+          getMaskTypeForVReg(valueType, rewriter.getContext());
+      if (failed(maskType))
+        return rewriter.notifyMatchFailure(
+            op, "unsupported element type for scalar group_store mask");
+      FailureOr<Value> mask =
+          createPrefixMask(op.getLoc(), *maskType, "PAT_VL1", rewriter);
+      if (failed(mask))
+        return rewriter.notifyMatchFailure(
+            op, "failed to create scalar group_store mask");
+      rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{},
+                              valueParts.front(), *destination, *offset,
+                              rewriter.getStringAttr(*pointDist), *mask);
+      rewriter.eraseOp(op);
+      return success();
+    }
+
     if (compactSmallGroupStore) {
       // The VMI input remains group_slots(num_groups=8, slots=8). Its active
       // group values occupy the leading physical lanes. Materialize the same

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7234,6 +7234,40 @@ struct OneToNVMIStoreOpPattern : OpConversionPattern<VMIStoreOp> {
       return failure();
 
     ValueRange valueParts = adaptor.getValue();
+    // A one-lane VMI value is a scalar memory operation. Although its
+    // physical carrier is a full vreg, a regular vsts still requires a
+    // 32-byte-aligned address even with a PAT_VL1 mask. Select the ISA
+    // point-store form so adjacent scalar elements can be addressed normally.
+    if (valueVMIType.getElementCount() == 1) {
+      if (valueParts.size() != 1)
+        return rewriter.notifyMatchFailure(
+            op, "scalar store requires one physical value part");
+      auto valueType = dyn_cast<VRegType>(valueParts.front().getType());
+      if (!valueType)
+        return rewriter.notifyMatchFailure(op,
+                                           "scalar store value must be vreg");
+      std::optional<std::string> pointDist =
+          getPointStoreDistToken(valueVMIType.getElementType());
+      if (!pointDist)
+        return rewriter.notifyMatchFailure(
+            op, "scalar store requires 1PT_B8/B16/B32 store support");
+      FailureOr<MaskType> maskType =
+          getMaskTypeForVReg(valueType, rewriter.getContext());
+      if (failed(maskType))
+        return rewriter.notifyMatchFailure(
+            op, "unsupported element type for scalar store mask");
+      FailureOr<Value> mask =
+          createPrefixMask(op.getLoc(), *maskType, "PAT_VL1", rewriter);
+      if (failed(mask))
+        return rewriter.notifyMatchFailure(
+            op, "failed to create scalar store mask");
+      rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{},
+                              valueParts.front(), *destination, *offset,
+                              rewriter.getStringAttr(*pointDist), *mask);
+      rewriter.eraseOp(op);
+      return success();
+    }
+
     if (std::optional<std::string> dist =
             getDenseLaneStrideStoreDistToken(valueVMIType)) {
       std::optional<StringRef> maskGranularity =

--- a/test/lit/vmi_new/vmi_compact_load_store_group_alias.pto
+++ b/test/lit/vmi_new/vmi_compact_load_store_group_alias.pto
@@ -108,14 +108,16 @@ module {
 
 // LOWER-LABEL: func.func @compact_1(
 // LOWER: pto.vlds {{.*}} {dist = "BRC_B32"}
-// LOWER: pto.vsts
+// LOWER: pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
+// LOWER: pto.vsts {{.*}} {dist = "1PT_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
 // LOWER-NOT: pto.vmi.
 
 // LOWER-LABEL: func.func @compact_1_after_addptr(
 // LOWER: %[[SRC_ELEMENT:.*]] = pto.addptr %arg0, %arg2
 // LOWER: pto.vlds %[[SRC_ELEMENT]][%{{.*}}] {dist = "BRC_B32"}
 // LOWER-NOT: pto.vsldb
-// LOWER: pto.vsts
+// LOWER: pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
+// LOWER: pto.vsts {{.*}} {dist = "1PT_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
 // LOWER-NOT: pto.vmi.
 
 
@@ -140,5 +142,6 @@ module {
 // LOWER-LABEL: func.func @compact_reduce_through_elementwise(
 // LOWER: pto.vcmax
 // LOWER: pto.vdiv
-// LOWER: pto.vsts
+// LOWER: pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
+// LOWER: pto.vsts {{.*}} {dist = "1PT_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
 // LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_widen_dense_reduce_multi_consumer.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_widen_dense_reduce_multi_consumer.pto
@@ -69,12 +69,12 @@ module {
 // LOWER: pto.vmul
 // LOWER: pto.vadd
 // LOWER: pto.vcadd
-// LOWER: pto.vdup
-// LOWER: pto.vsts
+// LOWER: pto.pset_b32 "PAT_VL1"
+// LOWER: pto.vsts {{.*}} {dist = "1PT_B32"}
 // LOWER: pto.vadd
 // LOWER: pto.vcadd
-// LOWER: pto.vdup
-// LOWER: pto.vsts
+// LOWER: pto.pset_b32 "PAT_VL1"
+// LOWER: pto.vsts {{.*}} {dist = "1PT_B32"}
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.
 // LOWER-NOT: unrealized_conversion_cast


### PR DESCRIPTION
## Status

WIP / draft. This PR intentionally records the remaining simulator failure; it is **not ready for review**.

## Investigation

- The original PR #1198 fixture used a 64-lane broadcast value with `group=1`, which is a full vector store into storage sized for one f32 per iteration.
- The corrected fixture keeps the VMI value scalar (`size=1`).
- `sim_dsl` now runs the corrected kernel and the numeric check passes, but the simulator reports `RV_VST` 32-byte misalignment for scalar stores at UB addresses `0x64` through `0xBC`.
- This is a real alignment bug: `PAT_VL1` on ordinary `vsts` remains subject to vector-store alignment. Scalar contiguous outputs require the `1PT_B32` point-store form.

## Current WIP

This change attempts to select `1PT_B32` for one-lane VMI stores and updates the focused lit expectation plus the reproducer checks. The first focused lit run still emits unqualified `vsts`; unified-to-legacy lowering widens the scalar before this attempted pattern sees it. The next step is to move the decision into the actual legacy store lowering path.

## Validation

- `sim_dsl` on the corrected scalar fixture: numeric `PASS`, but simulator reports 23 `vec_err_instr_misalign_t0` errors (pre-fix).
- Incremental rebuild: `pto-test-opt` succeeds.
- Focused FileCheck: currently fails as described above; expected `1PT_B32` has not yet been emitted.
- `git diff --check`: pass.

## Scope

Adds a self-contained reproducer under `docs/repro/compact_f32_store`, corrects its VMI spelling, and keeps the test changes alongside the WIP lowering change.