### PR TITLE
feat(vpto): add L1 fill intrinsic support

### DIFF
--- a/docs/isa/micro-isa/16-cube-matmul.md
+++ b/docs/isa/micro-isa/16-cube-matmul.md
@@ -397,6 +397,61 @@ pto.mte_l1_ub %l1_src, %ub_dst, %c64_i64
 
 ---
 
+### `pto.mte_fill_l1`
+
+- **syntax:**
+```mlir
+pto.mte_fill_l1 %dst, %byte_offset, %raw_value, %repeat_times,
+  %block_num_32b, %dst_gap_32b, fill_word_bits
+  : !pto.ptr<T, l1>, i64, i64, i64, i64, i64
+```
+- **semantics:** Fill a strided L1 region with a repeated 16-bit or 32-bit
+  word. The destination address is `%dst + %byte_offset`. Each repeat writes
+  `%block_num_32b` consecutive 32-byte blocks, then skips `%dst_gap_32b`
+  32-byte blocks before the next repeat.
+
+**Parameter Table:**
+
+| Parameter | Width | Description |
+|-----------|-------|-------------|
+| `%dst` | ptr | L1 destination base pointer |
+| `%byte_offset` | i64 | Non-negative byte offset from `%dst` to the first written byte |
+| `%raw_value` | i64 | Raw repeated word; the low `fill_word_bits` bits are used |
+| `%repeat_times` | i64 | Number of repeated fill regions |
+| `%block_num_32b` | i64 | Number of consecutive 32-byte blocks written per repeat |
+| `%dst_gap_32b` | i64 | Number of skipped 32-byte blocks between repeats |
+| `fill_word_bits` | integer attribute | Repeated word width: `16` or `32` |
+
+Reference behavior:
+
+```text
+word = low_bits(raw_value, fill_word_bits)
+for r in 0 .. repeat_times-1:
+  repeat_start = byte_offset + r * (block_num_32b + dst_gap_32b) * 32
+  fill dst[repeat_start : repeat_start + block_num_32b * 32] with word
+```
+
+**Constraints:**
+
+- `%dst` must be in the `l1` address space.
+- `%byte_offset` must be non-negative.
+- `%repeat_times`, `%block_num_32b`, and `%dst_gap_32b` must each be in
+  `[0, 32767]`.
+- `fill_word_bits` must be `16` or `32`.
+
+**Example:**
+
+```mlir
+pto.mte_fill_l1 %l1, %c32_i64, %zero_i64, %c2_i64,
+  %c4_i64, %c1_i64, 16
+  : !pto.ptr<f16, l1>, i64, i64, i64, i64, i64
+```
+
+This fills four 32-byte blocks starting at byte offset 32, skips one 32-byte
+block, then fills another four blocks with 16-bit zero words.
+
+---
+
 ### `pto.mte_gm_l1_frac`
 
 - **syntax:**

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -1333,7 +1333,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | 13 | [DSA/SFU Ops](isa/micro-isa/13-dsa-sfu-ops.md) | Specialized ops, index generation, and sorting helpers | 11 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdif`, `pto.vaxpy`, `pto.vmulscvt`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4`, `pto.get_vms4_sr` |
 | 14 | [Arith (Shared MLIR Dialect)](isa/micro-isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
 | 15 | [SCF (Shared MLIR Dialect)](isa/micro-isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
-| 16 | [Cube Matrix Multiply](isa/micro-isa/16-cube-matmul.md) | GM↔L1 (`l1`/cbuf) staging, L1 (`l1`)↔UB/BT/FB side moves, L1→L0A/L0B loads, L0C (`l0c`) matmul, and FIXPIPE MTE writeback | 19 | `pto.mte_gm_l1`, `pto.mte_l1_ub`, `pto.mte_gm_l1_frac`, `pto.mte_l1_bt`, `pto.mte_l1_fb`, `pto.mte_l1_l0a`, `pto.mte_l1_l0b`, `pto.mte_l1_l0a_mx`, `pto.mte_l1_l0b_mx`, `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias`, `pto.mte_l0c_l1`, `pto.mte_l0c_gm`, `pto.mte_l0c_ub` |
+| 16 | [Cube Matrix Multiply](isa/micro-isa/16-cube-matmul.md) | GM↔L1 (`l1`/cbuf) staging and fill, L1 (`l1`)↔UB/BT/FB side moves, L1→L0A/L0B loads, L0C (`l0c`) matmul, and FIXPIPE MTE writeback | 20 | `pto.mte_gm_l1`, `pto.mte_l1_ub`, `pto.mte_fill_l1`, `pto.mte_gm_l1_frac`, `pto.mte_l1_bt`, `pto.mte_l1_fb`, `pto.mte_l1_l0a`, `pto.mte_l1_l0b`, `pto.mte_l1_l0a_mx`, `pto.mte_l1_l0b_mx`, `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias`, `pto.mte_l0c_l1`, `pto.mte_l0c_gm`, `pto.mte_l0c_ub` |
 | 17 | [SIMT Ops](isa/micro-isa/17-simt.md) | SIMT launch, thread/lane queries, vote/shuffle/redux, scalar memory, atomics, scalar math, conversion, entry synchronization, and state preservation | ~65 | `pto.store_vfsimt_info`, `pto.simt_launch`, `pto.get_tid_x`, `pto.get_laneid`, `pto.vote_*`, `pto.shuffle_*`, `pto.redux_*`, `pto.load`, `pto.store`, `pto.atomic_*`, `pto.convert`, `pto.syncthreads`, `pto.keep`, `pto.resume`, etc. |
 | 18 | [Special Scalar Operations](isa/micro-isa/18-special-scalar.md) | PTO scalar kernel queries, typed pointer/address calculation, scalar-pipeline memory, and ordinary AICore GM L1-bypass access | 10 | `pto.get_block_idx`, `pto.get_subblock_idx`, `pto.get_block_num`, `pto.get_subblock_num`, `pto.castptr`, `pto.addptr`, `pto.load_scalar`, `pto.store_scalar`, `pto.ld_dev`, `pto.st_dev` |
 
@@ -1350,6 +1350,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | UB→UB / UB→L1 copy | 2 | `pto.mte_ub_ub`, `pto.mte_ub_l1` |
 | GM→L1 | 16 | `pto.mte_gm_l1`, `pto.mte_gm_l1_frac` |
 | L1→UB | 16 | `pto.mte_l1_ub` |
+| L1 fill | 16 | `pto.mte_fill_l1` |
 | L1→BT | 16 | `pto.mte_l1_bt` |
 | L1→FB | 16 | `pto.mte_l1_fb` |
 | L1→L0A / L1→L0B | 16 | `pto.mte_l1_l0a`, `pto.mte_l1_l0b`, `pto.mte_l1_l0a_mx`, `pto.mte_l1_l0b_mx` |
@@ -1420,6 +1421,7 @@ shared structured-control semantics remain in Group 15.
 - `pto.mte_l1_fb`
 - `pto.mte_gm_l1`
 - `pto.mte_gm_l1_frac`
+- `pto.mte_fill_l1`
 - `pto.mte_l1_ub`
 - `pto.mte_l1_l0a`
 - `pto.mte_l1_l0b`

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -1308,6 +1308,33 @@ def PTO_CopyGmToCbufMultiDn2NzOp : PTO_MteOp<"copy_gm_to_cbuf_multi_dn2nz"> {
   }];
 }
 
+def PTO_MteFillL1Op : PTO_MteOp<"mte_fill_l1", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  ]> {
+  let summary = "Fill a strided L1 region with a repeated 16/32-bit pattern";
+
+  let arguments = (ins
+    PTO_BufferType:$destination,
+    I64:$byte_offset,
+    I64:$raw_value,
+    I64:$repeat_times,
+    I64:$block_num_32b,
+    I64:$dst_gap_32b,
+    I64Attr:$fill_word_bits
+  );
+
+  let results = (outs);
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $destination `,` $byte_offset `,` $raw_value `,` $repeat_times `,`
+    $block_num_32b `,` $dst_gap_32b `,` $fill_word_bits
+    attr-dict `:` type($destination) `,` type($byte_offset) `,`
+    type($raw_value) `,` type($repeat_times) `,` type($block_num_32b) `,`
+    type($dst_gap_32b)
+  }];
+}
+
 def PTO_CopyCbufToBtOp : PTO_MteOp<"copy_cbuf_to_bt"> {
   let arguments = (ins
     PTO_BufferType:$source,

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -7677,6 +7677,38 @@ void MteGmL1FracOp::getEffects(
   effects.emplace_back(MemoryEffects::Write::get(), &getDestinationMutable());
 }
 
+LogicalResult MteFillL1Op::verify() {
+  constexpr uint64_t kMaxFillConfigField = 0x7fff;
+  auto ptrType = dyn_cast<pto::PtrType>(getDestination().getType());
+  if (!ptrType || ptrType.getMemorySpace().getAddressSpace() != AddressSpace::MAT)
+    return emitOpError("requires destination in mat address space");
+  if (getFillWordBits() != 16 && getFillWordBits() != 32)
+    return emitOpError("fill_word_bits must be 16 or 32");
+
+  auto checkConfigField = [&](Value value, StringRef name) -> LogicalResult {
+    APInt intValue;
+    if (matchPattern(value, m_ConstantInt(&intValue)) &&
+        (intValue.isNegative() || intValue.ugt(kMaxFillConfigField)))
+      return emitOpError() << name << " must be in range [0, 32767]";
+    return success();
+  };
+  APInt byteOffset;
+  if (matchPattern(getByteOffset(), m_ConstantInt(&byteOffset)) &&
+      byteOffset.isNegative())
+    return emitOpError("byte_offset must be non-negative");
+  if (failed(checkConfigField(getRepeatTimes(), "repeat_times")) ||
+      failed(checkConfigField(getBlockNum_32b(), "block_num_32b")) ||
+      failed(checkConfigField(getDstGap_32b(), "dst_gap_32b")))
+    return failure();
+  return success();
+}
+
+void MteFillL1Op::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), &getDestinationMutable());
+}
+
 ParseResult MteL0cL1Op::parse(OpAsmParser &parser, OperationState &result) {
   Builder builder(parser.getContext());
   StructuredAccStoreAsmState state;

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -5289,6 +5289,63 @@ private:
   LoweringState &state;
 };
 
+class LowerMteFillL1OpPattern final
+    : public OpConversionPattern<pto::MteFillL1Op> {
+public:
+  explicit LowerMteFillL1OpPattern(TypeConverter &typeConverter,
+                                   MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<pto::MteFillL1Op>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult matchAndRewrite(pto::MteFillL1Op op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    Value destinationRaw = adaptor.getDestination();
+    if (!destinationRaw || !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
+      return rewriter.notifyMatchFailure(op, "expected converted MAT pointer");
+    FailureOr<Value> destination = reinterpretPointerToAddrSpace(
+        op, destinationRaw, static_cast<unsigned>(pto::AddressSpace::MAT));
+    if (failed(destination))
+      return rewriter.notifyMatchFailure(op, "failed to map MAT pointer space");
+
+    Type i64Ty = rewriter.getI64Type();
+    Value base = rewriter.create<LLVM::PtrToIntOp>(op.getLoc(), i64Ty, *destination);
+    Value byteOffset = castIntegerLikeTo(op, adaptor.getByteOffset(), i64Ty);
+    Value address = rewriter.create<arith::AddIOp>(op.getLoc(), base, byteOffset);
+    Value pointer = rewriter.create<LLVM::IntToPtrOp>(
+        op.getLoc(), destination->getType(), address);
+    Value fieldMask = getI64Constant(rewriter, op.getLoc(), 0x7fff);
+    auto maskConfigField = [&](Value value) -> Value {
+      return rewriter.create<arith::AndIOp>(
+          op.getLoc(), castIntegerLikeTo(op, value, i64Ty), fieldMask);
+    };
+    Value config = maskConfigField(adaptor.getRepeatTimes());
+    config = rewriter.create<arith::OrIOp>(
+        op.getLoc(), config,
+        rewriter.create<arith::ShLIOp>(
+            op.getLoc(), maskConfigField(adaptor.getBlockNum_32b()),
+            getI64Constant(rewriter, op.getLoc(), 16)));
+    config = rewriter.create<arith::OrIOp>(
+        op.getLoc(), config,
+        rewriter.create<arith::ShLIOp>(
+            op.getLoc(), maskConfigField(adaptor.getDstGap_32b()),
+            getI64Constant(rewriter, op.getLoc(), 32)));
+    Value rawValue = castIntegerLikeTo(op, adaptor.getRawValue(), i64Ty);
+    StringRef suffix = op.getFillWordBits() == 16 ? ".v3.u16" : ".v3.u32";
+    StringRef calleeName = StringAttr::get(
+        op.getContext(), "llvm.hivm.CREATE.CBUF.MATRIX" + suffix).getValue();
+    auto funcType = rewriter.getFunctionType(
+        TypeRange{pointer.getType(), i64Ty, i64Ty}, TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{},
+                                  ValueRange{pointer, config, rawValue});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
 class LowerCopyCbufToBtOpPattern final
     : public OpConversionPattern<pto::CopyCbufToBtOp> {
 public:
@@ -11026,6 +11083,7 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerCopyCbufToBtOpPattern, LowerCopyCbufToFbufOpPattern,
                LowerCopyGmToCbufMultiOpPattern<pto::CopyGmToCbufMultiNd2NzOp>,
                LowerCopyGmToCbufMultiOpPattern<pto::CopyGmToCbufMultiDn2NzOp>,
+               LowerMteFillL1OpPattern,
                LowerMadRawPattern<pto::MadRawOp>,
                LowerMadRawPattern<pto::MadBiasRawOp>,
                LowerMadRawPattern<pto::MadMxRawOp>,
@@ -11090,7 +11148,8 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                       pto::SetStoreAtomicCfgOp,
                       pto::SetAtomicS32Op, pto::SetAtomicS8Op, pto::SetCtrlOp,
                       pto::StoreVfSimtInfoOp,
-                      pto::SetMovPadValOp, pto::SetQuantPreOp>();
+                      pto::SetMovPadValOp, pto::SetQuantPreOp,
+                      pto::MteFillL1Op>();
   target.addIllegalOp<pto::Sbitset0Op, pto::Sbitset1Op>();
   target.addIllegalOp<pto::VldsOp, pto::Vldsx2Op, pto::VsldbOp,
                       pto::VldasOp, pto::InitAlignOp, pto::VldusOp,

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -5895,6 +5895,63 @@ private:
   LoweringState &state;
 };
 
+class LowerMteFillL1OpPattern final
+    : public OpConversionPattern<pto::MteFillL1Op> {
+public:
+  explicit LowerMteFillL1OpPattern(TypeConverter &typeConverter,
+                                   MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<pto::MteFillL1Op>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult matchAndRewrite(pto::MteFillL1Op op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    Value destinationRaw = adaptor.getDestination();
+    if (!destinationRaw || !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
+      return rewriter.notifyMatchFailure(op, "expected converted MAT pointer");
+    FailureOr<Value> destination = reinterpretPointerToAddrSpace(
+        op, destinationRaw, static_cast<unsigned>(pto::AddressSpace::MAT));
+    if (failed(destination))
+      return rewriter.notifyMatchFailure(op, "failed to map MAT pointer space");
+
+    Type i64Ty = rewriter.getI64Type();
+    Value base = rewriter.create<LLVM::PtrToIntOp>(op.getLoc(), i64Ty, *destination);
+    Value byteOffset = castIntegerLikeTo(op, adaptor.getByteOffset(), i64Ty);
+    Value address = rewriter.create<arith::AddIOp>(op.getLoc(), base, byteOffset);
+    Value pointer = rewriter.create<LLVM::IntToPtrOp>(
+        op.getLoc(), destination->getType(), address);
+    Value fieldMask = getI64Constant(rewriter, op.getLoc(), 0x7fff);
+    auto maskConfigField = [&](Value value) -> Value {
+      return rewriter.create<arith::AndIOp>(
+          op.getLoc(), castIntegerLikeTo(op, value, i64Ty), fieldMask);
+    };
+    Value config = maskConfigField(adaptor.getRepeatTimes());
+    config = rewriter.create<arith::OrIOp>(
+        op.getLoc(), config,
+        rewriter.create<arith::ShLIOp>(
+            op.getLoc(), maskConfigField(adaptor.getBlockNum_32b()),
+            getI64Constant(rewriter, op.getLoc(), 16)));
+    config = rewriter.create<arith::OrIOp>(
+        op.getLoc(), config,
+        rewriter.create<arith::ShLIOp>(
+            op.getLoc(), maskConfigField(adaptor.getDstGap_32b()),
+            getI64Constant(rewriter, op.getLoc(), 32)));
+    Value rawValue = castIntegerLikeTo(op, adaptor.getRawValue(), i64Ty);
+    StringRef suffix = op.getFillWordBits() == 16 ? ".v3.u16" : ".v3.u32";
+    StringRef calleeName = StringAttr::get(
+        op.getContext(), "llvm.hivm.CREATE.CBUF.MATRIX" + suffix).getValue();
+    auto funcType = rewriter.getFunctionType(
+        TypeRange{pointer.getType(), i64Ty, i64Ty}, TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{},
+                                  ValueRange{pointer, config, rawValue});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
 class LowerCopyCbufToBtOpPattern final
     : public OpConversionPattern<pto::CopyCbufToBtOp> {
 public:
@@ -11550,6 +11607,7 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerCopyCbufToBtOpPattern, LowerCopyCbufToFbufOpPattern,
                LowerCopyGmToCbufMultiOpPattern<pto::CopyGmToCbufMultiNd2NzOp>,
                LowerCopyGmToCbufMultiOpPattern<pto::CopyGmToCbufMultiDn2NzOp>,
+               LowerMteFillL1OpPattern,
                LowerMadRawPattern<pto::MadRawOp>,
                LowerMadRawPattern<pto::MadBiasRawOp>,
                LowerMadRawPattern<pto::MadMxRawOp>,
@@ -11680,7 +11738,8 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                       pto::SetStoreAtomicCfgOp,
                       pto::SetAtomicS32Op, pto::SetAtomicS8Op, pto::SetCtrlOp,
                       pto::StoreVfSimtInfoOp,
-                      pto::SetMovPadValOp, pto::SetQuantPreOp>();
+                      pto::SetMovPadValOp, pto::SetQuantPreOp,
+                      pto::MteFillL1Op>();
   target.addIllegalOp<pto::Sbitset0Op, pto::Sbitset1Op>();
   target.addIllegalOp<pto::VldsOp, pto::Vldsx2Op, pto::VsldbOp,
                       pto::VldasOp, pto::InitAlignOp, pto::VldusOp,

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -5297,6 +5297,8 @@ def mte_gm_l1_frac(source, destination, mode, *, shape, src_layout, dst_group, c
         src_layout,
         context="mte_gm_l1_frac(...)",
     )
+
+
     group_count, dst_loop2_stride, dst_loop3_stride, dst_loop4_stride = _normalize_frac_dst_group(
         dst_group,
         context="mte_gm_l1_frac(...)",
@@ -5316,6 +5318,31 @@ def mte_gm_l1_frac(source, destination, mode, *, shape, src_layout, dst_group, c
         smallc0_en,
         _cube_load_frac_mode_attr(mode),
         src_outer_stride=src_outer_stride,
+    )
+
+
+@_explicit_mode_only("pto.mte_fill_l1(...)")
+def mte_fill_l1(
+    destination,
+    raw_value,
+    *,
+    byte_offset,
+    repeat_times,
+    block_num_32b,
+    dst_gap_32b,
+    fill_word_bits=16,
+):
+    """Fill a strided MAT/L1 region using the cube MTE2 fill instruction."""
+    if fill_word_bits not in (16, 32):
+        raise ValueError("mte_fill_l1 fill_word_bits must be 16 or 32")
+    _pto.MteFillL1Op(
+        unwrap_surface_value(destination),
+        _coerce_i64(byte_offset, context="mte_fill_l1 byte_offset"),
+        _coerce_i64(raw_value, context="mte_fill_l1 raw_value"),
+        _coerce_i64(repeat_times, context="mte_fill_l1 repeat_times"),
+        _coerce_i64(block_num_32b, context="mte_fill_l1 block_num_32b"),
+        _coerce_i64(dst_gap_32b, context="mte_fill_l1 dst_gap_32b"),
+        fill_word_bits,
     )
 
 
@@ -6760,7 +6787,7 @@ __all__ = [
     "chistv2",
     "as_ptr",
     "mte_load", "mte_store", "mte_gm_ub", "mte_ub_gm", "mte_ub_ub", "mte_ub_l1",
-    "mte_gm_l1", "mte_l1_ub", "mte_gm_l1_frac", "mte_l1_bt", "mte_l1_fb", "mem_bar",
+    "mte_gm_l1", "mte_l1_ub", "mte_gm_l1_frac", "mte_fill_l1", "mte_l1_bt", "mte_l1_fb", "mem_bar",
     "set_store_atomic_cfg",
     "set_atomic_add", "set_atomic_max", "set_atomic_min", "set_atomic_none",
     "set_atomic_f32", "set_atomic_f16", "set_atomic_bf16",

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -122,7 +122,7 @@ from ._ops import (             # noqa: F401
     alloc_buffer, alloc_tile,
     tsort32, tmrgsort, tgather, tscatter,
     mte_load, mte_store, mte_gm_ub, mte_ub_gm, mte_ub_ub, mte_ub_l1,
-    mte_gm_l1, mte_l1_ub, mte_gm_l1_frac, mte_l1_bt, mte_l1_fb, mem_bar,
+    mte_gm_l1, mte_l1_ub, mte_gm_l1_frac, mte_fill_l1, mte_l1_bt, mte_l1_fb, mem_bar,
     set_store_atomic_cfg,
     set_atomic_add, set_atomic_max, set_atomic_min, set_atomic_none,
     set_atomic_f32, set_atomic_f16, set_atomic_bf16,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -3242,6 +3242,15 @@ def public_data_movement_surface_probe():
         dst_group=(1, 0, 0, 0),
         ctrl=(0, False),
     )
+    pto.mte_fill_l1(
+        l1_dst,
+        0,
+        byte_offset=32,
+        repeat_times=2,
+        block_num_32b=4,
+        dst_gap_32b=1,
+        fill_word_bits=16,
+    )
     pto.mte_l1_bt(l1_dst, bias_dst, 8, nburst=(1, 0, 0))
     pto.mte_l1_fb(l1_dst, scaling_dst, 8, nburst=(1, 0, 0))
 
@@ -3806,6 +3815,7 @@ def main() -> None:
         "mte_gm_l1",
         "mte_l1_ub",
         "mte_gm_l1_frac",
+        "mte_fill_l1",
         "mte_l1_bt",
         "mte_l1_fb",
         "vldsx2",
@@ -6837,6 +6847,7 @@ def main() -> None:
     expect("pto.mte_gm_l1" in data_movement_surface_text, "public grouped GM->L1 wrapper should lower to pto.mte_gm_l1")
     expect("pto.mte_l1_ub" in data_movement_surface_text, "public grouped L1->UB wrapper should lower to pto.mte_l1_ub")
     expect("pto.mte_gm_l1_frac" in data_movement_surface_text, "public GM->L1 frac wrapper should lower to pto.mte_gm_l1_frac")
+    expect("pto.mte_fill_l1" in data_movement_surface_text, "public L1 fill wrapper should lower to pto.mte_fill_l1")
     expect("pto.mte_l1_bt" in data_movement_surface_text, "public L1->BT wrapper should lower to pto.mte_l1_bt")
     expect("pto.mte_l1_fb" in data_movement_surface_text, "public L1->FB wrapper should lower to pto.mte_l1_fb")
     expect("pto.vldas" in data_movement_surface_text, "vldas(...) should lower to pto.vldas")

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -235,7 +235,7 @@ class VectorCubeSurfaceTest(unittest.TestCase):
             "vcmin", "vcgmin", "vcpadd",
             "vadds", "vmuls", "vmaxs", "vmins", "vlrelu", "vshls", "vshrs", "vands", "vors", "vxors",
             "vaxpy", "vmula", "vci", "vaddrelu", "vsubrelu", "vsel",
-            "mte_gm_l1", "mte_l1_ub", "mte_gm_l1_frac", "mte_l1_bt", "mte_l1_fb",
+            "mte_gm_l1", "mte_l1_ub", "mte_gm_l1_frac", "mte_fill_l1", "mte_l1_bt", "mte_l1_fb",
             "mad_acc", "mad_bias", "mad_mx", "mad_mx_acc", "mad_mx_bias",
             "FractalMode", "AccStoreUnitFlagCtrl", "MadUnitFlagMode", "SatMode", "Tf32Mode", "SplitMode",
         ]

--- a/test/lit/vpto/mte_fill_l1_verify.pto
+++ b/test/lit/vpto/mte_fill_l1_verify.pto
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: split-file %s %t
+// RUN: ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %t/max.pto -o /dev/null
+// RUN: not ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %t/repeat-negative.pto -o - 2>&1 | FileCheck %s --check-prefix=REPEAT
+// RUN: not ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %t/repeat-overflow.pto -o - 2>&1 | FileCheck %s --check-prefix=REPEAT
+// RUN: not ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %t/blocks-negative.pto -o - 2>&1 | FileCheck %s --check-prefix=BLOCKS
+// RUN: not ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %t/blocks-overflow.pto -o - 2>&1 | FileCheck %s --check-prefix=BLOCKS
+// RUN: not ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %t/gap-negative.pto -o - 2>&1 | FileCheck %s --check-prefix=GAP
+// RUN: not ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %t/gap-overflow.pto -o - 2>&1 | FileCheck %s --check-prefix=GAP
+
+// REPEAT: repeat_times must be in range [0, 32767]
+// BLOCKS: block_num_32b must be in range [0, 32767]
+// GAP: dst_gap_32b must be in range [0, 32767]
+
+//--- max.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @max_fields() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %max = arith.constant 32767 : i64
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<ui16, l1>
+    pto.mte_fill_l1 %dst, %c0, %c0, %max, %max, %max, 16
+      : !pto.ptr<ui16, l1>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- repeat-negative.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %bad = arith.constant -1 : i64
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<ui16, l1>
+    pto.mte_fill_l1 %dst, %c0, %c0, %bad, %c0, %c0, 16 : !pto.ptr<ui16, l1>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- repeat-overflow.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %bad = arith.constant 32768 : i64
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<ui16, l1>
+    pto.mte_fill_l1 %dst, %c0, %c0, %bad, %c0, %c0, 16 : !pto.ptr<ui16, l1>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- blocks-negative.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %bad = arith.constant -1 : i64
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<ui16, l1>
+    pto.mte_fill_l1 %dst, %c0, %c0, %c0, %bad, %c0, 16 : !pto.ptr<ui16, l1>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- blocks-overflow.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %bad = arith.constant 32768 : i64
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<ui16, l1>
+    pto.mte_fill_l1 %dst, %c0, %c0, %c0, %bad, %c0, 16 : !pto.ptr<ui16, l1>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- gap-negative.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %bad = arith.constant -1 : i64
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<ui16, l1>
+    pto.mte_fill_l1 %dst, %c0, %c0, %c0, %c0, %bad, 16 : !pto.ptr<ui16, l1>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- gap-overflow.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %bad = arith.constant 32768 : i64
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<ui16, l1>
+    pto.mte_fill_l1 %dst, %c0, %c0, %c0, %c0, %bad, 16 : !pto.ptr<ui16, l1>, i64, i64, i64, i64, i64
+    return
+  }
+}

--- a/test/lit/vpto/mte_fill_l1_vpto_llvm.pto
+++ b/test/lit/vpto/mte_fill_l1_vpto_llvm.pto
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @mte_fill_l1_intrinsics() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c2 = arith.constant 2 : i64
+    %c4 = arith.constant 4 : i64
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<ui16, l1>
+
+    pto.mte_fill_l1 %dst, %c0, %c0, %c2, %c4, %c1, 16
+      : !pto.ptr<ui16, l1>, i64, i64, i64, i64, i64
+    pto.mte_fill_l1 %dst, %c0, %c0, %c2, %c4, %c1, 32
+      : !pto.ptr<ui16, l1>, i64, i64, i64, i64, i64
+    return
+  }
+
+  func.func @mte_fill_l1_dynamic(%repeat: i64, %blocks: i64, %gap: i64)
+      attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<ui16, l1>
+    pto.mte_fill_l1 %dst, %c0, %c0, %repeat, %blocks, %gap, 16
+      : !pto.ptr<ui16, l1>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: define void @mte_fill_l1_intrinsics_mix_aic
+// CHECK: call void @llvm.hivm.CREATE.CBUF.MATRIX.v3.u16(ptr addrspace(2) null, i64 4295229442, i64 0)
+// CHECK: call void @llvm.hivm.CREATE.CBUF.MATRIX.v3.u32(ptr addrspace(2) null, i64 4295229442, i64 0)
+// CHECK-LABEL: define void @mte_fill_l1_dynamic_mix_aic
+// CHECK-SAME: (i64 [[REPEAT_ARG:%.*]], i64 [[BLOCKS_ARG:%.*]], i64 [[GAP_ARG:%.*]])
+// CHECK: [[REPEAT:%.*]] = and i64 [[REPEAT_ARG]], 32767
+// CHECK: [[BLOCKS:%.*]] = and i64 [[BLOCKS_ARG]], 32767
+// CHECK: [[BLOCKS_SHIFTED:%.*]] = shl i64 [[BLOCKS]], 16
+// CHECK: [[CONFIG_LOW:%.*]] = or i64 [[REPEAT]], [[BLOCKS_SHIFTED]]
+// CHECK: [[GAP:%.*]] = and i64 [[GAP_ARG]], 32767
+// CHECK: [[GAP_SHIFTED:%.*]] = shl i64 [[GAP]], 32
+// CHECK: [[CONFIG:%.*]] = or i64 [[CONFIG_LOW]], [[GAP_SHIFTED]]
+// CHECK: call void @llvm.hivm.CREATE.CBUF.MATRIX.v3.u16(ptr addrspace(2) null, i64 [[CONFIG]], i64 0)


### PR DESCRIPTION
## Motivation

This PR adds a low-level PTO/VPTO operation for filling an L1 (MAT/CBUF) region with a repeated 16-bit or 32-bit value. The intent is to expose the hardware `create_cbuf_matrix` capability directly so that callers can initialize L1 without first materializing data in GM or UB and issuing a separate copy.

## What changes

- Adds `pto.mte_fill_l1` to the PTO dialect and documents its semantics.
- Adds verifier checks for the L1 destination, fill word width, byte offset, and constant configuration fields.
- Lowers the operation in both VPTO LLVM emitter paths to:
  - `llvm.hivm.CREATE.CBUF.MATRIX.v3.u16`
  - `llvm.hivm.CREATE.CBUF.MATRIX.v3.u32`
- Exposes the operation through PTODSL as `pto.mte_fill_l1(...)`.
- Adds lowering, verifier, PTODSL surface, and public-export coverage.

## Parameter mapping

The hardware configuration operand is assembled as:

```text
config = repeat_times
       | (block_num_32b << 16)
       | (dst_gap_32b << 32)
```

Each field is 15 bits. `byte_offset` is applied to the destination pointer before calling the intrinsic, and the low 16 or 32 bits of `raw_value` provide the repeated fill pattern.

Semantically, each repeat fills `block_num_32b` consecutive 32-byte blocks, skips `dst_gap_32b` blocks, and then starts the next repeat.

## Reviewer notes

The main points worth checking are:

1. Whether the intrinsic names and argument order match the CANN 9.0 and default VPTO emitter conventions.
2. Whether the packed field positions and 15-bit masks match `create_cbuf_matrix`.
3. Whether the exposed PTODSL parameter names make the hardware units (bytes vs. 32-byte blocks) sufficiently clear.
