### PR TITLE
Fix ui32 arith.select VPTO LLVM lowering

### DIFF
--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -10191,9 +10191,6 @@ public:
   LogicalResult
   matchAndRewrite(arith::SelectOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!hasVPTOConvertibleType(op->getOperandTypes()) &&
-        !hasVPTOConvertibleType(op->getResultTypes()))
-      return failure();
     if (!op.getCondition().getType().isInteger(1))
       return rewriter.notifyMatchFailure(
           op, "only scalar i1 conditions supported for VPTO arith.select");
@@ -11273,6 +11270,10 @@ static LogicalResult lowerVPTOTypes(ModuleOp module, llvm::raw_ostream &diagOS) 
         return isLegalForBranchOpInterfaceTypeConversionPattern(op,
                                                                 typeConverter);
       });
+  target.addDynamicallyLegalOp<arith::SelectOp>([&](arith::SelectOp op) {
+    return typeConverter.isLegal(op->getOperandTypes()) &&
+           typeConverter.isLegal(op->getResultTypes());
+  });
   target.addIllegalOp<pto::AddPtrOp, pto::CastPtrOp, pto::LoadScalarOp,
                       pto::StoreScalarOp, pto::PTOLoadOp, pto::PTOStoreOp,
                       pto::PTOLdgOp, pto::PTOStgOp, pto::PTOLdDevOp,

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -12122,9 +12122,6 @@ public:
   LogicalResult
   matchAndRewrite(arith::SelectOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!hasVPTOConvertibleType(op->getOperandTypes()) &&
-        !hasVPTOConvertibleType(op->getResultTypes()))
-      return failure();
     if (!op.getCondition().getType().isInteger(1))
       return rewriter.notifyMatchFailure(
           op, "only scalar i1 conditions supported for VPTO arith.select");
@@ -13248,6 +13245,10 @@ static LogicalResult lowerVPTOTypes(ModuleOp module, llvm::raw_ostream &diagOS) 
         return isLegalForBranchOpInterfaceTypeConversionPattern(op,
                                                                 typeConverter);
       });
+  target.addDynamicallyLegalOp<arith::SelectOp>([&](arith::SelectOp op) {
+    return typeConverter.isLegal(op->getOperandTypes()) &&
+           typeConverter.isLegal(op->getResultTypes());
+  });
   target.addIllegalOp<pto::AddPtrOp, pto::CastPtrOp, pto::LoadScalarOp,
                       pto::StoreScalarOp, pto::PTOLoadOp, pto::PTOStoreOp,
                       pto::PTOLdgOp, pto::PTOStgOp, pto::DeclareStructOp,

--- a/test/lit/vpto/issue_1225_nested_ui32_scf_if.pto
+++ b/test/lit/vpto/issue_1225_nested_ui32_scf_if.pto
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards VPTO type lowering of nested multi-result ui32 scf.if operations.
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - | FileCheck %s
+// RUN: ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @nested_ui32_scf_if(
+      %src: !pto.ptr<ui32, gm>,
+      %dst: !pto.ptr<ui32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %lhs = pto.load_scalar %src[%c0]
+        : !pto.ptr<ui32, gm> -> ui32
+    %rhs = pto.load_scalar %src[%c1]
+        : !pto.ptr<ui32, gm> -> ui32
+    %block_idx = pto.get_block_idx
+    %outer_cond = arith.cmpi eq, %block_idx, %c0_i64 : i64
+    %inner_cond = arith.cmpi eq, %block_idx, %c1_i64 : i64
+
+    %result:2 = scf.if %outer_cond -> (ui32, ui32) {
+      scf.yield %lhs, %rhs : ui32, ui32
+    } else {
+      %nested:2 = scf.if %inner_cond -> (ui32, ui32) {
+        scf.yield %rhs, %lhs : ui32, ui32
+      } else {
+        scf.yield %lhs, %rhs : ui32, ui32
+      }
+      scf.yield %nested#0, %nested#1 : ui32, ui32
+    }
+
+    pto.store_scalar %result#0, %dst[%c0]
+        : !pto.ptr<ui32, gm>, ui32
+    pto.store_scalar %result#1, %dst[%c1]
+        : !pto.ptr<ui32, gm>, ui32
+    return
+  }
+}
+
+// CHECK-LABEL: define void @nested_ui32_scf_if_mix_aiv
+// CHECK: select i1 {{.*}}, i32 {{.*}}, i32
+// CHECK: select i1 {{.*}}, i32 {{.*}}, i32


### PR DESCRIPTION
## Summary
- lower ui32 arith.select through the VPTO LLVM type converter instead of leaving it illegal
- apply the legality fix to the default and CANN 9.0 LLVM emitters
- add a nested multi-result scf.if regression covering ui32 scalar values

## Root cause
scf.if canonicalization can produce arith.select operations with ui32 operands/results. The type converter normalizes ui32 to signless i32, but arith.select was only rewritten when it contained a PTO-specific type. That left the ui32 select illegal without a matching conversion pattern.

## Validation
- cmake --build /home/zhangzhendong/ptoas-workspace/builds/issue-1225 --target PTOASCompiler -j8
- llvm-lit -v /home/zhangzhendong/ptoas-workspace/builds/issue-1225/test/lit --filter 'issue_1225_nested_ui32_scf_if|arith_select_vpto_llvm'\n- default and CANN 9.0 emission both produce LLVM select i1 with i32 values\n\n

Fixes #1225