### PR TITLE
feat(vpto): add raw L1 fill primitive

### DIFF
--- a/docs/isa/micro-isa/16-cube-matmul.md
+++ b/docs/isa/micro-isa/16-cube-matmul.md
@@ -371,8 +371,8 @@ pto.mte_gm_l1 %bias_gm, %l1_bias, %c32_i64
 - **syntax:**
 ```mlir
 pto.raw_fill_l1 %dst, %byte_offset, %raw_value, %repeat_times,
-  %block_num_32b, %dst_gap_32b, %fill_word_bits
-  : !pto.ptr<T, mat>, i64, i32, i64, i64, i64, i64
+  %block_num_32b, %dst_gap_32b {fill_word_bits = 16 : i64}
+  : !pto.ptr<T, mat>, i64, i32, i64, i64, i64
 ```
 - **semantics:** Fill a strided L1 matrix region beginning at `%dst +
   %byte_offset` with the selected raw word pattern. Each repetition writes
@@ -387,29 +387,32 @@ pto.raw_fill_l1 %dst, %byte_offset, %raw_value, %repeat_times,
 | Parameter | Width | Description |
 |-----------|-------|-------------|
 | `%dst` | ptr or memref | Destination buffer in the `mat` L1 address space; accepts `!pto.ptr<T, mat>` or a `memref` with `#pto.address_space<mat>` |
-| `%byte_offset` | i64 | Non-negative byte offset from `%dst` to the first filled word |
+| `%byte_offset` | i64 | Non-negative byte offset from `%dst` to the first filled word; must be a multiple of 32 bytes |
 | `%raw_value` | i32 | Raw pattern; low 16 bits are repeated for a 16-bit fill, all 32 bits are used for a 32-bit fill |
 | `%repeat_times` | i64 | Number of strided fill repetitions |
 | `%block_num_32b` | i64 | Number of 32-byte blocks written by each repetition |
 | `%dst_gap_32b` | i64 | Destination gap between repetitions, measured in 32-byte blocks |
-| `%fill_word_bits` | i64 | Compile-time fill-word width: exactly `16` or `32` |
+| `fill_word_bits` | i64 attribute | Static fill-word width: exactly `16` or `32` |
 
 **Constraints:**
 
 - `%dst` must have the `mat` L1 address space.
 - `%byte_offset`, `%repeat_times`, `%block_num_32b`, and `%dst_gap_32b` must
   be non-negative. PTOAS diagnoses known constant violations.
+- The effective destination address `%dst + %byte_offset` must be 32-byte
+  aligned. PTOAS rejects known constant offsets that are not multiples of 32;
+  alignment of dynamically computed offsets is a caller precondition.
 - `%repeat_times`, `%block_num_32b`, and `%dst_gap_32b` must each be at most
   `32767`, including dynamically computed values. PTOAS diagnoses known
   constant violations; dynamic values are a caller precondition.
-- `%fill_word_bits` must be a compile-time `16` or `32` value.
+- `fill_word_bits` is a static i64 attribute; it must be exactly `16` or `32`.
 
 **Example:**
 
 ```mlir
 pto.raw_fill_l1 %l1_dst, %c32_i64, %zero_i32, %c4_i64, %c2_i64,
-  %c6_i64, %c16_i64
-  : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+  %c6_i64 {fill_word_bits = 16 : i64}
+  : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64
 ```
 
 ---

--- a/docs/isa/micro-isa/16-cube-matmul.md
+++ b/docs/isa/micro-isa/16-cube-matmul.md
@@ -401,6 +401,10 @@ pto.raw_fill_l1 %dst, %byte_offset, %raw_value, %repeat_times,
   `32767` when constant.
 - `%fill_word_bits` must be a compile-time `16` or `32` value.
 
+Wrapper expansion applies `%byte_offset` in byte units and casts the resulting
+destination to the canonical `!pto.ptr<ui16, mat>` or `!pto.ptr<ui32, mat>`
+view selected by `%fill_word_bits` before emitting the raw fill micro-op.
+
 **Example:**
 
 ```mlir

--- a/docs/isa/micro-isa/16-cube-matmul.md
+++ b/docs/isa/micro-isa/16-cube-matmul.md
@@ -366,6 +366,51 @@ pto.mte_gm_l1 %bias_gm, %l1_bias, %c32_i64
 
 ---
 
+### `pto.raw_fill_l1`
+
+- **syntax:**
+```mlir
+pto.raw_fill_l1 %dst, %byte_offset, %raw_value, %repeat_times,
+  %block_num_32b, %dst_gap_32b, %fill_word_bits
+  : !pto.ptr<T, mat>, i64, i32, i64, i64, i64, i64
+```
+- **semantics:** Fill a strided L1 matrix region beginning at `%dst +
+  %byte_offset` with the selected raw word pattern. Each repetition writes
+  `%block_num_32b` contiguous 32-byte blocks, and `%dst_gap_32b` gives the
+  destination gap between repetitions in 32-bit blocks. No fill range is
+  omitted when the final repetition is a tail region.
+
+**Parameter Table:**
+
+| Parameter | Width | Description |
+|-----------|-------|-------------|
+| `%dst` | ptr | Destination base pointer in the `mat` L1 address space |
+| `%byte_offset` | i64 | Non-negative byte offset from `%dst` to the first filled word |
+| `%raw_value` | i32 | Raw bit pattern repeated through the selected fill-word view |
+| `%repeat_times` | i64 | Number of strided fill repetitions |
+| `%block_num_32b` | i64 | Number of 32-byte blocks written by each repetition |
+| `%dst_gap_32b` | i64 | Destination gap between repetitions, measured in 32-bit blocks |
+| `%fill_word_bits` | i64 | Compile-time fill-word width: exactly `16` or `32` |
+
+**Constraints:**
+
+- `%dst` must have the `mat` L1 address space.
+- `%byte_offset`, `%repeat_times`, `%block_num_32b`, and `%dst_gap_32b` must
+  be non-negative when constant.
+- `%repeat_times`, `%block_num_32b`, and `%dst_gap_32b` must not exceed
+  `32767` when constant.
+- `%fill_word_bits` must be a compile-time `16` or `32` value.
+
+**Example:**
+
+```mlir
+pto.raw_fill_l1 %l1_dst, %c32_i64, %zero_i32, %c4_i64, %c2_i64,
+  %c6_i64, %c16_i64
+  : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+```
+
+---
+
 ### `pto.mte_l1_ub`
 
 - **syntax:**

--- a/docs/isa/micro-isa/16-cube-matmul.md
+++ b/docs/isa/micro-isa/16-cube-matmul.md
@@ -377,8 +377,10 @@ pto.raw_fill_l1 %dst, %byte_offset, %raw_value, %repeat_times,
 - **semantics:** Fill a strided L1 matrix region beginning at `%dst +
   %byte_offset` with the selected raw word pattern. Each repetition writes
   `%block_num_32b` contiguous 32-byte blocks, and `%dst_gap_32b` gives the
-  destination gap between repetitions in 32-bit blocks. No fill range is
-  omitted when the final repetition is a tail region.
+  destination gap between repetitions in 32-byte blocks. For a 16-bit fill,
+  the low 16 bits of `%raw_value` are repeated in every 16-bit word; for a
+  32-bit fill, all 32 bits of `%raw_value` are used. No fill range is omitted
+  when the final repetition is a tail region.
 
 **Parameter Table:**
 
@@ -386,24 +388,21 @@ pto.raw_fill_l1 %dst, %byte_offset, %raw_value, %repeat_times,
 |-----------|-------|-------------|
 | `%dst` | ptr | Destination base pointer in the `mat` L1 address space |
 | `%byte_offset` | i64 | Non-negative byte offset from `%dst` to the first filled word |
-| `%raw_value` | i32 | Raw bit pattern repeated through the selected fill-word view |
+| `%raw_value` | i32 | Raw pattern; low 16 bits are repeated for a 16-bit fill, all 32 bits are used for a 32-bit fill |
 | `%repeat_times` | i64 | Number of strided fill repetitions |
 | `%block_num_32b` | i64 | Number of 32-byte blocks written by each repetition |
-| `%dst_gap_32b` | i64 | Destination gap between repetitions, measured in 32-bit blocks |
+| `%dst_gap_32b` | i64 | Destination gap between repetitions, measured in 32-byte blocks |
 | `%fill_word_bits` | i64 | Compile-time fill-word width: exactly `16` or `32` |
 
 **Constraints:**
 
 - `%dst` must have the `mat` L1 address space.
 - `%byte_offset`, `%repeat_times`, `%block_num_32b`, and `%dst_gap_32b` must
-  be non-negative when constant.
-- `%repeat_times`, `%block_num_32b`, and `%dst_gap_32b` must not exceed
-  `32767` when constant.
+  be non-negative. PTOAS diagnoses known constant violations.
+- `%repeat_times`, `%block_num_32b`, and `%dst_gap_32b` must each be at most
+  `32767`, including dynamically computed values. PTOAS diagnoses known
+  constant violations; dynamic values are a caller precondition.
 - `%fill_word_bits` must be a compile-time `16` or `32` value.
-
-Wrapper expansion applies `%byte_offset` in byte units and casts the resulting
-destination to the canonical `!pto.ptr<ui16, mat>` or `!pto.ptr<ui32, mat>`
-view selected by `%fill_word_bits` before emitting the raw fill micro-op.
 
 **Example:**
 

--- a/docs/isa/micro-isa/16-cube-matmul.md
+++ b/docs/isa/micro-isa/16-cube-matmul.md
@@ -386,7 +386,7 @@ pto.raw_fill_l1 %dst, %byte_offset, %raw_value, %repeat_times,
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%dst` | ptr | Destination base pointer in the `mat` L1 address space |
+| `%dst` | ptr or memref | Destination buffer in the `mat` L1 address space; accepts `!pto.ptr<T, mat>` or a `memref` with `#pto.address_space<mat>` |
 | `%byte_offset` | i64 | Non-negative byte offset from `%dst` to the first filled word |
 | `%raw_value` | i32 | Raw pattern; low 16 bits are repeated for a 16-bit fill, all 32 bits are used for a 32-bit fill |
 | `%repeat_times` | i64 | Number of strided fill repetitions |

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -1333,7 +1333,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | 13 | [DSA/SFU Ops](isa/micro-isa/13-dsa-sfu-ops.md) | Specialized ops, index generation, and sorting helpers | 11 | `pto.vlrelu`, `pto.vprelu`, `pto.vexpdif`, `pto.vaxpy`, `pto.vmulscvt`, `pto.vmull`, `pto.vmula`, `pto.vci`, `pto.vbitsort`, `pto.vmrgsort4`, `pto.get_vms4_sr` |
 | 14 | [Arith (Shared MLIR Dialect)](isa/micro-isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
 | 15 | [SCF (Shared MLIR Dialect)](isa/micro-isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
-| 16 | [Cube Matrix Multiply](isa/micro-isa/16-cube-matmul.md) | GM↔L1 (`l1`/cbuf) staging, L1 (`l1`)↔UB/BT/FB side moves, L1→L0A/L0B loads, L0C (`l0c`) matmul, and FIXPIPE MTE writeback | 19 | `pto.mte_gm_l1`, `pto.mte_l1_ub`, `pto.mte_gm_l1_frac`, `pto.mte_l1_bt`, `pto.mte_l1_fb`, `pto.mte_l1_l0a`, `pto.mte_l1_l0b`, `pto.mte_l1_l0a_mx`, `pto.mte_l1_l0b_mx`, `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias`, `pto.mte_l0c_l1`, `pto.mte_l0c_gm`, `pto.mte_l0c_ub` |
+| 16 | [Cube Matrix Multiply](isa/micro-isa/16-cube-matmul.md) | GM↔L1 (`l1`/cbuf) staging, L1 raw fill and L1 (`l1`)↔UB/BT/FB side moves, L1→L0A/L0B loads, L0C (`l0c`) matmul, and FIXPIPE MTE writeback | 20 | `pto.mte_gm_l1`, `pto.raw_fill_l1`, `pto.mte_l1_ub`, `pto.mte_gm_l1_frac`, `pto.mte_l1_bt`, `pto.mte_l1_fb`, `pto.mte_l1_l0a`, `pto.mte_l1_l0b`, `pto.mte_l1_l0a_mx`, `pto.mte_l1_l0b_mx`, `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias`, `pto.mte_l0c_l1`, `pto.mte_l0c_gm`, `pto.mte_l0c_ub` |
 | 17 | [SIMT Ops](isa/micro-isa/17-simt.md) | SIMT launch, thread/lane queries, vote/shuffle/redux, scalar memory, atomics, scalar math, conversion, entry synchronization, and state preservation | ~65 | `pto.store_vfsimt_info`, `pto.simt_launch`, `pto.get_tid_x`, `pto.get_laneid`, `pto.vote_*`, `pto.shuffle_*`, `pto.redux_*`, `pto.load`, `pto.store`, `pto.atomic_*`, `pto.convert`, `pto.syncthreads`, `pto.keep`, `pto.resume`, etc. |
 | 18 | [Special Scalar Operations](isa/micro-isa/18-special-scalar.md) | PTO scalar kernel queries, typed pointer/address calculation, scalar-pipeline memory, and ordinary AICore GM L1-bypass access | 10 | `pto.get_block_idx`, `pto.get_subblock_idx`, `pto.get_block_num`, `pto.get_subblock_num`, `pto.castptr`, `pto.addptr`, `pto.load_scalar`, `pto.store_scalar`, `pto.ld_dev`, `pto.st_dev` |
 
@@ -1349,6 +1349,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | UB→GM DMA | 2 | `pto.mte_ub_gm` |
 | UB→UB / UB→L1 copy | 2 | `pto.mte_ub_ub`, `pto.mte_ub_l1` |
 | GM→L1 | 16 | `pto.mte_gm_l1`, `pto.mte_gm_l1_frac` |
+| L1 raw fill | 16 | `pto.raw_fill_l1` |
 | L1→UB | 16 | `pto.mte_l1_ub` |
 | L1→BT | 16 | `pto.mte_l1_bt` |
 | L1→FB | 16 | `pto.mte_l1_fb` |
@@ -1419,6 +1420,7 @@ shared structured-control semantics remain in Group 15.
 - `pto.mte_l1_bt`
 - `pto.mte_l1_fb`
 - `pto.mte_gm_l1`
+- `pto.raw_fill_l1`
 - `pto.mte_gm_l1_frac`
 - `pto.mte_l1_ub`
 - `pto.mte_l1_l0a`

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -3100,7 +3100,7 @@ def PTO_RawFillL1Op : PTO_MicroOp<"raw_fill_l1", [
   }];
 }
 
-def PTO_CreateCbufMatrixOp : PTO_MicroOp<"create_cbuf_matrix", [
+def PTO_CreateCbufMatrixOp : PTO_CubeMicroOp<"create_cbuf_matrix", [
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   ]> {
   let summary = "Canonical L1 raw-pattern fill micro-op";
@@ -3108,7 +3108,7 @@ def PTO_CreateCbufMatrixOp : PTO_MicroOp<"create_cbuf_matrix", [
     Canonical micro-op for filling a strided L1/CBUF matrix region with a raw
     bit pattern. Produced by the `pto.raw_fill_l1` wrapper expansion.
 
-    `dst` must be a `!pto.ptr<i16|i32, #pto.address_space<mat>>` pointer that
+    `dst` must be a `!pto.ptr<ui16|ui32, #pto.address_space<mat>>` pointer that
     already includes `byte_offset`; `raw_value` is the raw 32-bit bit pattern
     and `fill_word_bits` (exactly 16 or 32) selects whether the 16-bit or
     32-bit fill view is used. The control fields pack into the hardware

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -3068,14 +3068,16 @@ def PTO_RawFillL1Op : PTO_MicroOp<"raw_fill_l1", [
     - `dst`: destination buffer; after expansion must resolve to the MAT/L1
       address space.
     - `byte_offset`: byte distance applied to `dst` before the fill.
-    - `raw_value`: raw 32-bit bit pattern replicated over the fill words.
-    - `repeat_times`: number of 32-byte fill repeats.
-    - `block_num_32b`: number of 32-bit blocks per repeat.
-    - `dst_gap_32b`: destination gap between repeats, in 32-bit blocks.
+    - `raw_value`: raw fill pattern. For a 16-bit fill, the low 16 bits are
+      repeated in every 16-bit word; for a 32-bit fill, all 32 bits are used.
+    - `repeat_times`: number of fill repetitions.
+    - `block_num_32b`: number of 32-byte blocks per repeat.
+    - `dst_gap_32b`: destination gap between repeats, in 32-byte blocks.
     - `fill_word_bits`: compile-time fill word width, exactly 16 or 32.
 
-    The expansion performs only pointer normalization, byte offset, and the
-    16/32-bit view cast. It does not split loops or change the tail fill range.
+    `repeat_times`, `block_num_32b`, and `dst_gap_32b` must each be in the
+    inclusive range [0, 32767], including when dynamically computed. The
+    verifier diagnoses known constants outside that range.
   }];
 
   let arguments = (ins
@@ -3109,11 +3111,11 @@ def PTO_CreateCbufMatrixOp : PTO_CubeMicroOp<"create_cbuf_matrix", [
     bit pattern. Produced by the `pto.raw_fill_l1` wrapper expansion.
 
     `dst` must be a `!pto.ptr<ui16|ui32, #pto.address_space<mat>>` pointer that
-    already includes `byte_offset`; `raw_value` is the raw 32-bit bit pattern
-    and `fill_word_bits` (exactly 16 or 32) selects whether the 16-bit or
-    32-bit fill view is used. The control fields pack into the hardware
-    intrinsic config as `repeat_times | (block_num_32b << 16) |
-    (dst_gap_32b << 32)`.
+    already includes `byte_offset`. For a 16-bit fill, the low 16 bits of
+    `raw_value` are repeated in every 16-bit word; for a 32-bit fill, all 32
+    bits are used. `repeat_times` counts repetitions; `block_num_32b` and
+    `dst_gap_32b` count 32-byte blocks. All three geometry operands must be
+    in the inclusive range [0, 32767].
   }];
 
   let arguments = (ins

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -3053,6 +3053,90 @@ def PTO_MteGmL1FracOp : PTO_MteOp<"mte_gm_l1_frac", [
   ];
 }
 
+def PTO_RawFillL1Op : PTO_MicroOp<"raw_fill_l1", [
+    CubeMicroOpInterface,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  ]> {
+  let summary = "Fill a strided L1/MAT region with a raw bit pattern";
+  let description = [{
+    Public wrapper for filling a strided L1 matrix-buffer region with a raw
+    bit pattern. `dst` may be a memref or `!pto.ptr` buffer-like value and is
+    expanded to the canonical `pto.create_cbuf_matrix` micro-op by the
+    wrapper-expansion pass.
+
+    Fields (in order):
+    - `dst`: destination buffer; after expansion must resolve to the MAT/L1
+      address space.
+    - `byte_offset`: byte distance applied to `dst` before the fill.
+    - `raw_value`: raw 32-bit bit pattern replicated over the fill words.
+    - `repeat_times`: number of 32-byte fill repeats.
+    - `block_num_32b`: number of 32-bit blocks per repeat.
+    - `dst_gap_32b`: destination gap between repeats, in 32-bit blocks.
+    - `fill_word_bits`: compile-time fill word width, exactly 16 or 32.
+
+    The expansion performs only pointer normalization, byte offset, and the
+    16/32-bit view cast. It does not split loops or change the tail fill range.
+  }];
+
+  let arguments = (ins
+    PTO_BufferLikeType:$dst,
+    I64:$byte_offset,
+    I32:$raw_value,
+    I64:$repeat_times,
+    I64:$block_num_32b,
+    I64:$dst_gap_32b,
+    I64:$fill_word_bits
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $dst `,` $byte_offset `,` $raw_value `,` $repeat_times `,` $block_num_32b `,`
+    $dst_gap_32b `,` $fill_word_bits attr-dict `:` type($dst) `,` type($byte_offset) `,`
+    type($raw_value) `,` type($repeat_times) `,` type($block_num_32b) `,`
+    type($dst_gap_32b) `,` type($fill_word_bits)
+  }];
+}
+
+def PTO_CreateCbufMatrixOp : PTO_MicroOp<"create_cbuf_matrix", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  ]> {
+  let summary = "Canonical L1 raw-pattern fill micro-op";
+  let description = [{
+    Canonical micro-op for filling a strided L1/CBUF matrix region with a raw
+    bit pattern. Produced by the `pto.raw_fill_l1` wrapper expansion.
+
+    `dst` must be a `!pto.ptr<i16|i32, #pto.address_space<mat>>` pointer that
+    already includes `byte_offset`; `raw_value` is the raw 32-bit bit pattern
+    and `fill_word_bits` (exactly 16 or 32) selects whether the 16-bit or
+    32-bit fill view is used. The control fields pack into the hardware
+    intrinsic config as `repeat_times | (block_num_32b << 16) |
+    (dst_gap_32b << 32)`.
+  }];
+
+  let arguments = (ins
+    PTO_BufferType:$dst,
+    I32:$raw_value,
+    I64:$repeat_times,
+    I64:$block_num_32b,
+    I64:$dst_gap_32b,
+    I64:$fill_word_bits
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $dst `,` $raw_value `,` $repeat_times `,` $block_num_32b `,`
+    $dst_gap_32b `,` $fill_word_bits attr-dict `:` type($dst) `,` type($raw_value) `,`
+    type($repeat_times) `,` type($block_num_32b) `,` type($dst_gap_32b) `,`
+    type($fill_word_bits)
+  }];
+}
+
 def PTO_MteL1L0aOp : PTO_MteOp<"mte_l1_l0a", [
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   ]> {

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -3067,17 +3067,23 @@ def PTO_RawFillL1Op : PTO_MicroOp<"raw_fill_l1", [
     Fields (in order):
     - `dst`: destination buffer; after expansion must resolve to the MAT/L1
       address space.
-    - `byte_offset`: byte distance applied to `dst` before the fill.
+    - `byte_offset`: non-negative byte distance applied to `dst` before the
+      fill; it must be a multiple of 32 bytes.
     - `raw_value`: raw fill pattern. For a 16-bit fill, the low 16 bits are
       repeated in every 16-bit word; for a 32-bit fill, all 32 bits are used.
     - `repeat_times`: number of fill repetitions.
     - `block_num_32b`: number of 32-byte blocks per repeat.
     - `dst_gap_32b`: destination gap between repeats, in 32-byte blocks.
-    - `fill_word_bits`: compile-time fill word width, exactly 16 or 32.
+    - `fill_word_bits`: static i64 attribute selecting the compile-time fill
+      word width, exactly 16 or 32.
 
     `repeat_times`, `block_num_32b`, and `dst_gap_32b` must each be in the
     inclusive range [0, 32767], including when dynamically computed. The
     verifier diagnoses known constants outside that range.
+
+    The effective destination address (`dst + byte_offset`) must be aligned to
+    32 bytes. The verifier diagnoses known constant offsets that are not
+    multiples of 32; dynamic offsets are a caller precondition.
   }];
 
   let arguments = (ins
@@ -3087,7 +3093,7 @@ def PTO_RawFillL1Op : PTO_MicroOp<"raw_fill_l1", [
     I64:$repeat_times,
     I64:$block_num_32b,
     I64:$dst_gap_32b,
-    I64:$fill_word_bits
+    I64Attr:$fill_word_bits
   );
 
   let results = (outs);
@@ -3096,9 +3102,9 @@ def PTO_RawFillL1Op : PTO_MicroOp<"raw_fill_l1", [
 
   let assemblyFormat = [{
     $dst `,` $byte_offset `,` $raw_value `,` $repeat_times `,` $block_num_32b `,`
-    $dst_gap_32b `,` $fill_word_bits attr-dict `:` type($dst) `,` type($byte_offset) `,`
+    $dst_gap_32b attr-dict `:` type($dst) `,` type($byte_offset) `,`
     type($raw_value) `,` type($repeat_times) `,` type($block_num_32b) `,`
-    type($dst_gap_32b) `,` type($fill_word_bits)
+    type($dst_gap_32b)
   }];
 }
 
@@ -3110,12 +3116,15 @@ def PTO_CreateCbufMatrixOp : PTO_CubeMicroOp<"create_cbuf_matrix", [
     Canonical micro-op for filling a strided L1/CBUF matrix region with a raw
     bit pattern. Produced by the `pto.raw_fill_l1` wrapper expansion.
 
-    `dst` must be a `!pto.ptr<ui16|ui32, #pto.address_space<mat>>` pointer that
-    already includes `byte_offset`. For a 16-bit fill, the low 16 bits of
+    `dst` must be a 32-byte-aligned
+    `!pto.ptr<ui16|ui32, #pto.address_space<mat>>` pointer that already
+    includes `byte_offset`. For a 16-bit fill, the low 16 bits of
     `raw_value` are repeated in every 16-bit word; for a 32-bit fill, all 32
-    bits are used. `repeat_times` counts repetitions; `block_num_32b` and
-    `dst_gap_32b` count 32-byte blocks. All three geometry operands must be
-    in the inclusive range [0, 32767].
+    bits are used. The static `fill_word_bits` i64 attribute selects the fill
+    word width, exactly 16 or 32, and must match the destination view width.
+    `repeat_times` counts repetitions; `block_num_32b` and `dst_gap_32b`
+    count 32-byte blocks. All three geometry operands must be in the
+    inclusive range [0, 32767].
   }];
 
   let arguments = (ins
@@ -3124,7 +3133,7 @@ def PTO_CreateCbufMatrixOp : PTO_CubeMicroOp<"create_cbuf_matrix", [
     I64:$repeat_times,
     I64:$block_num_32b,
     I64:$dst_gap_32b,
-    I64:$fill_word_bits
+    I64Attr:$fill_word_bits
   );
 
   let results = (outs);
@@ -3133,9 +3142,8 @@ def PTO_CreateCbufMatrixOp : PTO_CubeMicroOp<"create_cbuf_matrix", [
 
   let assemblyFormat = [{
     $dst `,` $raw_value `,` $repeat_times `,` $block_num_32b `,`
-    $dst_gap_32b `,` $fill_word_bits attr-dict `:` type($dst) `,` type($raw_value) `,`
-    type($repeat_times) `,` type($block_num_32b) `,` type($dst_gap_32b) `,`
-    type($fill_word_bits)
+    $dst_gap_32b attr-dict `:` type($dst) `,` type($raw_value) `,`
+    type($repeat_times) `,` type($block_num_32b) `,` type($dst_gap_32b)
   }];
 }
 

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -7560,71 +7560,93 @@ static LogicalResult verifyRawFillGeometry(Operation *op, Value byteOffset,
                                            Value repeatTimes,
                                            Value blockNum32b, Value dstGap32b) {
   auto checkNonNegativeConst = [&](Value value, StringRef name) -> LogicalResult {
-    if (!value)
+    if (!value) {
       return success();
+    }
     APInt intValue;
-    if (matchPattern(value, m_ConstantInt(&intValue)) && intValue.isNegative())
-      return op->emitOpError() << name << " must be non-negative";
+    if (matchPattern(value, m_ConstantInt(&intValue))) {
+      if (intValue.isNegative()) {
+        return op->emitOpError() << name << " must be non-negative";
+      }
+    }
     return success();
   };
   auto checkConstMax = [&](Value value, StringRef name,
                            uint64_t max) -> LogicalResult {
-    if (!value)
+    if (!value) {
       return success();
+    }
     APInt intValue;
-    if (matchPattern(value, m_ConstantInt(&intValue)) &&
-        intValue.getZExtValue() > max)
-      return op->emitOpError() << name << " must be <= " << max;
+    if (matchPattern(value, m_ConstantInt(&intValue))) {
+      uint64_t fieldValue = intValue.getZExtValue();
+      if (fieldValue > max) {
+        return op->emitOpError() << name << " must be <= " << max;
+      }
+    }
     return success();
   };
-  if (failed(checkNonNegativeConst(byteOffset, "byte_offset")) ||
-      failed(checkNonNegativeConst(repeatTimes, "repeat_times")) ||
-      failed(checkNonNegativeConst(blockNum32b, "block_num_32b")) ||
-      failed(checkNonNegativeConst(dstGap32b, "dst_gap_32b")))
+  const bool hasNonNegativeGeometry =
+      succeeded(checkNonNegativeConst(byteOffset, "byte_offset")) &&
+      succeeded(checkNonNegativeConst(repeatTimes, "repeat_times")) &&
+      succeeded(checkNonNegativeConst(blockNum32b, "block_num_32b")) &&
+      succeeded(checkNonNegativeConst(dstGap32b, "dst_gap_32b"));
+  if (!hasNonNegativeGeometry) {
     return failure();
+  }
   if (failed(checkConstMax(repeatTimes, "repeat_times",
                            kRawFillControlFieldMax)) ||
       failed(checkConstMax(blockNum32b, "block_num_32b",
                            kRawFillControlFieldMax)) ||
       failed(checkConstMax(dstGap32b, "dst_gap_32b",
-                           kRawFillControlFieldMax)))
+                           kRawFillControlFieldMax))) {
     return failure();
+  }
   return success();
 }
 
 static LogicalResult verifyRawFillWordBits(Operation *op, Value fillWordBits) {
-  if (!fillWordBits)
+  if (!fillWordBits) {
     return op->emitOpError("missing fill_word_bits");
+  }
   APInt wordBits;
-  if (!matchPattern(fillWordBits, m_ConstantInt(&wordBits)))
+  if (!matchPattern(fillWordBits, m_ConstantInt(&wordBits))) {
     return op->emitOpError(
         "fill_word_bits must be a compile-time constant 16 or 32");
-  if (wordBits.getZExtValue() != 16 && wordBits.getZExtValue() != 32)
+  }
+  const bool validWordBits = wordBits.getZExtValue() == 16 ||
+                             wordBits.getZExtValue() == 32;
+  if (!validWordBits) {
     return op->emitOpError()
            << "fill_word_bits must be 16 or 32, got "
            << wordBits.getZExtValue();
+  }
   return success();
 }
 
 static LogicalResult verifyRawFillDestination(Operation *op, Type dstType,
                                               StringRef dstName) {
   auto addressSpace = getBufferAddressSpace(dstType);
-  if (!addressSpace)
+  if (!addressSpace) {
     return op->emitOpError()
            << "requires " << dstName
            << " with an explicit PTO address space for L1 raw fill";
-  if (*addressSpace != pto::AddressSpace::MAT)
+  }
+  if (*addressSpace != pto::AddressSpace::MAT) {
     return op->emitOpError()
            << "requires " << dstName << " in the mat/l1 address space, got "
            << getAddressSpaceDiagnosticName(*addressSpace);
+  }
   return success();
 }
 
 LogicalResult RawFillL1Op::verify() {
-  if (failed(verifyRawFillDestination(getOperation(), getDst().getType(), "dst")))
+  if (failed(
+          verifyRawFillDestination(getOperation(), getDst().getType(), "dst"))) {
     return failure();
-  if (failed(verifyRawFillWordBits(getOperation(), getFillWordBits())))
+  }
+  if (failed(verifyRawFillWordBits(getOperation(), getFillWordBits()))) {
     return failure();
+  }
   return verifyRawFillGeometry(getOperation(), getByteOffset(),
                                getRepeatTimes(), getBlockNum_32b(),
                                getDstGap_32b());
@@ -7632,9 +7654,12 @@ LogicalResult RawFillL1Op::verify() {
 
 LogicalResult CreateCbufMatrixOp::verify() {
   auto ptrType = dyn_cast<pto::PtrType>(getDst().getType());
-  if (!ptrType)
+  if (!ptrType) {
     return emitOpError("requires a typed !pto.ptr destination");
-  if (ptrType.getMemorySpace().getAddressSpace() != pto::AddressSpace::MAT) {
+  }
+  const bool matDestination =
+      ptrType.getMemorySpace().getAddressSpace() == pto::AddressSpace::MAT;
+  if (!matDestination) {
     return emitOpError()
            << "requires a mat/l1 destination, got "
            << getAddressSpaceDiagnosticName(
@@ -7642,21 +7667,28 @@ LogicalResult CreateCbufMatrixOp::verify() {
   }
   Type elementType = ptrType.getElementType();
   auto integerType = dyn_cast<IntegerType>(elementType);
-  if (!integerType ||
-      (integerType.getWidth() != 16 && integerType.getWidth() != 32))
+  const bool canonicalView =
+      integerType && integerType.isUnsigned() &&
+      (integerType.getWidth() == 16 || integerType.getWidth() == 32);
+  if (!canonicalView) {
     return emitOpError()
-           << "requires a 16-bit or 32-bit integer destination view, got "
+           << "requires a ui16 or ui32 destination view, got "
               "element type "
            << elementType;
-  if (failed(verifyRawFillWordBits(getOperation(), getFillWordBits())))
+  }
+  if (failed(verifyRawFillWordBits(getOperation(), getFillWordBits()))) {
     return failure();
+  }
   APInt wordBits;
-  if (matchPattern(getFillWordBits(), m_ConstantInt(&wordBits)) &&
-      wordBits.getZExtValue() != integerType.getWidth())
+  const bool wordWidthMatches =
+      !matchPattern(getFillWordBits(), m_ConstantInt(&wordBits)) ||
+      wordBits.getZExtValue() == integerType.getWidth();
+  if (!wordWidthMatches) {
     return emitOpError()
            << "fill_word_bits " << wordBits.getZExtValue()
            << " does not match the " << integerType.getWidth()
            << "-bit destination view";
+  }
   return verifyRawFillGeometry(getOperation(), /*byteOffset=*/{},
                                getRepeatTimes(), getBlockNum_32b(),
                                getDstGap_32b());

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -7531,6 +7531,7 @@ void MteGmL1FracOp::print(OpAsmPrinter &printer) {
 }
 
 static constexpr uint64_t kRawFillControlFieldMax = 32767;
+static constexpr uint64_t kRawFillByteOffsetAlignment = 32;
 
 static StringRef getAddressSpaceDiagnosticName(pto::AddressSpace space) {
   switch (space) {
@@ -7585,12 +7586,31 @@ static LogicalResult verifyRawFillGeometry(Operation *op, Value byteOffset,
     }
     return success();
   };
+  auto checkConstAlignment = [&](Value value, StringRef name,
+                                 uint64_t alignment) -> LogicalResult {
+    if (!value) {
+      return success();
+    }
+    APInt intValue;
+    const bool hasUnalignedConstant =
+        matchPattern(value, m_ConstantInt(&intValue)) &&
+        intValue.urem(alignment) != 0;
+    if (hasUnalignedConstant) {
+      return op->emitOpError()
+             << name << " must be a multiple of " << alignment << " bytes";
+    }
+    return success();
+  };
   const bool hasNonNegativeGeometry =
       succeeded(checkNonNegativeConst(byteOffset, "byte_offset")) &&
       succeeded(checkNonNegativeConst(repeatTimes, "repeat_times")) &&
       succeeded(checkNonNegativeConst(blockNum32b, "block_num_32b")) &&
       succeeded(checkNonNegativeConst(dstGap32b, "dst_gap_32b"));
   if (!hasNonNegativeGeometry) {
+    return failure();
+  }
+  if (failed(checkConstAlignment(byteOffset, "byte_offset",
+                                 kRawFillByteOffsetAlignment))) {
     return failure();
   }
   if (failed(checkConstMax(repeatTimes, "repeat_times",
@@ -7604,21 +7624,11 @@ static LogicalResult verifyRawFillGeometry(Operation *op, Value byteOffset,
   return success();
 }
 
-static LogicalResult verifyRawFillWordBits(Operation *op, Value fillWordBits) {
-  if (!fillWordBits) {
-    return op->emitOpError("missing fill_word_bits");
-  }
-  APInt wordBits;
-  if (!matchPattern(fillWordBits, m_ConstantInt(&wordBits))) {
-    return op->emitOpError(
-        "fill_word_bits must be a compile-time constant 16 or 32");
-  }
-  const bool validWordBits = wordBits.getZExtValue() == 16 ||
-                             wordBits.getZExtValue() == 32;
+static LogicalResult verifyRawFillWordBits(Operation *op, int64_t fillWordBits) {
+  const bool validWordBits = fillWordBits == 16 || fillWordBits == 32;
   if (!validWordBits) {
-    return op->emitOpError()
-           << "fill_word_bits must be 16 or 32, got "
-           << wordBits.getZExtValue();
+    return op->emitOpError() << "fill_word_bits must be 16 or 32, got "
+                             << fillWordBits;
   }
   return success();
 }
@@ -7679,13 +7689,11 @@ LogicalResult CreateCbufMatrixOp::verify() {
   if (failed(verifyRawFillWordBits(getOperation(), getFillWordBits()))) {
     return failure();
   }
-  APInt wordBits;
   const bool wordWidthMatches =
-      !matchPattern(getFillWordBits(), m_ConstantInt(&wordBits)) ||
-      wordBits.getZExtValue() == integerType.getWidth();
+      static_cast<unsigned>(getFillWordBits()) == integerType.getWidth();
   if (!wordWidthMatches) {
     return emitOpError()
-           << "fill_word_bits " << wordBits.getZExtValue()
+           << "fill_word_bits " << getFillWordBits()
            << " does not match the " << integerType.getWidth()
            << "-bit destination view";
   }

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -7530,6 +7530,150 @@ void MteGmL1FracOp::print(OpAsmPrinter &printer) {
           << getL2CacheCtrl().getType() << ", " << getSmallc0En().getType();
 }
 
+static constexpr uint64_t kRawFillControlFieldMax = 32767;
+
+static StringRef getAddressSpaceDiagnosticName(pto::AddressSpace space) {
+  switch (space) {
+  case pto::AddressSpace::GM:
+    return "gm";
+  case pto::AddressSpace::MAT:
+    return "mat/l1";
+  case pto::AddressSpace::LEFT:
+    return "left/l0a";
+  case pto::AddressSpace::RIGHT:
+    return "right/l0b";
+  case pto::AddressSpace::ACC:
+    return "acc/l0c";
+  case pto::AddressSpace::VEC:
+    return "vec/ub";
+  case pto::AddressSpace::BIAS:
+    return "bt/bias";
+  case pto::AddressSpace::SCALING:
+    return "fb/scaling";
+  case pto::AddressSpace::Zero:
+    return "zero";
+  }
+  return "unknown";
+}
+
+static LogicalResult verifyRawFillGeometry(Operation *op, Value byteOffset,
+                                           Value repeatTimes,
+                                           Value blockNum32b, Value dstGap32b) {
+  auto checkNonNegativeConst = [&](Value value, StringRef name) -> LogicalResult {
+    if (!value)
+      return success();
+    APInt intValue;
+    if (matchPattern(value, m_ConstantInt(&intValue)) && intValue.isNegative())
+      return op->emitOpError() << name << " must be non-negative";
+    return success();
+  };
+  auto checkConstMax = [&](Value value, StringRef name,
+                           uint64_t max) -> LogicalResult {
+    if (!value)
+      return success();
+    APInt intValue;
+    if (matchPattern(value, m_ConstantInt(&intValue)) &&
+        intValue.getZExtValue() > max)
+      return op->emitOpError() << name << " must be <= " << max;
+    return success();
+  };
+  if (failed(checkNonNegativeConst(byteOffset, "byte_offset")) ||
+      failed(checkNonNegativeConst(repeatTimes, "repeat_times")) ||
+      failed(checkNonNegativeConst(blockNum32b, "block_num_32b")) ||
+      failed(checkNonNegativeConst(dstGap32b, "dst_gap_32b")))
+    return failure();
+  if (failed(checkConstMax(repeatTimes, "repeat_times",
+                           kRawFillControlFieldMax)) ||
+      failed(checkConstMax(blockNum32b, "block_num_32b",
+                           kRawFillControlFieldMax)) ||
+      failed(checkConstMax(dstGap32b, "dst_gap_32b",
+                           kRawFillControlFieldMax)))
+    return failure();
+  return success();
+}
+
+static LogicalResult verifyRawFillWordBits(Operation *op, Value fillWordBits) {
+  if (!fillWordBits)
+    return op->emitOpError("missing fill_word_bits");
+  APInt wordBits;
+  if (!matchPattern(fillWordBits, m_ConstantInt(&wordBits)))
+    return op->emitOpError(
+        "fill_word_bits must be a compile-time constant 16 or 32");
+  if (wordBits.getZExtValue() != 16 && wordBits.getZExtValue() != 32)
+    return op->emitOpError()
+           << "fill_word_bits must be 16 or 32, got "
+           << wordBits.getZExtValue();
+  return success();
+}
+
+static LogicalResult verifyRawFillDestination(Operation *op, Type dstType,
+                                              StringRef dstName) {
+  auto addressSpace = getBufferAddressSpace(dstType);
+  if (!addressSpace)
+    return op->emitOpError()
+           << "requires " << dstName
+           << " with an explicit PTO address space for L1 raw fill";
+  if (*addressSpace != pto::AddressSpace::MAT)
+    return op->emitOpError()
+           << "requires " << dstName << " in the mat/l1 address space, got "
+           << getAddressSpaceDiagnosticName(*addressSpace);
+  return success();
+}
+
+LogicalResult RawFillL1Op::verify() {
+  if (failed(verifyRawFillDestination(getOperation(), getDst().getType(), "dst")))
+    return failure();
+  if (failed(verifyRawFillWordBits(getOperation(), getFillWordBits())))
+    return failure();
+  return verifyRawFillGeometry(getOperation(), getByteOffset(),
+                               getRepeatTimes(), getBlockNum_32b(),
+                               getDstGap_32b());
+}
+
+LogicalResult CreateCbufMatrixOp::verify() {
+  auto ptrType = dyn_cast<pto::PtrType>(getDst().getType());
+  if (!ptrType)
+    return emitOpError("requires a typed !pto.ptr destination");
+  if (ptrType.getMemorySpace().getAddressSpace() != pto::AddressSpace::MAT) {
+    return emitOpError()
+           << "requires a mat/l1 destination, got "
+           << getAddressSpaceDiagnosticName(
+                  ptrType.getMemorySpace().getAddressSpace());
+  }
+  Type elementType = ptrType.getElementType();
+  auto integerType = dyn_cast<IntegerType>(elementType);
+  if (!integerType ||
+      (integerType.getWidth() != 16 && integerType.getWidth() != 32))
+    return emitOpError()
+           << "requires a 16-bit or 32-bit integer destination view, got "
+              "element type "
+           << elementType;
+  if (failed(verifyRawFillWordBits(getOperation(), getFillWordBits())))
+    return failure();
+  APInt wordBits;
+  if (matchPattern(getFillWordBits(), m_ConstantInt(&wordBits)) &&
+      wordBits.getZExtValue() != integerType.getWidth())
+    return emitOpError()
+           << "fill_word_bits " << wordBits.getZExtValue()
+           << " does not match the " << integerType.getWidth()
+           << "-bit destination view";
+  return verifyRawFillGeometry(getOperation(), /*byteOffset=*/{},
+                               getRepeatTimes(), getBlockNum_32b(),
+                               getDstGap_32b());
+}
+
+void RawFillL1Op::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), &getDstMutable());
+}
+
+void CreateCbufMatrixOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), &getDstMutable());
+}
+
 LogicalResult MteGmL1Op::verify() {
   if (failed(verifyCopyGmToUbufOp(*this, true)))
     return failure();

--- a/lib/PTO/Transforms/PTOVPTOPtrBoundary.cpp
+++ b/lib/PTO/Transforms/PTOVPTOPtrBoundary.cpp
@@ -118,7 +118,7 @@ static bool isSupportedVPTOBufferLikeBoundaryOp(Operation *op) {
              pto::VsldbOp, pto::VsstbOp, pto::VstasOp, pto::VstarOp,
              pto::LoadScalarOp, pto::StoreScalarOp, pto::MteGmL1FracOp,
              pto::MteL1FbOp, pto::MteL1L0aOp, pto::MteL1L0bOp,
-             pto::MteL0cL1Op, pto::MteL0cGmOp>(op);
+             pto::MteL0cL1Op, pto::MteL0cGmOp, pto::RawFillL1Op>(op);
 }
 
 static LogicalResult canonicalizeBoundaryCastPtrOps(ModuleOp module,

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -5109,12 +5109,7 @@ public:
     }
 
     Location loc = op.getLoc();
-    APInt fillWordBits;
-    if (!matchPattern(op.getFillWordBits(), m_ConstantInt(&fillWordBits))) {
-      return rewriter.notifyMatchFailure(op,
-                                         "expected constant fill word width");
-    }
-    uint64_t fillWordWidth = fillWordBits.getZExtValue();
+    const uint64_t fillWordWidth = static_cast<uint64_t>(op.getFillWordBits());
     StringRef calleeName;
     Value fillPattern;
     if (fillWordWidth == 16) {

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -5092,8 +5092,10 @@ public:
 
     Type i32Ty = rewriter.getI32Type();
     Type i64Ty = rewriter.getI64Type();
-    if (rawValue.getType() != i32Ty || repeatTimes.getType() != i64Ty ||
-        blockNum32b.getType() != i64Ty || dstGap32b.getType() != i64Ty) {
+    const bool validControlTypes =
+        rawValue.getType() == i32Ty && repeatTimes.getType() == i64Ty &&
+        blockNum32b.getType() == i64Ty && dstGap32b.getType() == i64Ty;
+    if (!validControlTypes) {
       return rewriter.notifyMatchFailure(op, "expected i32 value and i64 controls");
     }
 

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -5064,6 +5064,78 @@ private:
   LoweringState &state;
 };
 
+class LowerCreateCbufMatrixOpPattern final
+    : public OpConversionPattern<pto::CreateCbufMatrixOp> {
+public:
+  explicit LowerCreateCbufMatrixOpPattern(TypeConverter &typeConverter,
+                                          MLIRContext *context,
+                                          LoweringState &state)
+      : OpConversionPattern<pto::CreateCbufMatrixOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::CreateCbufMatrixOp op,
+                  pto::CreateCbufMatrixOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value destinationRaw = adaptor.getDst();
+    Value rawValue = adaptor.getRawValue();
+    Value repeatTimes = adaptor.getRepeatTimes();
+    Value blockNum32b = adaptor.getBlockNum_32b();
+    Value dstGap32b = adaptor.getDstGap_32b();
+    if (!destinationRaw || !rawValue || !repeatTimes || !blockNum32b ||
+        !dstGap32b) {
+      return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
+    if (!isa<LLVM::LLVMPointerType>(destinationRaw.getType())) {
+      return rewriter.notifyMatchFailure(op, "expected LLVM pointer destination");
+    }
+
+    Type i32Ty = rewriter.getI32Type();
+    Type i64Ty = rewriter.getI64Type();
+    if (rawValue.getType() != i32Ty || repeatTimes.getType() != i64Ty ||
+        blockNum32b.getType() != i64Ty || dstGap32b.getType() != i64Ty) {
+      return rewriter.notifyMatchFailure(op, "expected i32 value and i64 controls");
+    }
+
+    constexpr unsigned cbufAddressSpace =
+        static_cast<unsigned>(pto::AddressSpace::MAT);
+    FailureOr<Value> destination = reinterpretPointerToAddrSpace(
+        op, destinationRaw, cbufAddressSpace);
+    if (failed(destination)) {
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to map destination to mat/l1");
+    }
+
+    Location loc = op.getLoc();
+    Value fieldMask = getI64Constant(rewriter, loc, 0x7FFFU);
+    auto maskField = [&](Value value) -> Value {
+      return rewriter.create<arith::AndIOp>(loc, value, fieldMask);
+    };
+    auto shiftField = [&](Value value, uint64_t amount) -> Value {
+      return rewriter.create<arith::ShLIOp>(
+          loc, value, getI64Constant(rewriter, loc, amount));
+    };
+
+    Value config = maskField(repeatTimes);
+    config = rewriter.create<arith::OrIOp>(
+        loc, config, shiftField(maskField(blockNum32b), 16));
+    config = rewriter.create<arith::OrIOp>(
+        loc, config, shiftField(maskField(dstGap32b), 32));
+
+    StringRef calleeName = "llvm.hivm.SET.L1.2D";
+    auto funcType = rewriter.getFunctionType(
+        TypeRange{destination->getType(), i64Ty, i32Ty}, TypeRange{});
+    rewriter.create<func::CallOp>(loc, calleeName, TypeRange{},
+                                  ValueRange{*destination, config, rawValue});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
 static LogicalResult lowerMadRawOp(pto::MadRawOpInterface op,
                                    ValueRange convertedOperands,
                                    ConversionPatternRewriter &rewriter,
@@ -11034,7 +11106,8 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerCopyOpPattern<pto::CopyUbufToGmOp>,
                LowerCopyUbufToUbufOpPattern,
                LowerCopyCbufToUbufOpPattern,
-               LowerCopyUbufToCbufOpPattern>(
+               LowerCopyUbufToCbufOpPattern,
+               LowerCreateCbufMatrixOpPattern>(
       typeConverter, patterns.getContext(), state);
 }
 
@@ -11135,7 +11208,8 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                       pto::CopyGmToUbufOp, pto::CopyUbufToGmOp,
                       pto::CopyUbufToUbufOp, pto::CopyCbufToUbufOp,
                       pto::CopyUbufToCbufOp,
-                      pto::CopyGmToCbufOp, pto::LoadCbufToCaOp,
+                      pto::CopyGmToCbufOp, pto::CreateCbufMatrixOp,
+                      pto::LoadCbufToCaOp,
                       pto::LoadCbufToCbOp, pto::LoadCbufToCaS4Op,
                       pto::LoadCbufToCbS4Op, pto::LoadCbufToCaMxOp,
                       pto::LoadCbufToCbMxOp, pto::CopyMatrixCcToGmOp,

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -5115,14 +5115,20 @@ public:
                                          "expected constant fill word width");
     }
     uint64_t fillWordWidth = fillWordBits.getZExtValue();
-    Value fillPattern = rawValue;
+    StringRef calleeName;
+    Value fillPattern;
     if (fillWordWidth == 16) {
       Value wordMask = getI32Constant(rewriter, loc, 0xFFFFU);
       Value lowWord = rewriter.create<arith::AndIOp>(loc, rawValue, wordMask);
-      Value highWord = rewriter.create<arith::ShLIOp>(
-          loc, lowWord, getI32Constant(rewriter, loc, 16));
-      fillPattern = rewriter.create<arith::OrIOp>(loc, lowWord, highWord);
-    } else if (fillWordWidth != 32) {
+      Value wordBits = rewriter.create<arith::TruncIOp>(
+          loc, rewriter.getI16Type(), lowWord);
+      fillPattern =
+          rewriter.create<LLVM::BitcastOp>(loc, rewriter.getF16Type(), wordBits);
+      calleeName = "llvm.hivm.CREATE.CBUF.MATRIX.v3.u16.h";
+    } else if (fillWordWidth == 32) {
+      fillPattern = rewriter.create<arith::ExtUIOp>(loc, i64Ty, rawValue);
+      calleeName = "llvm.hivm.CREATE.CBUF.MATRIX.v3.u32";
+    } else {
       return rewriter.notifyMatchFailure(op, "expected a 16-bit or 32-bit fill word");
     }
 
@@ -5141,9 +5147,8 @@ public:
     config = rewriter.create<arith::OrIOp>(
         loc, config, shiftField(maskField(dstGap32b), 32));
 
-    StringRef calleeName = "llvm.hivm.SET.L1.2D";
     auto funcType = rewriter.getFunctionType(
-        TypeRange{destination->getType(), i64Ty, i32Ty}, TypeRange{});
+        TypeRange{destination->getType(), i64Ty, fillPattern.getType()}, TypeRange{});
     rewriter.create<func::CallOp>(loc, calleeName, TypeRange{},
                                   ValueRange{*destination, config, fillPattern});
     state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -5109,6 +5109,23 @@ public:
     }
 
     Location loc = op.getLoc();
+    APInt fillWordBits;
+    if (!matchPattern(op.getFillWordBits(), m_ConstantInt(&fillWordBits))) {
+      return rewriter.notifyMatchFailure(op,
+                                         "expected constant fill word width");
+    }
+    uint64_t fillWordWidth = fillWordBits.getZExtValue();
+    Value fillPattern = rawValue;
+    if (fillWordWidth == 16) {
+      Value wordMask = getI32Constant(rewriter, loc, 0xFFFFU);
+      Value lowWord = rewriter.create<arith::AndIOp>(loc, rawValue, wordMask);
+      Value highWord = rewriter.create<arith::ShLIOp>(
+          loc, lowWord, getI32Constant(rewriter, loc, 16));
+      fillPattern = rewriter.create<arith::OrIOp>(loc, lowWord, highWord);
+    } else if (fillWordWidth != 32) {
+      return rewriter.notifyMatchFailure(op, "expected a 16-bit or 32-bit fill word");
+    }
+
     Value fieldMask = getI64Constant(rewriter, loc, 0x7FFFU);
     auto maskField = [&](Value value) -> Value {
       return rewriter.create<arith::AndIOp>(loc, value, fieldMask);
@@ -5128,7 +5145,7 @@ public:
     auto funcType = rewriter.getFunctionType(
         TypeRange{destination->getType(), i64Ty, i32Ty}, TypeRange{});
     rewriter.create<func::CallOp>(loc, calleeName, TypeRange{},
-                                  ValueRange{*destination, config, rawValue});
+                                  ValueRange{*destination, config, fillPattern});
     state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
     rewriter.eraseOp(op);
     return success();

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -1374,11 +1374,7 @@ struct ExpandRawFillL1Pattern : public OpRewritePattern<pto::RawFillL1Op> {
                                 PatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
 
-    APInt wordBits;
-    if (!matchPattern(op.getFillWordBits(), m_ConstantInt(&wordBits))) {
-      return rewriter.notifyMatchFailure(op, "fill_word_bits not constant");
-    }
-    unsigned viewWidth = wordBits.getZExtValue() == 16 ? 16 : 32;
+    const unsigned viewWidth = op.getFillWordBits() == 16 ? 16 : 32;
 
     Value basePtr = materializeBufferPointer(op.getDst(), rewriter, loc);
     if (!basePtr || !isa<pto::PtrType>(basePtr.getType())) {
@@ -1404,7 +1400,8 @@ struct ExpandRawFillL1Pattern : public OpRewritePattern<pto::RawFillL1Op> {
 
     rewriter.create<pto::CreateCbufMatrixOp>(
         loc, viewPtr, op.getRawValue(), op.getRepeatTimes(),
-        op.getBlockNum_32b(), op.getDstGap_32b(), op.getFillWordBits());
+        op.getBlockNum_32b(), op.getDstGap_32b(),
+        static_cast<uint64_t>(op.getFillWordBits()));
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -1367,6 +1367,43 @@ struct ExpandCubeLoadPattern : public OpRewritePattern<pto::MteGmL1Op> {
   }
 };
 
+struct ExpandRawFillL1Pattern : public OpRewritePattern<pto::RawFillL1Op> {
+  using OpRewritePattern<pto::RawFillL1Op>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(pto::RawFillL1Op op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+
+    APInt wordBits;
+    if (!matchPattern(op.getFillWordBits(), m_ConstantInt(&wordBits)))
+      return rewriter.notifyMatchFailure(op, "fill_word_bits not constant");
+    unsigned viewWidth = wordBits.getZExtValue() == 16 ? 16 : 32;
+
+    Value basePtr = materializeBufferPointer(op.getDst(), rewriter, loc);
+    if (!basePtr || !isa<pto::PtrType>(basePtr.getType()))
+      return rewriter.notifyMatchFailure(op, "failed to materialize dst ptr");
+
+    Value targetPtr =
+        offsetPointerByBytes(basePtr, op.getByteOffset(), rewriter, loc);
+    if (!targetPtr)
+      return rewriter.notifyMatchFailure(op, "failed to apply byte offset");
+
+    auto dstPtrType = cast<pto::PtrType>(targetPtr.getType());
+    Type viewElement =
+        viewWidth == 16 ? rewriter.getI16Type() : rewriter.getI32Type();
+    auto viewType = pto::PtrType::get(rewriter.getContext(), viewElement,
+                                      dstPtrType.getMemorySpace());
+    Value viewPtr =
+        rewriter.create<pto::CastPtrOp>(loc, viewType, targetPtr);
+
+    rewriter.create<pto::CreateCbufMatrixOp>(
+        loc, viewPtr, op.getRawValue(), op.getRepeatTimes(),
+        op.getBlockNum_32b(), op.getDstGap_32b(), op.getFillWordBits());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct ExpandCubeStorePattern : public OpRewritePattern<pto::MteL1UbOp> {
   using OpRewritePattern<pto::MteL1UbOp>::OpRewritePattern;
 
@@ -2037,6 +2074,7 @@ struct VPTOExpandWrapperOpsPass
                  ExpandRightLoadMxPattern, ExpandAccStorePattern,
                  ExpandAccStoreGmPattern,
                  ExpandAccStoreUbPattern,
+                 ExpandRawFillL1Pattern,
                  ExpandSimtLaunchPattern,
                  ExpandAtomicConfigPattern<pto::SetAtomicAddOp>,
                  ExpandAtomicConfigPattern<pto::SetAtomicMaxOp>,

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -1375,26 +1375,32 @@ struct ExpandRawFillL1Pattern : public OpRewritePattern<pto::RawFillL1Op> {
     Location loc = op.getLoc();
 
     APInt wordBits;
-    if (!matchPattern(op.getFillWordBits(), m_ConstantInt(&wordBits)))
+    if (!matchPattern(op.getFillWordBits(), m_ConstantInt(&wordBits))) {
       return rewriter.notifyMatchFailure(op, "fill_word_bits not constant");
+    }
     unsigned viewWidth = wordBits.getZExtValue() == 16 ? 16 : 32;
 
     Value basePtr = materializeBufferPointer(op.getDst(), rewriter, loc);
-    if (!basePtr || !isa<pto::PtrType>(basePtr.getType()))
+    if (!basePtr || !isa<pto::PtrType>(basePtr.getType())) {
       return rewriter.notifyMatchFailure(op, "failed to materialize dst ptr");
+    }
 
     Value targetPtr =
         offsetPointerByBytes(basePtr, op.getByteOffset(), rewriter, loc);
-    if (!targetPtr)
+    if (!targetPtr) {
       return rewriter.notifyMatchFailure(op, "failed to apply byte offset");
+    }
 
     auto dstPtrType = cast<pto::PtrType>(targetPtr.getType());
-    Type viewElement =
-        viewWidth == 16 ? rewriter.getI16Type() : rewriter.getI32Type();
+    Type viewElement = IntegerType::get(rewriter.getContext(), viewWidth,
+                                        IntegerType::Unsigned);
     auto viewType = pto::PtrType::get(rewriter.getContext(), viewElement,
                                       dstPtrType.getMemorySpace());
-    Value viewPtr =
-        rewriter.create<pto::CastPtrOp>(loc, viewType, targetPtr);
+    Value viewPtr = targetPtr;
+    const bool needsViewCast = targetPtr.getType() != viewType;
+    if (needsViewCast) {
+      viewPtr = rewriter.create<pto::CastPtrOp>(loc, viewType, targetPtr);
+    }
 
     rewriter.create<pto::CreateCbufMatrixOp>(
         loc, viewPtr, op.getRawValue(), op.getRepeatTimes(),

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -5670,6 +5670,78 @@ private:
   LoweringState &state;
 };
 
+class LowerCreateCbufMatrixOpPattern final
+    : public OpConversionPattern<pto::CreateCbufMatrixOp> {
+public:
+  explicit LowerCreateCbufMatrixOpPattern(TypeConverter &typeConverter,
+                                          MLIRContext *context,
+                                          LoweringState &state)
+      : OpConversionPattern<pto::CreateCbufMatrixOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::CreateCbufMatrixOp op,
+                  pto::CreateCbufMatrixOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value destinationRaw = adaptor.getDst();
+    Value rawValue = adaptor.getRawValue();
+    Value repeatTimes = adaptor.getRepeatTimes();
+    Value blockNum32b = adaptor.getBlockNum_32b();
+    Value dstGap32b = adaptor.getDstGap_32b();
+    if (!destinationRaw || !rawValue || !repeatTimes || !blockNum32b ||
+        !dstGap32b) {
+      return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
+    if (!isa<LLVM::LLVMPointerType>(destinationRaw.getType())) {
+      return rewriter.notifyMatchFailure(op, "expected LLVM pointer destination");
+    }
+
+    Type i32Ty = rewriter.getI32Type();
+    Type i64Ty = rewriter.getI64Type();
+    if (rawValue.getType() != i32Ty || repeatTimes.getType() != i64Ty ||
+        blockNum32b.getType() != i64Ty || dstGap32b.getType() != i64Ty) {
+      return rewriter.notifyMatchFailure(op, "expected i32 value and i64 controls");
+    }
+
+    constexpr unsigned cbufAddressSpace =
+        static_cast<unsigned>(pto::AddressSpace::MAT);
+    FailureOr<Value> destination = reinterpretPointerToAddrSpace(
+        op, destinationRaw, cbufAddressSpace);
+    if (failed(destination)) {
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to map destination to mat/l1");
+    }
+
+    Location loc = op.getLoc();
+    Value fieldMask = getI64Constant(rewriter, loc, 0x7FFFU);
+    auto maskField = [&](Value value) -> Value {
+      return rewriter.create<arith::AndIOp>(loc, value, fieldMask);
+    };
+    auto shiftField = [&](Value value, uint64_t amount) -> Value {
+      return rewriter.create<arith::ShLIOp>(
+          loc, value, getI64Constant(rewriter, loc, amount));
+    };
+
+    Value config = maskField(repeatTimes);
+    config = rewriter.create<arith::OrIOp>(
+        loc, config, shiftField(maskField(blockNum32b), 16));
+    config = rewriter.create<arith::OrIOp>(
+        loc, config, shiftField(maskField(dstGap32b), 32));
+
+    StringRef calleeName = "llvm.hivm.SET.L1.2D";
+    auto funcType = rewriter.getFunctionType(
+        TypeRange{destination->getType(), i64Ty, i32Ty}, TypeRange{});
+    rewriter.create<func::CallOp>(loc, calleeName, TypeRange{},
+                                  ValueRange{*destination, config, rawValue});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
 static LogicalResult lowerMadRawOp(pto::MadRawOpInterface op,
                                    ValueRange convertedOperands,
                                    ConversionPatternRewriter &rewriter,
@@ -11556,7 +11628,8 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerMadRawPattern<pto::MadMxBiasRawOp>,
                LowerCopyUbufToUbufOpPattern,
                LowerCopyCbufToUbufOpPattern,
-               LowerCopyUbufToCbufOpPattern>(
+               LowerCopyUbufToCbufOpPattern,
+               LowerCreateCbufMatrixOpPattern>(
       typeConverter, patterns.getContext(), state);
 
   patterns.add<LowerCopyOpPattern<pto::CopyGmToUbufOp>>(
@@ -11725,7 +11798,8 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                       pto::CopyGmToUbufOp, pto::CopyUbufToGmOp,
                       pto::CopyUbufToUbufOp, pto::CopyCbufToUbufOp,
                       pto::CopyUbufToCbufOp,
-                      pto::CopyGmToCbufOp, pto::LoadCbufToCaOp,
+                      pto::CopyGmToCbufOp, pto::CreateCbufMatrixOp,
+                      pto::LoadCbufToCaOp,
                       pto::LoadCbufToCbOp, pto::LoadCbufToCaS4Op,
                       pto::LoadCbufToCbS4Op, pto::LoadCbufToCaMxOp,
                       pto::LoadCbufToCbMxOp, pto::CopyMatrixCcToGmOp,

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -5715,12 +5715,7 @@ public:
     }
 
     Location loc = op.getLoc();
-    APInt fillWordBits;
-    if (!matchPattern(op.getFillWordBits(), m_ConstantInt(&fillWordBits))) {
-      return rewriter.notifyMatchFailure(op,
-                                         "expected constant fill word width");
-    }
-    uint64_t fillWordWidth = fillWordBits.getZExtValue();
+    const uint64_t fillWordWidth = static_cast<uint64_t>(op.getFillWordBits());
     StringRef calleeName;
     Value fillPattern;
     if (fillWordWidth == 16) {

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -5698,8 +5698,10 @@ public:
 
     Type i32Ty = rewriter.getI32Type();
     Type i64Ty = rewriter.getI64Type();
-    if (rawValue.getType() != i32Ty || repeatTimes.getType() != i64Ty ||
-        blockNum32b.getType() != i64Ty || dstGap32b.getType() != i64Ty) {
+    const bool validControlTypes =
+        rawValue.getType() == i32Ty && repeatTimes.getType() == i64Ty &&
+        blockNum32b.getType() == i64Ty && dstGap32b.getType() == i64Ty;
+    if (!validControlTypes) {
       return rewriter.notifyMatchFailure(op, "expected i32 value and i64 controls");
     }
 

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -5715,6 +5715,23 @@ public:
     }
 
     Location loc = op.getLoc();
+    APInt fillWordBits;
+    if (!matchPattern(op.getFillWordBits(), m_ConstantInt(&fillWordBits))) {
+      return rewriter.notifyMatchFailure(op,
+                                         "expected constant fill word width");
+    }
+    uint64_t fillWordWidth = fillWordBits.getZExtValue();
+    Value fillPattern = rawValue;
+    if (fillWordWidth == 16) {
+      Value wordMask = getI32Constant(rewriter, loc, 0xFFFFU);
+      Value lowWord = rewriter.create<arith::AndIOp>(loc, rawValue, wordMask);
+      Value highWord = rewriter.create<arith::ShLIOp>(
+          loc, lowWord, getI32Constant(rewriter, loc, 16));
+      fillPattern = rewriter.create<arith::OrIOp>(loc, lowWord, highWord);
+    } else if (fillWordWidth != 32) {
+      return rewriter.notifyMatchFailure(op, "expected a 16-bit or 32-bit fill word");
+    }
+
     Value fieldMask = getI64Constant(rewriter, loc, 0x7FFFU);
     auto maskField = [&](Value value) -> Value {
       return rewriter.create<arith::AndIOp>(loc, value, fieldMask);
@@ -5734,7 +5751,7 @@ public:
     auto funcType = rewriter.getFunctionType(
         TypeRange{destination->getType(), i64Ty, i32Ty}, TypeRange{});
     rewriter.create<func::CallOp>(loc, calleeName, TypeRange{},
-                                  ValueRange{*destination, config, rawValue});
+                                  ValueRange{*destination, config, fillPattern});
     state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
     rewriter.eraseOp(op);
     return success();

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -5721,14 +5721,20 @@ public:
                                          "expected constant fill word width");
     }
     uint64_t fillWordWidth = fillWordBits.getZExtValue();
-    Value fillPattern = rawValue;
+    StringRef calleeName;
+    Value fillPattern;
     if (fillWordWidth == 16) {
       Value wordMask = getI32Constant(rewriter, loc, 0xFFFFU);
       Value lowWord = rewriter.create<arith::AndIOp>(loc, rawValue, wordMask);
-      Value highWord = rewriter.create<arith::ShLIOp>(
-          loc, lowWord, getI32Constant(rewriter, loc, 16));
-      fillPattern = rewriter.create<arith::OrIOp>(loc, lowWord, highWord);
-    } else if (fillWordWidth != 32) {
+      Value wordBits = rewriter.create<arith::TruncIOp>(
+          loc, rewriter.getI16Type(), lowWord);
+      fillPattern =
+          rewriter.create<LLVM::BitcastOp>(loc, rewriter.getF16Type(), wordBits);
+      calleeName = "llvm.hivm.CREATE.CBUF.MATRIX.v3.u16.h";
+    } else if (fillWordWidth == 32) {
+      fillPattern = rewriter.create<arith::ExtUIOp>(loc, i64Ty, rawValue);
+      calleeName = "llvm.hivm.CREATE.CBUF.MATRIX.v3.u32";
+    } else {
       return rewriter.notifyMatchFailure(op, "expected a 16-bit or 32-bit fill word");
     }
 
@@ -5747,9 +5753,8 @@ public:
     config = rewriter.create<arith::OrIOp>(
         loc, config, shiftField(maskField(dstGap32b), 32));
 
-    StringRef calleeName = "llvm.hivm.SET.L1.2D";
     auto funcType = rewriter.getFunctionType(
-        TypeRange{destination->getType(), i64Ty, i32Ty}, TypeRange{});
+        TypeRange{destination->getType(), i64Ty, fillPattern.getType()}, TypeRange{});
     rewriter.create<func::CallOp>(loc, calleeName, TypeRange{},
                                   ValueRange{*destination, config, fillPattern});
     state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});

--- a/lib/PTO/Transforms/VPTOPtrNormalize.cpp
+++ b/lib/PTO/Transforms/VPTOPtrNormalize.cpp
@@ -605,10 +605,12 @@ struct ConvertRawFillL1OperandPattern
                   ConversionPatternRewriter &rewriter) const override {
     Value dst =
         materializeBoundaryOperandPtr(adaptor.getDst(), rewriter, op.getLoc());
-    if (!dst)
+    if (!dst) {
       return rewriter.notifyMatchFailure(op, "failed to materialize dst ptr");
-    if (!isa<pto::PtrType>(dst.getType()))
+    }
+    if (!isa<pto::PtrType>(dst.getType())) {
       return rewriter.notifyMatchFailure(op, "expected ptr-form dst");
+    }
 
     SmallVector<Value> operands(adaptor.getOperands().begin(),
                                 adaptor.getOperands().end());

--- a/lib/PTO/Transforms/VPTOPtrNormalize.cpp
+++ b/lib/PTO/Transforms/VPTOPtrNormalize.cpp
@@ -596,6 +596,35 @@ struct ConvertCubeLoadOperandPattern
   }
 };
 
+struct ConvertRawFillL1OperandPattern
+    : public OpConversionPattern<pto::RawFillL1Op> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(pto::RawFillL1Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value dst =
+        materializeBoundaryOperandPtr(adaptor.getDst(), rewriter, op.getLoc());
+    if (!dst)
+      return rewriter.notifyMatchFailure(op, "failed to materialize dst ptr");
+    if (!isa<pto::PtrType>(dst.getType()))
+      return rewriter.notifyMatchFailure(op, "expected ptr-form dst");
+
+    SmallVector<Value> operands(adaptor.getOperands().begin(),
+                                adaptor.getOperands().end());
+    operands[0] = dst;
+
+    OperationState state(op.getLoc(), op->getName().getStringRef());
+    state.addOperands(operands);
+    state.addTypes(op->getResultTypes());
+    state.addAttributes(op->getAttrs());
+    state.propertiesAttr = op->getPropertiesAsAttribute();
+    Operation *newOp = rewriter.create(state);
+    rewriter.replaceOp(op, newOp->getResults());
+    return success();
+  }
+};
+
 struct ConvertCubeStoreOperandPattern
     : public OpConversionPattern<pto::MteL1UbOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -949,6 +978,9 @@ struct VPTOPtrNormalizePass
       return isa<pto::PtrType>(op.getSource().getType()) &&
              isa<pto::PtrType>(op.getDestination().getType());
     });
+    target.addDynamicallyLegalOp<pto::RawFillL1Op>([](pto::RawFillL1Op op) {
+      return isa<pto::PtrType>(op.getDst().getType());
+    });
     target.addDynamicallyLegalOp<pto::MteUbL1Op>([](pto::MteUbL1Op op) {
       return isa<pto::PtrType>(op.getSource().getType()) &&
              isa<pto::PtrType>(op.getDestination().getType());
@@ -1031,6 +1063,7 @@ struct VPTOPtrNormalizePass
                  ConvertMteUbUbOperandPattern,
                  ConvertMteUbL1OperandPattern,
                  ConvertCubeLoadOperandPattern,
+                 ConvertRawFillL1OperandPattern,
                  ConvertCubeStoreOperandPattern,
                  ConvertBiasLoadOperandPattern,
                  ConvertCubeLoadFracOperandPattern,

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -899,29 +899,35 @@ Cube compute step; it does not issue those transfers itself.
 
 ---
 
-#### `pto.raw_fill_l1(dst: PtrType, byte_offset: int, raw_value: int, repeat_times: int, block_num_32b: int, dst_gap_32b: int, fill_word_bits: int) -> None`
+#### `pto.raw_fill_l1(dst: PtrType, byte_offset: int, raw_value: int, *, repeat_times: int, block_num_32b: int, dst_gap_32b: int, fill_word_bits: int) -> None`
 
 **Description**: Fill a strided region in the L1 (MAT) buffer with one raw
 16-bit or 32-bit word pattern. This is the explicit PTO surface used for
 padding and tail regions, including the final strided repetition.
+
+All parameters from `repeat_times` onward are keyword-only.
 
 **Parameters**:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `dst` | `PtrType` (L1/MAT) | Destination L1 buffer |
-| `byte_offset` | `int` | Non-negative byte offset to the first filled word |
+| `byte_offset` | `int` | Non-negative byte offset to the first filled word; must be a multiple of 32 bytes |
 | `raw_value` | `int` | Raw pattern; low 16 bits are repeated for a 16-bit fill, all 32 bits are used for a 32-bit fill |
 | `repeat_times` | `int` | Number of fill repetitions; all values must be at most `32767` |
 | `block_num_32b` | `int` | Number of contiguous 32-byte blocks per repetition; all values must be at most `32767` |
 | `dst_gap_32b` | `int` | Gap between repetitions in 32-byte blocks; all values must be at most `32767` |
-| `fill_word_bits` | `int` | Compile-time view width, exactly `16` or `32` |
+| `fill_word_bits` | `int` | Static view width, exactly `16` or `32`; must be a Python `int` |
 
 **Constraints**: `dst` must be in the L1/MAT address space. Offsets and
 geometry values must be non-negative. `repeat_times`, `block_num_32b`, and
 `dst_gap_32b` must be at most `32767`, including when dynamically computed;
-PTOAS diagnoses known constant violations. `fill_word_bits` must be a
-compile-time `16` or `32` value.
+PTODSL diagnoses static Python `int` violations up front, and PTOAS diagnoses
+known constant violations for dynamically computed values. `fill_word_bits`
+must be a static `16` or `32` value and is recorded as an IR attribute. The
+effective destination address `dst + byte_offset` must be 32-byte aligned;
+PTODSL rejects non-aligned static Python `int` offsets, while dynamic offset
+alignment is a caller precondition.
 
 **Example**:
 

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -899,6 +899,44 @@ Cube compute step; it does not issue those transfers itself.
 
 ---
 
+#### `pto.raw_fill_l1(dst: PtrType, byte_offset: int, raw_value: int, repeat_times: int, block_num_32b: int, dst_gap_32b: int, fill_word_bits: int) -> None`
+
+**Description**: Fill a strided region in the L1 (MAT) buffer with one raw
+16-bit or 32-bit word pattern. This is the explicit PTO surface used for
+padding and tail regions, including the final strided repetition.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `dst` | `PtrType` (L1/MAT) | Destination L1 buffer |
+| `byte_offset` | `int` | Non-negative byte offset to the first filled word |
+| `raw_value` | `int` | Raw 32-bit bit pattern; the selected view determines the word width |
+| `repeat_times` | `int` | Number of fill repetitions; constant values must be at most `32767` |
+| `block_num_32b` | `int` | Number of contiguous 32-byte blocks per repetition; constant values must be at most `32767` |
+| `dst_gap_32b` | `int` | Gap between repetitions in 32-bit blocks; constant values must be at most `32767` |
+| `fill_word_bits` | `int` | Compile-time view width, exactly `16` or `32` |
+
+**Constraints**: `dst` must be in the L1/MAT address space. Constant offsets and
+geometry values must be non-negative. `fill_word_bits` must be a compile-time
+`16` or `32` value.
+
+**Example**:
+
+```python
+pto.raw_fill_l1(
+    l1_dst,
+    byte_offset=32,
+    raw_value=0,
+    repeat_times=4,
+    block_num_32b=2,
+    dst_gap_32b=6,
+    fill_word_bits=16,
+)
+```
+
+---
+
 #### `pto.mte_gm_l1_frac(src: PtrType, dst: PtrType, mode: pto.FractalMode, *, shape: tuple[int, int], src_layout: tuple[int] | tuple[int, int], dst_group: tuple[int, int, int, int], ctrl: tuple[int, bool]) -> None`
 
 **Description**: Fractal GM-to-L1 load for specialized layouts (`ND2NZ`, `DN2NZ`).
@@ -1202,6 +1240,7 @@ pto.mte_l0c_gm(
 | Data Flow | Operation | Src Space | Dst Space |
 |-----------|-----------|-----------|-----------|
 | GM → L1 | `mte_gm_l1` | gm | l1 |
+| L1 raw fill | `raw_fill_l1` | l1 | l1 |
 | GM → L1 (fractal) | `mte_gm_l1_frac` | gm | l1 |
 | L1 → UB | `mte_l1_ub` | l1 | ub |
 | L1 → L0A (explicit control) | `mte_l1_l0a` | l1 | l0a |

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -911,15 +911,17 @@ padding and tail regions, including the final strided repetition.
 |-----------|------|-------------|
 | `dst` | `PtrType` (L1/MAT) | Destination L1 buffer |
 | `byte_offset` | `int` | Non-negative byte offset to the first filled word |
-| `raw_value` | `int` | Raw 32-bit bit pattern; the selected view determines the word width |
-| `repeat_times` | `int` | Number of fill repetitions; constant values must be at most `32767` |
-| `block_num_32b` | `int` | Number of contiguous 32-byte blocks per repetition; constant values must be at most `32767` |
-| `dst_gap_32b` | `int` | Gap between repetitions in 32-bit blocks; constant values must be at most `32767` |
+| `raw_value` | `int` | Raw pattern; low 16 bits are repeated for a 16-bit fill, all 32 bits are used for a 32-bit fill |
+| `repeat_times` | `int` | Number of fill repetitions; all values must be at most `32767` |
+| `block_num_32b` | `int` | Number of contiguous 32-byte blocks per repetition; all values must be at most `32767` |
+| `dst_gap_32b` | `int` | Gap between repetitions in 32-byte blocks; all values must be at most `32767` |
 | `fill_word_bits` | `int` | Compile-time view width, exactly `16` or `32` |
 
-**Constraints**: `dst` must be in the L1/MAT address space. Constant offsets and
-geometry values must be non-negative. `fill_word_bits` must be a compile-time
-`16` or `32` value.
+**Constraints**: `dst` must be in the L1/MAT address space. Offsets and
+geometry values must be non-negative. `repeat_times`, `block_num_32b`, and
+`dst_gap_32b` must be at most `32767`, including when dynamically computed;
+PTOAS diagnoses known constant violations. `fill_word_bits` must be a
+compile-time `16` or `32` value.
 
 **Example**:
 

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -1242,7 +1242,7 @@ pto.mte_l0c_gm(
 | Data Flow | Operation | Src Space | Dst Space |
 |-----------|-----------|-----------|-----------|
 | GM → L1 | `mte_gm_l1` | gm | l1 |
-| L1 raw fill | `raw_fill_l1` | l1 | l1 |
+| L1 raw fill | `raw_fill_l1` | -- | l1 |
 | GM → L1 (fractal) | `mte_gm_l1_frac` | gm | l1 |
 | L1 → UB | `mte_l1_ub` | l1 | ub |
 | L1 → L0A (explicit control) | `mte_l1_l0a` | l1 | l0a |

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -82,6 +82,7 @@ from ptoas.mlir.ir import (
     Float8E5M2Type,
     FloatAttr,
     IndexType,
+    IntegerAttr,
     IntegerType,
     MemRefType,
     Operation,
@@ -4438,6 +4439,27 @@ def _coerce_i64(value, *, context: str):
     return coerce_runtime_integer_value(raw_value, IntegerType.get_signless(64), context=context)
 
 
+def _validate_raw_fill_l1_static_scalar(
+        value, *, context: str, maximum=None, alignment=None):
+    if isinstance(value, bool):
+        raise TypeError(f"{context} does not accept bool values")
+    if not isinstance(value, int):
+        return
+    if value < 0:
+        raise ValueError(f"{context} expects a non-negative static value, got {value}")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"{context} expects a static value in [0, {maximum}], got {value}")
+    if alignment is not None and value % alignment != 0:
+        raise ValueError(f"{context} expects a static value aligned to {alignment} bytes, got {value}")
+
+
+def _validate_raw_fill_l1_fill_word_bits(fill_word_bits, *, context: str):
+    if isinstance(fill_word_bits, bool) or not isinstance(fill_word_bits, int):
+        raise TypeError(f"{context} expects a static int fill_word_bits, got {fill_word_bits!r}")
+    if fill_word_bits not in (16, 32):
+        raise ValueError(f"{context} expects fill_word_bits 16 or 32, got {fill_word_bits}")
+
+
 def _coerce_i1(value, *, context: str):
     raw_value = unwrap_surface_value(value)
     return coerce_runtime_i1_value(raw_value, context=context)
@@ -5265,9 +5287,19 @@ def mte_gm_l1(source, destination, len_burst, *, nburst, loops=None):
 
 
 @_explicit_mode_only("pto.raw_fill_l1(...)")
-def raw_fill_l1(dst, byte_offset, raw_value, repeat_times, block_num_32b,
-                dst_gap_32b, fill_word_bits):
+def raw_fill_l1(dst, byte_offset, raw_value, *,
+                repeat_times, block_num_32b, dst_gap_32b, fill_word_bits):
     """Fill a strided L1/MAT region with a raw 16-bit or 32-bit pattern."""
+    _validate_raw_fill_l1_static_scalar(
+        byte_offset, context="raw_fill_l1 byte_offset", alignment=32)
+    _validate_raw_fill_l1_static_scalar(
+        repeat_times, context="raw_fill_l1 repeat_times", maximum=32767)
+    _validate_raw_fill_l1_static_scalar(
+        block_num_32b, context="raw_fill_l1 block_num_32b", maximum=32767)
+    _validate_raw_fill_l1_static_scalar(
+        dst_gap_32b, context="raw_fill_l1 dst_gap_32b", maximum=32767)
+    _validate_raw_fill_l1_fill_word_bits(
+        fill_word_bits, context="raw_fill_l1 fill_word_bits")
     _pto.RawFillL1Op(
         unwrap_surface_value(dst),
         _coerce_i64(byte_offset, context="raw_fill_l1 byte_offset"),
@@ -5275,7 +5307,7 @@ def raw_fill_l1(dst, byte_offset, raw_value, repeat_times, block_num_32b,
         _coerce_i64(repeat_times, context="raw_fill_l1 repeat_times"),
         _coerce_i64(block_num_32b, context="raw_fill_l1 block_num_32b"),
         _coerce_i64(dst_gap_32b, context="raw_fill_l1 dst_gap_32b"),
-        _coerce_i64(fill_word_bits, context="raw_fill_l1 fill_word_bits"),
+        IntegerAttr.get(IntegerType.get_signless(64), fill_word_bits),
     )
 
 

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -5264,6 +5264,21 @@ def mte_gm_l1(source, destination, len_burst, *, nburst, loops=None):
     )
 
 
+@_explicit_mode_only("pto.raw_fill_l1(...)")
+def raw_fill_l1(dst, byte_offset, raw_value, repeat_times, block_num_32b,
+                dst_gap_32b, fill_word_bits):
+    """Fill a strided L1/MAT region with a raw 16-bit or 32-bit pattern."""
+    _pto.RawFillL1Op(
+        unwrap_surface_value(dst),
+        _coerce_i64(byte_offset, context="raw_fill_l1 byte_offset"),
+        _coerce_i32(raw_value, context="raw_fill_l1 raw_value"),
+        _coerce_i64(repeat_times, context="raw_fill_l1 repeat_times"),
+        _coerce_i64(block_num_32b, context="raw_fill_l1 block_num_32b"),
+        _coerce_i64(dst_gap_32b, context="raw_fill_l1 dst_gap_32b"),
+        _coerce_i64(fill_word_bits, context="raw_fill_l1 fill_word_bits"),
+    )
+
+
 @_explicit_mode_only("pto.mte_l1_ub(...)")
 def mte_l1_ub(source, destination, len_burst, *, nburst, loops=None):
     """``pto.mte_l1_ub`` – grouped L1/CBUF-to-UB DMA surface."""
@@ -6760,7 +6775,7 @@ __all__ = [
     "chistv2",
     "as_ptr",
     "mte_load", "mte_store", "mte_gm_ub", "mte_ub_gm", "mte_ub_ub", "mte_ub_l1",
-    "mte_gm_l1", "mte_l1_ub", "mte_gm_l1_frac", "mte_l1_bt", "mte_l1_fb", "mem_bar",
+    "mte_gm_l1", "raw_fill_l1", "mte_l1_ub", "mte_gm_l1_frac", "mte_l1_bt", "mte_l1_fb", "mem_bar",
     "set_store_atomic_cfg",
     "set_atomic_add", "set_atomic_max", "set_atomic_min", "set_atomic_none",
     "set_atomic_f32", "set_atomic_f16", "set_atomic_bf16",

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -122,7 +122,7 @@ from ._ops import (             # noqa: F401
     alloc_buffer, alloc_tile,
     tsort32, tmrgsort, tgather, tscatter,
     mte_load, mte_store, mte_gm_ub, mte_ub_gm, mte_ub_ub, mte_ub_l1,
-    mte_gm_l1, mte_l1_ub, mte_gm_l1_frac, mte_l1_bt, mte_l1_fb, mem_bar,
+    mte_gm_l1, raw_fill_l1, mte_l1_ub, mte_gm_l1_frac, mte_l1_bt, mte_l1_fb, mem_bar,
     set_store_atomic_cfg,
     set_atomic_add, set_atomic_max, set_atomic_min, set_atomic_none,
     set_atomic_f32, set_atomic_f16, set_atomic_bf16,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -3239,6 +3239,15 @@ def public_data_movement_surface_probe():
     pto.mte_ub_ub(ub_src, ub_dst, 8, nburst=(16, 0, 4))
     pto.mte_ub_l1(ub_src, l1_dst, 8, nburst=(16, 0, 4))
     pto.mte_gm_l1(gm_src, l1_dst, 256, nburst=(8, 256, 256), loops=[(2, 2048, 2048)])
+    pto.raw_fill_l1(
+        l1_dst,
+        byte_offset=32,
+        raw_value=0,
+        repeat_times=4,
+        block_num_32b=2,
+        dst_gap_32b=6,
+        fill_word_bits=16,
+    )
     pto.mte_l1_ub(l1_dst, ub_dst, 256, nburst=(8, 256, 256), loops=[(2, 2048, 2048)])
     pto.mte_gm_l1_frac(
         gm_src,
@@ -3811,6 +3820,7 @@ def main() -> None:
         "mte_ub_ub",
         "mte_ub_l1",
         "mte_gm_l1",
+        "raw_fill_l1",
         "mte_l1_ub",
         "mte_gm_l1_frac",
         "mte_l1_bt",
@@ -6852,6 +6862,10 @@ def main() -> None:
     expect("pto.mte_ub_ub" in data_movement_surface_text, "public grouped UB->UB wrapper should lower to pto.mte_ub_ub")
     expect("pto.mte_ub_l1" in data_movement_surface_text, "public grouped UB->L1 wrapper should lower to pto.mte_ub_l1")
     expect("pto.mte_gm_l1" in data_movement_surface_text, "public grouped GM->L1 wrapper should lower to pto.mte_gm_l1")
+    expect(
+        "pto.raw_fill_l1" in data_movement_surface_text,
+        "public L1 raw-fill wrapper should lower to pto.raw_fill_l1",
+    )
     expect("pto.mte_l1_ub" in data_movement_surface_text, "public grouped L1->UB wrapper should lower to pto.mte_l1_ub")
     expect("pto.mte_gm_l1_frac" in data_movement_surface_text, "public GM->L1 frac wrapper should lower to pto.mte_gm_l1_frac")
     expect("pto.mte_l1_bt" in data_movement_surface_text, "public L1->BT wrapper should lower to pto.mte_l1_bt")

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -235,13 +235,36 @@ class VectorCubeSurfaceTest(unittest.TestCase):
             "vcmin", "vcgmin", "vcpadd",
             "vadds", "vmuls", "vmaxs", "vmins", "vlrelu", "vshls", "vshrs", "vands", "vors", "vxors",
             "vaxpy", "vmula", "vci", "vaddrelu", "vsubrelu", "vsel",
-            "mte_gm_l1", "mte_l1_ub", "mte_gm_l1_frac", "mte_l1_bt", "mte_l1_fb",
+            "mte_gm_l1", "raw_fill_l1", "mte_l1_ub", "mte_gm_l1_frac", "mte_l1_bt", "mte_l1_fb",
             "mad_acc", "mad_bias", "mad_mx", "mad_mx_acc", "mad_mx_bias",
             "FractalMode", "AccStoreUnitFlagCtrl", "MadUnitFlagMode", "SatMode", "Tf32Mode", "SplitMode",
         ]
 
         for name in names:
             self.assertTrue(hasattr(pto, name), name)
+
+    def test_raw_fill_l1_preserves_all_control_fields(self):
+        destination = object()
+
+        def coerce(value, *, context):
+            return f"{context}:{value}"
+
+        with patch.object(_ops, "_require_explicit_mode"), \
+             patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_ops, "_coerce_i64", side_effect=coerce), \
+             patch.object(_ops, "_coerce_i32", side_effect=coerce), \
+             patch.object(_ops._pto, "RawFillL1Op") as raw_fill:
+            pto.raw_fill_l1(destination, 32, 0x12345678, 3, 7, 11, 16)
+
+        raw_fill.assert_called_once_with(
+            destination,
+            "raw_fill_l1 byte_offset:32",
+            "raw_fill_l1 raw_value:305419896",
+            "raw_fill_l1 repeat_times:3",
+            "raw_fill_l1 block_num_32b:7",
+            "raw_fill_l1 dst_gap_32b:11",
+            "raw_fill_l1 fill_word_bits:16",
+        )
 
     def test_tile_bitwise_aliases_are_exposed_without_legacy_names(self):
         preferred_names = [

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -9,7 +9,7 @@
 import unittest
 import inspect
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import ptodsl._ops as _ops
 import ptodsl._pipe_namespace as _pipe_namespace
@@ -253,9 +253,21 @@ class VectorCubeSurfaceTest(unittest.TestCase):
              patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_ops, "_coerce_i64", side_effect=coerce), \
              patch.object(_ops, "_coerce_i32", side_effect=coerce), \
+             patch.object(_ops, "IntegerAttr") as integer_attr, \
+             patch.object(_ops, "IntegerType") as integer_type, \
              patch.object(_ops._pto, "RawFillL1Op") as raw_fill:
-            pto.raw_fill_l1(destination, 32, 0x12345678, 3, 7, 11, 16)
+            pto.raw_fill_l1(
+                destination,
+                32,
+                0x12345678,
+                repeat_times=3,
+                block_num_32b=7,
+                dst_gap_32b=11,
+                fill_word_bits=16,
+            )
 
+        integer_type.get_signless.assert_called_once_with(64)
+        integer_attr.get.assert_called_once_with(ANY, 16)
         raw_fill.assert_called_once_with(
             destination,
             "raw_fill_l1 byte_offset:32",
@@ -263,8 +275,64 @@ class VectorCubeSurfaceTest(unittest.TestCase):
             "raw_fill_l1 repeat_times:3",
             "raw_fill_l1 block_num_32b:7",
             "raw_fill_l1 dst_gap_32b:11",
-            "raw_fill_l1 fill_word_bits:16",
+            integer_attr.get.return_value,
         )
+
+    def test_raw_fill_l1_rejects_positional_control_fields(self):
+        destination = object()
+        with patch.object(_ops, "_require_explicit_mode"):
+            with self.assertRaises(TypeError):
+                pto.raw_fill_l1(destination, 32, 0x12345678, 3, 7, 11, 16)
+
+    def test_raw_fill_l1_validates_fill_word_bits(self):
+        destination = object()
+        with patch.object(_ops, "_require_explicit_mode"):
+            with self.assertRaises(ValueError):
+                pto.raw_fill_l1(
+                    destination, 32, 0,
+                    repeat_times=1, block_num_32b=1, dst_gap_32b=0,
+                    fill_word_bits=8,
+                )
+            with self.assertRaises(TypeError):
+                pto.raw_fill_l1(
+                    destination, 32, 0,
+                    repeat_times=1, block_num_32b=1, dst_gap_32b=0,
+                    fill_word_bits=True,
+                )
+            with self.assertRaises(TypeError):
+                pto.raw_fill_l1(
+                    destination, 32, 0,
+                    repeat_times=1, block_num_32b=1, dst_gap_32b=0,
+                    fill_word_bits=16.0,
+                )
+
+    def test_raw_fill_l1_validates_static_geometry(self):
+        destination = object()
+        with patch.object(_ops, "_require_explicit_mode"):
+            with self.assertRaises(ValueError):
+                pto.raw_fill_l1(
+                    destination, 2, 0,
+                    repeat_times=1, block_num_32b=1, dst_gap_32b=0,
+                    fill_word_bits=16,
+                )
+            with self.assertRaises(ValueError):
+                pto.raw_fill_l1(
+                    destination, -1, 0,
+                    repeat_times=1, block_num_32b=1, dst_gap_32b=0,
+                    fill_word_bits=16,
+                )
+            with self.assertRaises(ValueError):
+                pto.raw_fill_l1(
+                    destination, 32, 0,
+                    repeat_times=32768, block_num_32b=1, dst_gap_32b=0,
+                    fill_word_bits=16,
+                )
+            with self.assertRaises(ValueError):
+                pto.raw_fill_l1(
+                    destination, 32, 0,
+                    repeat_times=1, block_num_32b=1, dst_gap_32b=-2,
+                    fill_word_bits=16,
+                )
 
     def test_tile_bitwise_aliases_are_exposed_without_legacy_names(self):
         preferred_names = [

--- a/test/lit/vpto/raw_fill_l1_dynamic_controls.pto
+++ b/test/lit/vpto/raw_fill_l1_dynamic_controls.pto
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @raw_fill_l1_dynamic_controls_16(
+      %dst: !pto.ptr<bf16, mat>, %byte_offset: i64, %repeat_times: i64,
+      %block_num_32b: i64, %dst_gap_32b: i64) attributes {pto.kernel} {
+    %zero_i32 = arith.constant 0 : i32
+    %c16_i64 = arith.constant 16 : i64
+    pto.raw_fill_l1 %dst, %byte_offset, %zero_i32, %repeat_times,
+      %block_num_32b, %dst_gap_32b, %c16_i64
+      : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+
+  func.func @raw_fill_l1_dynamic_controls_32(
+      %dst: !pto.ptr<f32, mat>, %byte_offset: i64, %repeat_times: i64,
+      %block_num_32b: i64, %dst_gap_32b: i64) attributes {pto.kernel} {
+    %zero_i32 = arith.constant 0 : i32
+    %c32_i64 = arith.constant 32 : i64
+    pto.raw_fill_l1 %dst, %byte_offset, %zero_i32, %repeat_times,
+      %block_num_32b, %dst_gap_32b, %c32_i64
+      : !pto.ptr<f32, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: define void @raw_fill_l1_dynamic_controls_16{{.*}}
+// CHECK: and i64 {{.*}}, 32767
+// CHECK: and i64 {{.*}}, 32767
+// CHECK: shl i64 {{.*}}, 16
+// CHECK: or i64
+// CHECK: and i64 {{.*}}, 32767
+// CHECK: shl i64 {{.*}}, 32
+// CHECK: or i64
+// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 {{.*}}, i32 0)
+
+// CHECK-LABEL: define void @raw_fill_l1_dynamic_controls_32{{.*}}
+// CHECK: and i64 {{.*}}, 32767
+// CHECK: and i64 {{.*}}, 32767
+// CHECK: shl i64 {{.*}}, 16
+// CHECK: or i64
+// CHECK: and i64 {{.*}}, 32767
+// CHECK: shl i64 {{.*}}, 32
+// CHECK: or i64
+// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 {{.*}}, i32 0)

--- a/test/lit/vpto/raw_fill_l1_dynamic_controls.pto
+++ b/test/lit/vpto/raw_fill_l1_dynamic_controls.pto
@@ -15,8 +15,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
       attributes {pto.kernel} {
     %c16_i64 = arith.constant 16 : i64
     pto.raw_fill_l1 %dst, %byte_offset, %raw_value, %repeat_times,
-      %block_num_32b, %dst_gap_32b, %c16_i64
-      : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64, i64
+      %block_num_32b, %dst_gap_32b {fill_word_bits = 16 : i64} : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64
     return
   }
 
@@ -26,8 +25,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %zero_i32 = arith.constant 0 : i32
     %c32_i64 = arith.constant 32 : i64
     pto.raw_fill_l1 %dst, %byte_offset, %zero_i32, %repeat_times,
-      %block_num_32b, %dst_gap_32b, %c32_i64
-      : !pto.ptr<f32, mat>, i64, i32, i64, i64, i64, i64
+      %block_num_32b, %dst_gap_32b {fill_word_bits = 32 : i64} : !pto.ptr<f32, mat>, i64, i32, i64, i64, i64
     return
   }
 }

--- a/test/lit/vpto/raw_fill_l1_dynamic_controls.pto
+++ b/test/lit/vpto/raw_fill_l1_dynamic_controls.pto
@@ -34,8 +34,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 
 // CHECK-LABEL: define void @raw_fill_l1_dynamic_controls_16{{.*}}
 // CHECK: %[[WORD16:.*]] = and i32 %{{.*}}, 65535
-// CHECK: %[[HIGH16:.*]] = shl i32 %[[WORD16]], 16
-// CHECK: %[[PATTERN16:.*]] = or i32 %[[WORD16]], %[[HIGH16]]
+// CHECK: %[[WORD_BITS:.*]] = trunc i32 %[[WORD16]] to i16
+// CHECK: %[[PATTERN16:.*]] = bitcast i16 %[[WORD_BITS]] to half
 // CHECK: and i64 {{.*}}, 32767
 // CHECK: and i64 {{.*}}, 32767
 // CHECK: shl i64 {{.*}}, 16
@@ -43,7 +43,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 // CHECK: and i64 {{.*}}, 32767
 // CHECK: shl i64 {{.*}}, 32
 // CHECK: or i64
-// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 {{.*}}, i32 %[[PATTERN16]])
+// CHECK: call void @llvm.hivm.CREATE.CBUF.MATRIX.v3.u16.h(ptr addrspace(2) {{.*}}, i64 {{.*}}, half %[[PATTERN16]])
 
 // CHECK-LABEL: define void @raw_fill_l1_dynamic_controls_32{{.*}}
 // CHECK: and i64 {{.*}}, 32767
@@ -53,4 +53,4 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 // CHECK: and i64 {{.*}}, 32767
 // CHECK: shl i64 {{.*}}, 32
 // CHECK: or i64
-// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 {{.*}}, i32 0)
+// CHECK: call void @llvm.hivm.CREATE.CBUF.MATRIX.v3.u32(ptr addrspace(2) {{.*}}, i64 {{.*}}, i64 0)

--- a/test/lit/vpto/raw_fill_l1_dynamic_controls.pto
+++ b/test/lit/vpto/raw_fill_l1_dynamic_controls.pto
@@ -11,10 +11,10 @@
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
   func.func @raw_fill_l1_dynamic_controls_16(
       %dst: !pto.ptr<bf16, mat>, %byte_offset: i64, %repeat_times: i64,
-      %block_num_32b: i64, %dst_gap_32b: i64) attributes {pto.kernel} {
-    %zero_i32 = arith.constant 0 : i32
+      %block_num_32b: i64, %dst_gap_32b: i64, %raw_value: i32)
+      attributes {pto.kernel} {
     %c16_i64 = arith.constant 16 : i64
-    pto.raw_fill_l1 %dst, %byte_offset, %zero_i32, %repeat_times,
+    pto.raw_fill_l1 %dst, %byte_offset, %raw_value, %repeat_times,
       %block_num_32b, %dst_gap_32b, %c16_i64
       : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64, i64
     return
@@ -33,6 +33,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 }
 
 // CHECK-LABEL: define void @raw_fill_l1_dynamic_controls_16{{.*}}
+// CHECK: %[[WORD16:.*]] = and i32 %{{.*}}, 65535
+// CHECK: %[[HIGH16:.*]] = shl i32 %[[WORD16]], 16
+// CHECK: %[[PATTERN16:.*]] = or i32 %[[WORD16]], %[[HIGH16]]
 // CHECK: and i64 {{.*}}, 32767
 // CHECK: and i64 {{.*}}, 32767
 // CHECK: shl i64 {{.*}}, 16
@@ -40,7 +43,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 // CHECK: and i64 {{.*}}, 32767
 // CHECK: shl i64 {{.*}}, 32
 // CHECK: or i64
-// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 {{.*}}, i32 0)
+// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 {{.*}}, i32 %[[PATTERN16]])
 
 // CHECK-LABEL: define void @raw_fill_l1_dynamic_controls_32{{.*}}
 // CHECK: and i64 {{.*}}, 32767

--- a/test/lit/vpto/raw_fill_l1_infers_cube_kernel_kind.pto
+++ b/test/lit/vpto/raw_fill_l1_infers_cube_kernel_kind.pto
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s
+
+// L1 raw fill is an MTE1/Cube operation. Without an explicit kernel kind,
+// section normalization must infer and retain a Cube-only module.
+
+module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
+    func.func @raw_fill_l1_infers_cube_kind(
+        %dst: !pto.ptr<ui16, mat>) attributes {pto.entry} {
+      %c0_i64 = arith.constant 0 : i64
+      %c1_i64 = arith.constant 1 : i64
+      %c16_i64 = arith.constant 16 : i64
+      %zero_i32 = arith.constant 0 : i32
+      pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64,
+        %c0_i64, %c16_i64
+        : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+      return
+    }
+  }
+}
+
+// CHECK: module attributes {pto.backend = "vpto", pto.kernel_kind = #pto.kernel_kind<cube>
+// CHECK: func.func @raw_fill_l1_infers_cube_kind
+// CHECK: pto.create_cbuf_matrix
+// CHECK-NOT: pto.kernel_kind = #pto.kernel_kind<vector>

--- a/test/lit/vpto/raw_fill_l1_infers_cube_kernel_kind.pto
+++ b/test/lit/vpto/raw_fill_l1_infers_cube_kernel_kind.pto
@@ -20,8 +20,7 @@ module attributes {pto.target_arch = "a5"} {
       %c16_i64 = arith.constant 16 : i64
       %zero_i32 = arith.constant 0 : i32
       pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64,
-        %c0_i64, %c16_i64
-        : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+        %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64
       return
     }
   }

--- a/test/lit/vpto/raw_fill_l1_tilelang_col_tail.pto
+++ b/test/lit/vpto/raw_fill_l1_tilelang_col_tail.pto
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// TileLang-shaped lowered VPTO fixture for BF16 15x13x47 K-column padding.
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto \
+// RUN:   --mlir-print-ir-before=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=ROUNDTRIP
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto \
+// RUN:   --mlir-print-ir-after=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=EXPAND
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - | FileCheck %s --check-prefix=LLVM
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @raw_fill_l1_tilelang_col_tail(%dst: !pto.ptr<bf16, mat>)
+      attributes {pto.kernel} {
+    %c832_i64 = arith.constant 832 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c13_i64 = arith.constant 13 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %zero_i32 = arith.constant 0 : i32
+    %c16_i64 = arith.constant 16 : i64
+
+    // valid_c0_blocks = floor(47 / 16) = 2; tail_c0_blocks = 1.
+    // byte_offset = 2 * 13 * 32 = 832; config = 1 | (13 << 16) = 851969.
+    pto.raw_fill_l1 %dst, %c832_i64, %zero_i32, %c1_i64, %c13_i64,
+      %c0_i64, %c16_i64
+      : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// ROUNDTRIP-LABEL: func.func @raw_fill_l1_tilelang_col_tail(
+// ROUNDTRIP: pto.raw_fill_l1 %{{.*}}, %c832_i64, %{{.*}}, %c1_i64, %c13_i64, %c0_i64, %c16_i64
+
+// EXPAND-LABEL: func.func @raw_fill_l1_tilelang_col_tail(
+// EXPAND: pto.castptr %{{.*}} : !pto.ptr<bf16, l1> -> !pto.ptr<ui16, l1>
+// EXPAND: pto.create_cbuf_matrix
+// EXPAND-NOT: pto.raw_fill_l1
+
+// LLVM-LABEL: define void @raw_fill_l1_tilelang_col_tail{{.*}}
+// LLVM: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 851969, i32 0)

--- a/test/lit/vpto/raw_fill_l1_tilelang_col_tail.pto
+++ b/test/lit/vpto/raw_fill_l1_tilelang_col_tail.pto
@@ -43,4 +43,4 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 // EXPAND-NOT: pto.raw_fill_l1
 
 // LLVM-LABEL: define void @raw_fill_l1_tilelang_col_tail{{.*}}
-// LLVM: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 851969, i32 0)
+// LLVM: call void @llvm.hivm.CREATE.CBUF.MATRIX.v3.u16.h(ptr addrspace(2) {{.*}}, i64 851969, half {{.*}})

--- a/test/lit/vpto/raw_fill_l1_tilelang_col_tail.pto
+++ b/test/lit/vpto/raw_fill_l1_tilelang_col_tail.pto
@@ -28,14 +28,13 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     // valid_c0_blocks = floor(47 / 16) = 2; tail_c0_blocks = 1.
     // byte_offset = 2 * 13 * 32 = 832; config = 1 | (13 << 16) = 851969.
     pto.raw_fill_l1 %dst, %c832_i64, %zero_i32, %c1_i64, %c13_i64,
-      %c0_i64, %c16_i64
-      : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64, i64
+      %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64
     return
   }
 }
 
 // ROUNDTRIP-LABEL: func.func @raw_fill_l1_tilelang_col_tail(
-// ROUNDTRIP: pto.raw_fill_l1 %{{.*}}, %c832_i64, %{{.*}}, %c1_i64, %c13_i64, %c0_i64, %c16_i64
+// ROUNDTRIP: pto.raw_fill_l1 %{{.*}}, %c832_i64, %{{.*}}, %c1_i64, %c13_i64, %c0_i64 {fill_word_bits = 16 : i64}
 
 // EXPAND-LABEL: func.func @raw_fill_l1_tilelang_col_tail(
 // EXPAND: pto.castptr %{{.*}} : !pto.ptr<bf16, l1> -> !pto.ptr<ui16, l1>

--- a/test/lit/vpto/raw_fill_l1_tilelang_ordering.pto
+++ b/test/lit/vpto/raw_fill_l1_tilelang_ordering.pto
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// The raw fill is a write to the same L1 buffer used by its GM->L1 producer and
+// L1->L0A consumer. The IR order below is the dependence contract.
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto \
+// RUN:   --mlir-print-ir-before=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=ROUNDTRIP
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto \
+// RUN:   --mlir-print-ir-after=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=EXPAND
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @raw_fill_l1_tilelang_ordering(
+      %src: !pto.ptr<bf16, gm>, %dst: !pto.ptr<bf16, mat>,
+      %l0a: !pto.ptr<bf16, left>) attributes {pto.kernel} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c13_i64 = arith.constant 13 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c832_i64 = arith.constant 832 : i64
+    %false = arith.constant false
+    %zero_i32 = arith.constant 0 : i32
+
+    pto.section.cube {
+      pto.mte_gm_l1_frac %src, %dst, nd2nz,
+        shape(%c16_i64, %c16_i64), src_layout(%c16_i64),
+        dst_group(%c1_i64, %c1_i64, %c16_i64, %c0_i64),
+        ctrl(%c0_i64, %false)
+        : !pto.ptr<bf16, gm>, !pto.ptr<bf16, mat>, nd2nz,
+          shape i64, i64, src_layout(i64), dst_group i64, i64, i64, i64,
+          ctrl i64, i1
+      pto.raw_fill_l1 %dst, %c832_i64, %zero_i32, %c1_i64, %c13_i64,
+        %c0_i64, %c16_i64
+        : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64, i64
+      pto.mte_l1_l0a %dst, %l0a, %c16_i64, %c16_i64, %c0_i64, %c0_i64
+        : !pto.ptr<bf16, mat>, !pto.ptr<bf16, left>, i64, i64, i64, i64
+    }
+    return
+  }
+}
+
+// ROUNDTRIP-LABEL: func.func @raw_fill_l1_tilelang_ordering(
+// ROUNDTRIP: pto.mte_gm_l1_frac
+// ROUNDTRIP: pto.raw_fill_l1
+// ROUNDTRIP: pto.mte_l1_l0a
+// ROUNDTRIP-NOT: pto.section.vector
+
+// EXPAND-LABEL: func.func @raw_fill_l1_tilelang_ordering(
+// EXPAND: pto.set_mte2_nz_para
+// EXPAND: pto.copy_gm_to_cbuf_multi_nd2nz
+// EXPAND: pto.create_cbuf_matrix
+// EXPAND: pto.load_cbuf_to_ca
+// EXPAND-NOT: pto.raw_fill_l1

--- a/test/lit/vpto/raw_fill_l1_tilelang_ordering.pto
+++ b/test/lit/vpto/raw_fill_l1_tilelang_ordering.pto
@@ -36,8 +36,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
           shape i64, i64, src_layout(i64), dst_group i64, i64, i64, i64,
           ctrl i64, i1
       pto.raw_fill_l1 %dst, %c832_i64, %zero_i32, %c1_i64, %c13_i64,
-        %c0_i64, %c16_i64
-        : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64, i64
+        %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64
       pto.mte_l1_l0a %dst, %l0a, %c16_i64, %c16_i64, %c0_i64, %c0_i64
         : !pto.ptr<bf16, mat>, !pto.ptr<bf16, left>, i64, i64, i64, i64
     }

--- a/test/lit/vpto/raw_fill_l1_tilelang_row_tail.pto
+++ b/test/lit/vpto/raw_fill_l1_tilelang_row_tail.pto
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// TileLang-shaped lowered VPTO fixture for BF16 15x13x47 K-row padding.
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto \
+// RUN:   --mlir-print-ir-before=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=ROUNDTRIP
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto \
+// RUN:   --mlir-print-ir-after=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=EXPAND
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - | FileCheck %s --check-prefix=LLVM
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @raw_fill_l1_tilelang_row_tail(%dst: !pto.ptr<bf16, mat>)
+      attributes {pto.kernel} {
+    %c480_i64 = arith.constant 480 : i64
+    %c3_i64 = arith.constant 3 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c15_i64 = arith.constant 15 : i64
+    %zero_i32 = arith.constant 0 : i32
+    %c16_i64 = arith.constant 16 : i64
+
+    // valid_rows = 15; tail_rows = 1; dst_c0_blocks = ceil(47 / 16) = 3.
+    // dst_n = 16 is the physical C0 row stride, so dst_gap_32b = 16 - 1 = 15.
+    // config = 3 | (1 << 16) | (15 << 32) = 64424574979.
+    pto.raw_fill_l1 %dst, %c480_i64, %zero_i32, %c3_i64, %c1_i64,
+      %c15_i64, %c16_i64
+      : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// ROUNDTRIP-LABEL: func.func @raw_fill_l1_tilelang_row_tail(
+// ROUNDTRIP: pto.raw_fill_l1 %{{.*}}, %c480_i64, %{{.*}}, %c3_i64, %c1_i64, %c15_i64, %c16_i64
+
+// EXPAND-LABEL: func.func @raw_fill_l1_tilelang_row_tail(
+// EXPAND: pto.castptr %{{.*}} : !pto.ptr<bf16, l1> -> !pto.ptr<ui16, l1>
+// EXPAND: pto.create_cbuf_matrix
+// EXPAND-NOT: pto.raw_fill_l1
+
+// LLVM-LABEL: define void @raw_fill_l1_tilelang_row_tail{{.*}}
+// LLVM: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 64424574979, i32 0)

--- a/test/lit/vpto/raw_fill_l1_tilelang_row_tail.pto
+++ b/test/lit/vpto/raw_fill_l1_tilelang_row_tail.pto
@@ -44,4 +44,4 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 // EXPAND-NOT: pto.raw_fill_l1
 
 // LLVM-LABEL: define void @raw_fill_l1_tilelang_row_tail{{.*}}
-// LLVM: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 64424574979, i32 0)
+// LLVM: call void @llvm.hivm.CREATE.CBUF.MATRIX.v3.u16.h(ptr addrspace(2) {{.*}}, i64 64424574979, half {{.*}})

--- a/test/lit/vpto/raw_fill_l1_tilelang_row_tail.pto
+++ b/test/lit/vpto/raw_fill_l1_tilelang_row_tail.pto
@@ -29,14 +29,13 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     // dst_n = 16 is the physical C0 row stride, so dst_gap_32b = 16 - 1 = 15.
     // config = 3 | (1 << 16) | (15 << 32) = 64424574979.
     pto.raw_fill_l1 %dst, %c480_i64, %zero_i32, %c3_i64, %c1_i64,
-      %c15_i64, %c16_i64
-      : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64, i64
+      %c15_i64 {fill_word_bits = 16 : i64} : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64
     return
   }
 }
 
 // ROUNDTRIP-LABEL: func.func @raw_fill_l1_tilelang_row_tail(
-// ROUNDTRIP: pto.raw_fill_l1 %{{.*}}, %c480_i64, %{{.*}}, %c3_i64, %c1_i64, %c15_i64, %c16_i64
+// ROUNDTRIP: pto.raw_fill_l1 %{{.*}}, %c480_i64, %{{.*}}, %c3_i64, %c1_i64, %c15_i64 {fill_word_bits = 16 : i64}
 
 // EXPAND-LABEL: func.func @raw_fill_l1_tilelang_row_tail(
 // EXPAND: pto.castptr %{{.*}} : !pto.ptr<bf16, l1> -> !pto.ptr<ui16, l1>

--- a/test/lit/vpto/raw_fill_l1_tilelang_views.pto
+++ b/test/lit/vpto/raw_fill_l1_tilelang_views.pto
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// TileLang passes its data element view to the wrapper; expansion owns the raw
+// ui16/ui32 fill view after byte-address calculation.
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto \
+// RUN:   --mlir-print-ir-after=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 \
+// RUN:   | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @raw_fill_l1_tilelang_views(
+      %bf16_dst: !pto.ptr<bf16, mat>,
+      %fp8_dst: !pto.ptr<f8E4M3FN, mat>,
+      %f32_dst: !pto.ptr<f32, mat>) attributes {pto.kernel} {
+    %c32_i64 = arith.constant 32 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c96_i64 = arith.constant 96 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %zero_i32 = arith.constant 0 : i32
+    %c16_i64 = arith.constant 16 : i64
+    %c32_word_i64 = arith.constant 32 : i64
+
+    pto.raw_fill_l1 %bf16_dst, %c32_i64, %zero_i32, %c1_i64, %c2_i64,
+      %c0_i64, %c16_i64
+      : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64, i64
+    pto.raw_fill_l1 %fp8_dst, %c64_i64, %zero_i32, %c1_i64, %c2_i64,
+      %c0_i64, %c16_i64
+      : !pto.ptr<f8E4M3FN, mat>, i64, i32, i64, i64, i64, i64
+    pto.raw_fill_l1 %f32_dst, %c96_i64, %zero_i32, %c1_i64, %c2_i64,
+      %c0_i64, %c32_word_i64
+      : !pto.ptr<f32, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @raw_fill_l1_tilelang_views(
+// CHECK: %[[BF16_BYTES:.*]] = pto.castptr %{{.*}} : !pto.ptr<bf16, l1> -> !pto.ptr<i8, l1>
+// CHECK: %[[BF16_ADVANCED:.*]] = pto.addptr %[[BF16_BYTES]], %{{.*}}
+// CHECK: %[[BF16_BASE:.*]] = pto.castptr %[[BF16_ADVANCED]] : !pto.ptr<i8, l1> -> !pto.ptr<bf16, l1>
+// CHECK: %[[BF16_VIEW:.*]] = pto.castptr %[[BF16_BASE]] : !pto.ptr<bf16, l1> -> !pto.ptr<ui16, l1>
+// CHECK: pto.create_cbuf_matrix %[[BF16_VIEW]]
+// CHECK: %[[FP8_BYTES:.*]] = pto.castptr %{{.*}} : !pto.ptr<f8E4M3FN, l1> -> !pto.ptr<i8, l1>
+// CHECK: %[[FP8_ADVANCED:.*]] = pto.addptr %[[FP8_BYTES]], %{{.*}}
+// CHECK: %[[FP8_BASE:.*]] = pto.castptr %[[FP8_ADVANCED]] : !pto.ptr<i8, l1> -> !pto.ptr<f8E4M3FN, l1>
+// CHECK: %[[FP8_VIEW:.*]] = pto.castptr %[[FP8_BASE]] : !pto.ptr<f8E4M3FN, l1> -> !pto.ptr<ui16, l1>
+// CHECK: pto.create_cbuf_matrix %[[FP8_VIEW]]
+// CHECK: %[[F32_BYTES:.*]] = pto.castptr %{{.*}} : !pto.ptr<f32, l1> -> !pto.ptr<i8, l1>
+// CHECK: %[[F32_ADVANCED:.*]] = pto.addptr %[[F32_BYTES]], %{{.*}}
+// CHECK: %[[F32_BASE:.*]] = pto.castptr %[[F32_ADVANCED]] : !pto.ptr<i8, l1> -> !pto.ptr<f32, l1>
+// CHECK: %[[F32_VIEW:.*]] = pto.castptr %[[F32_BASE]] : !pto.ptr<f32, l1> -> !pto.ptr<ui32, l1>
+// CHECK: pto.create_cbuf_matrix %[[F32_VIEW]]

--- a/test/lit/vpto/raw_fill_l1_tilelang_views.pto
+++ b/test/lit/vpto/raw_fill_l1_tilelang_views.pto
@@ -28,14 +28,11 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c32_word_i64 = arith.constant 32 : i64
 
     pto.raw_fill_l1 %bf16_dst, %c32_i64, %zero_i32, %c1_i64, %c2_i64,
-      %c0_i64, %c16_i64
-      : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64, i64
+      %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<bf16, mat>, i64, i32, i64, i64, i64
     pto.raw_fill_l1 %fp8_dst, %c64_i64, %zero_i32, %c1_i64, %c2_i64,
-      %c0_i64, %c16_i64
-      : !pto.ptr<f8E4M3FN, mat>, i64, i32, i64, i64, i64, i64
+      %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<f8E4M3FN, mat>, i64, i32, i64, i64, i64
     pto.raw_fill_l1 %f32_dst, %c96_i64, %zero_i32, %c1_i64, %c2_i64,
-      %c0_i64, %c32_word_i64
-      : !pto.ptr<f32, mat>, i64, i32, i64, i64, i64, i64
+      %c0_i64 {fill_word_bits = 32 : i64} : !pto.ptr<f32, mat>, i64, i32, i64, i64, i64
     return
   }
 }

--- a/test/lit/vpto/raw_fill_l1_verify_invalid_address_space.pto
+++ b/test/lit/vpto/raw_fill_l1_verify_invalid_address_space.pto
@@ -14,9 +14,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %c16_i64 = arith.constant 16 : i64
     %zero_i32 = arith.constant 0 : i32
-    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
-      %c16_i64
-      : !pto.ptr<ui16, ub>, i64, i32, i64, i64, i64, i64
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64, %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<ui16, ub>, i64, i32, i64, i64, i64
     return
   }
 }

--- a/test/lit/vpto/raw_fill_l1_verify_invalid_address_space.pto
+++ b/test/lit/vpto/raw_fill_l1_verify_invalid_address_space.pto
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @raw_fill_l1_requires_mat(%dst: !pto.ptr<ui16, ub>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %zero_i32 = arith.constant 0 : i32
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
+      %c16_i64
+      : !pto.ptr<ui16, ub>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.raw_fill_l1' op requires dst in the mat/l1 address space, got vec/ub

--- a/test/lit/vpto/raw_fill_l1_verify_invalid_canonical_view.pto
+++ b/test/lit/vpto/raw_fill_l1_verify_invalid_canonical_view.pto
@@ -15,8 +15,7 @@ module {
     %c0_i64 = arith.constant 0 : i64
     %zero_i32 = arith.constant 0 : i32
     %c32_i64 = arith.constant 32 : i64
-    pto.create_cbuf_matrix %dst, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
-      %c32_i64 : !pto.ptr<ui16, mat>, i32, i64, i64, i64, i64
+    pto.create_cbuf_matrix %dst, %zero_i32, %c1_i64, %c1_i64, %c0_i64 {fill_word_bits = 32 : i64} : !pto.ptr<ui16, mat>, i32, i64, i64, i64
     return
   }
 }
@@ -32,8 +31,7 @@ module {
     %c0_i64 = arith.constant 0 : i64
     %zero_i32 = arith.constant 0 : i32
     %c16_i64 = arith.constant 16 : i64
-    pto.create_cbuf_matrix %dst, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
-      %c16_i64 : !pto.ptr<i16, mat>, i32, i64, i64, i64, i64
+    pto.create_cbuf_matrix %dst, %zero_i32, %c1_i64, %c1_i64, %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<i16, mat>, i32, i64, i64, i64
     return
   }
 }
@@ -49,8 +47,7 @@ module {
     %c0_i64 = arith.constant 0 : i64
     %zero_i32 = arith.constant 0 : i32
     %c16_i64 = arith.constant 16 : i64
-    pto.create_cbuf_matrix %dst, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
-      %c16_i64 : !pto.ptr<ui8, mat>, i32, i64, i64, i64, i64
+    pto.create_cbuf_matrix %dst, %zero_i32, %c1_i64, %c1_i64, %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<ui8, mat>, i32, i64, i64, i64
     return
   }
 }

--- a/test/lit/vpto/raw_fill_l1_verify_invalid_canonical_view.pto
+++ b/test/lit/vpto/raw_fill_l1_verify_invalid_canonical_view.pto
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -split-input-file 2>&1 | FileCheck %s
+
+module {
+  func.func @create_cbuf_matrix_rejects_word_width_mismatch(
+      %dst: !pto.ptr<ui16, mat>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %zero_i32 = arith.constant 0 : i32
+    %c32_i64 = arith.constant 32 : i64
+    pto.create_cbuf_matrix %dst, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
+      %c32_i64 : !pto.ptr<ui16, mat>, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.create_cbuf_matrix' op fill_word_bits 32 does not match the 16-bit destination view
+
+// -----
+
+module {
+  func.func @create_cbuf_matrix_rejects_signless_view(
+      %dst: !pto.ptr<i16, mat>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %zero_i32 = arith.constant 0 : i32
+    %c16_i64 = arith.constant 16 : i64
+    pto.create_cbuf_matrix %dst, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
+      %c16_i64 : !pto.ptr<i16, mat>, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.create_cbuf_matrix' op requires a ui16 or ui32 destination view, got element type 'i16'
+
+// -----
+
+module {
+  func.func @create_cbuf_matrix_rejects_noncanonical_width(
+      %dst: !pto.ptr<ui8, mat>) {
+    %c1_i64 = arith.constant 1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %zero_i32 = arith.constant 0 : i32
+    %c16_i64 = arith.constant 16 : i64
+    pto.create_cbuf_matrix %dst, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
+      %c16_i64 : !pto.ptr<ui8, mat>, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.create_cbuf_matrix' op requires a ui16 or ui32 destination view, got element type 'ui8'

--- a/test/lit/vpto/raw_fill_l1_verify_invalid_geometry.pto
+++ b/test/lit/vpto/raw_fill_l1_verify_invalid_geometry.pto
@@ -16,8 +16,7 @@ module {
     %c32768_i64 = arith.constant 32768 : i64
     %zero_i32 = arith.constant 0 : i32
     pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c32768_i64, %c1_i64,
-      %c0_i64, %c16_i64
-      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+      %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64
     return
   }
 }
@@ -34,8 +33,7 @@ module {
     %c32768_i64 = arith.constant 32768 : i64
     %zero_i32 = arith.constant 0 : i32
     pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64,
-      %c32768_i64, %c16_i64
-      : !pto.ptr<ui32, mat>, i64, i32, i64, i64, i64, i64
+      %c32768_i64 {fill_word_bits = 16 : i64} : !pto.ptr<ui32, mat>, i64, i32, i64, i64, i64
     return
   }
 }
@@ -52,8 +50,7 @@ module {
     %c32768_i64 = arith.constant 32768 : i64
     %zero_i32 = arith.constant 0 : i32
     pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c32768_i64,
-      %c0_i64, %c16_i64
-      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+      %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64
     return
   }
 }
@@ -71,13 +68,29 @@ module {
     %c16_i64 = arith.constant 16 : i64
     %zero_i32 = arith.constant 0 : i32
     pto.raw_fill_l1 %dst, %cm1_i64, %zero_i32, %c1_i64, %c1_i64,
-      %c0_i64, %c16_i64
-      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+      %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64
     return
   }
 }
 
 // CHECK: 'pto.raw_fill_l1' op byte_offset must be non-negative
+
+// -----
+
+module {
+  func.func @raw_fill_l1_rejects_unaligned_byte_offset(
+      %dst: !pto.ptr<ui16, mat>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %zero_i32 = arith.constant 0 : i32
+    pto.raw_fill_l1 %dst, %c2_i64, %zero_i32, %c1_i64, %c1_i64,
+      %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.raw_fill_l1' op byte_offset must be a multiple of 32 bytes
 
 // -----
 
@@ -90,8 +103,7 @@ module {
     %c16_i64 = arith.constant 16 : i64
     %zero_i32 = arith.constant 0 : i32
     pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %cm1_i64, %c1_i64,
-      %c0_i64, %c16_i64
-      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+      %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64
     return
   }
 }
@@ -109,8 +121,7 @@ module {
     %c16_i64 = arith.constant 16 : i64
     %zero_i32 = arith.constant 0 : i32
     pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %cm1_i64,
-      %c0_i64, %c16_i64
-      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+      %c0_i64 {fill_word_bits = 16 : i64} : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64
     return
   }
 }
@@ -127,8 +138,7 @@ module {
     %c16_i64 = arith.constant 16 : i64
     %zero_i32 = arith.constant 0 : i32
     pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64,
-      %cm1_i64, %c16_i64
-      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+      %cm1_i64 {fill_word_bits = 16 : i64} : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64
     return
   }
 }

--- a/test/lit/vpto/raw_fill_l1_verify_invalid_geometry.pto
+++ b/test/lit/vpto/raw_fill_l1_verify_invalid_geometry.pto
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -split-input-file 2>&1 | FileCheck %s
+
+module {
+  func.func @raw_fill_l1_rejects_repeat_overflow(%dst: !pto.ptr<ui16, mat>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c32768_i64 = arith.constant 32768 : i64
+    %zero_i32 = arith.constant 0 : i32
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c32768_i64, %c1_i64,
+      %c0_i64, %c16_i64
+      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.raw_fill_l1' op repeat_times must be <= 32767
+
+// -----
+
+module {
+  func.func @raw_fill_l1_rejects_gap_overflow(%dst: !pto.ptr<ui32, mat>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c32768_i64 = arith.constant 32768 : i64
+    %zero_i32 = arith.constant 0 : i32
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64,
+      %c32768_i64, %c16_i64
+      : !pto.ptr<ui32, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.raw_fill_l1' op dst_gap_32b must be <= 32767

--- a/test/lit/vpto/raw_fill_l1_verify_invalid_geometry.pto
+++ b/test/lit/vpto/raw_fill_l1_verify_invalid_geometry.pto
@@ -41,3 +41,96 @@ module {
 }
 
 // CHECK: 'pto.raw_fill_l1' op dst_gap_32b must be <= 32767
+
+// -----
+
+module {
+  func.func @raw_fill_l1_rejects_block_overflow(%dst: !pto.ptr<ui16, mat>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c32768_i64 = arith.constant 32768 : i64
+    %zero_i32 = arith.constant 0 : i32
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c32768_i64,
+      %c0_i64, %c16_i64
+      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.raw_fill_l1' op block_num_32b must be <= 32767
+
+// -----
+
+module {
+  func.func @raw_fill_l1_rejects_negative_byte_offset(
+      %dst: !pto.ptr<ui16, mat>) {
+    %cm1_i64 = arith.constant -1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %zero_i32 = arith.constant 0 : i32
+    pto.raw_fill_l1 %dst, %cm1_i64, %zero_i32, %c1_i64, %c1_i64,
+      %c0_i64, %c16_i64
+      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.raw_fill_l1' op byte_offset must be non-negative
+
+// -----
+
+module {
+  func.func @raw_fill_l1_rejects_negative_repeat_times(
+      %dst: !pto.ptr<ui16, mat>) {
+    %cm1_i64 = arith.constant -1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %zero_i32 = arith.constant 0 : i32
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %cm1_i64, %c1_i64,
+      %c0_i64, %c16_i64
+      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.raw_fill_l1' op repeat_times must be non-negative
+
+// -----
+
+module {
+  func.func @raw_fill_l1_rejects_negative_block_num(
+      %dst: !pto.ptr<ui16, mat>) {
+    %cm1_i64 = arith.constant -1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %zero_i32 = arith.constant 0 : i32
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %cm1_i64,
+      %c0_i64, %c16_i64
+      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.raw_fill_l1' op block_num_32b must be non-negative
+
+// -----
+
+module {
+  func.func @raw_fill_l1_rejects_negative_gap(%dst: !pto.ptr<ui16, mat>) {
+    %cm1_i64 = arith.constant -1 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %zero_i32 = arith.constant 0 : i32
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64,
+      %cm1_i64, %c16_i64
+      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.raw_fill_l1' op dst_gap_32b must be non-negative

--- a/test/lit/vpto/raw_fill_l1_verify_invalid_word_bits.pto
+++ b/test/lit/vpto/raw_fill_l1_verify_invalid_word_bits.pto
@@ -14,9 +14,7 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %c8_i64 = arith.constant 8 : i64
     %zero_i32 = arith.constant 0 : i32
-    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
-      %c8_i64
-      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64, %c0_i64 {fill_word_bits = 8 : i64} : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64
     return
   }
 }
@@ -31,28 +29,9 @@ module {
     %c1_i64 = arith.constant 1 : i64
     %c64_i64 = arith.constant 64 : i64
     %zero_i32 = arith.constant 0 : i32
-    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
-      %c64_i64
-      : !pto.ptr<ui32, mat>, i64, i32, i64, i64, i64, i64
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64, %c0_i64 {fill_word_bits = 64 : i64} : !pto.ptr<ui32, mat>, i64, i32, i64, i64, i64
     return
   }
 }
 
 // CHECK: 'pto.raw_fill_l1' op fill_word_bits must be 16 or 32, got 64
-
-// -----
-
-module {
-  func.func @raw_fill_l1_rejects_dynamic_word_width(
-      %dst: !pto.ptr<ui16, mat>, %word_bits: i64) {
-    %c0_i64 = arith.constant 0 : i64
-    %c1_i64 = arith.constant 1 : i64
-    %zero_i32 = arith.constant 0 : i32
-    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
-      %word_bits
-      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
-    return
-  }
-}
-
-// CHECK: 'pto.raw_fill_l1' op fill_word_bits must be a compile-time constant 16 or 32

--- a/test/lit/vpto/raw_fill_l1_verify_invalid_word_bits.pto
+++ b/test/lit/vpto/raw_fill_l1_verify_invalid_word_bits.pto
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -split-input-file 2>&1 | FileCheck %s
+
+module {
+  func.func @raw_fill_l1_rejects_8_bit_words(%dst: !pto.ptr<ui16, mat>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c8_i64 = arith.constant 8 : i64
+    %zero_i32 = arith.constant 0 : i32
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
+      %c8_i64
+      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.raw_fill_l1' op fill_word_bits must be 16 or 32, got 8
+
+// -----
+
+module {
+  func.func @raw_fill_l1_rejects_64_bit_words(%dst: !pto.ptr<ui32, mat>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %zero_i32 = arith.constant 0 : i32
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
+      %c64_i64
+      : !pto.ptr<ui32, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.raw_fill_l1' op fill_word_bits must be 16 or 32, got 64
+
+// -----
+
+module {
+  func.func @raw_fill_l1_rejects_dynamic_word_width(
+      %dst: !pto.ptr<ui16, mat>, %word_bits: i64) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %zero_i32 = arith.constant 0 : i32
+    pto.raw_fill_l1 %dst, %c0_i64, %zero_i32, %c1_i64, %c1_i64, %c0_i64,
+      %word_bits
+      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: 'pto.raw_fill_l1' op fill_word_bits must be a compile-time constant 16 or 32

--- a/test/lit/vpto/raw_fill_l1_vpto_llvm.pto
+++ b/test/lit/vpto/raw_fill_l1_vpto_llvm.pto
@@ -31,14 +31,11 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c65535_i32 = arith.constant 65535 : i32
 
     pto.raw_fill_l1 %dst16, %c32_i64, %c4660_i32, %c3_i64, %c7_i64,
-      %c11_i64, %c16_i64
-      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+      %c11_i64 {fill_word_bits = 16 : i64} : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64
     pto.raw_fill_l1 %dst32, %c64_i64, %c305419896_i32, %c5_i64, %c2_i64,
-      %c9_i64, %c32_word_i64
-      : !pto.ptr<ui32, mat>, i64, i32, i64, i64, i64, i64
+      %c9_i64 {fill_word_bits = 32 : i64} : !pto.ptr<ui32, mat>, i64, i32, i64, i64, i64
     pto.raw_fill_l1 %dst16_memref, %c32_i64, %c65535_i32, %c32767_i64,
-      %c32767_i64, %c32767_i64, %c16_i64
-      : memref<?xui16, #pto.address_space<mat>>, i64, i32, i64, i64, i64, i64
+      %c32767_i64, %c32767_i64 {fill_word_bits = 16 : i64} : memref<?xui16, #pto.address_space<mat>>, i64, i32, i64, i64, i64
     return
   }
 }

--- a/test/lit/vpto/raw_fill_l1_vpto_llvm.pto
+++ b/test/lit/vpto/raw_fill_l1_vpto_llvm.pto
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - | FileCheck %s
+// RUN: ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto \
+// RUN:   --emit-vpto-llvm-ir %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @raw_fill_l1_views_and_tail(
+      %dst16: !pto.ptr<ui16, mat>,
+      %dst32: !pto.ptr<ui32, mat>,
+      %dst16_memref: memref<?xui16, #pto.address_space<mat>>) attributes {pto.kernel} {
+    %c32_i64 = arith.constant 32 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c3_i64 = arith.constant 3 : i64
+    %c5_i64 = arith.constant 5 : i64
+    %c7_i64 = arith.constant 7 : i64
+    %c9_i64 = arith.constant 9 : i64
+    %c11_i64 = arith.constant 11 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c32_word_i64 = arith.constant 32 : i64
+    %c32767_i64 = arith.constant 32767 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %c4660_i32 = arith.constant 4660 : i32
+    %c305419896_i32 = arith.constant 305419896 : i32
+    %c65535_i32 = arith.constant 65535 : i32
+
+    pto.raw_fill_l1 %dst16, %c32_i64, %c4660_i32, %c3_i64, %c7_i64,
+      %c11_i64, %c16_i64
+      : !pto.ptr<ui16, mat>, i64, i32, i64, i64, i64, i64
+    pto.raw_fill_l1 %dst32, %c64_i64, %c305419896_i32, %c5_i64, %c2_i64,
+      %c9_i64, %c32_word_i64
+      : !pto.ptr<ui32, mat>, i64, i32, i64, i64, i64, i64
+    pto.raw_fill_l1 %dst16_memref, %c32_i64, %c65535_i32, %c32767_i64,
+      %c32767_i64, %c32767_i64, %c16_i64
+      : memref<?xui16, #pto.address_space<mat>>, i64, i32, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK: declare void @llvm.hivm.SET.L1.2D(ptr addrspace(2), i64, i32)
+// CHECK-LABEL: define void @raw_fill_l1_views_and_tail_mix_aic
+// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 47245099011, i32 4660)
+// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 38654836741, i32 305419896)
+// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 140735340838911, i32 65535)

--- a/test/lit/vpto/raw_fill_l1_vpto_llvm.pto
+++ b/test/lit/vpto/raw_fill_l1_vpto_llvm.pto
@@ -45,6 +45,6 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
 
 // CHECK: declare void @llvm.hivm.SET.L1.2D(ptr addrspace(2), i64, i32)
 // CHECK-LABEL: define void @raw_fill_l1_views_and_tail_mix_aic
-// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 47245099011, i32 4660)
+// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 47245099011, i32 305402420)
 // CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 38654836741, i32 305419896)
-// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 140735340838911, i32 65535)
+// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 140735340838911, i32 -1)

--- a/test/lit/vpto/raw_fill_l1_vpto_llvm.pto
+++ b/test/lit/vpto/raw_fill_l1_vpto_llvm.pto
@@ -43,8 +43,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
   }
 }
 
-// CHECK: declare void @llvm.hivm.SET.L1.2D(ptr addrspace(2), i64, i32)
+// CHECK: declare void @llvm.hivm.CREATE.CBUF.MATRIX.v3.u16.h(ptr addrspace(2), i64, half)
+// CHECK: declare void @llvm.hivm.CREATE.CBUF.MATRIX.v3.u32(ptr addrspace(2), i64, i64)
 // CHECK-LABEL: define void @raw_fill_l1_views_and_tail_mix_aic
-// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 47245099011, i32 305402420)
-// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 38654836741, i32 305419896)
-// CHECK: call void @llvm.hivm.SET.L1.2D(ptr addrspace(2) {{.*}}, i64 140735340838911, i32 -1)
+// CHECK: call void @llvm.hivm.CREATE.CBUF.MATRIX.v3.u16.h(ptr addrspace(2) {{.*}}, i64 47245099011, half {{.*}})
+// CHECK: call void @llvm.hivm.CREATE.CBUF.MATRIX.v3.u32(ptr addrspace(2) {{.*}}, i64 38654836741, i64 305419896)
+// CHECK: call void @llvm.hivm.CREATE.CBUF.MATRIX.v3.u16.h(ptr addrspace(2) {{.*}}, i64 140735340838911, half {{.*}})


### PR DESCRIPTION
## Summary
- add the `pto.raw_fill_l1` public wrapper and canonical `pto.create_cbuf_matrix` raw op for MAT/L1 fills
- verify MAT address space, 16/32-bit fill views, control-field bounds, and write effects; normalize pointers and lower both LLVM emission paths to `llvm.hivm.SET.L1.2D`
- expose the PTODSL surface and document the micro-ISA contract
- classify raw L1 fill as a Cube micro-op so unannotated VPTO modules infer Cube kernel kind

## Validation
- 144: rebuilt `PTOASCompiler` and `pto-test-opt`
- 144: `llvm-lit -sv build-fill/test/lit/vpto --filter raw_fill_l1` (5 passed)
- local existing artifacts: `ptodsl/tests/test_jit_compile.py`
- local existing artifacts: `ptodsl/tests/test_vector_cube_ops.py` (54 passed)
- `git diff --check`

## Notes
- no TileLang changes included
- control fields retain the documented 15-bit maximum (`32767`)
close #1227 