### PR TITLE
Revert PR #1217 pending complete CI validation

### DIFF
--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -579,7 +579,6 @@ def VMITruncFOp : VMI_Op<"truncf", [Pure]> {
 def VMIFPToSIOp : VMI_Op<"fptosi", [Pure]> {
   let summary = "VMI floating-point to signed integer elementwise conversion";
   let arguments = (ins VMI_VRegTypeConstraint:$source,
-                   OptionalAttr<StrAttr>:$rounding,
                    OptionalAttr<StrAttr>:$saturate);
   let results = (outs VMI_VRegTypeConstraint:$result);
   let hasVerifier = 1;
@@ -589,7 +588,6 @@ def VMIFPToSIOp : VMI_Op<"fptosi", [Pure]> {
 def VMIFPToUIOp : VMI_Op<"fptoui", [Pure]> {
   let summary = "VMI floating-point to unsigned integer elementwise conversion";
   let arguments = (ins VMI_VRegTypeConstraint:$source,
-                   OptionalAttr<StrAttr>:$rounding,
                    OptionalAttr<StrAttr>:$saturate);
   let results = (outs VMI_VRegTypeConstraint:$result);
   let hasVerifier = 1;
@@ -1383,10 +1381,9 @@ def VMICvtOp : VMI_Op<"vcvt", [Pure]> {
     - int → int, |dst| < |src|: integer truncation         (replaces trunci)
 
     Attributes:
-    - `rounding`: rounding mode for fp narrowing and fp-to-integer
-      conversions. Narrowing accepts R=nearest-even, A=away-from-zero,
-      H=half-up, Z=toward-zero; fp-to-integer accepts the hardware modes
-      R/A/F/C/Z.
+    - `rounding`: rounding mode for fp narrowing (R=nearest-even,
+      A=away-from-zero, H=half-up, Z=toward-zero). Valid only when dst
+      bit-width < src bit-width for fp types.
     - `saturate`: "SAT" or "NOSAT"; required for fp narrowing, integer
       narrowing, and fp-to-int conversion.
     - `pmode`: predication mode ("merge" | "zero").

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -1996,12 +1996,6 @@ LogicalResult VMIFPToSIOp::verify() {
   if (!contract) {
     return emitOpError("unsupported fp-to-si conversion element type pair");
   }
-  if (auto roundingAttr = (*this)->getAttrOfType<StringAttr>("rounding")) {
-    StringRef rounding = roundingAttr.getValue();
-    if (rounding != "R" && rounding != "A" && rounding != "F" &&
-        rounding != "C" && rounding != "Z")
-      return emitOpError("rounding attr must be R, A, F, C, or Z");
-  }
   if (contract->requiresSat) {
     auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
     if (!satAttr)
@@ -2036,12 +2030,6 @@ LogicalResult VMIFPToUIOp::verify() {
                               resultType.getElementType());
   if (!contract) {
     return emitOpError("unsupported fp-to-ui conversion element type pair");
-  }
-  if (auto roundingAttr = (*this)->getAttrOfType<StringAttr>("rounding")) {
-    StringRef rounding = roundingAttr.getValue();
-    if (rounding != "R" && rounding != "A" && rounding != "F" &&
-        rounding != "C" && rounding != "Z")
-      return emitOpError("rounding attr must be R, A, F, C, or Z");
   }
   if (contract->requiresSat) {
     auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
@@ -3950,21 +3938,14 @@ LogicalResult VMICvtOp::verify() {
 
   // --- rounding ---
   if (auto roundingAttr = (*this)->getAttrOfType<StringAttr>("rounding")) {
-    if (dir != CvtDirection::FpNarrow && dir != CvtDirection::FpToSi &&
-        dir != CvtDirection::FpToUi)
-      return emitOpError("'rounding' attribute is only valid for floating-point "
-                         "narrowing or floating-point-to-integer conversions");
+    if (dir != CvtDirection::FpNarrow)
+      return emitOpError("'rounding' attribute is only valid for "
+                         "fp-narrowing conversions");
     StringRef rnd = roundingAttr.getValue();
-    if (dir == CvtDirection::FpNarrow) {
-      if (rnd != "R" && rnd != "A" && rnd != "H" && rnd != "Z")
-        return emitOpError("rounding must be 'R' (nearest-even), "
-                           "'A' (away-from-zero), 'H' (half-up), "
-                           "or 'Z' (toward-zero)");
-    } else if (rnd != "R" && rnd != "A" && rnd != "F" && rnd != "C" &&
-               rnd != "Z") {
-      return emitOpError("rounding must be 'R', 'A', 'F', 'C', or 'Z' for "
-                         "floating-point-to-integer conversions");
-    }
+    if (rnd != "R" && rnd != "A" && rnd != "H" && rnd != "Z")
+      return emitOpError("rounding must be 'R' (nearest-even), "
+                         "'A' (away-from-zero), 'H' (half-up), "
+                         "or 'Z' (toward-zero)");
   }
 
   // --- saturate ---

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -396,15 +396,11 @@ static LogicalResult lowerVCvt(VMICvtOp op, OpBuilder &builder) {
             .getResult();
   } else if (direction == "fptosi") {
     result =
-        builder
-            .create<VMIFPToSIOp>(loc, resultType, source,
-                                 op.getRoundingAttr(), saturateAttr)
+        builder.create<VMIFPToSIOp>(loc, resultType, source, saturateAttr)
             .getResult();
   } else if (direction == "fptoui") {
     result =
-        builder
-            .create<VMIFPToUIOp>(loc, resultType, source,
-                                 op.getRoundingAttr(), saturateAttr)
+        builder.create<VMIFPToUIOp>(loc, resultType, source, saturateAttr)
             .getResult();
   } else if (direction == "sitofp") {
     result =

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12017,9 +12017,7 @@ struct OneToNVMIFPToSIOpPattern : OpConversionPattern<VMIFPToSIOp> {
       resultVRegTypes.push_back(resultType);
     }
 
-    StringAttr rnd = op->getAttrOfType<StringAttr>("rounding");
-    if (!rnd)
-      rnd = rewriter.getStringAttr("R");
+    StringAttr rnd = rewriter.getStringAttr("R");
     StringAttr sat =
         contract->requiresSat
             ? op->getAttrOfType<StringAttr>("saturate")
@@ -12232,9 +12230,7 @@ struct OneToNVMIFPToUIOpPattern : OpConversionPattern<VMIFPToUIOp> {
       resultVRegTypes.push_back(resultType);
     }
 
-    StringAttr rnd = op->getAttrOfType<StringAttr>("rounding");
-    if (!rnd)
-      rnd = rewriter.getStringAttr("R");
+    StringAttr rnd = rewriter.getStringAttr("R");
     StringAttr sat = contract->requiresSat
                          ? op->getAttrOfType<StringAttr>("saturate")
                          : nullptr;

--- a/test/lit/vmi_new/vmi_conversion_contract_matrix.pto
+++ b/test/lit/vmi_new/vmi_conversion_contract_matrix.pto
@@ -1,11 +1,3 @@
-// Copyright (c) 2026 Huawei Technologies Co., Ltd.
-// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
-// CANN Open Software License Agreement Version 2.0 (the "License").
-// Please refer to the License for details. You may not use this file except in compliance with the License.
-// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
-// See LICENSE in the root of the software repository for the full text of the License.
-
 // RUN: pto-test-opt %s -verify-diagnostics -split-input-file
 
 // Positive matrix: six directions, all rounding tokens, saturation values,
@@ -31,7 +23,7 @@ module {
 
 module {
   func.func @rounding_wrong_direction(%x: !pto.vmi.vreg<64xf16>) {
-    // expected-error@+1 {{'rounding' attribute is only valid for floating-point narrowing or floating-point-to-integer conversions}}
+    // expected-error@+1 {{'rounding' attribute is only valid for fp-narrowing conversions}}
     %r = pto.vmi.vcvt %x {rounding = "R"} : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xf32>
     return
   }

--- a/test/lit/vmi_new/vmi_to_vpto_fptosi_same_width.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_fptosi_same_width.pto
@@ -36,19 +36,6 @@ module {
         -> !pto.vreg<64xsi32>
     return %r : !pto.vreg<64xsi32>
   }
-
-  // ROUND_Z must survive both unified-to-legacy and VMI-to-VPTO lowering.
-  func.func @f32_to_s32_round_z(
-      %input: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>)
-      -> !pto.vreg<64xsi32> {
-    %cvt = pto.vmi.vcvt %input {rounding = "Z", saturate = "SAT"}
-        : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
-        -> !pto.vmi.vreg<64xsi32, #pto.vmi.layout<contiguous>>
-    %r = "pto.vmi.unpack"(%cvt)
-        : (!pto.vmi.vreg<64xsi32, #pto.vmi.layout<contiguous>>)
-        -> !pto.vreg<64xsi32>
-    return %r : !pto.vreg<64xsi32>
-  }
 }
 
 // CHECK-LABEL: func.func @f16_to_s16(
@@ -57,8 +44,4 @@ module {
 
 // CHECK-LABEL: func.func @f32_to_s32(
 // CHECK: pto.vcvt {{.*}} {rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xsi32>
-// CHECK-NOT: part
-
-// CHECK-LABEL: func.func @f32_to_s32_round_z(
-// CHECK: pto.vcvt {{.*}} {rnd = "Z", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xsi32>
 // CHECK-NOT: part

--- a/test/lit/vmi_new/vmi_vcvt_fptosi_lower_to_legacy_new.pto
+++ b/test/lit/vmi_new/vmi_vcvt_fptosi_lower_to_legacy_new.pto
@@ -22,12 +22,6 @@ module {
     %r = pto.vmi.vcvt %s {saturate = "SAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xsi16>
     return %r : !pto.vmi.vreg<64xsi16>
   }
-  // Rounding must be preserved when vcvt lowers to the legacy fptosi op.
-  func.func @f32_to_s32_round_z(%s: !pto.vmi.vreg<64xf32>) -> !pto.vmi.vreg<64xsi32> {
-    %r = pto.vmi.vcvt %s {rounding = "Z", saturate = "SAT"}
-        : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xsi32>
-    return %r : !pto.vmi.vreg<64xsi32>
-  }
   // f16->s8: NOSAT on vcvt -> NOSAT on fptosi
   func.func @f16_to_s8(%s: !pto.vmi.vreg<64xf16>) -> !pto.vmi.vreg<64xsi8> {
     %r = pto.vmi.vcvt %s {saturate = "NOSAT"} : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xsi8>
@@ -41,9 +35,6 @@ module {
 
 // CHECK-LABEL: func.func @f32_to_s16
 // CHECK: pto.vmi.fptosi %{{.*}} {saturate = "SAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xsi16>
-
-// CHECK-LABEL: func.func @f32_to_s32_round_z
-// CHECK: pto.vmi.fptosi %{{.*}} {rounding = "Z", saturate = "SAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xsi32>
 
 // CHECK-LABEL: func.func @f16_to_s8
 // CHECK: pto.vmi.fptosi %{{.*}} {saturate = "NOSAT"} : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xsi8>


### PR DESCRIPTION
Reverts #1217 because it was merged before the latest vpto-sim-validation completed.\n\nThe #585 fix will be reopened from the reverted main baseline and merged only after all CI checks, including vpto-sim-validation, finish successfully.