### PR TITLE
fix(vpto): support low-precision vbitcast

### DIFF
--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -6195,20 +6195,11 @@ LogicalResult VbitcastOp::verify() {
   if (!inputType || !resultType)
     return emitOpError("input and result must be !pto.vreg<...>");
 
-  auto getStorageBits = [](VRegType type) -> std::optional<int64_t> {
-    Type elementType = type.getElementType();
-    if (auto intType = dyn_cast<IntegerType>(elementType))
-      return type.getElementCount() * static_cast<int64_t>(intType.getWidth());
-    if (auto floatType = dyn_cast<FloatType>(elementType))
-      return type.getElementCount() *
-             static_cast<int64_t>(floatType.getWidth());
-    return std::nullopt;
-  };
-
-  auto inputBits = getStorageBits(inputType);
-  auto resultBits = getStorageBits(resultType);
+  auto inputBits = getVRegStorageBitWidth(inputType);
+  auto resultBits = getVRegStorageBitWidth(resultType);
   if (!inputBits || !resultBits)
-    return emitOpError("requires integer or floating-point vreg element type");
+    return emitOpError("requires integer, floating-point, or supported "
+                       "low-precision vreg element type");
   if (*inputBits != *resultBits) {
     return emitOpError("requires source and result vectors to carry the same "
                        "total number of bits");

--- a/test/lit/vpto/issue_1192_repro.pto
+++ b/test/lit/vpto/issue_1192_repro.pto
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Minimal VPTO IR reproduction for https://github.com/hw-native-sys/PTOAS/issues/1192.
+// A packed FP4 vreg is a byte-storage carrier and should be bitcastable to ui8.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @test_vbitcast_f4e2m1x2(
+      %src: !pto.ptr<!pto.f4E2M1x2, ub>, %dst: !pto.ptr<ui8, ub>)
+      attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %input = pto.vlds %src[%c0] : !pto.ptr<!pto.f4E2M1x2, ub>
+        -> !pto.vreg<256x!pto.f4E2M1x2>
+      %output = pto.vbitcast %input : !pto.vreg<256x!pto.f4E2M1x2>
+        -> !pto.vreg<256xui8>
+      pto.vsts %output, %dst[%c0], %mask : !pto.vreg<256xui8>,
+        !pto.ptr<ui8, ub>, !pto.mask<b8>
+    }
+    return
+  }
+}

--- a/test/lit/vpto/issue_1192_repro.pto
+++ b/test/lit/vpto/issue_1192_repro.pto
@@ -9,6 +9,11 @@
 // Minimal VPTO IR reproduction for https://github.com/hw-native-sys/PTOAS/issues/1192.
 // A packed FP4 vreg is a byte-storage carrier and should be bitcastable to ui8.
 
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+// CHECK: @llvm.hivm.vldsx1.v256f4e2m1x2
+// CHECK: bitcast <256 x i8> {{.*}} to <256 x float4e2m1x2>
+// CHECK: @llvm.hivm.vstsx1.v256i8
+
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @test_vbitcast_f4e2m1x2(
       %src: !pto.ptr<!pto.f4E2M1x2, ub>, %dst: !pto.ptr<ui8, ub>)

--- a/test/lit/vpto/vbitcast_low_precision_vpto_llvm.pto
+++ b/test/lit/vpto/vbitcast_low_precision_vpto_llvm.pto
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Regression test for https://github.com/hw-native-sys/PTOAS/issues/1192.
+// Packed FP4 values use one byte of storage per vreg element and can be
+// reinterpreted as ui8 without changing the total vector storage width.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vbitcast_f4e2m1x2_to_ui8(
+      %src: !pto.ptr<!pto.f4E2M1x2, ub>, %dst: !pto.ptr<ui8, ub>)
+      attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %input = pto.vlds %src[%c0] : !pto.ptr<!pto.f4E2M1x2, ub>
+        -> !pto.vreg<256x!pto.f4E2M1x2>
+      %output = pto.vbitcast %input : !pto.vreg<256x!pto.f4E2M1x2>
+        -> !pto.vreg<256xui8>
+      pto.vsts %output, %dst[%c0], %mask : !pto.vreg<256xui8>,
+        !pto.ptr<ui8, ub>, !pto.mask<b8>
+    }
+    return
+  }
+
+  func.func @vbitcast_f4e1m2x2_to_ui8(
+      %src: !pto.ptr<!pto.f4E1M2x2, ub>, %dst: !pto.ptr<ui8, ub>)
+      attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %input = pto.vlds %src[%c0] : !pto.ptr<!pto.f4E1M2x2, ub>
+        -> !pto.vreg<256x!pto.f4E1M2x2>
+      %output = pto.vbitcast %input : !pto.vreg<256x!pto.f4E1M2x2>
+        -> !pto.vreg<256xui8>
+      pto.vsts %output, %dst[%c0], %mask : !pto.vreg<256xui8>,
+        !pto.ptr<ui8, ub>, !pto.mask<b8>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: define void @vbitcast_f4e2m1x2_to_ui8_mix_aiv
+// CHECK: call <256 x i8> @llvm.hivm.vldsx1.v256f4e2m1x2
+// CHECK: bitcast <256 x i8> %{{.*}} to <256 x float4e2m1x2>
+// CHECK: call void @llvm.hivm.vstsx1.v256i8
+// CHECK-LABEL: define void @vbitcast_f4e1m2x2_to_ui8_mix_aiv
+// CHECK: call <256 x i8> @llvm.hivm.vldsx1.v256f4e1m2x2
+// CHECK: bitcast <256 x i8> %{{.*}} to <256 x float4e1m2x2>
+// CHECK: call void @llvm.hivm.vstsx1.v256i8


### PR DESCRIPTION
## Summary
- Reuse PTO storage-width accounting in `pto.vbitcast` verification.
- Allow packed FP4 vregs to be bitcast to byte-sized integer vregs when total storage width matches.
- Add VPTO IR and LLVM emission regression coverage for `f4E2M1x2`/`f4E1M2x2` to `ui8`.

## Validation
- Issue #1192 minimal reproduction passes.
- New `vbitcast_low_precision_vpto_llvm.pto` FileCheck passes.
- Existing `vbitcast_vpto_llvm.pto` passes.
- Full `check-pto`: 1594 passed, 118 unrelated baseline failures.

Closes #1192