### PR TITLE
fix(vmi): support fused vexpdif contracts

### DIFF
--- a/docs/isa/vmi-isa/07-sfu.md
+++ b/docs/isa/vmi-isa/07-sfu.md
@@ -16,8 +16,7 @@
 
 ### `pto.vmi.vexpdif`
 
-- **semantics:** Fused `exp(x − max)` for softmax numerical stability. Single
-  hardware instruction.
+- **semantics:** Fused `exp(x − max)` for softmax numerical stability.
 
   ```c
   for (int i = 0; i < L; i++)
@@ -26,14 +25,14 @@
 
 - **syntax:**
   ```mlir
-  %e = pto.vmi.vexpdif %x, %max, %mask : !pto.vmi.vreg<L×T_x>, !pto.vmi.vreg<L×f32>, !pto.vmi.mask<L> -> !pto.vmi.vreg<L×f32>
+  %e = pto.vmi.vexpdif %x, %max, %mask : !pto.vmi.vreg<L×T>, !pto.vmi.vreg<L×T>, !pto.vmi.mask<L> -> !pto.vmi.vreg<L×f32>
   ```
 - **operands:**
 
   | Operand | Type | Description |
   |---|---|---|
-  | `x` | `!pto.vmi.vreg<L×T_x>` | Input (`f16` or `f32`) |
-  | `max` | `!pto.vmi.vreg<L×f32>` | Subtracted max (always `f32`) |
+  | `x` | `!pto.vmi.vreg<L×T>` | Input (`f16` or `f32`) |
+  | `max` | `!pto.vmi.vreg<L×T>` | Subtracted max with the same type as `x` |
   | `mask` | `!pto.vmi.mask<L>` | Governing predicate |
 
 - **results:**
@@ -42,13 +41,14 @@
   |---|---|---|
   | `result` | `!pto.vmi.vreg<L×f32>` | `exp(x − max)` (always `f32`) |
 
-- **attributes:** `pmode` (`"zero"` / `"merge"`)
-- **datatypes:** Input `x`: `f16`, `f32`; `max` and result: always `f32`
+- **attributes:** `pmode` (`"zero"` / `"merge"`), default `"zero"`
+- **datatypes:** `x` and `max`: matching `f16` or `f32`; result: `f32`
 - **lowering to `pto.mi`:**
   ```
-  K × pto.vexpdif
+  f32: K × pto.vexpdif
+  f16: 2K × pto.vexpdif
   ```
-  `#mi = K`, `dep = 1`. Fuses `vsub` + `vexp`.
+  Fuses `vsub` + `vexp`.
 
 - **example:**
   ```mlir

--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -1648,8 +1648,8 @@ def VMIVscatterOp : VMI_Op<"vscatter", [DeclareOpInterfaceMethods<MemoryEffectsO
 def VMIVexpdifOp : VMI_Op<"vexpdif", [Pure]> {
   let summary = "VMI fused exp(x - max) for softmax numerical stability";
   let description = [{
-    Computes exp(x - max) in a single hardware instruction.
-    x may be f16 or f32; max and result are always f32 (hardware constraint).
+    Computes exp(x - max). x and max use the same f16 or f32 element type.
+    The result preserves the logical lane count and always uses f32 elements.
 
     Example:
     ```

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -3748,18 +3748,12 @@ LogicalResult VMIVexpdifOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
 
-  if (failed(verifyBF16x2ComputeElementType(
-          getOperation(), xType.getElementType()))) {
-    return failure();
-  }
-
-  if (!isVMIFloatLikeType(xType.getElementType())) {
+  if (!isVMIF16OrF32Type(xType.getElementType())) {
     return emitOpError("requires x element type to be f16 or f32");
   }
 
-  auto maxElemType = dyn_cast<FloatType>(maxType.getElementType());
-  if (!maxElemType || maxElemType.getWidth() != 32) {
-    return emitOpError("requires max element type to be f32");
+  if (maxType.getElementType() != xType.getElementType()) {
+    return emitOpError("requires x and max to have the same element type");
   }
 
   auto resultElemType = dyn_cast<FloatType>(resultType.getElementType());
@@ -3772,7 +3766,7 @@ LogicalResult VMIVexpdifOp::verify() {
     return emitOpError(
         "requires x, max, and result logical lane counts to match");
 
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, xType))) {
     return failure();
   }
 

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -1142,6 +1142,29 @@ struct LayoutSolver {
           return WalkResult::interrupt();
         return WalkResult::advance();
       }
+      if (auto vexpdif = dyn_cast<VMIVexpdifOp>(op)) {
+        auto sourceType = cast<VMIVRegType>(vexpdif.getX().getType());
+        auto resultType = cast<VMIVRegType>(vexpdif.getResult().getType());
+        if (failed(unite(vexpdif.getX(), vexpdif.getMax(), op))) {
+          return WalkResult::interrupt();
+        }
+        if (sourceType.getElementType().isF32()) {
+          if (failed(unite(vexpdif.getX(), vexpdif.getResult(), op))) {
+            return WalkResult::interrupt();
+          }
+          return WalkResult::advance();
+        }
+
+        VMILayoutSupport supports;
+        FailureOr<VMICastLayoutFact> fact =
+            supports.getPreferredCastLayoutFact(sourceType, resultType);
+        if (succeeded(fact) &&
+            failed(setPreferredLayout(vexpdif.getResult(), fact->resultLayout,
+                                      op, getCastSeedPhase(*fact)))) {
+          return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      }
       if (auto extf = dyn_cast<VMIExtFOp>(op)) {
         auto sourceType = cast<VMIVRegType>(extf.getSource().getType());
         auto resultType = cast<VMIVRegType>(extf.getResult().getType());

--- a/lib/PTO/Transforms/VMILayoutPropagation.cpp
+++ b/lib/PTO/Transforms/VMILayoutPropagation.cpp
@@ -170,16 +170,14 @@ public:
 
 static bool isSameLayoutOp(Operation *op) {
   return isa<VMIAddFOp, VMIAddIOp, VMISubFOp, VMISubIOp, VMIMulFOp, VMIMulIOp,
-             VMIVaddcOp, VMIVaddcsOp,
-             VMIAddSOp, VMIMulSOp, VMIMaxSOp, VMIMinSOp, VMIShlSOp, VMIShrSOp,
-             VMIVmullOp, VMIFmaOp, VMIDivFOp, VMIMinFOp, VMIMinIOp, VMIMaxFOp,
-             VMIMaxIOp, VMINegFOp, VMIAbsFOp, VMIAbsIOp, VMISqrtOp, VMIExpOp,
-             VMILnOp, VMIReluOp, VMIVexpdifOp, VMIFPToSIOp, VMISIToFPOp,
-             VMIAndIOp, VMIOrIOp,
-             VMIXOrIOp, VMIShLIOp, VMIShRUIOp, VMIShRSIOp, VMINotOp, VMICmpFOp,
-             VMICmpIOp, VMISelectOp, VMIMaskAndOp, VMIMaskOrOp,
-             VMIMaskXOrOp, VMIMaskNotOp, VMIActivePrefixIndexOp, VMICompressOp,
-             VMIExpandLoadOp>(op);
+             VMIVaddcOp, VMIVaddcsOp, VMIAddSOp, VMIMulSOp, VMIMaxSOp,
+             VMIMinSOp, VMIShlSOp, VMIShrSOp, VMIVmullOp, VMIFmaOp, VMIDivFOp,
+             VMIMinFOp, VMIMinIOp, VMIMaxFOp, VMIMaxIOp, VMINegFOp, VMIAbsFOp,
+             VMIAbsIOp, VMISqrtOp, VMIExpOp, VMILnOp, VMIReluOp, VMIFPToSIOp,
+             VMISIToFPOp, VMIAndIOp, VMIOrIOp, VMIXOrIOp, VMIShLIOp, VMIShRUIOp,
+             VMIShRSIOp, VMINotOp, VMICmpFOp, VMICmpIOp, VMISelectOp,
+             VMIMaskAndOp, VMIMaskOrOp, VMIMaskXOrOp, VMIMaskNotOp,
+             VMIActivePrefixIndexOp, VMICompressOp, VMIExpandLoadOp>(op);
 }
 
 static bool isCastOp(Operation *op) {
@@ -248,6 +246,70 @@ public:
       return relations;
     }
     return failure();
+  }
+};
+
+class VMIVexpdifTransfer final : public VMILayoutTransfer {
+public:
+  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
+        const VMILayoutPropagator &propagator,
+        OpOperand *changedOperand) const override {
+    auto vexpdif = dyn_cast<VMIVexpdifOp>(op);
+    if (!vexpdif) {
+      return failure();
+    }
+
+    auto sourceType = dyn_cast<VMIVRegType>(vexpdif.getX().getType());
+    auto resultType = dyn_cast<VMIVRegType>(vexpdif.getResult().getType());
+    if (!sourceType || !resultType) {
+      return failure();
+    }
+
+    auto makeFacts = [&](VMILayoutAttr sourceLayout,
+                         VMILayoutAttr resultLayout) {
+      return makeRelation(SmallVector<VMILayoutFact, 4>{
+          operandFact(vexpdif.getXMutable(), sourceLayout),
+          operandFact(vexpdif.getMaxMutable(), sourceLayout),
+          operandFact(vexpdif.getMaskMutable(), sourceLayout),
+          valueFact(vexpdif.getResult(), resultLayout)});
+    };
+
+    if (sourceType.getElementType().isF32()) {
+      return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+          operandFact(vexpdif.getXMutable(), changedLayout),
+          operandFact(vexpdif.getMaxMutable(), changedLayout),
+          operandFact(vexpdif.getMaskMutable(), changedLayout),
+          valueFact(vexpdif.getResult(), changedLayout)});
+    }
+
+    VMICastLayoutPort port;
+    if (changedValue == vexpdif.getResult()) {
+      port = VMICastLayoutPort::Result;
+    } else if (changedValue == vexpdif.getX() ||
+               changedValue == vexpdif.getMax() ||
+               changedValue == vexpdif.getMask() ||
+               changedOperand == &vexpdif.getXMutable() ||
+               changedOperand == &vexpdif.getMaxMutable() ||
+               changedOperand == &vexpdif.getMaskMutable()) {
+      port = VMICastLayoutPort::Source;
+    } else {
+      return failure();
+    }
+
+    VMILayoutSupport supports;
+    FailureOr<SmallVector<VMICastLayoutFact, 4>> facts =
+        supports.getCastLayoutFactsForLayout(sourceType, resultType, port,
+                                             changedLayout);
+    if (failed(facts) || facts->empty()) {
+      return failure();
+    }
+
+    SmallVector<VMILayoutRelation, 4> relations;
+    for (const VMICastLayoutFact &fact : *facts) {
+      relations.push_back(makeFacts(fact.sourceLayout, fact.resultLayout));
+    }
+    return relations;
   }
 };
 
@@ -823,6 +885,7 @@ public:
 const VMILayoutTransfer *getTransfer(Operation *op) {
   static VMISameLayoutTransfer sameLayoutTransfer;
   static VMICastTransfer castTransfer;
+  static VMIVexpdifTransfer vexpdifTransfer;
   static VMIBitcastTransfer bitcastTransfer;
   static VMIMaskGranularityCastTransfer maskGranularityCastTransfer;
   static VMIFreeResultLayoutTransfer freeResultLayoutTransfer;
@@ -868,6 +931,9 @@ const VMILayoutTransfer *getTransfer(Operation *op) {
     return &gatherTransfer;
   if (isa<VMIBitcastOp>(op))
     return &bitcastTransfer;
+  if (isa<VMIVexpdifOp>(op)) {
+    return &vexpdifTransfer;
+  }
   if (isa<VMIFPToSIOp, VMIFPToUIOp, VMISIToFPOp>(op)) {
     // Same-width fp<->int: same-layout.  Widen/narrow: cast.
     auto srcType = dyn_cast<VMIVRegType>(op->getOperand(0).getType());

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -75,7 +75,8 @@
 //   vexpdif → kept unified for direct VMI-to-VPTO fused lowering
 //   vlrelu  → maxf + minf + broadcast + mulf + addf
 //   vprelu  → maxf + minf + mulf + addf
-//   Category C7/C8/C9 bypass mask/pmode synthesis here and skip pmode="merge".
+//   Lowered Category C7/C8/C9 ops bypass mask/pmode synthesis here and skip
+//   pmode="merge".
 //
 // Category D — no legacy equivalent (explicitly skipped, 13 ops):
 //   vadds/vmuls/vmaxs/vmins/vshls/vshrs
@@ -1016,7 +1017,7 @@ static LogicalResult lowerVscatter(VMIVscatterOp op, OpBuilder &builder) {
 }
 
 //===----------------------------------------------------------------------===//
-// Category C9 helpers: vexpdif / vlrelu / vprelu (fused → legacy chains)
+// Category C9 helpers: vlrelu / vprelu (fused → legacy chains)
 //===----------------------------------------------------------------------===//
 
 /// Lower vlrelu (x>0 ? x : slope*x) to max(x,0) + slope*min(x,0).

--- a/lib/PTO/Transforms/VMIMaskGranularityAssignment.cpp
+++ b/lib/PTO/Transforms/VMIMaskGranularityAssignment.cpp
@@ -267,6 +267,12 @@ struct MaskGranularitySolver {
           return WalkResult::interrupt();
         return WalkResult::advance();
       }
+      if (auto vexpdif = dyn_cast<VMIVexpdifOp>(op)) {
+        if (failed(requestMaskUseForSource(vexpdif.getMaskMutable(),
+                                           vexpdif.getX(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
       if (auto vmull = dyn_cast<VMIVmullOp>(op)) {
         if (failed(requestMaskUse(vmull.getMaskMutable(), "b32", op)))
           return WalkResult::interrupt();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9642,27 +9642,65 @@ struct OneToNVMIVexpdifOpPattern : OpConversionPattern<VMIVexpdifOp> {
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
-    if (xParts.size() != maxParts.size() ||
-        xParts.size() != maskParts.size() ||
-        xParts.size() != resultTypes.size())
+    if (xParts.size() != maxParts.size() || xParts.size() != maskParts.size()) {
       return rewriter.notifyMatchFailure(op, "vexpdif physical arity mismatch");
+    }
 
+    auto sourceVMIType = cast<VMIVRegType>(op.getX().getType());
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
-    for (auto [x, max, mask, resultType] :
-         llvm::zip_equal(xParts, maxParts, maskParts, resultTypes)) {
-      auto vregType = dyn_cast<VRegType>(resultType);
-      auto maskType = dyn_cast<MaskType>(mask.getType());
-      if (!vregType || !maskType || !vregType.getElementType().isF32() ||
-          x.getType() != resultType || max.getType() != resultType ||
-          maskType.getGranularity() != "b32")
+
+    if (sourceVMIType.getElementType().isF32()) {
+      if (xParts.size() != resultTypes.size()) {
         return rewriter.notifyMatchFailure(
-            op, "fused vexpdif requires matching physical f32 parts and b32 masks");
-      results.push_back(
-          rewriter
-              .create<VexpdifOp>(op.getLoc(), resultType, x, max, mask,
-                                  rewriter.getStringAttr("EVEN"))
-              .getResult());
+            op, "f32 vexpdif requires one result per source part");
+      }
+      for (auto [x, max, mask, resultType] :
+           llvm::zip_equal(xParts, maxParts, maskParts, resultTypes)) {
+        auto vregType = dyn_cast<VRegType>(resultType);
+        auto maskType = dyn_cast<MaskType>(mask.getType());
+        if (!vregType || !maskType || !vregType.getElementType().isF32() ||
+            x.getType() != resultType || max.getType() != resultType ||
+            maskType.getGranularity() != "b32") {
+          return rewriter.notifyMatchFailure(
+              op, "f32 vexpdif requires matching f32 parts and b32 masks");
+        }
+        results.push_back(rewriter
+                              .create<VexpdifOp>(op.getLoc(), resultType, x,
+                                                 max, mask,
+                                                 rewriter.getStringAttr("ODD"))
+                              .getResult());
+      }
+    } else {
+      if (!sourceVMIType.getElementType().isF16() ||
+          resultTypes.size() != 2 * xParts.size()) {
+        return rewriter.notifyMatchFailure(
+            op, "f16 vexpdif requires EVEN/ODD f32 result parts");
+      }
+
+      static constexpr StringRef kParts[] = {"EVEN", "ODD"};
+      for (auto [partIndex, part] : llvm::enumerate(kParts)) {
+        for (auto [chunkIndex, x] : llvm::enumerate(xParts)) {
+          Value max = maxParts[chunkIndex];
+          Value mask = maskParts[chunkIndex];
+          Type resultType = resultTypes[partIndex * xParts.size() + chunkIndex];
+          auto xType = dyn_cast<VRegType>(x.getType());
+          auto resultVRegType = dyn_cast<VRegType>(resultType);
+          auto maskType = dyn_cast<MaskType>(mask.getType());
+          if (!xType || !resultVRegType || !maskType ||
+              !xType.getElementType().isF16() ||
+              !resultVRegType.getElementType().isF32() ||
+              max.getType() != x.getType() ||
+              maskType.getGranularity() != "b16")
+            return rewriter.notifyMatchFailure(
+                op, "f16 vexpdif requires matching f16 parts and b16 masks");
+          results.push_back(rewriter
+                                .create<VexpdifOp>(op.getLoc(), resultType, x,
+                                                   max, mask,
+                                                   rewriter.getStringAttr(part))
+                                .getResult());
+        }
+      }
     }
 
     replaceOpWithFlatConvertedValues(rewriter, op, results,

--- a/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
+++ b/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
@@ -990,15 +990,15 @@ stable softmax numerator.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `x` | `VRegType` | Input vector |
-| `max_value` | `VRegType` | Maximum value vector to subtract before exponentiation |
+| `x` | `VRegType` | Input vector with `f16` or `f32` elements |
+| `max_value` | `VRegType` | Maximum value vector with the same type as `x` |
 | `mask` | VMI mask | **Required.** Predicate mask gating lane participation |
-| `pmode` | `str` or `None` | Optional predicate mode: `"merge"` keeps predicate-inactive lanes at their prior value; `"zero"` writes 0 |
+| `pmode` | `str` or `None` | Optional predicate mode: `"zero"` zeros inactive lanes; `"merge"` preserves their prior values. Defaults to `"zero"`. |
 **Returns**:
 
 | Return Value | Type | Description |
 |--------------|------|-------------|
-| `result` | `VRegType` | `exp(x - max_value)` |
+| `result` | `VRegType` | `exp(x - max_value)` with the same logical lane count and `f32` elements |
 
 ---
 

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -1118,9 +1118,32 @@ class _VMINamespace:
 
     @staticmethod
     def vexpdif(x, max_value, mask, *, pmode=None, loc=None, ip=None):
+        context = "pto.vmi.vexpdif(...)"
+        x_type = _as_vmi_vreg_type(_type_of(x), context=context)
+        max_type = _as_vmi_vreg_type(_type_of(max_value), context=context)
+        if x_type != max_type:
+            raise TypeError(
+                f"{context} requires x and max_value to have identical VMI vreg types"
+            )
+        if not (
+            F16Type.isinstance(x_type.element_type)
+            or F32Type.isinstance(x_type.element_type)
+        ):
+            raise TypeError(f"{context} requires f16 or f32 input vectors")
+        mask_type = _as_vmi_mask_type(_type_of(mask), context=context)
+        if (
+            _vmi_mask_element_count(mask_type, context=context)
+            != x_type.element_count
+        ):
+            raise TypeError(f"{context} requires mask and input lane counts to match")
+        result_type = _pto.VMIVRegType.get(
+            x_type.element_count,
+            F32Type.get(),
+            layout=x_type.layout if F32Type.isinstance(x_type.element_type) else None,
+        )
         return _call_value(
             "vexpdif",
-            _type_of(max_value),
+            result_type,
             _raw(x),
             _raw(max_value),
             _required_mask(mask, context="pto.vmi.vexpdif(...)"),

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -2691,6 +2691,8 @@ def vmi_wrapper_dispatch_probe():
     int_other_tile = pto.alloc_tile(shape=[1, 64], dtype=pto.i32)
     hist_acc_tile = pto.alloc_tile(shape=[1, 256], dtype=pto.ui16)
     hist_src_tile = pto.alloc_tile(shape=[1, 256], dtype=pto.ui8)
+    half_src_tile = pto.alloc_tile(shape=[1, 128], dtype=pto.f16)
+    half_max_tile = pto.alloc_tile(shape=[1, 128], dtype=pto.f16)
 
     src_ptr = src_tile.as_ptr()
     other_ptr = other_tile.as_ptr()
@@ -2699,6 +2701,8 @@ def vmi_wrapper_dispatch_probe():
     int_other_ptr = int_other_tile.as_ptr()
     hist_acc_ptr = hist_acc_tile.as_ptr()
     hist_src_ptr = hist_src_tile.as_ptr()
+    half_src_ptr = half_src_tile.as_ptr()
+    half_max_ptr = half_max_tile.as_ptr()
 
     offset = pto.const(0, dtype=pto.index)
     active_lanes = pto.const(64, dtype=pto.index)
@@ -2724,6 +2728,9 @@ def vmi_wrapper_dispatch_probe():
     int_lhs = pto.vmi.vload(int_src_ptr, offset, size=64)
     int_rhs = pto.vmi.vload(int_other_ptr, offset, size=64)
     hist_mask = pto.vmi.create_mask(pto.const(256, dtype=pto.index), size=256)
+    half_mask = pto.vmi.create_mask(pto.const(128, dtype=pto.index), size=128)
+    half_lhs = pto.vmi.vload(half_src_ptr, offset, size=128)
+    half_max = pto.vmi.vload(half_max_ptr, offset, size=128)
     added = pto.vmi.vadd(lhs, rhs, mask)
     carry_sum, carry = pto.vmi.vaddc(int_lhs, int_rhs, mask)
     carry_next, carry_out = pto.vmi.vaddcs(carry_sum, int_rhs, carry, mask)
@@ -2767,6 +2774,7 @@ def vmi_wrapper_dispatch_probe():
     hist = pto.vmi.vdhist(hist_acc, hist_src, hist_mask)
     cumul = pto.vmi.vchist(hist_acc, hist_src, hist_mask)
     exp_difference = pto.vmi.vexpdif(lhs, rhs, mask)
+    half_exp_difference = pto.vmi.vexpdif(half_lhs, half_max, half_mask)
     axpy = pto.vmi.vaxpy(lhs, rhs, 2.0, mask)
     leaky_relu = pto.vmi.vlrelu(lhs, 0.125, mask)
     parametric_relu = pto.vmi.vprelu(lhs, rhs, mask)
@@ -7016,12 +7024,20 @@ def main() -> None:
             f"pto.vmi.{op_name} should emit both omitted-group and explicit-group probes",
         )
     expect(
+        vmi_wrapper_dispatch_text.count("pto.vmi.vexpdif") == 2,
+        "VMI wrapper dispatch should cover both f32 and f16 vexpdif forms",
+    )
+    expect(
+        "!pto.vmi.vreg<128xf32>" in vmi_wrapper_dispatch_text,
+        "f16 vexpdif should produce a logical f32 result",
+    )
+    expect(
         vmi_wrapper_dispatch_text.count("group = 1") >= 6,
         "VMI reductions should make the omitted group equivalent to group=1",
     )
     expect(
-        vmi_wrapper_dispatch_text.count("pto.vmi.vload") == 7,
-        "vmi wrapper dispatch probe should lower seven explicit VMI loads",
+        vmi_wrapper_dispatch_text.count("pto.vmi.vload") == 9,
+        "vmi wrapper dispatch probe should lower nine explicit VMI loads",
     )
     expect(
         "pto.backend = \"vpto\"" in vmi_wrapper_dispatch_text,

--- a/test/lit/vmi_new/vmi_layout_assignment_vexpdif.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_vexpdif.pto
@@ -36,7 +36,6 @@ module {
 // ASSIGN-SAME: -> !pto.vmi.vreg<1xf32, #pto.vmi.layout<num_groups = 1, slots = 1>>
 
 // LOWER-LABEL: func.func @vmi_layout_assignment_vexpdif(
-// LOWER: pto.vexpdif
+// LOWER: pto.vexpdif {{.*}}, "ODD"
 // LOWER-NOT: pto.vldsx2
-// LOWER-NOT: "ODD"
 // LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_vexpdif_f16.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vexpdif_f16.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under
+// the terms of the CANN Open Software License Agreement Version 2.0.
+// Please refer to the License for details. THIS SOFTWARE IS PROVIDED ON AN
+// "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER
+
+module {
+  func.func @vexpdif_f16(
+      %x: !pto.vmi.vreg<128xf16>,
+      %max: !pto.vmi.vreg<128xf16>,
+      %mask: !pto.vmi.mask<128xpred>) -> !pto.vmi.vreg<128xf32> {
+    %result = pto.vmi.vexpdif %x, %max, %mask
+        : !pto.vmi.vreg<128xf16>, !pto.vmi.vreg<128xf16>,
+          !pto.vmi.mask<128xpred> -> !pto.vmi.vreg<128xf32>
+    return %result : !pto.vmi.vreg<128xf32>
+  }
+}
+
+// ASSIGN-LABEL: func.func @vexpdif_f16(
+// ASSIGN-SAME: %arg0: !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
+// ASSIGN-SAME: %arg1: !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
+// ASSIGN-SAME: %arg2: !pto.vmi.mask<128xb32, #pto.vmi.layout<contiguous>>
+// ASSIGN: %[[MASK:.*]] = pto.vmi.ensure_mask_granularity
+// ASSIGN-SAME: -> !pto.vmi.mask<128xb16, #pto.vmi.layout<contiguous>>
+// ASSIGN: %[[RESULT:.*]] = pto.vmi.vexpdif %arg0, %arg1, %[[MASK]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: return %[[RESULT]]
+
+// LOWER-LABEL: func.func @vexpdif_f16(
+// LOWER: %[[EVEN:.*]] = pto.vexpdif %arg0, %arg1, %{{.*}}, "EVEN"
+// LOWER: %[[ODD:.*]] = pto.vexpdif %arg0, %arg1, %{{.*}}, "ODD"
+// LOWER: return %[[EVEN]], %[[ODD]]
+// LOWER-NOT: pto.vsub
+// LOWER-NOT: pto.vexp {{.*}} :
+// LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_vexpdif_f32.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vexpdif_f32.pto
@@ -18,10 +18,24 @@ module {
           !pto.vmi.mask<64xpred> -> !pto.vmi.vreg<64xf32>
     return %result : !pto.vmi.vreg<64xf32>
   }
+
+  func.func @vexpdif_f32_explicit_zero(
+      %x: !pto.vmi.vreg<64xf32>,
+      %max: !pto.vmi.vreg<64xf32>,
+      %mask: !pto.vmi.mask<64xpred>) -> !pto.vmi.vreg<64xf32> {
+    %result = pto.vmi.vexpdif %x, %max, %mask {pmode = "zero"}
+        : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>,
+          !pto.vmi.mask<64xpred> -> !pto.vmi.vreg<64xf32>
+    return %result : !pto.vmi.vreg<64xf32>
+  }
 }
 
 // CHECK-LABEL: func.func @vexpdif_f32(
-// CHECK: %[[RESULT:.*]] = pto.vexpdif %arg0, %arg1, %arg2, "EVEN"
+// CHECK: %[[RESULT:.*]] = pto.vexpdif %arg0, %arg1, %arg2, "ODD"
 // CHECK-NOT: pto.vsub
 // CHECK-NOT: pto.vexp {{.*}} :
 // CHECK: return %[[RESULT]]
+
+// CHECK-LABEL: func.func @vexpdif_f32_explicit_zero(
+// CHECK: %[[ZERO_RESULT:.*]] = pto.vexpdif %arg0, %arg1, %arg2, "ODD"
+// CHECK: return %[[ZERO_RESULT]]

--- a/test/lit/vmi_new/vmi_vexpdif_type_invalid.pto
+++ b/test/lit/vmi_new/vmi_vexpdif_type_invalid.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under
+// the terms of the CANN Open Software License Agreement Version 2.0.
+// Please refer to the License for details. THIS SOFTWARE IS PROVIDED ON AN
+// "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository.
+
+// RUN: not pto-test-opt %s 2>&1 | FileCheck %s
+
+module {
+  func.func @vexpdif_mixed_sources(
+      %x: !pto.vmi.vreg<128xf16>,
+      %max: !pto.vmi.vreg<128xf32>,
+      %mask: !pto.vmi.mask<128xpred>) -> !pto.vmi.vreg<128xf32> {
+    %result = pto.vmi.vexpdif %x, %max, %mask
+        : !pto.vmi.vreg<128xf16>, !pto.vmi.vreg<128xf32>,
+          !pto.vmi.mask<128xpred> -> !pto.vmi.vreg<128xf32>
+    return %result : !pto.vmi.vreg<128xf32>
+  }
+}
+
+// CHECK: 'pto.vmi.vexpdif' op requires x and max to have the same element type


### PR DESCRIPTION
## 背景

补全并修正 VMI `vexpdif` 的类型契约、layout 与 VPTO fused lowering，使其与 A5/CANN 底层 `VEXPDIF` 契约一致。

Closes mouliangyu/PTOAS#587

## 变更

- 修正类型契约：支持 `f32 × f32 -> f32` 和 `f16 × f16 -> f32`，要求 `x` 与 `max` 类型一致，mask 粒度跟随输入类型。
- 保持既有可选 `pmode` 接口，默认语义为 `zero`。
- 修正 layout assignment/propagation：f32 使用同 layout；f16 结果使用 16→32 widening layout。
- 保持 fused lowering：f32 生成一个结果 part，f16 生成两个 f32 结果 part。
- 同步 PTODSL API、VMI ISA 文档和用户手册，并补充 f16、显式 zero 和非法混合类型测试。

## 验证

- LLVM 21 环境下重新构建 `pto-test-opt`
- `vexpdif` targeted lit：4/4 passed
- `python3 ptodsl/tests/test_jit_compile.py`：passed
- Python `py_compile`：passed
- `git diff --check`：passed
- 此前完整 VMI lit suite：500/500 passed
