### PR TITLE
fix(vmi): materialize packed group-slot widening

### DIFF
--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -521,10 +521,13 @@ static constexpr LegalCastLayoutPattern kLegalCastLayoutPatterns[] = {
     // inherited from the anchor layout at query time.  Packed narrowing records
     // the selected sub-lane stride on the result; widening is the inverse.
     {bits<8>(), bits<16>(), gs(1), gs(1)},
+    {bits<8>(), bits<16>(), gs(8), gs(8)},
     {bits<8>(), bits<16>(), gs(8, 2), gs(8)},
     {bits<16>(), bits<32>(), gs(1), gs(1)},
+    {bits<16>(), bits<32>(), gs(8), gs(8)},
     {bits<16>(), bits<32>(), gs(8, 2), gs(8)},
     {bits<8>(), bits<32>(), gs(1), gs(1)},
+    {bits<8>(), bits<32>(), gs(8), gs(8)},
     {bits<8>(), bits<32>(), gs(8, 4), gs(8)},
     {bits<16>(), bits<8>(), gs(1), gs(1)},
     {bits<16>(), bits<8>(), gs(8), gs(8, 2)},

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3512,6 +3512,122 @@ FailureOr<Value> bitcastVReg(Location loc, Value value, Type resultType,
   return rewriter.create<VbitcastOp>(loc, outputType, value).getResult();
 }
 
+// A compact group-slot carrier keeps the values for a slot block in adjacent
+// lanes.  Widening partitions those lanes by their low factor bits, so rebuild
+// the compact order with an interleave tree before exposing the result carrier.
+FailureOr<SmallVector<Value>> materializePackedGroupSlotWidening(
+    Operation *op, ValueRange sourceParts, TypeRange resultTypes,
+    VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+    PatternRewriter &rewriter) {
+  auto fail = [&](const Twine &message) -> FailureOr<SmallVector<Value>> {
+    (void)rewriter.notifyMatchFailure(op, message);
+    return failure();
+  };
+
+  VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
+  VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
+  if (!sourceLayout || !resultLayout || !sourceLayout.isGroupSlots() ||
+      !resultLayout.isGroupSlots())
+    return fail("packed group-slot widening requires group-slot layouts");
+  if (sourceLayout.getNumGroups() != resultLayout.getNumGroups() ||
+      sourceLayout.getSlots() != resultLayout.getSlots() ||
+      sourceLayout.getSlots() <= 1 ||
+      sourceLayout.getLaneStride() != 1 || resultLayout.getLaneStride() != 1)
+    return fail("packed group-slot widening requires matching compact layouts");
+  if (sourceParts.empty() || sourceParts.size() != resultTypes.size())
+    return fail("packed group-slot widening requires matching non-empty "
+                "physical arity");
+
+  unsigned sourceBits =
+      pto::getPTOStorageElemBitWidth(sourceVMIType.getElementType());
+  unsigned resultBits =
+      pto::getPTOStorageElemBitWidth(resultVMIType.getElementType());
+  if (sourceBits == 0 || resultBits % sourceBits != 0)
+    return fail("packed group-slot widening requires integral storage widths");
+  unsigned widenFactor = resultBits / sourceBits;
+  if (widenFactor != 2 && widenFactor != 4)
+    return fail("packed group-slot widening requires a 2x or 4x width ratio");
+
+  FailureOr<int64_t> sourceLanes =
+      getDataLanesPerPart(sourceVMIType.getElementType());
+  FailureOr<int64_t> resultLanes =
+      getDataLanesPerPart(resultVMIType.getElementType());
+  FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceVMIType);
+  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultVMIType);
+  if (failed(sourceLanes) || failed(resultLanes) || failed(sourceArity) ||
+      failed(resultArity) || *sourceArity != *resultArity ||
+      static_cast<int64_t>(sourceParts.size()) != *sourceArity)
+    return fail("packed group-slot widening requires matching physical "
+                "carrier arity");
+
+  VRegType expectedSourceType = VRegType::get(
+      rewriter.getContext(), *sourceLanes, sourceVMIType.getElementType());
+  VRegType expectedResultType = VRegType::get(
+      rewriter.getContext(), *resultLanes, resultVMIType.getElementType());
+  FailureOr<MaskType> sourceMaskType =
+      getMaskTypeForVReg(expectedSourceType, rewriter.getContext());
+  if (failed(sourceMaskType))
+    return fail("failed to derive packed group-slot widening mask type");
+
+  static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+  static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
+  ArrayRef<StringRef> conversionParts =
+      widenFactor == 2 ? ArrayRef<StringRef>(kEvenOddParts)
+                       : ArrayRef<StringRef>(kPacked4Parts);
+
+  SmallVector<Value> results;
+  results.reserve(resultTypes.size());
+  for (auto [partIndex, sourcePart] : llvm::enumerate(sourceParts)) {
+    auto sourceType = dyn_cast<VRegType>(sourcePart.getType());
+    auto resultType = dyn_cast<VRegType>(resultTypes[partIndex]);
+    if (sourceType != expectedSourceType || resultType != expectedResultType)
+      return fail("packed group-slot widening requires full physical carriers");
+
+    int64_t groupBegin = partIndex * sourceLayout.getSlots();
+    int64_t activeSlots = std::min<int64_t>(
+        sourceLayout.getSlots(), sourceLayout.getNumGroups() - groupBegin);
+    if (activeSlots <= 0 || activeSlots > *sourceLanes ||
+        activeSlots > *resultLanes)
+      return fail("packed group-slot widening has invalid active slot count");
+    FailureOr<Value> sourceMask = createPrefixMaskForActiveLanes(
+        op->getLoc(), *sourceMaskType, activeSlots, rewriter);
+    if (failed(sourceMask))
+      return fail("failed to build packed group-slot widening mask");
+
+    SmallVector<Value> currentLevel;
+    currentLevel.reserve(widenFactor);
+    for (StringRef conversionPart : conversionParts) {
+      currentLevel.push_back(
+          rewriter
+              .create<VcvtOp>(op->getLoc(), expectedResultType, sourcePart,
+                              *sourceMask, /*rnd=*/nullptr, /*sat=*/nullptr,
+                              rewriter.getStringAttr(conversionPart))
+              .getResult());
+    }
+
+    // Part P0/P1/P2/P3 is indexed by the low two source-lane bits.  Merge
+    // the high bit first, then the low bit, to restore lane order.
+    for (unsigned stride = widenFactor / 2; stride != 0; stride /= 2) {
+      SmallVector<Value> nextLevel;
+      nextLevel.reserve(currentLevel.size() / 2);
+      for (size_t base = 0; base < currentLevel.size(); base += 2 * stride) {
+        for (size_t offset = 0; offset < stride; ++offset) {
+          auto interleave = rewriter.create<VintlvOp>(
+              op->getLoc(), expectedResultType, expectedResultType,
+              currentLevel[base + offset],
+              currentLevel[base + offset + stride]);
+          nextLevel.push_back(interleave.getLow());
+        }
+      }
+      currentLevel = std::move(nextLevel);
+    }
+    if (currentLevel.size() != 1)
+      return fail("failed to rebuild packed group-slot lane order");
+    results.push_back(currentLevel.front());
+  }
+  return results;
+}
+
 FailureOr<VRegType> getVcaddResultType(VRegType inputType) {
   auto inputIntegerType = dyn_cast<IntegerType>(inputType.getElementType());
   if (!inputIntegerType || inputIntegerType.getWidth() == 32)
@@ -10390,6 +10506,18 @@ struct OneToNVMIExtFOpPattern : OpConversionPattern<VMIExtFOp> {
         pto::getPTOStorageElemBitWidth(sourceType.getElementType());
     VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
     VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
+    if (sourceLayout && resultLayout && sourceLayout.isGroupSlots() &&
+        resultLayout.isGroupSlots() && sourceLayout.getSlots() > 1 &&
+        resultLayout.getSlots() > 1 && sourceLayout.getLaneStride() == 1 &&
+        resultLayout.getLaneStride() == 1) {
+      FailureOr<SmallVector<Value>> results = materializePackedGroupSlotWidening(
+          op, sourceParts, resultTypes, sourceVMIType, resultVMIType, rewriter);
+      if (failed(results))
+        return failure();
+      replaceOpWithFlatConvertedValues(rewriter, op, *results,
+                                       *this->getTypeConverter());
+      return success();
+    }
     if (sourceLayout && resultLayout && sourceLayout.isContiguous() &&
         resultLayout.isContiguous() && resultLayout.getLaneStride() == 1 &&
         ((sourceBits == 16 && sourceLayout.getLaneStride() == 2) ||
@@ -10738,6 +10866,18 @@ struct OneToNVMIExtIOpPattern : OpConversionPattern<OpT> {
 
     VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
     VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
+    if (sourceLayout && resultLayout && sourceLayout.isGroupSlots() &&
+        resultLayout.isGroupSlots() && sourceLayout.getSlots() > 1 &&
+        resultLayout.getSlots() > 1 && sourceLayout.getLaneStride() == 1 &&
+        resultLayout.getLaneStride() == 1) {
+      FailureOr<SmallVector<Value>> results = materializePackedGroupSlotWidening(
+          op, sourceParts, resultTypes, sourceVMIType, resultVMIType, rewriter);
+      if (failed(results))
+        return failure();
+      replaceOpWithFlatConvertedValues(rewriter, op, *results,
+                                       *this->getTypeConverter());
+      return success();
+    }
     if (sourceLayout && resultLayout && sourceLayout.isGroupSlots() &&
         resultLayout.isGroupSlots()) {
       unsigned sourceBits =

--- a/test/lit/vmi_new/vmi_to_vpto_group_slots_bf16_extf_store.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_slots_bf16_extf_store.pto
@@ -1,0 +1,83 @@
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER
+
+module {
+  func.func @group_slots_bf16_extf_store(
+      %src: !pto.ptr<bf16, ub>, %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c256 = arith.constant 256 : index
+    %mask = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xpred>
+    %input = pto.vmi.vload %src[%c0]
+        : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+    %bits = pto.vmi.vinterpret_cast %input
+        : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xui16>
+    %max_bits = pto.vmi.vcmax %bits, %mask {group = 8}
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.mask<256xpred>
+        -> !pto.vmi.vreg<8xui16>
+    %max = pto.vmi.vinterpret_cast %max_bits
+        : !pto.vmi.vreg<8xui16> -> !pto.vmi.vreg<8xbf16>
+    %wide = pto.vmi.vcvt %max
+        : !pto.vmi.vreg<8xbf16> -> !pto.vmi.vreg<8xf32>
+    pto.vmi.vstore %wide, %dst[%c0], %c1 {group = 8}
+        : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
+    return
+  }
+
+  func.func @group_slots_bf16_extf_store_tail(
+      %src: !pto.ptr<bf16, ub>, %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c384 = arith.constant 384 : index
+    %mask = pto.vmi.create_mask %c384 : index -> !pto.vmi.mask<384xpred>
+    %input = pto.vmi.vload %src[%c0]
+        : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<384xbf16>
+    %bits = pto.vmi.vinterpret_cast %input
+        : !pto.vmi.vreg<384xbf16> -> !pto.vmi.vreg<384xui16>
+    %max_bits = pto.vmi.vcmax %bits, %mask {group = 12}
+        : !pto.vmi.vreg<384xui16>, !pto.vmi.mask<384xpred>
+        -> !pto.vmi.vreg<12xui16>
+    %max = pto.vmi.vinterpret_cast %max_bits
+        : !pto.vmi.vreg<12xui16> -> !pto.vmi.vreg<12xbf16>
+    %wide = pto.vmi.vcvt %max
+        : !pto.vmi.vreg<12xbf16> -> !pto.vmi.vreg<12xf32>
+    pto.vmi.vstore %wide, %dst[%c0], %c1 {group = 12}
+        : !pto.vmi.vreg<12xf32>, !pto.ptr<f32, ub>
+    return
+  }
+}
+
+// ASSIGN-LABEL: func.func @group_slots_bf16_extf_store
+// ASSIGN: %[[MAX:.*]] = pto.vmi.group_reduce_maxi
+// ASSIGN-SAME: -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>
+// ASSIGN: %[[BF16:.*]] = pto.vmi.bitcast %[[MAX]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<8xbf16, #pto.vmi.layout<num_groups = 8, slots = 8>>
+// ASSIGN: %[[WIDE:.*]] = pto.vmi.extf %[[BF16]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+// ASSIGN: pto.vmi.group_store %[[WIDE]]
+
+// ASSIGN-LABEL: func.func @group_slots_bf16_extf_store_tail
+// ASSIGN: %[[MAX_TAIL:.*]] = pto.vmi.group_reduce_maxi
+// ASSIGN-SAME: -> !pto.vmi.vreg<12xui16, #pto.vmi.layout<num_groups = 12, slots = 8>>
+// ASSIGN: %[[BF16_TAIL:.*]] = pto.vmi.bitcast %[[MAX_TAIL]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<12xbf16, #pto.vmi.layout<num_groups = 12, slots = 8>>
+// ASSIGN: %[[WIDE_TAIL:.*]] = pto.vmi.extf %[[BF16_TAIL]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<12xf32, #pto.vmi.layout<num_groups = 12, slots = 8>>
+// ASSIGN: pto.vmi.group_store %[[WIDE_TAIL]]
+
+// LOWER-LABEL: func.func @group_slots_bf16_extf_store
+// LOWER: pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+// LOWER: pto.vcvt {{.*}} {part = "ODD"} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+// LOWER: %[[LOW:.*]], %{{.*}} = pto.vintlv {{.*}} : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
+// LOWER: %[[STORE8:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
+// LOWER: pto.vsts %[[LOW]], {{.*}}, %[[STORE8]] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+
+// LOWER-LABEL: func.func @group_slots_bf16_extf_store_tail
+// LOWER: pto.pset_b16 "PAT_VL8"
+// LOWER: %[[LOW0:.*]], %{{.*}} = pto.vintlv {{.*}} : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
+// LOWER: pto.pset_b16 "PAT_VL4"
+// LOWER: %[[LOW1:.*]], %{{.*}} = pto.vintlv {{.*}} : !pto.vreg<64xf32>, !pto.vreg<64xf32> -> !pto.vreg<64xf32>, !pto.vreg<64xf32>
+// LOWER: %[[STORE8_TAIL:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
+// LOWER: pto.vsts %[[LOW0]], {{.*}}, %[[STORE8_TAIL]] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// LOWER: %[[STORE4:.*]] = pto.pset_b32 "PAT_VL4" : !pto.mask<b32>
+// LOWER: pto.vsts %[[LOW1]], {{.*}}, %[[STORE4]] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>

--- a/test/lit/vmi_new/vmi_to_vpto_group_slots_integer_widen.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_slots_integer_widen.pto
@@ -1,0 +1,51 @@
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s
+
+module {
+  func.func @group_slots_ui8_to_ui16(
+      %src: !pto.ptr<ui8, ub>, %dst: !pto.ptr<ui16, ub>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c256 = arith.constant 256 : index
+    %mask = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xpred>
+    %input = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<256xui8>
+    %max = pto.vmi.vcmax %input, %mask {group = 8}
+        : !pto.vmi.vreg<256xui8>, !pto.vmi.mask<256xpred>
+        -> !pto.vmi.vreg<8xui8>
+    %wide = pto.vmi.vcvt %max
+        : !pto.vmi.vreg<8xui8> -> !pto.vmi.vreg<8xui16>
+    pto.vmi.vstore %wide, %dst[%c0], %c1 {group = 8}
+        : !pto.vmi.vreg<8xui16>, !pto.ptr<ui16, ub>
+    return
+  }
+
+  func.func @group_slots_ui8_to_ui32(
+      %src: !pto.ptr<ui8, ub>, %dst: !pto.ptr<ui32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c256 = arith.constant 256 : index
+    %mask = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xpred>
+    %input = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<256xui8>
+    %max = pto.vmi.vcmax %input, %mask {group = 8}
+        : !pto.vmi.vreg<256xui8>, !pto.vmi.mask<256xpred>
+        -> !pto.vmi.vreg<8xui8>
+    %wide = pto.vmi.vcvt %max
+        : !pto.vmi.vreg<8xui8> -> !pto.vmi.vreg<8xui32>
+    pto.vmi.vstore %wide, %dst[%c0], %c1 {group = 8}
+        : !pto.vmi.vreg<8xui32>, !pto.ptr<ui32, ub>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @group_slots_ui8_to_ui16
+// CHECK: pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<128xui16>
+// CHECK: pto.vcvt {{.*}} {part = "ODD"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<128xui16>
+// CHECK: pto.vintlv {{.*}} : !pto.vreg<128xui16>, !pto.vreg<128xui16> -> !pto.vreg<128xui16>, !pto.vreg<128xui16>
+
+// CHECK-LABEL: func.func @group_slots_ui8_to_ui32
+// CHECK: pto.vcvt {{.*}} {part = "P0"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
+// CHECK: pto.vcvt {{.*}} {part = "P1"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
+// CHECK: pto.vcvt {{.*}} {part = "P2"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
+// CHECK: pto.vcvt {{.*}} {part = "P3"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
+// CHECK-COUNT-3: pto.vintlv {{.*}} : !pto.vreg<64xui32>, !pto.vreg<64xui32> -> !pto.vreg<64xui32>, !pto.vreg<64xui32>


### PR DESCRIPTION
## Summary
- materialize compact `group_slots` widening with `vcvt` partition streams and register interleaves
- support 2x and 4x storage-width widening for floating-point and integer VMI extension lowering
- derive and validate 256-byte physical carriers per chunk; avoid invalid logical-size VPTO vregs
- add BF16 8/12-group and UI8 widening coverage through public VMI ops

## Scope
This PR fixes the lowering required to express the ASC-style group-result conversion/store sequence. It does **not** rewrite the #1209 reproducer end to end or establish an A5 performance result by itself.

## Root cause
A grouped BF16 reduction produces compact `group_slots` values. Widening those values partitions compact source lanes (`EVEN`/`ODD` for 2x, `P0`..`P3` for 4x); the old lowering had no legal materialization that restored their original lane order before a group store.

The current #1209 VMI fixture works around this limitation by widening the full `abs_bits` vector to f32 and running a second f32 group reduction for `scale_out`. ASC instead reuses the BF16 grouped maximum directly (`vcgmax -> bitcast -> vcvt PART_EVEN -> store`). Thus this PR removes the lowering blocker, but the fixture must still be rewritten to consume the original group maximum before the VMI source algorithm aligns with ASC.

## Lowering
- 2x: `vcvt EVEN`, `vcvt ODD`, then `vintlv.low`
- 4x: `vcvt P0..P3`, then three `vintlv.low` operations

`slots=1` remains on the existing sparse path and is deliberately excluded.

## Validation
- full local `ninja` build
- `llvm-lit` 7 focused VMI tests, all passed
- `git diff --check`

Relates to #1209.