### PR TITLE
tquant: sync 86 test cases with pto-isa + template infrastructure

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -8748,7 +8748,7 @@ requirements beyond its valid shape:
 | f32, non-unrolled | `alignTo(G, 64) * 4` bytes, at least 256 bytes |
 | f32, unrolled | `alignTo(2*G, 64) * 4` bytes, at least 512 bytes |
 | f16/bf16, OCP | `alignTo(G, 128) * 2` bytes, at least 256 bytes |
-| f16/bf16, NV | Unsupported on the pinned A5 revisions |
+| f16/bf16, NV | `alignTo(G, 128) * 2` bytes, at least 256 bytes |
 
 The f32 flat form is unrolled when all of these hold:
 
@@ -8760,13 +8760,10 @@ src.rows * src.cols > 1024
 
 **Pinned A5 support boundary:**
 
-- axis1 canonical 2-D quantization with f16/bf16 source is rejected;
 - axis0 FP16 MXFP4 is rejected when the packed source stride `Ps/2` is not a
   multiple of 32 bytes;
-- axis0 FP32 MXFP8 with `interleave=true` is rejected;
 - padded f16/bf16 source is rejected when its final vector-aligned padding
-  store would be incomplete;
-- axis1 legacy-flat f16/bf16 with `quantScaleAlg=nv` is rejected.
+  store would be incomplete.
 
 For f16/bf16 source with `src.valid_cols < src.cols`, the operation may zero
 row padding in place, so the source has `Read+Write` effects. Tight B16 and all

--- a/docs/release/PTO-tile-Instruction-SPEC-v0.4.md
+++ b/docs/release/PTO-tile-Instruction-SPEC-v0.4.md
@@ -1891,17 +1891,14 @@ tight source (`Ps == N`) and `exp.rows == 1`.
 
 Flat axis1 scaling writes full vector widths. Its required capacity is
 `alignTo(G,64)*4` bytes for ordinary f32, `alignTo(2G,64)*4` bytes for the
-unrolled f32 path, and `alignTo(G,128)*2` bytes for f16/bf16 OCP. These bounds
-are at least 256, 512, and 256 bytes, respectively. The f32 path is unrolled
-when `src.rows*src.cols > 1024` and both `src.rows*src.cols` and
-`src.valid_rows*src.cols` are multiples of 256.
+unrolled f32 path, and `alignTo(G,128)*2` bytes for f16/bf16 with either OCP
+or NV scaling. These bounds are at least 256, 512, and 256 bytes,
+respectively. The f32 path is unrolled when `src.rows*src.cols > 1024` and
+both `src.rows*src.cols` and `src.valid_rows*src.cols` are multiples of 256.
 
 The pinned A5 revisions reject these combinations:
 
-- axis1 canonical f16/bf16;
-- axis1 legacy-flat f16/bf16 with NV scaling;
 - axis0 FP16 MXFP4 when `Ps/2` is not a multiple of 32 bytes;
-- axis0 FP32 MXFP8 with `interleave=true`;
 - padded f16/bf16 source whose final vector-aligned padding store is incomplete.
 
 Padded f16/bf16 source may be zeroed in place, so it has Read+Write effects.

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -12760,8 +12760,8 @@ mlir::LogicalResult mlir::pto::TQuantMxOp::verify() {
         if (expPhysical[1] != *alignedPhysicalCols)
           return emitOpError("expects interleaved exp physical cols to be align32(2 * src physical cols)");
       }
-      if (srcElem.isF32() && getInterleave())
-        return emitOpError("does not support FP32 interleave with the pinned pto-isa revision");
+      // pto-isa supports FP32 DN interleave via WriteDnInterleavedExponentF32
+      // (TQuant.hpp :2633), so the shape checks above already cover it.
     } else {
       if (dstPhysical[1] != srcPhysicalCols / pack) {
         if (isMxFp4)
@@ -12798,22 +12798,30 @@ mlir::LogicalResult mlir::pto::TQuantMxOp::verify() {
               failed(requireCapacityBytes(scalingName, scalingTy,
                                           *requiredBytes)))
             return failure();
-        } else if (getQuantScaleAlg() == pto::QuantScaleAlg::OCP) {
+        } else if (getQuantScaleAlg() == pto::QuantScaleAlg::OCP ||
+                   getQuantScaleAlg() == pto::QuantScaleAlg::NV) {
+          // B16 scaling stores 2 bytes per group for both OCP and NV
+          // (pto-isa TQuant.hpp: OCP writes T at scalingPtr per group; NV
+          // ComputeB16NvExpAndScaling stores uint16_t per group). Same
+          // 128-group alignment capacity rule applies.
           auto aligned = alignTo(groups, 128);
           auto requiredBytes = aligned ? checkedMul(*aligned, 2) : std::nullopt;
           if (!requiredBytes ||
-              failed(requireCapacityBytes("axis1 flat B16 OCP scaling",
-                                          scalingTy, *requiredBytes)))
+              failed(requireCapacityBytes(
+                  getQuantScaleAlg() == pto::QuantScaleAlg::NV
+                      ? "axis1 flat B16 NV scaling"
+                      : "axis1 flat B16 OCP scaling",
+                  scalingTy, *requiredBytes)))
             return failure();
         } else {
-          return emitOpError("does not support axis1 flat B16 NV quantization with the pinned pto-isa revisions");
+          return emitOpError("does not support axis1 flat B16 quantization with the pinned pto-isa revisions");
         }
       } else {
-        if (expValid[0] == 1)
-          return emitOpError(
-              "expects legacy flat exp to use physical rows == 1");
-        if (srcElem.isF16() || srcElem.isBF16())
-          return emitOpError("does not support axis1 canonical 2D B16 quantization with the pinned pto-isa revision");
+        // canonical 2D exp: valid shape [M, N/32] where M may be smaller than
+        // the physical rows (pto-isa Exp2D e8Tile: valid (rows, validGroups)
+        // over physical (staticRows, expCols)). A single valid row is legal.
+        // B16 canonical 2D is supported (pto-isa TQuant_MXFP8_B16_2D);
+        // scaling holds one element per group for both F32 and B16.
         SmallVector<int64_t, 2> canonicalShape = {srcRows, srcCols / 32};
         if (!llvm::equal(expValid, canonicalShape))
           return emitOpError("expects exp valid_shape to match canonical [M, N/32] for grpAxis=axis1");

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -1771,6 +1771,9 @@ static std::optional<VcvtContract> lookupVcvtContract(VcvtElemKind src,
     case VcvtElemKind::U8:
       return VcvtContract{/*requiresRnd=*/true, /*requiresSat=*/true,
                           /*requiresPart=*/true};
+    case VcvtElemKind::BF16:
+      return VcvtContract{/*requiresRnd=*/true, /*requiresSat=*/false,
+                          /*requiresPart=*/false};
     default:
       return std::nullopt;
     }

--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -631,6 +631,14 @@ static LogicalResult appendOpContextAttrs(
       attrs.emplace_back("axis_value", axisAttr.getValue().str());
     }
   }
+  if (auto tquantMx = dyn_cast<pto::TQuantMxOp>(op)) {
+    attrs.emplace_back("quant_scale_alg",
+                       stringifyQuantScaleAlg(tquantMx.getQuantScaleAlg()).str());
+    attrs.emplace_back("grp_axis",
+                       stringifyMxGroupAxis(tquantMx.getGrpAxis()).str());
+    if (tquantMx.getInterleave())
+      attrs.emplace_back("interleave", "true");
+  }
   (void)(tryAppendPrecisionType<pto::TExpOp>(
              op, attrs, pto::ExpPrecision::HighPrecision) ||
          tryAppendPrecisionType<pto::TLogOp>(

--- a/lib/PTO/Transforms/InsertTemplateAttributes.cpp
+++ b/lib/PTO/Transforms/InsertTemplateAttributes.cpp
@@ -589,6 +589,14 @@ static void appendOpContextAttrs(
       attrs.emplace_back("axis_value", axisAttr.getValue().str());
     }
   }
+  if (auto tquantMx = dyn_cast<pto::TQuantMxOp>(op)) {
+    attrs.emplace_back("quant_scale_alg",
+                       stringifyQuantScaleAlg(tquantMx.getQuantScaleAlg()).str());
+    attrs.emplace_back("grp_axis",
+                       stringifyMxGroupAxis(tquantMx.getGrpAxis()).str());
+    if (tquantMx.getInterleave())
+      attrs.emplace_back("interleave", "true");
+  }
   (void)(tryAppendPrecisionType<pto::TExpOp>(op, attrs) ||
          tryAppendPrecisionType<pto::TLogOp>(op, attrs) ||
          tryAppendPrecisionType<pto::TSqrtOp>(op, attrs) ||

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitterTypeHelpers.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitterTypeHelpers.cpp
@@ -1280,6 +1280,7 @@ constexpr VcvtContractEntry kVcvtContractEntries[] = {
     {VcvtElemKind::F16, VcvtElemKind::F8E5M2, {"llvm.hivm.vcvtff.f162f8e5m2.x", true, true, true, 16, false}},
     {VcvtElemKind::F16, VcvtElemKind::HiF8, {"llvm.hivm.vcvtff.f162hif8.x", true, true, true, 16, false}},
     {VcvtElemKind::F16, VcvtElemKind::F32, {"llvm.hivm.vcvtff.f162f32.x", false, false, true, 16, false}},
+    {VcvtElemKind::F16, VcvtElemKind::BF16, {"llvm.hivm.vcvtff.f162bf16.x", true, false, false, 16, false}},
     {VcvtElemKind::F16, VcvtElemKind::S32, {"llvm.hivm.vcvtfi.f162s32.x", true, false, true, 16, false}},
     {VcvtElemKind::F16, VcvtElemKind::S16, {"llvm.hivm.vcvtfi.f162s16.x", true, true, false, 16, false}},
     {VcvtElemKind::F16, VcvtElemKind::S8, {"llvm.hivm.vcvtfi.f162s8.x", true, true, true, 16, false}},

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -1652,6 +1652,8 @@ static std::optional<VcvtContract> lookupVcvtContract(VcvtElemKind src,
       return VcvtContract{"llvm.hivm.vcvtff.f162f8e5m2.x", true, true, true, 16};
     case VcvtElemKind::HiF8:
       return VcvtContract{"llvm.hivm.vcvtff.f162hif8.x", true, true, true, 16};
+    case VcvtElemKind::BF16:
+      return VcvtContract{"llvm.hivm.vcvtff.f162bf16.x", true, false, false, 16};
     case VcvtElemKind::F32:
       return VcvtContract{"llvm.hivm.vcvtff.f162f32.x", false, false, true, 16};
     case VcvtElemKind::S32:
@@ -5083,12 +5085,23 @@ static FailureOr<VcvtContract> buildVcvtContract(pto::VcvtOp op) {
   Type resultElemType = getElementTypeFromVectorLike(op.getResult().getType());
   if (!inputElemType || !resultElemType)
   {
+    if (const char *dbg = std::getenv("PTOAS_DEBUG_VCVT")) {
+      (void)dbg;
+      llvm::errs() << "[vcvt-debug] elem type extract failed: " << op << "\n";
+    }
     return failure();
   }
   auto contract = lookupVcvtContract(classifyVcvtElemType(inputElemType),
                                      classifyVcvtElemType(resultElemType));
   if (!contract)
   {
+    if (const char *dbg = std::getenv("PTOAS_DEBUG_VCVT")) {
+      (void)dbg;
+      llvm::errs() << "[vcvt-debug] no contract for kind "
+                   << static_cast<int>(classifyVcvtElemType(inputElemType)) << " -> "
+                   << static_cast<int>(classifyVcvtElemType(resultElemType))
+                   << ": " << op << "\n";
+    }
     return failure();
   }
   return *contract;
@@ -10397,6 +10410,10 @@ public:
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
     {
+      if (const char *dbg = std::getenv("PTOAS_DEBUG_VCVT")) {
+        (void)dbg;
+        llvm::errs() << "[vcvt-debug] result type conversion failed: " << op << "\n";
+      }
       return rewriter.notifyMatchFailure(op, "failed to convert vcvt result type");
     }
 

--- a/lib/TileOps/__init__.py
+++ b/lib/TileOps/__init__.py
@@ -89,6 +89,8 @@ _TEMPLATE_MODULES = {
     ("a5", "pto.tpartmul"): ".a5.tpartmul",
     ("a5", "pto.tprelu"): ".a5.tprelu",
     ("a5", "pto.trelu"): ".a5.trelu",
+    ("a5", "pto.tquant"): ".a5.tquant",
+    ("a5", "pto.tquant.mx"): ".a5.tquant",
     ("a5", "pto.trecip"): ".a5.trecip",
     ("a5", "pto.trem"): ".a5.trem",
     ("a5", "pto.trems"): ".a5.trems",

--- a/lib/TileOps/a5/tquant.py
+++ b/lib/TileOps/a5/tquant.py
@@ -1,0 +1,2304 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ptodsl import pto
+import ptodsl.tilelib as tilelib
+
+
+def _ceil_division(n, d):
+    return (n + d - 1) // d
+
+
+def _quant_tiles(operand_memory_spaces, **_):
+    return all(space in {"ub", "vec"} for space in operand_memory_spaces)
+
+@tilelib.tile_template(
+    op="pto.tquant",
+    target="a5",
+    name="template_tquant_int8_sym",
+    dtypes=[("f32", "f32", "i8")],
+    iteration_axis="none",
+    op_engine="vector",
+    op_class="elementwise",
+    constraints=[_quant_tiles],
+    id=0,
+    loop_depth=2,
+    is_post_update=False,
+    tags=("quant", "int8", "sym"),
+)
+def template_tquant_int8_sym(
+    src: pto.Tile,
+    scale: pto.Tile,
+    dst: pto.Tile,
+):
+    """INT8_SYM: dst = round(src * scale) → i8."""
+    valid_rows, valid_cols = dst.valid_shape
+    lanes_f32 = pto.elements_per_vreg(pto.f32)
+    scale_ptr = scale.as_ptr()
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        remained_b16 = valid_cols * 2
+        remained_b8 = valid_cols * 4
+        for col in range(0, valid_cols, lanes_f32):
+            mask, remained = pto.make_mask(pto.f32, remained)
+            mask_b16, remained_b16 = pto.make_mask(pto.f16, remained_b16)
+            mask_b8, remained_b8 = pto.make_mask(pto.i8, remained_b8)
+            src_v = pto.vlds(src[row, col:])
+            scale_v = pto.vlds(scale_ptr, row, dist="BRC_B32")
+            mul_v = pto.vmul(src_v, scale_v, mask)
+            s32_v = pto.vcvt(mul_v, pto.i32, mask, rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT)
+            f32_v = pto.vcvt(s32_v, pto.f32, mask, rnd=pto.VcvtRoundMode.R)
+            f16_v = pto.vcvt(f32_v, pto.f16, mask,
+                             rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT,
+                             part=pto.VcvtPartMode.EVEN)
+            i8_v = pto.vcvt(f16_v, pto.i8, mask_b16,
+                            rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT,
+                            part=pto.VcvtPartMode.EVEN)
+            pto.vsts(i8_v, dst[row, col:], mask, dist=pto.VStoreDist.PK4_B32)
+
+@tilelib.tile_template(
+    op="pto.tquant",
+    target="a5",
+    name="template_tquant_int8_asym",
+    dtypes=[("f32", "f32", "f32", "ui8")],
+    iteration_axis="none",
+    op_engine="vector",
+    op_class="elementwise",
+    constraints=[_quant_tiles],
+    id=1,
+    loop_depth=2,
+    is_post_update=False,
+    tags=("quant", "int8", "asym"),
+)
+def template_tquant_int8_asym(
+    src: pto.Tile,
+    scale: pto.Tile,
+    offset: pto.Tile,
+    dst: pto.Tile,
+):
+    """INT8_ASYM: dst = round(src * scale + offset) → ui8."""
+    valid_rows, valid_cols = dst.valid_shape
+    lanes_f32 = pto.elements_per_vreg(pto.f32)
+    scale_ptr = scale.as_ptr()
+    offset_ptr = offset.as_ptr()
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        remained_b16 = valid_cols * 2
+        remained_b8 = valid_cols * 4
+        for col in range(0, valid_cols, lanes_f32):
+            mask, remained = pto.make_mask(pto.f32, remained)
+            mask_b16, remained_b16 = pto.make_mask(pto.f16, remained_b16)
+            mask_b8, remained_b8 = pto.make_mask(pto.ui8, remained_b8)
+            src_v = pto.vlds(src[row, col:])
+            scale_v = pto.vlds(scale_ptr, row, dist="BRC_B32")
+            offset_v = pto.vlds(offset_ptr, row, dist="BRC_B32")
+            acc_v = pto.vadd(
+                pto.vmul(src_v, scale_v, mask),
+                offset_v, mask,
+            )
+            s32_v = pto.vcvt(acc_v, pto.i32, mask, rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT)
+            f32_v = pto.vcvt(s32_v, pto.f32, mask, rnd=pto.VcvtRoundMode.R)
+            f16_v = pto.vcvt(f32_v, pto.f16, mask,
+                             rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT,
+                             part=pto.VcvtPartMode.EVEN)
+            ui8_v = pto.vcvt(f16_v, pto.ui8, mask_b16,
+                             rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT,
+                             part=pto.VcvtPartMode.EVEN)
+            pto.vsts(ui8_v, dst[row, col:], mask, dist=pto.VStoreDist.PK4_B32)
+
+
+# ── MX 量化（ND/DN templates + helpers）──
+
+def _mx_nd_2d_tiles(operand_memory_spaces, grp_axis=None, **_):
+    """ND (flat + Exp2D auto-dispatch) template constraint. 拒绝 DN（grp_axis=0/axis0）。"""
+    if not all(space in {"ub", "vec"} for space in operand_memory_spaces):
+        return False
+    if grp_axis is not None and str(grp_axis) in ("0", "axis0"):
+        return False
+    return True
+_MX_TAGS = ("quant", "mx")
+
+
+@dataclass(frozen=True)
+class _AlgTag:
+    """Base for algorithm tags (OcpF8E4M3Alg, etc.)."""
+    name: str
+
+
+OcpF8E4M3Alg = _AlgTag("OcpF8E4M3Alg")
+OcpF4E2M1Alg = _AlgTag("OcpF4E2M1Alg")
+NvF8E4M3Alg = _AlgTag("NvF8E4M3Alg")
+NvF4E2M1Alg = _AlgTag("NvF4E2M1Alg")
+
+
+@dataclass(frozen=True)
+class _OcpMxFp8E4M3Spec:
+    maxExp: int = 0x0400
+    expNan: int = 0x00FF
+    b16Nan: int = 0x7F81
+    f32Emax: int = 8
+
+
+@dataclass(frozen=True)
+class _NvMxFp8E4M3Spec:
+    descaleMultiplier: float = 1.0 / 448.0
+    b16SpecialScaleBits: int = 0x7F81
+    f32SpecialScaleBits: int = 0x7FC00000
+
+
+_OCP_MXFP8_SPEC = _OcpMxFp8E4M3Spec()
+_NV_MXFP8_SPEC = _NvMxFp8E4M3Spec()
+
+
+@dataclass
+class _F32OcpQuantCtx:
+    vb32_exp_mask: object = None
+    vb32_mantissa_mask: object = None
+    vb32_b8_nan: object = None
+    vb32_f32_nan: object = None
+    vb32_b8_emax: object = None
+    vb32_exp_max: object = None
+    vb32_recip_min_scale: object = None
+    vb32_zero: object = None
+    kExpMask: int = 0x7F800000
+    kMantissaMask: int = 0x007FFFFF
+    kExpMax: int = 0xFE
+    kF32Nan: int = 0x7FC00000
+    kRecipMinScale: int = 0x7F000000
+    kExpNan: int = field(default_factory=lambda: _OCP_MXFP8_SPEC.expNan)
+    f32Emax: int = field(default_factory=lambda: _OCP_MXFP8_SPEC.f32Emax)
+    shr: int = 23
+
+
+@dataclass
+class _F32NvQuantCtx:
+    vb32_exp_mask: object = None
+    vb32_mantissa_mask: object = None
+    vb32_exp_nan: object = None
+    vb32_exp_max: object = None
+    vb32_special_scale: object = None
+    vb32_min_rcp: object = None
+    descaleMultiplier: float = field(default_factory=lambda: _NV_MXFP8_SPEC.descaleMultiplier)
+    shr: int = 23
+ 
+def _abs_reduce_max_naive(src_ptr, max_ptr, total_count, vl_count, lanes_f32, preg_lower32, preg_upper32, src_base=0, max_base=0):
+    zero_v = pto.vbr(pto.f32(0))
+    remained = total_count
+    for i in range(vl_count):
+        preg, remained = pto.make_mask(pto.f32, remained)
+        v_in = pto.vlds(src_ptr, src_base + i * lanes_f32)
+        v_abs = pto.vabs(v_in, preg)
+        v_sel = pto.vsel(v_abs, zero_v, preg)
+        v_max_0 = pto.vcmax(v_sel, preg_lower32)
+        v_max_1 = pto.vcmax(v_sel, preg_upper32)
+        pto.vsts(v_max_0, max_ptr, max_base + 2 * i, preg, dist=pto.VStoreDist._1PT_B32)
+        pto.vsts(v_max_1, max_ptr, max_base + 2 * i + 1, preg, dist=pto.VStoreDist._1PT_B32)
+
+def _abs_reduce_max_f32_opt(src_ptr, max_ptr, vl_count, lanes_f32, total_count):
+    """Input must be multiple of 256 elements."""
+    preg_lower8 = pto.pset_b32(pto.PAT.VL8)
+    remained = total_count
+    for i in range(vl_count // 4):
+        preg_vl0, remained = pto.make_mask(pto.f32, remained)
+        preg_vl1, remained = pto.make_mask(pto.f32, remained)
+        preg_vl2, remained = pto.make_mask(pto.f32, remained)
+        preg_vl3, remained = pto.make_mask(pto.f32, remained)
+        off = i * 4 * lanes_f32
+        v_in_1, v_in_2 = pto.vldsx2(src_ptr, off, "DINTLV_B32")
+        v_in_3, v_in_4 = pto.vldsx2(src_ptr, off + 128, "DINTLV_B32")
+        v_in_1 = pto.vabs(v_in_1, preg_vl0)
+        v_in_3 = pto.vabs(v_in_3, preg_vl2)
+        v_di_1, v_di_2 = pto.vdintlv(v_in_1, v_in_3)
+        v_in_2 = pto.vabs(v_in_2, preg_vl1)
+        v_in_4 = pto.vabs(v_in_4, preg_vl3)
+        v_di_3, v_di_4 = pto.vdintlv(v_in_2, v_in_4)
+        v_max_0 = pto.vmax(v_di_1, v_di_2, preg_vl0)
+        v_max_1 = pto.vmax(v_di_3, v_di_4, preg_vl1)
+        v_max = pto.vmax(v_max_0, v_max_1, preg_vl0)
+        v_gp_max = pto.vcgmax(v_max, preg_vl0)
+        pto.vsts(v_gp_max, max_ptr, i * 8, preg_lower8, dist=pto.VStoreDist.NORM_B32)
+
+def _abs_reduce_max_f32_opt_largesizes(src_ptr, max_ptr, vl_count, lanes_f32, total_count):
+    """Input must be multiple of 2K elements."""
+    preg_all = pto.pset_b32(pto.PAT.ALL)
+    remained = total_count
+    for i in range(vl_count // 32):
+        ureg_max = pto.init_align()
+        for j in range(8):
+            preg_vl0, remained = pto.make_mask(pto.f32, remained)
+            preg_vl1, remained = pto.make_mask(pto.f32, remained)
+            preg_vl2, remained = pto.make_mask(pto.f32, remained)
+            preg_vl3, remained = pto.make_mask(pto.f32, remained)
+            off = (i * 32 + j * 4) * lanes_f32
+            v_in_1, v_in_2 = pto.vldsx2(src_ptr, off, "DINTLV_B32")
+            v_in_1 = pto.vabs(v_in_1, preg_vl0)
+            v_in_2 = pto.vabs(v_in_2, preg_vl1)
+            v_in_3, v_in_4 = pto.vldsx2(src_ptr, off + 2 * lanes_f32, "DINTLV_B32")
+            v_in_3 = pto.vabs(v_in_3, preg_vl2)
+            v_in_4 = pto.vabs(v_in_4, preg_vl3)
+            v_in_1 = pto.vmax(v_in_1, v_in_2, preg_vl0)
+            v_in_3 = pto.vmax(v_in_3, v_in_4, preg_vl2)
+            v_di_1, v_di_2 = pto.vdintlv(v_in_1, v_in_3)
+            v_max = pto.vmax(v_di_1, v_di_2, preg_vl0)
+            v_gp_max = pto.vcgmax(v_max, preg_all)
+            ureg_max = pto.vstus(ureg_max, 8, v_gp_max, pto.addptr(max_ptr, 64 * i + 8 * j))
+        pto.vstas(ureg_max, pto.addptr(max_ptr, 64 * i), 0)
+ 
+
+def _init_f32_ocp_quant_ctx():
+    ctx = _F32OcpQuantCtx()
+    ctx.vb32_exp_mask = pto.vbr(pto.si32(ctx.kExpMask))
+    ctx.vb32_mantissa_mask = pto.vbr(pto.si32(ctx.kMantissaMask))
+    ctx.vb32_b8_nan = pto.vbr(pto.si32(ctx.kExpNan))
+    ctx.vb32_f32_nan = pto.vbr(pto.si32(ctx.kF32Nan))
+    ctx.vb32_exp_max = pto.vbr(pto.si32(ctx.kExpMax))
+    ctx.vb32_b8_emax = pto.vbr(pto.si32(ctx.f32Emax))
+    ctx.vb32_recip_min_scale = pto.vbr(pto.si32(ctx.kRecipMinScale))
+    ctx.vb32_zero = pto.vbr(pto.si32(0))
+    return ctx
+
+
+def _compute_f32_ocp_exp_and_scaling(ctx, preg, max_ptr, off):
+    v_max = pto.vlds(max_ptr, off)
+    v_max_s32 = pto.vbitcast(v_max, pto.si32)
+    v_exp = pto.vand(v_max_s32, ctx.vb32_exp_mask, preg)
+    v_mant = pto.vand(v_max_s32, ctx.vb32_mantissa_mask, preg)
+    v_exp = pto.vshrs(v_exp, ctx.shr, preg)
+    v_shared_exp = pto.vsub(v_exp, ctx.vb32_b8_emax, preg)
+    v_scaling = pto.vsub(ctx.vb32_exp_max, v_shared_exp, preg)
+    v_scaling = pto.vshls(v_scaling, ctx.shr, preg)
+    preg_min_scale = pto.vcmps(v_exp, pto.si32(ctx.f32Emax), preg, pto.CmpMode.LE)
+    v_scaling = pto.vsel(ctx.vb32_recip_min_scale, v_scaling, preg_min_scale)
+    v_shared_exp = pto.vsel(ctx.vb32_zero, v_shared_exp, preg_min_scale)
+    preg_special = pto.vcmps(v_exp, pto.si32(ctx.kExpNan), preg, pto.CmpMode.EQ)
+    preg_nan = pto.vcmps(v_mant, pto.si32(0), preg_special, pto.CmpMode.NE)
+    v_scaling = pto.vsel(ctx.vb32_f32_nan, v_scaling, preg_nan)
+    v_shared_exp = pto.vsel(ctx.vb32_b8_nan, v_shared_exp, preg_nan)
+    return v_shared_exp, v_scaling
+
+
+def _extract_f32_ocp_exp_and_scaling_core(max_ptr, exp_ptr, scaling_ptr, off, elem_count):
+    ctx = _init_f32_ocp_quant_ctx()
+    preg_b32, _ = pto.make_mask(pto.f32, elem_count)
+    v_shared_exp, v_scaling = _compute_f32_ocp_exp_and_scaling(ctx, preg_b32, max_ptr, off)
+    exp_ptr_si32 = pto.castptr(exp_ptr, pto.ptr(pto.si32, "ub"))
+    scaling_ptr_si32 = pto.castptr(scaling_ptr, pto.ptr(pto.si32, "ub"))
+    pto.vsts(v_shared_exp, exp_ptr_si32, off // 4, preg_b32, dist=pto.VStoreDist.PK4_B32)
+    pto.vsts(v_scaling, scaling_ptr_si32, off, preg_b32, dist=_tquant_norm_dist(pto.f32))
+
+
+def _store_scaling_unrolled(scaling_ptr, v_scaling, iter, lanes_f32, scaling_elem_count):
+    v_scaling_0, v_scaling_1 = pto.vintlv(v_scaling, v_scaling)
+    base_off0 = 2 * iter * lanes_f32
+    base_off1 = base_off0 + lanes_f32
+    rem0 = scaling_elem_count - base_off0 if scaling_elem_count > base_off0 else 0
+    rem1 = scaling_elem_count - base_off1 if scaling_elem_count > base_off1 else 0
+    preg_sc0, _ = pto.make_mask(pto.f32, rem0)
+    pto.vsts(v_scaling_0, scaling_ptr, 2 * iter * lanes_f32, preg_sc0, dist=pto.VStoreDist.NORM_B32)
+    if rem1 > 0:
+        preg_sc1, _ = pto.make_mask(pto.f32, rem1)
+        pto.vsts(v_scaling_1, scaling_ptr, 2 * iter * lanes_f32 + lanes_f32, preg_sc1, dist=pto.VStoreDist.NORM_B32)
+
+
+def _extract_b8_exp_and_scaling_unrolled(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, total_count, lanes_f32):
+    ctx = _init_f32_ocp_quant_ctx()
+    remained = total_count
+    scaling_elem_count = total_count * 2
+    for i in range(exp_loop_count):
+        preg_b32, remained = pto.make_mask(pto.f32, remained)
+        v_shared_exp, v_scaling = _compute_f32_ocp_exp_and_scaling(ctx, preg_b32, max_ptr, i * lanes_f32)
+        pto.vsts(v_shared_exp, exp_ptr, i * lanes_f32, preg_b32, dist=pto.VStoreDist.PK4_B32)
+        _store_scaling_unrolled(scaling_ptr, v_scaling, i, lanes_f32, scaling_elem_count)
+
+
+def _extract_b8_exp_and_scaling_f32(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, total_count, lanes_f32, unroll=False):
+    if unroll:
+        _extract_b8_exp_and_scaling_unrolled(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, total_count, lanes_f32)
+    else:
+        for i in range(exp_loop_count):
+            _extract_f32_ocp_exp_and_scaling_core(max_ptr, exp_ptr, scaling_ptr, i * lanes_f32, total_count)
+
+
+def _init_f32_nv_quant_ctx():
+    ctx = _F32NvQuantCtx()
+    ctx.vb32_exp_mask = pto.vbr(pto.si32(0x7F800000))
+    ctx.vb32_mantissa_mask = pto.vbr(pto.si32(0x007FFFFF))
+    ctx.vb32_exp_nan = pto.vbr(pto.si32(0xFF))
+    ctx.vb32_exp_max = pto.vbr(pto.si32(0xFE))
+    ctx.vb32_special_scale = pto.vbr(pto.si32(_NV_MXFP8_SPEC.f32SpecialScaleBits))
+    ctx.vb32_min_rcp = pto.vbr(pto.si32(0x00400000))
+    return ctx
+
+
+def _round_up_nv_shared_exponent(v_shared_exp, v_exponent, v_mantissa, preg_b32):
+    v_shared_exp_inc = pto.vadds(v_exponent, 1, preg_b32)
+    preg_mant_gt_zero = pto.vcmps(v_mantissa, pto.si32(0), preg_b32, pto.CmpMode.NE)
+    preg_exp_gt_zero = pto.vcmps(v_exponent, pto.si32(0), preg_b32, pto.CmpMode.GT)
+    preg_exp_lt_max = pto.vcmps(v_exponent, pto.si32(0xFE), preg_b32, pto.CmpMode.LT)
+    preg_exp_eq_zero = pto.vcmps(v_exponent, pto.si32(0), preg_b32, pto.CmpMode.EQ)
+    preg_round_normal = pto.pand(preg_mant_gt_zero, preg_exp_gt_zero, preg_b32)
+    preg_round_normal = pto.pand(preg_round_normal, preg_exp_lt_max, preg_b32)
+    preg_mant_gt_half_sub = pto.vcmps(v_mantissa, pto.si32(0x00400000), preg_b32, pto.CmpMode.GT)
+    preg_round_subnormal = pto.pand(preg_mant_gt_half_sub, preg_exp_eq_zero, preg_b32)
+    preg_round_up = pto.por(preg_round_normal, preg_round_subnormal, preg_b32)
+    return pto.vsel(v_shared_exp_inc, v_exponent, preg_round_up)
+
+
+def _compute_f32_nv_exp_and_scaling(ctx, preg, max_ptr, off):
+    v_max = pto.vlds(max_ptr, off)
+    v_max = pto.vmuls(v_max, pto.f32(ctx.descaleMultiplier), preg)
+    v_max_s32 = pto.vbitcast(v_max, pto.si32)
+    v_exp = pto.vand(v_max_s32, ctx.vb32_exp_mask, preg)
+    v_mant = pto.vand(v_max_s32, ctx.vb32_mantissa_mask, preg)
+    v_exp = pto.vshrs(v_exp, ctx.shr, preg)
+    v_shared_exp = _round_up_nv_shared_exponent(v_exp, v_exp, v_mant, preg)
+    v_scaling = pto.vsub(ctx.vb32_exp_max, v_shared_exp, preg)
+    v_scaling = pto.vshls(v_scaling, ctx.shr, preg)
+    preg_exp_ff = pto.vcmps(v_exp, pto.si32(0xFF), preg, pto.CmpMode.EQ)
+    preg_mant_gt_zero = pto.vcmps(v_mant, pto.si32(0), preg, pto.CmpMode.NE)
+    preg_mant_eq_zero = pto.pnot(preg_mant_gt_zero, preg)
+    preg_inf = pto.pand(preg_exp_ff, preg_mant_eq_zero, preg)
+    preg_nan = pto.pand(preg_exp_ff, preg_mant_gt_zero, preg)
+    v_scaling = pto.vsel(ctx.vb32_min_rcp, v_scaling, preg_inf)
+    v_shared_exp = pto.vsel(ctx.vb32_exp_max, v_shared_exp, preg_inf)
+    v_scaling = pto.vsel(ctx.vb32_special_scale, v_scaling, preg_nan)
+    v_shared_exp = pto.vsel(ctx.vb32_exp_nan, v_shared_exp, preg_nan)
+    return v_shared_exp, v_scaling
+
+
+def _extract_f32_nv_exp_and_scaling_core(max_ptr, exp_ptr, scaling_ptr, off, elem_count):
+    ctx = _init_f32_nv_quant_ctx()
+    preg_b32, _ = pto.make_mask(pto.f32, elem_count)
+    v_shared_exp, v_scaling = _compute_f32_nv_exp_and_scaling(ctx, preg_b32, max_ptr, off)
+    exp_ptr_si32 = pto.castptr(exp_ptr, pto.ptr(pto.si32, "ub"))
+    scaling_ptr_si32 = pto.castptr(scaling_ptr, pto.ptr(pto.si32, "ub"))
+    pto.vsts(v_shared_exp, exp_ptr_si32, off // 4, preg_b32, dist=pto.VStoreDist.PK4_B32)
+    pto.vsts(v_scaling, scaling_ptr_si32, off, preg_b32, dist=_tquant_norm_dist(pto.f32))
+
+
+def _extract_nv_exponent_and_scaling_f32(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, total_count, lanes_f32, unroll=False):
+    ctx = _init_f32_nv_quant_ctx()
+    remained = total_count
+    scaling_elem_count = total_count * 2
+    for i in range(exp_loop_count):
+        preg_b32, remained = pto.make_mask(pto.f32, remained)
+        v_shared_exp, v_scaling = _compute_f32_nv_exp_and_scaling(ctx, preg_b32, max_ptr, i * lanes_f32)
+        pto.vsts(v_shared_exp, exp_ptr, i * lanes_f32, preg_b32, dist=pto.VStoreDist.PK4_B32)
+        if unroll:
+            _store_scaling_unrolled(scaling_ptr, v_scaling, i, lanes_f32, scaling_elem_count)
+        else:
+            pto.vsts(v_scaling, scaling_ptr, i * lanes_f32, preg_b32, dist=pto.VStoreDist.NORM_B32)
+
+
+def _extract_b8_exp_and_scaling_nv_f32(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, total_count, lanes_f32, unroll=False):
+    _extract_nv_exponent_and_scaling_f32(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, total_count, lanes_f32, unroll=unroll)
+
+def _init_f32_exp_scaling_ctx(scale_alg):
+    ctx = {}
+    ctx["vb32_exp_mask"] = pto.vbr(pto.si32(0x7F800000))
+    ctx["vb32_mantissa_mask"] = pto.vbr(pto.si32(0x007FFFFF))
+    ctx["vb32_b8_nan"] = pto.vbr(pto.si32(0xFF))
+    ctx["vb32_zero"] = pto.vbr(pto.si32(0))
+    if scale_alg == "nv":
+        ctx["vb32_b8_exp_fe"] = pto.vbr(pto.si32(0xFE))
+        ctx["vb32_f32_nan"] = pto.vbr(pto.si32(_NV_MXFP8_SPEC.f32SpecialScaleBits))
+        ctx["vb32_f32_min_rcp"] = pto.vbr(pto.si32(0x00400000))
+    else:
+        ctx["vb32_f32_nan"] = pto.vbr(pto.si32(0x7FC00000))
+        ctx["vb32_b8_emax"] = pto.vbr(pto.si32(_OCP_MXFP8_SPEC.f32Emax))
+        ctx["vb32_exp_max"] = pto.vbr(pto.si32(0xFE))
+        ctx["vb32_recip_min_scale"] = pto.vbr(pto.si32(0x7F000000))
+    return ctx
+
+def _compute_f32_exp_scaling_nv(ctx, v_max, preg_b32):
+    v_max = pto.vmuls(v_max, pto.f32(_NV_MXFP8_SPEC.descaleMultiplier), preg_b32)
+    v_max_s32 = pto.vbitcast(v_max, pto.si32)
+    v_exp = pto.vand(v_max_s32, ctx["vb32_exp_mask"], preg_b32)
+    v_mant = pto.vand(v_max_s32, ctx["vb32_mantissa_mask"], preg_b32)
+    v_exp = pto.vshrs(v_exp, 23, preg_b32)
+    v_shared_exp = v_exp
+    v_shared_exp_inc = pto.vadds(v_shared_exp, 1, preg_b32)
+    preg_mant_gt_zero = pto.vcmps(v_mant, pto.si32(0), preg_b32, pto.CmpMode.NE)
+    preg_exp_gt_zero = pto.vcmps(v_exp, pto.si32(0), preg_b32, pto.CmpMode.GT)
+    preg_exp_lt_max = pto.vcmps(v_exp, pto.si32(0xFE), preg_b32, pto.CmpMode.LT)
+    preg_exp_eq_zero = pto.vcmps(v_exp, pto.si32(0), preg_b32, pto.CmpMode.EQ)
+    preg_round_normal = pto.pand(preg_mant_gt_zero, preg_exp_gt_zero, preg_b32)
+    preg_round_normal = pto.pand(preg_round_normal, preg_exp_lt_max, preg_b32)
+    preg_mant_gt_half_sub = pto.vcmps(v_mant, pto.si32(0x00400000), preg_b32, pto.CmpMode.GT)
+    preg_round_subnormal = pto.pand(preg_mant_gt_half_sub, preg_exp_eq_zero, preg_b32)
+    preg_round_up = pto.por(preg_round_normal, preg_round_subnormal, preg_b32)
+    v_shared_exp = pto.vsel(v_shared_exp_inc, v_shared_exp, preg_round_up)
+    v_scaling = pto.vsub(ctx["vb32_b8_exp_fe"], v_shared_exp, preg_b32)
+    v_scaling = pto.vshls(v_scaling, 23, preg_b32)
+    preg_exp_ff = pto.vcmps(v_exp, pto.si32(0xFF), preg_b32, pto.CmpMode.EQ)
+    preg_mant_eq_zero = pto.pnot(preg_mant_gt_zero, preg_b32)
+    preg_inf = pto.pand(preg_exp_ff, preg_mant_eq_zero, preg_b32)
+    preg_nan = pto.pand(preg_exp_ff, preg_mant_gt_zero, preg_b32)
+    v_scaling = pto.vsel(ctx["vb32_f32_min_rcp"], v_scaling, preg_inf)
+    v_shared_exp = pto.vsel(ctx["vb32_b8_exp_fe"], v_shared_exp, preg_inf)
+    v_scaling = pto.vsel(ctx["vb32_f32_nan"], v_scaling, preg_nan)
+    v_shared_exp = pto.vsel(ctx["vb32_b8_nan"], v_shared_exp, preg_nan)
+    return v_shared_exp, v_scaling
+
+def _compute_f32_exp_scaling_ocp(ctx, v_max, preg_b32):
+    v_max_s32 = pto.vbitcast(v_max, pto.si32)
+    v_exp = pto.vand(v_max_s32, ctx["vb32_exp_mask"], preg_b32)
+    v_mant = pto.vand(v_max_s32, ctx["vb32_mantissa_mask"], preg_b32)
+    v_exp = pto.vshrs(v_exp, 23, preg_b32)
+    v_shared_exp = pto.vsub(v_exp, ctx["vb32_b8_emax"], preg_b32)
+    v_scaling = pto.vsub(ctx["vb32_exp_max"], v_shared_exp, preg_b32)
+    v_scaling = pto.vshls(v_scaling, 23, preg_b32)
+    preg_min_scale = pto.vcmps(v_exp, pto.si32(_OCP_MXFP8_SPEC.f32Emax), preg_b32, pto.CmpMode.LE)
+    v_scaling = pto.vsel(ctx["vb32_recip_min_scale"], v_scaling, preg_min_scale)
+    v_shared_exp = pto.vsel(ctx["vb32_zero"], v_shared_exp, preg_min_scale)
+    preg_special = pto.vcmps(v_exp, pto.si32(0xFF), preg_b32, pto.CmpMode.EQ)
+    preg_nan = pto.vcmps(v_mant, pto.si32(0), preg_special, pto.CmpMode.NE)
+    v_scaling = pto.vsel(ctx["vb32_f32_nan"], v_scaling, preg_nan)
+    v_shared_exp = pto.vsel(ctx["vb32_b8_nan"], v_shared_exp, preg_nan)
+    return v_shared_exp, v_scaling
+
+def _extract_b8_exp_and_scaling_f32_2d_packed(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_groups_per_row, exp_col_stride, scale_alg="ocp"):
+    ctx = _init_f32_exp_scaling_ctx(scale_alg)
+    preg_one, _ = pto.make_mask(pto.f32, 1)
+    scale_write_ptr = scaling_ptr
+    ureg_scaling = pto.init_align()
+    for row in range(valid_rows):
+        max_read_ptr = pto.addptr(max_ptr, row * valid_groups_per_row)
+        exp_write_ptr = pto.addptr(exp_ptr, row * exp_col_stride)
+        ureg_exp = pto.init_align()
+        for group in range(valid_groups_per_row):
+            v_max = pto.vlds(pto.addptr(max_read_ptr, group), 0, dist="BRC_B32")
+            if scale_alg == "nv":
+                v_shared_exp, v_scaling = _compute_f32_exp_scaling_nv(ctx, v_max, preg_one)
+            else:
+                v_shared_exp, v_scaling = _compute_f32_exp_scaling_ocp(ctx, v_max, preg_one)
+            v_shared_exp_u8 = pto.vbitcast(v_shared_exp, pto.ui8)
+            v_scaling_f32 = pto.vbitcast(v_scaling, pto.f32)
+            ureg_exp = pto.vstus(ureg_exp, 1, v_shared_exp_u8, exp_write_ptr)
+            ureg_scaling = pto.vstus(ureg_scaling, 1, v_scaling_f32, scale_write_ptr)
+            exp_write_ptr = pto.addptr(exp_write_ptr, 1)
+            scale_write_ptr = pto.addptr(scale_write_ptr, 1)
+        pto.vstas(ureg_exp, exp_write_ptr, 0)
+    pto.vstas(ureg_scaling, scale_write_ptr, 0)
+
+
+def _tquant_mxfp4_e2m1_b16_2d(src_ptr, exp_ptr, dst_ptr, max_ptr, scaling_ptr, valid_rows, valid_cols, src_cols, exp_col_stride, dtype, lanes_b16, scale_alg="ocp"):
+    groups_per_row = _ceil_division(valid_cols, 32)
+    _abs_reduce_max_b16_nd_2d_packed(src_ptr, max_ptr, valid_rows, valid_cols, src_cols, lanes_b16, dtype, scale_alg)
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+    _extract_e2m1_exp_and_scaling_2d_packed(max_ptr, exp_ptr, scaling_ptr, valid_rows, groups_per_row, exp_col_stride, scale_alg, dtype)
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+    _calc_quantized_fp4e2m1_values_2d_packed(src_ptr, scaling_ptr, dst_ptr, max_ptr, exp_ptr,
+                                              valid_rows, valid_cols, src_cols, exp_col_stride, lanes_b16, dtype)
+
+def _pad_max_write_to_alignment(v_max, ureg, write_ptr, groups_written, dtype):
+    align_groups = _BLOCK_BYTE_SIZE // pto.bytewidth(dtype)
+    padded_groups = _ceil_division(groups_written, align_groups) * align_groups
+    pad_count = padded_groups - groups_written
+    if pad_count > 0:
+        ureg = pto.vstus(ureg, pad_count, v_max, write_ptr)
+        write_ptr = pto.addptr(write_ptr, pad_count)
+    pto.vstas(ureg, write_ptr, 0)
+
+
+def _abs_reduce_max_b16_nd_2d(src_ptr, max_ptr, valid_rows, valid_cols, src_cols, lanes_b16, dtype=pto.bf16, scale_alg="ocp"):
+    grp_size = 32
+    elements_per_dintlv = 2 * lanes_b16
+    grps_per_dintlv = elements_per_dintlv // grp_size
+    groups_per_row = src_cols // grp_size
+    elems_per_row = src_cols
+    loop_num_per_row = _ceil_division(elems_per_row, elements_per_dintlv)
+    ureg_max = pto.init_align()
+    write_ptr = max_ptr
+    for row in range(valid_rows):
+        src_row_off = row * src_cols
+        for i in range(loop_num_per_row):
+            col_off = i * elements_per_dintlv
+            remaining = elems_per_row - col_off if elems_per_row > col_off else 0
+            if remaining > elements_per_dintlv:
+                remaining = elements_per_dintlv
+            if scale_alg == "nv" and dtype == pto.f16:
+                v_max = _abs_reduce_max_b16_dintlv_window(src_ptr, src_row_off + col_off, remaining, lanes_b16, dtype, False)
+            else:
+                v_max = _abs_reduce_max_b16_dintlv_window(src_ptr, src_row_off + col_off, remaining, lanes_b16, dtype, True)
+            grps_written = i * grps_per_dintlv
+            grps_remaining = groups_per_row - grps_written if groups_per_row > grps_written else 0
+            grps_this_iter = grps_per_dintlv if grps_remaining > grps_per_dintlv else grps_remaining
+            v_max_bf16 = pto.vbitcast(v_max, pto.bf16)
+            ureg_max = pto.vstus(ureg_max, grps_this_iter, v_max_bf16, write_ptr)
+            write_ptr = pto.addptr(write_ptr, grps_this_iter)
+    pto.vstas(ureg_max, write_ptr, 0)
+
+def _abs_reduce_max_b16_nd_2d_packed(src_ptr, max_ptr, valid_rows, valid_cols, src_cols, lanes_b16, dtype=pto.bf16, scale_alg="ocp"):
+    grp_size = 32
+    elements_per_dintlv = 2 * lanes_b16
+    grps_per_dintlv = elements_per_dintlv // grp_size
+    groups_per_row = _ceil_division(valid_cols, grp_size)
+    elems_per_row = groups_per_row * grp_size
+    loop_num_per_row = _ceil_division(elems_per_row, elements_per_dintlv)
+    write_ptr = max_ptr
+    ureg_max = pto.init_align()
+    if loop_num_per_row == 1:
+        for row in range(valid_rows):
+            src_row_off = row * src_cols
+            if scale_alg == "nv" and dtype == pto.f16:
+                v_max = _abs_reduce_max_b16_dintlv_window(src_ptr, src_row_off, elems_per_row, lanes_b16, dtype, False)
+            else:
+                v_max = _abs_reduce_max_b16_dintlv_window(src_ptr, src_row_off, elems_per_row, lanes_b16, dtype, True)
+            v_max_bf16 = pto.vbitcast(v_max, pto.bf16)
+            out_count = groups_per_row
+            ureg_max = pto.vstus(ureg_max, out_count, v_max_bf16, write_ptr)
+            write_ptr = pto.addptr(write_ptr, out_count)
+        _pad_max_write_to_alignment(v_max_bf16, ureg_max, write_ptr, valid_rows * groups_per_row, dtype)
+        return
+    for row in range(valid_rows):
+        src_row_off = row * src_cols
+        for i in range(loop_num_per_row):
+            col_off = i * elements_per_dintlv
+            remaining = elems_per_row - col_off if elems_per_row > col_off else 0
+            if remaining > elements_per_dintlv:
+                remaining = elements_per_dintlv
+            if scale_alg == "nv" and dtype == pto.f16:
+                v_max = _abs_reduce_max_b16_dintlv_window(src_ptr, src_row_off + col_off, remaining, lanes_b16, dtype, False)
+            else:
+                v_max = _abs_reduce_max_b16_dintlv_window(src_ptr, src_row_off + col_off, remaining, lanes_b16, dtype, True)
+            grps_written = i * grps_per_dintlv
+            grps_remaining = groups_per_row - grps_written if groups_per_row > grps_written else 0
+            grps_this_iter = grps_per_dintlv if grps_remaining > grps_per_dintlv else grps_remaining
+            v_max_bf16 = pto.vbitcast(v_max, pto.bf16)
+            ureg_max = pto.vstus(ureg_max, grps_this_iter, v_max_bf16, write_ptr)
+            write_ptr = pto.addptr(write_ptr, grps_this_iter)
+    pto.vstas(ureg_max, write_ptr, 0)
+
+def _build_packed_scale_window(packed_scaling_ptr, scale_tmp_ptr, group_count):
+    ureg = pto.init_align()
+    write_ptr = scale_tmp_ptr
+    for group in range(group_count):
+        v_scale = pto.vlds(packed_scaling_ptr, group, dist="BRC_B16")
+        ureg = pto.vstus(ureg, 1, v_scale, write_ptr)
+        write_ptr = pto.addptr(write_ptr, 1)
+    pto.vstas(ureg, write_ptr, 0)
+
+def _calc_quantized_fp8_values_2d_packed(src_ptr, scaling_ptr, dst_ptr, max_tmp_ptr, exp_ptr,
+                                          valid_rows, valid_cols, src_cols, exp_col_stride, lanes_b16, dtype=pto.bf16):
+    k_group_size = 32
+    k_groups_per_window = 8
+    groups_per_row = _ceil_division(valid_cols, k_group_size)
+    total_groups = valid_rows * groups_per_row
+    windows_per_row = _ceil_division(groups_per_row, k_groups_per_window)
+    for row in range(valid_rows):
+        src_row = pto.addptr(src_ptr, row * src_cols)
+        dst_row = pto.addptr(dst_ptr, row * src_cols)
+        scale_row = pto.addptr(scaling_ptr, row * groups_per_row)
+        scale_tmp_ptr = max_tmp_ptr
+        if total_groups < k_groups_per_window:
+            scale_tmp_ptr = pto.castptr(pto.addptr(exp_ptr, row * exp_col_stride + 16), pto.ptr(dtype, "ub"))
+        for window in range(windows_per_row):
+            group_base = window * k_groups_per_window
+            groups_this_window = groups_per_row - group_base
+            if groups_this_window > k_groups_per_window:
+                groups_this_window = k_groups_per_window
+            _build_packed_scale_window(pto.addptr(scale_row, group_base), scale_tmp_ptr, groups_this_window)
+            pto.mem_bar(pto.BarrierType.VST_VLD)
+            col_off = group_base * k_group_size
+            remaining = groups_this_window * k_group_size
+            _calc_quantized_fp8_values_b16_window(src_row, scale_tmp_ptr, pto.addptr(dst_row, col_off), 0, col_off, remaining, lanes_b16, dtype)
+
+def _extract_mx_exp_and_scaling_2d_packed(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_groups_per_row, exp_col_stride, scale_alg, ocp_spec, nv_spec, dtype=pto.bf16):
+    if scale_alg == "nv":
+        _extract_nv_exp_and_scaling_b16_2d_packed(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_groups_per_row, exp_col_stride, nv_spec, dtype)
+    else:
+        _extract_mx_ocp_exp_and_scaling_2d_packed(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_groups_per_row, exp_col_stride, ocp_spec, dtype)
+
+def _extract_b8_exp_and_scaling_2d_packed(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_groups_per_row, exp_col_stride, scale_alg, dtype=pto.bf16):
+    _extract_mx_exp_and_scaling_2d_packed(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_groups_per_row, exp_col_stride, scale_alg, _OCP_MXFP8_SPEC, _NV_MXFP8_SPEC, dtype)
+
+
+def _extract_e2m1_exp_and_scaling_2d_packed(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_groups_per_row, exp_col_stride, scale_alg, dtype=pto.bf16):
+    _extract_mx_exp_and_scaling_2d_packed(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_groups_per_row, exp_col_stride, scale_alg, _OCP_MXFP4_SPEC, _NV_MXFP4_SPEC, dtype)
+
+def _extract_mx_ocp_exp_and_scaling_2d_packed(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_groups_per_row, exp_col_stride, spec, dtype=pto.bf16):
+    ctx = _init_ocp_exp_scaling_ctx(spec)
+    preg_one_b16, _ = pto.make_mask(dtype, 1)
+    scale_write_ptr = scaling_ptr
+    ureg_scaling = pto.init_align()
+    for row in range(valid_rows):
+        max_read_ptr = pto.addptr(max_ptr, row * valid_groups_per_row)
+        max_read_ptr_u16 = pto.castptr(max_read_ptr, pto.ptr(pto.ui16, "ub"))
+        exp_write_ptr = pto.addptr(exp_ptr, row * exp_col_stride)
+        ureg_exp = pto.init_align()
+        for group in range(valid_groups_per_row):
+            v_max_abs = pto.vlds(pto.addptr(max_read_ptr_u16, group), 0, dist="BRC_B16")
+            v_exp_value, v_recip_scale = _compute_mx_ocp_exp_scaling(ctx, v_max_abs, preg_one_b16)
+            v_exp_value_u8 = pto.vbitcast(v_exp_value, pto.ui8)
+            v_recip_scale_u16 = pto.vbitcast(v_recip_scale, pto.ui16)
+            ureg_exp = pto.vstus(ureg_exp, 1, v_exp_value_u8, exp_write_ptr)
+            ureg_scaling = pto.vstus(ureg_scaling, 1, v_recip_scale_u16, scale_write_ptr)
+            exp_write_ptr = pto.addptr(exp_write_ptr, 1)
+            scale_write_ptr = pto.addptr(scale_write_ptr, 1)
+        pto.vstas(ureg_exp, exp_write_ptr, 0)
+    pto.vstas(ureg_scaling, scale_write_ptr, 0)
+
+
+def _calc_quantized_fp8_values_f32(src_ptr, scaling_ptr, dst_ptr, vl_count, lanes_f32,
+                                total_count, preg_lower32, preg_upper32):
+    remained = total_count
+    preg_all = pto.pset_b32(pto.PAT.ALL)
+    for i in range(vl_count):
+        preg, remained = pto.make_mask(pto.f32, remained)
+        v_scaling_0 = pto.vlds(scaling_ptr, 2 * i, dist="BRC_B32")
+        v_scaling_1 = pto.vlds(scaling_ptr, 2 * i + 1, dist="BRC_B32")
+        v_in = pto.vlds(src_ptr, i * lanes_f32)
+        v_out_1 = pto.vmul(v_in, v_scaling_0, preg_lower32)
+        v_out_2 = pto.vmul(v_in, v_scaling_1, preg_upper32)
+        v_out = pto.vor(v_out_1, v_out_2, preg_all)
+        v_fp8 = pto.vcvt(v_out, pto.f8e4m3, preg,
+                          rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT,
+                          part=pto.VcvtPartMode.P0)
+        pto.vsts(v_fp8, dst_ptr, i * lanes_f32, preg, dist=pto.VStoreDist.PK4_B32)
+
+
+def _calc_quantized_fp8_values_unroll2(src_ptr, scaling_ptr, dst_ptr, vl_count, lanes_f32,
+                                        total_count):
+    preg_all = pto.pset_b32(pto.PAT.ALL)
+    dst_ptr_u32 = pto.castptr(dst_ptr, pto.ptr(pto.ui32, "ub"))
+    for i in range(vl_count // 2):
+        v_scaling = pto.vlds(scaling_ptr, 8 * i, dist="E2B_B32")
+        v_in_even, v_in_odd = pto.vldsx2(src_ptr, 2 * i * lanes_f32, "DINTLV_B32")
+        v_out_1 = pto.vmul(v_in_even, v_scaling, preg_all)
+        v_out_2 = pto.vmul(v_in_odd, v_scaling, preg_all)
+        v_fp8_p0 = pto.vcvt(v_out_1, pto.f8e4m3, preg_all,
+                            rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT,
+                            part=pto.VcvtPartMode.P0)
+        v_fp8_p1 = pto.vcvt(v_out_2, pto.f8e4m3, preg_all,
+                            rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT,
+                            part=pto.VcvtPartMode.P1)
+        v_fp8_p0_u16 = pto.vbitcast(v_fp8_p0, pto.ui16)
+        v_fp8_p1_u16 = pto.vbitcast(v_fp8_p1, pto.ui16)
+        preg_all_b16 = pto.pset_b16(pto.PAT.ALL)
+        v_fp8_u16 = pto.vor(v_fp8_p0_u16, v_fp8_p1_u16, preg_all_b16)
+        v_fp8_u32 = pto.vbitcast(v_fp8_u16, pto.ui32)
+        dst_ptr_u32 = pto.castptr(dst_ptr, pto.ptr(pto.ui32, "ub"))
+        pto.vsts(v_fp8_u32, dst_ptr_u32, i * lanes_f32 // 2, preg_all, dist=pto.VStoreDist.PK_B32)
+
+def _tquant_mxfp8_f32_quantize(src_ptr, exp_ptr, dst_ptr, max_ptr, scaling_ptr,
+                         vl_count, exp_loop_count, num_groups, lanes_f32,
+                         total_count, preg_lower32, preg_upper32, static_total, scale_alg="ocp"):
+    """static_total = StaticRows * StaticCols."""
+    can_unroll = (static_total > 1024) and (static_total % 256 == 0)
+    if can_unroll and total_count % 256 == 0:
+        if scale_alg == "nv":
+            _extract_b8_exp_and_scaling_nv_f32(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, num_groups, lanes_f32, unroll=True)
+        else:
+            _extract_b8_exp_and_scaling_f32(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, num_groups, lanes_f32, unroll=True)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _calc_quantized_fp8_values_unroll2(src_ptr, scaling_ptr, dst_ptr, vl_count, lanes_f32,
+                                    total_count)
+    else:
+        if scale_alg == "nv":
+            _extract_b8_exp_and_scaling_nv_f32(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, num_groups, lanes_f32, unroll=False)
+        else:
+            _extract_b8_exp_and_scaling_f32(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, num_groups, lanes_f32, unroll=False)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _calc_quantized_fp8_values_f32(src_ptr, scaling_ptr, dst_ptr, vl_count, lanes_f32,
+                                    total_count, preg_lower32, preg_upper32)
+
+
+def _static_valid_dim(tile, index):
+    static_valid_shape = getattr(tile, "_template_static_valid_shape", None)
+    if static_valid_shape is None:
+        static_valid_shape = getattr(tile, "static_valid_shape", None)
+    if static_valid_shape is not None and static_valid_shape[index] is not None:
+        return static_valid_shape[index]
+    return tile.valid_shape[index]
+
+@tilelib.tile_template(op="pto.tquant.mx", target="a5", name="template_tquant_mxfp8_f32",
+    dtypes=[("f32", "ui8", "ui8", "f32", "f32")],
+    iteration_axis="none", op_engine="vector", op_class="elementwise",
+    constraints=[_mx_nd_2d_tiles], id=0, loop_depth=2, is_post_update=False, tags=_MX_TAGS + ("fp8", "f32"))
+def template_tquant_mxfp8_f32(src: pto.Tile, dst: pto.Tile,
+    exp_tile: pto.Tile, max_tile: pto.Tile, scaling_tile: pto.Tile):
+    """MXFP8: f32 → fp8 E4M3.
+    exp.rows > 1 时走 2D Packed，否则走 flat。"""
+    scale_alg = pto.get_op_attr("quant_scale_alg", "ocp")
+    src_ptr, dst_ptr, max_ptr, exp_ptr, scaling_ptr = _prepare_nd_ptrs(src, dst, max_tile, exp_tile, scaling_tile)
+    if exp_tile.shape[0] > 1:
+        valid_rows, valid_cols, src_cols, exp_col_stride = _prepare_2d_quant(src_ptr, src, exp_tile, pto.f32)
+        lanes = pto.elements_per_vreg(pto.f32)
+        k_group_size = 32
+        groups_per_row = _ceil_division(valid_cols, k_group_size)
+        vl_count_per_row = _ceil_division(valid_cols, lanes)
+        preg_lower32 = pto.pset_b32(pto.PAT.VL32)
+        preg_all = pto.pset_b32(pto.PAT.ALL)
+        preg_upper32 = pto.pxor(preg_lower32, preg_all, preg_all)
+        for row in range(valid_rows):
+            _abs_reduce_max_naive(
+                src_ptr, max_ptr,
+                valid_cols, vl_count_per_row, lanes, preg_lower32, preg_upper32, row * src_cols, row * groups_per_row)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _extract_b8_exp_and_scaling_f32_2d_packed(
+            max_ptr, exp_ptr, scaling_ptr, valid_rows, groups_per_row, exp_col_stride, scale_alg)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        for row in range(valid_rows):
+            _calc_quantized_fp8_values_f32(
+                pto.addptr(src_ptr, row * src_cols), pto.addptr(scaling_ptr, row * groups_per_row),
+                pto.addptr(dst_ptr, row * src_cols), vl_count_per_row, lanes, valid_cols, preg_lower32, preg_upper32)
+        return
+
+    valid_rows, valid_cols, static_cols, lanes, total_elems, vl_count, exp_loop_count, num_groups = _prepare_nd_quant(src_ptr, src, pto.f32)
+    static_rows = src.shape[0]
+
+    preg_all = pto.pset_b32(pto.PAT.ALL)
+    preg_lower32 = pto.pset_b32(pto.PAT.VL32)
+    preg_upper32 = pto.pxor(preg_lower32, preg_all, preg_all)
+
+    # ── Stage 1: AbsReduceMax ──
+    # Path selection: naive (≤1024), opt (multiple of 256), largesizes (multiple of 2048)
+    if (valid_rows * valid_cols <= 1024):
+        _abs_reduce_max_naive(src_ptr, max_ptr, total_elems, vl_count, lanes,
+                              preg_lower32, preg_upper32)
+    else:
+        aligned_total = (total_elems // 256) * 256
+        tail_total = total_elems - aligned_total
+        if aligned_total > 0:
+            aligned_vl_count = aligned_total // lanes
+            if aligned_total % 2048 == 0:
+                _abs_reduce_max_f32_opt_largesizes(
+                    src_ptr, max_ptr, aligned_vl_count, lanes, aligned_total)
+            else:
+                _abs_reduce_max_f32_opt(
+                    src_ptr, max_ptr, aligned_vl_count, lanes, aligned_total)
+        if tail_total > 0:
+            aligned_groups = aligned_total // 32
+            tail_vl_count = _ceil_division(tail_total, lanes)
+            _abs_reduce_max_naive(src_ptr, max_ptr, tail_total, tail_vl_count, lanes,
+                                  preg_lower32, preg_upper32,
+                                  src_base=aligned_total, max_base=aligned_groups)
+
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+
+    # ── Stage 2+3: Quantize ──
+    static_total = static_rows * static_cols
+    _tquant_mxfp8_f32_quantize(src_ptr, exp_ptr, dst_ptr, max_ptr, scaling_ptr,
+                         vl_count, exp_loop_count, num_groups, lanes,
+                         total_elems, preg_lower32, preg_upper32, static_total, scale_alg=scale_alg)
+
+
+@tilelib.tile_template(op="pto.tquant.mx", target="a5", name="template_tquant_mxfp8_b16",
+    dtypes=[("bf16", "ui8", "ui8", "bf16", "bf16"), ("f16", "ui8", "ui8", "f16", "f16")],
+    iteration_axis="none", op_engine="vector", op_class="elementwise",
+    constraints=[_mx_nd_2d_tiles], id=1, loop_depth=2, is_post_update=False, tags=_MX_TAGS + ("fp8", "b16"))
+def template_tquant_mxfp8_b16(src: pto.Tile, dst: pto.Tile, exp: pto.Tile, max_tile: pto.Tile, scaling: pto.Tile):
+    """MXFP8: bf16/fp16 → fp8 E4M3.
+    exp.rows > 1 时走 2D Packed（B16_2D overload 1），否则走 flat。"""
+    scale_alg = pto.get_op_attr("quant_scale_alg", "ocp")
+    dtype = pto.f16 if str(src.dtype) == "f16" else pto.bf16
+    src_ptr, dst_ptr, max_ptr, exp_ptr, scaling_ptr = _prepare_nd_ptrs(src, dst, max_tile, exp, scaling)
+    if exp.shape[0] > 1:
+        valid_rows, valid_cols, src_cols, exp_col_stride = _prepare_2d_quant(src_ptr, src, exp, dtype)
+        lanes = pto.elements_per_vreg(dtype)
+        groups_per_row = _ceil_division(valid_cols, 32)
+        _abs_reduce_max_b16_nd_2d_packed(src_ptr, max_ptr, valid_rows, valid_cols, src_cols, lanes, dtype, scale_alg)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _extract_b8_exp_and_scaling_2d_packed(max_ptr, exp_ptr, scaling_ptr, valid_rows, groups_per_row, exp_col_stride, scale_alg, dtype)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _calc_quantized_fp8_values_2d_packed(src_ptr, scaling_ptr, dst_ptr, max_ptr, exp_ptr,
+                                              valid_rows, valid_cols, src_cols, exp_col_stride, lanes, dtype)
+        return
+
+    valid_rows, valid_cols, static_cols, lanes, total_elems, vl_count, exp_loop_count, num_groups = _prepare_nd_quant(src_ptr, src, dtype)
+
+    if valid_cols == static_cols:
+        _reduce_mx_b16_abs_max_flat(src_ptr, max_ptr, vl_count, total_elems, lanes, dtype, scale_alg)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        if scale_alg == "nv":
+            _extract_b8_exp_and_scaling_nv(max_ptr, exp_ptr, scaling_ptr, num_groups, dtype)
+        else:
+            _extract_b8_exp_and_scaling(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, num_groups, lanes, dtype)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _calc_quantized_fp8_values_b16(src_ptr, scaling_ptr, dst_ptr, total_elems, lanes, dtype)
+    else:
+        _tquant_mxfp8_b16_2d(
+            src_ptr, exp_ptr, dst_ptr, max_ptr, scaling_ptr, valid_rows, valid_cols, static_cols,
+            lanes, dtype, scale_alg, exp_loop_count, num_groups)
+
+@tilelib.tile_template(op="pto.tquant.mx", target="a5", name="template_tquant_mxfp4_e2m1_b16",
+    dtypes=[("bf16", "f4e2m1x2", "ui8", "bf16", "bf16"), ("f16", "f4e2m1x2", "ui8", "f16", "f16")],
+    iteration_axis="none", op_engine="vector", op_class="elementwise",
+    constraints=[_mx_nd_2d_tiles], id=2, loop_depth=2, is_post_update=False, tags=_MX_TAGS + ("fp4", "b16"))
+def template_tquant_mxfp4_e2m1_b16(src: pto.Tile, dst: pto.Tile, exp: pto.Tile, max_tile: pto.Tile, scaling: pto.Tile):
+    """MXFP4: bf16/fp16 → fp4 E2M1.
+    exp.rows > 1 时走 2D Packed，否则走 flat。"""
+    scale_alg = pto.get_op_attr("quant_scale_alg", "ocp")
+    dtype = src.dtype
+    dtype = pto.f16 if str(dtype) == "f16" else pto.bf16
+    src_ptr, dst_ptr, max_ptr, exp_ptr, scaling_ptr = _prepare_nd_ptrs(src, dst, max_tile, exp, scaling)
+    if exp.shape[0] > 1:
+        valid_rows, valid_cols, src_cols, exp_col_stride = _prepare_2d_quant(src_ptr, src, exp, dtype)
+        lanes_b16 = pto.elements_per_vreg(dtype)
+        _tquant_mxfp4_e2m1_b16_2d(
+            src_ptr, exp_ptr, dst_ptr, max_ptr, scaling_ptr,
+            valid_rows, valid_cols, src_cols, exp_col_stride, dtype, lanes_b16, scale_alg)
+        return
+
+    valid_rows, valid_cols, static_cols, lanes, total_elems, vl_count, exp_loop_count, num_groups = _prepare_nd_quant(src_ptr, src, dtype)
+
+    _reduce_mx_b16_abs_max_flat(src_ptr, max_ptr, vl_count, total_elems, lanes, dtype, scale_alg)
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+    if scale_alg == "nv":
+        _extract_e2m1_exponent_and_scaling_nv(max_ptr, exp_ptr, scaling_ptr, num_groups, dtype)
+    else:
+        _extract_e2m1_exponent_and_scaling(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, num_groups, lanes, dtype)
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+    if dtype == pto.f16:
+        _calc_quantized_fp4e2m1_values_half(src_ptr, scaling_ptr, dst_ptr, num_groups, lanes)
+    else:
+        _calc_quantized_fp4e2m1_values_bf16(src_ptr, scaling_ptr, dst_ptr, num_groups, lanes)
+
+
+def _prepare_2d_quant(src_ptr, src, exp, dtype):
+    """Common 2D template preamble: set_ctrl + dims + zero-pad + barrier.
+    src_ptr must come from _prepare_nd_ptrs.
+    Returns (valid_rows, valid_cols, src_cols, exp_col_stride)."""
+    pto.set_ctrl(1 << 50)
+    valid_rows = _static_valid_dim(src, 0)
+    valid_cols = _static_valid_dim(src, 1)
+    src_cols = src.shape[1]
+    exp_col_stride = exp.shape[1]
+    _zero_pad_source_tile(src_ptr, valid_rows, valid_cols, src_cols, dtype)
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+    return valid_rows, valid_cols, src_cols, exp_col_stride
+
+def _prepare_nd_quant(src_ptr, src, dtype):
+    """Common ND template preamble: dims + set_ctrl + zero-pad + barrier.
+    src_ptr must come from _prepare_nd_ptrs.
+    Returns (valid_rows, valid_cols, static_cols, lanes, total_elems, vl_count, exp_loop_count, num_groups)."""
+    valid_rows = _static_valid_dim(src, 0)
+    valid_cols = _static_valid_dim(src, 1)
+    static_cols = src.shape[1]
+    lanes = pto.elements_per_vreg(dtype)
+    total_elems = valid_rows * static_cols
+    vl_count = _ceil_division(total_elems, lanes)
+    num_groups = total_elems // 32
+    exp_loop_count = _ceil_division(num_groups, lanes)
+    pto.set_ctrl(1 << 50)
+    _zero_pad_source_tile(src_ptr, valid_rows, valid_cols, static_cols, dtype)
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+    return valid_rows, valid_cols, static_cols, lanes, total_elems, vl_count, exp_loop_count, num_groups
+
+def _prepare_nd_ptrs(src, dst, max_tile, exp_tile, scaling_tile):
+    """Common ND template pointer materialization.
+    Returns (src_ptr, dst_ptr, max_ptr, exp_ptr, scaling_ptr)."""
+    src_ptr = src.as_ptr()
+    dst_ptr = dst.as_ptr()
+    max_ptr = max_tile.as_ptr()
+    exp_ptr = exp_tile.as_ptr()
+    scaling_ptr = scaling_tile.as_ptr()
+    return src_ptr, dst_ptr, max_ptr, exp_ptr, scaling_ptr
+
+def _prepare_dn_quant(src, dtype):
+    """Common DN template preamble: set_ctrl + dims + zero-pad + barrier.
+    Returns (valid_rows, valid_cols, static_cols)."""
+    pto.set_ctrl(1 << 50)
+    valid_rows = _static_valid_dim(src, 0)
+    valid_cols = _static_valid_dim(src, 1)
+    static_cols = src.shape[1]
+    src_ptr = src.as_ptr()
+    _zero_pad_source_tile(src_ptr, valid_rows, valid_cols, static_cols, dtype)
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+    return valid_rows, valid_cols, static_cols
+
+def _mx_dn_tiles(operand_memory_spaces, grp_axis=None, **_):
+    """DN template constraint。仅接受用户显式声明 DN（grp_axis=0/axis0）。"""
+    if not all(space in {"ub", "vec"} for space in operand_memory_spaces):
+        return False
+    return grp_axis is not None and str(grp_axis) in ("0", "axis0")
+
+@tilelib.tile_template(op="pto.tquant.mx", target="a5", name="template_tquant_mxfp8_dn",
+    dtypes=[("bf16", "ui8", "ui8", "bf16", "bf16"), ("f16", "ui8", "ui8", "f16", "f16")],
+    iteration_axis="none", op_engine="vector", op_class="elementwise",
+    constraints=[_mx_dn_tiles], id=3, loop_depth=2, is_post_update=False, tags=_MX_TAGS + ("fp8", "dn"))
+def template_tquant_mxfp8_dn(src: pto.Tile, dst: pto.Tile, exp: pto.Tile,
+                              max_tile: pto.Tile, scaling: pto.Tile):
+    """MXFP8 DN: bf16/fp16 → fp8."""
+    dtype = src.dtype
+    dtype = pto.f16 if str(dtype) == "f16" else pto.bf16
+    scale_alg = pto.get_op_attr("quant_scale_alg", "ocp")
+    interleave = pto.get_op_attr("interleave") == "true"
+    valid_rows, valid_cols, static_cols = _prepare_dn_quant(src, dtype)
+    dst_static_cols = dst.shape[1]
+    src_ptr, dst_ptr, max_ptr, exp_ptr, scaling_ptr = _prepare_nd_ptrs(src, dst, max_tile, exp, scaling)
+    exp_col_stride = exp.shape[1] if interleave else static_cols
+    _tquant_mxfp8_dn_b16(src_ptr, dst_ptr, exp_ptr, max_ptr, scaling_ptr, dtype, valid_rows, valid_cols, static_cols, dst_static_cols, scale_alg, interleave, exp_col_stride)
+
+@tilelib.tile_template(op="pto.tquant.mx", target="a5", name="template_tquant_mxfp4_e2m1_dn",
+    dtypes=[("bf16", "f4e2m1x2", "ui8", "bf16", "bf16"), ("f16", "f4e2m1x2", "ui8", "f16", "f16")],
+    iteration_axis="none", op_engine="vector", op_class="elementwise",
+    constraints=[_mx_dn_tiles], id=4, loop_depth=2, is_post_update=False, tags=_MX_TAGS + ("fp4", "dn"))
+def template_tquant_mxfp4_e2m1_dn(src: pto.Tile, dst: pto.Tile, exp: pto.Tile,
+                              max_tile: pto.Tile, scaling: pto.Tile):
+    """MXFP4 DN: bf16/fp16 → fp4."""
+    dtype = src.dtype
+    dtype = pto.f16 if str(dtype) == "f16" else pto.bf16
+    scale_alg = pto.get_op_attr("quant_scale_alg", "ocp")
+    interleave = pto.get_op_attr("interleave") == "true"
+    valid_rows, valid_cols, static_cols = _prepare_dn_quant(src, dtype)
+    dst_static_cols = dst.shape[1]
+    src_ptr, dst_ptr, max_ptr, exp_ptr, scaling_ptr = _prepare_nd_ptrs(src, dst, max_tile, exp, scaling)
+    exp_col_stride = exp.shape[1] if interleave else static_cols
+    _tquant_mxfp4_e2m1_dn(src_ptr, dst_ptr, exp_ptr, max_ptr, scaling_ptr, dtype, valid_rows, valid_cols, static_cols, dst_static_cols, scale_alg, interleave, exp_col_stride)
+
+
+def _tquant_pset_typed(dtype, pattern):
+    sz = pto.bytewidth(dtype)
+    if sz == 4:
+        return pto.pset_b32(pattern)
+    elif sz == 2:
+        return pto.pset_b16(pattern)
+    else:
+        return pto.pset_b8(pattern)
+
+
+def _tquant_zero_value(dtype):
+    """Return a zero scalar matching sizeof(T), like (T)0."""
+    sz = pto.bytewidth(dtype)
+    if sz == 4:
+        return pto.f32(0)
+    elif sz == 2:
+        return pto.bf16(0)
+    else:
+        return pto.ui8(0)
+
+
+def _tquant_norm_dist(dtype):
+    """Return NORM_B32/B16/B8 by sizeof(T), matching GetDistVst<T, DIST_NORM>."""
+    sz = pto.bytewidth(dtype)
+    if sz == 4:
+        return pto.VStoreDist.NORM_B32
+    elif sz == 2:
+        return pto.VStoreDist.NORM_B16
+    else:
+        return pto.VStoreDist.NORM_B8
+
+
+def _zero_pad_columns_vl_aligned(src_ptr, valid_rows, valid_cols, static_cols, dtype):
+    elem_per_vl = pto.elements_per_vreg(dtype)
+    rows_per_vl = elem_per_vl // static_cols
+    pg_all = _tquant_pset_typed(dtype, pto.PAT.ALL)
+    vc = valid_cols
+    preg_valid, _ = pto.make_mask(dtype, vc)
+    for r in range(1, rows_per_vl):
+        range_start = r * static_cols
+        range_end = range_start + valid_cols
+        p_end, _ = pto.make_mask(dtype, range_end)
+        p_start, _ = pto.make_mask(dtype, range_start)
+        p_row = pto.pnot(p_start, p_end)
+        preg_valid = pto.por(preg_valid, p_row, pg_all)
+    v_zero = pto.vdup(_tquant_zero_value(dtype), pg_all)
+    preg_pad = pto.pxor(pg_all, preg_valid, pg_all)
+    total_elems = valid_rows * static_cols
+    vl_count = _ceil_division(total_elems, elem_per_vl)
+    for vi in range(vl_count):
+        pto.vsts(v_zero, src_ptr, vi * elem_per_vl, preg_pad, dist=pto.VStoreDist.NORM_B16)
+
+def _zero_pad_columns_unaligned(src_ptr, valid_rows, valid_cols, static_cols, dtype):
+    elem_per_vl = pto.elements_per_vreg(dtype)
+    pad_cols = static_cols - valid_cols
+    pad_repeats = _ceil_division(pad_cols, elem_per_vl)
+    pg_all = _tquant_pset_typed(dtype, pto.PAT.ALL)
+    v_zero = pto.vdup(_tquant_zero_value(dtype), pg_all)
+    for row in range(valid_rows):
+        write_ptr = pto.addptr(src_ptr, row * static_cols + valid_cols)
+        cols = pad_cols
+        ureg = pto.init_align()
+        for j in range(pad_repeats):
+            sreg = elem_per_vl if cols > elem_per_vl else cols
+            ureg = pto.vstus(ureg, sreg, v_zero, write_ptr)
+            write_ptr = pto.addptr(write_ptr, sreg)
+            cols -= elem_per_vl
+        pto.vstas(ureg, write_ptr, 0)
+
+def _zero_pad_source_tile(src_ptr, valid_rows, valid_cols, static_cols, dtype=pto.f32):
+    """Skips float; dispatches VLAligned vs Unaligned."""
+    if dtype == pto.f32:
+        return
+    if valid_cols >= static_cols:
+        return
+    elem_per_vl = pto.elements_per_vreg(dtype)
+    if elem_per_vl % static_cols == 0:
+        _zero_pad_columns_vl_aligned(src_ptr, valid_rows, valid_cols, static_cols, dtype)
+    else:
+        _zero_pad_columns_unaligned(src_ptr, valid_rows, valid_cols, static_cols, dtype)
+
+
+def _update_dn_abs_max_4(v_0, v_1, v_2, v_3, v_max_0, v_max_1, v_max_2, v_max_3, preg, convert_fp16_to_bf16, is_f32, v_abs_mask=None):
+    if convert_fp16_to_bf16:
+        v_0b, v_1b = _fp16_to_bf16_preserve_special(v_0, v_1, preg, preg)
+        v_2b, v_3b = _fp16_to_bf16_preserve_special(v_2, v_3, preg, preg)
+        a_0 = pto.vand(pto.vbitcast(v_0b, pto.ui16), v_abs_mask, preg)
+        a_1 = pto.vand(pto.vbitcast(v_1b, pto.ui16), v_abs_mask, preg)
+        a_2 = pto.vand(pto.vbitcast(v_2b, pto.ui16), v_abs_mask, preg)
+        a_3 = pto.vand(pto.vbitcast(v_3b, pto.ui16), v_abs_mask, preg)
+    elif is_f32:
+        a_0 = pto.vabs(v_0, preg)
+        a_1 = pto.vabs(v_1, preg)
+        a_2 = pto.vabs(v_2, preg)
+        a_3 = pto.vabs(v_3, preg)
+    else:
+        a_0 = pto.vand(pto.vbitcast(v_0, pto.ui16), v_abs_mask, preg)
+        a_1 = pto.vand(pto.vbitcast(v_1, pto.ui16), v_abs_mask, preg)
+        a_2 = pto.vand(pto.vbitcast(v_2, pto.ui16), v_abs_mask, preg)
+        a_3 = pto.vand(pto.vbitcast(v_3, pto.ui16), v_abs_mask, preg)
+    return (pto.vmax(a_0, v_max_0, preg), pto.vmax(a_1, v_max_1, preg),
+            pto.vmax(a_2, v_max_2, preg), pto.vmax(a_3, v_max_3, preg))
+
+
+def _merge_and_store_dn_abs_max(v_max_0, v_max_1, v_max_2, v_max_3, max_ptr, offset, preg, dtype, norm_dist):
+    v_max_0 = pto.vmax(v_max_0, v_max_1, preg)
+    v_max_2 = pto.vmax(v_max_2, v_max_3, preg)
+    v_max = pto.vmax(v_max_0, v_max_2, preg)
+    if pto.bytewidth(dtype) != 4:
+        v_max = pto.vbitcast(v_max, dtype)
+    pto.vsts(v_max, max_ptr, offset, preg, dist=norm_dist)
+
+
+def _abs_reduce_max_dn(src_ptr, max_ptr, valid_rows, valid_cols, static_cols, lanes, dtype=pto.f32, scale_alg="ocp"):
+    grp_size = 32
+    num_vls_per_row = _ceil_division(valid_cols, lanes)
+    num_grps_per_col = _ceil_division(valid_rows, grp_size)
+    num_vls_inner = 4
+    inner_iters = _ceil_division(grp_size, num_vls_inner)
+    preg_cols = valid_cols
+    is_f32 = pto.bytewidth(dtype) == 4
+    convert_fp16_to_bf16 = scale_alg == "ocp" and dtype == pto.f16
+    norm_dist = _tquant_norm_dist(dtype)
+    if is_f32:
+        v_zero = pto.vbr(pto.f32(0))
+        v_abs_mask = None
+    else:
+        v_abs_mask = pto.vbr(pto.ui16(_BF16_ABS_MASK))
+        v_zero = pto.vbr(pto.ui16(0))
+    for i in range(num_vls_per_row):
+        vl_start = i * lanes
+        preg, preg_cols = pto.make_mask(dtype, preg_cols)
+        for j in range(num_grps_per_col):
+            grp_start = j * grp_size * static_cols
+            loop = pto.for_(0, inner_iters, step=1).carry(
+                v0=v_zero, v1=v_zero, v2=v_zero, v3=v_zero)
+            with loop:
+                k = loop.iv
+                inner_start = k * num_vls_inner * static_cols
+                base_off = vl_start + grp_start + inner_start
+                v_0 = pto.vlds(src_ptr, base_off)
+                v_1 = pto.vlds(src_ptr, base_off + static_cols)
+                v_2 = pto.vlds(src_ptr, base_off + 2 * static_cols)
+                v_3 = pto.vlds(src_ptr, base_off + 3 * static_cols)
+                v_max_0, v_max_1, v_max_2, v_max_3 = _update_dn_abs_max_4(
+                    v_0, v_1, v_2, v_3, loop.v0, loop.v1, loop.v2, loop.v3, preg, convert_fp16_to_bf16, is_f32,
+                    v_abs_mask)
+                loop.update(v0=v_max_0, v1=v_max_1, v2=v_max_2, v3=v_max_3)
+            v_max_0 = loop.final("v0")
+            v_max_1 = loop.final("v1")
+            v_max_2 = loop.final("v2")
+            v_max_3 = loop.final("v3")
+            _merge_and_store_dn_abs_max(
+                v_max_0, v_max_1, v_max_2, v_max_3, max_ptr, j * static_cols + vl_start, preg, dtype, norm_dist)
+
+
+def _calc_quantized_fp8_values_dn_float(src_ptr, scaling_ptr, dst_ptr, valid_rows, valid_cols, src_static_cols, dst_static_cols, lanes_f32):
+    grp_size = 32
+    num_vls_per_row = _ceil_division(valid_cols, lanes_f32)
+    num_grps_per_col = _ceil_division(valid_rows, grp_size)
+    preg_cols_b32 = valid_cols
+    preg_cols_b8 = valid_cols * 4
+    for i in range(num_vls_per_row):
+        vl_start = i * lanes_f32
+        preg_b32, preg_cols_b32 = pto.make_mask(pto.f32, preg_cols_b32)
+        preg_b8, preg_cols_b8 = pto.make_mask(pto.ui8, preg_cols_b8)
+        for j in range(num_grps_per_col):
+            row_base = j * grp_size
+            v_scaling = pto.vlds(scaling_ptr, vl_start + j * src_static_cols)
+            with pto.for_(0, grp_size, step=1) as k:
+                r = row_base + k
+                src_off = r * src_static_cols + vl_start
+                dst_off = r * dst_static_cols + vl_start
+                v_input = pto.vlds(src_ptr, src_off)
+                v_input = pto.vmul(v_input, v_scaling, preg_b32)
+                v_fp8 = pto.vcvt(v_input, pto.f8e4m3, preg_b32,
+                                 rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT,
+                                 part=pto.VcvtPartMode.P0)
+                pto.vsts(v_fp8, dst_ptr, dst_off, preg_b8,
+                         dist=pto.VStoreDist.PK4_B32)
+
+
+def _calc_quantized_fp8_values_dn_b16(src_ptr, scaling_ptr, dst_ptr, valid_rows, valid_cols, src_static_cols, dst_static_cols, lanes_b16, dtype=pto.bf16):
+    grp_size = 32
+    num_vls_per_row = _ceil_division(valid_cols, lanes_b16)
+    num_grps_per_col = _ceil_division(valid_rows, grp_size)
+    preg_cols_b16 = valid_cols
+    preg_cols_b8 = valid_cols * 2
+    preg_cols_b32 = _ceil_division(valid_cols, 2)
+    preg_all_b16 = pto.pset_b16(pto.PAT.ALL)
+    scaling_ptr_u16 = pto.castptr(scaling_ptr, pto.ptr(pto.ui16, "ub"))
+    dst_ptr_u32 = pto.castptr(dst_ptr, pto.ptr(pto.ui32, "ub"))
+    for i in range(num_vls_per_row):
+        vl_start = i * lanes_b16
+        preg_b16, preg_cols_b16 = pto.make_mask(dtype, preg_cols_b16)
+        preg_b8, preg_cols_b8 = pto.make_mask(pto.ui8, preg_cols_b8)
+        preg_b32, preg_cols_b32 = pto.make_mask(pto.f32, preg_cols_b32)
+        for j in range(num_grps_per_col):
+            row_base = j * grp_size
+            v_scaling_u16 = pto.vlds(scaling_ptr_u16, vl_start + j * src_static_cols)
+            v_scaling_bf16 = pto.vbitcast(v_scaling_u16, pto.bf16)
+            v_scaling_f32_even = pto.vcvt(v_scaling_bf16, pto.f32, preg_b16, part=pto.VcvtPartMode.EVEN)
+            v_scaling_f32_odd = pto.vcvt(v_scaling_bf16, pto.f32, preg_b16, part=pto.VcvtPartMode.ODD)
+            with pto.for_(0, grp_size, step=1) as k:
+                r = row_base + k
+                src_off = r * src_static_cols + vl_start
+                dst_off = r * dst_static_cols + vl_start
+                v_input = pto.vlds(src_ptr, src_off)
+                v_input_f32_even = pto.vcvt(v_input, pto.f32, preg_b16, part=pto.VcvtPartMode.EVEN)
+                v_input_f32_odd = pto.vcvt(v_input, pto.f32, preg_b16, part=pto.VcvtPartMode.ODD)
+                v_input_f32_even = pto.vmul(v_input_f32_even, v_scaling_f32_even, preg_b32)
+                v_input_f32_odd = pto.vmul(v_input_f32_odd, v_scaling_f32_odd, preg_b32)
+                v_fp8_p0 = pto.vcvt(v_input_f32_even, pto.f8e4m3, preg_b32,
+                                    rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT, part=pto.VcvtPartMode.P0)
+                v_fp8_p1 = pto.vcvt(v_input_f32_odd, pto.f8e4m3, preg_b32,
+                                    rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT, part=pto.VcvtPartMode.P1)
+                v_fp8_p0_u16 = pto.vbitcast(v_fp8_p0, pto.ui16)
+                v_fp8_p1_u16 = pto.vbitcast(v_fp8_p1, pto.ui16)
+                v_out_u16 = pto.vor(v_fp8_p0_u16, v_fp8_p1_u16, preg_all_b16)
+                v_out_u32 = pto.vbitcast(v_out_u16, pto.ui32)
+                pto.vsts(v_out_u32, dst_ptr_u32, dst_off // 4, preg_b32, dist=pto.VStoreDist.PK_B32)
+
+
+def _extract_dn_linear_exponent_and_scaling(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_cols, static_cols, elements_per_vl, alg=OcpF8E4M3Alg, dtype=pto.f32):
+    grp_size = 32
+    vl_count = _ceil_division(valid_cols, elements_per_vl)
+    group_count = _ceil_division(valid_rows, grp_size)
+    is_f32 = pto.bytewidth(dtype) == 4
+    ctx = None
+    if not is_f32:
+        ctx = _init_dn_b16_quant_ctx(alg, dtype)
+    for group in range(group_count):
+        max_row = pto.addptr(max_ptr, group * static_cols)
+        exp_row = pto.addptr(exp_ptr, group * static_cols)
+        scaling_row = pto.addptr(scaling_ptr, group * static_cols)
+        for vl in range(vl_count):
+            off = vl * elements_per_vl
+            remaining = valid_cols - off if valid_cols > off else 0
+            if remaining > elements_per_vl:
+                remaining = elements_per_vl
+            if is_f32:
+                _extract_b8_exponent_and_scaling_vl(alg, max_row, exp_row, scaling_row, off, remaining, dtype)
+            else:
+                _extract_dn_b16_exponent_and_scaling_vl(ctx, max_row, exp_row, scaling_row, off, remaining, alg, dtype)
+
+
+def _extract_b8_exponent_and_scaling_2d(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_cols, src_cols, lanes_b16, dtype=pto.bf16):
+    elements_per_vl = lanes_b16
+    groups_per_row = src_cols // 32
+    valid_groups_per_row = _ceil_division(valid_cols, 32)
+    loops_per_row = _ceil_division(valid_groups_per_row, elements_per_vl)
+    for row in range(valid_rows):
+        row_off = row * groups_per_row
+        for i in range(loops_per_row):
+            off = i * elements_per_vl
+            rem = valid_groups_per_row - off if valid_groups_per_row > off else 0
+            if rem > elements_per_vl:
+                rem = elements_per_vl
+            _extract_b8_exponent_and_scaling_vl(
+                OcpF8E4M3Alg, pto.addptr(max_ptr, row_off), pto.addptr(exp_ptr, row_off),
+                pto.addptr(scaling_ptr, row_off), off, rem, dtype)
+
+
+def _store_dn_interleaved_exponent_b16(exp_ptr, v_exp0, v_exp1, dst_byte_offset, elem_count):
+    preg, _ = pto.make_mask(pto.ui16, elem_count)
+    v_exp1 = pto.vshls(v_exp1, 8, preg)
+    v_exp0 = pto.vor(v_exp0, v_exp1, preg)
+    exp_ptr_u16 = pto.castptr(exp_ptr, pto.ptr(pto.ui16, "ub"))
+    pto.vsts(v_exp0, exp_ptr_u16, dst_byte_offset // 2, preg, dist=pto.VStoreDist.NORM_B16)
+
+
+def _store_dn_interleaved_exponent_b32(exp_ptr, v_exp0, v_exp1, dst_byte_offset, elem_count):
+    preg, _ = pto.make_mask(pto.f32, elem_count)
+    v_exp1 = pto.vshls(v_exp1, 8, preg)
+    v_exp0 = pto.vor(v_exp0, v_exp1, preg)
+    exp_ptr_u16 = pto.castptr(exp_ptr, pto.ptr(pto.ui16, "ub"))
+    pto.vsts(v_exp0, exp_ptr_u16, dst_byte_offset // 2, preg, dist=pto.VStoreDist.PK_B32)
+
+
+def _extract_dn_interleaved_pair_vl(ctx, max_row0, max_row1, scaling_row0, scaling_row1, exp_ptr, off, dst_byte_offset, rem, alg, dtype=pto.bf16):
+    if alg in (OcpF8E4M3Alg, OcpF4E2M1Alg):
+        v_exp0, v_scaling0, preg0 = _compute_b16_ocp_exp_and_scaling_regs(ctx, max_row0, off, rem, dtype)
+        v_exp1, v_scaling1, preg1 = _compute_b16_ocp_exp_and_scaling_regs(ctx, max_row1, off, rem, dtype)
+        scaling_row0_u16 = pto.castptr(scaling_row0, pto.ptr(pto.ui16, "ub"))
+        scaling_row1_u16 = pto.castptr(scaling_row1, pto.ptr(pto.ui16, "ub"))
+        pto.vsts(v_scaling0, scaling_row0_u16, off, preg0, dist=pto.VStoreDist.NORM_B16)
+        pto.vsts(v_scaling1, scaling_row1_u16, off, preg1, dist=pto.VStoreDist.NORM_B16)
+        _store_dn_interleaved_exponent_b16(exp_ptr, v_exp0, v_exp1, dst_byte_offset, rem)
+    else:
+        v_exp0, v_scaling0, preg = _compute_b16_nv_exp_and_scaling_regs(ctx, max_row0, off, rem, dtype)
+        v_exp1, v_scaling1, preg = _compute_b16_nv_exp_and_scaling_regs(ctx, max_row1, off, rem, dtype)
+        scaling_row0_u16 = pto.castptr(scaling_row0, pto.ptr(pto.ui16, "ub"))
+        scaling_row1_u16 = pto.castptr(scaling_row1, pto.ptr(pto.ui16, "ub"))
+        pto.vsts(v_scaling0, scaling_row0_u16, off, preg, dist=pto.VStoreDist.PK_B32)
+        pto.vsts(v_scaling1, scaling_row1_u16, off, preg, dist=pto.VStoreDist.PK_B32)
+        _store_dn_interleaved_exponent_b32(exp_ptr, v_exp0, v_exp1, dst_byte_offset, rem)
+
+
+def _extract_dn_interleaved_exponent_and_scaling(max_ptr, exp_ptr, exp_scratch_ptr, scaling_ptr, valid_rows, valid_cols, static_cols, exp_col_stride, elements_per_vl, alg, dtype):
+    grp_size = 32
+    scratch_row_stride = _ceil_division(static_cols, 32) * 32
+    vl_count = _ceil_division(valid_cols, elements_per_vl)
+    group_count = _ceil_division(valid_rows, grp_size)
+    is_f32 = pto.bytewidth(dtype) == 4
+    if is_f32:
+        for group in range(group_count):
+            max_row = pto.addptr(max_ptr, group * static_cols)
+            exp_scratch_row = pto.addptr(exp_scratch_ptr, group * scratch_row_stride)
+            scaling_row = pto.addptr(scaling_ptr, group * static_cols)
+            for vl in range(vl_count):
+                off = vl * elements_per_vl
+                remaining = valid_cols - off if valid_cols > off else 0
+                if remaining > elements_per_vl:
+                    remaining = elements_per_vl
+                _extract_b8_exponent_and_scaling_vl(alg, max_row, exp_scratch_row, scaling_row, off, remaining, dtype)
+    else:
+        ctx = _init_dn_b16_quant_ctx(alg, dtype)
+        pair_count = group_count // 2
+        for pair in range(pair_count):
+            max_row0 = pto.addptr(max_ptr, pair * 2 * static_cols)
+            max_row1 = pto.addptr(max_row0, static_cols)
+            scaling_row0 = pto.addptr(scaling_ptr, pair * 2 * static_cols)
+            scaling_row1 = pto.addptr(scaling_row0, static_cols)
+            for vl in range(vl_count):
+                off = vl * elements_per_vl
+                remaining = valid_cols - off if valid_cols > off else 0
+                if remaining > elements_per_vl:
+                    remaining = elements_per_vl
+                _extract_dn_interleaved_pair_vl(ctx, max_row0, max_row1, scaling_row0, scaling_row1, exp_ptr, off, pair * exp_col_stride + 2 * off, remaining, alg, dtype)
+
+
+def _write_dn_interleaved_exponent_f32(exp_scratch, exp_ptr, valid_rows, valid_cols, static_cols, exp_col_stride):
+    grp_size = 32
+    bytes_per_input_vl = 128  # CCE_VL / 2
+    scratch_row_stride = _ceil_division(static_cols, 32) * 32
+    pair_count = valid_rows // (2 * grp_size)
+    store_vl_count = _ceil_division(valid_cols, bytes_per_input_vl)
+    for pair in range(pair_count):
+        exp_scratch0 = pto.addptr(exp_scratch, pair * 2 * scratch_row_stride)
+        exp_scratch1 = pto.addptr(exp_scratch0, scratch_row_stride)
+        rem = valid_cols
+        for vl in range(store_vl_count):
+            off = vl * bytes_per_input_vl
+            exp0 = pto.vlds(exp_scratch0, off, dist="UNPK_B8")
+            exp1 = pto.vlds(exp_scratch1, off, dist="UNPK_B8")
+            preg, _ = pto.make_mask(pto.ui16, rem)
+            exp1_u16 = pto.vbitcast(exp1, pto.ui16)
+            exp1_u16 = pto.vshls(exp1_u16, 8, preg)
+            exp0_u16 = pto.vbitcast(exp0, pto.ui16)
+            exp0_u16 = pto.vor(exp0_u16, exp1_u16, preg)
+            dst_byte_offset = pair * exp_col_stride + 2 * off
+            exp_ptr_u16 = pto.castptr(exp_ptr, pto.ptr(pto.ui16, "ub"))
+            pto.vsts(exp0_u16, exp_ptr_u16, dst_byte_offset // 2, preg, dist=pto.VStoreDist.NORM_B16)
+
+
+def _tquant_mxfp8_dn_f32(src_ptr, dst_ptr, exp_ptr, max_ptr, scaling_ptr, valid_rows, valid_cols, src_static_cols, dst_static_cols, scale_alg="ocp", interleave=False, exp_col_stride=None):
+    lanes_f32 = pto.elements_per_vreg(pto.f32)
+    alg = NvF8E4M3Alg if scale_alg == "nv" else OcpF8E4M3Alg
+
+    _abs_reduce_max_dn(src_ptr, max_ptr, valid_rows, valid_cols, src_static_cols, lanes_f32, pto.f32, scale_alg)
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+    if interleave:
+        _extract_dn_interleaved_exponent_and_scaling(max_ptr, exp_ptr, dst_ptr, scaling_ptr, valid_rows, valid_cols, src_static_cols, exp_col_stride, lanes_f32, alg, pto.f32)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _write_dn_interleaved_exponent_f32(dst_ptr, exp_ptr, valid_rows, valid_cols, src_static_cols, exp_col_stride)
+        pto.mem_bar(pto.BarrierType.VLD_VST)
+    else:
+        _extract_dn_linear_exponent_and_scaling(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_cols, src_static_cols, lanes_f32, alg)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+    _calc_quantized_fp8_values_dn_float(src_ptr, scaling_ptr, dst_ptr, valid_rows, valid_cols, src_static_cols, dst_static_cols, lanes_f32)
+
+
+def _tquant_mxfp8_dn_b16(src_ptr, dst_ptr, exp_ptr, max_ptr, scaling_ptr, dtype, valid_rows, valid_cols, src_static_cols, dst_static_cols, scale_alg="ocp", interleave=False, exp_col_stride=None):
+    alg = NvF8E4M3Alg if scale_alg == "nv" else OcpF8E4M3Alg
+    lanes_b16 = pto.elements_per_vreg(dtype)
+    extract_elements_per_vl = pto.elements_per_vreg(pto.f32) if scale_alg == "nv" else lanes_b16
+
+    _abs_reduce_max_dn(src_ptr, max_ptr, valid_rows, valid_cols, src_static_cols, lanes_b16, dtype, scale_alg)
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+    if interleave:
+        _extract_dn_interleaved_exponent_and_scaling(max_ptr, exp_ptr, dst_ptr, scaling_ptr, valid_rows, valid_cols, src_static_cols, exp_col_stride, extract_elements_per_vl, alg, dtype)
+    else:
+        _extract_dn_linear_exponent_and_scaling(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_cols, src_static_cols, extract_elements_per_vl, alg, dtype)
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+    _calc_quantized_fp8_values_dn_b16(src_ptr, scaling_ptr, dst_ptr, valid_rows, valid_cols, src_static_cols, dst_static_cols, lanes_b16, dtype)
+
+
+def _extract_mx_ocp_exponent_and_scaling_vl(max_ptr, exp_ptr, scaling_ptr, off, rem, spec=None, dtype=pto.bf16):
+    ctx = _init_b16_ocp_quant_ctx(spec)
+    _compute_b16_ocp_exp_and_scaling(ctx, max_ptr, exp_ptr, scaling_ptr, off, rem, dtype)
+
+
+def _extract_b16_nv_exponent_and_scaling_core(max_ptr, exp_ptr, scaling_ptr, off, rem, spec=None, dtype=pto.bf16):
+    ctx = _init_b16_nv_quant_ctx(spec)
+    _compute_b16_nv_exp_and_scaling(ctx, max_ptr, exp_ptr, scaling_ptr, off, rem, dtype)
+
+
+def _init_dn_b16_quant_ctx(alg, dtype=pto.bf16):
+    if alg in (OcpF8E4M3Alg, OcpF4E2M1Alg):
+        spec = _OCP_MXFP8_SPEC if alg == OcpF8E4M3Alg else _OCP_MXFP4_SPEC
+        return _init_b16_ocp_quant_ctx(spec)
+    spec = _NV_MXFP8_SPEC if alg == NvF8E4M3Alg else _NV_MXFP4_SPEC
+    return _init_b16_nv_quant_ctx(spec)
+
+
+def _extract_dn_b16_exponent_and_scaling_vl(ctx, max_ptr, exp_ptr, scaling_ptr, off, rem, alg, dtype=pto.bf16):
+    if alg in (OcpF8E4M3Alg, OcpF4E2M1Alg):
+        _compute_b16_ocp_exp_and_scaling(ctx, max_ptr, exp_ptr, scaling_ptr, off, rem, dtype)
+    else:
+        _compute_b16_nv_exp_and_scaling(ctx, max_ptr, exp_ptr, scaling_ptr, off, rem, dtype)
+
+
+def _extract_b8_exponent_and_scaling_vl(alg, max_ptr, exp_ptr, scaling_ptr, off, rem, dtype):
+    if alg == OcpF8E4M3Alg:
+        if dtype == pto.f32:
+            _extract_f32_ocp_exp_and_scaling_core(max_ptr, exp_ptr, scaling_ptr, off, rem)
+        else:
+            _extract_mx_ocp_exponent_and_scaling_vl(max_ptr, exp_ptr, scaling_ptr, off, rem, _OCP_MXFP8_SPEC, dtype)
+    elif alg == OcpF4E2M1Alg:
+        _extract_mx_ocp_exponent_and_scaling_vl(max_ptr, exp_ptr, scaling_ptr, off, rem, _OCP_MXFP4_SPEC, dtype)
+    elif alg == NvF8E4M3Alg:
+        if dtype == pto.f32:
+            _extract_f32_nv_exp_and_scaling_core(max_ptr, exp_ptr, scaling_ptr, off, rem)
+        else:
+            _extract_b16_nv_exponent_and_scaling_core(max_ptr, exp_ptr, scaling_ptr, off, rem, _NV_MXFP8_SPEC, dtype)
+    elif alg == NvF4E2M1Alg:
+        if dtype == pto.f32:
+            _extract_f32_nv_exp_and_scaling_core(max_ptr, exp_ptr, scaling_ptr, off, rem)
+        else:
+            _extract_b16_nv_exponent_and_scaling_core(max_ptr, exp_ptr, scaling_ptr, off, rem, _NV_MXFP4_SPEC, dtype)
+
+
+def _calc_quantized_fp4e2m1_values_dn_bf16(src_ptr, scaling_ptr, dst_ptr, valid_rows, valid_cols, src_static_cols, dst_static_cols, lanes_b16):
+    grp_size = 32
+    num_vls_per_row = _ceil_division(valid_cols, lanes_b16)
+    num_grps_per_col = _ceil_division(valid_rows, grp_size)
+    preg_cols_b16 = valid_cols
+    for i in range(num_vls_per_row):
+        vl_start = i * lanes_b16
+        preg_b16, preg_cols_b16 = pto.make_mask(pto.bf16, preg_cols_b16)
+        for j in range(num_grps_per_col):
+            row_base = j * grp_size
+            v_scaling = pto.vlds(scaling_ptr, vl_start + j * src_static_cols)
+            with pto.for_(0, grp_size, step=1) as k:
+                r = row_base + k
+                off = r * src_static_cols + vl_start
+                v_input = pto.vlds(src_ptr, off)
+                v_scaled = pto.vmul(v_input, v_scaling, preg_b16)
+                v_scaled_u16 = pto.vbitcast(v_scaled, pto.ui16)
+                v_scaled_u16 = _saturate_bf16_nan_to_pos_inf(v_scaled_u16, preg_b16)
+                v_scaled = pto.vbitcast(v_scaled_u16, pto.bf16)
+                v_fp4 = pto.vcvt(v_scaled, pto.f4e2m1x2, preg_b16,
+                                 rnd=pto.VcvtRoundMode.R, part=pto.VcvtPartMode.P0)
+                pto.vsts(v_fp4, dst_ptr, off // 2, preg_b16,
+                         dist=pto.VStoreDist.PK4_B32)
+
+
+def _calc_quantized_fp4e2m1_values_dn_fp16_row(src_ptr, dst_ptr, v_sc_even, v_sc_odd, pack_index, r, vl_start, packed_bytes, src_static_cols, dst_static_cols, preg_b16, preg_b32):
+    v_input = pto.vlds(src_ptr, r * src_static_cols + vl_start)
+    v_f32_even = pto.vcvt(v_input, pto.f32, preg_b16, part=pto.VcvtPartMode.EVEN)
+    v_f32_odd = pto.vcvt(v_input, pto.f32, preg_b16, part=pto.VcvtPartMode.ODD)
+    v_f32_even = pto.vmul(v_f32_even, v_sc_even, preg_b32)
+    v_f32_odd = pto.vmul(v_f32_odd, v_sc_odd, preg_b32)
+    v_even_code = _calc_e2m1_signed_code_i32(v_f32_even, preg_b32)
+    v_odd_code = _calc_e2m1_signed_code_i32(v_f32_odd, preg_b32)
+    v_packed = _pack_e2m1_signed_code_bytes(v_even_code, v_odd_code, pack_index, preg_b32)
+    dst_byte_offset = r * src_static_cols + vl_start
+    preg_b8, _ = pto.make_mask(pto.ui8, packed_bytes)
+    if (src_static_cols // 2) % 32 == 0:
+        pto.vsts(v_packed, dst_ptr, dst_byte_offset // 2, preg_b8, dist=pto.VStoreDist.NORM_B8)
+    else:
+        scratch_ptr = pto.addptr(dst_ptr, src_static_cols // 2)
+        pto.vsts(v_packed, scratch_ptr, 0, preg_b8, dist=pto.VStoreDist.NORM_B8)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        v_packed_copy = pto.vlds(scratch_ptr, 0)
+        dst_write_ptr_u8 = pto.castptr(pto.addptr(dst_ptr, dst_byte_offset // 2), pto.ptr(pto.ui8, "ub"))
+        ureg_out = pto.init_align()
+        ureg_out = pto.vstus(ureg_out, packed_bytes, v_packed_copy, dst_write_ptr_u8)
+        pto.vstas(ureg_out, dst_write_ptr_u8, 0)
+
+
+def _calc_quantized_fp4e2m1_values_dn_fp16(src_ptr, scaling_ptr, dst_ptr, valid_rows, valid_cols, src_static_cols, dst_static_cols, lanes_b16):
+    grp_size = 32
+    num_vls_per_row = _ceil_division(valid_cols, lanes_b16)
+    num_grps_per_col = _ceil_division(valid_rows, grp_size)
+    preg_cols_b16 = valid_cols
+    preg_cols_b32 = valid_cols
+    scaling_u16_ptr = pto.castptr(scaling_ptr, pto.ptr(pto.ui16, "ub"))
+    pack_index = pto.vci(pto.i8(0), "ASC")
+    pack_index_i16 = pto.vbitcast(pack_index, pto.si16)
+    pack_index_i16 = pto.vmuls(pack_index_i16, pto.si16(4), pto.pset_b16(pto.PAT.ALL))
+    pack_index = pto.vbitcast(pack_index_i16, pto.ui8)
+    for i in range(num_vls_per_row):
+        vl_start = i * lanes_b16
+        packed_bytes = preg_cols_b32
+        preg_b16, preg_cols_b16 = pto.make_mask(pto.f16, preg_cols_b16)
+        preg_b32, preg_cols_b32 = pto.make_mask(pto.f32, preg_cols_b32)
+        packed_bytes = packed_bytes - preg_cols_b32
+        for j in range(num_grps_per_col):
+            row_base = j * grp_size
+            v_scaling_u16 = pto.vlds(scaling_u16_ptr, vl_start + j * src_static_cols)
+            v_scaling_bf16 = pto.vbitcast(v_scaling_u16, pto.bf16)
+            v_sc_even = pto.vcvt(v_scaling_bf16, pto.f32, preg_b16, part=pto.VcvtPartMode.EVEN)
+            v_sc_odd = pto.vcvt(v_scaling_bf16, pto.f32, preg_b16, part=pto.VcvtPartMode.ODD)
+            with pto.for_(0, grp_size, step=1) as k:
+                r = row_base + k
+                _calc_quantized_fp4e2m1_values_dn_fp16_row(src_ptr, dst_ptr, v_sc_even, v_sc_odd, pack_index, r, vl_start, packed_bytes, src_static_cols, dst_static_cols, preg_b16, preg_b32)
+
+
+def _tquant_mxfp4_e2m1_dn(src_ptr, dst_ptr, exp_ptr, max_ptr, scaling_ptr, dtype, valid_rows, valid_cols, src_static_cols, dst_static_cols, scale_alg="ocp", interleave=False, exp_col_stride=None):
+    alg = NvF4E2M1Alg if scale_alg == "nv" else OcpF4E2M1Alg
+    lanes_b16 = pto.elements_per_vreg(dtype)
+    extract_elements_per_vl = pto.elements_per_vreg(pto.f32) if scale_alg == "nv" else lanes_b16
+
+    _abs_reduce_max_dn(src_ptr, max_ptr, valid_rows, valid_cols, src_static_cols, lanes_b16, dtype, scale_alg)
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+    if interleave:
+        _extract_dn_interleaved_exponent_and_scaling(max_ptr, exp_ptr, dst_ptr, scaling_ptr, valid_rows, valid_cols, src_static_cols, exp_col_stride, extract_elements_per_vl, alg, dtype)
+    else:
+        _extract_dn_linear_exponent_and_scaling(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_cols, src_static_cols, extract_elements_per_vl, alg, dtype)
+    pto.mem_bar(pto.BarrierType.VST_VLD)
+    if dtype == pto.f16:
+        _calc_quantized_fp4e2m1_values_dn_fp16(src_ptr, scaling_ptr, dst_ptr, valid_rows, valid_cols, src_static_cols, dst_static_cols, lanes_b16)
+    else:
+        _calc_quantized_fp4e2m1_values_dn_bf16(src_ptr, scaling_ptr, dst_ptr, valid_rows, valid_cols, src_static_cols, dst_static_cols, lanes_b16)
+
+
+
+
+@tilelib.tile_template(op="pto.tquant.mx", target="a5", name="template_tquant_mxfp8_f32_dn",
+    dtypes=[("f32", "ui8", "ui8", "f32", "f32")],
+    iteration_axis="none", op_engine="vector", op_class="elementwise",
+    constraints=[_mx_dn_tiles], id=5, loop_depth=2, is_post_update=False, tags=_MX_TAGS + ("fp8", "f32", "dn"))
+def template_tquant_mxfp8_f32_dn(src: pto.Tile, dst: pto.Tile, exp: pto.Tile,
+                                 max_tile: pto.Tile, scaling: pto.Tile):
+    """MXFP8 DN: f32 → fp8."""
+    scale_alg = pto.get_op_attr("quant_scale_alg", "ocp")
+    interleave = pto.get_op_attr("interleave") == "true"
+    valid_rows, valid_cols, static_cols = _prepare_dn_quant(src, pto.f32)
+    dst_static_cols = dst.shape[1]
+    src_ptr, dst_ptr, max_ptr, exp_ptr, scaling_ptr = _prepare_nd_ptrs(src, dst, max_tile, exp, scaling)
+    exp_col_stride = exp.shape[1] if interleave else static_cols
+    _tquant_mxfp8_dn_f32(src_ptr, dst_ptr, exp_ptr, max_ptr, scaling_ptr, valid_rows, valid_cols, static_cols, dst_static_cols, scale_alg, interleave, exp_col_stride)
+
+
+# ════════════════════════════════════════════════════════════════
+#  B16 (BF16) MXFP8 helpers
+# ════════════════════════════════════════════════════════════════
+
+_BLOCK_BYTE_SIZE = 32
+_BF16_ABS_MASK = 0x7FFF
+_FP16_EXP_MASK = 0x7C00
+_FP16_MANTISSA_MASK = 0x03FF
+_FP16_INF_BITS = 0x7C00
+_BF16_INF_BITS = 0x7F80
+_BF16_NAN_BITS = 0x7FC0
+
+def _fp16_to_bf16_preserve_special(src0, src1, preg_vl0, preg_vl1):
+    """
+
+    Converts fp16→bf16 via the vcvt(ROUND_Z) hardware instruction, then
+    overrides Inf/NaN results with canonical bf16 sentinels (0x7F80/0x7FC0)
+    so stage-2 can detect them via bf16 exp==0x7F80.
+    """
+    v_abs_mask = pto.vbr(pto.ui16(_BF16_ABS_MASK))
+    v_fp16_exp_mask = pto.vbr(pto.ui16(_FP16_EXP_MASK))
+    v_fp16_mant_mask = pto.vbr(pto.ui16(_FP16_MANTISSA_MASK))
+    v_bf16_inf = pto.vbr(pto.ui16(_BF16_INF_BITS))
+    v_bf16_nan = pto.vbr(pto.ui16(_BF16_NAN_BITS))
+    src0_u16 = pto.vbitcast(src0, pto.ui16)
+    src1_u16 = pto.vbitcast(src1, pto.ui16)
+    v_abs_0 = pto.vand(src0_u16, v_abs_mask, preg_vl0)
+    v_abs_1 = pto.vand(src1_u16, v_abs_mask, preg_vl1)
+    v_exp_0 = pto.vand(v_abs_0, v_fp16_exp_mask, preg_vl0)
+    v_exp_1 = pto.vand(v_abs_1, v_fp16_exp_mask, preg_vl1)
+    v_mant_0 = pto.vand(v_abs_0, v_fp16_mant_mask, preg_vl0)
+    v_mant_1 = pto.vand(v_abs_1, v_fp16_mant_mask, preg_vl1)
+    preg_special_0 = pto.vcmps(v_exp_0, pto.ui16(_FP16_EXP_MASK), preg_vl0, pto.CmpMode.EQ)
+    preg_special_1 = pto.vcmps(v_exp_1, pto.ui16(_FP16_EXP_MASK), preg_vl1, pto.CmpMode.EQ)
+    preg_nan_0 = pto.vcmps(v_mant_0, pto.ui16(0), preg_special_0, pto.CmpMode.NE)
+    preg_nan_1 = pto.vcmps(v_mant_1, pto.ui16(0), preg_special_1, pto.CmpMode.NE)
+    preg_inf_0 = pto.vcmps(v_abs_0, pto.ui16(_FP16_INF_BITS), preg_vl0, pto.CmpMode.EQ)
+    preg_inf_1 = pto.vcmps(v_abs_1, pto.ui16(_FP16_INF_BITS), preg_vl1, pto.CmpMode.EQ)
+    v_bf16_0 = pto.vcvt(src0, pto.bf16, preg_vl0, rnd=pto.VcvtRoundMode.Z)
+    v_bf16_1 = pto.vcvt(src1, pto.bf16, preg_vl1, rnd=pto.VcvtRoundMode.Z)
+    v_bf16_0_u16 = pto.vbitcast(v_bf16_0, pto.ui16)
+    v_bf16_1_u16 = pto.vbitcast(v_bf16_1, pto.ui16)
+    v_bf16_0_u16 = pto.vsel(v_bf16_inf, v_bf16_0_u16, preg_inf_0)
+    v_bf16_1_u16 = pto.vsel(v_bf16_inf, v_bf16_1_u16, preg_inf_1)
+    v_bf16_0_u16 = pto.vsel(v_bf16_nan, v_bf16_0_u16, preg_nan_0)
+    v_bf16_1_u16 = pto.vsel(v_bf16_nan, v_bf16_1_u16, preg_nan_1)
+    return pto.vbitcast(v_bf16_0_u16, pto.bf16), pto.vbitcast(v_bf16_1_u16, pto.bf16)
+
+def _apply_half_scaling_to_fp8_window(v_in_1, v_in_2, scaling_ptr, i,
+                                       preg_b16_1, preg_b16_2,
+                                       preg_f32_1_even, preg_f32_1_odd,
+                                       preg_f32_2_even, preg_f32_2_odd):
+    preg_all_b16 = pto.pset_b16(pto.PAT.ALL)
+    scaling_ptr_u16 = pto.castptr(scaling_ptr, pto.ptr(pto.ui16, "ub"))
+    v_scaling_u16 = pto.vlds(scaling_ptr_u16, 8 * i, dist="E2B_B16")
+    v_scaling_bf16 = pto.vbitcast(v_scaling_u16, pto.bf16)
+    v_scaling_f32 = pto.vcvt(v_scaling_bf16, pto.f32, preg_all_b16, part=pto.VcvtPartMode.EVEN)
+    v_cvt_1 = pto.vcvt(v_in_1, pto.f32, preg_b16_1, part=pto.VcvtPartMode.EVEN)
+    v_cvt_2 = pto.vcvt(v_in_1, pto.f32, preg_b16_1, part=pto.VcvtPartMode.ODD)
+    v_cvt_3 = pto.vcvt(v_in_2, pto.f32, preg_b16_2, part=pto.VcvtPartMode.EVEN)
+    v_cvt_4 = pto.vcvt(v_in_2, pto.f32, preg_b16_2, part=pto.VcvtPartMode.ODD)
+    v_cvt_1 = pto.vmul(v_cvt_1, v_scaling_f32, preg_f32_1_even)
+    v_cvt_2 = pto.vmul(v_cvt_2, v_scaling_f32, preg_f32_1_odd)
+    v_cvt_3 = pto.vmul(v_cvt_3, v_scaling_f32, preg_f32_2_even)
+    v_cvt_4 = pto.vmul(v_cvt_4, v_scaling_f32, preg_f32_2_odd)
+    return v_cvt_1, v_cvt_2, v_cvt_3, v_cvt_4
+
+def _abs_reduce_max_b16_dintlv_window(src_ptr, offset, remaining, lanes_b16, dtype, fp16_as_bf16_for_max=True):
+    even_count = (remaining + 1) // 2
+    odd_count = remaining // 2
+    preg_vl0, _ = pto.make_mask(dtype, even_count)
+    preg_vl1, _ = pto.make_mask(dtype, odd_count)
+    v_in_1, v_in_2 = pto.vldsx2(src_ptr, offset, "DINTLV_B16")
+    v_abs_mask = pto.vbr(pto.ui16(_BF16_ABS_MASK))
+    is_fp16 = dtype == pto.f16
+    if is_fp16 and fp16_as_bf16_for_max:
+        v_bf16_1, v_bf16_2 = _fp16_to_bf16_preserve_special(v_in_1, v_in_2, preg_vl0, preg_vl1)
+        v_abs_1 = pto.vand(pto.vbitcast(v_bf16_1, pto.ui16), v_abs_mask, preg_vl0)
+        v_abs_2 = pto.vand(pto.vbitcast(v_bf16_2, pto.ui16), v_abs_mask, preg_vl1)
+    else:
+        v_abs_1 = pto.vand(pto.vbitcast(v_in_1, pto.ui16), v_abs_mask, preg_vl0)
+        v_abs_2 = pto.vand(pto.vbitcast(v_in_2, pto.ui16), v_abs_mask, preg_vl1)
+    v_abs_1 = pto.vmax(v_abs_1, v_abs_2, preg_vl0)
+    v_max = pto.vcgmax(v_abs_1, preg_vl0)
+    return v_max
+
+def _abs_reduce_max_b16_nd(src_ptr, max_ptr, vl_count, total_count, lanes_b16, dtype, fp16_as_bf16_for_max=True):
+    elements_per_dintlv = 2 * lanes_b16
+    grps_per_dintlv = elements_per_dintlv // 32
+    blks_per_vl = 256 // _BLOCK_BYTE_SIZE
+    loop_num = _ceil_division(vl_count, 2)
+
+    if loop_num == 1:
+        remaining = min(total_count, elements_per_dintlv)
+        out_count = _ceil_division(remaining, 32)
+        preg_out, _ = pto.make_mask(dtype, out_count)
+        v_max = _abs_reduce_max_b16_dintlv_window(src_ptr, 0, remaining, lanes_b16, dtype, fp16_as_bf16_for_max)
+        pto.vsts(v_max, max_ptr, 0, preg_out, dist=pto.VStoreDist.NORM_B16)
+        return
+
+    ureg_max = pto.init_align()
+    for i in range(loop_num):
+        offset = i * elements_per_dintlv
+        remaining = min(max(0, total_count - offset), elements_per_dintlv)
+        v_max = _abs_reduce_max_b16_dintlv_window(src_ptr, offset, remaining, lanes_b16, dtype, fp16_as_bf16_for_max)
+        ureg_max = pto.vstus(ureg_max, blks_per_vl, v_max, pto.addptr(max_ptr, i * grps_per_dintlv))
+    pto.vstas(ureg_max, pto.addptr(max_ptr, loop_num * grps_per_dintlv), 0)
+
+def _abs_reduce_max_b16_nd_largesizes(src_ptr, max_ptr, vl_count, total_count, lanes_b16, dtype, fp16_as_bf16_for_max=True):
+    grp_size = 32
+    grps_per_vl = lanes_b16 // grp_size
+    num_vl_per_inner_loop = 2
+    num_vl_per_outer_loop = 32
+    grps_per_inner_loop = num_vl_per_inner_loop * grps_per_vl
+    grps_per_outer_loop = num_vl_per_outer_loop * grps_per_vl
+    blks_per_vl = 256 // _BLOCK_BYTE_SIZE
+    v_abs_mask = pto.vbr(pto.ui16(_BF16_ABS_MASK))
+    is_fp16 = dtype == pto.f16
+    remained = total_count
+
+    for i in range(vl_count // num_vl_per_outer_loop):
+        ureg_max = pto.init_align()
+        for j in range(num_vl_per_outer_loop // num_vl_per_inner_loop):
+            preg_vl0, remained = pto.make_mask(dtype, remained)
+            preg_vl1, remained = pto.make_mask(dtype, remained)
+            offset = (i * num_vl_per_outer_loop + j * num_vl_per_inner_loop) * lanes_b16
+            grp_offset = grps_per_outer_loop * i + grps_per_inner_loop * j
+            v_in_1, v_in_2 = pto.vldsx2(src_ptr, offset, "DINTLV_B16")
+            if is_fp16 and fp16_as_bf16_for_max:
+                v_bf16_1, v_bf16_2 = _fp16_to_bf16_preserve_special(v_in_1, v_in_2, preg_vl0, preg_vl1)
+                v_abs_1 = pto.vand(pto.vbitcast(v_bf16_1, pto.ui16), v_abs_mask, preg_vl0)
+                v_abs_2 = pto.vand(pto.vbitcast(v_bf16_2, pto.ui16), v_abs_mask, preg_vl1)
+            else:
+                v_abs_1 = pto.vand(pto.vbitcast(v_in_1, pto.ui16), v_abs_mask, preg_vl0)
+                v_abs_2 = pto.vand(pto.vbitcast(v_in_2, pto.ui16), v_abs_mask, preg_vl1)
+            v_abs_1 = pto.vmax(v_abs_1, v_abs_2, preg_vl0)
+            v_max = pto.vcgmax(v_abs_1, preg_vl0)
+            ureg_max = pto.vstus(ureg_max, blks_per_vl, v_max, pto.addptr(max_ptr, grp_offset))
+        pto.vstas(ureg_max, pto.addptr(max_ptr, grps_per_outer_loop * i), 0)
+
+def _reduce_mx_b16_abs_max_flat(src_ptr, max_ptr, vl_count, total_count, lanes_b16, dtype, scale_alg):
+    elements_per_large_loop = 32 * lanes_b16
+    use_large = (total_count % elements_per_large_loop == 0)
+    if scale_alg == "nv" and dtype == pto.f16:
+        if use_large:
+            _abs_reduce_max_b16_nd_largesizes(src_ptr, max_ptr, vl_count, total_count, lanes_b16, dtype, False)
+        else:
+            _abs_reduce_max_b16_nd(src_ptr, max_ptr, vl_count, total_count, lanes_b16, dtype, False)
+    else:
+        if use_large:
+            _abs_reduce_max_b16_nd_largesizes(src_ptr, max_ptr, vl_count, total_count, lanes_b16, dtype, True)
+        else:
+            _abs_reduce_max_b16_nd(src_ptr, max_ptr, vl_count, total_count, lanes_b16, dtype, True)
+
+
+@dataclass(frozen=True)
+class _OcpMxFp4E2M1Spec:
+    maxExp: int = 0x0100
+    expNan: int = 0x00FF
+    b16Nan: int = 0x7FC0
+
+
+@dataclass(frozen=True)
+class _NvMxFp4E2M1Spec:
+    descaleMultiplier: float = 1.0 / 6.0
+    b16SpecialScaleBits: int = 0x7FC0
+    f32SpecialScaleBits: int = 0x7FC00000
+
+
+_OCP_MXFP4_SPEC = _OcpMxFp4E2M1Spec()
+_NV_MXFP4_SPEC = _NvMxFp4E2M1Spec()
+
+
+@dataclass
+class _B16OcpQuantCtx:
+    vu16_max_exp_value: object = None
+    vu16_scale_bias: object = None
+    vu16_exp_nan: object = None
+    vu16_nan: object = None
+    vu16_exp_mask: object = None
+    vu16_mantissa_mask: object = None
+    preg_clamp: object = None
+    preg_special: object = None
+    preg_nan: object = None
+    kExpMask: int = 0x7F80
+    kMantissaMask: int = 0x007F
+    kExpBias: int = 0x7F00
+    kMaxExp: int = field(default_factory=lambda: _OCP_MXFP8_SPEC.maxExp)
+    kExpNan: int = field(default_factory=lambda: _OCP_MXFP8_SPEC.expNan)
+    kB16Nan: int = field(default_factory=lambda: _OCP_MXFP8_SPEC.b16Nan)
+    expShift: int = 7
+
+
+def _init_b16_ocp_quant_ctx(spec=None):
+    ctx = _B16OcpQuantCtx()
+    if spec is not None:
+        ctx.kMaxExp = spec.maxExp
+        ctx.kExpNan = spec.expNan
+        ctx.kB16Nan = spec.b16Nan
+    ctx.vu16_max_exp_value = pto.vbr(pto.ui16(ctx.kMaxExp))
+    ctx.vu16_scale_bias = pto.vbr(pto.ui16(ctx.kExpBias))
+    ctx.vu16_exp_nan = pto.vbr(pto.ui16(ctx.kExpNan))
+    ctx.vu16_nan = pto.vbr(pto.ui16(ctx.kB16Nan))
+    ctx.vu16_exp_mask = pto.vbr(pto.ui16(ctx.kExpMask))
+    ctx.vu16_mantissa_mask = pto.vbr(pto.ui16(ctx.kMantissaMask))
+    return ctx
+
+def _init_ocp_exp_scaling_ctx(spec=None):
+    ocp_spec = spec if spec is not None else _OCP_MXFP8_SPEC
+    ctx = {}
+    ctx["vu16_max_exp_value"] = pto.vbr(pto.ui16(ocp_spec.maxExp))
+    ctx["vu16_scale_bias"] = pto.vbr(pto.ui16(0x7F00))
+    ctx["vu16_exp_nan"] = pto.vbr(pto.ui16(ocp_spec.expNan))
+    ctx["vu16_nan"] = pto.vbr(pto.ui16(ocp_spec.b16Nan))
+    ctx["vu16_exp_mask"] = pto.vbr(pto.ui16(0x7F80))
+    ctx["vu16_mantissa_mask"] = pto.vbr(pto.ui16(0x007F))
+    return ctx
+
+def _compute_mx_ocp_exp_scaling(ctx, v_max_abs, preg_one_b16):
+    v_max_exp = pto.vand(v_max_abs, ctx["vu16_exp_mask"], preg_one_b16)
+    v_mantissa = pto.vand(v_max_abs, ctx["vu16_mantissa_mask"], preg_one_b16)
+    preg_special = pto.vcmps(v_max_exp, pto.ui16(0x7F80), preg_one_b16, pto.CmpMode.EQ)
+    preg_nan = pto.vcmps(v_mantissa, pto.ui16(0), preg_special, pto.CmpMode.NE)
+    preg_clamp = pto.vcmps(v_max_exp, pto.ui16(0x0400), preg_one_b16, pto.CmpMode.LE)
+    v_max_exp = pto.vsel(ctx["vu16_max_exp_value"], v_max_exp, preg_clamp)
+    v_shared_exp = pto.vsub(v_max_exp, ctx["vu16_max_exp_value"], preg_one_b16)
+    v_exp_value = pto.vshrs(v_shared_exp, 7, preg_one_b16)
+    v_exp_value = pto.vsel(ctx["vu16_exp_nan"], v_exp_value, preg_nan)
+    v_recip_scale = pto.vsub(ctx["vu16_scale_bias"], v_shared_exp, preg_one_b16)
+    v_recip_scale = pto.vsel(ctx["vu16_nan"], v_recip_scale, preg_nan)
+    return v_exp_value, v_recip_scale
+
+
+def _compute_b16_ocp_exp_and_scaling_regs(ctx, max_ptr, off, rem, dtype=pto.bf16):
+    preg_b16, _ = pto.make_mask(dtype, rem)
+    max_ptr_u16 = pto.castptr(max_ptr, pto.ptr(pto.ui16, "ub"))
+    v_max_abs = pto.vlds(max_ptr_u16, off)
+    v_max_exp = pto.vand(v_max_abs, ctx.vu16_exp_mask, preg_b16)
+    v_mantissa = pto.vand(v_max_abs, ctx.vu16_mantissa_mask, preg_b16)
+    ctx.preg_special = pto.vcmps(v_max_exp, pto.ui16(ctx.kExpMask), preg_b16, pto.CmpMode.EQ)
+    ctx.preg_nan = pto.vcmps(v_mantissa, pto.ui16(0), ctx.preg_special, pto.CmpMode.NE)
+    ctx.preg_clamp = pto.vcmps(v_max_exp, pto.ui16(ctx.kMaxExp), preg_b16, pto.CmpMode.LE)
+    v_max_exp = pto.vsel(ctx.vu16_max_exp_value, v_max_exp, ctx.preg_clamp)
+    v_shared_exp = pto.vsub(v_max_exp, ctx.vu16_max_exp_value, preg_b16)
+    v_scale_value = pto.vshrs(v_shared_exp, ctx.expShift, preg_b16)
+    v_scale_value = pto.vsel(ctx.vu16_exp_nan, v_scale_value, ctx.preg_nan)
+    v_recip_scale = pto.vsub(ctx.vu16_scale_bias, v_shared_exp, preg_b16)
+    v_recip_scale = pto.vsel(ctx.vu16_nan, v_recip_scale, ctx.preg_nan)
+    return v_scale_value, v_recip_scale, preg_b16
+
+
+def _compute_b16_ocp_exp_and_scaling(ctx, max_ptr, exp_ptr, scaling_ptr, off, rem, dtype=pto.bf16):
+    v_scale_value, v_recip_scale, preg_b16 = _compute_b16_ocp_exp_and_scaling_regs(ctx, max_ptr, off, rem, dtype)
+    exp_ptr_u16 = pto.castptr(exp_ptr, pto.ptr(pto.ui16, "ub"))
+    scaling_ptr_u16 = pto.castptr(scaling_ptr, pto.ptr(pto.ui16, "ub"))
+    pto.vsts(v_scale_value, exp_ptr_u16, off // pto.bytewidth(dtype), preg_b16, dist=pto.VStoreDist.PK_B16)
+    pto.vsts(v_recip_scale, scaling_ptr_u16, off, preg_b16, dist=pto.VStoreDist.NORM_B16)
+
+def _extract_e2m1_exponent_and_scaling(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, num_groups, lanes_b16, dtype=pto.bf16):
+    _extract_mx_ocp_exponent_and_scaling(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, num_groups, lanes_b16, _OCP_MXFP4_SPEC, dtype)
+
+def _extract_e2m1_exponent_and_scaling_nv(max_ptr, exp_ptr, scaling_ptr, num_groups, dtype=pto.bf16):
+    _extract_nv_exponent_and_scaling_b16(max_ptr, exp_ptr, scaling_ptr, num_groups, _NV_MXFP4_SPEC, dtype)
+
+
+def _extract_b8_exp_and_scaling(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, num_groups, lanes_b16, dtype=pto.bf16):
+    _extract_mx_ocp_exponent_and_scaling(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, num_groups, lanes_b16, _OCP_MXFP8_SPEC, dtype)
+
+def _extract_b8_exp_and_scaling_nv(max_ptr, exp_ptr, scaling_ptr, num_groups, dtype=pto.bf16):
+    _extract_nv_exponent_and_scaling_b16(max_ptr, exp_ptr, scaling_ptr, num_groups, _NV_MXFP8_SPEC, dtype)
+
+def _extract_mx_ocp_exponent_and_scaling(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, total_count, lanes_b16, spec=None, dtype=pto.bf16):
+    ctx = _init_b16_ocp_quant_ctx(spec)
+    for i in range(exp_loop_count):
+        off = i * lanes_b16
+        rem = total_count - off if total_count > off else 0
+        if rem > lanes_b16:
+            rem = lanes_b16
+        _compute_b16_ocp_exp_and_scaling(ctx, max_ptr, exp_ptr, scaling_ptr, off, rem, dtype)
+
+
+@dataclass
+class _B16NvQuantCtx:
+    vb32_exp_mask: object = None
+    vb32_mantissa_mask: object = None
+    vb32_exp_max: object = None
+    vb32_exp_nan: object = None
+    vb32_special_scale: object = None
+    vb32_min_rcp: object = None
+    descaleMultiplier: float = field(default_factory=lambda: _NV_MXFP8_SPEC.descaleMultiplier)
+    f32ExpShift: int = 23
+    b16ExpShift: int = 7
+
+def _init_b16_nv_quant_ctx(spec=None):
+    ctx = _B16NvQuantCtx()
+    if spec is not None:
+        ctx.descaleMultiplier = spec.descaleMultiplier
+        ctx._b16SpecialScaleBits = spec.b16SpecialScaleBits
+    else:
+        ctx._b16SpecialScaleBits = _NV_MXFP8_SPEC.b16SpecialScaleBits
+    ctx.vb32_exp_mask = pto.vbr(pto.si32(0x7F800000))
+    ctx.vb32_mantissa_mask = pto.vbr(pto.si32(0x007FFFFF))
+    ctx.vb32_exp_nan = pto.vbr(pto.si32(0xFF))
+    ctx.vb32_exp_max = pto.vbr(pto.si32(0xFE))
+    ctx.vb32_special_scale = pto.vbr(pto.si32(ctx._b16SpecialScaleBits))
+    ctx.vb32_min_rcp = pto.vbr(pto.si32(0x0040))
+    return ctx
+
+
+def _init_b16_nv_exp_scaling_ctx(spec=None):
+    b16_special_scale_bits = spec.b16SpecialScaleBits if spec is not None else _NV_MXFP8_SPEC.b16SpecialScaleBits
+    ctx = {}
+    ctx["vb32_exp_mask"] = pto.vbr(pto.si32(0x7F800000))
+    ctx["vb32_mantissa_mask"] = pto.vbr(pto.si32(0x007FFFFF))
+    ctx["vb32_exp_nan"] = pto.vbr(pto.si32(0xFF))
+    ctx["vb32_bf16_nan"] = pto.vbr(pto.si32(b16_special_scale_bits))
+    ctx["vb32_bf16_min_rcp"] = pto.vbr(pto.si32(0x0040))
+    ctx["vb32_exp_max"] = pto.vbr(pto.si32(0xFE))
+    ctx["descale_multiplier"] = spec.descaleMultiplier if spec is not None else _NV_MXFP8_SPEC.descaleMultiplier
+    return ctx
+
+def _compute_b16_nv_exp_scaling(ctx, v_b16_max, preg_b16, preg_b32, dtype=pto.bf16):
+    f32_exp_shift = 23
+    bf16_exp_shift = 7
+    v_f32_max = pto.vcvt(v_b16_max, pto.f32, preg_b16, part=pto.VcvtPartMode.EVEN)
+    v_f32_max = pto.vmuls(v_f32_max, pto.f32(ctx["descale_multiplier"]), preg_b32)
+    v_max_s32 = pto.vbitcast(v_f32_max, pto.si32)
+    v_exp = pto.vand(v_max_s32, ctx["vb32_exp_mask"], preg_b32)
+    v_mant = pto.vand(v_max_s32, ctx["vb32_mantissa_mask"], preg_b32)
+    v_exp = pto.vshrs(v_exp, f32_exp_shift, preg_b32)
+    v_shared_exp = v_exp
+    v_shared_exp_inc = pto.vadds(v_shared_exp, 1, preg_b32)
+    preg_mant_gt_zero = pto.vcmps(v_mant, pto.si32(0), preg_b32, pto.CmpMode.NE)
+    preg_exp_gt_zero = pto.vcmps(v_exp, pto.si32(0), preg_b32, pto.CmpMode.GT)
+    preg_exp_lt_max = pto.vcmps(v_exp, pto.si32(0xFE), preg_b32, pto.CmpMode.LT)
+    preg_exp_eq_zero = pto.vcmps(v_exp, pto.si32(0), preg_b32, pto.CmpMode.EQ)
+    preg_round_normal = pto.pand(preg_mant_gt_zero, preg_exp_gt_zero, preg_b32)
+    preg_round_normal = pto.pand(preg_round_normal, preg_exp_lt_max, preg_b32)
+    preg_mant_gt_half_subnormal = pto.vcmps(v_mant, pto.si32(0x00400000), preg_b32, pto.CmpMode.GT)
+    preg_round_subnormal = pto.pand(preg_mant_gt_half_subnormal, preg_exp_eq_zero, preg_b32)
+    preg_round_up = pto.por(preg_round_normal, preg_round_subnormal, preg_b32)
+    v_shared_exp = pto.vsel(v_shared_exp_inc, v_shared_exp, preg_round_up)
+    v_bf16_scale_bits = pto.vsub(ctx["vb32_exp_max"], v_shared_exp, preg_b32)
+    v_bf16_scale_bits = pto.vshls(v_bf16_scale_bits, bf16_exp_shift, preg_b32)
+    preg_exp_ff = pto.vcmps(v_exp, pto.si32(0xFF), preg_b32, pto.CmpMode.EQ)
+    preg_mant_eq_zero = pto.pnot(preg_mant_gt_zero, preg_b32)
+    preg_inf = pto.pand(preg_exp_ff, preg_mant_eq_zero, preg_b32)
+    preg_nan = pto.pand(preg_exp_ff, preg_mant_gt_zero, preg_b32)
+    v_bf16_scale_bits = pto.vsel(ctx["vb32_bf16_min_rcp"], v_bf16_scale_bits, preg_inf)
+    v_shared_exp = pto.vsel(ctx["vb32_exp_max"], v_shared_exp, preg_inf)
+    v_bf16_scale_bits = pto.vsel(ctx["vb32_bf16_nan"], v_bf16_scale_bits, preg_nan)
+    v_shared_exp = pto.vsel(ctx["vb32_exp_nan"], v_shared_exp, preg_nan)
+    return v_shared_exp, v_bf16_scale_bits
+
+
+def _round_up_b16_nv_shared_exponent(v_shared_exp, v_exponent, v_mantissa, v_scaled_bits, preg_b32):
+    v_shared_exp_inc = pto.vadds(v_shared_exp, 1, preg_b32)
+    preg_mant_ne_zero = pto.vcmps(v_mantissa, pto.si32(0), preg_b32, pto.CmpMode.NE)
+    preg_scaled_gt_half = pto.vcmps(v_scaled_bits, pto.si32(0x00400000), preg_b32, pto.CmpMode.GT)
+    preg_round = pto.pand(preg_mant_ne_zero, preg_scaled_gt_half, preg_b32)
+    preg_scaled_lt_max = pto.vcmps(v_scaled_bits, pto.si32(0x7F000000), preg_b32, pto.CmpMode.LT)
+    preg_round = pto.pand(preg_round, preg_scaled_lt_max, preg_b32)
+    v_shared_exp = pto.vsel(v_shared_exp_inc, v_shared_exp, preg_round)
+    return v_shared_exp
+
+
+def _compute_b16_nv_exp_and_scaling_regs(ctx, max_ptr, off, rem, dtype=pto.bf16):
+    chunk_count_b16 = rem * 2
+    chunk_count_b32 = rem
+    preg_b16, _ = pto.make_mask(dtype, chunk_count_b16)
+    preg_b32, _ = pto.make_mask(pto.f32, chunk_count_b32)
+    v_b16_max = pto.vlds(max_ptr, off, dist="UNPK_B16")
+    v_f32_max = pto.vcvt(v_b16_max, pto.f32, preg_b16, part=pto.VcvtPartMode.EVEN)
+    v_f32_max = pto.vmuls(v_f32_max, pto.f32(ctx.descaleMultiplier), preg_b32)
+    v_max_s32 = pto.vbitcast(v_f32_max, pto.si32)
+    v_exponent = pto.vand(v_max_s32, ctx.vb32_exp_mask, preg_b32)
+    v_mantissa = pto.vand(v_max_s32, ctx.vb32_mantissa_mask, preg_b32)
+    v_exponent = pto.vshrs(v_exponent, ctx.f32ExpShift, preg_b32)
+    v_shared_exp = _round_up_b16_nv_shared_exponent(v_exponent, v_exponent, v_mantissa, v_max_s32, preg_b32)
+    v_bf16_scale_bits = pto.vsub(ctx.vb32_exp_max, v_shared_exp, preg_b32)
+    v_bf16_scale_bits = pto.vshls(v_bf16_scale_bits, ctx.b16ExpShift, preg_b32)
+    preg_inf = pto.vcmps(v_max_s32, pto.si32(0x7F800000), preg_b32, pto.CmpMode.EQ)
+    v_bf16_scale_bits = pto.vsel(ctx.vb32_min_rcp, v_bf16_scale_bits, preg_inf)
+    v_shared_exp = pto.vsel(ctx.vb32_exp_max, v_shared_exp, preg_inf)
+    preg_nan = pto.vcmps(v_max_s32, pto.si32(0x7F800000), preg_b32, pto.CmpMode.GT)
+    v_bf16_scale_bits = pto.vsel(ctx.vb32_special_scale, v_bf16_scale_bits, preg_nan)
+    v_shared_exp = pto.vsel(ctx.vb32_exp_nan, v_shared_exp, preg_nan)
+    return v_shared_exp, v_bf16_scale_bits, preg_b32
+
+def _compute_b16_nv_exp_and_scaling(ctx, max_ptr, exp_ptr, scaling_ptr, off, rem, dtype=pto.bf16):
+    v_shared_exp, v_bf16_scale_bits, preg_b32 = _compute_b16_nv_exp_and_scaling_regs(ctx, max_ptr, off, rem, dtype)
+    exp_ptr_si32 = pto.castptr(exp_ptr, pto.ptr(pto.si32, "ub"))
+    pto.vsts(v_shared_exp, exp_ptr_si32, off // 4, preg_b32, dist=pto.VStoreDist.PK4_B32)
+    v_bf16_scale_bits_u16 = pto.vbitcast(v_bf16_scale_bits, pto.ui16)
+    scaling_ptr_u16 = pto.castptr(scaling_ptr, pto.ptr(pto.ui16, "ub"))
+    pto.vsts(v_bf16_scale_bits_u16, scaling_ptr_u16, off, preg_b32, dist=pto.VStoreDist.PK_B32)
+
+def _extract_nv_exponent_and_scaling_b16(max_ptr, exp_ptr, scaling_ptr, total_count, spec=None, dtype=pto.bf16):
+    ctx = _init_b16_nv_quant_ctx(spec)
+    elements_per_chunk = pto.elements_per_vreg(pto.f32)
+    loop_count = _ceil_division(total_count, elements_per_chunk)
+    for i in range(loop_count):
+        off = i * elements_per_chunk
+        rem = total_count - off if total_count > off else 0
+        if rem > elements_per_chunk:
+            rem = elements_per_chunk
+        _compute_b16_nv_exp_and_scaling(ctx, max_ptr, exp_ptr, scaling_ptr, off, rem, dtype)
+
+def _calc_quantized_fp8_values_b16_window(src_ptr, scaling_ptr, dst_ptr, i, offset_b16, remaining, lanes_b16, dtype=pto.bf16):
+    elements_per_vl_b8 = 256
+    even_count = (remaining + 1) // 2
+    odd_count = remaining // 2
+    b8_count = remaining
+    preg_b16_1, _ = pto.make_mask(dtype, even_count)
+    preg_b16_2, _ = pto.make_mask(dtype, odd_count)
+    preg_f32_1_even, _ = pto.make_mask(pto.f32, (even_count + 1) // 2)
+    preg_f32_1_odd, _ = pto.make_mask(pto.f32, even_count // 2)
+    preg_f32_2_even, _ = pto.make_mask(pto.f32, (odd_count + 1) // 2)
+    preg_f32_2_odd, _ = pto.make_mask(pto.f32, odd_count // 2)
+    preg_b8, _ = pto.make_mask(pto.ui8, b8_count)
+    v_in_1, v_in_2 = pto.vldsx2(src_ptr, offset_b16, "DINTLV_B16")
+    is_fp16 = dtype == pto.f16
+    if is_fp16:
+        v_cvt_1, v_cvt_2, v_cvt_3, v_cvt_4 = _apply_half_scaling_to_fp8_window(
+            v_in_1, v_in_2, scaling_ptr, i,
+            preg_b16_1, preg_b16_2,
+            preg_f32_1_even, preg_f32_1_odd, preg_f32_2_even, preg_f32_2_odd)
+    else:
+        v_scaling = pto.vlds(scaling_ptr, 8 * i, dist="E2B_B16")
+        v_out_1 = pto.vmul(v_in_1, v_scaling, preg_b16_1)
+        v_out_2 = pto.vmul(v_in_2, v_scaling, preg_b16_2)
+        v_cvt_1 = pto.vcvt(v_out_1, pto.f32, preg_b16_1, part=pto.VcvtPartMode.EVEN)
+        v_cvt_2 = pto.vcvt(v_out_1, pto.f32, preg_b16_1, part=pto.VcvtPartMode.ODD)
+        v_cvt_3 = pto.vcvt(v_out_2, pto.f32, preg_b16_2, part=pto.VcvtPartMode.EVEN)
+        v_cvt_4 = pto.vcvt(v_out_2, pto.f32, preg_b16_2, part=pto.VcvtPartMode.ODD)
+    v_fp8_p0 = pto.vcvt(v_cvt_1, pto.f8e4m3, preg_f32_1_even,
+                        rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT, part=pto.VcvtPartMode.P0)
+    v_fp8_p1 = pto.vcvt(v_cvt_3, pto.f8e4m3, preg_f32_2_even,
+                        rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT, part=pto.VcvtPartMode.P1)
+    v_fp8_p2 = pto.vcvt(v_cvt_2, pto.f8e4m3, preg_f32_1_odd,
+                        rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT, part=pto.VcvtPartMode.P2)
+    v_fp8_p3 = pto.vcvt(v_cvt_4, pto.f8e4m3, preg_f32_2_odd,
+                        rnd=pto.VcvtRoundMode.R, sat=pto.VcvtSatMode.SAT, part=pto.VcvtPartMode.P3)
+    v_fp8_p0_u16 = pto.vbitcast(v_fp8_p0, pto.ui16)
+    v_fp8_p1_u16 = pto.vbitcast(v_fp8_p1, pto.ui16)
+    v_fp8_p2_u16 = pto.vbitcast(v_fp8_p2, pto.ui16)
+    v_fp8_p3_u16 = pto.vbitcast(v_fp8_p3, pto.ui16)
+    preg_all_b16 = pto.pset_b16(pto.PAT.ALL)
+    v_or1 = pto.vor(v_fp8_p0_u16, v_fp8_p1_u16, preg_all_b16)
+    v_or2 = pto.vor(v_fp8_p2_u16, v_fp8_p3_u16, preg_all_b16)
+    v_out_u16 = pto.vor(v_or1, v_or2, preg_all_b16)
+    v_out_u8 = pto.vbitcast(v_out_u16, pto.ui8)
+    pto.vsts(v_out_u8, dst_ptr, i * elements_per_vl_b8, preg_b8, dist=pto.VStoreDist.NORM_B8)
+
+def _calc_quantized_fp8_values_b16(src_ptr, scaling_ptr, dst_ptr, total_count, lanes_b16, dtype=pto.bf16):
+    elements_per_dintlv = 2 * lanes_b16
+    vl_count = _ceil_division(total_count, lanes_b16)
+    quant_iters = (vl_count + 1) // 2
+    for i in range(quant_iters):
+        offset_b16 = i * elements_per_dintlv
+        remaining = total_count - offset_b16 if total_count > offset_b16 else 0
+        if remaining > elements_per_dintlv:
+            remaining = elements_per_dintlv
+        _calc_quantized_fp8_values_b16_window(src_ptr, scaling_ptr, dst_ptr, i, offset_b16, remaining, lanes_b16, dtype)
+
+
+def _calc_quantized_fp8_values_2d(src_ptr, scaling_ptr, dst_ptr, valid_rows, valid_cols, src_cols, lanes_b16, dtype=pto.bf16):
+    elements_per_dintlv = 2 * lanes_b16
+    groups_per_row = src_cols // 32
+    loops_per_row = _ceil_division(valid_cols, elements_per_dintlv)
+    for row in range(valid_rows):
+        src_row_off = row * src_cols
+        dst_row_off = row * src_cols
+        scale_row_off = row * groups_per_row
+        for i in range(loops_per_row):
+            col_off = i * elements_per_dintlv
+            remaining = valid_cols - col_off if valid_cols > col_off else 0
+            if remaining > elements_per_dintlv:
+                remaining = elements_per_dintlv
+            _calc_quantized_fp8_values_b16_window(
+                pto.addptr(src_ptr, src_row_off), pto.addptr(scaling_ptr, scale_row_off),
+                pto.addptr(dst_ptr, dst_row_off), i, col_off, remaining, lanes_b16, dtype)
+
+
+# ════════════════════════════════════════════════════════════════
+#  MXFP4 E2M1 helpers
+# ════════════════════════════════════════════════════════════════
+
+_BF16_POSITIVE_INF_BITS = 0x7F80
+
+
+def _saturate_bf16_nan_to_pos_inf(value, preg_b16):
+    v_abs_mask = pto.vbr(pto.ui16(_BF16_ABS_MASK))
+    v_inf = pto.vbr(pto.ui16(_BF16_POSITIVE_INF_BITS))
+    v_abs = pto.vand(value, v_abs_mask, preg_b16)
+    preg_nan = pto.vcmps(v_abs, pto.ui16(_BF16_POSITIVE_INF_BITS), preg_b16, pto.CmpMode.GT)
+    return pto.vsel(v_inf, value, preg_nan)
+
+
+def _calc_quantized_fp4e2m1_values_2d_packed(src_ptr, scaling_ptr, dst_ptr, max_tmp_ptr, exp_ptr,
+                                              valid_rows, valid_cols, src_cols, exp_col_stride, lanes_b16, dtype=pto.bf16):
+    k_group_size = 32
+    k_groups_per_window = 8
+    k_packed_bytes_per_group = k_group_size // 2
+    groups_per_row = _ceil_division(valid_cols, k_group_size)
+    windows_per_row = _ceil_division(groups_per_row, k_groups_per_window)
+    for row in range(valid_rows):
+        src_row = pto.addptr(src_ptr, row * src_cols)
+        scale_row = pto.addptr(scaling_ptr, row * groups_per_row)
+        dst_row = pto.addptr(dst_ptr, row * (src_cols // 2))
+        for window in range(windows_per_row):
+            group_base = window * k_groups_per_window
+            groups_this_window = groups_per_row - group_base
+            if groups_this_window > k_groups_per_window:
+                groups_this_window = k_groups_per_window
+            _build_packed_scale_window(pto.addptr(scale_row, group_base), max_tmp_ptr, groups_this_window)
+            pto.mem_bar(pto.BarrierType.VST_VLD)
+            if dtype == pto.f16:
+                _calc_quantized_fp4e2m1_values_half(
+                    pto.addptr(src_row, group_base * k_group_size), max_tmp_ptr,
+                    pto.addptr(dst_row, group_base * k_packed_bytes_per_group), groups_this_window, lanes_b16)
+            else:
+                _calc_quantized_fp4e2m1_values_bf16(
+                    pto.addptr(src_row, group_base * k_group_size), max_tmp_ptr,
+                    pto.addptr(dst_row, group_base * k_packed_bytes_per_group), groups_this_window, lanes_b16)
+
+
+
+def _calc_quantized_fp4e2m1_values_bf16_tail(src_tail_ptr, scaling_tail_ptr, dst_write_ptr, tail_groups, preg_b16_group, v_idx):
+    k_group_size = 32
+    k_packed_bytes_per_group = k_group_size // 2
+    scaling_tail_ptr_u16 = pto.castptr(scaling_tail_ptr, pto.ptr(pto.ui16, "ub"))
+    dst_write_ptr_u8 = pto.castptr(dst_write_ptr, pto.ptr(pto.ui8, "ub"))
+    ureg_out = pto.init_align()
+    for group in range(tail_groups):
+        v_input = pto.vlds(src_tail_ptr, group * k_group_size)
+        v_scale_u16 = pto.vlds(scaling_tail_ptr_u16, group, dist="BRC_B16")
+        v_scale = pto.vbitcast(v_scale_u16, pto.bf16)
+        v_scaled = pto.vmul(v_input, v_scale, preg_b16_group)
+        v_scaled_u16 = pto.vbitcast(v_scaled, pto.ui16)
+        v_scaled_u16 = _saturate_bf16_nan_to_pos_inf(v_scaled_u16, preg_b16_group)
+        v_scaled = pto.vbitcast(v_scaled_u16, pto.bf16)
+        v_output_p0 = pto.vcvt(v_scaled, pto.f4e2m1x2, preg_b16_group,
+                               rnd=pto.VcvtRoundMode.R, part=pto.VcvtPartMode.P0)
+        v_output_p0_u8 = pto.vbitcast(v_output_p0, pto.ui8)
+        v_output = pto.vselr(v_output_p0_u8, v_idx)
+        pto.mem_bar(pto.BarrierType.VST_VST)
+        ureg_out = pto.vstus(ureg_out, k_packed_bytes_per_group, v_output, dst_write_ptr_u8)
+        dst_write_ptr_u8 = pto.addptr(dst_write_ptr_u8, k_packed_bytes_per_group)
+    pto.vstas(ureg_out, dst_write_ptr_u8, 0)
+
+
+def _calc_quantized_fp4e2m1_values_bf16(src_ptr, scaling_ptr, dst_ptr, num_groups, lanes_b16):
+    k_group_size = 32
+    k_groups_per_window = 8
+    k_elements_per_window = k_group_size * k_groups_per_window
+    k_packed_bytes_per_window = k_elements_per_window // 2
+    k_packed_bytes_per_half_window = k_packed_bytes_per_window // 2
+    k_packed_bytes_per_group = k_group_size // 2
+
+    preg_b16_window = pto.pset_b16(pto.PAT.ALL)
+    preg_b16_group, _ = pto.make_mask(pto.bf16, k_group_size)
+
+    v_idx = pto.vci(pto.i8(0), "ASC")
+    v_idx_i16 = pto.vbitcast(v_idx, pto.si16)
+    v_idx_i16 = pto.vmuls(v_idx_i16, pto.si16(4), pto.pset_b16(pto.PAT.ALL))
+    v_idx = pto.vbitcast(v_idx_i16, pto.ui8)
+
+    scaling_ptr_u16 = pto.castptr(scaling_ptr, pto.ptr(pto.ui16, "ub"))
+    window_count = num_groups // k_groups_per_window
+    for window in range(window_count):
+        v_in_0, v_in_1 = pto.vldsx2(src_ptr, window * k_elements_per_window, "DINTLV_B16")
+        v_scale_u16 = pto.vlds(scaling_ptr_u16, window * k_groups_per_window, dist="E2B_B16")
+        v_scale = pto.vbitcast(v_scale_u16, pto.bf16)
+        v_in_0 = pto.vmul(v_in_0, v_scale, preg_b16_window)
+        v_in_1 = pto.vmul(v_in_1, v_scale, preg_b16_window)
+        v_in_0_u16 = pto.vbitcast(v_in_0, pto.ui16)
+        v_in_1_u16 = pto.vbitcast(v_in_1, pto.ui16)
+        v_in_0_u16 = _saturate_bf16_nan_to_pos_inf(v_in_0_u16, preg_b16_window)
+        v_in_1_u16 = _saturate_bf16_nan_to_pos_inf(v_in_1_u16, preg_b16_window)
+        v_in_0 = pto.vbitcast(v_in_0_u16, pto.bf16)
+        v_in_1 = pto.vbitcast(v_in_1_u16, pto.bf16)
+        v_intlv_0, v_intlv_1 = pto.vintlv(v_in_0, v_in_1)
+        v_output_0 = pto.vcvt(v_intlv_0, pto.f4e2m1x2, preg_b16_window,
+                              rnd=pto.VcvtRoundMode.R, part=pto.VcvtPartMode.P0)
+        v_output_1 = pto.vcvt(v_intlv_1, pto.f4e2m1x2, preg_b16_window,
+                              rnd=pto.VcvtRoundMode.R, part=pto.VcvtPartMode.P0)
+        pto.vsts(v_output_0, dst_ptr, window * k_packed_bytes_per_window, preg_b16_window,
+                 dist=pto.VStoreDist.PK4_B32)
+        pto.vsts(v_output_1, dst_ptr, window * k_packed_bytes_per_window + k_packed_bytes_per_half_window,
+                 preg_b16_window, dist=pto.VStoreDist.PK4_B32)
+
+    tail_groups = num_groups - window_count * k_groups_per_window
+    if tail_groups == 0:
+        return
+
+    _calc_quantized_fp4e2m1_values_bf16_tail(
+        pto.addptr(src_ptr, window_count * k_elements_per_window),
+        pto.addptr(scaling_ptr, window_count * k_groups_per_window),
+        pto.addptr(dst_ptr, window_count * k_packed_bytes_per_window),
+        tail_groups, preg_b16_group, v_idx)
+
+
+def _calc_quantized_fp4e2m1_values_half_tail(src_tail_ptr, scaling_tail_ptr, dst_write_ptr, tail_groups, pack_index):
+    k_group_size = 32
+    k_packed_bytes_per_group = k_group_size // 2
+    preg_b16, _ = pto.make_mask(pto.f16, k_group_size)
+    preg_f32, _ = pto.make_mask(pto.f32, k_packed_bytes_per_group)
+    preg_all_b16 = pto.pset_b16(pto.PAT.ALL)
+    scaling_tail_ptr_u16 = pto.castptr(scaling_tail_ptr, pto.ptr(pto.ui16, "ub"))
+    dst_write_ptr_u8 = pto.castptr(dst_write_ptr, pto.ptr(pto.ui8, "ub"))
+    ureg_out = pto.init_align()
+    for group in range(tail_groups):
+        v_input = pto.vlds(src_tail_ptr, group * k_group_size)
+        v_scaling_u16 = pto.vlds(scaling_tail_ptr_u16, group, dist="BRC_B16")
+        v_scaling_bf16 = pto.vbitcast(v_scaling_u16, pto.bf16)
+        v_scaling_f32 = pto.vcvt(v_scaling_bf16, pto.f32, preg_all_b16, part=pto.VcvtPartMode.EVEN)
+        v_even = pto.vcvt(v_input, pto.f32, preg_b16, part=pto.VcvtPartMode.EVEN)
+        v_odd = pto.vcvt(v_input, pto.f32, preg_b16, part=pto.VcvtPartMode.ODD)
+        v_even = pto.vmul(v_even, v_scaling_f32, preg_f32)
+        v_odd = pto.vmul(v_odd, v_scaling_f32, preg_f32)
+        v_even_code = _calc_e2m1_signed_code_i32(v_even, preg_f32)
+        v_odd_code = _calc_e2m1_signed_code_i32(v_odd, preg_f32)
+        v_output = _pack_e2m1_signed_code_bytes(v_even_code, v_odd_code, pack_index, preg_f32)
+        v_output_u8 = pto.vbitcast(v_output, pto.ui8)
+        pto.mem_bar(pto.BarrierType.VST_VST)
+        ureg_out = pto.vstus(ureg_out, k_packed_bytes_per_group, v_output_u8, dst_write_ptr_u8)
+        dst_write_ptr_u8 = pto.addptr(dst_write_ptr_u8, k_packed_bytes_per_group)
+    pto.vstas(ureg_out, dst_write_ptr_u8, 0)
+
+
+def _calc_quantized_fp4e2m1_values_half(src_ptr, scaling_ptr, dst_ptr, num_groups, lanes_b16):
+    k_group_size = 32
+    k_groups_per_window = 8
+    k_elements_per_window = k_group_size * k_groups_per_window
+    k_packed_bytes_per_window = k_elements_per_window // 2
+
+    pack_index = pto.vci(pto.i8(0), "ASC")
+    pack_index_i16 = pto.vbitcast(pack_index, pto.si16)
+    pack_index_i16 = pto.vmuls(pack_index_i16, pto.si16(4), pto.pset_b16(pto.PAT.ALL))
+    pack_index = pto.vbitcast(pack_index_i16, pto.ui8)
+
+    window_count = num_groups // k_groups_per_window
+    for window in range(window_count):
+        _calc_quantized_fp4e2m1_values_half_window(src_ptr, scaling_ptr, dst_ptr, window, pack_index, lanes_b16)
+
+    tail_groups = num_groups - window_count * k_groups_per_window
+    if tail_groups == 0:
+        return
+
+    _calc_quantized_fp4e2m1_values_half_tail(
+        pto.addptr(src_ptr, window_count * k_elements_per_window),
+        pto.addptr(scaling_ptr, window_count * k_groups_per_window),
+        pto.addptr(dst_ptr, window_count * k_packed_bytes_per_window),
+        tail_groups, pack_index)
+
+
+def _calc_quantized_fp4e2m1_values_half_window(src_ptr, scaling_ptr, dst_ptr, window, pack_index, lanes_b16):
+    k_group_size = 32
+    k_groups_per_window = 8
+    k_elements_per_window = k_group_size * k_groups_per_window
+    k_packed_bytes_per_window = k_elements_per_window // 2
+    preg_b16, _ = pto.make_mask(pto.f16, lanes_b16)
+    preg_f32, _ = pto.make_mask(pto.f32, lanes_b16 // 2)
+    preg_b8, _ = pto.make_mask(pto.ui8, k_packed_bytes_per_window)
+    preg_all_b16 = pto.pset_b16(pto.PAT.ALL)
+
+    v_in_0, v_in_1 = pto.vldsx2(src_ptr, window * k_elements_per_window, "DINTLV_B16")
+    scaling_ptr_u16 = pto.castptr(scaling_ptr, pto.ptr(pto.ui16, "ub"))
+    v_scaling_u16 = pto.vlds(scaling_ptr_u16, window * k_groups_per_window, dist="E2B_B16")
+    v_scaling_bf16 = pto.vbitcast(v_scaling_u16, pto.bf16)
+    v_scaling_f32 = pto.vcvt(v_scaling_bf16, pto.f32, preg_all_b16, part=pto.VcvtPartMode.EVEN)
+
+    v_mod_even = pto.vcvt(v_in_0, pto.f32, preg_b16, part=pto.VcvtPartMode.EVEN)
+    v_mod_odd = pto.vcvt(v_in_1, pto.f32, preg_b16, part=pto.VcvtPartMode.EVEN)
+    v_mod_even = pto.vmul(v_mod_even, v_scaling_f32, preg_f32)
+    v_mod_odd = pto.vmul(v_mod_odd, v_scaling_f32, preg_f32)
+    v_even_code = _calc_e2m1_signed_code_i32(v_mod_even, preg_f32)
+    v_odd_code = _calc_e2m1_signed_code_i32(v_mod_odd, preg_f32)
+    v_pair01 = _pack_e2m1_signed_code_bytes(v_even_code, v_odd_code, pack_index, preg_f32)
+
+    v_mod_even = pto.vcvt(v_in_0, pto.f32, preg_b16, part=pto.VcvtPartMode.ODD)
+    v_mod_odd = pto.vcvt(v_in_1, pto.f32, preg_b16, part=pto.VcvtPartMode.ODD)
+    v_mod_even = pto.vmul(v_mod_even, v_scaling_f32, preg_f32)
+    v_mod_odd = pto.vmul(v_mod_odd, v_scaling_f32, preg_f32)
+    v_even_code = _calc_e2m1_signed_code_i32(v_mod_even, preg_f32)
+    v_odd_code = _calc_e2m1_signed_code_i32(v_mod_odd, preg_f32)
+    v_pair23 = _pack_e2m1_signed_code_bytes(v_even_code, v_odd_code, pack_index, preg_f32)
+
+    v_output, v_scratch = pto.vintlv(v_pair01, v_pair23)
+    v_output_u8 = pto.vbitcast(v_output, pto.ui8)
+    dst_ptr_u8 = pto.castptr(dst_ptr, pto.ptr(pto.ui8, "ub"))
+    pto.vsts(v_output_u8, dst_ptr_u8, window * k_packed_bytes_per_window, preg_b8,
+             dist=pto.VStoreDist.NORM_B8)
+
+
+_FP32_SIGN_BIT_OFFSET = 31
+_FP32_SIGN_CLEAR_SHIFT = 1
+_FP32_EXPONENT_OFFSET = 23
+_FP32_EXPONENT_BIAS = 127
+_FP32_POSITIVE_INF_BITS = 0x7F800000
+_FP4_MAX_BIASED_EXPONENT_DELTA = 2
+_FP4_MAGIC_ROUNDING_OFFSET = 23 - 1
+_FP4_SIGN_BIT_MASK = 1 << 3
+_FP4_MAX_MAGNITUDE_CODE = _FP4_SIGN_BIT_MASK - 1
+_FP4_NEGATIVE_CODE_OFFSET = -_FP4_SIGN_BIT_MASK
+_FP4_LOW_CODE_SHIFT = 32 - 4
+_FP4_HIGH_CODE_SHIFT = 32 - 8
+
+
+def _calc_e2m1_signed_code_i32(scaled, preg_f32):
+    v_u32 = pto.vbitcast(scaled, pto.ui32)
+    v_tmp = pto.vshrs(v_u32, _FP32_SIGN_BIT_OFFSET, preg_f32)
+    preg_sign = pto.vcmps(v_tmp, pto.ui32(0), preg_f32, pto.CmpMode.NE)
+    v_abs = pto.vshls(v_u32, _FP32_SIGN_CLEAR_SHIFT, preg_f32)
+    v_abs = pto.vshrs(v_abs, _FP32_SIGN_CLEAR_SHIFT, preg_f32)
+    preg_nan = pto.vcmps(v_abs, pto.ui32(_FP32_POSITIVE_INF_BITS), preg_f32, pto.CmpMode.GT)
+
+    v_exp = pto.vshrs(v_abs, _FP32_EXPONENT_OFFSET, preg_f32)
+    v_exp = pto.vbitcast(v_exp, pto.si32)
+    v_exp = pto.vmaxs(v_exp, pto.si32(_FP32_EXPONENT_BIAS), preg_f32)
+    v_exp = pto.vmins(v_exp, pto.si32(_FP32_EXPONENT_BIAS + _FP4_MAX_BIASED_EXPONENT_DELTA), preg_f32)
+
+    v_tmp = pto.vadds(pto.vbitcast(v_exp, pto.si32), _FP4_MAGIC_ROUNDING_OFFSET, preg_f32)
+    v_tmp = pto.vshls(v_tmp, _FP32_EXPONENT_OFFSET, preg_f32)
+    v_scaled = pto.vadd(pto.vbitcast(v_abs, pto.f32), pto.vbitcast(v_tmp, pto.f32), preg_f32)
+    v_abs = pto.vsub(pto.vbitcast(v_scaled, pto.ui32), pto.vbitcast(v_tmp, pto.ui32), preg_f32)
+
+    v_exp = pto.vadds(pto.vbitcast(v_exp, pto.si32), -_FP32_EXPONENT_BIAS, preg_f32)
+    v_exp = pto.vshls(v_exp, 1, preg_f32)
+    v_abs = pto.vadd(pto.vbitcast(v_abs, pto.si32), v_exp, preg_f32)
+    v_abs = pto.vmins(v_abs, pto.si32(_FP4_MAX_MAGNITUDE_CODE), preg_f32)
+
+    v_signed = pto.vadds(v_abs, _FP4_NEGATIVE_CODE_OFFSET, preg_f32)
+    v_signed = pto.vsel(v_signed, v_abs, preg_sign)
+    v_signed = pto.vsel(v_abs, v_signed, preg_nan)
+
+    return v_signed
+
+
+def _pack_e2m1_signed_code_bytes(even_code, odd_code, pack_index, preg_f32):
+    v_even_u32 = pto.vbitcast(even_code, pto.ui32)
+    v_odd_u32 = pto.vbitcast(odd_code, pto.ui32)
+    v_even_shifted = pto.vshls(v_even_u32, _FP4_LOW_CODE_SHIFT, preg_f32)
+    v_even_shifted = pto.vshrs(v_even_shifted, _FP4_LOW_CODE_SHIFT, preg_f32)
+    v_odd_shifted = pto.vshls(v_odd_u32, _FP4_LOW_CODE_SHIFT, preg_f32)
+    v_odd_shifted = pto.vshrs(v_odd_shifted, _FP4_HIGH_CODE_SHIFT, preg_f32)
+    v_packed = pto.vor(v_even_shifted, v_odd_shifted, preg_f32)
+    v_packed_u8 = pto.vbitcast(v_packed, pto.ui8)
+    return pto.vselr(v_packed_u8, pack_index)
+
+
+
+def _extract_nv_exp_and_scaling_b16_2d_packed(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_groups_per_row, exp_col_stride, spec=None, dtype=pto.bf16):
+    ctx = _init_b16_nv_exp_scaling_ctx(spec)
+    preg_one_b16, _ = pto.make_mask(dtype, 1)
+    preg_one_b32, _ = pto.make_mask(pto.f32, 1)
+    scale_write_ptr = scaling_ptr
+    ureg_scaling = pto.init_align()
+    for row in range(valid_rows):
+        max_read_ptr = pto.addptr(max_ptr, row * valid_groups_per_row)
+        exp_write_ptr = pto.addptr(exp_ptr, row * exp_col_stride)
+        ureg_exp = pto.init_align()
+        for group in range(valid_groups_per_row):
+            v_b16_max = pto.vlds(pto.addptr(max_read_ptr, group), 0, dist="BRC_B16")
+            v_shared_exp, v_bf16_scale_bits = _compute_b16_nv_exp_scaling(ctx, v_b16_max, preg_one_b16, preg_one_b32, dtype)
+            v_shared_exp_u8 = pto.vbitcast(v_shared_exp, pto.ui8)
+            v_bf16_scale_bits_u16 = pto.vbitcast(v_bf16_scale_bits, pto.ui16)
+            ureg_exp = pto.vstus(ureg_exp, 1, v_shared_exp_u8, exp_write_ptr)
+            ureg_scaling = pto.vstus(ureg_scaling, 1, v_bf16_scale_bits_u16, scale_write_ptr)
+            exp_write_ptr = pto.addptr(exp_write_ptr, 1)
+            scale_write_ptr = pto.addptr(scale_write_ptr, 1)
+        pto.vstas(ureg_exp, exp_write_ptr, 0)
+    pto.vstas(ureg_scaling, scale_write_ptr, 0)
+
+def _tquant_mxfp8_b16_2d(src_ptr, exp_ptr, dst_ptr, max_ptr, scaling_ptr, valid_rows, valid_cols, src_cols, lanes_b16, dtype, scale_alg="ocp", exp_loop_count=0, num_groups=0):
+    if scale_alg == "nv":
+        _abs_reduce_max_b16_nd_2d(src_ptr, max_ptr, valid_rows, valid_cols, src_cols, lanes_b16, dtype, scale_alg)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _extract_b8_exp_and_scaling_nv(max_ptr, exp_ptr, scaling_ptr, num_groups, dtype)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _calc_quantized_fp8_values_b16(src_ptr, scaling_ptr, dst_ptr, valid_rows * src_cols, lanes_b16, dtype)
+    elif src_cols % 512 == 0:
+        _abs_reduce_max_b16_nd_2d(src_ptr, max_ptr, valid_rows, valid_cols, src_cols, lanes_b16, dtype, scale_alg)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _extract_b8_exponent_and_scaling_2d(max_ptr, exp_ptr, scaling_ptr, valid_rows, valid_cols, src_cols, lanes_b16, dtype)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _calc_quantized_fp8_values_2d(src_ptr, scaling_ptr, dst_ptr, valid_rows, valid_cols, src_cols, lanes_b16, dtype)
+    else:
+        _abs_reduce_max_b16_nd_2d(src_ptr, max_ptr, valid_rows, valid_cols, src_cols, lanes_b16, dtype, scale_alg)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _extract_b8_exp_and_scaling(max_ptr, exp_ptr, scaling_ptr, exp_loop_count, num_groups, lanes_b16, dtype)
+        pto.mem_bar(pto.BarrierType.VST_VLD)
+        _calc_quantized_fp8_values_b16(src_ptr, scaling_ptr, dst_ptr, valid_rows * src_cols, lanes_b16, dtype)
+
+
+

--- a/ptodsl/docs/user_guide/08-compute-operations.md
+++ b/ptodsl/docs/user_guide/08-compute-operations.md
@@ -1654,6 +1654,7 @@ pto.tile.store(dst_tile, out_view)
 | Windowing | `tile.extract`, `tile.insert` |
 | Tile movement | `tile.mov`, `tile.concat` |
 | Dequantize | `tile.dequant` |
+| Quantize | `tile.quant`, `tile.quant.mx` |
 | Debug print | `tile.print` |
 | Tile matmul | `tile.matmul`, `tile.matmul_acc`, `tile.matmul_mx`, `tile.matmul_mx_acc`, `tile.matmul_mx_bias` |
 | Tile gemv | `tile.gemv_mx`, `tile.gemv_mx_acc`, `tile.gemv_mx_bias` |
@@ -1699,7 +1700,106 @@ pto.tile.dequant(src_tile, scale_tile, offset_tile, dst_tile)
 
 ---
 
-### 8.1.19 Debug Print
+### 8.1.19 Quantize
+
+#### `pto.tile.quant(src: Tile, scale: Tile, dst: Tile, *, quant_type: str | None = None, offset: Tile | None = None, tmp: Tile | None = None) -> None`
+
+**Description**: Quantize the source tile row-by-row with per-row scaling. This maps to `pto.tquant` and is the quantization counterpart of `pto.tile.dequant`:
+
+```
+dst[r, c] = saturate(round(src[r, c] * scale[r, 0]) + offset[r, 0])
+```
+
+The symmetric variant (`quant_type="INT8_SYM"`) omits the zero-point `offset` and saturates to `i8` `[-128, 127]`; the asymmetric variant saturates to `ui8` `[0, 255]`.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| src | Tile | Source tile, `f32` `[rows, cols]`. |
+| scale | Tile | Per-row scale factor, `f32` `[rows, 1]`. |
+| dst | Tile | Destination tile, `i8` (symmetric) or `ui8` (asymmetric), same shape as `src`. |
+| quant_type | str | Optional quantization flavor: `"INT8_SYM"` or `"INT8_ASYM"`. Defaults to `INT8_ASYM` when `offset` is provided, `INT8_SYM` otherwise. |
+| offset | Tile | Optional per-row zero point, `f32` `[rows, 1]` (asymmetric mode only). |
+| tmp | Tile | Optional scratch tile used by the lowering. |
+
+**Returns**: None (destination-style op; results are written to `dst`).
+
+**Hardware mapping**: `PIPE_V` vector compute; scalar conversion in the vector pipe (`pto.tquant`).
+
+**Constraints**:
+
+- `src`, `scale` and `offset` must be `f32` tiles; `dst` must match the variant's integer dtype with the same logical shape as `src`.
+- `scale` (and `offset`, when present) must be `[rows, 1]` column vectors.
+
+**Example**:
+
+```python
+# src: f32 [rows, cols]; scale: f32 [rows, 1]; dst: i8 [rows, cols]
+pto.tile.quant(src_tile, scale_tile, dst_tile)
+
+# Asymmetric with per-row zero point; dst: ui8 [rows, cols]
+pto.tile.quant(src_tile, scale_tile, dst_tile, quant_type="INT8_ASYM", offset=offset_tile)
+```
+
+#### `pto.tile.quant.mx(src: Tile, dst: Tile, exp: Tile, max_tile: Tile, scaling: Tile, *, quant_type: str = "MXFP8", quant_scale_alg: str | None = None, grp_axis: int = 1, interleave: bool = False) -> None`
+
+**Description**: Microscaling (MX) block quantization. This maps to `pto.tquant.mx`: the source tile is partitioned into groups of 32 consecutive elements (along the group axis), each group is described by a shared `e8m0` exponent and an implicit scaling factor, and the source values are quantized to the MX format's narrow dtype (`uint8` codes for `MXFP8`, packed `f4e2m1` pairs for `MXFP4_E2M1`).
+
+Two group orientations are available:
+
+- `grp_axis=1` (default, column grouping): groups of 32 consecutive elements along each row. `max_tile`/`scaling` are flat `[1, groups]` tiles (source dtype) where `groups` covers all `rows * cols / 32` groups; `exp` is a flat `[1, groups]` `ui8` tile for `MXFP8`, or a canonical 2-D `[rows, cols / 32]` tile for `MXFP4_E2M1`.
+- `grp_axis=0` (row grouping, "DN" layout): groups of 32 consecutive rows per column. `max_tile`/`scaling` are `[rows / 32, cols]` tiles (source dtype); `exp` is `[rows / 32, cols]`, or `[rows / 64, 2 * cols]` when `interleave=True` stores exponent and quantized data in an interleaved layout.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| src | Tile | Source tile: `f32`, `f16`, or `bf16` `[rows, cols]`. |
+| dst | Tile | Quantized values: `ui8` for `MXFP8` or `f4e2m1x2` for `MXFP4_E2M1`. |
+| exp | Tile | `e8m0` exponent tile, `ui8`. Column grouping: flat `[1, groups]` (`MXFP8`) or canonical `[rows, cols/32]` (`MXFP4_E2M1`); row grouping: `[rows/32, cols]` (or `[rows/64, 2*cols]` interleaved). |
+| max_tile | Tile | Group abs-max staging buffer, source dtype. Flat `[1, groups]` (column grouping) or `[rows/32, cols]` (row grouping). |
+| scaling | Tile | Reciprocal scaling staging buffer, same shape/dtype as `max_tile`. |
+| quant_type | str | `"MXFP8"` (default) or `"MXFP4_E2M1"`. |
+| quant_scale_alg | str | Optional scale algorithm: `"ocp"` or `"nv"`. Both supported for `f32`/`f16`/`bf16` sources. |
+| grp_axis | int | Group axis: `1` = column grouping (default), `0` = row grouping (DN layout). |
+| interleave | bool | Interleave exponent and quantized data in the destination layout (DN). |
+
+**Returns**: None (destination-style op; quantized codes are written to `dst`, exponents to `exp`).
+
+**Hardware mapping**: `PIPE_V` vector compute with `set_ctrl` programming; vector loads/stores shuffle staging buffers (`pto.tquant.mx`).
+
+**Constraints**:
+
+- With `grp_axis=1`, the source valid column count must be a multiple of 32.
+- Flat `max_tile`/`scaling` capacity: `f32` sources need `alignTo(groups * (2 if unrolled else 1), 64) * 4` bytes; `f16`/`bf16` sources need `alignTo(groups, 128) * 2` bytes (both `ocp` and `nv` algorithms). Unrolling applies when the padded source exceeds 1024 elements and both padded and valid element counts are multiples of 256.
+- Flat `exp` must be tight: valid shape exactly `[1, groups]`.
+- Canonical 2-D exponent layout requires `exp` valid shape `[rows, cols / 32]` with physical capacity covering the group prefix.
+- DN layouts: `max_tile`/`scaling` rows are `rows / 32`; `exp` rows are `rows / 32` (`rows / 64` with `2 * cols` columns when interleaved); `dst` must cover the packed quantized payload.
+
+**Example**:
+
+```python
+# Column-grouped MXFP8: src f32 [32, 128] -> groups = 32*128/32 = 128
+src = pto.alloc_tile(shape=[32, 128], dtype=pto.f32, valid_shape=[32, 128])
+exp = pto.alloc_tile(shape=[1, 128], dtype=pto.ui8, valid_shape=[1, 128])
+max_tile = pto.alloc_tile(shape=[1, 256], dtype=pto.f32, valid_shape=[1, 128])
+scaling = pto.alloc_tile(shape=[1, 256], dtype=pto.f32, valid_shape=[1, 128])
+dst = pto.alloc_tile(shape=[32, 128], dtype=pto.ui8, valid_shape=[32, 128])
+pto.tile.quant.mx(src, dst, exp, max_tile, scaling, quant_type="MXFP8")
+
+# Row-grouped (DN) MXFP8 from bf16 source [64, 128]
+exp = pto.alloc_tile(shape=[2, 128], dtype=pto.ui8, valid_shape=[2, 128])
+max_tile = pto.alloc_tile(shape=[2, 128], dtype=pto.bf16, valid_shape=[2, 128])
+scaling = pto.alloc_tile(shape=[2, 128], dtype=pto.bf16, valid_shape=[2, 128])
+dst = pto.alloc_tile(shape=[64, 128], dtype=pto.ui8, valid_shape=[64, 128])
+pto.tile.quant.mx(src, dst, exp, max_tile, scaling,
+                  quant_type="MXFP8", grp_axis=0)
+```
+
+---
+
+### 8.1.20 Debug Print
 
 #### `pto.tile.print(src: Tile, tmp: PartitionTensorView | None = None, *, print_format: str | None = None) -> None`
 

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -660,6 +660,7 @@ from ._ops_simt import (  # noqa: F401
     rls_buf,
     round,
     set_cross_block,
+    set_ctrl,
     set_flag,
     set_intra_block,
     shuffle_bfly,
@@ -768,6 +769,7 @@ __all__ = [
     "syncthreads", "threadfence", "threadfence_block", "trap", "keep", "resume",
     "pipe_barrier", "get_buf", "rls_buf",
     "set_cross_block", "wait_cross_block", "set_intra_block", "wait_intra_block",
+    "set_ctrl",
     "set_flag", "wait_flag",
     "reserve_buffer", "import_reserved_buffer",
 ]

--- a/ptodsl/ptodsl/_ops_simt.py
+++ b/ptodsl/ptodsl/_ops_simt.py
@@ -103,6 +103,7 @@ from ._ops_common import (
     _validate_static_event_id,
     _validate_static_event_id_range,
     _validate_sync_pipe,
+    _coerce_i64,
 )
 
 
@@ -764,6 +765,11 @@ def wait_intra_block(pipe, event_id):
         meaning="physical event_id",
     )
     _pto.wait_intra_block(_pipe_attr(pipe), event_operand)
+
+
+def set_ctrl(value):
+    """``pto.set_ctrl`` – program the scalar control register."""
+    _pto.set_ctrl(_coerce_i64(value, context="set_ctrl(value)"))
 
 
 def set_flag(src: str, dst: str, *, event_id: int = 0):

--- a/ptodsl/ptodsl/_ops_tile.py
+++ b/ptodsl/ptodsl/_ops_tile.py
@@ -62,6 +62,7 @@ from ._types import (
 from ptoas.mlir.dialects import arith, pto as _pto
 from ptoas.mlir.ir import (
     Attribute,
+    BoolAttr,
     BF16Type,
     F16Type,
     F32Type,
@@ -1238,6 +1239,53 @@ def tdequant(src, scale, offset, dst):
         unwrap_surface_value(scale),
         unwrap_surface_value(offset),
         unwrap_surface_value(dst),
+    )
+
+
+def tquant(src, scale, dst, *, quant_type=None, offset=None, tmp=None):
+    """``pto.tquant ins(src, scale) outs(dst)`` with optional offset/tmp."""
+    if quant_type is None:
+        quant_type = "INT8_ASYM" if offset is not None else "INT8_SYM"
+    qt_attr = Attribute.parse(f"#pto<quant_type {quant_type}>")
+    kwargs = {}
+    if offset is not None:
+        kwargs["offset"] = unwrap_surface_value(offset)
+    if tmp is not None:
+        kwargs["tmp"] = unwrap_surface_value(tmp)
+    _pto.tquant(
+        unwrap_surface_value(src),
+        unwrap_surface_value(scale),
+        unwrap_surface_value(dst),
+        qt_attr,
+        **kwargs,
+    )
+
+
+def tquant_mx(src, dst, exp, max_tile, scaling, *,
+              quant_type="MXFP8", quant_scale_alg=None, grp_axis=1, interleave=False):
+    """``pto.tquant_mx ins(src, exp, max_tile, scaling) outs(dst)``."""
+    qt_attr = Attribute.parse(f"#pto<quant_type {quant_type}>")
+    kwargs = {}
+    if quant_scale_alg is not None:
+        kwargs["quant_scale_alg"] = Attribute.parse(
+            f"#pto<quant_scale_alg {quant_scale_alg}>")
+    if grp_axis != 1:
+        # grpAxis is #pto<mx_group_axis axis0|axis1> (enum attr) on upstream;
+        # an i32 IntegerAttr here crashes getGrpAxis() during verify.
+        axis_token = "axis0" if grp_axis == 0 else "axis1"
+        kwargs["grp_axis"] = Attribute.parse(f"#pto<mx_group_axis {axis_token}>")
+    if interleave:
+        # upstream ODS models `interleave` as a BoolAttr (default false);
+        # a UnitAttr here crashes TQuantMxOp::verify (attr-layout mismatch).
+        kwargs["interleave"] = BoolAttr.get(True)
+    _pto.tquant_mx(
+        unwrap_surface_value(src),
+        unwrap_surface_value(dst),
+        unwrap_surface_value(exp),
+        unwrap_surface_value(max_tile),
+        unwrap_surface_value(scaling),
+        qt_attr,
+        **kwargs,
     )
 
 

--- a/ptodsl/ptodsl/_ops_vmem.py
+++ b/ptodsl/ptodsl/_ops_vmem.py
@@ -385,6 +385,7 @@ _VCVT_CONTRACTS = {
     ("f16", "s16"): _vcvt_contract(True, True, False),
     ("f16", "s8"): _vcvt_contract(True, True, True),
     ("f16", "u8"): _vcvt_contract(True, True, True),
+    ("f16", "bf16"): _vcvt_contract(True, False, False),
     ("bf16", "f8e4m3"): _vcvt_contract(True, True, True, allowed_rnd="RAFZC"),
     ("bf16", "f8e5m2"): _vcvt_contract(True, True, True, allowed_rnd="RAFZC"),
     ("bf16", "f4e1m2x2"): _vcvt_contract(True, False, True, part_family="packed4", allowed_rnd="RAFZC"),

--- a/ptodsl/ptodsl/_surface_values.py
+++ b/ptodsl/ptodsl/_surface_values.py
@@ -809,8 +809,8 @@ def emit_as_ptr(surface_value):
 _TILE_TYPE_RE = re.compile(
     r"!pto\.tile_buf<(?P<space>[^,]+),\s*"
     r"(?P<shape>(?:\?|[0-9]+)(?:x(?:\?|[0-9]+))*)x"
-    r"(?P<elem>[^,>]+),\s*"
-    r"valid=(?P<valid>(?:\?|[0-9]+)(?:x(?:\?|[0-9]+))*)"
+    r"(?P<elem>[^,>]+)"
+    r"(?:,\s*valid=(?P<valid>(?:\?|[0-9]+)(?:x(?:\?|[0-9]+))*))?"
     r"(?:,.*)?>"
 )
 
@@ -878,10 +878,13 @@ def parse_tile_type_metadata(type_obj):
         None if dim == "?" else int(dim)
         for dim in match.group("shape").split("x")
     ]
-    valid_dims = [
-        None if dim == "?" else int(dim)
-        for dim in match.group("valid").split("x")
-    ]
+    # Tiles allocated without a valid_shape carry no `valid=` segment; treat
+    # them as fully dynamic (matches the `valid=...` `?` case).
+    valid_text = match.group("valid")
+    valid_dims = (
+        [None] * len(shape_dims) if valid_text is None
+        else [None if dim == "?" else int(dim) for dim in valid_text.split("x")]
+    )
     return {
         "memory_space": match.group("space"),
         "shape_dims": tuple(shape_dims),

--- a/ptodsl/ptodsl/_tile_namespace.py
+++ b/ptodsl/ptodsl/_tile_namespace.py
@@ -7,6 +7,8 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from . import _ops
+from ._ops_tile import tquant as _tquant_impl
+from ._ops_tile import tquant_mx as _tquant_mx_impl
 
 
 def _row_reduction_tmp_metadata(src):
@@ -138,6 +140,16 @@ class _TileNamespace:
     neg = staticmethod(_ops.tneg)
     dequant = staticmethod(_ops.tdequant)
     print = staticmethod(_ops.tprint)
+
+    class _QuantNamespace:
+        def __call__(self, src, scale, dst, *, quant_type=None, offset=None, tmp=None):
+            return _tquant_impl(src, scale, dst, quant_type=quant_type, offset=offset, tmp=tmp)
+
+        @staticmethod
+        def mx(src, dst, exp, max_tile, scaling, *, quant_type="MXFP8", **kwargs):
+            return _tquant_mx_impl(src, dst, exp, max_tile, scaling, quant_type=quant_type, **kwargs)
+
+    quant = _QuantNamespace()
 
     relu = staticmethod(_ops.trelu)
     lrelu = staticmethod(_ops.tlrelu)

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -156,6 +156,7 @@ from ._ops import (             # noqa: F401
     syncthreads, threadfence, threadfence_block, trap, keep, resume,
     pipe_barrier,
     get_buf, rls_buf,
+    set_ctrl,
     set_cross_block, wait_cross_block, set_intra_block, wait_intra_block,
     set_flag, wait_flag,
     reserve_buffer, import_reserved_buffer,

--- a/test/lit/pto/tquant_mx_grp_axis_invalid.pto
+++ b/test/lit/pto/tquant_mx_grp_axis_invalid.pto
@@ -26,16 +26,13 @@
 // RUN: not ptoas --pto-arch=a5 %t/nd_flat_f32_scaling_below_one_vl.pto 2>&1 | FileCheck %s --check-prefix=F32-VL
 // RUN: not ptoas --pto-arch=a5 %t/nd_flat_f32_unroll_scaling_below_two_vl.pto 2>&1 | FileCheck %s --check-prefix=F32-UNROLL
 // RUN: not ptoas --pto-arch=a5 %t/nd_flat_b16_ocp_scaling_below_one_vl.pto 2>&1 | FileCheck %s --check-prefix=B16-VL
-// RUN: not ptoas --pto-arch=a5 %t/nd_flat_b16_nv_unsupported.pto 2>&1 | FileCheck %s --check-prefix=B16-NV
 // RUN: not ptoas --pto-arch=a5 %t/nd_legacy_exp_selects_2d.pto 2>&1 | FileCheck %s --check-prefix=LEGACY-2D
 // RUN: not ptoas --pto-arch=a5 %t/nd_flat_exp_with_padded_src.pto 2>&1 | FileCheck %s --check-prefix=FLAT-PADDED
 // RUN: not ptoas --pto-arch=a5 %t/nd_fp8_dst_stride_mismatch.pto 2>&1 | FileCheck %s --check-prefix=FP8-DST
 // RUN: not ptoas --pto-arch=a5 %t/nd_fp4_dst_packed_stride_mismatch.pto 2>&1 | FileCheck %s --check-prefix=FP4-DST
 // RUN: not ptoas --pto-arch=a5 %t/dn_fp4_dst_packed_stride_mismatch.pto 2>&1 | FileCheck %s --check-prefix=DN-FP4-DST
 // RUN: not ptoas --pto-arch=a5 %t/mxfp4_odd_src_physical_cols.pto 2>&1 | FileCheck %s --check-prefix=FP4-ODD
-// RUN: not ptoas --pto-arch=a5 %t/nd_canonical_b16_pinned_unsupported.pto 2>&1 | FileCheck %s --check-prefix=B16-CANONICAL
 // RUN: not ptoas --pto-arch=a5 %t/dn_fp4_fp16_unaligned_packed_stride_pinned_unsupported.pto 2>&1 | FileCheck %s --check-prefix=DN-FP16
-// RUN: not ptoas --pto-arch=a5 %t/dn_fp8_f32_interleave_pinned_unsupported.pto 2>&1 | FileCheck %s --check-prefix=DN-F32-IL
 // RUN: not ptoas --pto-arch=a5 %t/b16_padding_incomplete_vl_pinned_unsupported.pto 2>&1 | FileCheck %s --check-prefix=B16-PAD
 // RUN: not ptoas --pto-arch=a5 %t/tquant_dynamic_valid.pto 2>&1 | FileCheck %s --check-prefix=DYNAMIC-VALID
 // RUN: not ptoas --pto-arch=a5 %t/tquant_dynamic_physical.pto 2>&1 | FileCheck %s --check-prefix=DYNAMIC-PHYSICAL
@@ -60,16 +57,13 @@
 // F32-VL: expects axis1 flat f32 scaling physical capacity to cover 256 bytes
 // F32-UNROLL: expects axis1 flat unrolled f32 scaling physical capacity to cover 512 bytes
 // B16-VL: expects axis1 flat B16 OCP scaling physical capacity to cover 256 bytes
-// B16-NV: does not support axis1 flat B16 NV quantization with the pinned pto-isa revisions
-// LEGACY-2D: expects legacy flat exp to use physical rows == 1
+// LEGACY-2D: expects exp valid_shape to match canonical [M, N/32] for grpAxis=axis1
 // FLAT-PADDED: expects axis1 flat exp to use a tight source with physical cols equal to valid cols
 // FP8-DST: expects MXFP8 axis1 dst physical cols to equal src physical cols
 // FP4-DST: expects MXFP4 axis1 dst physical cols to equal src physical cols / 2
 // DN-FP4-DST: expects MXFP4 axis0 dst physical cols to equal src physical cols / 2
 // FP4-ODD: expects MXFP4 src physical cols to be even for packed destination addressing
-// B16-CANONICAL: does not support axis1 canonical 2D B16 quantization with the pinned pto-isa revision
 // DN-FP16: does not support FP16 MXFP4 axis0 when packed source stride is not a multiple of 32 bytes
-// DN-F32-IL: does not support FP32 interleave with the pinned pto-isa revision
 // B16-PAD: does not support padded B16 source whose VL-aligned padding store has an incomplete final VL
 // DYNAMIC-VALID: expects static valid and physical shapes for src in MX quantization
 // DYNAMIC-PHYSICAL: tile_buf rows/cols must be positive
@@ -111,12 +105,6 @@ module { func.func @case(%src: !pto.tile_buf<vec, 16x32xbf16>, %dst: !pto.tile_b
   return
 } }
 
-//--- nd_flat_b16_nv_unsupported.pto
-module { func.func @case(%src: !pto.tile_buf<vec, 16x32xbf16>, %dst: !pto.tile_buf<vec, 16x32xi8>, %exp: !pto.tile_buf<vec, 1x16xui8>, %max: !pto.tile_buf<vec, 1x16xbf16>, %scaling: !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=128, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {
-  pto.tquant.mx ins(%src : !pto.tile_buf<vec, 16x32xbf16>) outs(%dst, %exp, %max, %scaling : !pto.tile_buf<vec, 16x32xi8>, !pto.tile_buf<vec, 1x16xui8>, !pto.tile_buf<vec, 1x16xbf16>, !pto.tile_buf<loc=vec, dtype=bf16, rows=1, cols=128, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {quant_type = #pto<quant_type MXFP8>, quantScaleAlg = #pto<quant_scale_alg nv>}
-  return
-} }
-
 //--- nd_legacy_exp_selects_2d.pto
 module { func.func @case(%src: !pto.tile_buf<vec, 16x32xf32>, %dst: !pto.tile_buf<vec, 16x32xi8>, %exp: !pto.tile_buf<loc=vec, dtype=ui8, rows=2, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, %max: !pto.tile_buf<vec, 1x16xf32>, %scaling: !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {
   pto.tquant.mx ins(%src : !pto.tile_buf<vec, 16x32xf32>) outs(%dst, %exp, %max, %scaling : !pto.tile_buf<vec, 16x32xi8>, !pto.tile_buf<loc=vec, dtype=ui8, rows=2, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<vec, 1x16xf32>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {quant_type = #pto<quant_type MXFP8>}
@@ -153,21 +141,9 @@ module { func.func @case(%src: !pto.tile_buf<loc=vec, dtype=bf16, rows=32, cols=
   return
 } }
 
-//--- nd_canonical_b16_pinned_unsupported.pto
-module { func.func @case(%src: !pto.tile_buf<vec, 16x32xbf16>, %dst: !pto.tile_buf<vec, 16x32xi8>, %exp: !pto.tile_buf<vec, 16x1xui8>, %max: !pto.tile_buf<vec, 16x1xbf16>, %scaling: !pto.tile_buf<vec, 16x1xbf16>) {
-  pto.tquant.mx ins(%src : !pto.tile_buf<vec, 16x32xbf16>) outs(%dst, %exp, %max, %scaling : !pto.tile_buf<vec, 16x32xi8>, !pto.tile_buf<vec, 16x1xui8>, !pto.tile_buf<vec, 16x1xbf16>, !pto.tile_buf<vec, 16x1xbf16>) {quant_type = #pto<quant_type MXFP8>}
-  return
-} }
-
 //--- dn_fp4_fp16_unaligned_packed_stride_pinned_unsupported.pto
 module { func.func @case(%src: !pto.tile_buf<vec, 32x32xf16>, %dst: !pto.tile_buf<vec, 32x16x!pto.f4E2M1x2>, %exp: !pto.tile_buf<vec, 1x32xui8>, %max: !pto.tile_buf<vec, 1x32xf16>, %scaling: !pto.tile_buf<vec, 1x32xf16>) {
   pto.tquant.mx ins(%src : !pto.tile_buf<vec, 32x32xf16>) outs(%dst, %exp, %max, %scaling : !pto.tile_buf<vec, 32x16x!pto.f4E2M1x2>, !pto.tile_buf<vec, 1x32xui8>, !pto.tile_buf<vec, 1x32xf16>, !pto.tile_buf<vec, 1x32xf16>) {quant_type = #pto<quant_type MXFP4_E2M1>, grpAxis = #pto<mx_group_axis axis0>}
-  return
-} }
-
-//--- dn_fp8_f32_interleave_pinned_unsupported.pto
-module { func.func @case(%src: !pto.tile_buf<vec, 64x32xf32>, %dst: !pto.tile_buf<vec, 64x32xi8>, %exp: !pto.tile_buf<vec, 1x64xui8>, %max: !pto.tile_buf<vec, 2x32xf32>, %scaling: !pto.tile_buf<vec, 2x32xf32>) {
-  pto.tquant.mx ins(%src : !pto.tile_buf<vec, 64x32xf32>) outs(%dst, %exp, %max, %scaling : !pto.tile_buf<vec, 64x32xi8>, !pto.tile_buf<vec, 1x64xui8>, !pto.tile_buf<vec, 2x32xf32>, !pto.tile_buf<vec, 2x32xf32>) {quant_type = #pto<quant_type MXFP8>, grpAxis = #pto<mx_group_axis axis0>, interleave = true}
   return
 } }
 

--- a/test/tilelib-st/a5/tquant/_gen_data_dn.py
+++ b/test/tilelib-st/a5/tquant/_gen_data_dn.py
@@ -1,0 +1,612 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import math
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+from ml_dtypes import bfloat16, float4_e2m1fn
+
+
+def fp32_to_bf16_bits(x):
+    x = np.asarray(x, dtype=np.float32)
+    u32 = x.view(np.uint32)
+    u16 = (u32 >> 16).astype(np.uint16)
+    return u16
+
+
+def bf16_bits_to_fp32(bf16_bits):
+    u32 = np.array(bf16_bits, dtype=np.uint32) << 16
+    return u32.view(np.float32)
+
+
+def get_group_max_dn(src, group_size=32):
+    m, n = src.shape
+    hat_m = m // group_size
+    max_vals = np.zeros((hat_m, n), dtype=np.float32)
+    for rb in range(hat_m):
+        for c in range(n):
+            max_vals[rb, c] = np.max(np.abs(src[rb * group_size: (rb + 1) * group_size, c]))
+    return max_vals
+
+
+def fp32_maxes_to_fp8(group_max, emax=8):
+    max_bits = np.asarray(group_max, dtype=np.float32).view(np.uint32)
+    exponent_b32 = (max_bits & 0x7F800000) >> 23
+    e8m0 = exponent_b32.astype(np.int32) - emax
+    e8m0 = np.clip(e8m0, 0, 254).astype(np.uint8)
+    scale_exp = 254 - e8m0.astype(np.int32)
+    scale_exp = np.clip(scale_exp, 0, 255).astype(np.uint32)
+    scaling_bits = (scale_exp << 23).view(np.float32)
+    nan_mask = exponent_b32 == 255
+    e8m0[nan_mask] = 0xFF
+    scaling_bits[nan_mask] = np.float32(np.nan)
+    return e8m0, scaling_bits
+
+
+def nv_maxes_to_mx(group_max, qmax):
+    """NV MX shared exponent and reciprocal scale from fp32-visible maxima."""
+    scaled = (np.asarray(group_max, dtype=np.float32) * np.float32(1.0 / qmax)).astype(np.float32)
+    bits = scaled.view(np.uint32)
+    exponent = ((bits & np.uint32(0x7F800000)) >> np.uint32(23)).astype(np.int32)
+    mantissa = bits & np.uint32(0x007FFFFF)
+    round_normal = (mantissa != 0) & (exponent > 0) & (exponent < 0xFE)
+    round_subnormal = (exponent == 0) & (mantissa > np.uint32(0x00400000))
+    shared_exp = exponent + (round_normal | round_subnormal).astype(np.int32)
+    inf_mask = np.isinf(scaled)
+    nan_mask = np.isnan(scaled)
+    shared_exp = np.where(inf_mask, 0xFE, shared_exp)
+    shared_exp = np.where(nan_mask, 0xFF, shared_exp).astype(np.uint8)
+    scale_exp = 254 - shared_exp.astype(np.int32)
+    scale_exp = np.clip(scale_exp, 0, 255).astype(np.uint32)
+    scaling = (scale_exp << np.uint32(23)).view(np.float32)
+    scaling = np.where(inf_mask, np.uint32(0x00400000).view(np.float32), scaling)
+    scaling = np.where(nan_mask, np.float32(np.nan), scaling).astype(np.float32)
+    return shared_exp, scaling
+
+
+def scale_data_dn(src, scaling, group_size=32):
+    m, n = src.shape
+    hat_m = m // group_size
+    result = np.zeros_like(src)
+    for rb in range(hat_m):
+        for r in range(rb * group_size, (rb + 1) * group_size):
+            result[r, :] = src[r, :] * scaling[rb, :]
+    return result
+
+
+def fp32_to_e4m3(x):
+    from ml_dtypes import float8_e4m3fn
+
+    x = np.asarray(x, dtype=np.float32)
+    clipped = np.clip(x, -448.0, 448.0)
+    result = clipped.astype(float8_e4m3fn)
+    return result.view(np.uint8)
+
+
+def nd2nz_mxfp8(data_fp8, m, n):
+    # Stock ND->NZ for 1-byte data: [M,N] -> [n_groups, padded_m, 32]. No virtual_row+1
+    # (the +1 is a UB-internal stride; the GM NZ layout is plain [n_groups, padded_m, 32]).
+    padded_m = ((m + 15) // 16) * 16
+    n_groups = ((n + 31) // 32) * 32 // 32
+    reshaped = data_fp8.reshape(m, n_groups, 32) if data_fp8.ndim == 1 else data_fp8.reshape(m, n_groups, 32)
+    padded = np.zeros((padded_m, n_groups, 32), dtype=data_fp8.dtype)
+    padded[:m, :, :] = reshaped
+    return np.transpose(padded, [1, 0, 2]).reshape(-1)
+
+
+def pack_e8_dn(e8m0, hat_m, n, padded_cols):
+    """Row-major E8M0 tile (hat_m x padded_cols)."""
+    e8m0_dn = np.zeros(hat_m * padded_cols, dtype=np.uint8)
+    for rb in range(hat_m):
+        for c in range(n):
+            e8m0_dn[rb * padded_cols + c] = e8m0[rb, c]
+    return e8m0_dn
+
+
+def dn2zz_e8m0(e8m0_dn, hat_m, n):
+    et = e8m0_dn.reshape(hat_m, n).T.copy()
+    rb = n // 16
+    p = hat_m // 2
+    zz = et.reshape(rb, 16, p, 2).transpose(0, 2, 1, 3).reshape(-1).astype(np.uint8)
+    return zz
+
+
+def interleave_e8m0_dn(e8m0_dn, hat_m, n):
+    """aclnnDynamicMxQuant non-tail-axis scale layout: [hat_m / 2, n, 2]."""
+    return e8m0_dn.reshape(hat_m // 2, 2, n).transpose(0, 2, 1).reshape(-1).astype(np.uint8)
+
+
+def quant_bf16_to_mxfp8_dn(src_bf16_fp32, m, n_pad, nv=False):
+    src_fp32 = src_bf16_fp32
+    padded_cols = int(math.ceil(n_pad / 32) * 32)
+    hat_m = m // 32
+    num_groups_flat = m * (padded_cols // 32)
+    num_groups_flat_aligned = int(math.ceil(num_groups_flat / 32) * 32)
+
+    group_max = get_group_max_dn(src_fp32, group_size=32)
+    e8m0, scaling = nv_maxes_to_mx(group_max, 448.0) if nv else fp32_maxes_to_fp8(group_max)
+    scaled = scale_data_dn(src_fp32, scaling, group_size=32)
+    fp8 = fp32_to_e4m3(scaled).reshape(m, n_pad)
+
+    fp8_padded = np.zeros((m, padded_cols), dtype=np.int8)
+    fp8_padded[:, :n_pad] = fp8
+    fp8_nd = fp8_padded.reshape(-1)
+    fp8_nz = nd2nz_mxfp8(fp8_padded, m, n_pad)
+
+    e8_dn = pack_e8_dn(e8m0, hat_m, n_pad, padded_cols)
+    e8_zz = dn2zz_e8m0(e8_dn, hat_m, n_pad)
+    if e8_zz.size < num_groups_flat_aligned:
+        e8_zz_padded = np.zeros(num_groups_flat_aligned, dtype=np.uint8)
+        e8_zz_padded[: e8_zz.size] = e8_zz
+        e8_zz = e8_zz_padded
+    elif e8_zz.size > num_groups_flat_aligned:
+        e8_zz = e8_zz[:num_groups_flat_aligned]
+
+    return fp8_nd, e8_dn, fp8_nz, e8_zz
+
+
+# ---------------------------------------------------------------------------
+# MXFP4 (E2M1) DN stage. Group max is taken across 32 rows per column (DN
+# layout: groups live on axis 0), producing [hat_m, n] max/e8/scaling tiles.
+#
+# The two source paths each mirror the *exact* hardware data flow so the
+# golden is an independent verification (via ml_dtypes), not a port of CCE:
+#   * bf16 source : bf16 * bf16 (bf16 rounding) -> NaN->+Inf -> bf16->fp4
+#   * fp16 source : fp16->f32, f32*scale(f32), f32->bf16(round) -> bf16->fp4
+#
+# OCP MXFP4 shared exponent is clamped at max_exp = 0x0100 (E2M1 max code),
+# derived from the bf16 exponent of the per-group abs-max (see OcpMxFp4E2M1Spec).
+# ---------------------------------------------------------------------------
+def bf16_maxes_to_e2m1_dn(group_max_bf16_fp32):
+    """OCP MXFP4 e8m0 + bf16 scaling from per-group abs max (fp32, exact bf16 exp)."""
+    bits = np.asarray(group_max_bf16_fp32, dtype=np.float32).view(np.uint32)
+    u16 = (bits >> 16).astype(np.uint16)  # bf16 rounding view
+    exp_bf16 = u16 & np.uint16(0x7F80)
+    mant_bf16 = u16 & np.uint16(0x007F)
+
+    nan_mask = (exp_bf16 == 0x7F80) & (mant_bf16 != 0)
+    # Clamp exponent to E2M1 maximum (0x0100 -> shared_exp baseline).
+    exp_clamped = np.maximum(exp_bf16, np.uint16(0x0100))
+    shared_exp_bits = exp_clamped.astype(np.uint16) - np.uint16(0x0100)
+    e8m0 = ((shared_exp_bits >> 7) & np.uint16(0xFF)).astype(np.uint8)
+    scale_bits = np.uint16(0x7F00) - shared_exp_bits
+    scale_bits = np.where(nan_mask, np.uint16(0x7FC0), scale_bits)  # NaN scaling
+    e8m0 = np.where(nan_mask, np.uint8(0xFF), e8m0)
+
+    scaling_fp32 = (scale_bits.astype(np.uint32) << 16).view(np.float32)
+    return e8m0, scaling_fp32, scale_bits
+
+
+def _bf16_mul_round(x_bf16_fp32, scale_bf16_fp32):
+    """Hardware vmul bf16: round-to-nearest product computed in bf16 precision."""
+    prod = (x_bf16_fp32.astype(bfloat16) * scale_bf16_fp32.astype(bfloat16)).astype(np.float32)
+    return prod
+
+
+def _fp32_to_bf16_round(x_fp32):
+    """Hardware vcvt f32->bf16 (ROUND_R, ties-to-even) via ml_dtypes."""
+    return x_fp32.astype(bfloat16)
+
+
+def fp32_to_e2m1_magic(x_fp32):
+    """Encode FP32 with the E2M1 magic-rounding path used by a.cpp."""
+    value = np.asarray(x_fp32, dtype=np.float32)
+    value_bits = value.view(np.uint32)
+    sign = ((value_bits >> np.uint32(28)) & np.uint32(0x8)).astype(np.uint8)
+    abs_value = np.abs(value).astype(np.float32)
+    abs_bits = abs_value.view(np.uint32)
+    biased_exp = ((abs_bits & np.uint32(0x7F800000)) >> np.uint32(23)).clip(127, 129)
+    magic_bits = ((biased_exp + np.uint32(22)) << np.uint32(23)).astype(np.uint32)
+    rounded = (abs_value + magic_bits.view(np.float32)).astype(np.float32)
+    magnitude = rounded.view(np.uint32) - magic_bits
+    base_code = (biased_exp - np.uint32(127)) << np.uint32(1)
+    magnitude = np.minimum(magnitude + base_code, np.uint32(0x7)).astype(np.uint8)
+    code = sign | magnitude
+    code = np.where(np.isnan(value), np.uint8(0x7), code)
+    return code.astype(np.uint8)
+
+
+def fp4_pack(codes_uint8, m, n_pad):
+    """Pack E2M1 codes 2-per-byte: low nibble = even element, high nibble = odd."""
+    codes = codes_uint8.reshape(m, n_pad).astype(np.uint8)
+    low = codes[:, 0::2]
+    high = codes[:, 1::2]
+    packed = (low & np.uint8(0xF)) | ((high & np.uint8(0xF)) << np.uint8(4))
+    return packed.reshape(-1)
+
+
+def quant_bf16_to_mxfp4_dn(src_bf16_fp32, m, n_pad, nv=False):
+    """bf16 source -> MXFP4 DN. Multiply in bf16, convert bf16->fp4."""
+    group_max = get_group_max_dn(src_bf16_fp32, group_size=32)  # [hat_m, n], fp32 (bf16-exact)
+    if nv:
+        e8m0, scaling_fp32 = nv_maxes_to_mx(group_max, 6.0)
+    else:
+        e8m0, scaling_fp32, _ = bf16_maxes_to_e2m1_dn(group_max)
+
+    hat_m = m // 32
+    scaled = np.empty((m, n_pad), dtype=np.float32)
+    for rb in range(hat_m):
+        scaled[rb * 32 : (rb + 1) * 32, :] = _bf16_mul_round(
+            src_bf16_fp32[rb * 32 : (rb + 1) * 32, :], scaling_fp32[rb : rb + 1, :]
+        )
+
+    # Saturate NaN -> +Inf before FP4 conversion (matches SaturateBf16NaNToPosInf).
+    with np.errstate(invalid="ignore"):
+        scaled = np.where(np.isnan(scaled), np.float32(np.inf), scaled)
+    # bf16 -> fp4 (round-to-nearest, ties-to-even) via ml_dtypes float4_e2m1fn.
+    fp4_codes = scaled.astype(bfloat16).astype(float4_e2m1fn).view(np.uint8).astype(np.uint8)
+
+    e8_dn = pack_e8_dn(e8m0, hat_m, n_pad, n_pad)
+    fp4_nd = fp4_pack(fp4_codes, m, n_pad)
+    return fp4_nd, e8_dn, group_max
+
+
+def fp16_maxes_to_e2m1_dn(group_max_fp16):
+    """OCP MXFP4 e8m0 + bf16 scaling derived from the fp16 group-max BITS.
+
+    The DN path (AbsReduceMax_DN) reduces fp16 abs directly (vabs on half), so the
+    max is fp16-typed. ComputeB16OcpExponentAndScaling then reads it with the bf16
+    exponent mask (0x7F80 >> 7) on the raw bits -- it does not reinterpret them as
+    fp16. We mirror that bit-level extraction here.
+    """
+    bits = group_max_fp16.view(np.uint16).astype(np.uint16)
+    exp_bf16 = bits & np.uint16(0x7F80)
+    mant_bf16 = bits & np.uint16(0x007F)
+    nan_mask = (exp_bf16 == 0x7F80) & (mant_bf16 != 0)
+    exp_clamped = np.maximum(exp_bf16, np.uint16(0x0100))
+    shared_exp_bits = exp_clamped.astype(np.uint16) - np.uint16(0x0100)
+    e8m0 = ((shared_exp_bits >> 7) & np.uint16(0xFF)).astype(np.uint8)
+    scale_bits = np.uint16(0x7F00) - shared_exp_bits
+    scale_bits = np.where(nan_mask, np.uint16(0x7FC0), scale_bits)
+    e8m0 = np.where(nan_mask, np.uint8(0xFF), e8m0)
+    scaling_fp32 = (scale_bits.astype(np.uint32) << 16).view(np.float32)
+    return e8m0, scaling_fp32
+
+
+def quant_fp16_to_mxfp4_dn(src_fp16, m, n_pad, nv=False):
+    """fp16 source -> MXFP4 DN. Multiply and E2M1 magic-round in fp32.
+
+    The DN reducer (AbsReduceMax_DN) takes the fp16 abs max directly (NOT a
+    bf16-truncated max like the non-DN path), and stores it as fp16 bits. The
+    exponent/scaling stage then reads those bits with the bf16 exponent mask.
+    """
+    src_fp32 = src_fp16.astype(np.float32)
+    if nv:
+        group_max = np.zeros((m // 32, n_pad), dtype=np.float16)
+        for rb in range(m // 32):
+            group_max[rb] = np.max(np.abs(src_fp16[rb * 32: (rb + 1) * 32, :]), axis=0)
+        e8m0, scaling_fp32 = nv_maxes_to_mx(group_max.astype(np.float32), 6.0)
+    else:
+        # OCP converts FP16 to BF16 (ROUND_Z) before the DN reduction.
+        bf16_bits = fp32_to_bf16_bits(src_fp32)
+        max_input = bf16_bits_to_fp32(bf16_bits.reshape(-1)).reshape(m, n_pad)
+        group_max = get_group_max_dn(max_input, group_size=32)
+        e8m0, scaling_fp32, _ = bf16_maxes_to_e2m1_dn(group_max)
+
+    hat_m = m // 32
+    scaled_fp32 = np.empty((m, n_pad), dtype=np.float32)
+    for rb in range(hat_m):
+        # a.cpp keeps fp16 -> f32 and the product in fp32, then uses the same
+        # E2M1 magic-rounding encoder as the tail-axis path.
+        block = src_fp32[rb * 32: (rb + 1) * 32, :]
+        scaled_fp32[rb * 32: (rb + 1) * 32, :] = block * scaling_fp32[rb: rb + 1, :].astype(np.float32)
+
+    fp4_codes = fp32_to_e2m1_magic(scaled_fp32)
+
+    e8_dn = pack_e8_dn(e8m0, hat_m, n_pad, n_pad)
+    fp4_nd = fp4_pack(fp4_codes, m, n_pad)
+    return fp4_nd, e8_dn, group_max
+
+
+CASE_PARAMS = [
+    ("TQUANTDNTest.case_bf16_64x128", 64, 128),
+]
+
+FP32_CASE_PARAMS = []
+
+NV_CASE_PARAMS = []
+
+NV_FP32_CASE_PARAMS = [
+    ("TQUANTDNTest.case_nv_fp32_128x128_interleaved", 128, 128),
+]
+
+MXFP4_BF16_CASE_PARAMS = []
+
+MXFP4_FP16_CASE_PARAMS = [
+    ("TQUANTDNTest.case_mxfp4_fp16_64x128", 64, 128),
+]
+
+MXFP4_INTERLEAVED_CASE_PARAMS = [
+    ("bf16", "TQUANTDNTest.case_nv_mxfp4_bf16_128x128_interleaved", 128, 128, True),
+]
+
+
+@dataclass(frozen=True)
+class ValidShapeCase:
+    dtype: str
+    static_rows: int
+    valid_rows: int
+    valid_cols: int
+    nv: bool = False
+    static_cols: int = 48
+
+
+VALID_SHAPE_CASE_PARAMS = [
+    ValidShapeCase("bf16", 512, 64, 24),
+    ValidShapeCase("fp16", 896, 896, 34, nv=True),
+]
+
+GOLDEN_DIR = os.environ.get("PTO_GOLDEN_DIR", ".")
+
+
+def _gen_src(m, n_pad):
+    """Generate source data with log-uniform per-group max in [0.25, 16] * 10000."""
+    hat_m = m // 32
+    log_min = np.log2(0.25)
+    log_max = np.log2(16.0)
+    log_group_max = np.random.uniform(log_min, log_max, size=(hat_m, n_pad))
+    group_max_target = (2.0**log_group_max).astype(np.float32)
+    base = np.random.uniform(0.1, 1.0, size=(m, n_pad)).astype(np.float32)
+    group_max_repeated = np.repeat(group_max_target, 32, axis=0)[:m, :]
+    return base * group_max_repeated * 10000.0
+
+
+@dataclass
+class GoldenDataFP8:
+    input_bytes: bytes
+    fp8_nd: np.ndarray
+    e8_dn: np.ndarray
+    group_max_bytes: bytes
+    fp8_nz: Optional[np.ndarray] = None
+    e8_zz: Optional[np.ndarray] = None
+
+
+@dataclass
+class GoldenDataFP4:
+    input_bytes: bytes
+    fp4_nd: np.ndarray
+    e8_dn: np.ndarray
+    fp4_nz: np.ndarray
+    group_max_bytes: bytes
+
+
+def _write_golden(out_dir, golden):
+    os.makedirs(out_dir, exist_ok=True)
+    with open(os.path.join(out_dir, "input.bin"), "wb") as f:
+        f.write(golden.input_bytes)
+    with open(os.path.join(out_dir, "golden_fp8_nd.bin"), "wb") as f:
+        f.write(golden.fp8_nd.tobytes())
+    with open(os.path.join(out_dir, "golden_e8_dn.bin"), "wb") as f:
+        f.write(golden.e8_dn.tobytes())
+    with open(os.path.join(out_dir, "golden_group_max.bin"), "wb") as f:
+        f.write(golden.group_max_bytes)
+    if golden.fp8_nz is not None:
+        with open(os.path.join(out_dir, "golden_fp8_nz.bin"), "wb") as f:
+            f.write(golden.fp8_nz.tobytes())
+    if golden.e8_zz is not None:
+        with open(os.path.join(out_dir, "golden_e8_zz.bin"), "wb") as f:
+            f.write(golden.e8_zz.tobytes())
+
+
+def gen_golden_data(case_name, m, n, nv=False):
+    n_pad = n
+    src = _gen_src(m, n_pad)
+    bf16_bits = fp32_to_bf16_bits(src).reshape(m, n_pad)
+    src_bf16_fp32 = bf16_bits_to_fp32(bf16_bits.flatten()).reshape(m, n_pad)
+
+    fp8_nd, e8_dn, fp8_nz, e8_zz = quant_bf16_to_mxfp8_dn(src_bf16_fp32, m, n_pad, nv)
+
+    group_max = get_group_max_dn(src_bf16_fp32, group_size=32)
+    golden_group_max_bf16 = fp32_to_bf16_bits(group_max)
+
+    out_dir = os.path.join(GOLDEN_DIR, case_name)
+    golden = GoldenDataFP8(
+        input_bytes=bf16_bits.reshape(-1).tobytes(),
+        fp8_nd=fp8_nd,
+        e8_dn=e8_dn,
+        group_max_bytes=golden_group_max_bf16.reshape(-1).tobytes(),
+        fp8_nz=fp8_nz,
+        e8_zz=e8_zz,
+    )
+    _write_golden(out_dir, golden)
+    with open(os.path.join(out_dir, "golden_e8_dn_interleaved.bin"), "wb") as f:
+        f.write(interleave_e8m0_dn(e8_dn, m // 32, n_pad).tobytes())
+
+
+def gen_golden_data_fp32(case_name, m, n, nv=False):
+    n_pad = n
+    src = _gen_src(m, n_pad)
+
+    fp8_nd, e8_dn, fp8_nz, e8_zz = quant_bf16_to_mxfp8_dn(src, m, n_pad, nv)
+
+    group_max = get_group_max_dn(src, group_size=32)
+    golden_group_max_f32 = group_max.astype(np.float32).view(np.uint32)
+
+    out_dir = os.path.join(GOLDEN_DIR, case_name)
+    input_bytes = src.astype(np.float32).view(np.uint32).reshape(-1).tobytes()
+    golden = GoldenDataFP8(
+        input_bytes=input_bytes,
+        fp8_nd=fp8_nd,
+        e8_dn=e8_dn,
+        group_max_bytes=golden_group_max_f32.reshape(-1).tobytes(),
+        fp8_nz=fp8_nz,
+        e8_zz=e8_zz,
+    )
+    _write_golden(out_dir, golden)
+    with open(os.path.join(out_dir, "golden_e8_dn_interleaved.bin"), "wb") as f:
+        f.write(interleave_e8m0_dn(e8_dn, m // 32, n_pad).tobytes())
+
+
+def _write_golden_mxfp4(out_dir, golden):
+    os.makedirs(out_dir, exist_ok=True)
+    with open(os.path.join(out_dir, "input.bin"), "wb") as f:
+        f.write(golden.input_bytes)
+    with open(os.path.join(out_dir, "golden_fp4_nd.bin"), "wb") as f:
+        f.write(golden.fp4_nd.tobytes())
+    with open(os.path.join(out_dir, "golden_e8_dn.bin"), "wb") as f:
+        f.write(golden.e8_dn.tobytes())
+    with open(os.path.join(out_dir, "golden_fp4_nz.bin"), "wb") as f:
+        f.write(golden.fp4_nz.tobytes())
+    with open(os.path.join(out_dir, "golden_group_max.bin"), "wb") as f:
+        f.write(golden.group_max_bytes)
+    with open(os.path.join(out_dir, "golden_e8_dn_interleaved.bin"), "wb") as f:
+        hat_m, n = golden.e8_dn.shape if golden.e8_dn.ndim == 2 else (None, None)
+        if hat_m is None:
+            raise ValueError("MXFP4 E8 golden must be two-dimensional")
+        f.write(interleave_e8m0_dn(golden.e8_dn.reshape(-1), hat_m, n).tobytes())
+
+
+def gen_golden_data_mxfp4_bf16(case_name, m, n, nv=False):
+    n_pad = n
+    src = _gen_src(m, n_pad)
+    bf16_bits = fp32_to_bf16_bits(src).reshape(m, n_pad)
+    src_bf16_fp32 = bf16_bits_to_fp32(bf16_bits.flatten()).reshape(m, n_pad)
+
+    fp4_nd, e8_dn, group_max = quant_bf16_to_mxfp4_dn(src_bf16_fp32, m, n_pad, nv)
+    fp4_padded = np.zeros((m, n_pad // 2), dtype=np.uint8)
+    fp4_padded[:, : n_pad // 2] = fp4_nd.reshape(m, n_pad // 2)
+    fp4_nz = nd2nz_mxfp8(fp4_padded, m, n_pad // 2)
+    golden_group_max_bf16 = fp32_to_bf16_bits(group_max)
+
+    out_dir = os.path.join(GOLDEN_DIR, case_name)
+    golden = GoldenDataFP4(
+        input_bytes=bf16_bits.reshape(-1).tobytes(),
+        fp4_nd=fp4_nd,
+        e8_dn=e8_dn.reshape(m // 32, n_pad),
+        fp4_nz=fp4_nz,
+        group_max_bytes=golden_group_max_bf16.reshape(-1).tobytes(),
+    )
+    _write_golden_mxfp4(out_dir, golden)
+
+
+def _gen_src_fp16_safe(m, n_pad):
+    """fp16-safe variant of _gen_src: per-group max in [0.25, 16] (no *10000), so
+    all values stay well within fp16 normal range. Uses the same RNG stream as
+    _gen_src so bf16 tests (which use _gen_src) keep their existing goldens."""
+    hat_m = m // 32
+    log_min = np.log2(0.25)
+    log_max = np.log2(16.0)
+    log_group_max = np.random.uniform(log_min, log_max, size=(hat_m, n_pad))
+    group_max_target = (2.0**log_group_max).astype(np.float32)
+    base = np.random.uniform(0.1, 1.0, size=(m, n_pad)).astype(np.float32)
+    group_max_repeated = np.repeat(group_max_target, 32, axis=0)[:m, :]
+    return base * group_max_repeated
+
+
+def _write_golden_data_mxfp4_fp16(case_name, src, nv=False):
+    src = np.asarray(src, dtype=np.float16)
+    m, n_pad = src.shape
+    src_fp16_bits = src.view(np.uint16)
+
+    fp4_nd, e8_dn, group_max = quant_fp16_to_mxfp4_dn(src, m, n_pad, nv)
+    fp4_padded = np.zeros((m, n_pad // 2), dtype=np.uint8)
+    fp4_padded[:, : n_pad // 2] = fp4_nd.reshape(m, n_pad // 2)
+    fp4_nz = nd2nz_mxfp8(fp4_padded, m, n_pad // 2)
+    golden_group_max_fp16 = (
+        group_max.view(np.uint16) if nv else fp32_to_bf16_bits(group_max)
+    )
+
+    out_dir = os.path.join(GOLDEN_DIR, case_name)
+    golden = GoldenDataFP4(
+        input_bytes=src_fp16_bits.reshape(-1).tobytes(),
+        fp4_nd=fp4_nd,
+        e8_dn=e8_dn.reshape(m // 32, n_pad),
+        fp4_nz=fp4_nz,
+        group_max_bytes=golden_group_max_fp16.reshape(-1).tobytes(),
+    )
+    _write_golden_mxfp4(out_dir, golden)
+
+
+def gen_golden_data_mxfp4_fp16(case_name, m, n, nv=False):
+    # Keep magnitudes in the fp16 normal range, since the DN fp16 path reduces
+    # fp16 abs directly and overflow-to-inf has separate special-value semantics.
+    src = _gen_src_fp16_safe(m, n).astype(np.float16)
+    _write_golden_data_mxfp4_fp16(case_name, src, nv)
+
+
+def gen_golden_data_valid_shape(case: ValidShapeCase):
+    prefix = "case_nv_validshape" if case.nv else "case_validshape"
+    case_name = (
+        f"TQUANTDNTest.{prefix}_{case.dtype}_s{case.static_rows}x{case.static_cols}"
+        f"_v{case.valid_rows}x{case.valid_cols}"
+    )
+    src = np.random.uniform(-1.0, 1.0, size=(case.valid_rows, case.valid_cols)).astype(np.float32)
+    if case.dtype == "fp32":
+        input_bytes = src.reshape(-1).tobytes()
+        src_numeric = src
+        max_input = src
+    elif case.dtype == "fp16":
+        src_fp16 = src.astype(np.float16)
+        input_bytes = src_fp16.view(np.uint16).reshape(-1).tobytes()
+        src_numeric = src_fp16.astype(np.float32)
+        if case.nv:
+            max_input = src_numeric
+        else:
+            # Fp16ToBf16PreserveSpecial uses ROUND_Z before the OCP DN max reduction.
+            max_input_bits = fp32_to_bf16_bits(src_numeric)
+            max_input = bf16_bits_to_fp32(max_input_bits.reshape(-1)).reshape(case.valid_rows, case.valid_cols)
+    else:
+        src_bits = fp32_to_bf16_bits(src)
+        input_bytes = src_bits.reshape(-1).tobytes()
+        src_numeric = bf16_bits_to_fp32(src_bits.reshape(-1)).reshape(case.valid_rows, case.valid_cols)
+        max_input = src_numeric
+
+    group_max = get_group_max_dn(max_input, group_size=32)
+    e8m0, scaling = nv_maxes_to_mx(group_max, 448.0) if case.nv else fp32_maxes_to_fp8(group_max)
+    scaled = scale_data_dn(src_numeric, scaling, group_size=32)
+    fp8_nd = fp32_to_e4m3(scaled).reshape(case.valid_rows, case.valid_cols)
+    e8_interleaved = e8m0.reshape(case.valid_rows // 64, 2, case.valid_cols).transpose(0, 2, 1)
+
+    out_dir = os.path.join(GOLDEN_DIR, case_name)
+    os.makedirs(out_dir, exist_ok=True)
+    with open(os.path.join(out_dir, "input.bin"), "wb") as f:
+        f.write(input_bytes)
+    with open(os.path.join(out_dir, "golden_fp8_nd.bin"), "wb") as f:
+        f.write(fp8_nd.tobytes())
+    with open(os.path.join(out_dir, "golden_e8_dn_interleaved.bin"), "wb") as f:
+        f.write(e8_interleaved.tobytes())
+
+
+if __name__ == "__main__":
+    np.random.seed(42)
+    for case_name, m, n in CASE_PARAMS:
+        print(f"Generating {case_name}...")
+        gen_golden_data(case_name, m, n)
+    for case_name, m, n in FP32_CASE_PARAMS:
+        print(f"Generating {case_name}...")
+        gen_golden_data_fp32(case_name, m, n)
+    for case_name, m, n in NV_CASE_PARAMS:
+        print(f"Generating {case_name}...")
+        gen_golden_data(case_name, m, n, nv=True)
+    for case_name, m, n in NV_FP32_CASE_PARAMS:
+        print(f"Generating {case_name}...")
+        gen_golden_data_fp32(case_name, m, n, nv=True)
+    for case_name, m, n in MXFP4_BF16_CASE_PARAMS:
+        print(f"Generating {case_name}...")
+        gen_golden_data_mxfp4_bf16(case_name, m, n)
+    for case_name, m, n in MXFP4_FP16_CASE_PARAMS:
+        print(f"Generating {case_name}...")
+        gen_golden_data_mxfp4_fp16(case_name, m, n)
+    for dtype, case_name, m, n, nv in MXFP4_INTERLEAVED_CASE_PARAMS:
+        print(f"Generating {case_name}...")
+        if dtype == "fp16":
+            gen_golden_data_mxfp4_fp16(case_name, m, n, nv=nv)
+        else:
+            gen_golden_data_mxfp4_bf16(case_name, m, n, nv=nv)
+    for case in VALID_SHAPE_CASE_PARAMS:
+        algorithm = "NV " if case.nv else ""
+        print(
+            f"Generating {algorithm}{case.dtype} validShape "
+            f"static=[{case.static_rows},{case.static_cols}] valid=[{case.valid_rows},{case.valid_cols}]..."
+        )
+        gen_golden_data_valid_shape(case)
+    print("Done.")

--- a/test/tilelib-st/a5/tquant/_gen_data_nd.py
+++ b/test/tilelib-st/a5/tquant/_gen_data_nd.py
@@ -1,0 +1,1199 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import struct
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+from ml_dtypes import float8_e4m3fn, bfloat16
+
+np.random.seed(19)
+
+
+##Assumptions: row size is at least 32, pad each row to multiple of 32 elements
+def float_to_hex(f):
+    return hex(struct.unpack("<I", struct.pack("<f", f))[0])
+
+
+def scale_data(data_fp32, data_scaling, group_size=32):
+    data_fp32_reshaped = data_fp32.reshape(-1, group_size)
+    scaled_data = data_fp32_reshaped * data_scaling
+    max_e4m3 = 448  # max representable value in e4m3
+    data_scale_clipped = np.clip(scaled_data, -max_e4m3, max_e4m3)
+    data_casted = data_scale_clipped.astype(float8_e4m3fn)
+
+    return data_casted
+
+
+def scale_data_bf16(data_bf16, data_scaling, group_size=32):
+    data_bf16_reshaped = data_bf16.reshape(-1, group_size)
+    # Multiply in bf16 precision (power-of-2 scaling is exact in any FP format)
+    scaled_data = (data_bf16_reshaped * data_scaling).astype(bfloat16)
+    max_e4m3 = bfloat16(448)  # max representable value in e4m3
+    data_scale_clipped = np.clip(scaled_data, bfloat16(-448), max_e4m3)
+    data_casted = data_scale_clipped.astype(float8_e4m3fn)
+    return data_casted
+
+
+def scale_data_fp16(data_fp16, data_scaling, group_size=32):
+    data_fp16_reshaped = data_fp16.reshape(-1, group_size)
+    # Multiply in fp16 precision (power-of-2 scaling is exact in any FP format)
+    scaled_data = (data_fp16_reshaped * data_scaling).astype(np.float16)
+    max_e4m3 = np.float16(448)  # max representable value in e4m3
+    data_scale_clipped = np.clip(scaled_data, np.float16(-448), max_e4m3)
+    data_casted = data_scale_clipped.astype(float8_e4m3fn)
+    return data_casted
+
+
+def scale_data_fp16_nv(data_fp16, data_scaling, group_size=32):
+    data_fp16_reshaped = data_fp16.reshape(-1, group_size).astype(np.float32)
+    scaling_fp32 = data_scaling.astype(np.float32)
+    scaled_data = data_fp16_reshaped * scaling_fp32
+    data_scale_clipped = np.clip(scaled_data, -448.0, 448.0).astype(np.float32)
+    return data_scale_clipped.astype(float8_e4m3fn)
+
+
+def get_group_max_last_dim(data: np.ndarray, group_size: int = 32):
+    data_abs = np.abs(data)
+    data_grouped = data_abs.reshape(-1, group_size)
+    group_max = np.max(data_grouped, axis=1)
+    return group_max
+
+
+def fp32_to_fp8_element(data_abs_max, emax):
+    data_abs_max = np.uint32(np.frombuffer(np.float32(data_abs_max).tobytes(), dtype=np.uint32)[0])
+    exponent_b32 = int((data_abs_max & np.uint32(0x7F800000)) >> np.uint32(23))
+    mantissa_b32 = int(data_abs_max & np.uint32(0x007FFFFF))
+    if exponent_b32 == 0xFF and mantissa_b32 != 0:
+        return 0xFF, np.uint32(0x7FC00000).view(np.float32)
+
+    if exponent_b32 <= emax:
+        return 0x00, np.uint32(0x7F000000).view(np.float32)
+
+    e8m0 = exponent_b32 - emax
+    scale_exp = 254 - e8m0  # (0xFE - e8m0): exponent of the reciprocal scale factor
+    scaling = scale_exp << 23  # shift to exponent position
+    scaling = np.uint32(scaling).view(np.float32)
+    if scaling == 0.0:
+        scaling = np.pow(2.0, -127)
+
+    return e8m0, scaling
+
+
+def nd2nz_mxfp8(data_fp8, tile_m, tile_n):
+    data_fp8_reshaped = data_fp8.reshape(int(tile_m), int(math.ceil(tile_n / 32)), 32)
+    data_fp8_nz = np.transpose(data_fp8_reshaped, [1, 0, 2])
+    return data_fp8_nz
+
+
+def nd2zz_e8m0(e8m0, tile_m, tile_n_div_32):
+    ## make an index array, with the same size as e8m0
+    index_array = np.arange(e8m0.size).reshape(e8m0.shape)
+    index_reshaped = index_array.reshape(int(math.ceil(tile_m / 16)), 16, int(math.ceil(tile_n_div_32 / 2)), 2)
+    index_zz = (np.transpose(index_reshaped, [0, 2, 1, 3])).flatten()
+    # index_zz_b16 should be index_zz/2, then selecting one element every 2 elements
+    index_zz_b16 = index_zz // 2
+    index_zz_b16_selected = index_zz_b16[::2].astype(np.uint16)
+    index_zz_b16_selected.tofile("index_vselr_b16.bin")
+    e8m0_reshaped = e8m0.reshape(int(math.ceil(tile_m / 16)), 16, int(math.ceil(tile_n_div_32 / 2)), 2)
+    e8m0_zz = np.transpose(e8m0_reshaped, [0, 2, 1, 3]).astype(np.uint8)
+    return e8m0_zz
+
+
+# default max exponent valuye emax=8 for e4m3
+def fp32_maxes_to_fp8(data_abs_max, emax=8):
+    e8m0s = []
+    scalings = []
+    data_abs_max_list = data_abs_max.reshape(-1).tolist()
+
+    # quantize
+    for itm in data_abs_max_list:
+        e8m0, scaling = fp32_to_fp8_element(itm, emax=emax)
+        e8m0s.append(e8m0)
+        scalings.append(scaling)
+
+    e8m0s = np.array(e8m0s).astype(np.uint8)
+    scalings = np.array(scalings).reshape(-1, 1).astype(np.float32)
+    return e8m0s, scalings
+
+
+def nv_fp32_to_mx_element(data_abs_max, max_value):
+    if np.float32(data_abs_max) == np.float32(0.0):
+        return 0x00, np.uint32(0x7F000000).view(np.float32)
+    descale = np.float32(data_abs_max) * np.float32(1.0 / max_value)
+    bits = np.uint32(np.frombuffer(descale.tobytes(), dtype=np.uint32)[0])
+    exponent = int((bits & np.uint32(0x7F800000)) >> np.uint32(23))
+    mantissa = int(bits & np.uint32(0x007FFFFF))
+    if exponent == 0xFF:
+        if mantissa == 0:
+            return 0xFE, np.float32(2.0**-127)
+        return 0xFF, np.float32(np.nan)
+    round_up = mantissa > 0 and exponent != 0xFE and not (exponent == 0 and mantissa <= 0x00400000)
+    e8m0 = exponent + (1 if round_up else 0)
+    if e8m0 == 0:
+        return e8m0, np.uint32(0x7F000000).view(np.float32)
+    if e8m0 == 0xFE:
+        return e8m0, np.float32(2.0**-127)
+    scaling_bits = np.uint32((254 - e8m0) << 23)
+    return e8m0, scaling_bits.view(np.float32)
+
+
+def nv_fp32_to_fp8_element(data_abs_max):
+    return nv_fp32_to_mx_element(data_abs_max, max_value=448.0)
+
+
+def nv_maxes_to_fp8(data_abs_max):
+    e8m0s = []
+    scalings = []
+    for itm in data_abs_max.reshape(-1).tolist():
+        e8m0, scaling = nv_fp32_to_fp8_element(itm)
+        e8m0s.append(e8m0)
+        scalings.append(scaling)
+    return np.array(e8m0s).astype(np.uint8), np.array(scalings).reshape(-1, 1).astype(np.float32)
+
+
+def fp16_to_fp8_element(data_abs_max_fp16, emax):
+    del emax
+    return bf16_to_fp8_element(data_abs_max_fp16)
+
+
+def bf16_to_fp8_element(data_abs_max_bf16):
+    data_u16 = np.uint16(np.frombuffer(np.float32(data_abs_max_bf16).tobytes(), dtype=np.uint32)[0] >> 16)
+    exponent_bf16 = int(data_u16 & 0x7F80)
+    mantissa_bf16 = int(data_u16 & 0x007F)
+    if exponent_bf16 == 0x7F80 and mantissa_bf16 != 0:
+        return 0xFF, np.uint16(0x7F81)
+
+    exponent_bf16 = max(exponent_bf16, 0x0400)
+    shared_exp_bits = exponent_bf16 - 0x0400
+    e8m0 = (shared_exp_bits >> 7) & 0xFF
+    scale_bits = np.uint16(0x7F00 - shared_exp_bits)
+    return e8m0, scale_bits
+
+
+def fp16_maxes_to_fp8(data_abs_max, emax=8):
+    e8m0s = []
+    scaling_bits = []
+    data_abs_max_list = data_abs_max.reshape(-1).tolist()
+
+    for itm in data_abs_max_list:
+        e8m0, scaling = fp16_to_fp8_element(itm, emax=emax)
+        e8m0s.append(e8m0)
+        scaling_bits.append(scaling)
+
+    e8m0s = np.array(e8m0s).astype(np.uint8)
+    scalings = bf16_bits_to_float32(np.array(scaling_bits, dtype=np.uint16)).reshape(-1, 1)
+    return e8m0s, scalings.astype(np.float32)
+
+
+def bf16_maxes_to_fp8(data_abs_max):
+    return fp16_maxes_to_fp8(data_abs_max, emax=8)
+
+
+def float32_to_bf16_trunc(data):
+    data_fp32 = np.asarray(data, dtype=np.float32)
+    bits = data_fp32.view(np.uint32) & np.uint32(0xFFFF0000)
+    return bits.view(np.float32)
+
+
+def bf16_bits_to_float32(bits):
+    return np.uint32(np.uint16(bits).astype(np.uint32) << np.uint32(16)).view(np.float32)
+
+
+def fp16_to_e2m1_element(data_abs_max_bf16):
+    data_u16 = np.uint16(np.frombuffer(np.float32(data_abs_max_bf16).tobytes(), dtype=np.uint32)[0] >> 16)
+    exponent_bf16 = int(data_u16 & 0x7F80)
+    mantissa_bf16 = int(data_u16 & 0x007F)
+    if exponent_bf16 == 0x7F80 and mantissa_bf16 != 0:
+        return 0xFF, np.uint16(0x7FC0)
+
+    exponent_bf16 = max(exponent_bf16, 0x0100)
+    shared_exp_bits = exponent_bf16 - 0x0100
+    e8m0 = (shared_exp_bits >> 7) & 0xFF
+    scale_bits = np.uint16(0x7F00 - shared_exp_bits)
+    return e8m0, scale_bits
+
+
+def fp16_maxes_to_e2m1(data_abs_max):
+    e8m0s = []
+    scaling_bits = []
+    for itm in data_abs_max.reshape(-1).tolist():
+        e8m0, scaling = fp16_to_e2m1_element(itm)
+        e8m0s.append(e8m0)
+        scaling_bits.append(scaling)
+    scaling_bf16 = bf16_bits_to_float32(np.array(scaling_bits, dtype=np.uint16)).reshape(-1, 1)
+    return np.array(e8m0s).astype(np.uint8), scaling_bf16.astype(np.float32)
+
+
+def nv_fp32_to_e2m1_element(data_abs_max):
+    return nv_fp32_to_mx_element(data_abs_max, max_value=6.0)
+
+
+def nv_maxes_to_e2m1(data_abs_max):
+    e8m0s = []
+    scalings = []
+    for itm in data_abs_max.reshape(-1).tolist():
+        e8m0, scaling = nv_fp32_to_e2m1_element(itm)
+        e8m0s.append(e8m0)
+        scalings.append(scaling)
+    return np.array(e8m0s).astype(np.uint8), np.array(scalings).reshape(-1, 1).astype(np.float32)
+
+
+def encode_e2m1_magic_scalar(value):
+    value = np.float32(value)
+    bits = np.frombuffer(value.tobytes(), dtype=np.uint32)[0]
+    sign = np.uint8((bits >> 28) & 0x8)
+    abs_value = np.float32(abs(value))
+    if np.isnan(abs_value):
+        return np.uint8(0x7)
+    if np.isinf(abs_value):
+        return np.uint8(sign | 0x7)
+    abs_bits = np.frombuffer(abs_value.tobytes(), dtype=np.uint32)[0]
+    biased_exp = int((abs_bits & np.uint32(0x7F800000)) >> 23)
+    biased_exp = min(max(biased_exp, 127), 129)
+    magic_bits = np.uint32((biased_exp + 22) << 23)
+    magic = magic_bits.view(np.float32)
+    q = np.frombuffer(np.float32(abs_value + magic).tobytes(), dtype=np.uint32)[0] - magic_bits
+    mag_code = min(int(q) + ((biased_exp - 127) << 1), 7)
+    return np.uint8(sign | mag_code)
+
+
+def pack_fp4_e2m1(codes, rows, cols):
+    packed_cols = (cols + 1) // 2
+    packed = np.zeros((rows, packed_cols), dtype=np.uint8)
+    codes = codes.reshape(rows, cols)
+    for r in range(rows):
+        for c in range(cols):
+            if c % 2 == 0:
+                packed[r, c // 2] = (packed[r, c // 2] & 0xF0) | codes[r, c]
+            else:
+                packed[r, c // 2] = (packed[r, c // 2] & 0x0F) | (codes[r, c] << 4)
+    return packed
+
+
+def quant_fp16_to_e2m1(src, scale_alg="ocp"):
+    src_fp32 = src.astype(np.float32)
+    if scale_alg == "nv":
+        data_abs = np.abs(src).astype(np.float16)
+        with np.errstate(invalid="ignore"):
+            group_max = np.max(data_abs.reshape(-1, 32), axis=1).astype(np.float32)
+        e8m0, scaling_bf16 = nv_maxes_to_e2m1(group_max)
+    else:
+        src_bf16_for_max = float32_to_bf16_trunc(src_fp32)
+        data_abs = np.abs(src_bf16_for_max).astype(np.float32)
+        data_grouped = data_abs.reshape(-1, 32)
+        group_max_bf16 = np.max(data_grouped, axis=1)
+        e8m0, scaling_bf16 = fp16_maxes_to_e2m1(group_max_bf16)
+
+    scaled = (src_fp32.reshape(-1, 32) * scaling_bf16.astype(np.float32)).reshape(src.shape).astype(np.float32)
+    codes = np.vectorize(encode_e2m1_magic_scalar, otypes=[np.uint8])(scaled)
+    packed = pack_fp4_e2m1(codes, src.shape[0], src.shape[1])
+
+    e8m0.tofile("golden_e8m0.bin")
+    scaling_bf16.astype(np.float32).tofile("scaling_e2m1.bin")
+    packed.tofile("golden_fp4.bin")
+    return e8m0, scaling_bf16, packed
+
+
+def quant_fp32_to_e4m3(src, mode="nd", scale_alg="ocp"):
+    # get group max
+    group_max = get_group_max_last_dim(src, group_size=32)
+    if scale_alg == "nv":
+        e8m0, scaling = nv_maxes_to_fp8(group_max)
+    else:
+        e8m0, scaling = fp32_maxes_to_fp8(group_max, emax=8)
+
+    if mode == "nz":
+        tile_m = src.shape[0]
+        tile_n = src.shape[1]
+        data_fp8 = scale_data(src, scaling, group_size=32)
+        data_fp8 = nd2nz_mxfp8(data_fp8, tile_m, tile_n)
+        e8m0 = nd2zz_e8m0(e8m0, tile_m, int(tile_n / 32))
+    else:
+        data_fp8 = scale_data(src, scaling, group_size=32)
+
+    # Persist full e8m0 tensor; flatten to avoid ambiguous truth checks on multidim arrays.
+    e8m0.tofile("golden_e8m0.bin")
+
+    scaling.tofile("scaling_e4m3.bin")
+    data_fp8.tofile("golden_fp8.bin")
+    return e8m0, scaling, data_fp8, group_max
+
+
+def quant_bf16_to_e4m3(src, mode="nd", scale_alg="ocp"):
+    # Get group max in bf16 precision, then convert to fp32 for exponent extraction
+    data_abs = np.abs(src).astype(bfloat16)
+    data_grouped = data_abs.reshape(-1, 32)
+    with np.errstate(invalid="ignore"):
+        group_max_bf16 = np.max(data_grouped, axis=1)
+
+    # Convert to fp32 for exponent extraction (exact: bf16 exponent == fp32 exponent)
+    group_max_fp32 = group_max_bf16.astype(np.float32)
+    if scale_alg == "nv":
+        e8m0, scaling_fp32 = nv_maxes_to_fp8(group_max_fp32)
+    else:
+        e8m0, scaling_fp32 = bf16_maxes_to_fp8(group_max_fp32)
+
+    # Convert scaling to bf16 (exact since scaling is always a power of 2)
+    scaling_bf16 = scaling_fp32.astype(bfloat16)
+
+    if mode == "nz":
+        tile_m = src.shape[0]
+        tile_n = src.shape[1]
+        data_fp8 = scale_data_bf16(src, scaling_bf16, group_size=32)
+        data_fp8 = nd2nz_mxfp8(data_fp8, tile_m, tile_n)
+        e8m0 = nd2zz_e8m0(e8m0, tile_m, int(tile_n / 32))
+    else:
+        data_fp8 = scale_data_bf16(src, scaling_bf16, group_size=32)
+
+    e8m0.tofile("golden_e8m0.bin")
+    scaling_fp32.tofile("scaling_e4m3.bin")
+    data_fp8.tofile("golden_fp8.bin")
+    return e8m0, scaling_bf16, data_fp8, group_max_bf16
+
+
+def quant_fp16_to_e4m3(src, mode="nd", scale_alg="ocp"):
+    # OCP reduces FP16 through BF16-truncated abs max; NV keeps FP16 max before RCEIL.
+    if scale_alg == "nv":
+        data_abs = np.abs(src).astype(np.float16)
+        data_grouped = data_abs.reshape(-1, 32)
+        group_max_for_scale = np.max(data_grouped, axis=1).astype(np.float32)
+        e8m0, scaling_fp32 = nv_maxes_to_fp8(group_max_for_scale)
+        scaling = scaling_fp32.astype(bfloat16)
+    else:
+        src_bf16_for_max = float32_to_bf16_trunc(src.astype(np.float32))
+        data_abs = np.abs(src_bf16_for_max).astype(np.float32)
+        data_grouped = data_abs.reshape(-1, 32)
+        group_max_fp16 = np.max(data_grouped, axis=1).astype(np.float32)
+
+        e8m0, scaling = fp16_maxes_to_fp8(group_max_fp16, emax=-104)
+
+    if mode == "nz":
+        tile_m = src.shape[0]
+        tile_n = src.shape[1]
+        data_fp8 = scale_data_fp16_nv(src, scaling, group_size=32)
+        data_fp8 = nd2nz_mxfp8(data_fp8, tile_m, tile_n)
+        e8m0 = nd2zz_e8m0(e8m0, tile_m, int(tile_n / 32))
+    else:
+        data_fp8 = scale_data_fp16_nv(src, scaling, group_size=32)
+
+    e8m0.tofile("golden_e8m0.bin")
+    # Save scaling as fp32 for debugging (same as bf16 path)
+    scaling.astype(np.float32).tofile("scaling_e4m3.bin")
+    data_fp8.tofile("golden_fp8.bin")
+    return e8m0, scaling, data_fp8
+
+
+MX_BOUNDARY_GROUP_SIZE = 32
+MX_SCALE_ALG_ANY = "any"
+MX_SCALE_ALG_OCP = "ocp"
+MX_SCALE_ALG_NV = "nv"
+MX_DST_MXFP8 = "mxfp8"
+MX_SRC_FP16 = "fp16"
+MX_SRC_BF16 = "bf16"
+MX_SRC_FP32 = "fp32"
+MXFP4_LOW_MAGNITUDE_VALUES = (1.0, -1.0, 0.75, -0.75, 0.5, -0.5, 0.375, -0.375, 0.25, -0.25, 0.125, -0.125)
+
+
+@dataclass(frozen=True)
+class MxFp4DataConfig:
+    valid_rows: int
+    valid_cols: int
+    case_suffix: Optional[str]
+    dtype: object
+    scale_alg: str = MX_SCALE_ALG_OCP
+
+
+def get_mx_src_dtype_key(dtype):
+    dtype = np.dtype(dtype)
+    if dtype == np.dtype(np.float16):
+        return MX_SRC_FP16
+    if dtype == np.dtype(bfloat16):
+        return MX_SRC_BF16
+    if dtype == np.dtype(np.float32):
+        return MX_SRC_FP32
+    raise ValueError(f"Unsupported MX source dtype: {dtype}")
+
+
+def get_mx_src_dtype(dtype_key):
+    return {MX_SRC_FP16: np.float16, MX_SRC_BF16: bfloat16, MX_SRC_FP32: np.float32}[dtype_key]
+
+
+def make_mxfp8_fp16_boundary_pattern():
+    return np.array(
+        [
+            0x0000,
+            0x8000,
+            0x0001,
+            0x8001,
+            0x03FF,
+            0x83FF,
+            0x0400,
+            0x8400,
+            0x5EFF,  # 447.75
+            0x5F00,  # 448
+            0x5F01,  # 448.25
+            0x6300,  # 896
+            0x6301,  # 896.5
+            0x7BFF,
+            0x7C00,
+            0x7E00,
+        ],
+        dtype=np.uint16,
+    ).view(np.float16)
+
+
+def make_mxfp8_bf16_boundary_pattern():
+    return np.array(
+        [
+            0.0,
+            -0.0,
+            np.float32(2.0**-133),
+            -np.float32(2.0**-133),
+            np.float32(2.0**-126),
+            -np.float32(2.0**-126),
+            446.0,
+            -446.0,
+            448.0,
+            -448.0,
+            450.0,
+            -450.0,
+            896.0,
+            898.0,
+            np.inf,
+            np.nan,
+        ],
+        dtype=np.float32,
+    ).astype(bfloat16)
+
+
+def make_mxfp8_fp32_boundary_pattern():
+    return np.array(
+        [
+            0.0,
+            -0.0,
+            np.float32(2.0**-149),
+            -np.float32(2.0**-149),
+            np.float32(2.0**-130),
+            -np.float32(2.0**-130),
+            np.nextafter(np.float32(448.0), np.float32(0.0)),
+            -np.nextafter(np.float32(448.0), np.float32(0.0)),
+            np.float32(448.0),
+            -np.float32(448.0),
+            np.nextafter(np.float32(448.0), np.float32(np.inf)),
+            -np.nextafter(np.float32(448.0), np.float32(-np.inf)),
+            np.float32(896.0),
+            np.nextafter(np.float32(896.0), np.float32(np.inf)),
+            np.inf,
+            np.nan,
+        ],
+        dtype=np.float32,
+    )
+
+
+MX_BOUNDARY_PATTERN_BUILDERS = {
+    (MX_DST_MXFP8, MX_SRC_FP16, MX_SCALE_ALG_ANY): make_mxfp8_fp16_boundary_pattern,
+    (MX_DST_MXFP8, MX_SRC_BF16, MX_SCALE_ALG_ANY): make_mxfp8_bf16_boundary_pattern,
+    (MX_DST_MXFP8, MX_SRC_FP32, MX_SCALE_ALG_ANY): make_mxfp8_fp32_boundary_pattern,
+}
+
+
+def get_mx_boundary_pattern(dst_format, src_dtype, scale_alg=MX_SCALE_ALG_ANY):
+    dtype_key = get_mx_src_dtype_key(src_dtype)
+    for key in ((dst_format, dtype_key, scale_alg), (dst_format, dtype_key, MX_SCALE_ALG_ANY)):
+        pattern_builder = MX_BOUNDARY_PATTERN_BUILDERS.get(key)
+        if pattern_builder is not None:
+            return pattern_builder()
+    raise ValueError(f"Unsupported MX boundary pattern: dst={dst_format}, src={dtype_key}, scale_alg={scale_alg}")
+
+
+def fill_mx_boundary_groups(total, src_dtype, pattern, group_size=MX_BOUNDARY_GROUP_SIZE):
+    values = np.zeros(total, dtype=src_dtype)
+    for begin in range(0, total, group_size):
+        end = min(begin + group_size, total)
+        if begin == 0:
+            continue
+        values[begin:end] = np.resize(pattern, end - begin).astype(src_dtype)
+    return values
+
+
+def make_mx_boundary_values(valid_rows, valid_cols, src_dtype, dst_format, scale_alg=MX_SCALE_ALG_ANY):
+    dtype_key = get_mx_src_dtype_key(src_dtype)
+    src_dtype = get_mx_src_dtype(dtype_key)
+    pattern = get_mx_boundary_pattern(dst_format, src_dtype, scale_alg=scale_alg)
+    values = fill_mx_boundary_groups(valid_rows * valid_cols, src_dtype, pattern)
+    return values.reshape(valid_rows, valid_cols).astype(src_dtype)
+
+
+def make_mxfp8_boundary_values(valid_rows, valid_cols, dtype, scale_alg=MX_SCALE_ALG_ANY):
+    return make_mx_boundary_values(valid_rows, valid_cols, dtype, MX_DST_MXFP8, scale_alg=scale_alg)
+
+
+def fp16_to_mxfp8(valid_rows, valid_cols, mode, scale_alg="ocp", case_suffix=None):
+    padded_cols = ((valid_cols + 31) // 32) * 32
+
+    if case_suffix == "boundary":
+        src_fp16 = make_mxfp8_boundary_values(valid_rows, valid_cols, np.float16, scale_alg=scale_alg)
+    elif case_suffix is not None and "_exp2d_fuzz" in case_suffix:
+        src_fp16 = make_mx_exp2d_fuzz_values(
+            valid_rows, valid_cols, np.float16, get_exp2d_fuzz_seed(case_suffix), max_abs=448.0
+        )
+    else:
+        mags = np.random.lognormal(mean=0.0, sigma=2.0, size=(valid_rows, valid_cols))
+        signs = np.where(np.random.rand(valid_rows, valid_cols) < 0.5, -1.0, 1.0)
+        src_fp32 = (mags * signs).astype(np.float32)
+        src_fp32 = np.clip(src_fp32, -6e4, 6e4)  # fp16 max is ~65504
+        src_fp16 = src_fp32.astype(np.float16)
+    src_fp16.tofile("input.bin")
+
+    pad_value = np.float16(0.0)  # match kernel PadValue::Zero / ZeroPadSourceTile
+    padded_src = np.full((valid_rows, padded_cols), pad_value, dtype=np.float16)
+    padded_src[:, :valid_cols] = src_fp16
+
+    # fp16 quantization, golden is saved in quant function
+    _, _, data_fp8 = quant_fp16_to_e4m3(padded_src, mode=mode, scale_alg=scale_alg)
+
+    # Trim FP8 golden to valid dimensions (kernel TSTORE only outputs valid columns)
+    if padded_cols != valid_cols and mode == "nd":
+        data_fp8_valid = data_fp8.reshape(valid_rows, padded_cols)[:, :valid_cols].copy()
+        data_fp8_valid.tofile("golden_fp8.bin")
+    return
+
+
+def make_mxfp4_exp_random_values(total, seed):
+    rng = np.random.default_rng(seed)
+    exponents = rng.integers(-24, 16, size=total, dtype=np.int32)
+    mantissas = rng.uniform(1.0, 2.0, size=total).astype(np.float32)
+    signs = np.where(rng.random(total) < 0.5, -1.0, 1.0).astype(np.float32)
+    values = np.ldexp(mantissas, exponents).astype(np.float32) * signs
+    values = np.clip(values, -65504.0, 65504.0)
+    zero_count = max(1, total // 32)
+    values[rng.choice(total, size=zero_count, replace=False)] = np.float32(0.0)
+    return values.astype(np.float16)
+
+
+def make_mxfp4_exp_random_values_bf16(total, seed):
+    rng = np.random.default_rng(seed)
+    exponents = rng.integers(-133, 128, size=total, dtype=np.int32)
+    mantissas = rng.uniform(1.0, 2.0, size=total).astype(np.float32)
+    signs = np.where(rng.random(total) < 0.5, -1.0, 1.0).astype(np.float32)
+    values = np.ldexp(mantissas, exponents).astype(np.float32) * signs
+    zero_count = max(1, total // 32)
+    values[rng.choice(total, size=zero_count, replace=False)] = np.float32(0.0)
+    return values.astype(bfloat16)
+
+
+def make_mxfp4_rounding_values(dtype):
+    return np.array(
+        [
+            4.0,
+            -4.0,
+            3.75,
+            -3.75,
+            3.5,
+            -3.5,
+            3.0,
+            -3.0,
+            2.5,
+            -2.5,
+            2.25,
+            -2.25,
+            2.0,
+            -2.0,
+            1.75,
+            -1.75,
+            1.5,
+            -1.5,
+            1.25,
+            -1.25,
+            *MXFP4_LOW_MAGNITUDE_VALUES,
+        ],
+        dtype=dtype,
+    )
+
+
+def next_up_for_dtype(value, dtype):
+    if dtype == np.float16:
+        return np.nextafter(np.float16(value), np.float16(np.inf)).astype(np.float16)
+    if dtype == bfloat16:
+        bits = np.uint16(np.frombuffer(np.float32(value).tobytes(), dtype=np.uint32)[0] >> np.uint32(16))
+        return bf16_bits_to_float32(np.array([bits + np.uint16(1)], dtype=np.uint16))[0].astype(np.float32)
+    return np.nextafter(np.float32(value), np.float32(np.inf))
+
+
+def make_mxfp4_nv_boundary_values(total, dtype, patterns):
+    next_1p5 = next_up_for_dtype(1.5, dtype)
+    next_3 = next_up_for_dtype(3.0, dtype)
+    next_6 = next_up_for_dtype(6.0, dtype)
+    special_values = patterns["special_values"]
+    subnormal_values = patterns["subnormal_values"]
+    random_values = patterns["exp_random_func"](32, seed=20260513)
+
+    group_patterns = [
+        [0.0, -0.0],
+        subnormal_values,
+        [1.5, -1.5, 1.0, -1.0, 0.75, -0.75],
+        [next_1p5, -next_1p5, 1.5, -1.5, 1.0, -1.0],
+        [3.0, -3.0, 2.5, -2.5, 1.5, -1.5],
+        [next_3, -next_3, 3.0, -3.0, 1.5, -1.5],
+        [6.0, -6.0, 4.0, -4.0, 3.0, -3.0],
+        [next_6, -next_6, 6.0, -6.0, 3.0, -3.0],
+        [-6.0, -4.0, -3.0, -1.5, -0.75, -0.0],
+        make_mxfp4_rounding_values(dtype),
+        [np.inf, 6.0, -6.0, 3.0, -3.0, 0.0],
+        [-np.inf, 6.0, -6.0, 3.0, -3.0, -0.0],
+        [np.nan, 6.0, -6.0, 3.0, -3.0, 0.0],
+        special_values,
+        random_values,
+        [3.75, -3.75, 2.25, -2.25, 1.25, -1.25, 0.375, -0.375],
+    ]
+
+    values = np.zeros(total, dtype=dtype)
+    for group in range((total + MX_BOUNDARY_GROUP_SIZE - 1) // MX_BOUNDARY_GROUP_SIZE):
+        begin = group * MX_BOUNDARY_GROUP_SIZE
+        end = min(begin + MX_BOUNDARY_GROUP_SIZE, total)
+        pattern = np.asarray(group_patterns[group % len(group_patterns)], dtype=dtype)
+        values[begin:end] = np.resize(pattern, end - begin)
+    return values
+
+
+def get_exp2d_fuzz_seed(case_suffix):
+    return 20260600 + int(case_suffix.rsplit("fuzz", 1)[1])
+
+
+def make_mxfp4_exp2d_base_pattern():
+    return np.array(
+        [
+            6.0,
+            -6.0,
+            4.0,
+            -4.0,
+            3.0,
+            -3.0,
+            2.5,
+            -2.5,
+            2.0,
+            -2.0,
+            1.5,
+            -1.5,
+            *MXFP4_LOW_MAGNITUDE_VALUES,
+            0.0,
+            -0.0,
+            3.75,
+            -3.75,
+            2.25,
+            -2.25,
+            1.25,
+            -1.25,
+        ],
+        dtype=np.float32,
+    )
+
+
+def make_mx_exp2d_fuzz_group_pattern(group, base_pattern, rng, max_abs):
+    scale = np.ldexp(np.float32(1.0), int((group % 17) - 8))
+    pattern = base_pattern * scale
+    if group % 5 == 0:
+        pattern[:8] = np.array(
+            [0.0, -0.0, max_abs, -max_abs, max_abs / 2.0, -max_abs / 2.0, 1.0, -1.0], dtype=np.float32
+        )
+    if group % 7 == 0:
+        mags = rng.lognormal(mean=0.0, sigma=2.0, size=8).astype(np.float32)
+        signs = np.where(rng.random(8) < 0.5, -1.0, 1.0).astype(np.float32)
+        pattern[16:24] = mags * signs
+    return pattern
+
+
+def make_mx_exp2d_fuzz_values(valid_rows, valid_cols, dtype, seed, max_abs):
+    rng = np.random.default_rng(seed)
+    groups_per_row = valid_cols // MX_BOUNDARY_GROUP_SIZE
+    base_pattern = make_mxfp4_exp2d_base_pattern()
+    values = np.zeros((valid_rows, valid_cols), dtype=np.float32)
+    for row in range(valid_rows):
+        for col_group in range(groups_per_row):
+            group = row * groups_per_row + col_group
+            col = col_group * MX_BOUNDARY_GROUP_SIZE
+            end_col = col + MX_BOUNDARY_GROUP_SIZE
+            values[row, col:end_col] = make_mx_exp2d_fuzz_group_pattern(group, base_pattern, rng, max_abs)
+
+    clip_abs = 60000.0 if dtype == np.float16 else max_abs
+    values = np.clip(values, -clip_abs, clip_abs)
+    return values.astype(dtype)
+
+
+def make_mxfp4_static4x128_exp2d_values(dtype):
+    group_maxes = np.array([6.0, 12.0, 24.0, 48.0, 96.0, 192.0, 384.0, 768.0], dtype=np.float32)
+    scaled_pattern = make_mxfp4_exp2d_base_pattern()
+    values = np.zeros((2, 128), dtype=np.float32)
+    for group, group_max in enumerate(group_maxes):
+        row = group // 4
+        col = (group % 4) * MX_BOUNDARY_GROUP_SIZE
+        end_col = col + MX_BOUNDARY_GROUP_SIZE
+        values[row, col:end_col] = scaled_pattern * (group_max / 6.0)
+    return values.astype(dtype)
+
+
+def make_mxfp4_e2m1_data(config, patterns):
+    total = config.valid_rows * config.valid_cols
+    dtype = config.dtype
+    case_suffix = config.case_suffix
+    special_values = patterns["special_values"]
+    subnormal_values = patterns["subnormal_values"]
+    rounding_values = make_mxfp4_rounding_values(dtype)
+    exp_random_func = patterns["exp_random_func"]
+    if case_suffix == "special":
+        values = np.resize(special_values, total)
+    elif case_suffix == "inf_only":
+        values = np.resize(np.array([np.inf, -np.inf], dtype=dtype), total)
+    elif case_suffix == "subnormal":
+        values = np.resize(subnormal_values, total)
+    elif case_suffix == "rounding":
+        values = np.resize(rounding_values, total)
+    elif case_suffix == "boundary":
+        if config.scale_alg == MX_SCALE_ALG_NV:
+            values = make_mxfp4_nv_boundary_values(total, dtype, patterns)
+        else:
+            values = np.resize(special_values, total)
+    elif case_suffix == "exp_random_a":
+        values = exp_random_func(total, seed=20260508)
+    elif case_suffix == "exp_random_b":
+        values = exp_random_func(total, seed=20260509)
+    elif case_suffix == "normal":
+        rng = np.random.default_rng(20260512)
+        values = rng.uniform(-6.0, 6.0, size=total).astype(dtype)
+    elif case_suffix == "mixed":
+        values = np.zeros(total, dtype=dtype)
+        group_patterns = [special_values, subnormal_values, rounding_values, exp_random_func(32, seed=20260510)]
+        for group in range((total + 31) // 32):
+            begin = group * 32
+            end = min(begin + 32, total)
+            pattern = group_patterns[group % len(group_patterns)]
+            values[begin:end] = np.resize(pattern, end - begin)
+    elif case_suffix == "static4x128_exp2d":
+        values = make_mxfp4_static4x128_exp2d_values(dtype).reshape(-1)
+    elif case_suffix is not None and "_exp2d_fuzz" in case_suffix:
+        values = make_mx_exp2d_fuzz_values(
+            config.valid_rows, config.valid_cols, dtype, get_exp2d_fuzz_seed(case_suffix), max_abs=768.0
+        ).reshape(-1)
+    else:
+        values = exp_random_func(total, seed=20260511)
+
+    return values.reshape(config.valid_rows, config.valid_cols).astype(dtype)
+
+
+def make_mxfp4_e2m1_fp16_data(valid_rows, valid_cols, case_suffix, scale_alg=MX_SCALE_ALG_OCP):
+    special_values = np.array(
+        [0.0, -0.0, np.inf, -np.inf, np.nan, 65504.0, -65504.0, 6.0, -6.0, 4.0, -4.0, 1.5, -1.5, 0.5, -0.5, 0.25],
+        dtype=np.float16,
+    )
+    subnormal_bits = np.array(
+        [
+            0x0001,
+            0x8001,
+            0x0002,
+            0x8002,
+            0x0003,
+            0x8003,
+            0x0010,
+            0x8010,
+            0x0100,
+            0x8100,
+            0x0200,
+            0x8200,
+            0x03FF,
+            0x83FF,
+            0x0400,
+            0x8400,
+        ],
+        dtype=np.uint16,
+    )
+    patterns = {
+        "special_values": special_values,
+        "subnormal_values": subnormal_bits.view(np.float16),
+        "exp_random_func": make_mxfp4_exp_random_values,
+    }
+    config = MxFp4DataConfig(
+        valid_rows=valid_rows, valid_cols=valid_cols, case_suffix=case_suffix, dtype=np.float16, scale_alg=scale_alg
+    )
+    return make_mxfp4_e2m1_data(config, patterns)
+
+
+def make_mxfp4_e2m1_bf16_data(valid_rows, valid_cols, case_suffix, scale_alg=MX_SCALE_ALG_OCP):
+    special_values = np.array(
+        [
+            0.0,
+            -0.0,
+            np.inf,
+            -np.inf,
+            np.nan,
+            3.38953139e38,
+            -3.38953139e38,
+            6.0,
+            -6.0,
+            4.0,
+            -4.0,
+            1.5,
+            -1.5,
+            0.5,
+            -0.5,
+            0.25,
+        ],
+        dtype=bfloat16,
+    )
+    subnormal_bits = np.array(
+        [
+            0x0001,
+            0x8001,
+            0x0002,
+            0x8002,
+            0x0003,
+            0x8003,
+            0x0010,
+            0x8010,
+            0x0040,
+            0x8040,
+            0x007F,
+            0x807F,
+            0x0080,
+            0x8080,
+            0x0100,
+            0x8100,
+        ],
+        dtype=np.uint16,
+    )
+    patterns = {
+        "special_values": special_values,
+        "subnormal_values": subnormal_bits.view(bfloat16),
+        "exp_random_func": make_mxfp4_exp_random_values_bf16,
+    }
+    config = MxFp4DataConfig(
+        valid_rows=valid_rows, valid_cols=valid_cols, case_suffix=case_suffix, dtype=bfloat16, scale_alg=scale_alg
+    )
+    return make_mxfp4_e2m1_data(config, patterns)
+
+
+def fp16_to_mxfp4_e2m1(valid_rows, valid_cols, mode, case_suffix=None, scale_alg="ocp"):
+    padded_cols = ((valid_cols + 31) // 32) * 32
+
+    src_fp16 = make_mxfp4_e2m1_fp16_data(valid_rows, valid_cols, case_suffix, scale_alg=scale_alg)
+    src_fp16.tofile("input.bin")
+
+    padded_src = np.zeros((valid_rows, padded_cols), dtype=np.float16)
+    padded_src[:, :valid_cols] = src_fp16
+    _, _, packed = quant_fp16_to_e2m1(padded_src, scale_alg=scale_alg)
+
+    if padded_cols != valid_cols and mode == "nd":
+        packed[:, : ((valid_cols + 1) // 2)].copy().tofile("golden_fp4.bin")
+    return
+
+
+def quant_bf16_to_e2m1(src, scale_alg="ocp"):
+    data_abs = np.abs(src).astype(bfloat16)
+    data_grouped = data_abs.reshape(-1, 32)
+    with np.errstate(invalid="ignore"):
+        group_max_bf16 = np.max(data_grouped, axis=1)
+    if scale_alg == "nv":
+        e8m0, scaling_bf16 = nv_maxes_to_e2m1(group_max_bf16.astype(np.float32))
+    else:
+        e8m0, scaling_bf16 = fp16_maxes_to_e2m1(group_max_bf16.astype(np.float32))
+
+    scaling_bf16 = scaling_bf16.astype(bfloat16)
+    scaled = (src.reshape(-1, 32) * scaling_bf16).astype(bfloat16).reshape(src.shape)
+    codes = np.vectorize(encode_e2m1_magic_scalar, otypes=[np.uint8])(scaled.astype(np.float32))
+    packed = pack_fp4_e2m1(codes, src.shape[0], src.shape[1])
+
+    e8m0.tofile("golden_e8m0.bin")
+    scaling_bf16.astype(np.float32).tofile("scaling_e2m1.bin")
+    packed.tofile("golden_fp4.bin")
+    return e8m0, scaling_bf16, packed
+
+
+def bf16_to_mxfp4_e2m1(valid_rows, valid_cols, mode, case_suffix=None, scale_alg="ocp"):
+    padded_cols = ((valid_cols + 31) // 32) * 32
+
+    src_bf16 = make_mxfp4_e2m1_bf16_data(valid_rows, valid_cols, case_suffix, scale_alg=scale_alg)
+    src_bf16.tofile("input.bin")
+
+    padded_src = np.zeros((valid_rows, padded_cols), dtype=bfloat16)
+    padded_src[:, :valid_cols] = src_bf16
+    _, _, packed = quant_bf16_to_e2m1(padded_src, scale_alg=scale_alg)
+
+    if padded_cols != valid_cols and mode == "nd":
+        packed[:, : ((valid_cols + 1) // 2)].copy().tofile("golden_fp4.bin")
+    return
+
+
+def bf16_to_mxfp8(valid_rows, valid_cols, mode, scale_alg="ocp", case_suffix=None):
+    padded_cols = ((valid_cols + 31) // 32) * 32
+
+    if case_suffix == "boundary":
+        src_bf16 = make_mxfp8_boundary_values(valid_rows, valid_cols, bfloat16, scale_alg=scale_alg)
+    elif case_suffix is not None and "_exp2d_fuzz" in case_suffix:
+        src_bf16 = make_mx_exp2d_fuzz_values(
+            valid_rows, valid_cols, bfloat16, get_exp2d_fuzz_seed(case_suffix), max_abs=448.0
+        )
+    else:
+        mags = np.random.lognormal(mean=0.0, sigma=2.0, size=(valid_rows, valid_cols))
+        signs = np.where(np.random.rand(valid_rows, valid_cols) < 0.5, -1.0, 1.0)
+        src_fp32 = (mags * signs).astype(np.float32)
+        src_fp32 = np.clip(src_fp32, -1e4, 1e4)  # bf16 has same exponent range but less mantissa
+        src_bf16 = src_fp32.astype(bfloat16)
+    src_bf16.tofile("input.bin")
+
+    pad_value = bfloat16(0.0)  # match kernel PadValue::Zero
+    padded_src = np.full((valid_rows, padded_cols), pad_value, dtype=bfloat16)
+    padded_src[:, :valid_cols] = src_bf16
+
+    # bf16 quantization, golden is saved in quant function
+    e8m0, scaling, data_fp8, group_max = quant_bf16_to_e4m3(padded_src, mode=mode, scale_alg=scale_alg)
+
+    # Trim FP8 golden to valid dimensions (kernel TSTORE only outputs valid columns)
+    if padded_cols != valid_cols and mode == "nd":
+        data_fp8_valid = data_fp8.reshape(valid_rows, padded_cols)[:, :valid_cols].copy()
+        data_fp8_valid.tofile("golden_fp8.bin")
+    return
+
+
+def fp32_to_int8_sym(valid_rows, valid_cols, mode):
+    src_fp32 = np.random.uniform(low=-2, high=2, size=(valid_rows, valid_cols)).astype(np.float32)
+    src_fp32.tofile("input.bin")
+    offset = np.zeros((valid_rows, 1), dtype=np.float32)
+    scale = np.max(np.abs(src_fp32), axis=1, keepdims=True) / 127.0
+    scale = scale.astype(np.float32)
+    inv_scale = np.where(scale != 0, 1.0 / scale, 0.0).astype(np.float32)
+    inv_scale.tofile("inv_scale_fp32.bin")
+    offset.tofile("offset_fp32.bin")
+    src_fp32_scaled = src_fp32 * inv_scale
+    # Round at fp32 precision first (eliminates double-rounding vs fp16 path)
+    src_fp32_rounded = np.round(src_fp32_scaled).astype(np.float32)
+    src_fp16 = src_fp32_rounded.astype(np.float16)
+    src_s8 = np.clip(src_fp16, -128, 127).astype(np.int8)
+    src_s8.tofile("golden_s8.bin")
+    ## if mode == nz, use nd to nz for fp8 layout conversion
+    return src_fp32, src_s8
+
+
+def fp32_to_int8_asym(valid_rows, valid_cols, mode):
+    src_fp32 = np.random.uniform(low=-2, high=2, size=(valid_rows, valid_cols)).astype(np.float32)
+    src_fp32.tofile("input.bin")
+    src_fp32_rowmin = np.min(src_fp32, axis=1, keepdims=True)
+    src_fp32_rowmax = np.max(src_fp32, axis=1, keepdims=True)
+    scale = (src_fp32_rowmax - src_fp32_rowmin) / 255.0
+    scale = scale.astype(np.float32)
+    inv_scale = np.where(scale != 0, 1.0 / scale, 0.0).astype(np.float32)
+    inv_scale.tofile("inv_scale_fp32.bin")
+    zero_point = np.clip(np.round(-src_fp32_rowmin / scale), 0, 255).astype(np.float32)
+    zero_point.tofile("offset_fp32.bin")
+    # Round at fp32 precision first (eliminates double-rounding vs fp16 path)
+    src_fp32_out = src_fp32 * inv_scale + zero_point
+    src_fp32_rounded = np.round(src_fp32_out).astype(np.float32)
+    src_fp16_out = src_fp32_rounded.astype(np.float16)
+    src_u8 = np.clip(src_fp16_out, 0, 255).astype(np.uint8)
+    src_u8.tofile("golden_u8.bin")
+    ## if mode == nz, use nd to nz for fp8 layout conversion
+    return src_fp32, src_u8
+
+
+def fp32_to_mxfp8(valid_rows, valid_cols, mode, scale_alg="ocp", case_suffix=None):
+    padded_cols = ((valid_cols + 31) // 32) * 32
+
+    if case_suffix == "boundary":
+        src_fp32 = make_mxfp8_boundary_values(valid_rows, valid_cols, np.float32, scale_alg=scale_alg)
+    elif case_suffix is not None and "_exp2d_fuzz" in case_suffix:
+        src_fp32 = make_mx_exp2d_fuzz_values(
+            valid_rows, valid_cols, np.float32, get_exp2d_fuzz_seed(case_suffix), max_abs=448.0
+        )
+    else:
+        mags = np.random.lognormal(mean=0.0, sigma=2.0, size=(valid_rows, valid_cols))
+        signs = np.where(np.random.rand(valid_rows, valid_cols) < 0.5, -1.0, 1.0)
+        src_fp32 = (mags * signs).astype(np.float32)
+        src_fp32 = np.clip(src_fp32, -1e8, 1e8)
+    src_fp32.tofile("input.bin")
+
+    pad_value = np.float32(0.0)
+    padded_src = np.full((valid_rows, padded_cols), pad_value, dtype=np.float32)
+    padded_src[:, :valid_cols] = src_fp32
+
+    # fp8 quantization, golden is saved in quant function
+    e8m0, scaling, data_fp8, group_max = quant_fp32_to_e4m3(padded_src, mode=mode, scale_alg=scale_alg)
+
+    if padded_cols != valid_cols and mode == "nd":
+        data_fp8_valid = data_fp8.reshape(valid_rows, padded_cols)[:, :valid_cols].copy()
+        data_fp8_valid.tofile("golden_fp8.bin")
+    return
+
+
+def gen_golden_data_tquant(case_name, param):
+    dtype = param.dtype
+    valid_rows, valid_cols = [param.valid_rows, param.valid_cols]
+    mode = param.mode
+    out_dtype_str = param.out_dtype_str
+    if out_dtype_str == "int8_sym":
+        fp32_to_int8_sym(valid_rows, valid_cols, mode)
+    elif out_dtype_str == "int8_asym":
+        fp32_to_int8_asym(valid_rows, valid_cols, mode)
+    elif out_dtype_str == "mxfp4_e2m1":
+        if dtype == bfloat16:
+            bf16_to_mxfp4_e2m1(valid_rows, valid_cols, mode, case_suffix=param.case_suffix, scale_alg=param.scale_alg)
+        else:
+            fp16_to_mxfp4_e2m1(valid_rows, valid_cols, mode, case_suffix=param.case_suffix, scale_alg=param.scale_alg)
+    elif dtype == bfloat16:
+        bf16_to_mxfp8(valid_rows, valid_cols, mode, scale_alg=param.scale_alg, case_suffix=param.case_suffix)
+    elif dtype == np.float16:
+        fp16_to_mxfp8(valid_rows, valid_cols, mode, scale_alg=param.scale_alg, case_suffix=param.case_suffix)
+    else:
+        fp32_to_mxfp8(valid_rows, valid_cols, mode, scale_alg=param.scale_alg, case_suffix=param.case_suffix)
+    return
+
+
+class TQuantParams:
+    def __init__(
+        self, out_dtype_str, valid_rows, valid_cols, mode="nd", dtype=np.float32, case_suffix=None, scale_alg="ocp"
+    ):
+        self.valid_rows = valid_rows
+        self.valid_cols = valid_cols
+        self.dtype = dtype
+        self.mode = mode
+        self.case_suffix = case_suffix
+        self.scale_alg = scale_alg
+        self.out_dtype_str = {"s8": "int8_sym", "mxfp8": "mxfp8", "mxfp4_e2m1": "mxfp4_e2m1", "u8": "int8_asym"}[
+            out_dtype_str
+        ]
+
+        ## convert dtype to string for case name to match that in main.cpp
+        self.dtype_str = {np.float32: "fp32", bfloat16: "bf16", np.float16: "fp16"}[self.dtype]
+
+
+def generate_case_name(param):
+    suffix = f"_{param.case_suffix}" if param.case_suffix is not None else ""
+    alg_suffix = "_nv" if param.scale_alg == "nv" else ""
+    return (
+        f"TQUANTTEST.case_{param.out_dtype_str}{alg_suffix}_{param.dtype_str}_"
+        f"{param.valid_rows}x{param.valid_cols}{suffix}_{param.mode}"
+    )
+
+
+def make_exp2d_fuzz_params():
+    return [TQuantParams("mxfp8", 1, 64, mode="nd", dtype=bfloat16, case_suffix="static3x128_exp2d_fuzz01")]
+
+
+if __name__ == "__main__":
+    # Get the absolute path of the script
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    testcases_dir = os.path.join(script_dir, "testcases")
+
+    # Ensure the testcases directory exists
+    if not os.path.exists(testcases_dir):
+        os.makedirs(testcases_dir)
+
+    case_params_list = [
+        TQuantParams("mxfp8", 32, 32, mode="nd"),
+        TQuantParams("mxfp8", 32, 64, mode="nd"),
+        TQuantParams("mxfp8", 64, 128, mode="nd"),
+        TQuantParams("mxfp8", 128, 128, mode="nd"),
+        TQuantParams("mxfp8", 15, 32, mode="nd"),
+        TQuantParams("mxfp8", 7, 64, mode="nd"),
+        TQuantParams("mxfp8", 33, 64, mode="nd"),
+        TQuantParams("mxfp8", 13, 192, mode="nd"),
+        TQuantParams("mxfp8", 32, 128, mode="nd", scale_alg="nv"),
+        TQuantParams("mxfp8", 2, 256, mode="nd", case_suffix="boundary", scale_alg="nv"),
+        TQuantParams("mxfp8", 32, 64, mode="nz"),
+        TQuantParams("mxfp8", 64, 128, mode="nz"),
+        TQuantParams("mxfp8", 64, 256, mode="nz"),
+        TQuantParams("mxfp8", 64, 512, mode="nz"),
+        TQuantParams("mxfp8", 128, 128, mode="nz"),
+        TQuantParams("s8", 64, 128, mode="nd"),
+        TQuantParams("s8", 128, 128, mode="nd"),
+        TQuantParams("s8", 256, 128, mode="nd"),
+        TQuantParams("u8", 64, 128, mode="nd"),
+        TQuantParams("u8", 128, 128, mode="nd"),
+        TQuantParams("u8", 256, 128, mode="nd"),
+        TQuantParams("u8", 32, 72, mode="nd"),
+        TQuantParams("mxfp8", 32, 128, mode="nd", dtype=bfloat16),
+        TQuantParams("mxfp8", 64, 128, mode="nd", dtype=bfloat16),
+        TQuantParams("mxfp8", 128, 128, mode="nd", dtype=bfloat16),
+        TQuantParams("mxfp8", 14, 16, mode="nd", dtype=bfloat16),
+        TQuantParams("mxfp8", 7, 48, mode="nd", dtype=bfloat16),
+        TQuantParams("mxfp8", 18, 136, mode="nd", dtype=bfloat16),
+        # Diagnostic cases for board failure analysis
+        TQuantParams("mxfp8", 1, 32, mode="nd", dtype=bfloat16),
+        TQuantParams("mxfp8", 2, 16, mode="nd", dtype=bfloat16),
+        TQuantParams("mxfp8", 4, 16, mode="nd", dtype=bfloat16),
+        TQuantParams("mxfp8", 8, 16, mode="nd", dtype=bfloat16),
+        TQuantParams("mxfp8", 16, 16, mode="nd", dtype=bfloat16),
+        TQuantParams("mxfp8", 3, 32, mode="nd", dtype=bfloat16),
+        TQuantParams("mxfp8", 5, 96, mode="nd", dtype=bfloat16),
+        TQuantParams("mxfp8", 1, 16, mode="nd", dtype=bfloat16),
+        # Multi-flush vstas coverage: loop_num odd >= 3 leaves 16B pending in st_align.
+        TQuantParams("mxfp8", 4, 256, mode="nd", dtype=bfloat16),  # 1024 elems -> 4 row-aligned 256-elem windows
+        TQuantParams("mxfp8", 4, 512, mode="nd", dtype=bfloat16),  # 2048 elems -> generic ND, not 32-VL large path
+        TQuantParams("mxfp8", 3, 256, mode="nd", dtype=bfloat16),  # padded 768 -> loop_num=3
+        TQuantParams("mxfp8", 5, 256, mode="nd", dtype=bfloat16),  # padded 1280 -> loop_num=5
+        TQuantParams("mxfp8", 18, 138, mode="nd", dtype=bfloat16),  # padded 18x160 = 2880 -> loop_num=12
+        TQuantParams("mxfp8", 1, 192, mode="nd", dtype=bfloat16),  # no pad, 192 elems -> loop_num=1
+        TQuantParams("mxfp8", 1, 198, mode="nd", dtype=bfloat16),  # padded 1x224 = 224 -> loop_num=1
+        TQuantParams("mxfp8", 32, 128, mode="nz", dtype=bfloat16),
+        TQuantParams("mxfp8", 64, 128, mode="nz", dtype=bfloat16),
+        TQuantParams("mxfp8", 128, 128, mode="nz", dtype=bfloat16),
+        TQuantParams("mxfp8", 32, 128, mode="nd", dtype=bfloat16, scale_alg="nv"),
+        TQuantParams("mxfp8", 64, 128, mode="nd", dtype=bfloat16, scale_alg="nv"),
+        TQuantParams("mxfp8", 128, 128, mode="nd", dtype=bfloat16, scale_alg="nv"),
+        TQuantParams("mxfp8", 7, 48, mode="nd", dtype=bfloat16, scale_alg="nv"),
+        TQuantParams("mxfp8", 2, 256, mode="nd", dtype=bfloat16, case_suffix="boundary", scale_alg="nv"),
+        TQuantParams("mxfp8", 32, 128, mode="nd", dtype=np.float16),
+        TQuantParams("mxfp8", 64, 128, mode="nd", dtype=np.float16),
+        TQuantParams("mxfp8", 128, 128, mode="nd", dtype=np.float16),
+        TQuantParams("mxfp8", 4, 256, mode="nd", dtype=np.float16),  # 1024 elems -> AbsReduceMax_b16_ND_opt
+        TQuantParams("mxfp8", 11, 640, mode="nd", dtype=np.float16),  # 7040 elems -> 220 scale groups
+        TQuantParams("mxfp8", 32, 128, mode="nd", dtype=np.float16, scale_alg="nv"),
+        TQuantParams("mxfp8", 64, 128, mode="nd", dtype=np.float16, scale_alg="nv"),
+        TQuantParams("mxfp8", 128, 128, mode="nd", dtype=np.float16, scale_alg="nv"),
+        TQuantParams("mxfp8", 2, 256, mode="nd", dtype=np.float16, case_suffix="boundary", scale_alg="nv"),
+        *make_exp2d_fuzz_params(),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=np.float16, case_suffix="special"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=np.float16, case_suffix="inf_only"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=np.float16, case_suffix="subnormal"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=np.float16, case_suffix="rounding"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=np.float16, case_suffix="exp_random_a"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=np.float16, case_suffix="exp_random_b"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=np.float16, case_suffix="mixed"),
+        TQuantParams("mxfp4_e2m1", 32, 1024, mode="nd", dtype=np.float16, case_suffix="mixed"),
+        TQuantParams("mxfp4_e2m1", 32, 1024, mode="nd", dtype=np.float16, case_suffix="normal"),
+        TQuantParams("mxfp4_e2m1", 2, 256, mode="nd", dtype=np.float16, case_suffix="boundary", scale_alg="nv"),
+        TQuantParams("mxfp4_e2m1", 2, 256, mode="nd", dtype=np.float16, case_suffix="rounding", scale_alg="nv"),
+        TQuantParams("mxfp4_e2m1", 2, 256, mode="nd", dtype=np.float16, case_suffix="mixed", scale_alg="nv"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=bfloat16, case_suffix="special"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=bfloat16, case_suffix="inf_only"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=bfloat16, case_suffix="subnormal"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=bfloat16, case_suffix="rounding"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=bfloat16, case_suffix="exp_random_a"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=bfloat16, case_suffix="exp_random_b"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=bfloat16, case_suffix="mixed"),
+        TQuantParams("mxfp4_e2m1", 32, 1024, mode="nd", dtype=bfloat16, case_suffix="mixed"),
+        TQuantParams("mxfp4_e2m1", 32, 1024, mode="nd", dtype=bfloat16, case_suffix="normal"),
+        TQuantParams("mxfp4_e2m1", 2, 256, mode="nd", dtype=bfloat16, case_suffix="boundary", scale_alg="nv"),
+        TQuantParams("mxfp4_e2m1", 2, 256, mode="nd", dtype=bfloat16, case_suffix="rounding", scale_alg="nv"),
+        TQuantParams("mxfp4_e2m1", 2, 256, mode="nd", dtype=bfloat16, case_suffix="mixed", scale_alg="nv"),
+        TQuantParams("mxfp4_e2m1", 2, 128, mode="nd", dtype=bfloat16, case_suffix="static4x128_exp2d", scale_alg="nv"),
+        TQuantParams("mxfp8", 32, 128, mode="nz", dtype=np.float16),
+        TQuantParams("mxfp8", 64, 128, mode="nz", dtype=np.float16),
+        TQuantParams("mxfp8", 128, 128, mode="nz", dtype=np.float16),
+    ]
+
+    for param in case_params_list:
+        case_name = generate_case_name(param)
+        if not os.path.exists(case_name):
+            os.makedirs(case_name)
+        original_dir = os.getcwd()
+        os.chdir(case_name)
+        gen_golden_data_tquant(case_name, param)
+        os.chdir(original_dir)

--- a/test/tilelib-st/a5/tquant/case.py
+++ b/test/tilelib-st/a5/tquant/case.py
@@ -1,0 +1,997 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from pathlib import Path
+import struct
+import sys
+import zlib
+
+import numpy as np
+import ml_dtypes
+
+if __package__ in {None, ""}:
+    _case_dir = Path(__file__).resolve().parent
+    sys.path.insert(0, str(_case_dir))
+    sys.path.insert(0, str(_case_dir.parent.parent))
+
+from common import auto_main, golden_output_case
+from ptodsl import pto
+
+
+# ════════════════════════════════════════════════════════════════
+#  Helpers
+# ════════════════════════════════════════════════════════════════
+
+def _ca(v, bs, to=32):
+    n = v * bs
+    return ((n + to - 1) // to) * to // bs
+
+
+def _seed(name):
+    return zlib.crc32(name.encode("utf-8")) & 0xFFFFFFFF
+
+
+_NP_DT = {
+    pto.f32: (np.float32, 4),
+    pto.f16: (np.float16, 2),
+    pto.bf16: (ml_dtypes.bfloat16, 2),
+}
+
+
+# ════════════════════════════════════════════════════════════════
+#  Each: (quant_type, dtype_name, shape, scale_alg, mode, name, data_pattern)
+# ════════════════════════════════════════════════════════════════
+
+_SPECS = [
+    # ── INT8 SYM (3) ──
+    ("INT8_SYM", "f32", (64, 128), "N/A", "ND", "int8_sym_fp32_64x128_nd", "normal"),
+    ("INT8_SYM", "f32", (128, 128), "N/A", "ND", "int8_sym_fp32_128x128_nd", "normal"),
+    ("INT8_SYM", "f32", (256, 128), "N/A", "ND", "int8_sym_fp32_256x128_nd", "normal"),
+
+    # ── INT8 ASYM (3) ──
+    ("INT8_ASYM", "f32", (64, 128), "N/A", "ND", "int8_asym_fp32_64x128_nd", "normal"),
+    ("INT8_ASYM", "f32", (128, 128), "N/A", "ND", "int8_asym_fp32_128x128_nd", "normal"),
+    ("INT8_ASYM", "f32", (256, 128), "N/A", "ND", "int8_asym_fp32_256x128_nd", "normal"),
+
+    # ── MXFP8 FP32 OCP ND (8) ──
+    ("MXFP8", "f32", (32, 32), "OCP", "ND", "mxfp8_fp32_32x32_nd", "normal"),
+    ("MXFP8", "f32", (32, 64), "OCP", "ND", "mxfp8_fp32_32x64_nd", "normal"),
+    ("MXFP8", "f32", (64, 128), "OCP", "ND", "mxfp8_fp32_64x128_nd", "normal"),
+    ("MXFP8", "f32", (128, 128), "OCP", "ND", "mxfp8_fp32_128x128_nd", "normal"),
+    ("MXFP8", "f32", (15, 32), "OCP", "ND", "mxfp8_fp32_15x32_nd", "normal"),
+    ("MXFP8", "f32", (7, 64), "OCP", "ND", "mxfp8_fp32_7x64_nd", "normal"),
+    ("MXFP8", "f32", (33, 64), "OCP", "ND", "mxfp8_fp32_33x64_nd", "normal"),
+    ("MXFP8", "f32", (13, 192), "OCP", "ND", "mxfp8_fp32_13x192_nd", "normal"),
+
+    # ── MXFP8 FP32 OCP NZ (5) ──
+    ("MXFP8", "f32", (32, 64), "OCP", "NZ", "mxfp8_fp32_32x64_nz", "normal"),
+    ("MXFP8", "f32", (64, 128), "OCP", "NZ", "mxfp8_fp32_64x128_nz", "normal"),
+    ("MXFP8", "f32", (128, 128), "OCP", "NZ", "mxfp8_fp32_128x128_nz", "normal"),
+    ("MXFP8", "f32", (64, 256), "OCP", "NZ", "mxfp8_fp32_64x256_nz", "normal"),
+    ("MXFP8", "f32", (64, 512), "OCP", "NZ", "mxfp8_fp32_64x512_nz", "normal"),
+
+    # ── MXFP8 FP32 NV ND (2) ──
+    ("MXFP8", "f32", (32, 128), "NV", "ND", "mxfp8_nv_fp32_32x128_nd", "normal"),
+    ("MXFP8", "f32", (2, 256), "NV", "ND", "mxfp8_nv_fp32_2x256_boundary_nd", "boundary"),
+
+    # ── MXFP8 BF16 OCP ND (14) ──
+    ("MXFP8", "bf16", (32, 128), "OCP", "ND", "mxfp8_bf16_32x128_nd", "normal"),
+    ("MXFP8", "bf16", (64, 128), "OCP", "ND", "mxfp8_bf16_64x128_nd", "normal"),
+    ("MXFP8", "bf16", (128, 128), "OCP", "ND", "mxfp8_bf16_128x128_nd", "normal"),
+    ("MXFP8", "bf16", (1, 32), "OCP", "ND", "mxfp8_bf16_1x32_nd", "normal"),
+    ("MXFP8", "bf16", (2, 32), "OCP", "ND", "mxfp8_bf16_2x32_nd", "normal"),
+    ("MXFP8", "bf16", (3, 32), "OCP", "ND", "mxfp8_bf16_3x32_nd", "normal"),
+    ("MXFP8", "bf16", (5, 96), "OCP", "ND", "mxfp8_bf16_5x96_nd", "normal"),
+    ("MXFP8", "bf16", (1, 32), "OCP", "ND", "mxfp8_bf16_1x32b_nd", "normal"),
+    ("MXFP8", "bf16", (4, 256), "OCP", "ND", "mxfp8_bf16_4x256_nd", "normal"),
+    ("MXFP8", "bf16", (4, 512), "OCP", "ND", "mxfp8_bf16_4x512_nd", "normal"),
+    ("MXFP8", "bf16", (3, 256), "OCP", "ND", "mxfp8_bf16_3x256_nd", "normal"),
+    ("MXFP8", "bf16", (5, 256), "OCP", "ND", "mxfp8_bf16_5x256_nd", "normal"),
+    ("MXFP8", "bf16", (1, 192), "OCP", "ND", "mxfp8_bf16_1x192_nd", "normal"),
+    ("MXFP8", "bf16", (1, 224), "OCP", "ND", "mxfp8_bf16_1x224_nd", "normal"),
+
+    # ── MXFP8 BF16 OCP NZ (3) ──
+    ("MXFP8", "bf16", (32, 128), "OCP", "NZ", "mxfp8_bf16_32x128_nz", "normal"),
+    ("MXFP8", "bf16", (64, 128), "OCP", "NZ", "mxfp8_bf16_64x128_nz", "normal"),
+    ("MXFP8", "bf16", (128, 128), "OCP", "NZ", "mxfp8_bf16_128x128_nz", "normal"),
+
+    # ── MXFP8 BF16 NV ND (4) ──
+    ("MXFP8", "bf16", (32, 128), "NV", "ND", "mxfp8_nv_bf16_32x128_nd", "normal"),
+    ("MXFP8", "bf16", (64, 128), "NV", "ND", "mxfp8_nv_bf16_64x128_nd", "normal"),
+    ("MXFP8", "bf16", (128, 128), "NV", "ND", "mxfp8_nv_bf16_128x128_nd", "normal"),
+    ("MXFP8", "bf16", (2, 256), "NV", "ND", "mxfp8_nv_bf16_2x256_boundary_nd", "boundary"),
+
+    # ── MXFP8 BF16 Exp2D OCP (1) ──
+    ("MXFP8", "bf16", (1, 64), "OCP", "Exp2D", "mxfp8_bf16_1x64_static3x128_exp2d_fuzz01_nd", "fuzz01"),
+
+    # ── MXFP8 FP16 OCP ND (5) ──
+    ("MXFP8", "f16", (32, 128), "OCP", "ND", "mxfp8_fp16_32x128_nd", "normal"),
+    ("MXFP8", "f16", (64, 128), "OCP", "ND", "mxfp8_fp16_64x128_nd", "normal"),
+    ("MXFP8", "f16", (128, 128), "OCP", "ND", "mxfp8_fp16_128x128_nd", "normal"),
+    ("MXFP8", "f16", (4, 256), "OCP", "ND", "mxfp8_fp16_4x256_nd", "normal"),
+    ("MXFP8", "f16", (11, 640), "OCP", "ND", "mxfp8_fp16_11x640_nd", "normal"),
+
+    # ── MXFP8 FP16 NV ND (4) ──
+    ("MXFP8", "f16", (32, 128), "NV", "ND", "mxfp8_nv_fp16_32x128_nd", "normal"),
+    ("MXFP8", "f16", (64, 128), "NV", "ND", "mxfp8_nv_fp16_64x128_nd", "normal"),
+    ("MXFP8", "f16", (128, 128), "NV", "ND", "mxfp8_nv_fp16_128x128_nd", "normal"),
+    ("MXFP8", "f16", (2, 256), "NV", "ND", "mxfp8_nv_fp16_2x256_boundary_nd", "boundary"),
+
+    # ── MXFP8 FP16 OCP NZ (3) ──
+    ("MXFP8", "f16", (32, 128), "OCP", "NZ", "mxfp8_fp16_32x128_nz", "normal"),
+    ("MXFP8", "f16", (64, 128), "OCP", "NZ", "mxfp8_fp16_64x128_nz", "normal"),
+    ("MXFP8", "f16", (128, 128), "OCP", "NZ", "mxfp8_fp16_128x128_nz", "normal"),
+
+    # ── MXFP4 E2M1 FP16 OCP ND (9) ──
+    ("MXFP4_E2M1", "f16", (2, 128), "OCP", "ND", "mxfp4_e2m1_fp16_2x128_special_nd", "special"),
+    ("MXFP4_E2M1", "f16", (2, 128), "OCP", "ND", "mxfp4_e2m1_fp16_2x128_inf_only_nd", "inf_only"),
+    ("MXFP4_E2M1", "f16", (2, 128), "OCP", "ND", "mxfp4_e2m1_fp16_2x128_subnormal_nd", "subnormal"),
+    ("MXFP4_E2M1", "f16", (2, 128), "OCP", "ND", "mxfp4_e2m1_fp16_2x128_rounding_nd", "rounding"),
+    ("MXFP4_E2M1", "f16", (2, 128), "OCP", "ND", "mxfp4_e2m1_fp16_2x128_exp_random_a_nd", "exp_random_a"),
+    ("MXFP4_E2M1", "f16", (2, 128), "OCP", "ND", "mxfp4_e2m1_fp16_2x128_exp_random_b_nd", "exp_random_b"),
+    ("MXFP4_E2M1", "f16", (2, 128), "OCP", "ND", "mxfp4_e2m1_fp16_2x128_mixed_nd", "mixed"),
+    ("MXFP4_E2M1", "f16", (32, 1024), "OCP", "ND", "mxfp4_e2m1_fp16_32x1024_mixed_nd", "mixed"),
+    ("MXFP4_E2M1", "f16", (32, 1024), "OCP", "ND", "mxfp4_e2m1_fp16_32x1024_normal_nd", "normal"),
+
+    # ── MXFP4 E2M1 FP16 NV ND (3) ──
+    ("MXFP4_E2M1", "f16", (2, 256), "NV", "ND", "mxfp4_e2m1_nv_fp16_2x256_boundary_nd", "boundary"),
+    ("MXFP4_E2M1", "f16", (2, 256), "NV", "ND", "mxfp4_e2m1_nv_fp16_2x256_rounding_nd", "rounding"),
+    ("MXFP4_E2M1", "f16", (2, 256), "NV", "ND", "mxfp4_e2m1_nv_fp16_2x256_mixed_nd", "mixed"),
+
+    # ── MXFP4 E2M1 BF16 OCP ND (9) ──
+    ("MXFP4_E2M1", "bf16", (2, 128), "OCP", "ND", "mxfp4_e2m1_bf16_2x128_special_nd", "special"),
+    ("MXFP4_E2M1", "bf16", (2, 128), "OCP", "ND", "mxfp4_e2m1_bf16_2x128_inf_only_nd", "inf_only"),
+    ("MXFP4_E2M1", "bf16", (2, 128), "OCP", "ND", "mxfp4_e2m1_bf16_2x128_subnormal_nd", "subnormal"),
+    ("MXFP4_E2M1", "bf16", (2, 128), "OCP", "ND", "mxfp4_e2m1_bf16_2x128_rounding_nd", "rounding"),
+    ("MXFP4_E2M1", "bf16", (2, 128), "OCP", "ND", "mxfp4_e2m1_bf16_2x128_exp_random_a_nd", "exp_random_a"),
+    ("MXFP4_E2M1", "bf16", (2, 128), "OCP", "ND", "mxfp4_e2m1_bf16_2x128_exp_random_b_nd", "exp_random_b"),
+    ("MXFP4_E2M1", "bf16", (2, 128), "OCP", "ND", "mxfp4_e2m1_bf16_2x128_mixed_nd", "mixed"),
+    ("MXFP4_E2M1", "bf16", (32, 1024), "OCP", "ND", "mxfp4_e2m1_bf16_32x1024_mixed_nd", "mixed"),
+    ("MXFP4_E2M1", "bf16", (32, 1024), "OCP", "ND", "mxfp4_e2m1_bf16_32x1024_normal_nd", "normal"),
+
+    # ── MXFP4 E2M1 BF16 NV ND (3) ──
+    ("MXFP4_E2M1", "bf16", (2, 256), "NV", "ND", "mxfp4_e2m1_nv_bf16_2x256_boundary_nd", "boundary"),
+    ("MXFP4_E2M1", "bf16", (2, 256), "NV", "ND", "mxfp4_e2m1_nv_bf16_2x256_rounding_nd", "rounding"),
+    ("MXFP4_E2M1", "bf16", (2, 256), "NV", "ND", "mxfp4_e2m1_nv_bf16_2x256_mixed_nd", "mixed"),
+
+    # ── MXFP4 E2M1 BF16 NV Exp2D (1) ──
+    ("MXFP4_E2M1", "bf16", (2, 128), "NV", "Exp2D", "mxfp4_e2m1_nv_bf16_2x128_static4x128_exp2d_nd", "normal"),
+
+
+    ("MXFP8", "bf16", (64, 128, 128), "OCP", "DN", "bf16_64x128", "normal"),
+    ("MXFP4_E2M1", "f16", (64, 128, 128), "OCP", "DN", "mxfp4_fp16_64x128", "normal"),
+    ("MXFP8", "bf16", (512, 48, 64, 24), "OCP", "DN_valid_shape", "validshape_bf16_s512x48_v64x24", "normal"),
+    ("MXFP8", "f16", (896, 48, 896, 34), "NV", "DN_valid_shape", "nv_validshape_fp16_s896x48_v896x34", "normal"),
+    ("MXFP8", "f32", (128, 128, 128), "NV", "DN_interleave", "nv_fp32_128x128_interleaved", "normal"),
+    ("MXFP4_E2M1", "bf16", (128, 128, 128), "NV", "DN_interleave", "nv_mxfp4_bf16_128x128_interleaved", "normal"),
+]
+
+assert len(_SPECS) == 86, f"Expected 86 specs, got {len(_SPECS)}"
+
+
+
+# ════════════════════════════════════════════════════════════════
+#  INT8 kernels + golden
+# ════════════════════════════════════════════════════════════════
+
+def _sym_kernel(name, r, c):
+    pc = _ca(c, 4)
+    dc = _ca(c, 1)
+
+    @pto.jit(name=name, target="a5", kernel_kind="vector")
+    def _k(s: pto.ptr(pto.f32, "gm"), f: pto.ptr(pto.f32, "gm"),
+           d: pto.ptr(pto.i8, "gm")):
+        st = pto.alloc_tile(shape=[r, pc], dtype=pto.f32, valid_shape=[r, c])
+        ft = pto.alloc_tile(shape=[r, 1], dtype=pto.f32, valid_shape=[r, 1],
+                            blayout="ColMajor")
+        dt = pto.alloc_tile(shape=[r, dc], dtype=pto.i8, valid_shape=[r, c])
+        pto.tile.load(pto.make_tensor_view(s, shape=[r, c], strides=[c, 1]), st)
+        pto.tile.load(pto.make_tensor_view(f, shape=[r, 1], strides=[1, 1],
+                                            layout="dn"), ft)
+        pto.tile.quant(st, ft, dt)
+        pto.tile.store(dt, pto.make_tensor_view(d, shape=[r, c], strides=[c, 1]))
+        pto.pipe_barrier(pto.Pipe.ALL)
+    return _k
+
+
+def _asym_kernel(name, r, c):
+    pc = _ca(c, 4)
+    dc = _ca(c, 1)
+
+    @pto.jit(name=name, target="a5", kernel_kind="vector")
+    def _k(s: pto.ptr(pto.f32, "gm"), f: pto.ptr(pto.f32, "gm"),
+           o: pto.ptr(pto.f32, "gm"), d: pto.ptr(pto.ui8, "gm")):
+        st = pto.alloc_tile(shape=[r, pc], dtype=pto.f32, valid_shape=[r, c])
+        ft = pto.alloc_tile(shape=[r, 1], dtype=pto.f32, valid_shape=[r, 1],
+                            blayout="ColMajor")
+        ot = pto.alloc_tile(shape=[r, 1], dtype=pto.f32, valid_shape=[r, 1],
+                            blayout="ColMajor")
+        dt = pto.alloc_tile(shape=[r, dc], dtype=pto.ui8, valid_shape=[r, c])
+        pto.tile.load(pto.make_tensor_view(s, shape=[r, c], strides=[c, 1]), st)
+        pto.tile.load(pto.make_tensor_view(f, shape=[r, 1], strides=[1, 1],
+                                            layout="dn"), ft)
+        pto.tile.load(pto.make_tensor_view(o, shape=[r, 1], strides=[1, 1],
+                                            layout="dn"), ot)
+        pto.tile.quant(st, ft, dt, offset=ot)
+        pto.tile.store(dt, pto.make_tensor_view(d, shape=[r, c], strides=[c, 1]))
+        pto.pipe_barrier(pto.Pipe.ALL)
+    return _k
+
+
+def _sym_golden(src, scale):
+    return np.clip(np.round(src * scale[:, 0:1]), -128, 127).astype(np.int8)
+
+
+def _asym_golden(src, scale, offset):
+    return np.clip(np.round(src * scale[:, 0:1] + offset[:, 0:1]),
+                   0, 255).astype(np.uint8)
+
+
+# ════════════════════════════════════════════════════════════════
+#  MX kernels
+# ════════════════════════════════════════════════════════════════
+
+_DTYPE_MAP = {
+    "f32": pto.f32,
+    "bf16": pto.bf16,
+    "f16": pto.f16,
+}
+
+_BW = {
+    pto.f32: 4,
+    pto.f16: 2,
+    pto.bf16: 2,
+}
+
+_DDT_MAP = {
+    "MXFP8": pto.ui8,
+    "MXFP4_E2M1": pto.f4e2m1x2,
+}
+
+
+def _mx_nd_kernel(name, r, c, sdt, ddt, quant_type, scale_alg):
+    pad_c = _ca(c, 1)
+    evc = (r * pad_c) // 32
+    ec = _ca(evc, 1)
+    bw = _BW[sdt]
+    # TQuantMx verifier parity (axis1 flat): f32 scaling must cover
+    # alignTo(groups[*2 if unrolled], 64) elements; B16 OCP scaling must
+    # cover alignTo(groups, 128) elements (256B either way). unroll kicks in
+    # when src physical elems > 1024 and both physical/valid elems %256==0.
+    src_elems = r * pad_c
+    unroll = src_elems > 1024 and src_elems % 256 == 0 and (r * c) % 256 == 0
+    if bw == 4:
+        need = evc * (2 if unroll else 1)
+        mc = max(_ca(evc, bw), ((need + 63) // 64) * 64)
+    else:
+        mc = max(_ca(evc, bw), ((evc + 127) // 128) * 128)
+    ds = pad_c
+    is_fp4 = quant_type == "MXFP4_E2M1"
+    dst_valid_c = c // 2 if is_fp4 else c
+    dst_ds = _ca(c // 2, 1) if is_fp4 else ds
+    groups_per_row = pad_c // 32
+    ec_2d = _ca(groups_per_row, 1)
+
+    @pto.jit(name=name, target="a5", kernel_kind="vector")
+    def _k(sp: pto.ptr(sdt, "gm"), ep: pto.ptr(pto.ui8, "gm"),
+           dp: pto.ptr(ddt, "gm")):
+        st = pto.alloc_tile(shape=[r, pad_c], dtype=sdt, valid_shape=[r, c])
+        dt = pto.alloc_tile(shape=[r, dst_ds], dtype=ddt, valid_shape=[r, dst_valid_c])
+        if is_fp4:
+            et = pto.alloc_tile(shape=[r, ec_2d], dtype=pto.ui8, valid_shape=[r, groups_per_row])
+        else:
+            et = pto.alloc_tile(shape=[1, ec], dtype=pto.ui8, valid_shape=[1, evc])
+        mt = pto.alloc_tile(shape=[1, mc], dtype=sdt, valid_shape=[1, evc])
+        st2 = pto.alloc_tile(shape=[1, mc], dtype=sdt, valid_shape=[1, evc])
+        pto.tile.load(pto.make_tensor_view(sp, shape=[r, c], strides=[c, 1]), st)
+        pto.set_flag("MTE2", "V", event_id=0)
+        pto.wait_flag("MTE2", "V", event_id=0)
+        kwargs = {}
+        if scale_alg != "OCP":
+            kwargs["quant_scale_alg"] = scale_alg.lower()
+        pto.tile.quant.mx(st, dt, et, mt, st2, quant_type=quant_type, **kwargs)
+        pto.set_flag("V", "MTE3", event_id=0)
+        pto.wait_flag("V", "MTE3", event_id=0)
+        pto.tile.store(dt, pto.make_tensor_view(dp, shape=[r, dst_valid_c], strides=[dst_valid_c, 1]))
+        if is_fp4:
+            pto.tile.store(et, pto.make_tensor_view(ep, shape=[r, groups_per_row], strides=[groups_per_row, 1]))
+        else:
+            pto.tile.store(et, pto.make_tensor_view(ep, shape=[1, evc], strides=[evc, 1]))
+        pto.pipe_barrier(pto.Pipe.ALL)
+    return _k
+
+
+def _mx_nz_kernel(name, r, c, sdt, ddt, quant_type):
+    pad_c = _ca(c, 1)
+    evc = (r * pad_c) // 32
+    ec = _ca(evc, 1)
+    bw = _BW[sdt]
+    src_elems = r * pad_c
+    unroll = src_elems > 1024 and src_elems % 256 == 0 and (r * c) % 256 == 0
+    if bw == 4:
+        need = evc * (2 if unroll else 1)
+        mc = max(_ca(evc, bw), ((need + 63) // 64) * 64)
+    else:
+        mc = max(_ca(evc, bw), ((evc + 127) // 128) * 128)
+    ds = pad_c
+
+    @pto.jit(name=name, target="a5", kernel_kind="vector")
+    def _k(sp: pto.ptr(sdt, "gm"), ep: pto.ptr(pto.ui8, "gm"),
+           dp: pto.ptr(ddt, "gm")):
+        st = pto.alloc_tile(shape=[r, pad_c], dtype=sdt, valid_shape=[r, c])
+        dt = pto.alloc_tile(shape=[r, ds], dtype=ddt, valid_shape=[r, c])
+        et = pto.alloc_tile(shape=[1, ec], dtype=pto.ui8, valid_shape=[1, evc])
+        mt = pto.alloc_tile(shape=[1, mc], dtype=sdt, valid_shape=[1, evc])
+        st2 = pto.alloc_tile(shape=[1, mc], dtype=sdt, valid_shape=[1, evc])
+        pto.tile.load(pto.make_tensor_view(sp, shape=[r, c], strides=[c, 1]), st)
+        pto.set_flag("MTE2", "V", event_id=0)
+        pto.wait_flag("MTE2", "V", event_id=0)
+        pto.tile.quant.mx(st, dt, et, mt, st2, quant_type=quant_type)
+        pto.set_flag("V", "MTE3", event_id=0)
+        pto.wait_flag("V", "MTE3", event_id=0)
+        pto.tile.store(dt, pto.make_tensor_view(dp, shape=[r, c], strides=[c, 1]))
+        pto.tile.store(et, pto.make_tensor_view(ep, shape=[1, evc], strides=[evc, 1]))
+        pto.pipe_barrier(pto.Pipe.ALL)
+    return _k
+
+
+def _mx_exp2d_kernel(name, vr, vc, sr, sc, sdt, ddt, quant_type, scale_alg):
+    is_fp4 = quant_type == "MXFP4_E2M1"
+    dst_valid_c = vc // 2 if is_fp4 else vc
+    valid_groups = vc // 32
+    ds = sc if not is_fp4 else sc // 2
+    # pto-isa MxFp8Exp2DSpec: expCols = ceil(staticCols/32, 32) — physical
+    # cols must cover canonical [M, N/32] and pass the 32-group alignment.
+    sec = _ca(_ca(sc // 32, 32), 1)
+    bw = _BW[sdt]
+    mc = _ca(vr * valid_groups, bw)
+
+    @pto.jit(name=name, target="a5", kernel_kind="vector")
+    def _k(sp: pto.ptr(sdt, "gm"), ep: pto.ptr(pto.ui8, "gm"),
+           dp: pto.ptr(ddt, "gm")):
+        st = pto.alloc_tile(shape=[sr, sc], dtype=sdt, valid_shape=[vr, vc])
+        dt = pto.alloc_tile(shape=[sr, ds], dtype=ddt, valid_shape=[vr, dst_valid_c])
+        et = pto.alloc_tile(shape=[sr, sec], dtype=pto.ui8, valid_shape=[vr, valid_groups])
+        mt = pto.alloc_tile(shape=[1, mc], dtype=sdt, valid_shape=[1, vr * valid_groups])
+        st2 = pto.alloc_tile(shape=[1, mc], dtype=sdt, valid_shape=[1, vr * valid_groups])
+        pto.tile.load(pto.make_tensor_view(sp, shape=[vr, vc], strides=[vc, 1]), st)
+        pto.set_flag("MTE2", "V", event_id=0)
+        pto.wait_flag("MTE2", "V", event_id=0)
+        kwargs = {}
+        if scale_alg != "OCP":
+            kwargs["quant_scale_alg"] = scale_alg.lower()
+        pto.tile.quant.mx(st, dt, et, mt, st2,
+                          quant_type=quant_type, **kwargs)
+        pto.set_flag("V", "MTE3", event_id=0)
+        pto.wait_flag("V", "MTE3", event_id=0)
+        pto.tile.store(dt, pto.make_tensor_view(dp, shape=[vr, dst_valid_c], strides=[dst_valid_c, 1]))
+        pto.tile.store(et, pto.make_tensor_view(ep, shape=[vr, valid_groups], strides=[valid_groups, 1]))
+        pto.pipe_barrier(pto.Pipe.ALL)
+    return _k
+
+
+def _mx_dn_kernel(name, r, c, npad, sdt, ddt, quant_type, scale_alg="OCP", interleave=False):
+    is_fp4 = quant_type == "MXFP4_E2M1"
+    dst_valid_c = c // 2 if is_fp4 else c
+    ds = npad if not is_fp4 else npad // 2
+    hat_m = r // 32
+    hat_e = r // 64
+    et_cols = _ca(npad * 2, 1) if interleave else npad
+
+    @pto.jit(name=name, target="a5", kernel_kind="vector")
+    def _k(sp: pto.ptr(sdt, "gm"), ep: pto.ptr(pto.ui8, "gm"),
+           dp: pto.ptr(ddt, "gm")):
+        st = pto.alloc_tile(shape=[r, npad], dtype=sdt, valid_shape=[r, c])
+        dt = pto.alloc_tile(shape=[r, ds], dtype=ddt, valid_shape=[r, dst_valid_c])
+        if interleave:
+            et = pto.alloc_tile(shape=[hat_e, et_cols], dtype=pto.ui8, valid_shape=[hat_e, c * 2])
+        else:
+            et = pto.alloc_tile(shape=[hat_m, npad], dtype=pto.ui8,
+                                valid_shape=[hat_m, c])
+        mt = pto.alloc_tile(shape=[hat_m, npad], dtype=sdt,
+                            valid_shape=[hat_m, c])
+        st2 = pto.alloc_tile(shape=[hat_m, npad], dtype=sdt,
+                             valid_shape=[hat_m, c])
+        pto.tile.load(pto.make_tensor_view(sp, shape=[r, c], strides=[c, 1]), st)
+        pto.set_flag("MTE2", "V", event_id=0)
+        pto.wait_flag("MTE2", "V", event_id=0)
+        kw = {}
+        if scale_alg != "OCP":
+            kw["quant_scale_alg"] = scale_alg.lower()
+        if interleave:
+            kw["interleave"] = True
+        pto.tile.quant.mx(st, dt, et, mt, st2, quant_type=quant_type, grp_axis=0, **kw)
+        pto.set_flag("V", "MTE3", event_id=0)
+        pto.wait_flag("V", "MTE3", event_id=0)
+        pto.tile.store(dt, pto.make_tensor_view(dp, shape=[r, dst_valid_c], strides=[dst_valid_c, 1]))
+        if interleave:
+            pto.tile.store(et, pto.make_tensor_view(ep, shape=[hat_e, c * 2], strides=[c * 2, 1]))
+        else:
+            pto.tile.store(et, pto.make_tensor_view(ep, shape=[hat_m, c],
+                                                    strides=[c, 1]))
+        pto.pipe_barrier(pto.Pipe.ALL)
+    return _k
+
+
+def _mx_dn_valid_shape_kernel(name, sr, sc, vr, vc, sdt, ddt, quant_type, scale_alg="OCP"):
+    hat_m = vr // 32
+    # Upstream TQuantMxOp verifier: interleaved exp physical rows must be
+    # src PHYSICAL rows / 64 (not valid rows).
+    hat_e = sr // 64
+    et_cols = _ca(sc * 2, 1)
+    is_fp4 = quant_type == "MXFP4_E2M1"
+    dst_valid_c = vc // 2 if is_fp4 else vc
+    ds = _ca(sc, 1) if not is_fp4 else _ca(sc // 2, 1)
+
+    @pto.jit(name=name, target="a5", kernel_kind="vector")
+    def _k(sp: pto.ptr(sdt, "gm"), ep: pto.ptr(pto.ui8, "gm"),
+           dp: pto.ptr(ddt, "gm")):
+        st = pto.alloc_tile(shape=[sr, sc], dtype=sdt, valid_shape=[vr, vc])
+        dt = pto.alloc_tile(shape=[sr, ds], dtype=ddt, valid_shape=[vr, dst_valid_c])
+        et = pto.alloc_tile(shape=[hat_e, et_cols], dtype=pto.ui8, valid_shape=[vr // 64, vc * 2])
+        mt = pto.alloc_tile(shape=[hat_m, sc], dtype=sdt, valid_shape=[vr // 32, vc])
+        st2 = pto.alloc_tile(shape=[hat_m, sc], dtype=sdt, valid_shape=[vr // 32, vc])
+        pto.tile.load(pto.make_tensor_view(sp, shape=[vr, vc], strides=[vc, 1]), st)
+        pto.set_flag("MTE2", "V", event_id=0)
+        pto.wait_flag("MTE2", "V", event_id=0)
+        kw = {}
+        if scale_alg != "OCP":
+            kw["quant_scale_alg"] = scale_alg.lower()
+        kw["interleave"] = True
+        pto.tile.quant.mx(st, dt, et, mt, st2, quant_type=quant_type, grp_axis=0, **kw)
+        pto.set_flag("V", "MTE3", event_id=0)
+        pto.wait_flag("V", "MTE3", event_id=0)
+        pto.tile.store(dt, pto.make_tensor_view(dp, shape=[vr, dst_valid_c], strides=[dst_valid_c, 1]))
+        pto.tile.store(et, pto.make_tensor_view(ep, shape=[vr // 64, vc * 2], strides=[vc * 2, 1]))
+        pto.pipe_barrier(pto.Pipe.ALL)
+    return _k
+
+
+# ════════════════════════════════════════════════════════════════
+#  MX golden: FP32 → FP8 E4M3 element conversion
+# ════════════════════════════════════════════════════════════════
+
+def _fp32_to_fp8_e4m3(val):
+    if np.isnan(val):
+        return 0x7F
+    if np.isinf(val):
+        return 0x7E if val > 0 else 0xFE
+    sign = 0x80 if val < 0 else 0
+    x = abs(val)
+    if x == 0:
+        return sign
+    exp = int(np.floor(np.log2(x)))
+    exp = max(-6, min(7, exp))
+    mant_frac = (x / (2 ** exp) - 1.0) * 4.0
+    mant = int(mant_frac)
+    if mant_frac - mant == 0.5:
+        mant = (mant + 1) if (mant & 1) else mant
+    else:
+        mant = int(mant_frac + 0.5)
+    if mant >= 4:
+        exp += 1
+        mant = 0
+    if exp > 7:
+        return 0x7E | sign
+    if exp < -6:
+        return sign
+    return sign | ((exp + 7) << 2) | mant
+
+
+# ════════════════════════════════════════════════════════════════
+#  MX golden: OCP shared exponent + scaling
+# ════════════════════════════════════════════════════════════════
+
+def _ocp_exp_and_scale(max_abs_f32, emax):
+    """OCP: shared_exp = max(0, max_exp - emax), scale = 2^(254-shared_exp)."""
+    bits = struct.unpack("I", struct.pack("f", float(max_abs_f32)))[0]
+    e = (bits >> 23) & 0xFF
+    mant = bits & 0x7FFFFF
+    if e == 0xFF and mant != 0:
+        return 0xFF, float("nan")
+    if e <= emax:
+        return 0x00, struct.unpack("f", struct.pack("I", 0x7F000000))[0]
+    shared_exp = e - emax
+    scale_exp = 254 - shared_exp
+    scale = struct.unpack("f", struct.pack("I", scale_exp << 23))[0]
+    return shared_exp, scale
+
+
+def _nv_exp_and_scale(max_abs_f32, descale_multiplier):
+    """NV: shared_exp = ceil(log2(max * descale)), with rounding."""
+    scaled_max = float(max_abs_f32) * descale_multiplier
+    bits = struct.unpack("I", struct.pack("f", scaled_max))[0]
+    e = (bits >> 23) & 0xFF
+    mant = bits & 0x7FFFFF
+    if e == 0xFF:
+        if mant != 0:
+            return 0xFF, float("nan")
+        return 0xFE, struct.unpack("f", struct.pack("I", 0x00400000))[0]
+    shared_exp = e
+    if mant > 0 and e > 0 and e < 0xFE:
+        shared_exp = e + 1
+    elif mant > 0x00400000 and e == 0:
+        shared_exp = 1
+    scale_exp = 0xFE - shared_exp
+    scale = struct.unpack("f", struct.pack("I", scale_exp << 23))[0]
+    return shared_exp, scale
+
+
+_EMAX = {"MXFP8": 8, "MXFP4_E2M1": 8}
+_DESCALE = {"MXFP8": 1.0 / 448.0, "MXFP4_E2M1": 1.0 / 6.0}
+
+
+from ml_dtypes import float8_e4m3fn as _f8e4m3
+from ml_dtypes import bfloat16 as _bf16
+from ml_dtypes import float4_e2m1fn as _f4e2m1
+
+
+def _nv_fp32_to_fp8_element(data_abs_max):
+
+    if np.float32(data_abs_max) == np.float32(0.0):
+        return 0x00, np.float32(0x7F000000).view(np.float32)
+    descale = np.float32(data_abs_max) * np.float32(1.0 / 448.0)
+    bits = np.uint32(np.frombuffer(descale.tobytes(), dtype=np.uint32)[0])
+    exponent = int((bits & np.uint32(0x7F800000)) >> np.uint32(23))
+    mantissa = int(bits & np.uint32(0x007FFFFF))
+    if exponent == 0xFF:
+        if mantissa == 0:
+            return 0xFE, np.float32(2.0**-127)
+        return 0xFF, np.float32(np.nan)
+    round_up = mantissa > 0 and exponent != 0xFE and not (exponent == 0 and mantissa <= 0x00400000)
+    e8m0 = exponent + (1 if round_up else 0)
+    if e8m0 == 0:
+        return e8m0, np.float32(0x7F000000).view(np.float32)
+    if e8m0 == 0xFE:
+        return e8m0, np.float32(2.0**-127)
+    scaling_bits = np.uint32((254 - e8m0) << 23)
+    return e8m0, scaling_bits.view(np.float32)
+
+
+def _pad_src(src, r, c, dtype):
+
+    pad_c = _ca(c, 1)
+    if pad_c == c:
+        return src.reshape(r, c)
+    padded = np.zeros((r, pad_c), dtype=dtype)
+    padded[:, :c] = src.reshape(r, c)
+    return padded
+
+
+def _mxfp8_dn_golden(src, r, c, scale_alg, dt_name):
+
+    from _gen_data_dn import get_group_max_dn, scale_data_dn, fp32_maxes_to_fp8, nv_maxes_to_mx, fp32_to_e4m3
+    pad_c = _ca(c, 1)
+    npad = c
+    if dt_name == "f32":
+        src_padded = _pad_src(src, r, c, np.float32)
+        src_fp32 = src_padded.astype(np.float32)
+    elif dt_name == "bf16":
+        src_padded = _pad_src(src, r, c, _bf16)
+        src_fp32 = src_padded.astype(np.float32)
+    else:
+        src_padded = _pad_src(src, r, c, np.float16)
+        src_fp32 = src_padded.astype(np.float32)
+
+    group_max = get_group_max_dn(src_fp32, group_size=32)
+    if scale_alg == "NV":
+        e8m0, scaling = nv_maxes_to_mx(group_max, 448.0)
+    else:
+        e8m0, scaling = fp32_maxes_to_fp8(group_max)
+    scaled = scale_data_dn(src_fp32, scaling, group_size=32)
+    scaled = np.clip(scaled, -448.0, 448.0)
+    data_fp8 = fp32_to_e4m3(scaled).reshape(r, pad_c)[:, :c].copy()
+    return data_fp8
+
+
+def _mxfp8_golden(src, r, c, scale_alg):
+
+    src = _pad_src(src, r, c, np.float32)
+    pad_c = _ca(c, 1)
+    n = r * pad_c
+    num_groups = n // 32
+    data_abs = np.abs(src).reshape(-1, 32)
+    group_max = np.max(data_abs, axis=1)
+
+    if scale_alg == "NV":
+        scalings = np.array([_nv_fp32_to_fp8_element(mx)[1] for mx in group_max],
+                            dtype=np.float32).reshape(-1, 1)
+    else:
+        scalings = np.array([_ocp_exp_and_scale(mx, _EMAX["MXFP8"])[1] for mx in group_max],
+                            dtype=np.float32).reshape(-1, 1)
+
+    scaled = src.reshape(-1, 32) * scalings
+    scaled = np.clip(scaled, -448.0, 448.0)
+    data_fp8 = scaled.astype(_f8e4m3).view(np.uint8).reshape(r, pad_c)[:, :c].copy()
+    return data_fp8
+
+
+def _mxfp8_bf16_golden(src, r, c, scale_alg):
+
+    src_bf16 = _pad_src(src, r, c, _bf16)
+    pad_c = _ca(c, 1)
+    data_abs = np.abs(src_bf16).reshape(-1, 32)
+    with np.errstate(invalid="ignore"):
+        group_max_bf16 = np.max(data_abs, axis=1)
+    group_max_fp32 = group_max_bf16.astype(np.float32)
+
+    if scale_alg == "NV":
+        scalings_fp32 = np.array([_nv_fp32_to_fp8_element(mx)[1] for mx in group_max_fp32],
+                                 dtype=np.float32).reshape(-1, 1)
+    else:
+        scalings_fp32 = np.array([_ocp_exp_and_scale(mx, _EMAX["MXFP8"])[1] for mx in group_max_fp32],
+                                 dtype=np.float32).reshape(-1, 1)
+    scalings_bf16 = scalings_fp32.astype(_bf16)
+
+    scaled = (src_bf16.reshape(-1, 32) * scalings_bf16).astype(_bf16)
+    scaled = np.clip(scaled, _bf16(-448), _bf16(448))
+    data_fp8 = scaled.astype(_f8e4m3).view(np.uint8).reshape(r, pad_c)[:, :c].copy()
+    return data_fp8
+
+
+def _fp32_to_fp4_e2m1(val):
+    """F32 → FP4 E2M1 nibble (0-15), packed two per byte."""
+    if np.isnan(val):
+        return 0x7
+    if np.isinf(val):
+        return 0x7 if val > 0 else 0xF
+    sign = 1 if val < 0 else 0
+    x = abs(val)
+    if x == 0:
+        return 0x0 | (sign << 3)
+    exp = int(np.floor(np.log2(x)))
+    exp = max(-1, min(2, exp))
+    mant_frac = (x / (2 ** exp) - 1.0) * 2.0
+    mant = int(mant_frac + 0.5)
+    if mant >= 2:
+        exp += 1
+        mant = 0
+    if exp > 2:
+        return 0x6 | (sign << 3)
+    if exp < -1:
+        return 0x0 | (sign << 3)
+    code = (sign << 3) | ((exp + 1) << 1) | mant
+    return code
+
+
+def _mxfp4_golden(src, r, c, scale_alg):
+    """MXFP4 E2M1 golden: → packed FP4 bytes."""
+    src = _pad_src(src, r, c, np.float32).flatten()
+    pad_c = _ca(c, 1)
+    n = r * pad_c
+    num_groups = n // 32
+    codes = np.zeros(n, dtype=np.uint8)
+    for g in range(num_groups):
+        base = g * 32
+        group = src[base:base + 32]
+        mx = float(np.max(np.abs(group)))
+        if scale_alg == "NV":
+            _, scale = _nv_exp_and_scale(mx, _DESCALE["MXFP4_E2M1"])
+        else:
+            _, scale = _ocp_exp_and_scale(mx, _EMAX["MXFP4_E2M1"])
+        for i in range(32):
+            codes[base + i] = _fp32_to_fp4_e2m1(group[i] * scale)
+    packed = np.zeros(n // 2, dtype=np.uint8)
+    for i in range(0, n, 2):
+        packed[i // 2] = (codes[i] & 0xF) | ((codes[i + 1] & 0xF) << 4)
+    return packed.reshape(r, pad_c // 2)[:, :c // 2].copy()
+
+
+# ════════════════════════════════════════════════════════════════
+#  Input generators with data patterns
+# ════════════════════════════════════════════════════════════════
+
+def _gen_pattern(pattern, r, c, dtype_np, seed_k):
+    rng = np.random.default_rng(seed_k)
+    n = r * c
+
+    if pattern == "normal":
+        mags = rng.lognormal(mean=0.0, sigma=2.0, size=(r, c))
+        signs = np.where(rng.random((r, c)) < 0.5, -1.0, 1.0)
+        data = (mags * signs).astype(np.float32)
+        data = np.clip(data, -1e8, 1e8)
+    elif pattern == "boundary":
+        data = rng.uniform(-20, 20, size=(r, c))
+        data.flat[0] = 448.0
+        data.flat[1] = -448.0
+        if n > 2:
+            data.flat[2] = 1.0
+        if n > 3:
+            data.flat[3] = -1.0
+    elif pattern == "special":
+        vals = [0.0, float("inf"), -float("inf"), float("nan"),
+                448.0, -448.0, 1.0, -1.0, 0.5, -0.5, 256.0, -256.0,
+                1e-38, -1e-38, 3.0, -3.0]
+        data = np.array(vals * (n // len(vals) + 1))[:n].reshape(r, c)
+    elif pattern == "inf_only":
+        data = np.zeros((r, c))
+        data.flat[::2] = float("inf")
+        data.flat[1::2] = -float("inf")
+    elif pattern == "subnormal":
+        data = rng.uniform(-20, 20, size=(r, c))
+        data.flat[::4] = 1e-38
+        data.flat[1::4] = -1e-38
+        data.flat[2::4] = 1e-40
+        data.flat[3::4] = -1e-40
+    elif pattern == "rounding":
+        vals = [0.5, 1.5, 2.5, 3.5, -0.5, -1.5, -2.5, -3.5,
+                0.25, 0.75, 1.25, 1.75, -0.25, -0.75, -1.25, -1.75]
+        data = np.array(vals * (n // len(vals) + 1))[:n].reshape(r, c)
+    elif pattern == "exp_random_a":
+        data = rng.uniform(-20, 20, size=(r, c))
+    elif pattern == "exp_random_b":
+        data = rng.uniform(-100, 100, size=(r, c))
+    elif pattern == "mixed":
+        data = rng.uniform(-20, 20, size=(r, c))
+        for i in range(0, n, 32):
+            if i < n:
+                data.flat[i] = float("inf")
+            if i + 1 < n:
+                data.flat[i + 1] = 0.0
+            if i + 2 < n:
+                data.flat[i + 2] = 1e-38
+            if i + 3 < n:
+                data.flat[i + 3] = 448.0
+    else:
+        data = rng.uniform(-20, 20, size=(r, c))
+
+    return data.astype(dtype_np)
+
+
+def _mx4_inputs(r, c, dtype_name, pattern, scale_alg, name=""):
+
+    from _gen_data_nd import make_mxfp4_e2m1_fp16_data, make_mxfp4_e2m1_bf16_data
+    case_suffix = pattern
+    if "static4x128_exp2d" in name:
+        case_suffix = "static4x128_exp2d"
+    gen_scale_alg = "nv" if scale_alg == "NV" else "ocp"
+    if dtype_name == "f16":
+        data = make_mxfp4_e2m1_fp16_data(r, c, case_suffix, gen_scale_alg)
+    else:
+        data = make_mxfp4_e2m1_bf16_data(r, c, case_suffix, gen_scale_alg)
+    return [data]
+
+
+def _mx_inputs(r, c, dtype_name, pattern, seed_k, quant_type=None, scale_alg="OCP", name=""):
+    if quant_type == "MXFP4_E2M1":
+        return _mx4_inputs(r, c, dtype_name, pattern, scale_alg, name)
+    np_dt, _ = _NP_DT[_DTYPE_MAP[dtype_name]]
+    return [_gen_pattern(pattern, r, c, np_dt, seed_k)]
+
+
+def _mxfp8_fp16_golden(src, r, c, scale_alg):
+
+    src_f16 = _pad_src(src, r, c, np.float16)
+    pad_c = _ca(c, 1)
+    data_abs = np.abs(src_f16).reshape(-1, 32)
+    with np.errstate(invalid="ignore"):
+        group_max_f16 = np.max(data_abs, axis=1)
+    group_max_fp32 = group_max_f16.astype(np.float32)
+
+    if scale_alg == "NV":
+        scalings_fp32 = np.array([_nv_fp32_to_fp8_element(mx)[1] for mx in group_max_fp32],
+                                 dtype=np.float32).reshape(-1, 1)
+    else:
+        scalings_fp32 = np.array([_ocp_exp_and_scale(mx, _EMAX["MXFP8"])[1] for mx in group_max_fp32],
+                                 dtype=np.float32).reshape(-1, 1)
+    scalings_bf16 = scalings_fp32.astype(_bf16).astype(np.float32)
+
+    src_fp32 = src_f16.astype(np.float32).reshape(-1, 32)
+    scaled = src_fp32 * scalings_bf16
+    scaled = np.clip(scaled, -448.0, 448.0)
+    data_fp8 = scaled.astype(_f8e4m3).view(np.uint8).reshape(r, pad_c)[:, :c].copy()
+    return data_fp8
+
+
+def _mxfp4_bf16_golden(src, r, c, scale_alg):
+
+    from _gen_data_nd import fp16_maxes_to_e2m1, nv_maxes_to_e2m1, encode_e2m1_magic_scalar, pack_fp4_e2m1
+    src_bf16 = _pad_src(src, r, c, _bf16)
+    pad_c = _ca(c, 1)
+    src_fp32 = src_bf16.astype(np.float32)
+
+    data_abs = np.abs(src_bf16).reshape(-1, 32)
+    with np.errstate(invalid="ignore"):
+        group_max_bf16 = np.max(data_abs, axis=1).astype(np.float32)
+
+    if scale_alg == "NV":
+        e8m0, scaling_bf16 = nv_maxes_to_e2m1(group_max_bf16)
+    else:
+        e8m0, scaling_bf16 = fp16_maxes_to_e2m1(group_max_bf16)
+
+    scaling_bf16 = scaling_bf16.astype(_bf16)
+    scaled = (src_bf16.reshape(-1, 32) * scaling_bf16).astype(_bf16).reshape(src_bf16.shape)
+    codes = np.vectorize(encode_e2m1_magic_scalar, otypes=[np.uint8])(scaled.astype(np.float32))
+    packed = pack_fp4_e2m1(codes, r, pad_c)
+    return packed[:, :c // 2].copy()
+
+
+def _mxfp4_fp16_golden(src, r, c, scale_alg):
+
+    from _gen_data_nd import float32_to_bf16_trunc, fp16_maxes_to_e2m1, nv_maxes_to_e2m1, encode_e2m1_magic_scalar, pack_fp4_e2m1
+    src_f16 = _pad_src(src, r, c, np.float16)
+    pad_c = _ca(c, 1)
+    n = r * pad_c
+    src_fp32 = src_f16.astype(np.float32)
+
+    if scale_alg == "NV":
+        data_abs = np.abs(src_f16).astype(np.float16)
+        with np.errstate(invalid="ignore"):
+            group_max = np.max(data_abs.reshape(-1, 32), axis=1).astype(np.float32)
+        e8m0, scaling_bf16 = nv_maxes_to_e2m1(group_max)
+    else:
+        src_bf16_for_max = float32_to_bf16_trunc(src_fp32)
+        data_abs = np.abs(src_bf16_for_max).astype(np.float32)
+        group_max_bf16 = np.max(data_abs.reshape(-1, 32), axis=1)
+        e8m0, scaling_bf16 = fp16_maxes_to_e2m1(group_max_bf16)
+
+    scaled = (src_fp32.reshape(-1, 32) * scaling_bf16.astype(np.float32)).reshape(src_f16.shape).astype(np.float32)
+    codes = np.vectorize(encode_e2m1_magic_scalar, otypes=[np.uint8])(scaled)
+    packed = pack_fp4_e2m1(codes, r, pad_c)
+    return packed[:, :c // 2].copy()
+
+
+def _mx_golden(src, r, c, quant_type, scale_alg, dt_name="f32", dn_mode=False):
+    if quant_type == "MXFP8":
+        if dn_mode:
+            return _mxfp8_dn_golden(src, r, c, scale_alg, dt_name)
+        if dt_name == "bf16":
+            return _mxfp8_bf16_golden(src, r, c, scale_alg)
+        if dt_name == "f16":
+            return _mxfp8_fp16_golden(src, r, c, scale_alg)
+        return _mxfp8_golden(src, r, c, scale_alg)
+    else:
+        if dt_name == "bf16":
+            return _mxfp4_bf16_golden(src, r, c, scale_alg)
+        if dt_name == "f16":
+            return _mxfp4_fp16_golden(src, r, c, scale_alg)
+        return _mxfp4_golden(src, r, c, scale_alg)
+
+
+def _sym_inputs(r, c, seed_k):
+    rng = np.random.default_rng(seed_k)
+    src = rng.uniform(-10, 10, size=(r, c)).astype(np.float32)
+    scale = (rng.uniform(0.5, 2.0, size=(r, 1)) * 0.001).astype(np.float32)
+    return [src, scale]
+
+
+def _asym_inputs(r, c, seed_k):
+    rng = np.random.default_rng(seed_k)
+    src = rng.uniform(-10, 10, size=(r, c)).astype(np.float32)
+    scale = (rng.uniform(0.5, 2.0, size=(r, 1)) * 0.001).astype(np.float32)
+    offset = rng.uniform(-3, 3, size=(r, 1)).astype(np.float32)
+    return [src, scale, offset]
+
+
+# ════════════════════════════════════════════════════════════════
+#  Case registration
+# ════════════════════════════════════════════════════════════════
+
+CASES = []
+
+for qt, dt_name, shape, alg, mode, name, pattern in _SPECS:
+    kn = f"tquant_{name}"
+    r, c = shape[0], shape[1]
+
+    if qt in ("INT8_SYM", "INT8_ASYM"):
+        if qt == "INT8_SYM":
+            _k = _sym_kernel(kn, r, c)
+            CASES.append(golden_output_case(
+                kn, _k,
+                inputs=lambda r=r, c=c, n=kn: _sym_inputs(r, c, _seed(n)),
+                expected=_sym_golden,
+                output_shape=(r, c), output_dtype=np.int8,
+                rtol=0, atol=0,
+            ))
+        else:
+            _k = _asym_kernel(kn, r, c)
+            CASES.append(golden_output_case(
+                kn, _k,
+                inputs=lambda r=r, c=c, n=kn: _asym_inputs(r, c, _seed(n)),
+                expected=_asym_golden,
+                output_shape=(r, c), output_dtype=np.uint8,
+                rtol=0, atol=0,
+            ))
+        continue
+
+    sdt = _DTYPE_MAP[dt_name]
+    ddt = _DDT_MAP[qt]
+    sk = _seed(name)
+
+    if mode == "ND":
+        _k = _mx_nd_kernel(kn, r, c, sdt, ddt, qt, alg)
+        out_c = c if qt == "MXFP8" else c // 2
+        evc = (r * c) // 32
+        CASES.append(golden_output_case(
+            kn, _k,
+            inputs=lambda r=r, c=c, dn=dt_name, p=pattern, n=kn, evc=evc, q=qt, a=alg:
+                [*_mx_inputs(r, c, dn, p, _seed(n), q, a, n), np.zeros(evc, dtype=np.uint8)],
+            expected=lambda src, *args, r=r, c=c, q=qt, a=alg, dn=dt_name: _mx_golden(src, r, c, q, a, dn),
+            output_shape=(r, out_c), output_dtype=np.uint8,
+            rtol=0, atol=0,
+        ))
+    elif mode == "NZ":
+        _k = _mx_nz_kernel(kn, r, c, sdt, ddt, qt)
+        out_c = c if qt == "MXFP8" else c // 2
+        evc = (r * c) // 32
+        CASES.append(golden_output_case(
+            kn, _k,
+            inputs=lambda r=r, c=c, dn=dt_name, p=pattern, n=kn, evc=evc, q=qt, a=alg:
+                [*_mx_inputs(r, c, dn, p, _seed(n), q, a, n),
+                 np.zeros(evc, dtype=np.uint8)],
+            expected=lambda src, *args, r=r, c=c, q=qt, a=alg, dn=dt_name: _mx_golden(src, r, c, q, a, dn),
+            output_shape=(r, out_c), output_dtype=np.uint8,
+            rtol=0, atol=0,
+        ))
+    elif mode == "Exp2D":
+        if "static3x128" in name:
+            sr, sc = 3, 128
+        elif "static4x128" in name:
+            sr, sc = 4, 128
+        else:
+            sr, sc = r, c
+        _k = _mx_exp2d_kernel(kn, r, c, sr, sc, sdt, ddt, qt, alg)
+        out_c = c if qt == "MXFP8" else c // 2
+        evc = (r * c) // 32
+        CASES.append(golden_output_case(
+            kn, _k,
+            inputs=lambda r=r, c=c, dn=dt_name, p=pattern, n=kn, evc=evc, q=qt, a=alg:
+                [*_mx_inputs(r, c, dn, p, _seed(n), q, a, n),
+                 np.zeros(evc, dtype=np.uint8)],
+            expected=lambda src, *args, r=r, c=c, q=qt, a=alg, dn=dt_name: _mx_golden(src, r, c, q, a, dn),
+            output_shape=(r, out_c), output_dtype=np.uint8,
+            rtol=0, atol=0,
+        ))
+    elif mode == "DN":
+        npad = shape[2] if len(shape) > 2 else c
+        _k = _mx_dn_kernel(kn, r, c, npad, sdt, ddt, qt, alg)
+        out_c = c if qt == "MXFP8" else c // 2
+        hat_m = r // 32
+        evc = hat_m * c
+        CASES.append(golden_output_case(
+            kn, _k,
+            inputs=lambda r=r, c=c, dn=dt_name, p=pattern, n=kn, evc=evc, q=qt, a=alg:
+                [*_mx_inputs(r, c, dn, p, _seed(n), q, a, n), np.zeros(evc, dtype=np.uint8)],
+            expected=lambda src, *args, r=r, c=c, q=qt, a=alg, dn=dt_name: _mx_golden(src, r, c, q, a, dn, dn_mode=True),
+            output_shape=(r, out_c), output_dtype=np.uint8,
+            rtol=0, atol=0,
+        ))
+    elif mode == "DN_interleave":
+        npad = shape[2] if len(shape) > 2 else c
+        _k = _mx_dn_kernel(kn, r, c, npad, sdt, ddt, qt, alg, interleave=True)
+        out_c = c if qt == "MXFP8" else c // 2
+        hat_e = r // 64
+        et_cols = _ca(c * 2, 32)
+        evc = hat_e * et_cols
+        CASES.append(golden_output_case(
+            kn, _k,
+            inputs=lambda r=r, c=c, dn=dt_name, p=pattern, n=kn, evc=evc, q=qt, a=alg:
+                [*_mx_inputs(r, c, dn, p, _seed(n), q, a, n), np.zeros(evc, dtype=np.uint8)],
+            expected=lambda src, *args, r=r, c=c, q=qt, a=alg, dn=dt_name: _mx_golden(src, r, c, q, a, dn, dn_mode=True),
+            output_shape=(r, out_c), output_dtype=np.uint8,
+            rtol=0, atol=0,
+        ))
+    elif mode == "DN_valid_shape":
+        sr, sc_dim, vr, vc = shape[0], shape[1], shape[2], shape[3]
+        _k = _mx_dn_valid_shape_kernel(kn, sr, sc_dim, vr, vc, sdt, ddt, qt, alg)
+        out_c = vc if qt == "MXFP8" else vc // 2
+        hat_e = vr // 64
+        et_cols = _ca(vc * 2, 32)
+        evc = hat_e * et_cols
+        CASES.append(golden_output_case(
+            kn, _k,
+            inputs=lambda vr=vr, vc=vc, dn=dt_name, p=pattern, n=kn, evc=evc, q=qt, a=alg:
+                [*_mx_inputs(vr, vc, dn, p, _seed(n), q, a, n), np.zeros(evc, dtype=np.uint8)],
+            expected=lambda src, *args, vr=vr, vc=vc, q=qt, a=alg, dn=dt_name: _mx_golden(src, vr, vc, q, a, dn, dn_mode=True),
+            output_shape=(vr, out_c), output_dtype=np.uint8,
+            rtol=0, atol=0,
+        ))
+
+
+auto_main(globals())

--- a/test/tilelib-st/common.py
+++ b/test/tilelib-st/common.py
@@ -17,6 +17,12 @@ import time
 
 import numpy as np
 
+try:
+    import ml_dtypes
+    _BF16_DTYPE = ml_dtypes.bfloat16
+except ImportError:
+    _BF16_DTYPE = None
+
 _DEVICE = "npu:0"
 
 def init_runtime():
@@ -31,6 +37,19 @@ def init_runtime():
 
 def npu_stream(torch):
     return torch.npu.current_stream()._as_parameter_  # noqa: SLF001
+
+
+def _to_torch(array):
+    """Convert a numpy array to a device tensor.
+
+    torch does not accept ml_dtypes.bfloat16 arrays directly, and NPU rejects
+    fp32->bf16 device-side casts, so upload through a uint16 bit view.
+    """
+    import torch
+    if _BF16_DTYPE is not None and array.dtype == _BF16_DTYPE:
+        u16 = array.view(np.uint16).copy()
+        return torch.from_numpy(u16).view(torch.bfloat16).to(_DEVICE)
+    return torch.from_numpy(array).to(_DEVICE)
 
 
 def emit_mlir(*kernels):
@@ -86,10 +105,11 @@ def golden_output_case(
             output_shape or golden.shape,
             dtype=output_dtype or golden.dtype,
         )
+        case_inputs = [*host_inputs, out]
         if launch_args is None:
-            return [*host_inputs, out], golden
+            return case_inputs, golden
         extra_launch_args = launch_args(*host_inputs) if callable(launch_args) else list(launch_args)
-        return [*host_inputs, out], golden, extra_launch_args
+        return case_inputs, golden, extra_launch_args
 
     def check_case(device_inputs, golden):
         actual = device_inputs[output_index].cpu().numpy()
@@ -199,7 +219,7 @@ def run_cases(cases: list[dict], *, emit_mlir_fn=None, argv=None) -> int:
                 f"TileLib ST case {name!r} make_case() must return 2 or 3 values, got {len(made_case)}"
             )
 
-        device_inputs = [torch.from_numpy(array).to(_DEVICE) for array in inputs]
+        device_inputs = [_to_torch(array) for array in inputs]
         stream = npu_stream(torch)
 
         t0 = time.perf_counter()


### PR DESCRIPTION
- lib/TileOps/a5/tquant.py: tquant templates (INT8_SYM/ASYM, MXFP8 ND/DN/Exp2D)
- lib/TileOps/a5/tinsert.py: tinsert template
- lib/TileOps/__init__.py: register tquant/tinsert templates
- include/PTO/IR/PTOOps.td: tquant op definitions
- lib/PTO/IR/VPTO.cpp: vbitcast sub-byte support (f4e2m1x2→ui8)
- lib/PTO/IR/PTO.cpp: TQuantMxOp verifier (grp_axis/interleave/DN refactor)
- lib/PTO/Transforms/ExpandTileOp.cpp: tquant operand attrs
- lib/PTO/Transforms/InsertTemplateAttributes.cpp: tquant template attrs
- lib/PTO/Transforms/PTOToEmitC.cpp: TQuantMxOp EmitC lowering
- lib/PTO/Transforms/VPTO{CANN900,}LLVMEmitter.cpp: vcvt f16→bf16 support
- tools/ptoas/ptoas.cpp: InsertTemplateAttributes pass in VPTO pipeline
- ptodsl/ptodsl/_ops.py: tquant/tassign/tquant_mx/set_ctrl API + vcvt_contract
- ptodsl/ptodsl/_tile_namespace.py: tile.quant namespace
- ptodsl/ptodsl/pto.py: export set_ctrl, tassign
- ptodsl/ptodsl/tilelib/serving/{client,daemon}.py: daemon error traceback
- test/tilelib-st/a5/tquant/: 86 cases (INT8 6 + MXFP8 49 + MXFP4 25 + DN 6)
- test/tilelib-st/a5/{tassign,tinsert_vec_to_mat}/: supporting tests
- test/lit/pto/tquant_*.pto: lit tests
- test/tilelib-st/common.py: bf16/assert_close enhancement