### PR TITLE
style: enforce C++ codecheck rules

### DIFF
--- a/include/PTO/IR/PTO.h
+++ b/include/PTO/IR/PTO.h
@@ -16,6 +16,8 @@
 #ifndef MLIR_DIALECT_PTO_IR_PTO_H_
 #define MLIR_DIALECT_PTO_IR_PTO_H_
 
+#include "PTO/Support/CodeConstants.h"
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -212,10 +214,12 @@ inline constexpr llvm::StringLiteral kPTODSLLogicalNameAttrName =
 /// the current symbol name. PTODSL uses this to mark ABI-specialized helper and
 /// kernel-module symbols without relying on symbol-name parsing.
 inline StringRef getPTODSLLogicalNameOrSymbolName(func::FuncOp func) {
-  if (!func)
+  if (!func) {
     return {};
-  if (auto attr = func->getAttrOfType<StringAttr>(kPTODSLLogicalNameAttrName))
+  }
+  if (auto attr = func->getAttrOfType<StringAttr>(kPTODSLLogicalNameAttrName)) {
     return attr.getValue();
+  }
   return func.getSymName();
 }
 

--- a/include/PTO/IR/PTOMultiBuffer.h
+++ b/include/PTO/IR/PTOMultiBuffer.h
@@ -14,7 +14,7 @@
 //   - `kPtoMultiBufferAddrsAttrName` is the internal address list written
 //     directly on tile-native `pto.alloc_multi_tile` by PlanMemory.
 //   - `kPtoMultiBufferMaxNum` is the upper bound on the slot count N. It is
-//     kept in lock-step with the InsertSync `MAX_MULTI_BUFFER_NUM`.
+//     kept in lock-step with the InsertSync `kMaxMultiBufferCount`.
 //
 //===----------------------------------------------------------------------===//
 
@@ -34,7 +34,7 @@ inline constexpr llvm::StringLiteral kPtoMultiBufferAttrName =
 inline constexpr llvm::StringLiteral kPtoMultiBufferAddrsAttrName =
     "pto.multi_buffer_addrs";
 
-/// Upper bound for N; must stay consistent with `MAX_MULTI_BUFFER_NUM` in
+/// Upper bound for N; must stay consistent with `kMaxMultiBufferCount` in
 /// insert-sync.
 inline constexpr unsigned kPtoMultiBufferMaxNum = 16;
 

--- a/include/PTO/Support/CANNVersion.h
+++ b/include/PTO/Support/CANNVersion.h
@@ -17,10 +17,14 @@
 
 namespace mlir::pto {
 
+inline constexpr unsigned kCANNVersionComponentCount = 3;
+inline constexpr unsigned kDecimalRadix = 10;
+
 struct CANNVersion {
   static constexpr unsigned RELEASE = std::numeric_limits<unsigned>::max();
 
-  CANNVersion(unsigned major, unsigned minor, unsigned patch, unsigned beta)
+  constexpr CANNVersion(unsigned major, unsigned minor, unsigned patch,
+                        unsigned beta)
       : major(major), minor(minor), patch(patch), beta(beta) {}
 
   static CANNVersion release(unsigned major, unsigned minor, unsigned patch) {
@@ -33,12 +37,15 @@ struct CANNVersion {
   unsigned beta;
 
   bool operator<(const CANNVersion &rhs) const {
-    if (major != rhs.major)
+    if (major != rhs.major) {
       return major < rhs.major;
-    if (minor != rhs.minor)
+    }
+    if (minor != rhs.minor) {
       return minor < rhs.minor;
-    if (patch != rhs.patch)
+    }
+    if (patch != rhs.patch) {
       return patch < rhs.patch;
+    }
     return beta < rhs.beta;
   }
 
@@ -50,39 +57,47 @@ struct CANNVersion {
   bool operator>=(const CANNVersion &rhs) const { return !(*this < rhs); }
 };
 
+inline constexpr CANNVersion kDefaultCANNVersion{9, 0, 0, 1};
+inline constexpr CANNVersion kCANN900Beta2Version{9, 0, 0, 2};
+
 inline std::optional<unsigned> parseCANNVersionComponent(
     llvm::StringRef value) {
   unsigned result = 0;
-  if (value.empty() || value.getAsInteger(10, result))
+  if (value.empty() || value.getAsInteger(kDecimalRadix, result)) {
     return std::nullopt;
+  }
   return result;
 }
 
 inline std::optional<unsigned> parseCANNBetaVersion(
     llvm::StringRef prerelease) {
-  if (!prerelease.consume_front("beta."))
+  if (!prerelease.consume_front("beta.")) {
     return std::nullopt;
+  }
   return parseCANNVersionComponent(prerelease);
 }
 
 inline std::optional<CANNVersion> parseCANNVersion(llvm::StringRef version) {
   auto [core, prerelease] = version.split('-');
-  llvm::SmallVector<llvm::StringRef, 3> components;
+  llvm::SmallVector<llvm::StringRef, kCANNVersionComponentCount> components;
   core.split(components, '.');
-  if (components.size() != 3)
+  if (components.size() != kCANNVersionComponentCount) {
     return std::nullopt;
+  }
 
   std::optional<unsigned> major = parseCANNVersionComponent(components[0]);
   std::optional<unsigned> minor = parseCANNVersionComponent(components[1]);
   std::optional<unsigned> patch = parseCANNVersionComponent(components[2]);
-  if (!major || !minor || !patch)
+  if (!major || !minor || !patch) {
     return std::nullopt;
+  }
 
   unsigned beta = CANNVersion::RELEASE;
   if (!prerelease.empty()) {
     std::optional<unsigned> parsedBeta = parseCANNBetaVersion(prerelease);
-    if (!parsedBeta)
+    if (!parsedBeta) {
       return std::nullopt;
+    }
     beta = *parsedBeta;
   }
 

--- a/include/PTO/Support/CodeConstants.h
+++ b/include/PTO/Support/CodeConstants.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef PTO_SUPPORT_CODECONSTANTS_H
+#define PTO_SUPPORT_CODECONSTANTS_H
+
+namespace mlir::pto {
+
+inline constexpr int kValue2 = 2;
+inline constexpr int kValue3 = 3;
+inline constexpr int kValue4 = 4;
+inline constexpr int kValue5 = 5;
+inline constexpr int kValue6 = 6;
+inline constexpr int kValue7 = 7;
+inline constexpr int kValue8 = 8;
+inline constexpr int kValue9 = 9;
+inline constexpr int kValue10 = 10;
+inline constexpr int kValue12 = 12;
+inline constexpr int kValue15 = 15;
+inline constexpr int kValue16 = 16;
+inline constexpr int kValue24 = 24;
+inline constexpr int kValue32 = 32;
+inline constexpr int kValue45 = 45;
+inline constexpr int kValue46 = 46;
+inline constexpr int kValue47 = 47;
+inline constexpr int kValue48 = 48;
+inline constexpr int kValue50 = 50;
+inline constexpr int kValue51 = 51;
+inline constexpr int kValue55 = 55;
+inline constexpr int kValue61 = 61;
+inline constexpr int kValue62 = 62;
+inline constexpr int kValue63 = 63;
+inline constexpr int kValue64 = 64;
+inline constexpr int kValue128 = 128;
+inline constexpr int kValue256 = 256;
+inline constexpr int kValue2048 = 2048;
+inline constexpr int kValue100000 = 100000;
+
+} // namespace mlir::pto
+
+#endif // PTO_SUPPORT_CODECONSTANTS_H

--- a/include/PTO/Support/PythonExecutable.h
+++ b/include/PTO/Support/PythonExecutable.h
@@ -21,18 +21,21 @@ namespace mlir::pto {
 
 inline std::optional<std::string>
 resolvePythonExecutable(llvm::StringRef pythonExe) {
-  if (pythonExe.empty())
+  if (pythonExe.empty()) {
     return std::nullopt;
+  }
 
   if (llvm::sys::path::is_absolute(pythonExe)) {
-    if (llvm::sys::fs::can_execute(pythonExe))
+    if (llvm::sys::fs::can_execute(pythonExe)) {
       return pythonExe.str();
+    }
     return std::nullopt;
   }
 
   auto found = llvm::sys::findProgramByName(pythonExe);
-  if (!found)
+  if (!found) {
     return std::nullopt;
+  }
   return *found;
 }
 

--- a/include/PTO/Transforms/GraphSyncSolver/EventIdSolver.h
+++ b/include/PTO/Transforms/GraphSyncSolver/EventIdSolver.h
@@ -152,7 +152,6 @@ public:
 };
 
 class EventIdSolver {
-
 private:
   int64_t eventIdsNumMax{-1};
   bool needRecalculateEventIds{false};

--- a/include/PTO/Transforms/GraphSyncSolver/SyncSolverIR.h
+++ b/include/PTO/Transforms/GraphSyncSolver/SyncSolverIR.h
@@ -59,8 +59,8 @@ using Body = std::vector<std::unique_ptr<OperationBase>>;
 
 // Currently gss-code-gen will handle offsetting induction variables for
 // multibuffer-enabled sync pairs, which can be done by create-preload.
-// TODO: move create-preload pass after gss in the PTO compilation pipeline and
-// let it handle preload-offset values.
+// Future pipeline ordering may move create-preload after gss so it can handle
+// preload-offset values.
 struct EventIdInfo {
   int64_t eventIdNum{0};
   int64_t eventIdRepeatNum{1};
@@ -113,7 +113,6 @@ enum struct OpType {
 std::string getOpTypeStr(OpType opType);
 
 class OperationBase {
-
 public:
   int id{-1};
   const OpType opType;
@@ -194,7 +193,6 @@ public:
 };
 
 class Scope : public OperationBase {
-
 public:
   Body body;
   std::optional<int64_t> preloadNum;
@@ -231,8 +229,6 @@ public:
 };
 
 class Loop : public Scope {
-
-private:
 public:
   bool isParallel{false};
   std::optional<int64_t> multibufferUnrollNum;
@@ -260,8 +256,6 @@ public:
 };
 
 class Condition : public Scope {
-
-private:
 public:
   Scope *trueScope{nullptr};
   Scope *falseScope{nullptr};
@@ -470,8 +464,6 @@ public:
 };
 
 class SetFlagOp : public SetWaitOp {
-
-private:
 public:
   SetFlagOp(Operation *op, OperationBase *parentOp,
             const llvm::SmallVector<int64_t> &eventIds, pto::PIPE pipeSrc,
@@ -492,8 +484,6 @@ public:
 };
 
 class WaitFlagOp : public SetWaitOp {
-
-private:
 public:
   WaitFlagOp(Operation *op, OperationBase *parentOp,
              const llvm::SmallVector<int64_t> &eventIds, pto::PIPE pipeSrc,
@@ -514,7 +504,6 @@ public:
 };
 
 class BarrierOp : public SyncOp {
-
 public:
   pto::PIPE pipe{pto::PIPE::PIPE_UNASSIGNED};
 

--- a/include/PTO/Transforms/GraphSyncSolver/Utility.h
+++ b/include/PTO/Transforms/GraphSyncSolver/Utility.h
@@ -27,16 +27,16 @@
 #include <pthread.h>
 #include <string>
 
-#define INTRA_CORE_EVENT_ID_NUM (int64_t)8
-#define CROSS_CORE_EVENT_ID_NUM (int64_t)16
-#define TEST_INTRA_CORE_EVENT_ID_NUM (int64_t)8
-#define TEST_CROSS_CORE_EVENT_ID_NUM (int64_t)999
-
 namespace mlir::pto::syncsolver {
-const int64_t blockAllIntraSyncFlagId1 = 15;
-const int64_t blockAllIntraSyncFlagId2 = 14;
-const int64_t reservedCrossCoreEventIdNum = 2;
-const int64_t reservedIntraCoreEventIdNum = 0;
+inline constexpr size_t kDebugIndentWidth = 2;
+inline constexpr int64_t kIntraCoreEventIdCount = 8;
+inline constexpr int64_t kCrossCoreEventIdCount = 16;
+inline constexpr int64_t kTestIntraCoreEventIdCount = 8;
+inline constexpr int64_t kTestCrossCoreEventIdCount = 999;
+inline constexpr int64_t kBlockAllIntraSyncFlagId1 = 15;
+inline constexpr int64_t kBlockAllIntraSyncFlagId2 = 14;
+inline constexpr int64_t kReservedCrossCoreEventIdCount = 2;
+inline constexpr int64_t kReservedIntraCoreEventIdCount = 0;
 } // namespace mlir::pto::syncsolver
 
 using SyncMap = llvm::MapVector<
@@ -291,7 +291,6 @@ struct Occurrence {
 struct EventIdNode;
 
 struct ConflictPair {
-
   static int globalIdCounter;
 
   const int id;
@@ -432,7 +431,7 @@ public:
     if (printConflictPairs) {
       for (auto [conflictPair, frq] : conflictPairs) {
         assert(frq > 0);
-        ret += std::string(2, ' ') + conflictPair->str() + "\n";
+        ret += std::string(kDebugIndentWidth, ' ') + conflictPair->str() + "\n";
       }
     }
     ret.pop_back();

--- a/include/PTO/Transforms/InsertSync/InsertSyncAnalysis.h
+++ b/include/PTO/Transforms/InsertSync/InsertSyncAnalysis.h
@@ -34,7 +34,7 @@ struct SyncRecord {
   llvm::DenseMap<int, bool> syncFinder;
 };
  
-using SyncRecordList = std::array<SyncRecord, MAX_MULTI_BUFFER_NUM>;
+using SyncRecordList = std::array<SyncRecord, kMaxMultiBufferCount>;
  
 class InsertSyncAnalysis {
 public:

--- a/include/PTO/Transforms/InsertSync/SyncCommon.h
+++ b/include/PTO/Transforms/InsertSync/SyncCommon.h
@@ -14,6 +14,7 @@
 #ifndef MLIR_DIALECT_PTO_TRANSFORMS_SYNC_COMMON_H
 #define MLIR_DIALECT_PTO_TRANSFORMS_SYNC_COMMON_H
  
+#include <cstddef>
 #include <utility>
 #include <deque>
 #include <string>
@@ -32,11 +33,11 @@
 // 引入 PTO Dialect 定义 (获取 AddressSpace 等)
 #include "PTO/IR/PTO.h"
  
-#define MAX_MULTI_BUFFER_NUM 16
- 
 namespace mlir {
 namespace pto {
- 
+
+inline constexpr size_t kMaxMultiBufferCount = 16;
+
 enum class SyncAnalysisMode {
   NORMALSYNC, // 核内同步 (Intra-Core): 解决流水线冒险
   BLOCKSYNC   // 核间同步 (Inter-Core): 解决 CV 分离后的通讯
@@ -112,25 +113,41 @@ struct BaseMemInfo {
  
   bool areVectorEqual(const SmallVector<uint64_t>& vec1,
                       const SmallVector<uint64_t>& vec2) const {
-    if (vec1.size() != vec2.size()) return false;
+    if (vec1.size() != vec2.size()) {
+      return false;
+    }
     for (size_t i = 0; i < vec1.size(); ++i) {
-      if (vec1[i] != vec2[i]) return false;
+      if (vec1[i] != vec2[i]) {
+        return false;
+      }
     }
     return true;
   }
  
   bool operator==(const BaseMemInfo &other) const {
-    if (!areVectorEqual(baseAddresses, other.baseAddresses)) return false;
-    if (rootBuffer != other.rootBuffer) return false;
-    if (scope != other.scope) return false;
-    if (hasKnownPhysicalAddresses != other.hasKnownPhysicalAddresses)
+    if (!areVectorEqual(baseAddresses, other.baseAddresses)) {
       return false;
-    if (aliasesUnknownRange != other.aliasesUnknownRange)
+    }
+    if (rootBuffer != other.rootBuffer) {
       return false;
+    }
+    if (scope != other.scope) {
+      return false;
+    }
+    if (hasKnownPhysicalAddresses != other.hasKnownPhysicalAddresses) {
+      return false;
+    }
+    if (aliasesUnknownRange != other.aliasesUnknownRange) {
+      return false;
+    }
     // allocateSize 和 baseBuffer 的严格相等性在某些别名分析中可能太强了，
     // 但为了保持原有逻辑，先保留。重点是 rootBuffer 必须一致。
-    if (allocateSize != other.allocateSize) return false;
-    if (baseBuffer != other.baseBuffer) return false;
+    if (allocateSize != other.allocateSize) {
+      return false;
+    }
+    if (baseBuffer != other.baseBuffer) {
+      return false;
+    }
     return true;
   }
  
@@ -251,13 +268,11 @@ bool hasSameSyncDepRoots(const SyncOperation *lhs, const SyncOperation *rhs);
 /// True when `sync` lowers to `pto.set_flag_dyn` / `pto.wait_flag_dyn`, i.e.
 /// its rendezvous is keyed on the runtime slot index rather than on a fixed
 /// event id.
-///
 /// Such a sync orders ONLY the accesses that resolve to its own event lane
 /// (`slotSSAExpr % slotCount`); it does not serialize its (src, dst) pipe pair
 /// the way a static flag does. Every place that reasons about one sync
 /// "covering" another must therefore exclude it, or a second access through a
 /// different slot is left unguarded (issue #1118).
-///
 /// `slotSSAExpr` is the discriminator, NOT `GetForEndIndex()`. Slot keying is
 /// only ever established for a back-edge dependency (InsertSyncOperation), so
 /// it may be tempting to test for one -- but the synthetic prologue-prime and

--- a/include/PTO/Transforms/SlotAffineAnalysis.h
+++ b/include/PTO/Transforms/SlotAffineAnalysis.h
@@ -44,7 +44,6 @@ mlir::Value findMultiTileSlotExpr(mlir::Value v);
 /// intentionally narrow: it accepts the forms commonly produced by
 /// frontends and lowerings (`iv % N`, `(iv + c) % N`, `c`, and same-SSA
 /// equality) and bails to `kUnknown` for anything else.
-///
 /// Examples (all with N == 2):
 ///   compareSlotSSA(%iv % 2, %iv % 2)         -> kEqual
 ///   compareSlotSSA((%iv + 1) % 2, %iv % 2)   -> kDisjoint

--- a/include/PTO/Transforms/TileFusion/FusionAnalysis.h
+++ b/include/PTO/Transforms/TileFusion/FusionAnalysis.h
@@ -9,6 +9,7 @@
 #ifndef PTO_TRANSFORMS_TILEFUSION_FUSIONANALYSIS_H
 #define PTO_TRANSFORMS_TILEFUSION_FUSIONANALYSIS_H
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/TileFusion/FusionOpSemantics.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -43,7 +44,7 @@ struct IterationDomainInfo {
 struct IterationDomainClass {
   unsigned id = 0;
   IterationDomainInfo info;
-  SmallVector<unsigned, 4> members;
+  SmallVector<unsigned, mlir::pto::kValue4> members;
 };
 
 struct FusionDFGEdge {
@@ -55,8 +56,8 @@ struct FusionDFGEdge {
 struct FusionValueLiveness {
   Value value;
   std::optional<unsigned> producerNode;
-  SmallVector<unsigned, 4> consumerNodes;
-  SmallVector<unsigned, 2> writeInstances;
+  SmallVector<unsigned, mlir::pto::kValue4> consumerNodes;
+  SmallVector<unsigned, mlir::pto::kValue2> writeInstances;
   std::optional<unsigned> lastLocalConsumer;
   bool hasExternalUsers = false;
   bool escapesBlock = false;
@@ -75,7 +76,7 @@ struct FusionWriteInstanceLiveness {
   Value value;
   Value storageValue;
   std::optional<unsigned> producerNode;
-  SmallVector<unsigned, 4> consumerNodes;
+  SmallVector<unsigned, mlir::pto::kValue4> consumerNodes;
   std::optional<unsigned> lastLocalConsumer;
   FusionWriteInstanceEscapeClass escapeClass =
       FusionWriteInstanceEscapeClass::Internal;
@@ -91,21 +92,21 @@ struct FusionComputeNode {
   Operation *op = nullptr;
   FusionOpSemantics semantics;
   unsigned iterationDomainClass = 0;
-  SmallVector<unsigned, 4> incomingEdges;
-  SmallVector<unsigned, 4> outgoingEdges;
+  SmallVector<unsigned, mlir::pto::kValue4> incomingEdges;
+  SmallVector<unsigned, mlir::pto::kValue4> outgoingEdges;
 };
 
 struct FusionBlockAnalysis {
   Block *block = nullptr;
-  SmallVector<FusionComputeNode, 8> computeNodes;
-  SmallVector<IterationDomainClass, 4> iterationDomainClasses;
-  SmallVector<FusionDFGEdge, 8> edges;
-  SmallVector<FusionValueLiveness, 8> liveness;
-  SmallVector<FusionWriteInstanceLiveness, 8> writeInstances;
+  SmallVector<FusionComputeNode, mlir::pto::kValue8> computeNodes;
+  SmallVector<IterationDomainClass, mlir::pto::kValue4> iterationDomainClasses;
+  SmallVector<FusionDFGEdge, mlir::pto::kValue8> edges;
+  SmallVector<FusionValueLiveness, mlir::pto::kValue8> liveness;
+  SmallVector<FusionWriteInstanceLiveness, mlir::pto::kValue8> writeInstances;
 };
 
 struct PreFusionAnalysisResult {
-  SmallVector<FusionBlockAnalysis, 8> blocks;
+  SmallVector<FusionBlockAnalysis, mlir::pto::kValue8> blocks;
 };
 
 /// Build the *shared* pre-fusion analysis: the tile dataflow graph
@@ -148,8 +149,9 @@ public:
   explicit PreFusionAnalysis(func::FuncOp func) {
     FailureOr<PreFusionAnalysisResult> resultOr =
         buildPreFusionAnalysisDFG(func);
-    if (succeeded(resultOr))
+    if (succeeded(resultOr)) {
       result = std::move(*resultOr);
+    }
   }
 
   bool isValid() const { return result.has_value(); }

--- a/include/PTO/Transforms/TileFusion/FusionOpSemantics.h
+++ b/include/PTO/Transforms/TileFusion/FusionOpSemantics.h
@@ -9,6 +9,7 @@
 #ifndef PTO_TRANSFORMS_TILEFUSION_FUSIONOPSEMANTICS_H
 #define PTO_TRANSFORMS_TILEFUSION_FUSIONOPSEMANTICS_H
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 
 #include "mlir/Support/LLVM.h"
@@ -38,9 +39,9 @@ struct FusionOpSemantics {
   FusionComputeFamily computeFamily = FusionComputeFamily::Unknown;
   Operation *op = nullptr;
   std::string opName;
-  SmallVector<Value, 4> tileInputs;
-  SmallVector<Value, 2> tileOutputs;
-  SmallVector<Value, 2> scalarInputs;
+  SmallVector<Value, mlir::pto::kValue4> tileInputs;
+  SmallVector<Value, mlir::pto::kValue2> tileOutputs;
+  SmallVector<Value, mlir::pto::kValue2> scalarInputs;
 };
 
 bool isSupportedPreFusionComputeOp(StringRef opName);

--- a/include/PTO/Transforms/TileOpExpansionUtils.h
+++ b/include/PTO/Transforms/TileOpExpansionUtils.h
@@ -17,8 +17,9 @@ namespace mlir::pto {
 /// Frontend pipe/sync pseudo-ops use TileOpInterface for surface
 /// classification but must be handled by their dedicated lowering instead.
 inline bool isTileLibExpandableOp(Operation *op) {
-  if (!op || !isa<TileOpInterface>(op))
+  if (!op || !isa<TileOpInterface>(op)) {
     return false;
+  }
   return !isa<TReshapeOp, TSyncOp, TAllocToAivOp, TAllocToAicOp,
               TPushToAivOp, TPushToAicOp, TPopFromAicOp, TPopFromAivOp,
               TFreeFromAicOp, TFreeFromAivOp>(op);

--- a/include/PTO/Transforms/VMILayoutPropagation.h
+++ b/include/PTO/Transforms/VMILayoutPropagation.h
@@ -12,6 +12,7 @@
 #ifndef PTO_TRANSFORMS_VMILAYOUTPROPAGATION_H
 #define PTO_TRANSFORMS_VMILAYOUTPROPAGATION_H
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 
 #include "mlir/IR/Operation.h"
@@ -32,7 +33,7 @@ struct VMILayoutConflict {
 
 struct VMIValueLayoutAssignment {
   VMILayoutAttr layout;
-  SmallVector<VMILayoutConflict, 2> conflicts;
+  SmallVector<VMILayoutConflict, mlir::pto::kValue2> conflicts;
 };
 
 class VMILayoutPropagator {
@@ -88,11 +89,11 @@ private:
   Operation *scope = nullptr;
   MLIRContext *ctx = nullptr;
   DenseMap<Value, VMIValueLayoutAssignment> assignments;
-  SmallVector<Value, 16> orderedValues;
-  SmallVector<LayoutFact, 16> worklist;
-  SmallVector<LayoutFact, 16> seenFacts;
-  SmallVector<OperandLayoutFact, 16> seenOperandFacts;
-  DenseMap<Value, SmallVector<Value, 2>> equivalentValues;
+  SmallVector<Value, mlir::pto::kValue16> orderedValues;
+  SmallVector<LayoutFact, mlir::pto::kValue16> worklist;
+  SmallVector<LayoutFact, mlir::pto::kValue16> seenFacts;
+  SmallVector<OperandLayoutFact, mlir::pto::kValue16> seenOperandFacts;
+  DenseMap<Value, SmallVector<Value, mlir::pto::kValue2>> equivalentValues;
 };
 
 } // namespace mlir::pto

--- a/include/PTO/Transforms/VMILayoutSupport.h
+++ b/include/PTO/Transforms/VMILayoutSupport.h
@@ -12,6 +12,7 @@
 #ifndef PTO_TRANSFORMS_VMILAYOUTSUPPORT_H
 #define PTO_TRANSFORMS_VMILAYOUTSUPPORT_H
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "mlir/Support/LLVM.h"
 
@@ -210,7 +211,7 @@ public:
   getPreferredDeinterleaveLoadLayoutFact(
       VMIVRegType valueType, std::string *reason = nullptr) const;
 
-  FailureOr<SmallVector<VMIDeinterleaveLoadLayoutFact, 4>>
+  FailureOr<SmallVector<VMIDeinterleaveLoadLayoutFact, mlir::pto::kValue4>>
   getDeinterleaveLoadLayoutFactsForLayout(
       VMIVRegType valueType, VMIDeinterleaveLoadLayoutPort port,
       VMILayoutAttr layout, std::string *reason = nullptr) const;
@@ -254,7 +255,7 @@ public:
   getPreferredCastLayoutFact(VMIVRegType sourceType, VMIVRegType resultType,
                              std::string *reason = nullptr) const;
 
-  FailureOr<SmallVector<VMICastLayoutFact, 4>>
+  FailureOr<SmallVector<VMICastLayoutFact, mlir::pto::kValue4>>
   getCastLayoutFactsForLayout(VMIVRegType sourceType, VMIVRegType resultType,
                               VMICastLayoutPort port, VMILayoutAttr layout,
                               std::string *reason = nullptr) const;
@@ -271,7 +272,7 @@ public:
       VMIVRegType sourceType, VMIVRegType resultType, VMILayoutAttr sourceLayout,
       VMILayoutAttr resultLayout, std::string *reason = nullptr) const;
 
-  FailureOr<SmallVector<VMIMaskGranularityCastLayoutFact, 4>>
+  FailureOr<SmallVector<VMIMaskGranularityCastLayoutFact, mlir::pto::kValue4>>
   getMaskGranularityCastLayoutFactsForLayout(
       VMIMaskType sourceType, VMIMaskType resultType, VMICastLayoutPort port,
       VMILayoutAttr layout, std::string *reason = nullptr) const;
@@ -294,13 +295,13 @@ public:
   getPreferredVdintlvLayoutFact(VMIVRegType valueType,
                                 std::string *reason = nullptr) const;
 
-  FailureOr<SmallVector<VMIInterleaveLayoutFact, 4>>
+  FailureOr<SmallVector<VMIInterleaveLayoutFact, mlir::pto::kValue4>>
   getVintlvLayoutFactsForLayout(VMIVRegType valueType,
                                 VMIInterleaveLayoutPort port,
                                 VMILayoutAttr layout,
                                 std::string *reason = nullptr) const;
 
-  FailureOr<SmallVector<VMIInterleaveLayoutFact, 4>>
+  FailureOr<SmallVector<VMIInterleaveLayoutFact, mlir::pto::kValue4>>
   getVdintlvLayoutFactsForLayout(VMIVRegType valueType,
                                  VMIInterleaveLayoutPort port,
                                  VMILayoutAttr layout,
@@ -336,7 +337,7 @@ public:
   getGroupStoreLayoutFact(VMIGroupStoreOp op, VMIVRegType valueType,
                           std::string *reason = nullptr) const;
 
-  FailureOr<SmallVector<VMIGroupStoreLayoutFact, 4>>
+  FailureOr<SmallVector<VMIGroupStoreLayoutFact, mlir::pto::kValue4>>
   getGroupStoreLayoutFactsForLayout(VMIGroupStoreOp op,
                                     VMIVRegType valueType,
                                     VMILayoutAttr layout,
@@ -359,7 +360,7 @@ public:
       VMIVRegType sourceType, VMIMaskType maskType, VMIVRegType resultType,
       int64_t numGroups, std::string *reason = nullptr) const;
 
-  FailureOr<SmallVector<VMIGroupReduceLayoutFact, 4>>
+  FailureOr<SmallVector<VMIGroupReduceLayoutFact, mlir::pto::kValue4>>
   getGroupReduceLayoutFactsForLayout(VMIVRegType sourceType,
                                      int64_t numGroups,
                                      VMIGroupReduceLayoutPort port,
@@ -372,7 +373,7 @@ public:
                                         int64_t numGroups,
                                         std::string *reason = nullptr) const;
 
-  FailureOr<SmallVector<VMIGroupBroadcastLayoutFact, 4>>
+  FailureOr<SmallVector<VMIGroupBroadcastLayoutFact, mlir::pto::kValue4>>
   getGroupBroadcastLayoutFactsForLayout(VMIVRegType sourceType,
                                         VMIVRegType resultType,
                                         int64_t numGroups,
@@ -458,7 +459,7 @@ public:
   getBitcastLayoutFact(VMIBitcastOp op,
                        std::string *reason = nullptr) const;
 
-  FailureOr<SmallVector<VMIBitcastLayoutFact, 4>>
+  FailureOr<SmallVector<VMIBitcastLayoutFact, mlir::pto::kValue4>>
   getBitcastLayoutFactsForLayout(VMIVRegType sourceType,
                                  VMIVRegType resultType,
                                  VMICastLayoutPort port,

--- a/include/PTO/Transforms/VPTOLLVMEmitter.h
+++ b/include/PTO/Transforms/VPTOLLVMEmitter.h
@@ -38,7 +38,7 @@ struct VPTOEmissionOptions {
   std::string aicoreArch;
   std::string defaultTargetCPU;
   std::string defaultTargetFeatures;
-  CANNVersion cannVersion = CANNVersion{9, 0, 0, 1};
+  CANNVersion cannVersion = kDefaultCANNVersion;
 };
 
 struct EmittedLLVMModule {

--- a/lib/Bindings/Python/PTOModule.cpp
+++ b/lib/Bindings/Python/PTOModule.cpp
@@ -14,20 +14,20 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <stdexcept>
+#include <string>
+#include "PTO/IR/PTO.h"
 #include "PTOModule.h"
-
+#include "mlir-c/BuiltinAttributes.h"
+#include "mlir-c/BuiltinTypes.h"
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+#include "pto-c/Dialect/PTO.h"
 #include "pybind11/stl.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 #include "mlir/CAPI/IR.h"
-#include "pto-c/Dialect/PTO.h"
-#include "mlir-c/IR.h"
-#include "PTO/IR/PTO.h"
-#include "mlir-c/BuiltinTypes.h"
-#include "mlir-c/BuiltinAttributes.h"
-#include "mlir-c/Support.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include <stdexcept>
-#include <string>
+
 namespace py = pybind11;
 using namespace mlir::python::adaptors;
 using llvm::cast;
@@ -36,16 +36,18 @@ using llvm::isa;
 static std::vector<int64_t> toInt64Vector(const py::sequence &seq) {
   std::vector<int64_t> out;
   out.reserve(seq.size());
-  for (py::handle h : seq)
+  for (py::handle h : seq) {
     out.push_back(py::cast<int64_t>(h));
+  }
   return out;
 }
 
 static std::vector<int64_t> toShapeVectorOrDynamicRank(py::object shapeOrRank) {
   if (py::isinstance<py::int_>(shapeOrRank)) {
     auto rank = shapeOrRank.cast<int64_t>();
-    if (rank < 0)
+    if (rank < 0) {
       throw py::value_error("rank must be non-negative");
+    }
     return std::vector<int64_t>(static_cast<size_t>(rank),
                                 mlir::ShapedType::kDynamic);
   }
@@ -54,19 +56,23 @@ static std::vector<int64_t> toShapeVectorOrDynamicRank(py::object shapeOrRank) {
 
 static MlirContext inferContextFromElementType(MlirContext context,
                                                MlirType elementType) {
-  if (!mlirContextIsNull(context))
+  if (!mlirContextIsNull(context)) {
     return context;
-  if (mlirTypeIsNull(elementType))
+  }
+  if (mlirTypeIsNull(elementType)) {
     throw py::value_error("context is required when element_type is null");
+  }
   return mlirTypeGetContext(elementType);
 }
 
 static int32_t enumValueFromPy(py::object value, const char *attrName,
                                const char *enumName) {
-  if (py::isinstance<py::int_>(value))
+  if (py::isinstance<py::int_>(value)) {
     return value.cast<int32_t>();
-  if (py::hasattr(value, "value"))
+  }
+  if (py::hasattr(value, "value")) {
     return value.attr("value").cast<int32_t>();
+  }
   throw std::runtime_error(std::string(attrName) + ".get expects int or " +
                            enumName + " enum");
 }
@@ -83,8 +89,9 @@ static void bindPTOEnumAttr(pybind11::module &m, const char *attrName,
                                     MlirContext ctx) -> py::object {
             int32_t v = enumValueFromPy(value, attrName, enumName);
             MlirAttribute a = get(ctx, v);
-            if (mlirAttributeIsNull(a))
+            if (mlirAttributeIsNull(a)) {
               return py::none();
+            }
             return cls.attr("__call__")(a);
           },
           py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -95,22 +102,25 @@ static void bindPTOEnumAttr(pybind11::module &m, const char *attrName,
 
 static py::list shapeToPyList(const int64_t *data, intptr_t n) {
   py::list lst;
-  for (intptr_t i = 0; i < n; ++i)
+  for (intptr_t i = 0; i < n; ++i) {
     lst.append(py::int_(data[i]));
+  }
   return lst;
 }
 
 static py::object wrapAttributeAs(const py::module_ &m, const char *className,
                                   MlirAttribute attr) {
-  if (mlirAttributeIsNull(attr))
+  if (mlirAttributeIsNull(attr)) {
     return py::none();
+  }
   py::object cls = m.attr(className);
   return cls.attr("__call__")(attr);
 }
 
 static MlirAttribute optionalAttributeFromPy(py::object attr) {
-  if (attr.is_none())
+  if (attr.is_none()) {
     return MlirAttribute{nullptr};
+  }
   return py::cast<MlirAttribute>(attr);
 }
 
@@ -119,7 +129,6 @@ static void populatePTODialectSubmodule(pybind11::module &m) {
 }
 
 void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
-
     // --------------------------------------------------------------------------
     // Dialect registration helper
     // --------------------------------------------------------------------------
@@ -128,8 +137,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
         [](MlirContext context, bool load) {
             MlirDialectHandle handle = mlirGetDialectHandle__pto__();
             mlirDialectHandleRegisterDialect(handle, context);
-            if (load)
-            mlirDialectHandleLoadDialect(handle, context);
+            if (load) {
+              mlirDialectHandleLoadDialect(handle, context);
+            }
         },
         py::arg("context"), py::arg("load") = true);
 
@@ -335,7 +345,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
         "get",
         [](py::object cls, mlir::pto::BLayout value, MlirContext ctx) -> py::object {
           MlirAttribute a = mlirPTOBLayoutAttrGet(ctx, static_cast<int32_t>(value));
-          if (mlirAttributeIsNull(a)) return py::none();
+          if (mlirAttributeIsNull(a)) {
+            return py::none();
+          }
           return cls(a);
         },
         py::arg("cls"), py::arg("value"), py::arg("context") = py::none());
@@ -348,7 +360,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             "get",
             [](py::object cls, mlir::pto::SLayout value, MlirContext ctx) -> py::object {
             MlirAttribute a = mlirPTOSLayoutAttrGet(ctx, static_cast<int32_t>(value));
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls(a);
             },
             py::arg("cls"), py::arg("value"), py::arg("context") = py::none());
@@ -361,7 +375,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             "get",
             [](py::object cls, mlir::pto::PadValue value, MlirContext ctx) -> py::object {
             MlirAttribute a = mlirPTOPadValueAttrGet(ctx, static_cast<int32_t>(value));
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls(a);
             },
             py::arg("cls"), py::arg("value"), py::arg("context") = py::none());
@@ -374,7 +390,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             "get",
             [](py::object cls, mlir::pto::CompactMode value, MlirContext ctx) -> py::object {
             MlirAttribute a = mlirPTOCompactModeAttrGet(ctx, static_cast<int32_t>(value));
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls(a);
             },
             py::arg("cls"), py::arg("value"), py::arg("context") = py::none());
@@ -387,7 +405,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             "get",
             [](py::object cls, mlir::pto::AccToVecMode value, MlirContext ctx) -> py::object {
             MlirAttribute a = mlirPTOAccToVecModeAttrGet(ctx, static_cast<int32_t>(value));
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls(a);
             },
             py::arg("cls"), py::arg("value"), py::arg("context") = py::none());
@@ -400,7 +420,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             "get",
             [](py::object cls, mlir::pto::TInsertMode value, MlirContext ctx) -> py::object {
             MlirAttribute a = mlirPTOTInsertModeAttrGet(ctx, static_cast<int32_t>(value));
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls(a);
             },
             py::arg("cls"), py::arg("value"), py::arg("context") = py::none());
@@ -413,7 +435,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             "get",
             [](py::object cls, mlir::pto::ReluPreMode value, MlirContext ctx) -> py::object {
             MlirAttribute a = mlirPTOReluPreModeAttrGet(ctx, static_cast<int32_t>(value));
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls(a);
             },
             py::arg("cls"), py::arg("value"), py::arg("context") = py::none());
@@ -426,7 +450,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             "get",
             [](py::object cls, mlir::pto::AtomicType value, MlirContext ctx) -> py::object {
             MlirAttribute a = mlirPTOAtomicTypeAttrGet(ctx, static_cast<int32_t>(value));
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls(a);
             },
             py::arg("cls"), py::arg("value"), py::arg("context") = py::none());
@@ -439,7 +465,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             "get",
             [](py::object cls, mlir::pto::NotifyOp value, MlirContext ctx) -> py::object {
             MlirAttribute a = mlirPTONotifyOpAttrGet(ctx, static_cast<int32_t>(value));
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls(a);
             },
             py::arg("cls"), py::arg("value"), py::arg("context") = py::none());
@@ -452,7 +480,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             "get",
             [](py::object cls, mlir::pto::WaitCmp value, MlirContext ctx) -> py::object {
             MlirAttribute a = mlirPTOWaitCmpAttrGet(ctx, static_cast<int32_t>(value));
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls(a);
             },
             py::arg("cls"), py::arg("value"), py::arg("context") = py::none());
@@ -465,7 +495,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             "get",
             [](py::object cls, mlir::pto::ReduceOp value, MlirContext ctx) -> py::object {
             MlirAttribute a = mlirPTOReduceOpAttrGet(ctx, static_cast<int32_t>(value));
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls(a);
             },
             py::arg("cls"), py::arg("value"), py::arg("context") = py::none());
@@ -507,7 +539,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             v = py::cast<int32_t>(value.attr("value").cast<py::int_>());
         }
         MlirAttribute a = mlirPTOFenceScopeAttrGet(context, v);
-        if (mlirAttributeIsNull(a)) return py::none();
+        if (mlirAttributeIsNull(a)) {
+          return py::none();
+        }
         return cls.attr("__call__")(a);
         },
         py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -534,7 +568,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
         }
 
         MlirAttribute a = mlirPTORoundModeAttrGet(ctx, v);
-        if (mlirAttributeIsNull(a)) return py::none();
+        if (mlirAttributeIsNull(a)) {
+          return py::none();
+        }
         return cls.attr("__call__")(a);
          },
         py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -594,7 +630,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
         }
 
         MlirAttribute a = mlirPTOSaturationModeAttrGet(ctx, v);
-        if (mlirAttributeIsNull(a)) return py::none();
+        if (mlirAttributeIsNull(a)) {
+          return py::none();
+        }
         return cls.attr("__call__")(a);
          },
         py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -620,8 +658,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
               throw std::runtime_error("PipeAttr.get expects int or PIPE enum");
             }
             MlirAttribute a = mlirPTOPipeAttrGet(ctx, v);
-            if (mlirAttributeIsNull(a))
+            if (mlirAttributeIsNull(a)) {
               return py::none();
+            }
             return cls.attr("__call__")(a);
           },
           py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -646,8 +685,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
               throw std::runtime_error("LayoutAttr.get expects int or Layout enum");
             }
             MlirAttribute a = mlirPTOLayoutAttrGet(ctx, v);
-            if (mlirAttributeIsNull(a))
+            if (mlirAttributeIsNull(a)) {
               return py::none();
+            }
             return cls.attr("__call__")(a);
           },
           py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -685,7 +725,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
               throw std::runtime_error("SyncOpTypeAttr.get expects int or SyncOpType enum");
             }
             MlirAttribute a = mlirPTOSyncOpTypeAttrGet(ctx, v);
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls.attr("__call__")(a);
           },
           py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -710,7 +752,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
               throw std::runtime_error("EventAttr.get expects int or EVENT enum");
             }
             MlirAttribute a = mlirPTOEventAttrGet(ctx, v);
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls.attr("__call__")(a);
           },
           py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -741,7 +785,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             }
             MlirAttribute a =
                 mlirPTOCoalesceAttrGet(ctx, static_cast<MlirPTOCoalesce>(v));
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls.attr("__call__")(a);
           },
           py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -788,7 +834,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
               throw std::runtime_error("QuantTypeAttr.get expects int or QuantType enum");
             }
             MlirAttribute a = mlirPTOQuantTypeAttrGet(ctx, v);
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls.attr("__call__")(a);
           },
           py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -813,7 +861,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
               throw std::runtime_error("QuantScaleAlgAttr.get expects int or QuantScaleAlg enum");
             }
             MlirAttribute a = mlirPTOQuantScaleAlgAttrGet(ctx, v);
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls.attr("__call__")(a);
           },
           py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -863,7 +913,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
               throw std::runtime_error("VecStoreModeAttr.get expects int or VecStoreMode enum");
             }
             MlirAttribute a = mlirPTOVecStoreModeAttrGet(ctx, v);
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls.attr("__call__")(a);
           },
           py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -888,14 +940,17 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             } else if (py::isinstance<py::int_>(value)) {
               int32_t v = py::cast<int32_t>(value);
               a = mlirPTOMaskPatternAttrGet(ctx, v);
-              if (mlirAttributeIsNull(a))
+              if (mlirAttributeIsNull(a)) {
                 throw std::runtime_error(
                     "MaskPatternAttr.get(int, ...) only accepts unambiguous values {0,3,6,7}; "
                     "use MaskPattern enum for ISA values and get_legacy_raw(...) for historical raw encodings");
+              }
             } else {
               throw std::runtime_error("MaskPatternAttr.get expects int or MaskPattern enum");
             }
-            if (mlirAttributeIsNull(a)) return py::none();
+            if (mlirAttributeIsNull(a)) {
+              return py::none();
+            }
             return cls.attr("__call__")(a);
           },
           py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -903,9 +958,10 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
           "get_legacy_raw",
           [](py::object cls, int32_t value, MlirContext ctx) -> py::object {
             MlirAttribute a = mlirPTOMaskPatternAttrGetLegacyRaw(ctx, value);
-            if (mlirAttributeIsNull(a))
+            if (mlirAttributeIsNull(a)) {
               throw std::runtime_error(
                   "MaskPatternAttr.get_legacy_raw(...) only accepts historical raw values {0,3,4,5}");
+            }
             return cls.attr("__call__")(a);
           },
           py::arg("cls"), py::arg("value"), py::arg("context") = py::none())
@@ -932,8 +988,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             [](py::object cls, MlirType elementType, py::object memorySpace,
                MlirContext context) -> py::object {
                 MlirContext ctx = context;
-                if (!ctx.ptr)
-                    ctx = mlirTypeGetContext(elementType);
+                if (!ctx.ptr) {
+                  ctx = mlirTypeGetContext(elementType);
+                }
                 MlirType t = {nullptr};
                 if (memorySpace.is_none()) {
                   t = mlirPTOPtrTypeGet(ctx, elementType);
@@ -1036,8 +1093,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             [](MlirType self) -> py::object {
                 mlir::Attribute attr =
                     cast<mlir::pto::VMIVRegType>(unwrap(self)).getLayout();
-                if (!attr)
-                    return py::none();
+                if (!attr) {
+                  return py::none();
+                }
                 return py::cast(wrap(attr));
             });
 
@@ -1074,8 +1132,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             [](MlirType self) -> py::object {
                 mlir::Attribute attr =
                     cast<mlir::pto::VMIMaskType>(unwrap(self)).getLayout();
-                if (!attr)
-                    return py::none();
+                if (!attr) {
+                  return py::none();
+                }
                 return py::cast(wrap(attr));
             });
 
@@ -1098,25 +1157,30 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             [](py::object cls, py::sequence fieldTypes, MlirContext context) -> py::object {
                 std::vector<MlirType> fields;
                 fields.reserve(fieldTypes.size());
-                for (py::handle field : fieldTypes)
+                for (py::handle field : fieldTypes) {
                   fields.push_back(py::cast<MlirType>(field));
-                if (fields.empty())
+                }
+                if (fields.empty()) {
                   throw py::value_error("StructType.get requires at least one field type");
-                if (!context.ptr)
+                }
+                if (!context.ptr) {
                   context = mlirTypeGetContext(fields.front());
+                }
                 llvm::SmallVector<mlir::Type> unwrappedFields;
                 unwrappedFields.reserve(fields.size());
-                for (MlirType field : fields)
+                for (MlirType field : fields) {
                   unwrappedFields.push_back(unwrap(field));
+                }
                 auto structType = mlir::pto::StructType::getChecked(
                     [&]() {
                       return mlir::emitError(
                           mlir::UnknownLoc::get(unwrap(context)));
                     },
                     unwrap(context), llvm::ArrayRef<mlir::Type>(unwrappedFields));
-                if (!structType)
+                if (!structType) {
                   throw py::value_error(
                       "StructType.get received invalid struct field types");
+                }
                 return cls.attr("__call__")(
                     wrap(structType));
             },
@@ -1126,8 +1190,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             [](MlirType self) -> py::list {
                 auto structType = cast<mlir::pto::StructType>(unwrap(self));
                 py::list fields;
-                for (mlir::Type field : structType.getFieldTypes())
+                for (mlir::Type field : structType.getFieldTypes()) {
                   fields.append(wrap(field));
+                }
                 return fields;
             });
 
@@ -1338,7 +1403,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             "get_default",
             [](py::object cls, MlirContext ctx) -> py::object {
                 MlirAttribute a = mlirPTOTileBufConfigAttrGetDefault(ctx);
-                if (mlirAttributeIsNull(a)) return py::none();
+                if (mlirAttributeIsNull(a)) {
+                  return py::none();
+                }
                 return cls(a);
             },
             py::arg("cls"), py::arg("context") = py::none())
@@ -1368,7 +1435,9 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
                 }
                 MlirAttribute a = mlirPTOTileBufConfigAttrGetWithCompactMode(
                     ctx, blayout, slayout, sz, pad, compactMode);
-                if (mlirAttributeIsNull(a)) return py::none();
+                if (mlirAttributeIsNull(a)) {
+                  return py::none();
+                }
                 return cls(a);
             },
             py::arg("cls"),
@@ -1380,143 +1449,107 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             py::arg("compact_mode") = py::none());
 
     // ---- TileBufType ----
-    mlir_type_subclass(m, "TileBufType",
-                        [](MlirType t) -> bool {
-                        return mlirPTOTypeIsATileBufType(t);
-                        })
+    mlir_type_subclass(m, "TileBufType", [](MlirType t) -> bool { return mlirPTOTypeIsATileBufType(t); })
         .def_classmethod(
-        "get",
-        [](py::object cls,
-            std::vector<int64_t> shape,
-            MlirType elementType,
-            MlirAttribute memorySpace,
-            py::object validShapeObj,
-            py::object configObj,
-            MlirContext ctx) -> py::object {
-            // 1) 计算 validShape（默认=shape）
-            std::vector<int64_t> validShape = shape;
+            "get",
+            [](py::object cls, std::vector<int64_t> shape, MlirType elementType, MlirAttribute memorySpace,
+               py::object validShapeObj, py::object configObj, MlirContext ctx) -> py::object {
+              // 1) 计算 validShape（默认=shape）
+              std::vector<int64_t> validShape = shape;
 
-            if (!validShapeObj.is_none()) {
-            // 支持 valid_shape 为 list[int] 或 list[Optional[int]]
-            py::list lst = validShapeObj.cast<py::list>();
-            if (static_cast<size_t>(lst.size()) != shape.size()) {
-                throw std::runtime_error("valid_shape rank must match shape rank");
-            }
-            validShape.resize(lst.size());
-            for (py::ssize_t i = 0; i < static_cast<py::ssize_t>(lst.size()); ++i) {
-                py::object e = lst[i];
-                if (e.is_none()) {
-                validShape[i] = -1;  // None -> dynamic
-                } else {
-                validShape[i] = e.cast<int64_t>();
+              if (!validShapeObj.is_none()) {
+                // 支持 valid_shape 为 list[int] 或 list[Optional[int]]
+                py::list lst = validShapeObj.cast<py::list>();
+                if (static_cast<size_t>(lst.size()) != shape.size()) {
+                  throw std::runtime_error("valid_shape rank must match shape rank");
                 }
-            }
-            }
+                validShape.resize(lst.size());
+                for (py::ssize_t i = 0; i < static_cast<py::ssize_t>(lst.size()); ++i) {
+                  py::object e = lst[i];
+                  if (e.is_none()) {
+                    validShape[i] = -1; // None -> dynamic
+                  } else {
+                    validShape[i] = e.cast<int64_t>();
+                  }
+                }
+              }
 
-            // 2) 调 CAPI
-            MlirType ty;
-            if (!configObj.is_none()) {
-            MlirAttribute cfg = configObj.cast<MlirAttribute>();
-            ty = mlirPTOTileBufTypeGetWithValidShapeAndConfig(
-                ctx,
-                static_cast<intptr_t>(shape.size()), shape.data(),
-                elementType, memorySpace,
-                static_cast<intptr_t>(validShape.size()), validShape.data(),
-                cfg);
-            } else {
-            ty = mlirPTOTileBufTypeGetWithValidShape(
-                ctx,
-                static_cast<intptr_t>(shape.size()), shape.data(),
-                elementType, memorySpace,
-                static_cast<intptr_t>(validShape.size()), validShape.data());
-            }
+              // 2) 调 CAPI
+              MlirType ty;
+              if (!configObj.is_none()) {
+                MlirAttribute cfg = configObj.cast<MlirAttribute>();
+                ty = mlirPTOTileBufTypeGetWithValidShapeAndConfig(
+                    ctx, static_cast<intptr_t>(shape.size()), shape.data(), elementType, memorySpace,
+                    static_cast<intptr_t>(validShape.size()), validShape.data(), cfg);
+              } else {
+                ty = mlirPTOTileBufTypeGetWithValidShape(ctx, static_cast<intptr_t>(shape.size()), shape.data(),
+                                                         elementType, memorySpace,
+                                                         static_cast<intptr_t>(validShape.size()), validShape.data());
+              }
 
-            if (mlirTypeIsNull(ty)) return py::none();
-            return cls(ty);
-        },
-        py::arg("cls"),
-        py::arg("shape"),
-        py::arg("element_type"),
-        py::arg("memory_space"),
-        py::arg("valid_shape") = py::none(),
-        py::arg("config") = py::none(),
-        py::arg("context") = py::none())
+              if (mlirTypeIsNull(ty)) {
+                return py::none();
+              }
+              return cls(ty);
+            },
+            py::arg("cls"), py::arg("shape"), py::arg("element_type"), py::arg("memory_space"),
+            py::arg("valid_shape") = py::none(), py::arg("config") = py::none(), py::arg("context") = py::none())
         .def_classmethod(
             "upcast_type",
             [](py::object cls, MlirType t) -> py::object {
-                if (mlirPTOTypeIsATileBufType(t)) return cls(t);
-                return py::none();
+              if (mlirPTOTypeIsATileBufType(t)) {
+                return cls(t);
+              }
+              return py::none();
             },
             py::arg("cls"), py::arg("type"))
-        .def_property_readonly(
-            "rank",
-            [](MlirType self) -> intptr_t {
-                return static_cast<intptr_t>(
-                    cast<mlir::pto::TileBufType>(unwrap(self)).getRank());
-            })
+        .def_property_readonly("rank",
+                               [](MlirType self) -> intptr_t {
+                                 return static_cast<intptr_t>(cast<mlir::pto::TileBufType>(unwrap(self)).getRank());
+                               })
         .def_property_readonly(
             "element_type",
-            [](MlirType self) -> MlirType {
-                return wrap(cast<mlir::pto::TileBufType>(unwrap(self)).getElementType());
-            })
-        .def_property_readonly(
-            "memory_space",
-            [m](MlirType self) -> py::object {
-                MlirAttribute attr =
-                    wrap(cast<mlir::pto::TileBufType>(unwrap(self)).getMemorySpace());
-                return wrapAttributeAs(m, "AddressSpaceAttr", attr);
-            })
-        .def_property_readonly(
-            "shape",
-            [](MlirType self) -> py::list {
-                auto shape = cast<mlir::pto::TileBufType>(unwrap(self)).getShape();
-                return shapeToPyList(shape.data(), static_cast<intptr_t>(shape.size()));
-            })
-        .def_property_readonly(
-            "valid_shape",
-            [](MlirType self) -> py::list {
-                auto validShape = cast<mlir::pto::TileBufType>(unwrap(self)).getValidShape();
-                return shapeToPyList(validShape.data(), static_cast<intptr_t>(validShape.size()));
-            })
-        .def_property_readonly(
-            "blayout_attr",
-            [m](MlirType self) -> py::object {
-                MlirAttribute attr =
-                    wrap(cast<mlir::pto::TileBufType>(unwrap(self)).getBLayoutAttr());
-                return wrapAttributeAs(m, "BLayoutAttr", attr);
-            })
-        .def_property_readonly(
-            "slayout_attr",
-            [m](MlirType self) -> py::object {
-                MlirAttribute attr =
-                    wrap(cast<mlir::pto::TileBufType>(unwrap(self)).getSLayoutAttr());
-                return wrapAttributeAs(m, "SLayoutAttr", attr);
-            })
+            [](MlirType self) -> MlirType { return wrap(cast<mlir::pto::TileBufType>(unwrap(self)).getElementType()); })
+        .def_property_readonly("memory_space",
+                               [m](MlirType self) -> py::object {
+                                 MlirAttribute attr = wrap(cast<mlir::pto::TileBufType>(unwrap(self)).getMemorySpace());
+                                 return wrapAttributeAs(m, "AddressSpaceAttr", attr);
+                               })
+        .def_property_readonly("shape",
+                               [](MlirType self) -> py::list {
+                                 auto shape = cast<mlir::pto::TileBufType>(unwrap(self)).getShape();
+                                 return shapeToPyList(shape.data(), static_cast<intptr_t>(shape.size()));
+                               })
+        .def_property_readonly("valid_shape",
+                               [](MlirType self) -> py::list {
+                                 auto validShape = cast<mlir::pto::TileBufType>(unwrap(self)).getValidShape();
+                                 return shapeToPyList(validShape.data(), static_cast<intptr_t>(validShape.size()));
+                               })
+        .def_property_readonly("blayout_attr",
+                               [m](MlirType self) -> py::object {
+                                 MlirAttribute attr = wrap(cast<mlir::pto::TileBufType>(unwrap(self)).getBLayoutAttr());
+                                 return wrapAttributeAs(m, "BLayoutAttr", attr);
+                               })
+        .def_property_readonly("slayout_attr",
+                               [m](MlirType self) -> py::object {
+                                 MlirAttribute attr = wrap(cast<mlir::pto::TileBufType>(unwrap(self)).getSLayoutAttr());
+                                 return wrapAttributeAs(m, "SLayoutAttr", attr);
+                               })
         .def_property_readonly(
             "blayout_value",
-            [](MlirType self) -> int32_t {
-                return cast<mlir::pto::TileBufType>(unwrap(self)).getBLayoutValueI32();
-            })
+            [](MlirType self) -> int32_t { return cast<mlir::pto::TileBufType>(unwrap(self)).getBLayoutValueI32(); })
         .def_property_readonly(
             "slayout_value",
-            [](MlirType self) -> int32_t {
-                return cast<mlir::pto::TileBufType>(unwrap(self)).getSLayoutValueI32();
-            })
+            [](MlirType self) -> int32_t { return cast<mlir::pto::TileBufType>(unwrap(self)).getSLayoutValueI32(); })
         .def_property_readonly(
             "pad_value",
-            [](MlirType self) -> int32_t {
-                return cast<mlir::pto::TileBufType>(unwrap(self)).getPadValueI32();
-            })
+            [](MlirType self) -> int32_t { return cast<mlir::pto::TileBufType>(unwrap(self)).getPadValueI32(); })
         .def_property_readonly(
             "compact_mode",
-            [](MlirType self) -> int32_t {
-                return cast<mlir::pto::TileBufType>(unwrap(self)).getCompactModeI32();
-            })
-        .def_property_readonly(
-            "s_fractal_size",
-            [](MlirType self) -> int32_t {
-                return cast<mlir::pto::TileBufType>(unwrap(self)).getSFractalSizeI32();
-            });
-	
-	populatePTODialectSubmodule(m);
+            [](MlirType self) -> int32_t { return cast<mlir::pto::TileBufType>(unwrap(self)).getCompactModeI32(); })
+        .def_property_readonly("s_fractal_size", [](MlirType self) -> int32_t {
+          return cast<mlir::pto::TileBufType>(unwrap(self)).getSFractalSizeI32();
+        });
+
+    populatePTODialectSubmodule(m);
 }

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -72,19 +72,23 @@ static void printShapeAndElem(AsmPrinter &printer,
 [[maybe_unused]] static ParseResult parseShape(AsmParser &parser, SmallVectorImpl<int64_t> &shape) {
   // parseDimensionList 会解析 "dim x dim x ...", 遇到无法解析为维度的字符停止
   // 参数 allowDynamic=true (允许 ?), withTrailingX=false (不吞掉末尾的 x)
-  if (parser.parseDimensionList(shape, /*allowDynamic=*/true, /*withTrailingX=*/false))
+  if (parser.parseDimensionList(shape, /*allowDynamic=*/true, /*withTrailingX=*/false)) {
     return failure();
+  }
   return success();
 }
 
 // 打印逻辑：打印形如 "32x32" 的维度列表
 [[maybe_unused]] static void printShape(AsmPrinter &printer, ArrayRef<int64_t> shape) {
   for (auto it = shape.begin(); it != shape.end(); ++it) {
-    if (it != shape.begin()) printer << "x"; // 维度间的分隔符
-    if (*it == ShapedType::kDynamic)
+    if (it != shape.begin()) {
+      printer << "x"; // 维度间的分隔符
+    }
+    if (*it == ShapedType::kDynamic) {
       printer << "?";
-    else
+    } else {
       printer << *it;
+}
   }
   // 注意：我们不在这里打印末尾的 'x'，因为 assemblyFormat 中已经写了 `x` $elementType
 }
@@ -244,17 +248,21 @@ static ParseResult parseI32LiteralAttr(OpAsmParser &parser, IntegerAttr &attr);
 [[maybe_unused]] static LogicalResult parseShapeAndElemStable(mlir::AsmParser &parser,
                                              llvm::SmallVectorImpl<int64_t> &shape,
                                              mlir::Type &elementType) {
-  if (failed(parser.parseLess()))
+  if (failed(parser.parseLess())) {
     return failure();
+  }
 
-  if (failed(parser.parseDimensionList(shape, /*allowDynamic=*/true)))
+  if (failed(parser.parseDimensionList(shape, /*allowDynamic=*/true))) {
     return failure();
+  }
 
-  if (failed(parser.parseType(elementType)))
+  if (failed(parser.parseType(elementType))) {
     return failure();
+  }
 
-  if (failed(parser.parseGreater()))
+  if (failed(parser.parseGreater())) {
     return failure();
+  }
 
   return success();
 }
@@ -262,23 +270,28 @@ static ParseResult parseI32LiteralAttr(OpAsmParser &parser, IntegerAttr &attr);
 static int64_t getPTOTypeRank(Type type) {
   // 1. 处理标准的 MLIR 类型 (Tensor, Vector)
   if (auto shapedTy = dyn_cast<ShapedType>(type)) {
-    if (shapedTy.hasRank())
+    if (shapedTy.hasRank()) {
       return shapedTy.getRank();
+    }
     return -1; // Unranked type
   }
   
   // 2. 处理 PTO 自定义类型
-  if (auto tvTy = dyn_cast<pto::TensorViewType>(type))
+  if (auto tvTy = dyn_cast<pto::TensorViewType>(type)) {
     return tvTy.getRank();
+  }
 
-  if (auto tileTy = dyn_cast<pto::TileType>(type))
+  if (auto tileTy = dyn_cast<pto::TileType>(type)) {
     return tileTy.getRank();
-    
-  if (auto tileViewTy = dyn_cast<pto::PartitionTensorViewType>(type))
-    return tileViewTy.getRank();
+  }
 
-  if (auto tileBufTy = dyn_cast<pto::TileBufType>(type))
+  if (auto tileViewTy = dyn_cast<pto::PartitionTensorViewType>(type)) {
+    return tileViewTy.getRank();
+  }
+
+  if (auto tileBufTy = dyn_cast<pto::TileBufType>(type)) {
     return tileBufTy.getRank();
+  }
 
   // 3. 不支持的类型
   return -1;
@@ -286,21 +299,25 @@ static int64_t getPTOTypeRank(Type type) {
 
 func::FuncOp mlir::pto::lookupPeerFuncAcrossContainer(Operation *op,
                                                       FlatSymbolRefAttr peerAttr) {
-  if (!op || !peerAttr)
+  if (!op || !peerAttr) {
     return {};
+  }
 
   auto currentFunc = op->getParentOfType<func::FuncOp>();
-  if (!currentFunc)
+  if (!currentFunc) {
     return {};
+  }
 
   auto currentChildModule = currentFunc->getParentOfType<ModuleOp>();
-  if (!currentChildModule)
+  if (!currentChildModule) {
     return {};
+  }
 
   StringRef target = peerAttr.getValue();
   for (func::FuncOp funcOp : currentChildModule.getOps<func::FuncOp>()) {
-    if (funcOp.getSymName() == target)
+    if (funcOp.getSymName() == target) {
       return funcOp;
+    }
   }
   if (auto localPeer = dyn_cast_or_null<func::FuncOp>(
           SymbolTable::lookupSymbolIn(currentChildModule, target))) {
@@ -309,25 +326,29 @@ func::FuncOp mlir::pto::lookupPeerFuncAcrossContainer(Operation *op,
 
   Operation *maybeOuter = currentChildModule->getParentOp();
   auto outerModule = dyn_cast_or_null<ModuleOp>(maybeOuter);
-  if (!outerModule)
+  if (!outerModule) {
     return {};
+  }
 
   SmallVector<func::FuncOp> fallbackMatches;
   outerModule.walk([&](func::FuncOp funcOp) {
     auto visibility = funcOp->getAttrOfType<StringAttr>("sym_visibility");
-    if (visibility && visibility.getValue() == "private")
+    if (visibility && visibility.getValue() == "private") {
       return WalkResult::advance();
+    }
 
     StringRef symbolName = funcOp.getSymName();
     if (symbolName == target ||
         (funcOp->hasAttr(kPTODSLLogicalNameAttrName) &&
-         getPTODSLLogicalNameOrSymbolName(funcOp) == target))
+         getPTODSLLogicalNameOrSymbolName(funcOp) == target)) {
       fallbackMatches.push_back(funcOp);
+    }
     return WalkResult::advance();
   });
 
-  if (fallbackMatches.size() == 1)
+  if (fallbackMatches.size() == 1) {
     return fallbackMatches.front();
+  }
   return {};
 }
 
@@ -336,19 +357,24 @@ static bool isA5DeviceSpec(StringRef spec) {
 }
 
 static bool isA5ModuleTarget(ModuleOp module) {
-  if (!module)
+  if (!module) {
     return false;
-  if (auto arch = module->getAttrOfType<StringAttr>(kPTOTargetArchAttrName))
-    if (arch.getValue().equals_insensitive("a5"))
+  }
+  if (auto arch = module->getAttrOfType<StringAttr>(kPTOTargetArchAttrName)) {
+    if (arch.getValue().equals_insensitive("a5")) {
       return true;
-  if (auto spec = module->getAttrOfType<StringAttr>("pto.device-spec"))
+    }
+  }
+  if (auto spec = module->getAttrOfType<StringAttr>("pto.device-spec")) {
     return isA5DeviceSpec(spec.getValue());
+  }
   return false;
 }
 
 PTOArch mlir::pto::getTargetArch(ModuleOp module) {
-  if (isA5ModuleTarget(module))
+  if (isA5ModuleTarget(module)) {
     return PTOArch::A5;
+  }
 
   switch (getPTOParserTargetArch(module ? module.getContext() : nullptr)) {
   case PTOParserTargetArch::A5:
@@ -361,10 +387,12 @@ PTOArch mlir::pto::getTargetArch(ModuleOp module) {
 }
 
 PTOArch mlir::pto::getTargetArch(Operation *op) {
-  if (!op)
+  if (!op) {
     return PTOArch::A3;
-  if (auto module = op->getParentOfType<ModuleOp>())
+  }
+  if (auto module = op->getParentOfType<ModuleOp>()) {
     return getTargetArch(module);
+  }
   switch (getPTOParserTargetArch(op->getContext())) {
   case PTOParserTargetArch::A5:
     return PTOArch::A5;
@@ -427,21 +455,26 @@ constexpr PredicateStoreAlignmentRule kA5PredicateStoreAlignmentRules[] = {
 
 static std::optional<PredicateLoadDist>
 parsePredicateLoadDist(StringRef dist) {
-  if (dist == "NORM")
+  if (dist == "NORM") {
     return PredicateLoadDist::Norm;
-  if (dist == "US")
+  }
+  if (dist == "US") {
     return PredicateLoadDist::Us;
-  if (dist == "DS")
+  }
+  if (dist == "DS") {
     return PredicateLoadDist::Ds;
+  }
   return std::nullopt;
 }
 
 static std::optional<PredicateStoreDist>
 parsePredicateStoreDist(StringRef dist) {
-  if (dist == "NORM")
+  if (dist == "NORM") {
     return PredicateStoreDist::Norm;
-  if (dist == "PK")
+  }
+  if (dist == "PK") {
     return PredicateStoreDist::Pk;
+  }
   return std::nullopt;
 }
 
@@ -450,15 +483,17 @@ static std::optional<int64_t> findAlignmentSize(const Rule (&rules)[N],
                                                 Dist dist) {
   auto rule = llvm::find_if(
       rules, [&](const Rule &entry) { return entry.dist == dist; });
-  if (rule == std::end(rules))
+  if (rule == std::end(rules)) {
     return std::nullopt;
+  }
   return rule->alignmentBytes;
 }
 
 std::optional<int64_t>
 mlir::pto::getLoadStoreVecAlignmentSize(Operation *op) {
-  if (!op || getTargetArch(op) != PTOArch::A5)
+  if (!op || getTargetArch(op) != PTOArch::A5) {
     return std::nullopt;
+  }
 
   if (auto pldi = dyn_cast<PldiOp>(op)) {
     auto dist = parsePredicateLoadDist(pldi.getDist());
@@ -471,8 +506,9 @@ mlir::pto::getLoadStoreVecAlignmentSize(Operation *op) {
                 : std::nullopt;
   }
   if (auto sprsti = dyn_cast<SprstiOp>(op)) {
-    if (sprsti.getSpr() == "AR")
+    if (sprsti.getSpr() == "AR") {
       return 4;
+    }
   }
   return std::nullopt;
 }
@@ -581,8 +617,9 @@ uint64_t mlir::pto::BF16x2Type::getPreferredAlignment(
 
 static VerifierTargetArch getVerifierTargetArch(Operation *op) {
   auto module = op ? op->getParentOfType<ModuleOp>() : ModuleOp();
-  if (isA5ModuleTarget(module))
+  if (isA5ModuleTarget(module)) {
     return VerifierTargetArch::A5;
+  }
 
   if (auto archName = getVerifierArchName(op)) {
     return archName->equals_insensitive("a5") ? VerifierTargetArch::A5
@@ -602,18 +639,21 @@ static VerifierTargetArch getVerifierTargetArch(Operation *op) {
 
 static std::optional<StringRef> getVerifierArchName(Operation *op) {
   auto module = op ? op->getParentOfType<ModuleOp>() : ModuleOp();
-  if (!module)
+  if (!module) {
     return std::nullopt;
-  if (auto arch = module->getAttrOfType<StringAttr>(kPTOTargetArchAttrName))
+  }
+  if (auto arch = module->getAttrOfType<StringAttr>(kPTOTargetArchAttrName)) {
     return arch.getValue();
+  }
   return std::nullopt;
 }
 
 static SmallVector<int64_t, 4> canonicalizeTileBufValidShape(ArrayRef<int64_t> validShape) {
   SmallVector<int64_t, 4> canonical;
   canonical.reserve(validShape.size());
-  for (int64_t dim : validShape)
+  for (int64_t dim : validShape) {
     canonical.push_back(dim < 0 ? ShapedType::kDynamic : dim);
+  }
   return canonical;
 }
 
@@ -678,39 +718,46 @@ static ParseResult parseSyncEventOpCommon(OpAsmParser &parser,
   PipeAttr pipeAttr;
   if (succeeded(parser.parseOptionalLess())) {
     StringRef pipeTok;
-    if (parser.parseKeyword(&pipeTok) || parser.parseGreater())
+    if (parser.parseKeyword(&pipeTok) || parser.parseGreater()) {
       return failure();
+    }
     auto pipeOr = symbolizePIPE(pipeTok);
-    if (!pipeOr)
+    if (!pipeOr) {
       return parser.emitError(parser.getCurrentLocation())
              << "unknown pipe token: " << pipeTok;
+    }
     pipeAttr = PipeAttr::get(parser.getContext(), *pipeOr);
     result.addAttribute(pipeAttrName, pipeAttr);
   } else if (parser.parseAttribute(pipeAttr, pipeAttrName,
                                    result.attributes)) {
     return failure();
   }
-  if (parser.parseComma())
+  if (parser.parseComma()) {
     return failure();
+  }
 
   OpAsmParser::UnresolvedOperand eventOperand;
   OptionalParseResult parseEventOperand =
       parser.parseOptionalOperand(eventOperand);
   if (parseEventOperand.has_value()) {
-    if (failed(*parseEventOperand))
+    if (failed(*parseEventOperand)) {
       return failure();
+    }
     if (parser.resolveOperand(eventOperand, parser.getBuilder().getIndexType(),
-                              result.operands))
+                              result.operands)) {
       return failure();
+    }
   } else {
     IntegerAttr eventAttr;
     if (parser.parseAttribute(eventAttr, parser.getBuilder().getI32Type(),
-                              eventIdAttrName, result.attributes))
+                              eventIdAttrName, result.attributes)) {
       return failure();
+    }
   }
 
-  if (parser.parseOptionalAttrDict(result.attributes))
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
   return success();
 }
 
@@ -719,10 +766,11 @@ static void printSyncEventOpCommon(OpAsmPrinter &p, Operation *op,
                                    Value eventDyn, StringRef pipeAttrName,
                                    StringRef eventIdAttrName) {
   p << " <" << stringifyPIPE(pipeAttr.getPipe()) << ">, ";
-  if (eventAttr)
+  if (eventAttr) {
     p << eventAttr.getInt();
-  else
+  } else {
     p << eventDyn;
+}
   p.printOptionalAttrDict(op->getAttrs(), {pipeAttrName, eventIdAttrName});
 }
 
@@ -731,59 +779,70 @@ static void printSyncEventOpCommon(OpAsmPrinter &p, Operation *op,
 
   mlir::OptionalParseResult opt = parser.parseOptionalType(ty);
 
-  if (opt.has_value()) {         
-    if (failed(*opt))
-      return mlir::Type();       
+  if (opt.has_value()) {
+    if (failed(*opt)) {
+      return mlir::Type();
+    }
     return ty;                    
   }
 
 
   llvm::StringRef head;
-  if (failed(parser.parseKeyword(&head)))
+  if (failed(parser.parseKeyword(&head))) {
     return mlir::Type();
+  }
 
   mlir::MLIRContext *ctx = parser.getContext();
 
   auto parseShapeElemForOpParser =
       [&](llvm::SmallVectorImpl<int64_t> &shape, mlir::Type &elem) -> mlir::LogicalResult {
-        if (failed(parser.parseLess()))
-          return failure();
-        if (failed(parser.parseDimensionList(shape, /*allowDynamic=*/true)))
-          return failure();
-        if (failed(parser.parseType(elem)))
-          return failure();
-        if (failed(parser.parseGreater()))
-          return failure();
-        return success();
-      };
+    if (failed(parser.parseLess())) {
+      return failure();
+    }
+    if (failed(parser.parseDimensionList(shape, /*allowDynamic=*/true))) {
+      return failure();
+    }
+    if (failed(parser.parseType(elem))) {
+      return failure();
+    }
+    if (failed(parser.parseGreater())) {
+      return failure();
+    }
+    return success();
+  };
 
   if (head == "pto.tile_view") {
     llvm::SmallVector<int64_t, 4> shape;
     mlir::Type elem;
-    if (failed(parseShapeElemForOpParser(shape, elem)))
+    if (failed(parseShapeElemForOpParser(shape, elem))) {
       return mlir::Type();
+    }
     return mlir::pto::PartitionTensorViewType::get(ctx, shape, elem);
   }
 
   if (head == "pto.tile") {
     llvm::SmallVector<int64_t, 4> shape;
     mlir::Type elem;
-    if (failed(parseShapeElemForOpParser(shape, elem)))
+    if (failed(parseShapeElemForOpParser(shape, elem))) {
       return mlir::Type();
+    }
     return mlir::pto::TileType::get(ctx, shape, elem);
   }
 
   if (head == "pto.ptr") {
-    if (failed(parser.parseLess()))
+    if (failed(parser.parseLess())) {
       return mlir::Type();
+    }
     mlir::Type elem;
-    if (failed(parser.parseType(elem)))
+    if (failed(parser.parseType(elem))) {
       return mlir::Type();
+    }
     auto memorySpace = pto::AddressSpaceAttr::get(ctx, pto::AddressSpace::GM);
     if (succeeded(parser.parseOptionalComma())) {
       StringRef memorySpaceKeyword;
-      if (failed(parser.parseKeyword(&memorySpaceKeyword)))
+      if (failed(parser.parseKeyword(&memorySpaceKeyword))) {
         return mlir::Type();
+      }
       auto parsed = parsePtrAddressSpaceKeyword(memorySpaceKeyword);
       if (!parsed) {
         parser.emitError(parser.getCurrentLocation(),
@@ -793,16 +852,18 @@ static void printSyncEventOpCommon(OpAsmPrinter &p, Operation *op,
       }
       memorySpace = pto::AddressSpaceAttr::get(ctx, *parsed);
     }
-    if (failed(parser.parseGreater()))
+    if (failed(parser.parseGreater())) {
       return mlir::Type();
+    }
     return mlir::pto::PtrType::get(ctx, elem, memorySpace);
   }
 
   if (head == "pto.tensor_view") {
     llvm::SmallVector<int64_t, 4> shape;
     mlir::Type elem;
-    if (failed(parseShapeElemForOpParser(shape, elem)))
+    if (failed(parseShapeElemForOpParser(shape, elem))) {
       return mlir::Type();
+    }
     return mlir::pto::TensorViewType::get(ctx, shape, elem);
   }
 
@@ -812,8 +873,9 @@ static void printSyncEventOpCommon(OpAsmPrinter &p, Operation *op,
 mlir::Type TensorViewType::parse(::mlir::AsmParser &parser) {
   SmallVector<int64_t, 4> shape;
   Type elementType;
-  if (failed(parseShapeAndElem(parser, shape, elementType, /*allowDynamic=*/true)))
+  if (failed(parseShapeAndElem(parser, shape, elementType, /*allowDynamic=*/true))) {
     return Type();
+  }
   return TensorViewType::get(parser.getContext(), shape, elementType);
 }
 
@@ -823,15 +885,17 @@ void TensorViewType::print(::mlir::AsmPrinter &printer) const {
 
 mlir::Type PtrType::parse(::mlir::AsmParser &parser) {
   Type elementType;
-  if (failed(parser.parseLess()) || failed(parser.parseType(elementType)))
+  if (failed(parser.parseLess()) || failed(parser.parseType(elementType))) {
     return {};
+  }
 
   auto memorySpace =
       pto::AddressSpaceAttr::get(parser.getContext(), pto::AddressSpace::GM);
   if (succeeded(parser.parseOptionalComma())) {
     StringRef memorySpaceKeyword;
-    if (failed(parser.parseKeyword(&memorySpaceKeyword)))
+    if (failed(parser.parseKeyword(&memorySpaceKeyword))) {
       return {};
+    }
     auto parsed = parsePtrAddressSpaceKeyword(memorySpaceKeyword);
     if (!parsed) {
       parser.emitError(parser.getCurrentLocation(),
@@ -842,8 +906,9 @@ mlir::Type PtrType::parse(::mlir::AsmParser &parser) {
     memorySpace = pto::AddressSpaceAttr::get(parser.getContext(), *parsed);
   }
 
-  if (failed(parser.parseGreater()))
+  if (failed(parser.parseGreater())) {
     return {};
+  }
   return PtrType::get(parser.getContext(), elementType, memorySpace);
 }
 
@@ -851,8 +916,9 @@ void PtrType::print(::mlir::AsmPrinter &printer) const {
   printer << "<" << getElementType();
   StringRef memorySpaceKeyword =
       printPtrAddressSpaceKeyword(getMemorySpace().getAddressSpace());
-  if (!memorySpaceKeyword.empty())
+  if (!memorySpaceKeyword.empty()) {
     printer << ", " << memorySpaceKeyword;
+  }
   printer << ">";
 }
 
@@ -870,36 +936,43 @@ ParseResult mlir::pto::TDivSOp::parse(OpAsmParser &parser, OperationState &resul
   if (parser.parseKeyword("ins") || parser.parseLParen() ||
       parser.parseOperand(op0) || parser.parseComma() ||
       parser.parseOperand(op1) || parser.parseColonType(ty0) ||
-      parser.parseComma() || parser.parseType(ty1) || parser.parseRParen())
+      parser.parseComma() || parser.parseType(ty1) || parser.parseRParen()) {
     return failure();
+  }
 
   if (parser.parseKeyword("outs") || parser.parseLParen() ||
       parser.parseOperand(dst) || parser.parseColonType(dstTy) ||
-      parser.parseRParen())
+      parser.parseRParen()) {
     return failure();
+  }
 
   NamedAttrList attrs;
-  if (parser.parseOptionalAttrDict(attrs))
+  if (parser.parseOptionalAttrDict(attrs)) {
     return failure();
+  }
 
   auto tile0 = dyn_cast<mlir::pto::TileBufType>(ty0);
   auto tile1 = dyn_cast<mlir::pto::TileBufType>(ty1);
-  if ((tile0 && tile1) || (!tile0 && !tile1))
+  if ((tile0 && tile1) || (!tile0 && !tile1)) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expected exactly one tile_buf operand and one scalar operand");
+  }
 
-  if (!dyn_cast<mlir::pto::TileBufType>(dstTy))
+  if (!dyn_cast<mlir::pto::TileBufType>(dstTy)) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expected outs type to be !pto.tile_buf<...>");
+  }
 
   // Keep textual order so later lowering can distinguish the two APIs by the
   // first ins operand type.
   if (parser.resolveOperand(op0, ty0, result.operands) ||
-      parser.resolveOperand(op1, ty1, result.operands))
+      parser.resolveOperand(op1, ty1, result.operands)) {
     return failure();
+  }
 
-  if (parser.resolveOperand(dst, dstTy, result.operands))
+  if (parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
+  }
 
   result.addAttributes(attrs);
   return success();
@@ -934,8 +1007,9 @@ ParseResult mlir::pto::TGatherOp::parse(OpAsmParser &parser, OperationState &res
   bool hasTmp = false;
   bool hasKValue = false;
 
-  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src))
+  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src)) {
     return failure();
+  }
 
   if (!succeeded(parser.parseOptionalComma())) {
     return parser.emitError(parser.getCurrentLocation(),
@@ -943,12 +1017,14 @@ ParseResult mlir::pto::TGatherOp::parse(OpAsmParser &parser, OperationState &res
   }
 
   if (succeeded(parser.parseOptionalLBrace())) {
-    if (parser.parseKeyword("maskPattern") || parser.parseEqual())
+    if (parser.parseKeyword("maskPattern") || parser.parseEqual()) {
       return failure();
+    }
 
     Attribute rawMaskAttr;
-    if (parser.parseAttribute(rawMaskAttr) || parser.parseRBrace())
+    if (parser.parseAttribute(rawMaskAttr) || parser.parseRBrace()) {
       return failure();
+    }
 
     auto mp = llvm::dyn_cast<mlir::pto::MaskPatternAttr>(rawMaskAttr);
     if (!mp) {
@@ -959,69 +1035,86 @@ ParseResult mlir::pto::TGatherOp::parse(OpAsmParser &parser, OperationState &res
     result.addAttribute("maskPattern", mp);
     hasMask = true;
 
-    if (parser.parseColonType(srcTy))
+    if (parser.parseColonType(srcTy)) {
       return failure();
+    }
     if (succeeded(parser.parseOptionalComma())) {
       StringAttr axisAttr;
-      if (parser.parseAttribute(axisAttr))
+      if (parser.parseAttribute(axisAttr)) {
         return failure();
-      if (axisAttr.getValue() != "row" && axisAttr.getValue() != "col")
+      }
+      if (axisAttr.getValue() != "row" && axisAttr.getValue() != "col") {
         return parser.emitError(parser.getCurrentLocation(),
                                 "axis must be \"row\" or \"col\"");
+      }
       result.addAttribute("axis", axisAttr);
     }
-    if (parser.parseRParen())
+    if (parser.parseRParen()) {
       return failure();
+    }
   } else {
     OpAsmParser::UnresolvedOperand extra;
-    if (parser.parseOperand(extra))
+    if (parser.parseOperand(extra)) {
       return failure();
+    }
     insOps.push_back(extra);
     while (succeeded(parser.parseOptionalComma())) {
       if (insOps.size() == 3) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "expected at most 3 extra operands in tgather ins(...)");
       }
-      if (parser.parseOperand(extra))
+      if (parser.parseOperand(extra)) {
         return failure();
+      }
       insOps.push_back(extra);
     }
 
-    if (parser.parseColon() || parser.parseType(srcTy))
+    if (parser.parseColon() || parser.parseType(srcTy)) {
       return failure();
+    }
     for (size_t i = 0; i < insOps.size(); ++i) {
       Type ty;
-      if (parser.parseComma() || parser.parseType(ty))
+      if (parser.parseComma() || parser.parseType(ty)) {
         return failure();
+      }
       insTypes.push_back(ty);
     }
-    if (parser.parseRParen())
+    if (parser.parseRParen()) {
       return failure();
+    }
   }
 
-  if (parser.parseKeyword("outs") || parser.parseLParen() || parser.parseOperand(dst))
+  if (parser.parseKeyword("outs") || parser.parseLParen() || parser.parseOperand(dst)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(cdst))
+    if (parser.parseOperand(cdst)) {
       return failure();
+    }
     hasCdst = true;
   }
-  if (parser.parseColonType(dstTy))
+  if (parser.parseColonType(dstTy)) {
     return failure();
-  if (hasCdst && (parser.parseComma() || parser.parseType(cdstTy)))
+  }
+  if (hasCdst && (parser.parseComma() || parser.parseType(cdstTy))) {
     return failure();
-  if (parser.parseRParen())
+  }
+  if (parser.parseRParen()) {
     return failure();
+  }
 
   if (succeeded(parser.parseOptionalKeyword("maskPattern"))) {
-    if (hasMask)
+    if (hasMask) {
       return parser.emitError(parser.getCurrentLocation(),
                               "maskPattern may only be specified once");
-    if (parser.parseEqual())
+    }
+    if (parser.parseEqual()) {
       return failure();
+    }
     Attribute rawMaskAttr;
-    if (parser.parseAttribute(rawMaskAttr))
+    if (parser.parseAttribute(rawMaskAttr)) {
       return failure();
+    }
     auto mp = llvm::dyn_cast<mlir::pto::MaskPatternAttr>(rawMaskAttr);
     if (!mp) {
       return parser.emitError(parser.getCurrentLocation(),
@@ -1031,27 +1124,32 @@ ParseResult mlir::pto::TGatherOp::parse(OpAsmParser &parser, OperationState &res
     hasMask = true;
   }
 
-  if (parser.parseOptionalAttrDict(result.attributes))
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
   if (hasMask) {
-    if (!insOps.empty())
+    if (!insOps.empty()) {
       return parser.emitError(parser.getCurrentLocation(),
                               "mask-pattern tgather does not take extra ins operands");
-    if (hasCdst)
+    }
+    if (hasCdst) {
       return parser.emitError(parser.getCurrentLocation(),
                               "mask-pattern tgather expects a single outs operand");
+    }
   } else if (hasCdst) {
     if (insOps.empty() ||
         !(mlir::isa<IntegerType>(insTypes.front()) ||
-          mlir::isa<FloatType>(insTypes.front())))
+          mlir::isa<FloatType>(insTypes.front()))) {
       return parser.emitError(parser.getCurrentLocation(),
                               "compare-form tgather expects a scalar kValue operand");
+    }
     hasKValue = true;
     if (insOps.size() >= 2) {
-      if (!isTileLikeType(insTypes[1]))
+      if (!isTileLikeType(insTypes[1])) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "compare-form tgather tmp must be tile-like");
+      }
       hasTmp = true;
     }
     if (insOps.size() == 3) {
@@ -1067,9 +1165,10 @@ ParseResult mlir::pto::TGatherOp::parse(OpAsmParser &parser, OperationState &res
     if (!insOps.empty()) {
       hasIndices = true;
       if (insOps.size() >= 2) {
-        if (!isTileLikeType(insTypes[1]))
+        if (!isTileLikeType(insTypes[1])) {
           return parser.emitError(parser.getCurrentLocation(),
                                   "index-form tgather tmp must be tile-like");
+        }
         hasTmp = true;
       }
     }
@@ -1080,16 +1179,21 @@ ParseResult mlir::pto::TGatherOp::parse(OpAsmParser &parser, OperationState &res
   }
 
   if (parser.resolveOperand(src, srcTy, result.operands) ||
-      parser.resolveOperand(dst, dstTy, result.operands))
+      parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
-  if (hasCdst && parser.resolveOperand(cdst, cdstTy, result.operands))
+  }
+  if (hasCdst && parser.resolveOperand(cdst, cdstTy, result.operands)) {
     return failure();
-  if (hasIndices && parser.resolveOperand(insOps[0], insTypes[0], result.operands))
+  }
+  if (hasIndices && parser.resolveOperand(insOps[0], insTypes[0], result.operands)) {
     return failure();
-  if (hasTmp && parser.resolveOperand(insOps[hasIndices ? 1 : 1], insTypes[1], result.operands))
+  }
+  if (hasTmp && parser.resolveOperand(insOps[hasIndices ? 1 : 1], insTypes[1], result.operands)) {
     return failure();
-  if (hasKValue && parser.resolveOperand(insOps[0], insTypes[0], result.operands))
+  }
+  if (hasKValue && parser.resolveOperand(insOps[0], insTypes[0], result.operands)) {
     return failure();
+  }
 
   result.addAttribute("operandSegmentSizes",
                       parser.getBuilder().getDenseI32ArrayAttr(
@@ -1102,8 +1206,9 @@ void mlir::pto::TGatherOp::print(OpAsmPrinter &p) {
   p << " ins(" << getSrc() << ", ";
   if (auto mp = getMaskPatternAttr()) {
     p << "{maskPattern = " << mp << "} : " << getSrc().getType();
-    if (auto axisAttr = getAxisAttr())
+    if (auto axisAttr = getAxisAttr()) {
       p << ", " << axisAttr;
+    }
   } else if (getCdst()) {
     p << getKValue();
     if (getTmp()) {
@@ -1124,11 +1229,13 @@ void mlir::pto::TGatherOp::print(OpAsmPrinter &p) {
     }
   }
   p << ") outs(" << getDst();
-  if (getCdst())
+  if (getCdst()) {
     p << ", " << getCdst();
+  }
   p << " : " << getDst().getType();
-  if (getCdst())
+  if (getCdst()) {
     p << ", " << getCdst().getType();
+  }
   p << ")";
 
   if (getMaskPatternAttr()) {
@@ -1148,69 +1255,86 @@ ParseResult mlir::pto::TScatterOp::parse(OpAsmParser &parser,
   bool hasIndexes = false;
 
   if (parser.parseKeyword("ins") || parser.parseLParen() ||
-      parser.parseOperand(src))
+      parser.parseOperand(src)) {
     return failure();
+  }
 
-  if (!succeeded(parser.parseOptionalComma()))
+  if (!succeeded(parser.parseOptionalComma())) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expected ',' after src operand in ins(...)");
+  }
 
   if (succeeded(parser.parseOptionalLBrace())) {
-    if (parser.parseKeyword("maskPattern") || parser.parseEqual())
+    if (parser.parseKeyword("maskPattern") || parser.parseEqual()) {
       return failure();
+    }
     Attribute rawMaskAttr;
-    if (parser.parseAttribute(rawMaskAttr))
+    if (parser.parseAttribute(rawMaskAttr)) {
       return failure();
+    }
     auto mp = llvm::dyn_cast<mlir::pto::MaskPatternAttr>(rawMaskAttr);
-    if (!mp)
+    if (!mp) {
       return parser.emitError(parser.getCurrentLocation(),
                               "expected #pto.mask_pattern<Pxxxx> for maskPattern");
+    }
     result.addAttribute("maskPattern", mp);
     hasMask = true;
-    if (parser.parseRBrace() || parser.parseColonType(srcTy))
+    if (parser.parseRBrace() || parser.parseColonType(srcTy)) {
       return failure();
+    }
     if (succeeded(parser.parseOptionalComma())) {
       StringAttr axisAttr;
-      if (parser.parseAttribute(axisAttr))
+      if (parser.parseAttribute(axisAttr)) {
         return failure();
-      if (axisAttr.getValue() != "row" && axisAttr.getValue() != "col")
+      }
+      if (axisAttr.getValue() != "row" && axisAttr.getValue() != "col") {
         return parser.emitError(parser.getCurrentLocation(),
                                 "axis must be \"row\" or \"col\"");
+      }
       result.addAttribute("axis", axisAttr);
     }
-    if (parser.parseRParen())
+    if (parser.parseRParen()) {
       return failure();
+    }
   } else {
-    if (parser.parseOperand(indexes))
+    if (parser.parseOperand(indexes)) {
       return failure();
+    }
     hasIndexes = true;
     if (parser.parseColon() || parser.parseType(srcTy) || parser.parseComma() ||
-        parser.parseType(idxTy) || parser.parseRParen())
+        parser.parseType(idxTy) || parser.parseRParen()) {
       return failure();
+    }
   }
 
   if (parser.parseKeyword("outs") || parser.parseLParen() ||
       parser.parseOperand(dst) || parser.parseColonType(dstTy) ||
-      parser.parseRParen())
+      parser.parseRParen()) {
     return failure();
+  }
 
-  if (parser.parseOptionalAttrDict(result.attributes))
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
-  if (result.attributes.get("maskPattern"))
+  if (result.attributes.get("maskPattern")) {
     hasMask = true;
+  }
 
-  if (hasMask && hasIndexes)
+  if (hasMask && hasIndexes) {
     return parser.emitError(parser.getCurrentLocation(),
                             "mask-pattern tscatter does not take indexes");
-  if (!hasMask && !hasIndexes)
+  }
+  if (!hasMask && !hasIndexes) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expected indexes operand or maskPattern for tscatter");
+  }
 
   if (parser.resolveOperand(src, srcTy, result.operands) ||
       parser.resolveOperand(dst, dstTy, result.operands) ||
-      (hasIndexes && parser.resolveOperand(indexes, idxTy, result.operands)))
+      (hasIndexes && parser.resolveOperand(indexes, idxTy, result.operands))) {
     return failure();
+  }
 
   return success();
 }
@@ -1219,8 +1343,9 @@ void mlir::pto::TScatterOp::print(OpAsmPrinter &p) {
   p << " ins(" << getSrc() << ", ";
   if (getMaskPatternAttr()) {
     p << "{maskPattern = " << getMaskPatternAttr() << "} : " << getSrc().getType();
-    if (auto axisAttr = getAxisAttr())
+    if (auto axisAttr = getAxisAttr()) {
       p << ", " << axisAttr;
+    }
   } else {
     p << getIndexes() << " : " << getSrc().getType() << ", "
       << getIndexes().getType();
@@ -1241,12 +1366,14 @@ struct CommRecvClause {
 static ParseResult parseCommRecvClause(OpAsmParser &parser,
                                        CommRecvClause &recvClause) {
   if (parser.parseKeyword("recv") || parser.parseLParen() ||
-      parser.parseOperand(recvClause.ping))
+      parser.parseOperand(recvClause.ping)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma())) {
     OpAsmParser::UnresolvedOperand pong;
-    if (parser.parseOperand(pong))
+    if (parser.parseOperand(pong)) {
       return failure();
+    }
     recvClause.pong = pong;
   }
   return parser.parseRParen();
@@ -1259,49 +1386,61 @@ static ParseResult parseCommCollectiveTail(
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &groupOps,
     SmallVectorImpl<Type> &groupTypes, ArrayRef<int32_t> operandSegmentsPrefix,
     ArrayRef<StringRef> requiredAttrs) {
-  if (parser.parseComma() || parser.parseKeyword("group") || parser.parseLParen())
+  if (parser.parseComma() || parser.parseKeyword("group") || parser.parseLParen()) {
     return failure();
+  }
 
   OpAsmParser::UnresolvedOperand group;
-  if (parser.parseOperand(group))
+  if (parser.parseOperand(group)) {
     return failure();
+  }
   groupOps.push_back(group);
   while (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(group))
+    if (parser.parseOperand(group)) {
       return failure();
+    }
     groupOps.push_back(group);
   }
 
-  if (parser.parseRParen())
+  if (parser.parseRParen()) {
     return failure();
+  }
 
-  if (parser.parseColon())
+  if (parser.parseColon()) {
     return failure();
+  }
 
   for (size_t i = 0; i < fixedTypes.size(); ++i) {
-    if (i != 0 && parser.parseComma())
+    if (i != 0 && parser.parseComma()) {
       return failure();
-    if (parser.parseType(fixedTypes[i]))
+    }
+    if (parser.parseType(fixedTypes[i])) {
       return failure();
+    }
   }
-  if (parser.parseComma() || parser.parseType(recvClause.pingTy))
+  if (parser.parseComma() || parser.parseType(recvClause.pingTy)) {
     return failure();
+  }
   if (recvClause.pong) {
-    if (parser.parseComma() || parser.parseType(recvClause.pongTy))
+    if (parser.parseComma() || parser.parseType(recvClause.pongTy)) {
       return failure();
+    }
   }
   for (size_t i = 0; i < groupOps.size(); ++i) {
     Type groupTy;
-    if (parser.parseComma() || parser.parseType(groupTy))
+    if (parser.parseComma() || parser.parseType(groupTy)) {
       return failure();
+    }
     groupTypes.push_back(groupTy);
   }
-  if (parser.parseRParen())
+  if (parser.parseRParen()) {
     return failure();
+  }
 
   NamedAttrList attrs;
-  if (parser.parseOptionalAttrDict(attrs))
+  if (parser.parseOptionalAttrDict(attrs)) {
     return failure();
+  }
   for (StringRef attrName : requiredAttrs) {
     if (!attrs.get(attrName)) {
       return parser.emitError(parser.getCurrentLocation())
@@ -1311,17 +1450,21 @@ static ParseResult parseCommCollectiveTail(
   result.addAttributes(attrs);
 
   for (auto [operand, type] : llvm::zip_equal(fixedOperands, fixedTypes)) {
-    if (parser.resolveOperand(operand, type, result.operands))
+    if (parser.resolveOperand(operand, type, result.operands)) {
       return failure();
+    }
   }
-  if (parser.resolveOperand(recvClause.ping, recvClause.pingTy, result.operands))
+  if (parser.resolveOperand(recvClause.ping, recvClause.pingTy, result.operands)) {
     return failure();
+  }
   if (recvClause.pong &&
-      parser.resolveOperand(*recvClause.pong, recvClause.pongTy, result.operands))
+      parser.resolveOperand(*recvClause.pong, recvClause.pongTy, result.operands)) {
     return failure();
+  }
   if (parser.resolveOperands(groupOps, groupTypes, parser.getCurrentLocation(),
-                             result.operands))
+                             result.operands)) {
     return failure();
+  }
 
   SmallVector<int32_t, 5> segmentSizes(operandSegmentsPrefix.begin(),
                                        operandSegmentsPrefix.end());
@@ -1333,14 +1476,16 @@ static ParseResult parseCommCollectiveTail(
 
 static void printCommRecvClause(OpAsmPrinter &p, Value ping, Value pong) {
   p << "recv(" << ping;
-  if (pong)
+  if (pong) {
     p << ", " << pong;
+  }
   p << ")";
 }
 
 static void printCommGroupTypes(OpAsmPrinter &p, ValueRange group) {
-  for (Value groupValue : group)
+  for (Value groupValue : group) {
     p << ", " << groupValue.getType();
+  }
 }
 
 static void printCommGroupClause(OpAsmPrinter &p, ValueRange group) {
@@ -1358,17 +1503,20 @@ ParseResult mlir::pto::TBroadcastOp::parse(OpAsmParser &parser,
   SmallVector<OpAsmParser::UnresolvedOperand, 4> groupOps;
   SmallVector<Type, 4> groupTypes;
 
-  if (parser.parseLParen() || parser.parseOperand(src) || parser.parseComma())
+  if (parser.parseLParen() || parser.parseOperand(src) || parser.parseComma()) {
     return failure();
-  if (failed(parseCommRecvClause(parser, recvClause)))
+  }
+  if (failed(parseCommRecvClause(parser, recvClause))) {
     return failure();
+  }
 
   SmallVector<OpAsmParser::UnresolvedOperand, 1> fixedOperands{src};
   SmallVector<Type, 1> fixedTypes(1);
   if (failed(parseCommCollectiveTail(parser, result, fixedOperands, fixedTypes,
                                      recvClause, groupOps, groupTypes,
-                                     {1, 1, recvClause.pong ? 1 : 0}, {"root"})))
+                                     {1, 1, recvClause.pong ? 1 : 0}, {"root"}))) {
     return failure();
+  }
   return success();
 }
 
@@ -1378,8 +1526,9 @@ void mlir::pto::TBroadcastOp::print(OpAsmPrinter &p) {
   p << ", ";
   printCommGroupClause(p, getGroup());
   p << " : " << getSrc().getType() << ", " << getPing().getType();
-  if (getPong())
+  if (getPong()) {
     p << ", " << getPong().getType();
+  }
   printCommGroupTypes(p, getGroup());
   p << ")";
   p.printOptionalAttrDict((*this)->getAttrs(),
@@ -1393,18 +1542,21 @@ ParseResult mlir::pto::CommTGatherOp::parse(OpAsmParser &parser,
   SmallVector<OpAsmParser::UnresolvedOperand, 4> groupOps;
   SmallVector<Type, 4> groupTypes;
 
-  if (parser.parseLParen() || parser.parseOperand(dst) || parser.parseComma())
+  if (parser.parseLParen() || parser.parseOperand(dst) || parser.parseComma()) {
     return failure();
-  if (failed(parseCommRecvClause(parser, recvClause)))
+  }
+  if (failed(parseCommRecvClause(parser, recvClause))) {
     return failure();
+  }
 
   SmallVector<OpAsmParser::UnresolvedOperand, 1> fixedOperands{dst};
   SmallVector<Type, 1> fixedTypes(1);
   if (failed(parseCommCollectiveTail(
           parser, result, fixedOperands, fixedTypes, recvClause, groupOps,
           groupTypes, {1, 1, recvClause.pong ? 1 : 0},
-          {"root"})))
+          {"root"}))) {
     return failure();
+  }
   return success();
 }
 
@@ -1414,8 +1566,9 @@ void mlir::pto::CommTGatherOp::print(OpAsmPrinter &p) {
   p << ", ";
   printCommGroupClause(p, getGroup());
   p << " : " << getDst().getType() << ", " << getPing().getType();
-  if (getPong())
+  if (getPong()) {
     p << ", " << getPong().getType();
+  }
   printCommGroupTypes(p, getGroup());
   p << ")";
   p.printOptionalAttrDict((*this)->getAttrs(),
@@ -1429,18 +1582,21 @@ ParseResult mlir::pto::CommTScatterOp::parse(OpAsmParser &parser,
   SmallVector<OpAsmParser::UnresolvedOperand, 4> groupOps;
   SmallVector<Type, 4> groupTypes;
 
-  if (parser.parseLParen() || parser.parseOperand(src) || parser.parseComma())
+  if (parser.parseLParen() || parser.parseOperand(src) || parser.parseComma()) {
     return failure();
-  if (failed(parseCommRecvClause(parser, recvClause)))
+  }
+  if (failed(parseCommRecvClause(parser, recvClause))) {
     return failure();
+  }
 
   SmallVector<OpAsmParser::UnresolvedOperand, 1> fixedOperands{src};
   SmallVector<Type, 1> fixedTypes(1);
   if (failed(parseCommCollectiveTail(
           parser, result, fixedOperands, fixedTypes, recvClause, groupOps,
           groupTypes, {1, 1, recvClause.pong ? 1 : 0},
-          {"root"})))
+          {"root"}))) {
     return failure();
+  }
   return success();
 }
 
@@ -1450,8 +1606,9 @@ void mlir::pto::CommTScatterOp::print(OpAsmPrinter &p) {
   p << ", ";
   printCommGroupClause(p, getGroup());
   p << " : " << getSrc().getType() << ", " << getPing().getType();
-  if (getPong())
+  if (getPong()) {
     p << ", " << getPong().getType();
+  }
   printCommGroupTypes(p, getGroup());
   p << ")";
   p.printOptionalAttrDict((*this)->getAttrs(),
@@ -1466,18 +1623,21 @@ ParseResult mlir::pto::TReduceOp::parse(OpAsmParser &parser,
   SmallVector<Type, 4> groupTypes;
 
   if (parser.parseLParen() || parser.parseOperand(dst) || parser.parseComma() ||
-      parser.parseOperand(acc) || parser.parseComma())
+      parser.parseOperand(acc) || parser.parseComma()) {
     return failure();
-  if (failed(parseCommRecvClause(parser, recvClause)))
+  }
+  if (failed(parseCommRecvClause(parser, recvClause))) {
     return failure();
+  }
 
   SmallVector<OpAsmParser::UnresolvedOperand, 2> fixedOperands{dst, acc};
   SmallVector<Type, 2> fixedTypes(2);
   if (failed(parseCommCollectiveTail(
           parser, result, fixedOperands, fixedTypes, recvClause, groupOps,
           groupTypes, {1, 1, 1, recvClause.pong ? 1 : 0},
-          {"reduceOp", "root"})))
+          {"reduceOp", "root"}))) {
     return failure();
+  }
   return success();
 }
 
@@ -1488,8 +1648,9 @@ void mlir::pto::TReduceOp::print(OpAsmPrinter &p) {
   printCommGroupClause(p, getGroup());
   p << " : " << getDst().getType() << ", " << getAcc().getType() << ", "
     << getRecvPing().getType();
-  if (getRecvPong())
+  if (getRecvPong()) {
     p << ", " << getRecvPong().getType();
+  }
   printCommGroupTypes(p, getGroup());
   p << ")";
   p.printOptionalAttrDict((*this)->getAttrs(),
@@ -1505,51 +1666,60 @@ ParseResult mlir::pto::MakeTensorViewOp::parse(OpAsmParser &parser,
   Type resultTy;
 
   // %ptr
-  if (parser.parseOperand(ptr))
+  if (parser.parseOperand(ptr)) {
     return failure();
+  }
 
   // , shape = [ ... ]
   if (parser.parseComma() || parser.parseKeyword("shape") || parser.parseEqual() ||
       parser.parseLSquare() ||
       parser.parseOperandList(shapeOps) ||
-      parser.parseRSquare())
+      parser.parseRSquare()) {
     return failure();
+  }
 
   // strides = [ ... ]
   if (parser.parseComma() || parser.parseKeyword("strides") || parser.parseEqual() ||
       parser.parseLSquare() ||
       parser.parseOperandList(strideOps) ||
-      parser.parseRSquare())
+      parser.parseRSquare()) {
     return failure();
+  }
 
   // attr-dict
-  if (parser.parseOptionalAttrDict(result.attributes))
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
   // : result-type
-  if (parser.parseColonType(resultTy))
+  if (parser.parseColonType(resultTy)) {
     return failure();
+  }
   result.addTypes(resultTy);
 
   auto tvTy = llvm::dyn_cast<mlir::pto::TensorViewType>(resultTy);
-  if (!tvTy)
+  if (!tvTy) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expected result type pto.tensor_view<...>");
+  }
 
   Type elemTy = tvTy.getElementType();
 
   Type ptrTy = mlir::pto::PtrType::get(parser.getContext(), elemTy);
 
   // resolve %ptr
-  if (parser.resolveOperand(ptr, ptrTy, result.operands))
+  if (parser.resolveOperand(ptr, ptrTy, result.operands)) {
     return failure();
+  }
 
   // resolve shape/strides 为 index
   Type indexTy = parser.getBuilder().getIndexType();
-  if (parser.resolveOperands(shapeOps, indexTy, result.operands))
+  if (parser.resolveOperands(shapeOps, indexTy, result.operands)) {
     return failure();
-  if (parser.resolveOperands(strideOps, indexTy, result.operands))
+  }
+  if (parser.resolveOperands(strideOps, indexTy, result.operands)) {
     return failure();
+  }
 
   auto segAttr = parser.getBuilder().getDenseI32ArrayAttr(
       {1, (int32_t)shapeOps.size(), (int32_t)strideOps.size()});
@@ -1577,11 +1747,13 @@ void mlir::pto::MakeTensorViewOp::print(OpAsmPrinter &p) {
 
 // Layout inference helpers for make_tensor_view
 static std::optional<int64_t> getConstIndexValue(Value v) {
-  if (auto c = v.getDefiningOp<arith::ConstantIndexOp>())
+  if (auto c = v.getDefiningOp<arith::ConstantIndexOp>()) {
     return c.value();
+  }
   if (auto c = v.getDefiningOp<arith::ConstantOp>()) {
-    if (auto ia = dyn_cast<IntegerAttr>(c.getValue()))
+    if (auto ia = dyn_cast<IntegerAttr>(c.getValue())) {
       return ia.getInt();
+    }
   }
   return std::nullopt;
 }
@@ -1589,20 +1761,23 @@ static std::optional<int64_t> getConstIndexValue(Value v) {
 static FailureOr<mlir::pto::PartitionTensorViewType>
 inferPartitionViewResultTypeFromSizes(mlir::pto::TensorViewType sourceType,
                                       ValueRange sizes) {
-  if (!sourceType)
+  if (!sourceType) {
     return failure();
+  }
 
-  if ((int64_t)sizes.size() != sourceType.getRank())
+  if ((int64_t)sizes.size() != sourceType.getRank()) {
     return failure();
+  }
 
   SmallVector<int64_t, 4> shape;
   shape.reserve(sizes.size());
   for (Value size : sizes) {
     auto constSize = getConstIndexValue(size);
-    if (constSize && *constSize >= 0)
+    if (constSize && *constSize >= 0) {
       shape.push_back(*constSize);
-    else
+    } else {
       shape.push_back(ShapedType::kDynamic);
+}
   }
 
   return mlir::pto::PartitionTensorViewType::get(
@@ -1625,22 +1800,26 @@ ParseResult mlir::pto::PartitionViewOp::parse(OpAsmParser &parser,
       parser.parseKeyword("sizes") || parser.parseEqual() ||
       parser.parseLSquare() || parser.parseOperandList(sizes) ||
       parser.parseRSquare() || parser.parseOptionalAttrDict(result.attributes) ||
-      parser.parseColonType(sourceTy))
+      parser.parseColonType(sourceTy)) {
     return failure();
+  }
 
   if (succeeded(parser.parseOptionalArrow())) {
-    if (parser.parseType(resultTy))
+    if (parser.parseType(resultTy)) {
       return failure();
+    }
     hasExplicitResultTy = true;
   }
 
-  if (parser.resolveOperand(source, sourceTy, result.operands))
+  if (parser.resolveOperand(source, sourceTy, result.operands)) {
     return failure();
+  }
 
   Type indexTy = parser.getBuilder().getIndexType();
   if (parser.resolveOperands(offsets, indexTy, result.operands) ||
-      parser.resolveOperands(sizes, indexTy, result.operands))
+      parser.resolveOperands(sizes, indexTy, result.operands)) {
     return failure();
+  }
 
   auto &properties = result.getOrAddProperties<PartitionViewOp::Properties>();
   llvm::copy(ArrayRef<int32_t>(
@@ -1679,8 +1858,9 @@ void mlir::pto::PartitionViewOp::print(OpAsmPrinter &printer) {
 
   auto inferredResultType = inferPartitionViewResultTypeFromSizes(
       dyn_cast<mlir::pto::TensorViewType>(getSource().getType()), getSizes());
-  if (succeeded(inferredResultType) && *inferredResultType == getResult().getType())
+  if (succeeded(inferredResultType) && *inferredResultType == getResult().getType()) {
     return;
+  }
 
   printer << " -> " << getResult().getType();
 }
@@ -1688,14 +1868,17 @@ void mlir::pto::PartitionViewOp::print(OpAsmPrinter &printer) {
 static std::optional<int64_t> getConstantIntegerValueEx(
     Value v, bool includeIndexAndIntOpsInConstFold) {
   if (includeIndexAndIntOpsInConstFold) {
-    if (auto c = v.getDefiningOp<arith::ConstantIndexOp>())
+    if (auto c = v.getDefiningOp<arith::ConstantIndexOp>()) {
       return c.value();
-    if (auto c = v.getDefiningOp<arith::ConstantIntOp>())
+    }
+    if (auto c = v.getDefiningOp<arith::ConstantIntOp>()) {
       return c.value();
+    }
   }
   if (auto c = v.getDefiningOp<arith::ConstantOp>()) {
-    if (auto ia = dyn_cast<IntegerAttr>(c.getValue()))
+    if (auto ia = dyn_cast<IntegerAttr>(c.getValue())) {
       return ia.getInt();
+    }
   }
   return std::nullopt;
 }
@@ -1703,16 +1886,19 @@ static std::optional<int64_t> getConstantIntegerValueEx(
 static LogicalResult verifyNonNegativeIndexRowCol(
     Operation &op, Value indexRow, Value indexCol,
     bool includeIndexAndIntOpsInConstFold) {
-  if (!indexRow.getType().isIndex() || !indexCol.getType().isIndex())
+  if (!indexRow.getType().isIndex() || !indexCol.getType().isIndex()) {
     return op.emitOpError("expects indexRow and indexCol to be index type");
+  }
   auto row =
       getConstantIntegerValueEx(indexRow, includeIndexAndIntOpsInConstFold);
   auto col =
       getConstantIntegerValueEx(indexCol, includeIndexAndIntOpsInConstFold);
-  if (row && *row < 0)
+  if (row && *row < 0) {
     return op.emitOpError("expects indexRow to be non-negative");
-  if (col && *col < 0)
+  }
+  if (col && *col < 0) {
     return op.emitOpError("expects indexCol to be non-negative");
+  }
   return success();
 }
 
@@ -1725,16 +1911,19 @@ static LogicalResult verifyExtractStaticBoundsCommon(
       getConstantIntegerValueEx(indexCol, includeIndexAndIntOpsInConstFold);
   auto srcShape = getShapeVec(srcTy);
   auto dstShape = getShapeVec(dstTy);
-  if (srcShape.size() != 2 || dstShape.size() != 2)
+  if (srcShape.size() != 2 || dstShape.size() != 2) {
     return op.emitOpError("expects src and dst to be rank-2 tile_buf");
+  }
   if (row && srcShape[0] != ShapedType::kDynamic &&
       dstShape[0] != ShapedType::kDynamic &&
-      *row + dstShape[0] > srcShape[0])
+      *row + dstShape[0] > srcShape[0]) {
     return op.emitOpError("expects indexRow + dst.rows <= src.rows");
+  }
   if (col && srcShape[1] != ShapedType::kDynamic &&
       dstShape[1] != ShapedType::kDynamic &&
-      *col + dstShape[1] > srcShape[1])
+      *col + dstShape[1] > srcShape[1]) {
     return op.emitOpError("expects indexCol + dst.cols <= src.cols");
+  }
   return success();
 }
 
@@ -1747,16 +1936,19 @@ static LogicalResult verifyInsertStaticBoundsCommon(
       getConstantIntegerValueEx(indexCol, includeIndexAndIntOpsInConstFold);
   auto srcShape = getValidShapeVec(srcTy);
   auto dstShape = getShapeVec(dstTy);
-  if (srcShape.size() != 2 || dstShape.size() != 2)
+  if (srcShape.size() != 2 || dstShape.size() != 2) {
     return op.emitOpError("expects src and dst to be rank-2 tile_buf");
+  }
   if (row && srcShape[0] != ShapedType::kDynamic &&
       dstShape[0] != ShapedType::kDynamic &&
-      *row + srcShape[0] > dstShape[0])
+      *row + srcShape[0] > dstShape[0]) {
     return op.emitOpError("expects indexRow + src.rows <= dst.rows");
+  }
   if (col && srcShape[1] != ShapedType::kDynamic &&
       dstShape[1] != ShapedType::kDynamic &&
-      *col + srcShape[1] > dstShape[1])
+      *col + srcShape[1] > dstShape[1]) {
     return op.emitOpError("expects indexCol + src.cols <= dst.cols");
+  }
   return success();
 }
 
@@ -1768,24 +1960,29 @@ static LogicalResult verifyTileBufLayoutConstraints(Operation *op,
                                                     pto::TileBufType tb,
                                                     StringRef name) {
   auto shape = tb.getShape();
-  if (shape.size() != 2)
+  if (shape.size() != 2) {
     return op->emitOpError() << "expects " << name << " to be rank-2";
+  }
 
   int64_t rows = shape[0];
   int64_t cols = shape[1];
-  if (rows != ShapedType::kDynamic && rows <= 0)
+  if (rows != ShapedType::kDynamic && rows <= 0) {
     return op->emitOpError() << "expects " << name << " rows to be positive";
-  if (cols != ShapedType::kDynamic && cols <= 0)
+  }
+  if (cols != ShapedType::kDynamic && cols <= 0) {
     return op->emitOpError() << "expects " << name << " cols to be positive";
+  }
 
   unsigned elemBytes = getElemByteSize(tb.getElementType());
-  if (elemBytes == 0)
+  if (elemBytes == 0) {
     return op->emitOpError() << "expects " << name
                              << " element type to have a byte size";
+  }
 
   auto cfg = tb.getConfigAttr();
-  if (!cfg)
+  if (!cfg) {
     cfg = TileBufConfigAttr::getDefault(tb.getContext());
+  }
   auto readBLayout = [](Attribute attr, int32_t &out) -> bool {
     if (auto layout = dyn_cast_or_null<BLayoutAttr>(attr)) {
       out = static_cast<int32_t>(layout.getValue());
@@ -1811,9 +2008,10 @@ static LogicalResult verifyTileBufLayoutConstraints(Operation *op,
   int32_t blayout = 0;
   int32_t slayout = 0;
   if (!readBLayout(cfg.getBLayout(), blayout) ||
-      !readSLayout(cfg.getSLayout(), slayout))
+      !readSLayout(cfg.getSLayout(), slayout)) {
     return op->emitOpError() << "expects " << name
                              << " to have concrete tile layout attributes";
+  }
   constexpr int64_t kAlignedBytes = 32;
   constexpr int64_t kPackedFp4AlignedBytes = 16;
   const int64_t requiredAlignment = isPTOFloat4PackedType(tb.getElementType())
@@ -1822,8 +2020,9 @@ static LogicalResult verifyTileBufLayoutConstraints(Operation *op,
 
   auto checkByteAlignment = [&](int64_t dim, StringRef layoutName,
                                 StringRef byteExpr) -> LogicalResult {
-    if (dim == ShapedType::kDynamic)
+    if (dim == ShapedType::kDynamic) {
       return success();
+    }
     int64_t bytes = dim * static_cast<int64_t>(elemBytes);
     if (bytes % requiredAlignment == 0)
       return success();
@@ -1835,9 +2034,10 @@ static LogicalResult verifyTileBufLayoutConstraints(Operation *op,
   };
 
   if (slayout == static_cast<int32_t>(SLayout::NoneBox)) {
-    if (blayout == static_cast<int32_t>(BLayout::RowMajor))
+    if (blayout == static_cast<int32_t>(BLayout::RowMajor)) {
       return checkByteAlignment(cols, "row-major",
                                 "row byte size (cols * sizeof(dtype))");
+    }
     return checkByteAlignment(rows, "col-major",
                               "column byte size (rows * sizeof(dtype))");
   }
@@ -1855,10 +2055,11 @@ static LogicalResult verifyTileBufLayoutConstraints(Operation *op,
     innerCols = 2;
     break;
   case 512:
-    if (kAlignedBytes % elemBytes != 0)
+    if (kAlignedBytes % elemBytes != 0) {
       return op->emitOpError() << "expects " << name
                                << " element byte size to divide 32 for boxed "
                                   "fractal-512 tile layout";
+    }
     if (slayout == static_cast<int32_t>(SLayout::RowMajor)) {
       innerRows = 16;
       innerCols = kAlignedBytes / static_cast<int64_t>(elemBytes);
@@ -1870,31 +2071,35 @@ static LogicalResult verifyTileBufLayoutConstraints(Operation *op,
   default:
     break;
   }
-  if (innerRows <= 0 || innerCols <= 0)
+  if (innerRows <= 0 || innerCols <= 0) {
     return op->emitOpError() << "expects " << name
                              << " to use a supported boxed tile layout";
+  }
 
   auto loc = getPTOMemorySpaceEnum(tb);
   bool allowUnalignedRows =
       (loc && *loc == pto::AddressSpace::VEC) || fractal == 32 || rows == 1;
   if (!allowUnalignedRows && rows != ShapedType::kDynamic &&
-      rows % innerRows != 0)
+      rows % innerRows != 0) {
     return op->emitOpError()
            << "expects " << name
            << " boxed tile rows to be a multiple of innerRows (" << innerRows
            << "), but got " << rows;
-  if (cols != ShapedType::kDynamic && cols % innerCols != 0)
+  }
+  if (cols != ShapedType::kDynamic && cols % innerCols != 0) {
     return op->emitOpError()
            << "expects " << name
            << " boxed tile cols to be a multiple of innerCols (" << innerCols
            << "), but got " << cols;
+  }
 
   return success();
 }
 
 [[maybe_unused]] static bool isSupportedLoadStoreElemTypeA2A3(Type ty) {
-  if (ty.isF16() || ty.isBF16() || ty.isF32())
+  if (ty.isF16() || ty.isBF16() || ty.isF32()) {
     return true;
+  }
   if (auto it = dyn_cast<IntegerType>(ty)) {
     unsigned width = it.getWidth();
     return width == 8 || width == 16 || width == 32 || width == 64;
@@ -1903,8 +2108,9 @@ static LogicalResult verifyTileBufLayoutConstraints(Operation *op,
 }
 
 static bool isSupportedGatherElemTypeA2A3(Type ty) {
-  if (ty.isF16() || ty.isF32())
+  if (ty.isF16() || ty.isF32()) {
     return true;
+  }
   if (auto it = dyn_cast<IntegerType>(ty)) {
     unsigned width = it.getWidth();
     return width == 16 || width == 32;
@@ -1913,16 +2119,19 @@ static bool isSupportedGatherElemTypeA2A3(Type ty) {
 }
 
 static bool isSupportedGatherElemTypeA5(Type ty) {
-  if (isSupportedGatherElemTypeA2A3(ty) || ty.isBF16())
+  if (isSupportedGatherElemTypeA2A3(ty) || ty.isBF16()) {
     return true;
-  if (isPTOHiFloat8Type(ty))
+  }
+  if (isPTOHiFloat8Type(ty)) {
     return true;
+  }
   if (auto ft = dyn_cast<FloatType>(ty)) {
     unsigned width = ft.getWidth();
     return width == 8;
   }
-  if (auto it = dyn_cast<IntegerType>(ty))
+  if (auto it = dyn_cast<IntegerType>(ty)) {
     return it.getWidth() == 8 || it.getWidth() == 16 || it.getWidth() == 32;
+  }
   return false;
 }
 
@@ -1932,20 +2141,23 @@ static bool isStaticLayoutInt(int64_t value) {
 
 static std::optional<int64_t> multiplyLayoutInts(int64_t lhs, int64_t rhs) {
   int64_t product = 0;
-  if (llvm::MulOverflow(lhs, rhs, product))
+  if (llvm::MulOverflow(lhs, rhs, product)) {
     return std::nullopt;
+  }
   return product;
 }
 
 static std::optional<mlir::pto::Layout>
 inferLayout(ArrayRef<int64_t> shape, ArrayRef<int64_t> strides,
             unsigned elemBytes) {
-  if (shape.size() != strides.size() || elemBytes == 0)
+  if (shape.size() != strides.size() || elemBytes == 0) {
     return std::nullopt;
+  }
   if (llvm::any_of(shape, [](int64_t dim) { return !isStaticLayoutInt(dim); }) ||
       llvm::any_of(strides,
-                   [](int64_t stride) { return !isStaticLayoutInt(stride); }))
+                   [](int64_t stride) { return !isStaticLayoutInt(stride); })) {
     return std::nullopt;
+  }
 
   // NZ / fractal: rank>=5, check middle dims (sh3/sh4/sh5 per spec)
   if (shape.size() >= 5) {
@@ -1958,8 +2170,9 @@ inferLayout(ArrayRef<int64_t> shape, ArrayRef<int64_t> strides,
             : std::nullopt;
     bool alignMatch = (sh3 == 16) && fractalBytes && (*fractalBytes == 512);
     bool strideMatch = (st5 == 1) && (st4 == sh5);
-    if (alignMatch && strideMatch)
+    if (alignMatch && strideMatch) {
       return mlir::pto::Layout::NZ;
+    }
   }
 
   // ND: row-major contiguous
@@ -1971,8 +2184,9 @@ inferLayout(ArrayRef<int64_t> shape, ArrayRef<int64_t> strides,
       break;
     }
   }
-  if (isRowMajor && strides.back() == 1)
+  if (isRowMajor && strides.back() == 1) {
     return mlir::pto::Layout::ND;
+  }
 
   // DN: col-major
   bool isColMajor = true;
@@ -1983,17 +2197,20 @@ inferLayout(ArrayRef<int64_t> shape, ArrayRef<int64_t> strides,
       break;
     }
   }
-  if (isColMajor && strides.front() == 1)
+  if (isColMajor && strides.front() == 1) {
     return mlir::pto::Layout::DN;
+  }
 
   return mlir::pto::Layout::ND; // fallback
 }
 
 static std::optional<pto::Layout> getLogicalViewLayout(Value value) {
-  if (!value)
+  if (!value) {
     return std::nullopt;
-  if (auto part = value.getDefiningOp<pto::PartitionViewOp>())
+  }
+  if (auto part = value.getDefiningOp<pto::PartitionViewOp>()) {
     return getLogicalViewLayout(part.getSource());
+  }
   if (auto make = value.getDefiningOp<pto::MakeTensorViewOp>()) {
     // Prefer the explicit layout attribute when available.  After rank-2 →
     // rank-5 canonicalization, the padded leading strides satisfy the ND
@@ -2003,18 +2220,21 @@ static std::optional<pto::Layout> getLogicalViewLayout(Value value) {
     // layout attribute carries the *intended* memory layout and is the
     // authoritative source — inferLayout is only a fallback for views that
     // lack an explicit layout.
-    if (auto layoutAttr = make.getLayoutAttr())
+    if (auto layoutAttr = make.getLayoutAttr()) {
       return layoutAttr.getLayout();
+    }
     auto tvTy = dyn_cast<pto::TensorViewType>(make.getResult().getType());
-    if (!tvTy)
+    if (!tvTy) {
       return std::nullopt;
+    }
     SmallVector<int64_t> shape(tvTy.getShape().begin(), tvTy.getShape().end());
     SmallVector<int64_t> strides;
     strides.reserve(make.getStrides().size());
     for (Value stride : make.getStrides()) {
       auto cst = getConstIndexValue(stride);
-      if (!cst)
+      if (!cst) {
         return std::nullopt;
+      }
       strides.push_back(*cst);
     }
     return inferLayout(shape, strides, getElemByteSize(tvTy.getElementType()));
@@ -2023,16 +2243,20 @@ static std::optional<pto::Layout> getLogicalViewLayout(Value value) {
 }
 
 static std::optional<pto::Layout> getTileBufLogicalLayout(pto::TileBufType type) {
-  if (!type)
+  if (!type) {
     return std::nullopt;
+  }
   int32_t sl = type.getSLayoutValueI32();
   int32_t bl = type.getBLayoutValueI32();
-  if (sl != static_cast<int32_t>(pto::SLayout::NoneBox))
+  if (sl != static_cast<int32_t>(pto::SLayout::NoneBox)) {
     return pto::Layout::NZ;
-  if (bl == static_cast<int32_t>(pto::BLayout::RowMajor))
+  }
+  if (bl == static_cast<int32_t>(pto::BLayout::RowMajor)) {
     return pto::Layout::ND;
-  if (bl == static_cast<int32_t>(pto::BLayout::ColMajor))
+  }
+  if (bl == static_cast<int32_t>(pto::BLayout::ColMajor)) {
     return pto::Layout::DN;
+  }
   return std::nullopt;
 }
 
@@ -2049,61 +2273,73 @@ static bool isColMajorTileBuf(Type ty) {
 
 static LogicalResult verifyRowReductionSrcLayout(Operation *op, Type ty,
                                                  StringRef name) {
-  if (failed(verifyTileBufCommon(op, ty, name)))
+  if (failed(verifyTileBufCommon(op, ty, name))) {
     return failure();
+  }
   auto as = getPTOMemorySpaceEnum(ty);
-  if (!as || *as != pto::AddressSpace::VEC)
+  if (!as || *as != pto::AddressSpace::VEC) {
     return op->emitOpError() << "expects " << name << " to be in the vec address space";
-  if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
-    if (tb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor))
-      return op->emitOpError() << "expects " << name << " to use the row_major blayout";
   }
   if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
-    if (tb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
+    if (tb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor)) {
+      return op->emitOpError() << "expects " << name << " to use the row_major blayout";
+    }
+  }
+  if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
+    if (tb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox)) {
       return op->emitOpError() << "expects " << name
                                << " to use the none_box slayout";
+    }
   }
   if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
     auto layout = getTileBufLogicalLayout(tb);
-    if (layout && *layout != pto::Layout::ND)
+    if (layout && *layout != pto::Layout::ND) {
       return op->emitOpError() << "expects " << name
                                << " to use an ND-style tile layout";
+    }
   }
   return success();
 }
 
 static LogicalResult verifyRowReductionDstLayout(Operation *op, Type ty,
                                                  StringRef name) {
-  if (failed(verifyTileBufCommon(op, ty, name)))
+  if (failed(verifyTileBufCommon(op, ty, name))) {
     return failure();
+  }
   auto as = getPTOMemorySpaceEnum(ty);
-  if (!as || *as != pto::AddressSpace::VEC)
+  if (!as || *as != pto::AddressSpace::VEC) {
     return op->emitOpError() << "expects " << name << " to be in the vec address space";
+  }
   if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
-    if (tb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
+    if (tb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox)) {
       return op->emitOpError() << "expects " << name
                                << " to use the none_box slayout";
+    }
   }
   if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
     if (tb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) &&
-        tb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor))
+        tb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor)) {
       return op->emitOpError() << "expects " << name
                                << " to use the row_major or col_major blayout";
+    }
   }
   if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
     auto layout = getTileBufLogicalLayout(tb);
     if (layout && *layout == pto::Layout::DN) {
       auto shape = getShapeVec(ty);
-      if (shape.size() == 2 && shape[1] != ShapedType::kDynamic && shape[1] != 1)
+      if (shape.size() == 2 && shape[1] != ShapedType::kDynamic && shape[1] != 1) {
         return op->emitOpError() << "expects DN-style " << name
                                  << " to have shape[1] == 1";
+      }
       return success();
     }
-    if (layout && *layout == pto::Layout::ND)
+    if (layout && *layout == pto::Layout::ND) {
       return success();
-    if (layout)
+    }
+    if (layout) {
       return op->emitOpError() << "expects " << name
                                << " to use a DN-style column vector tile or legacy ND-style tile";
+    }
   }
   // The dst valid_shape[1] == 1 constraint for row reductions is enforced in
   // verifyRowReductionValidRegion (it must be conditional on the no-op-marker
@@ -2117,8 +2353,9 @@ static LogicalResult verifyRowReductionValidRegion(Operation *op, Type srcTy,
                                                    bool allowEmptyMarker) {
   auto srcValid = getValidShapeVec(srcTy);
   auto dstValid = getValidShapeVec(dstTy);
-  if (srcValid.size() != 2 || dstValid.size() != 2)
+  if (srcValid.size() != 2 || dstValid.size() != 2) {
     return op->emitOpError("expects src and dst to have rank-2 valid_shape");
+  }
   // A fully-empty dst valid region (0x0) is PyPTO's dual-AIV no-op replay
   // marker: the op writes no elements, so accept it and skip the non-empty
   // structural constraints. Only plain reductions opt in (allowEmptyMarker);
@@ -2126,17 +2363,22 @@ static LogicalResult verifyRowReductionValidRegion(Operation *op, Type srcTy,
   // so they stay strict. One-sided empties (only one dim 0) still fall through
   // and are rejected below. Hardware Rv=0 no-op is tracked in pto-isa#143;
   // PTOAS only guarantees the IR is legal here.
-  if (allowEmptyMarker && dstValid[0] == 0 && dstValid[1] == 0)
+  if (allowEmptyMarker && dstValid[0] == 0 && dstValid[1] == 0) {
     return success();
-  if (srcValid[0] != ShapedType::kDynamic && srcValid[0] == 0)
+  }
+  if (srcValid[0] != ShapedType::kDynamic && srcValid[0] == 0) {
     return op->emitOpError("expects src valid_shape[0] to be non-zero");
-  if (srcValid[1] != ShapedType::kDynamic && srcValid[1] == 0)
+  }
+  if (srcValid[1] != ShapedType::kDynamic && srcValid[1] == 0) {
     return op->emitOpError("expects src valid_shape[1] to be non-zero");
+  }
   if (srcValid[0] != ShapedType::kDynamic && dstValid[0] != ShapedType::kDynamic &&
-      srcValid[0] != dstValid[0])
+      srcValid[0] != dstValid[0]) {
     return op->emitOpError("expects src and dst to have the same valid_shape[0]");
-  if (dstValid[1] != ShapedType::kDynamic && dstValid[1] != 1)
+  }
+  if (dstValid[1] != ShapedType::kDynamic && dstValid[1] != 1) {
     return op->emitOpError("expects dst valid_shape[1] to be 1");
+  }
   return success();
 }
 
@@ -2149,15 +2391,19 @@ static bool isSupportedRowReductionElemType(Type elem) {
 verifyTRowReductionNoTmpCommon(Operation *op, Type srcTy, Type dstTy,
                                StringRef elemTypeError) {
   if (failed(verifyRowReductionSrcLayout(op, srcTy, "src")) ||
-      failed(verifyRowReductionDstLayout(op, dstTy, "dst")))
+      failed(verifyRowReductionDstLayout(op, dstTy, "dst"))) {
     return failure();
-  if (getElemTy(srcTy) != getElemTy(dstTy))
+  }
+  if (getElemTy(srcTy) != getElemTy(dstTy)) {
     return op->emitOpError("expects src and dst to have the same element type");
+  }
   if (failed(verifyRowReductionValidRegion(op, srcTy, dstTy,
-                                           /*allowEmptyMarker=*/true)))
+                                           /*allowEmptyMarker=*/true))) {
     return failure();
-  if (!isSupportedRowReductionElemType(getElemTy(srcTy)))
+  }
+  if (!isSupportedRowReductionElemType(getElemTy(srcTy))) {
     return op->emitOpError(elemTypeError);
+  }
   return success();
 }
 
@@ -2166,35 +2412,43 @@ static LogicalResult verifyTRowReductionWithTmpCommon(Operation *op, Type srcTy,
                                                       StringRef elemTypeError) {
   if (failed(verifyRowReductionSrcLayout(op, srcTy, "src")) ||
       failed(verifyVecTileStorage(op, tmpTy, "tmp")) ||
-      failed(verifyRowReductionDstLayout(op, dstTy, "dst")))
+      failed(verifyRowReductionDstLayout(op, dstTy, "dst"))) {
     return failure();
-  if (getElemTy(srcTy) != getElemTy(dstTy))
+  }
+  if (getElemTy(srcTy) != getElemTy(dstTy)) {
     return op->emitOpError("expects src and dst to have the same element type");
+  }
   if (getTargetArch(op) != PTOArch::A5 &&
-      getElemTy(srcTy) != getElemTy(tmpTy))
+      getElemTy(srcTy) != getElemTy(tmpTy)) {
     return op->emitOpError("expects A2/A3 tmp to have the same element type as src and dst");
+  }
   if (failed(verifyRowReductionValidRegion(op, srcTy, dstTy,
-                                           /*allowEmptyMarker=*/true)))
+                                           /*allowEmptyMarker=*/true))) {
     return failure();
-  if (!isSupportedRowReductionElemType(getElemTy(srcTy)))
+  }
+  if (!isSupportedRowReductionElemType(getElemTy(srcTy))) {
     return op->emitOpError(elemTypeError);
+  }
   if (getTargetArch(op) != PTOArch::A5 &&
-      failed(verifyTmpCapacityAtLeast(op, tmpTy, 32)))
+      failed(verifyTmpCapacityAtLeast(op, tmpTy, 32))) {
     return failure();
+  }
   return success();
 }
 
 static std::optional<int64_t> getVectorRepeatElements(Type elemTy) {
   unsigned elemBits = elemTy ? getPTOStorageElemBitWidth(elemTy) : 0;
-  if (elemBits == 0 || 2048 % elemBits != 0)
+  if (elemBits == 0 || 2048 % elemBits != 0) {
     return std::nullopt;
+  }
   return static_cast<int64_t>(2048 / elemBits);
 }
 
 static std::optional<int64_t> getVectorBlockElements(Type elemTy) {
   unsigned elemBits = elemTy ? getPTOStorageElemBitWidth(elemTy) : 0;
-  if (elemBits == 0 || 256 % elemBits != 0)
+  if (elemBits == 0 || 256 % elemBits != 0) {
     return std::nullopt;
+  }
   return static_cast<int64_t>(256 / elemBits);
 }
 
@@ -2206,12 +2460,14 @@ static int64_t ceilDivInt64(int64_t numerator, int64_t denominator) {
 
 static std::optional<int64_t> getArgReductionTmpMinStride(Type elemTy,
                                                           int64_t srcValidCols) {
-  if (srcValidCols == ShapedType::kDynamic || srcValidCols < 0)
+  if (srcValidCols == ShapedType::kDynamic || srcValidCols < 0) {
     return std::nullopt;
+  }
   auto repeatElems = getVectorRepeatElements(elemTy);
   auto blockElems = getVectorBlockElements(elemTy);
-  if (!repeatElems || !blockElems)
+  if (!repeatElems || !blockElems) {
     return std::nullopt;
+  }
   int64_t repeats = ceilDivInt64(srcValidCols, *repeatElems);
   return (ceilDivInt64(repeats * 2, *blockElems) +
           ceilDivInt64(repeats, *blockElems)) *
@@ -2225,26 +2481,32 @@ static bool hasExactKnownValidShape(Type lhsTy, Type rhsTy) {
 static LogicalResult verifyTColArgTmpA2A3(Operation *op, Type srcTy,
                                           Type tmpTy) {
   if (failed(verifyVecTileCommon(op, tmpTy, "tmp")) ||
-      failed(verifyTileBufSameElemType(op, srcTy, tmpTy, "src", "tmp")))
+      failed(verifyTileBufSameElemType(op, srcTy, tmpTy, "src", "tmp"))) {
     return failure();
+  }
 
-  if (hasExactKnownValidShape(srcTy, tmpTy))
+  if (hasExactKnownValidShape(srcTy, tmpTy)) {
     return verifyTmpCapacityAtLeast(op, tmpTy, 32);
+  }
 
   auto srcValid = getValidShapeVec(srcTy);
   auto tmpValid = getValidShapeVec(tmpTy);
-  if (srcValid.size() != 2 || tmpValid.size() != 2)
+  if (srcValid.size() != 2 || tmpValid.size() != 2) {
     return op->emitOpError("expects src and tmp to have rank-2 valid_shape");
-  if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 1)
+  }
+  if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 1) {
     return op->emitOpError("expects A2/A3 tmp valid_shape[0] to be at least 1");
+  }
   if (srcValid[1] != ShapedType::kDynamic) {
     auto minStride = getArgReductionTmpMinStride(getElemTy(srcTy), srcValid[1]);
-    if (!minStride)
+    if (!minStride) {
       return op->emitOpError("failed to infer A2/A3 tmp stride from src element type");
-    if (tmpValid[1] != ShapedType::kDynamic && tmpValid[1] < *minStride)
+    }
+    if (tmpValid[1] != ShapedType::kDynamic && tmpValid[1] < *minStride) {
       return op->emitOpError()
              << "expects A2/A3 tmp valid_shape[1] to be at least "
              << *minStride << " for src valid_shape[1] = " << srcValid[1];
+    }
   }
   return verifyTmpCapacityAtLeast(op, tmpTy, 32);
 }
@@ -2253,20 +2515,24 @@ static LogicalResult verifyTColArgReductionOpA2A3(Operation *op, Type srcTy,
                                                   Type tmpTy, Type dstTy) {
   if (failed(verifyNDStyleVecTile(op, srcTy, "src")) ||
       failed(verifyTColArgTmpA2A3(op, srcTy, tmpTy)) ||
-      failed(verifyColArgReductionDstLayout(op, dstTy, "dst")))
+      failed(verifyColArgReductionDstLayout(op, dstTy, "dst"))) {
     return failure();
+  }
   if (failed(verifyColReductionValidRegion(op, srcTy, dstTy,
-                                           /*requireNonZeroSrc=*/true)))
+                                           /*requireNonZeroSrc=*/true))) {
     return failure();
+  }
   Type srcElemTy = getElemTy(srcTy);
   unsigned srcElemBits = srcElemTy ? getPTOStorageElemBitWidth(srcElemTy) : 0;
   if (!(mlir::isa<IntegerType, FloatType>(srcElemTy) &&
-        (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32)))
+        (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32))) {
     return op->emitOpError(
         "expects src/tmp element type to be 1, 2, or 4 bytes wide");
+  }
   auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
-  if (!dstInt || dstInt.getWidth() != 32)
+  if (!dstInt || dstInt.getWidth() != 32) {
     return op->emitOpError("expects dst element type to be i32 or ui32");
+  }
   return success();
 }
 
@@ -2275,17 +2541,20 @@ static LogicalResult verifyTColArgReductionNoTmp(Operation *op, Type srcTy,
   if (failed(verifyNDStyleVecTile(op, srcTy, "src")) ||
       failed(verifyColArgReductionDstLayout(op, dstTy, "dst")) ||
       failed(verifyColReductionValidRegion(op, srcTy, dstTy,
-                                           /*requireNonZeroSrc=*/true)))
+                                           /*requireNonZeroSrc=*/true))) {
     return failure();
+  }
   Type srcElemTy = getElemTy(srcTy);
   unsigned srcElemBits = srcElemTy ? getPTOStorageElemBitWidth(srcElemTy) : 0;
   if (!(mlir::isa<IntegerType, FloatType>(srcElemTy) &&
-        (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32)))
+        (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32))) {
     return op->emitOpError(
         "expects src element type to be 1, 2, or 4 bytes wide");
+  }
   auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
-  if (!dstInt || dstInt.getWidth() != 32)
+  if (!dstInt || dstInt.getWidth() != 32) {
     return op->emitOpError("expects dst element type to be i32 or ui32");
+  }
   return success();
 }
 
@@ -2293,32 +2562,38 @@ static LogicalResult verifyTColArgReductionOpA5(Operation *op, Type srcTy,
                                                 Type tmpTy, Type dstTy) {
   if (failed(verifyNDStyleVecTile(op, srcTy, "src")) ||
       failed(verifyVecTileCommon(op, tmpTy, "tmp")) ||
-      failed(verifyColArgReductionDstLayout(op, dstTy, "dst")))
+      failed(verifyColArgReductionDstLayout(op, dstTy, "dst"))) {
     return failure();
+  }
   if (failed(verifyColReductionValidRegion(op, srcTy, dstTy,
-                                           /*requireNonZeroSrc=*/true)))
+                                           /*requireNonZeroSrc=*/true))) {
     return failure();
+  }
   Type srcElemTy = getElemTy(srcTy);
   unsigned srcElemBits = srcElemTy ? getPTOStorageElemBitWidth(srcElemTy) : 0;
   if (!(mlir::isa<IntegerType, FloatType>(srcElemTy) &&
-        (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32)))
+        (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32))) {
     return op->emitOpError(
         "expects src element type to be 1, 2, or 4 bytes wide");
+  }
   auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
-  if (!dstInt || dstInt.getWidth() != 32)
+  if (!dstInt || dstInt.getWidth() != 32) {
     return op->emitOpError("expects dst element type to be i32 or ui32");
+  }
   return success();
 }
 
 static LogicalResult verifyTColSumTmpStride(Operation *op, Type srcTy,
                                             Type tmpTy, bool isBinary) {
-  if (!isBinary)
+  if (!isBinary) {
     return success();
+  }
 
   auto srcValid = getValidShapeVec(srcTy);
   auto tmpShape = getShapeVec(tmpTy);
-  if (srcValid.size() != 2 || tmpShape.size() != 2)
+  if (srcValid.size() != 2 || tmpShape.size() != 2) {
     return op->emitOpError("expects src and tmp to be rank-2 tiles");
+  }
 
   int64_t srcValidCols = srcValid[1];
   int64_t tmpStride = tmpShape[1];
@@ -2335,71 +2610,87 @@ static LogicalResult verifyTColSumTmpStride(Operation *op, Type srcTy,
 static LogicalResult verifyTRowArgTmpA2A3(Operation *op, Type srcTy,
                                           Type tmpTy) {
   if (failed(verifyVecTileStorage(op, tmpTy, "tmp")) ||
-      failed(verifyTileBufSameElemType(op, srcTy, tmpTy, "src", "tmp")))
+      failed(verifyTileBufSameElemType(op, srcTy, tmpTy, "src", "tmp"))) {
     return failure();
+  }
 
-  if (hasExactKnownValidShape(srcTy, tmpTy))
+  if (hasExactKnownValidShape(srcTy, tmpTy)) {
     return verifyTmpCapacityAtLeast(op, tmpTy, 32);
+  }
 
   auto srcShape = getShapeVec(srcTy);
   auto tmpShape = getShapeVec(tmpTy);
   auto srcValid = getValidShapeVec(srcTy);
   auto tmpValid = getValidShapeVec(tmpTy);
   if (srcShape.size() != 2 || tmpShape.size() != 2 || srcValid.size() != 2 ||
-      tmpValid.size() != 2)
+      tmpValid.size() != 2) {
     return op->emitOpError("expects src and tmp to be rank-2 tiles");
+  }
 
   auto repeatElems = getVectorRepeatElements(getElemTy(srcTy));
-  if (!repeatElems)
+  if (!repeatElems) {
     return op->emitOpError("failed to infer A2/A3 tmp contract from src element type");
+  }
 
   if (srcValid[1] != ShapedType::kDynamic && srcValid[1] <= *repeatElems) {
     auto tmpTile = dyn_cast<pto::TileBufType>(tmpTy);
     auto layout = tmpTile ? getTileBufLogicalLayout(tmpTile) : std::nullopt;
     if (layout && *layout == pto::Layout::DN) {
-      if (tmpShape[1] != ShapedType::kDynamic && tmpShape[1] != 1)
+      if (tmpShape[1] != ShapedType::kDynamic && tmpShape[1] != 1) {
         return op->emitOpError("expects A2/A3 tmp DN layout to have shape[1] == 1");
-      if (tmpValid[1] != ShapedType::kDynamic && tmpValid[1] != 1)
+      }
+      if (tmpValid[1] != ShapedType::kDynamic && tmpValid[1] != 1) {
         return op->emitOpError(
             "expects A2/A3 tmp DN layout to have valid_shape[1] == 1");
+      }
       if (srcValid[0] != ShapedType::kDynamic && tmpValid[0] != ShapedType::kDynamic &&
-          tmpValid[0] < srcValid[0] * 2)
+          tmpValid[0] < srcValid[0] * 2) {
         return op->emitOpError()
                << "expects A2/A3 tmp DN layout to have valid_shape[0] >= "
                << (srcValid[0] * 2);
+      }
       return verifyTmpCapacityAtLeast(op, tmpTy, 32);
     }
 
-    if (!layout || *layout != pto::Layout::ND)
+    if (!layout || *layout != pto::Layout::ND) {
       return op->emitOpError(
           "expects A2/A3 tmp to use DN 1-col or ND 2-col layout when src valid_shape[1] fits in one repeat");
-    if (failed(verifyVecTileCommon(op, tmpTy, "tmp")))
+    }
+    if (failed(verifyVecTileCommon(op, tmpTy, "tmp"))) {
       return failure();
+    }
     if (srcValid[0] != ShapedType::kDynamic && tmpValid[0] != ShapedType::kDynamic &&
-        tmpValid[0] < srcValid[0])
+        tmpValid[0] < srcValid[0]) {
       return op->emitOpError("expects A2/A3 tmp valid_shape[0] to cover src valid rows");
-    if (tmpValid[1] != ShapedType::kDynamic && tmpValid[1] < 2)
+    }
+    if (tmpValid[1] != ShapedType::kDynamic && tmpValid[1] < 2) {
       return op->emitOpError(
           "expects A2/A3 tmp valid_shape[1] to be at least 2 in the small-col ND path");
+    }
     return verifyTmpCapacityAtLeast(op, tmpTy, 32);
   }
 
-  if (failed(verifyVecTileCommon(op, tmpTy, "tmp")))
+  if (failed(verifyVecTileCommon(op, tmpTy, "tmp"))) {
     return failure();
+  }
   if (srcShape[0] != ShapedType::kDynamic && tmpShape[0] != ShapedType::kDynamic &&
-      tmpShape[0] != srcShape[0])
+      tmpShape[0] != srcShape[0]) {
     return op->emitOpError("expects A2/A3 tmp shape[0] to match src shape[0]");
+  }
   if (srcValid[0] != ShapedType::kDynamic && tmpValid[0] != ShapedType::kDynamic &&
-      tmpValid[0] < srcValid[0])
+      tmpValid[0] < srcValid[0]) {
     return op->emitOpError("expects A2/A3 tmp valid_shape[0] to cover src valid rows");
+  }
   if (srcValid[1] != ShapedType::kDynamic) {
     auto minStride = getArgReductionTmpMinStride(getElemTy(srcTy), srcValid[1]);
-    if (!minStride)
+    if (!minStride) {
       return op->emitOpError("failed to infer A2/A3 tmp stride from src element type");
-    if (tmpValid[1] != ShapedType::kDynamic && tmpValid[1] < *minStride)
+    }
+    if (tmpValid[1] != ShapedType::kDynamic && tmpValid[1] < *minStride) {
       return op->emitOpError()
              << "expects A2/A3 tmp valid_shape[1] to be at least "
              << *minStride << " for src valid_shape[1] = " << srcValid[1];
+    }
   }
   return verifyTmpCapacityAtLeast(op, tmpTy, 32);
 }
@@ -2408,17 +2699,21 @@ static LogicalResult verifyTRowArgReductionOpA2A3(Operation *op, Type srcTy,
                                                   Type tmpTy, Type dstTy) {
   if (failed(verifyRowReductionSrcLayout(op, srcTy, "src")) ||
       failed(verifyTRowArgTmpA2A3(op, srcTy, tmpTy)) ||
-      failed(verifyRowReductionDstLayout(op, dstTy, "dst")))
+      failed(verifyRowReductionDstLayout(op, dstTy, "dst"))) {
     return failure();
+  }
   if (failed(verifyRowReductionValidRegion(op, srcTy, dstTy,
-                                           /*allowEmptyMarker=*/false)))
+                                           /*allowEmptyMarker=*/false))) {
     return failure();
+  }
   Type srcElem = getElemTy(srcTy);
-  if (!isSupportedRowReductionElemType(srcElem))
+  if (!isSupportedRowReductionElemType(srcElem)) {
     return op->emitOpError("expects src element type to be i16/i32/f16/f32");
+  }
   auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
-  if (!dstInt || dstInt.getWidth() != 32)
+  if (!dstInt || dstInt.getWidth() != 32) {
     return op->emitOpError("expects dst element type to be i32 or ui32");
+  }
   return success();
 }
 
@@ -2427,14 +2722,17 @@ static LogicalResult verifyTRowArgReductionNoTmp(Operation *op, Type srcTy,
   if (failed(verifyRowReductionSrcLayout(op, srcTy, "src")) ||
       failed(verifyRowReductionDstLayout(op, dstTy, "dst")) ||
       failed(verifyRowReductionValidRegion(op, srcTy, dstTy,
-                                           /*allowEmptyMarker=*/false)))
+                                           /*allowEmptyMarker=*/false))) {
     return failure();
+  }
   Type srcElem = getElemTy(srcTy);
-  if (!isSupportedRowReductionElemType(srcElem))
+  if (!isSupportedRowReductionElemType(srcElem)) {
     return op->emitOpError("expects src element type to be i16/i32/f16/f32");
+  }
   auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
-  if (!dstInt || dstInt.getWidth() != 32)
+  if (!dstInt || dstInt.getWidth() != 32) {
     return op->emitOpError("expects dst element type to be i32 or ui32");
+  }
   return success();
 }
 
@@ -2442,32 +2740,40 @@ static LogicalResult verifyTRowArgReductionOpA5(Operation *op, Type srcTy,
                                                 Type tmpTy, Type dstTy) {
   if (failed(verifyRowReductionSrcLayout(op, srcTy, "src")) ||
       failed(verifyVecTileCommon(op, tmpTy, "tmp")) ||
-      failed(verifyRowReductionDstLayout(op, dstTy, "dst")))
+      failed(verifyRowReductionDstLayout(op, dstTy, "dst"))) {
     return failure();
+  }
   if (failed(verifyRowReductionValidRegion(op, srcTy, dstTy,
-                                           /*allowEmptyMarker=*/false)))
+                                           /*allowEmptyMarker=*/false))) {
     return failure();
+  }
   Type srcElem = getElemTy(srcTy);
-  if (!isSupportedRowReductionElemType(srcElem))
+  if (!isSupportedRowReductionElemType(srcElem)) {
     return op->emitOpError("expects src element type to be i16/i32/f16/f32");
+  }
   auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
-  if (!dstInt || dstInt.getWidth() != 32)
+  if (!dstInt || dstInt.getWidth() != 32) {
     return op->emitOpError("expects dst element type to be i32 or ui32");
+  }
   return success();
 }
 
 static LogicalResult verifyNDStyleVecTile(Operation *op, Type ty, StringRef name,
                                           bool allowLowPrecision) {
-  if (failed(verifyTileBufCommon(op, ty, name, allowLowPrecision)))
+  if (failed(verifyTileBufCommon(op, ty, name, allowLowPrecision))) {
     return failure();
+  }
   auto as = getPTOMemorySpaceEnum(ty);
-  if (!as || *as != pto::AddressSpace::VEC)
+  if (!as || *as != pto::AddressSpace::VEC) {
     return op->emitOpError() << "expects " << name << " to be in the vec address space";
+  }
   if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
-    if (tb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor))
+    if (tb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor)) {
       return op->emitOpError() << "expects " << name << " to use the row_major blayout";
-    if (tb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
+    }
+    if (tb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox)) {
       return op->emitOpError() << "expects " << name << " to use the none_box slayout";
+    }
   }
   return success();
 }
@@ -2477,8 +2783,9 @@ static LogicalResult verifyColReductionValidRegion(Operation *op, Type srcTy,
                                                    bool requireNonZeroSrc) {
   auto srcValid = getValidShapeVec(srcTy);
   auto dstValid = getValidShapeVec(dstTy);
-  if (srcValid.size() != 2 || dstValid.size() != 2)
+  if (srcValid.size() != 2 || dstValid.size() != 2) {
     return op->emitOpError("expects src and dst to have rank-2 valid_shape");
+  }
   // Fully-empty dst valid region (0x0): dual-AIV no-op replay marker. The op
   // writes no elements; accept and skip the non-empty constraints. One-sided
   // empties still fall through. See pto-isa#143 for hardware Rv=0 no-op.
@@ -2486,97 +2793,116 @@ static LogicalResult verifyColReductionValidRegion(Operation *op, Type srcTy,
   // 0x0 dst: verifyColArgReductionDstLayout enforces dst valid_shape[0] == 1
   // first, so they stay strict without needing a flag here (unlike the row
   // path, whose dst-layout check does not constrain valid).
-  if (dstValid[0] == 0 && dstValid[1] == 0)
+  if (dstValid[0] == 0 && dstValid[1] == 0) {
     return success();
+  }
   if (requireNonZeroSrc) {
-    if (srcValid[0] != ShapedType::kDynamic && srcValid[0] == 0)
+    if (srcValid[0] != ShapedType::kDynamic && srcValid[0] == 0) {
       return op->emitOpError("expects src valid_shape[0] to be non-zero");
-    if (srcValid[1] != ShapedType::kDynamic && srcValid[1] == 0)
+    }
+    if (srcValid[1] != ShapedType::kDynamic && srcValid[1] == 0) {
       return op->emitOpError("expects src valid_shape[1] to be non-zero");
+    }
   }
   if (srcValid[1] != ShapedType::kDynamic && dstValid[1] != ShapedType::kDynamic &&
-      srcValid[1] != dstValid[1])
+      srcValid[1] != dstValid[1]) {
     return op->emitOpError("expects src and dst to have the same valid_shape[1]");
+  }
   return success();
 }
 
 static LogicalResult verifyColArgReductionDstLayout(Operation *op, Type ty,
                                                     StringRef name) {
-  if (failed(verifyNDStyleVecTile(op, ty, name)))
+  if (failed(verifyNDStyleVecTile(op, ty, name))) {
     return failure();
+  }
   auto valid = getValidShapeVec(ty);
-  if (valid.size() != 2)
+  if (valid.size() != 2) {
     return op->emitOpError() << "expects " << name
                              << " to have rank-2 valid_shape";
-  if (valid[0] != ShapedType::kDynamic && valid[0] != 1)
+  }
+  if (valid[0] != ShapedType::kDynamic && valid[0] != 1) {
     return op->emitOpError() << "expects " << name
                              << " valid_shape[0] to be 1";
+  }
   return success();
 }
 
 static std::optional<int64_t> getConstantIntegerValue(Value value) {
-  if (!value)
+  if (!value) {
     return std::nullopt;
+  }
   if (auto arithCst = value.getDefiningOp<arith::ConstantOp>()) {
-    if (auto intAttr = dyn_cast<IntegerAttr>(arithCst.getValue()))
+    if (auto intAttr = dyn_cast<IntegerAttr>(arithCst.getValue())) {
       return intAttr.getInt();
+    }
   }
   return std::nullopt;
 }
 
 LogicalResult mlir::pto::SectionSimtOp::verify() {
   func::FuncOp func = getOperation()->getParentOfType<func::FuncOp>();
-  if (!func)
+  if (!func) {
     return emitOpError("must be nested under a func.func");
+  }
 
   if (getDimXAttr().getInt() < 0 || getDimYAttr().getInt() < 0 ||
-      getDimZAttr().getInt() < 0)
+      getDimZAttr().getInt() < 0) {
     return emitOpError("requires non-negative i32 launch dimensions");
+  }
 
-  if (func->hasAttr(pto::kPTOSimtEntryAttrName))
+  if (func->hasAttr(pto::kPTOSimtEntryAttrName)) {
     return emitOpError("must not appear inside a function marked with '")
            << pto::kPTOSimtEntryAttrName << "'";
+  }
 
   WalkResult nested = getBody().walk([&](SectionSimtOp nestedOp) {
     nestedOp.emitOpError("nested pto.section.simt is not allowed");
     return WalkResult::interrupt();
   });
-  if (nested.wasInterrupted())
+  if (nested.wasInterrupted()) {
     return failure();
+  }
 
   return success();
 }
 
 LogicalResult mlir::pto::FusionRegionOp::verify() {
   Region &bodyRegion = getBody();
-  if (bodyRegion.empty())
+  if (bodyRegion.empty()) {
     return emitOpError("expects a non-empty body region");
+  }
 
   Block &body = bodyRegion.front();
-  if (body.getNumArguments() != 0)
+  if (body.getNumArguments() != 0) {
     return emitOpError() << "expects body block to have no arguments, got "
                          << body.getNumArguments();
+  }
 
-  if (body.empty() || !body.back().hasTrait<OpTrait::IsTerminator>())
+  if (body.empty() || !body.back().hasTrait<OpTrait::IsTerminator>()) {
     return emitOpError("expects body to terminate with pto.yield");
+  }
 
   auto yield = dyn_cast<YieldOp>(&body.back());
-  if (!yield)
+  if (!yield) {
     return emitOpError("expects body to terminate with pto.yield");
+  }
 
-  if (yield.getValues().size() != getOutputs().size())
+  if (yield.getValues().size() != getOutputs().size()) {
     return emitOpError() << "expects pto.yield to return "
                          << getOutputs().size() << " values, got "
                          << yield.getValues().size();
+  }
 
   for (auto [idx, pair] :
        llvm::enumerate(llvm::zip(yield.getValues(), getOutputs()))) {
     Value yielded = std::get<0>(pair);
     Value output = std::get<1>(pair);
-    if (yielded.getType() != output.getType())
+    if (yielded.getType() != output.getType()) {
       return emitOpError() << "expects yielded value #" << idx << " to have "
                            << "type " << output.getType() << ", got "
                            << yielded.getType();
+    }
   }
 
   return success();
@@ -2584,22 +2910,25 @@ LogicalResult mlir::pto::FusionRegionOp::verify() {
 
 LogicalResult mlir::pto::YieldOp::verify() {
   auto parent = dyn_cast_or_null<FusionRegionOp>(getOperation()->getParentOp());
-  if (!parent)
+  if (!parent) {
     return emitOpError("expects parent op to be pto.fusion_region");
+  }
 
-  if (getValues().size() != parent.getOutputs().size())
+  if (getValues().size() != parent.getOutputs().size()) {
     return emitOpError() << "expects " << parent.getOutputs().size()
                          << " yielded values to match parent results, got "
                          << getValues().size();
+  }
 
   for (auto [idx, pair] :
        llvm::enumerate(llvm::zip(getValues(), parent.getOutputs()))) {
     Value yielded = std::get<0>(pair);
     Value output = std::get<1>(pair);
-    if (yielded.getType() != output.getType())
+    if (yielded.getType() != output.getType()) {
       return emitOpError() << "expects yielded value #" << idx << " to have "
                            << "type " << output.getType() << ", got "
                            << yielded.getType();
+    }
   }
 
   return success();
@@ -2607,24 +2936,28 @@ LogicalResult mlir::pto::YieldOp::verify() {
 
 LogicalResult mlir::pto::MakeTensorViewOp::verify() {
   auto tvTy = dyn_cast<mlir::pto::TensorViewType>(getResult().getType());
-  if (!tvTy)
+  if (!tvTy) {
     return emitOpError("result must be pto.tensor_view<...>");
+  }
 
   auto ptrTy = dyn_cast<mlir::pto::PtrType>(getPtr().getType());
-  if (!ptrTy)
+  if (!ptrTy) {
     return emitOpError("ptr operand must be !pto.ptr<...>");
+  }
   Type ptrElemTy = ptrTy.getElementType();
 
-  if (ptrElemTy != tvTy.getElementType())
+  if (ptrElemTy != tvTy.getElementType()) {
     return emitOpError() << "ptr element type must match tensor_view element "
                             "type, but got ptr="
                          << ptrElemTy << " view=" << tvTy.getElementType();
+  }
 
   int64_t rank = tvTy.getRank();
 
-  if ((int64_t)getShape().size() != rank || (int64_t)getStrides().size() != rank)
+  if ((int64_t)getShape().size() != rank || (int64_t)getStrides().size() != rank) {
     return emitOpError() << "shape/strides operand counts must match tensor_view rank="
                          << rank;
+  }
 
   // Detect dynamic shape/stride.
   bool hasDynamicShape = llvm::any_of(tvTy.getShape(), [](int64_t v) {
@@ -2671,22 +3004,26 @@ LogicalResult mlir::pto::MakeTensorViewOp::verify() {
 LogicalResult mlir::pto::PartitionViewOp::verify() {
   auto srcTy = dyn_cast<mlir::pto::TensorViewType>(getSource().getType());
   auto resTy = dyn_cast<mlir::pto::PartitionTensorViewType>(getResult().getType());
-  if (!srcTy || !resTy)
+  if (!srcTy || !resTy) {
     return emitOpError("expects tensor_view source and partition_tensor_view result");
+  }
 
-  if (srcTy.getElementType() != resTy.getElementType())
+  if (srcTy.getElementType() != resTy.getElementType()) {
     return emitOpError() << "element type mismatch between source and result: src="
                          << srcTy.getElementType() << " result="
                          << resTy.getElementType();
+  }
 
   int64_t srcRank = srcTy.getRank();
-  if ((int64_t)getOffsets().size() != srcRank)
+  if ((int64_t)getOffsets().size() != srcRank) {
     return emitOpError() << "offset count (" << getOffsets().size()
                          << ") must match source rank (" << srcRank << ")";
+  }
 
-  if ((int64_t)getSizes().size() != srcRank)
+  if ((int64_t)getSizes().size() != srcRank) {
     return emitOpError() << "size count (" << getSizes().size()
                          << ") must match source rank (" << srcRank << ")";
+  }
 
   ArrayRef<int64_t> srcShape = srcTy.getShape();
   ArrayRef<int64_t> resShape = resTy.getShape();
@@ -2696,34 +3033,40 @@ LogicalResult mlir::pto::PartitionViewOp::verify() {
     auto offVal = getConstIndexValue(getOffsets()[i]);
     auto sizeVal = getConstIndexValue(getSizes()[i]);
 
-    if (offVal && *offVal < 0)
+    if (offVal && *offVal < 0) {
       return emitOpError() << "offset at dim " << i
                            << " must be non-negative, got " << *offVal;
+    }
 
-    if (sizeVal && *sizeVal <= 0)
+    if (sizeVal && *sizeVal <= 0) {
       return emitOpError() << "size at dim " << i
                            << " must be positive, got " << *sizeVal;
+    }
 
     if (sameRank && sizeVal) {
       int64_t resDim = resShape[i];
-      if (resDim != ShapedType::kDynamic && *sizeVal != resDim)
+      if (resDim != ShapedType::kDynamic && *sizeVal != resDim) {
         return emitOpError() << "size/result mismatch at dim " << i
                              << ": size operand=" << *sizeVal
                              << " result type dim=" << resDim;
+      }
     }
 
     int64_t srcDim = srcShape[i];
-    if (srcDim == ShapedType::kDynamic)
+    if (srcDim == ShapedType::kDynamic) {
       continue;
+    }
 
-    if (sizeVal && *sizeVal > srcDim)
+    if (sizeVal && *sizeVal > srcDim) {
       return emitOpError() << "size at dim " << i << " (" << *sizeVal
                            << ") exceeds static source dim (" << srcDim << ")";
+    }
 
-    if (offVal && sizeVal && (*offVal + *sizeVal > srcDim))
+    if (offVal && sizeVal && (*offVal + *sizeVal > srcDim)) {
       return emitOpError() << "offset+size at dim " << i << " ("
                            << (*offVal + *sizeVal)
                            << ") exceeds static source dim (" << srcDim << ")";
+    }
   }
 
   return success();
@@ -2734,64 +3077,78 @@ LogicalResult mlir::pto::AddPtrOp::verify() {
   Value result = getOperation()->getResult(0);
 
   auto ptrTy = dyn_cast<mlir::pto::PtrType>(ptr.getType());
-  if (!ptrTy)
+  if (!ptrTy) {
     return emitOpError("ptr operand must be !pto.ptr<...>");
+  }
 
   auto resTy = dyn_cast<mlir::pto::PtrType>(result.getType());
-  if (!resTy)
+  if (!resTy) {
     return emitOpError("result must be !pto.ptr<...>");
+  }
 
-  if (ptrTy != resTy)
+  if (ptrTy != resTy) {
     return emitOpError("result type must match ptr operand type");
+  }
 
   return success();
 }
 
 static Type getPointerLikeElementType(Type type) {
-  if (auto ptrTy = dyn_cast<mlir::pto::PtrType>(type))
+  if (auto ptrTy = dyn_cast<mlir::pto::PtrType>(type)) {
     return ptrTy.getElementType();
+  }
   return Type();
 }
 
 static bool isEmitCSupportedScalarType(Type type) {
-  if (!type)
+  if (!type) {
     return false;
-  if (type.isF16() || type.isBF16() || type.isF32() || type.isF64())
+  }
+  if (type.isF16() || type.isBF16() || type.isF32() || type.isF64()) {
     return true;
-  if (auto intTy = dyn_cast<IntegerType>(type))
+  }
+  if (auto intTy = dyn_cast<IntegerType>(type)) {
     return intTy.getWidth() == 8 || intTy.getWidth() == 16 ||
            intTy.getWidth() == 32 || intTy.getWidth() == 64;
-  if (mlir::pto::isPTOFloat8Type(type))
+  }
+  if (mlir::pto::isPTOFloat8Type(type)) {
     return true;
+  }
   if (isa<mlir::pto::HiF8Type, mlir::pto::F4E1M2x2Type,
-          mlir::pto::F4E2M1x2Type>(type))
+          mlir::pto::F4E2M1x2Type>(type)) {
     return true;
+  }
   return false;
 }
 
 LogicalResult mlir::pto::PtrToIntOp::verify() {
   Type resultTy = getResult().getType();
   auto intTy = dyn_cast<IntegerType>(resultTy);
-  if (!intTy || intTy.getWidth() != 64)
+  if (!intTy || intTy.getWidth() != 64) {
     return emitOpError("result must be i64");
+  }
 
-  if (!isa<mlir::pto::PtrType>(getPtr().getType()))
+  if (!isa<mlir::pto::PtrType>(getPtr().getType())) {
     return emitOpError("ptr operand must be !pto.ptr<...>");
+  }
   return success();
 }
 
 LogicalResult mlir::pto::IntToPtrOp::verify() {
   auto addrTy = dyn_cast<IntegerType>(getAddr().getType());
-  if (!addrTy || addrTy.getWidth() != 64)
+  if (!addrTy || addrTy.getWidth() != 64) {
     return emitOpError("address operand must be i64");
+  }
 
-  if (!isa<mlir::pto::PtrType>(getResult().getType()))
+  if (!isa<mlir::pto::PtrType>(getResult().getType())) {
     return emitOpError("result must be !pto.ptr<...>");
+  }
 
   Type dstElem = getPointerLikeElementType(getResult().getType());
-  if (!isEmitCSupportedScalarType(dstElem))
+  if (!isEmitCSupportedScalarType(dstElem)) {
     return emitOpError("result element type is not supported by EmitC: ")
            << dstElem;
+  }
 
   return success();
 }
@@ -2800,15 +3157,17 @@ LogicalResult mlir::pto::LocalArrayGetOp::verify() {
   auto arrayTy = getArray().getType();
   int64_t rank = arrayTy.getRank();
   int64_t numIdx = static_cast<int64_t>(getIndices().size());
-  if (numIdx != rank)
+  if (numIdx != rank) {
     return emitOpError() << "expects " << rank
                          << " indices for !pto.local_array of rank " << rank
                          << ", got " << numIdx;
-  if (getResult().getType() != arrayTy.getElementType())
+  }
+  if (getResult().getType() != arrayTy.getElementType()) {
     return emitOpError()
            << "result type " << getResult().getType()
            << " does not match array element type "
            << arrayTy.getElementType();
+  }
   return success();
 }
 
@@ -2816,14 +3175,16 @@ LogicalResult mlir::pto::LocalArraySetOp::verify() {
   auto arrayTy = getArray().getType();
   int64_t rank = arrayTy.getRank();
   int64_t numIdx = static_cast<int64_t>(getIndices().size());
-  if (numIdx != rank)
+  if (numIdx != rank) {
     return emitOpError() << "expects " << rank
                          << " indices for !pto.local_array of rank " << rank
                          << ", got " << numIdx;
-  if (getValue().getType() != arrayTy.getElementType())
+  }
+  if (getValue().getType() != arrayTy.getElementType()) {
     return emitOpError() << "value type " << getValue().getType()
                          << " does not match array element type "
                          << arrayTy.getElementType();
+  }
   return success();
 }
 
@@ -2835,20 +3196,23 @@ LogicalResult mlir::pto::LocalArraySetOp::verify() {
 static LogicalResult walkStructPath(Operation *op, mlir::pto::StructType root,
                                     llvm::ArrayRef<int64_t> path,
                                     Type &fieldTyOut) {
-  if (path.empty())
+  if (path.empty()) {
     return op->emitOpError() << "struct path must have at least one index";
+  }
   Type cur = root;
   for (auto [depth, idx] : llvm::enumerate(path)) {
     auto st = dyn_cast<mlir::pto::StructType>(cur);
-    if (!st)
+    if (!st) {
       return op->emitOpError()
              << "struct path index " << depth
              << " descends into non-struct field of type " << cur;
-    if (idx < 0 || idx >= static_cast<int64_t>(st.getNumFields()))
+    }
+    if (idx < 0 || idx >= static_cast<int64_t>(st.getNumFields())) {
       return op->emitOpError()
              << "struct path index " << depth << " (" << idx
              << ") is out of range for " << st << " with " << st.getNumFields()
              << " field(s)";
+    }
     cur = st.getFieldType(static_cast<unsigned>(idx));
   }
   fieldTyOut = cur;
@@ -2863,8 +3227,9 @@ static LogicalResult walkStructPath(Operation *op, mlir::pto::StructType root,
 // looks fine and is undefined at run time.
 LogicalResult mlir::pto::DeclareStructOp::verify() {
   for (Operation *user : getS().getUsers()) {
-    if (!user->hasTrait<mlir::OpTrait::IsTerminator>())
+    if (!user->hasTrait<mlir::OpTrait::IsTerminator>()) {
       continue;
+    }
     return emitOpError()
            << "stack-local struct must not escape the scope that declares it, "
               "but its value is passed to '"
@@ -2883,38 +3248,45 @@ LogicalResult mlir::pto::DeclareStructOp::verify() {
 // it out of the struct — so reaching into a nested struct is spelled as a longer
 // path instead.
 static LogicalResult verifyStructLeafIsScalar(Operation *op, Type fieldTy) {
-  if (!fieldTy.isIntOrFloat())
+  if (!fieldTy.isIntOrFloat()) {
     return op->emitOpError()
            << "struct path must end at a scalar field, but ends at " << fieldTy
            << "; extend the path to reach a scalar inside it";
+  }
   return success();
 }
 
 LogicalResult mlir::pto::StructGetOp::verify() {
   Type fieldTy;
   if (failed(walkStructPath(getOperation(), getS().getType(), getPath(),
-                            fieldTy)))
+                            fieldTy))) {
     return failure();
-  if (failed(verifyStructLeafIsScalar(getOperation(), fieldTy)))
+  }
+  if (failed(verifyStructLeafIsScalar(getOperation(), fieldTy))) {
     return failure();
-  if (getValue().getType() != fieldTy)
+  }
+  if (getValue().getType() != fieldTy) {
     return emitOpError() << "result type " << getValue().getType()
                          << " does not match field type " << fieldTy
                          << " at the given path";
+  }
   return success();
 }
 
 LogicalResult mlir::pto::StructSetOp::verify() {
   Type fieldTy;
   if (failed(walkStructPath(getOperation(), getS().getType(), getPath(),
-                            fieldTy)))
+                            fieldTy))) {
     return failure();
-  if (failed(verifyStructLeafIsScalar(getOperation(), fieldTy)))
+  }
+  if (failed(verifyStructLeafIsScalar(getOperation(), fieldTy))) {
     return failure();
-  if (getValue().getType() != fieldTy)
+  }
+  if (getValue().getType() != fieldTy) {
     return emitOpError() << "value type " << getValue().getType()
                          << " does not match field type " << fieldTy
                          << " at the given path";
+  }
   return success();
 }
 
@@ -2928,24 +3300,29 @@ LogicalResult mlir::pto::CastPtrOp::verify() {
   bool inputIsInteger = isa<IntegerType>(inputType);
   bool resultIsInteger = isa<IntegerType>(resultType);
 
-  if (!inputPtrType && !inputMemRefType && !inputIsInteger)
+  if (!inputPtrType && !inputMemRefType && !inputIsInteger) {
     return emitOpError("input must be an integer, memref, or !pto.ptr<...>");
-  if (!resultPtrType && !resultIsInteger)
+  }
+  if (!resultPtrType && !resultIsInteger) {
     return emitOpError("result must be an integer or !pto.ptr<...>");
+  }
 
-  if (inputIsInteger && resultIsInteger)
+  if (inputIsInteger && resultIsInteger) {
     return emitOpError("integer-to-integer cast is not a ptr cast");
+  }
 
-  if (inputMemRefType && resultIsInteger)
+  if (inputMemRefType && resultIsInteger) {
     return emitOpError("memref-to-integer cast is unsupported");
+  }
 
   if (inputMemRefType && resultPtrType) {
     auto memrefSpace = dyn_cast_or_null<mlir::pto::AddressSpaceAttr>(
         inputMemRefType.getMemorySpace());
     auto resultSpace = resultPtrType.getMemorySpace();
-    if (memrefSpace && memrefSpace != resultSpace)
+    if (memrefSpace && memrefSpace != resultSpace) {
       return emitOpError(
           "memref-to-ptr cast must stay within the same PTO memory space");
+    }
   }
 
   if (inputPtrType && resultPtrType &&
@@ -2980,8 +3357,9 @@ void PTODialect::initialize() {
 
 
 AddressSpaceAttr mlir::pto::getPTOAddressSpaceAttr(Type type) {
-  if (auto ptrType = dyn_cast<PtrType>(type))
+  if (auto ptrType = dyn_cast<PtrType>(type)) {
     return ptrType.getMemorySpace();
+  }
   return {};
 }
 
@@ -3000,32 +3378,38 @@ bool mlir::pto::hasExplicitPTOEntryAttr(LLVM::LLVMFuncOp func) {
 }
 
 bool mlir::pto::isPTOEntryFunction(func::FuncOp func) {
-  if (!func || func.isDeclaration())
+  if (!func || func.isDeclaration()) {
     return false;
+  }
   return hasExplicitPTOEntryAttr(func);
 }
 
 bool mlir::pto::isPTOEntryFunction(LLVM::LLVMFuncOp func) {
-  if (!func || func.isDeclaration())
+  if (!func || func.isDeclaration()) {
     return false;
+  }
   return hasExplicitPTOEntryAttr(func);
 }
 
 bool mlir::pto::hasExternalArtifactVisibility(func::FuncOp func) {
-  if (!func || func.isDeclaration())
+  if (!func || func.isDeclaration()) {
     return false;
-  if (isPTOEntryFunction(func))
+  }
+  if (isPTOEntryFunction(func)) {
     return true;
+  }
   auto attr = func->getAttrOfType<StringAttr>(kPTOVisibilityAttrName);
-  if (!attr)
+  if (!attr) {
     return false;
+  }
   return attr.getValue() == kPTOVisibilityExternalValue;
 }
 
 void mlir::pto::setExternalArtifactVisibility(func::FuncOp func,
                                               bool isExternal) {
-  if (!func)
+  if (!func) {
     return;
+  }
   if (isExternal) {
     func->setAttr(kPTOVisibilityAttrName,
                   StringAttr::get(func.getContext(),
@@ -3036,12 +3420,14 @@ void mlir::pto::setExternalArtifactVisibility(func::FuncOp func,
 }
 
 LogicalResult mlir::pto::validatePTOEntryFunctions(ModuleOp module) {
-  if (!module)
+  if (!module) {
     return success();
+  }
 
   for (auto func : module.getOps<func::FuncOp>()) {
-    if (!hasExplicitPTOEntryAttr(func))
+    if (!hasExplicitPTOEntryAttr(func)) {
       continue;
+    }
     if (func.isDeclaration()) {
       return func.emitOpError()
              << "`" << kPTOEntryAttrName
@@ -3050,8 +3436,9 @@ LogicalResult mlir::pto::validatePTOEntryFunctions(ModuleOp module) {
   }
 
   for (auto func : module.getOps<func::FuncOp>()) {
-    if (!isPTOEntryFunction(func))
+    if (!isPTOEntryFunction(func)) {
       continue;
+    }
     if (func.getFunctionType().getNumResults() != 0) {
       return func.emitOpError()
              << "PTO entry functions must return void";
@@ -3069,15 +3456,17 @@ LogicalResult mlir::pto::validatePTOEntryFunctions(ModuleOp module) {
 // declaration safe to forward either: the branch is a terminator and is
 // rejected by DeclareStructOp::verify.
 LogicalResult mlir::pto::validateStructProvenance(ModuleOp module) {
-  if (!module)
+  if (!module) {
     return success();
+  }
 
   WalkResult result = module.walk([&](Operation *op) -> WalkResult {
     if (auto func = dyn_cast<func::FuncOp>(op)) {
       for (auto [i, inputTy] :
            llvm::enumerate(func.getFunctionType().getInputs())) {
-        if (!isa<StructType>(inputTy))
+        if (!isa<StructType>(inputTy)) {
           continue;
+        }
         func.emitOpError()
             << "argument " << i << " has type " << inputTy
             << ", but a stack-local struct must not be a function argument; "
@@ -3087,8 +3476,9 @@ LogicalResult mlir::pto::validateStructProvenance(ModuleOp module) {
       }
       for (auto [i, resultTy] :
            llvm::enumerate(func.getFunctionType().getResults())) {
-        if (!isa<StructType>(resultTy))
+        if (!isa<StructType>(resultTy)) {
           continue;
+        }
         func.emitOpError()
             << "result " << i << " has type " << resultTy
             << ", but a stack-local struct must not be returned: the value is "
@@ -3102,8 +3492,9 @@ LogicalResult mlir::pto::validateStructProvenance(ModuleOp module) {
 
     if (!isa<DeclareStructOp>(op)) {
       for (auto [i, opResult] : llvm::enumerate(op->getResults())) {
-        if (!isa<StructType>(opResult.getType()))
+        if (!isa<StructType>(opResult.getType())) {
           continue;
+        }
         op->emitOpError()
             << "result " << i << " has type " << opResult.getType()
             << ", but only 'pto.declare_struct' may produce a !pto.struct "
@@ -3129,8 +3520,9 @@ void mlir::pto::annotatePTOEntryFunctions(ModuleOp module) {
 static std::optional<uint64_t>
 getLocalAddressAlignmentBytes(Attribute memorySpace) {
   auto addrSpace = dyn_cast_or_null<AddressSpaceAttr>(memorySpace);
-  if (!addrSpace)
+  if (!addrSpace) {
     return std::nullopt;
+  }
 
   // Keep this verifier as a conservative front-line guard for explicit local
   // tile addresses. PTO-ISA's buffer_limits.hpp defines the baseline
@@ -3159,30 +3551,35 @@ static LogicalResult verifyConstantLocalAddress(Operation *op, Value addr,
                                                 int addrIndex = -1) {
   std::optional<uint64_t> alignment =
       getLocalAddressAlignmentBytes(memorySpace);
-  if (!alignment || *alignment == 0)
+  if (!alignment || *alignment == 0) {
     return success();
+  }
 
   std::optional<int64_t> constantAddr = mlir::getConstantIntValue(addr);
-  if (!constantAddr)
+  if (!constantAddr) {
     return success();
+  }
 
   auto emitAddrError = [&]() {
     InFlightDiagnostic diag = op->emitOpError();
-    if (addrIndex >= 0)
+    if (addrIndex >= 0) {
       diag << "addr[" << addrIndex << "]";
-    else
+    } else {
       diag << "addr";
+}
     return diag;
   };
 
-  if (*constantAddr < 0)
+  if (*constantAddr < 0) {
     return emitAddrError() << " must be non-negative, got " << *constantAddr;
+  }
 
   uint64_t unsignedAddr = static_cast<uint64_t>(*constantAddr);
-  if ((unsignedAddr % *alignment) != 0)
+  if ((unsignedAddr % *alignment) != 0) {
     return emitAddrError()
            << " must be aligned to " << *alignment
            << " bytes for local tile memory space, got " << unsignedAddr;
+  }
 
   return success();
 }
@@ -3190,12 +3587,14 @@ static LogicalResult verifyConstantLocalAddress(Operation *op, Value addr,
 LogicalResult AllocTileOp::verify() {
   auto ty = getResult().getType(); // TileBufType
 
-  if (failed(verifyTileBufLayoutConstraints(*this, ty, "result")))
+  if (failed(verifyTileBufLayoutConstraints(*this, ty, "result"))) {
     return failure();
+  }
 
   if (failed(verifyConstantLocalAddress(getOperation(), getAddr(),
-                                        ty.getMemorySpace())))
+                                        ty.getMemorySpace()))) {
     return failure();
+  }
 
   // op 上有没有传 operands
   bool hasVR = getValidRow() != nullptr;
@@ -3203,8 +3602,9 @@ LogicalResult AllocTileOp::verify() {
 
   // type 上的 validShape
   auto vs = ty.getValidShape();
-  if (vs.size() != 2)
+  if (vs.size() != 2) {
     return emitOpError("result tile_buf must have rank-2 validShape");
+  }
 
   // TileBuf valid dims use a negative sentinel (e.g. '?' / -1). Be robust to
   // any negative value (some code may materialize MLIR dynamic sentinels).
@@ -3213,17 +3613,19 @@ LogicalResult AllocTileOp::verify() {
 
   // 你要求的：v_row=?, v_col=? 时必须同时给两个
   // （这条规则由下面两句自然实现）
-  if (hasVR != needVR)
+  if (hasVR != needVR) {
     return emitOpError() << "valid_row operand "
                          << (needVR ? "is required" : "must be absent")
                          << " because result type v_row is "
                          << (needVR ? "?" : std::to_string(vs[0]));
+  }
 
-  if (hasVC != needVC)
+  if (hasVC != needVC) {
     return emitOpError() << "valid_col operand "
                          << (needVC ? "is required" : "must be absent")
                          << " because result type v_col is "
                          << (needVC ? "?" : std::to_string(vs[1]));
+  }
 
   return success();
 }
@@ -3234,25 +3636,30 @@ LogicalResult AllocTileOp::verify() {
 
 LogicalResult AllocMultiTileOp::verify() {
   auto mtbTy = getResult().getType();
-  if (!mtbTy)
+  if (!mtbTy) {
     return emitOpError("result must be `!pto.multi_tile_buf`");
+  }
 
   TileBufType slotTy = mtbTy.getSlotType();
-  if (!slotTy)
+  if (!slotTy) {
     return emitOpError("multi_tile_buf slot type must be non-null");
+  }
 
   // Reuse the AllocTileOp valid_row/valid_col contract on the slot type.
   Type elemTy = slotTy.getElementType();
-  if (isPTOLowPrecisionType(elemTy))
+  if (isPTOLowPrecisionType(elemTy)) {
     return emitOpError() << "slot dtype " << elemTy
                          << " is not supported by pto.alloc_multi_tile yet";
+  }
 
-  if (failed(verifyTileBufLayoutConstraints(*this, slotTy, "slot")))
+  if (failed(verifyTileBufLayoutConstraints(*this, slotTy, "slot"))) {
     return failure();
+  }
 
   if (failed(verifyConstantLocalAddress(getOperation(), getAddr(),
-                                        slotTy.getMemorySpace())))
+                                        slotTy.getMemorySpace()))) {
     return failure();
+  }
 
   // Multi-buffer slots are placed at product(shape) * element_size byte
   // intervals -- both level3 validation and PTOPlanMemory size them that way.
@@ -3263,31 +3670,35 @@ LogicalResult AllocMultiTileOp::verify() {
   // strided footprint. Non-boxed compact/`normal` and boxed fractal slayouts
   // pack densely (footprint == product(shape)), so they stay supported.
   if (slotTy.getCompactModeI32() ==
-      static_cast<int32_t>(mlir::pto::CompactMode::RowPlusOne))
+      static_cast<int32_t>(mlir::pto::CompactMode::RowPlusOne)) {
     return emitOpError()
            << "multi_tile_buf slot uses row_plus_one compaction, whose padded "
               "storage footprint exceeds product(shape) and would overlap "
               "adjacent multi-buffer slots; use a compact (non-row_plus_one) "
               "slot layout or a single pto.alloc_tile";
+  }
 
   bool hasVR = getValidRow() != nullptr;
   bool hasVC = getValidCol() != nullptr;
   auto vs = slotTy.getValidShape();
-  if (vs.size() != 2)
+  if (vs.size() != 2) {
     return emitOpError("slot tile_buf must have rank-2 validShape");
+  }
 
   bool needVR = (vs[0] < 0);
   bool needVC = (vs[1] < 0);
-  if (hasVR != needVR)
+  if (hasVR != needVR) {
     return emitOpError() << "valid_row operand "
                          << (needVR ? "is required" : "must be absent")
                          << " because slot v_row is "
                          << (needVR ? "?" : std::to_string(vs[0]));
-  if (hasVC != needVC)
+  }
+  if (hasVC != needVC) {
     return emitOpError() << "valid_col operand "
                          << (needVC ? "is required" : "must be absent")
                          << " because slot v_col is "
                          << (needVC ? "?" : std::to_string(vs[1]));
+  }
 
   // Count bounds are also enforced by MultiTileBufType::verify, but repeat
   // here so the error points at the alloc op the user wrote.
@@ -3300,37 +3711,43 @@ LogicalResult AllocMultiTileOp::verify() {
 
   if (Attribute rawAddrs = (*this)->getAttr(kPtoMultiBufferAddrsAttrName)) {
     auto addrs = dyn_cast<DenseI64ArrayAttr>(rawAddrs);
-    if (!addrs)
+    if (!addrs) {
       return emitOpError() << "expects internal '"
                            << kPtoMultiBufferAddrsAttrName
                            << "' to be a dense i64 array";
-    if (getAddr())
+    }
+    if (getAddr()) {
       return emitOpError() << "cannot carry both base 'addr' and internal '"
                            << kPtoMultiBufferAddrsAttrName << "'";
-    if (addrs.size() != count)
+    }
+    if (addrs.size() != count) {
       return emitOpError() << "expects " << count << " planned slot addresses, got "
                            << addrs.size();
+    }
 
     uint64_t elemBytes = getPTOStorageElemByteSize(slotTy.getElementType());
     uint64_t slotBytes = elemBytes;
     for (int64_t dim : slotTy.getShape()) {
-      if (dim == ShapedType::kDynamic)
+      if (dim == ShapedType::kDynamic) {
         return emitOpError(
             "planned multi-buffer addresses require a static slot shape");
+      }
       slotBytes *= static_cast<uint64_t>(dim);
     }
     for (auto [lhsIdx, lhs] : llvm::enumerate(addrs.asArrayRef())) {
-      if (lhs < 0)
+      if (lhs < 0) {
         return emitOpError("planned slot addresses must be non-negative");
+      }
       uint64_t lhsBegin = static_cast<uint64_t>(lhs);
       uint64_t lhsEnd = lhsBegin + slotBytes;
       for (size_t rhsIdx = lhsIdx + 1;
            rhsIdx < static_cast<size_t>(addrs.size()); ++rhsIdx) {
         uint64_t rhsBegin = static_cast<uint64_t>(addrs[rhsIdx]);
         uint64_t rhsEnd = rhsBegin + slotBytes;
-        if (std::max(lhsBegin, rhsBegin) < std::min(lhsEnd, rhsEnd))
+        if (std::max(lhsBegin, rhsBegin) < std::min(lhsEnd, rhsEnd)) {
           return emitOpError() << "planned slots " << lhsIdx << " and "
                                << rhsIdx << " overlap";
+        }
       }
     }
   }
@@ -3341,8 +3758,9 @@ LogicalResult AllocMultiTileOp::verify() {
 LogicalResult MultiTileGetOp::verify() {
   auto srcTy = getSource().getType();
   auto resultTy = getResult().getType();
-  if (!srcTy || !resultTy)
+  if (!srcTy || !resultTy) {
     return emitOpError("source and result types must be non-null");
+  }
 
   if (srcTy.getSlotType() != resultTy) {
     return emitOpError()
@@ -3372,12 +3790,14 @@ LogicalResult TAssignOp::verify() {
   }
 
   auto tileTy = dyn_cast<TileBufType>(getTile().getType());
-  if (!tileTy)
+  if (!tileTy) {
     return emitOpError("expects tile operand and result to be !pto.tile_buf");
+  }
 
   if (failed(verifyConstantLocalAddress(getOperation(), getAddr(),
-                                        tileTy.getMemorySpace())))
+                                        tileTy.getMemorySpace()))) {
     return failure();
+  }
 
   return success();
 }
@@ -3392,8 +3812,9 @@ LogicalResult TLoadOp::verify() {
       emitOpError("expects src to be !pto.partition_tensor_view and dst to be !pto.tile_buf");
       return failure();
     }
-    if (failed(verifyTileBufCommon(*this, dstTile, "dst", allowLowPrecision)))
+    if (failed(verifyTileBufCommon(*this, dstTile, "dst", allowLowPrecision))) {
       return failure();
+    }
 
     auto srcShape = srcPart.getShape();
     for (unsigned i = 0; i < srcShape.size(); ++i) {
@@ -3414,52 +3835,63 @@ LogicalResult TLoadOp::verify() {
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     auto common = verifyCommon(/*allowLowPrecision=*/false);
-    if (failed(common))
+    if (failed(common)) {
       return failure();
+    }
     auto [srcPart, dstTile] = *common;
 
     Type srcElem = srcPart.getElementType();
     Type dstElem = dstTile.getElementType();
-    if (isPTOLowPrecisionType(srcElem) || isPTOLowPrecisionType(dstElem))
+    if (isPTOLowPrecisionType(srcElem) || isPTOLowPrecisionType(dstElem)) {
       return emitOpError("expects A2/A3 tload low-precision element types to be unsupported");
+    }
     if (!(dstElem.isInteger(8) || dstElem.isInteger(16) || dstElem.isInteger(32) ||
-          dstElem.isInteger(64) || dstElem.isF16() || dstElem.isBF16() || dstElem.isF32()))
+          dstElem.isInteger(64) || dstElem.isF16() || dstElem.isBF16() || dstElem.isF32())) {
       return emitOpError("expects A2/A3 tload dst element type to be i8/i16/i32/i64/u64/f16/bf16/f32");
+    }
 
     auto dstSpace = getPTOMemorySpaceEnum(dstTile);
     if (!dstSpace || (*dstSpace != pto::AddressSpace::VEC &&
-                      *dstSpace != pto::AddressSpace::MAT))
+                      *dstSpace != pto::AddressSpace::MAT)) {
       return emitOpError("expects A2/A3 tload dst to use loc=vec or loc=mat");
+    }
 
-    if (getElemByteSize(srcElem) != getElemByteSize(dstElem))
+    if (getElemByteSize(srcElem) != getElemByteSize(dstElem)) {
       return emitOpError("expects src and dst element types to have the same bitwidth");
+    }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     auto common = verifyCommon(/*allowLowPrecision=*/true);
-    if (failed(common))
+    if (failed(common)) {
       return failure();
+    }
     auto [srcPart, dstTile] = *common;
 
     Type srcElem = srcPart.getElementType();
     Type dstElem = dstTile.getElementType();
     unsigned srcBytes = getElemByteSize(srcElem);
     unsigned dstBytes = getElemByteSize(dstElem);
-    if (srcBytes != dstBytes)
+    if (srcBytes != dstBytes) {
       return emitOpError("expects src and dst element types to have the same element size");
-    if (!(dstBytes == 1 || dstBytes == 2 || dstBytes == 4 || dstBytes == 8))
+    }
+    if (!(dstBytes == 1 || dstBytes == 2 || dstBytes == 4 || dstBytes == 8)) {
       return emitOpError("expects A5 tload dst element size to be 1, 2, 4, or 8 bytes");
-    if (!isA5TLoadStoreTransferElemType(srcElem))
+    }
+    if (!isA5TLoadStoreTransferElemType(srcElem)) {
       return emitOpError("expects A5 tload src element type to be i8/i16/i32/i64/f16/bf16/f32/f8/hif8/fp4");
-    if (!isA5TLoadStoreTransferElemType(dstElem))
+    }
+    if (!isA5TLoadStoreTransferElemType(dstElem)) {
       return emitOpError("expects A5 tload dst element type to be i8/i16/i32/i64/f16/bf16/f32/f8/hif8/fp4");
+    }
 
     if (dstElem.isInteger(64)) {
       auto pad = dstTile.getPadValueI32();
       if (pad != static_cast<int32_t>(pto::PadValue::Null) &&
-          pad != static_cast<int32_t>(pto::PadValue::Zero))
+          pad != static_cast<int32_t>(pto::PadValue::Zero)) {
         return emitOpError("expects A5 i64/u64 tload dst pad to be null or zero");
+      }
     }
 
     auto dstSpace = getPTOMemorySpaceEnum(dstTile);
@@ -3472,8 +3904,9 @@ LogicalResult TLoadOp::verify() {
                    sl == static_cast<int32_t>(pto::SLayout::NoneBox));
       bool isNZ = (bl == static_cast<int32_t>(pto::BLayout::ColMajor) &&
                    sl == static_cast<int32_t>(pto::SLayout::RowMajor));
-      if (!isND && !isDN && !isNZ)
+      if (!isND && !isDN && !isNZ) {
         return emitOpError("expects A5 tload vec dst layout to be ND, DN, or NZ");
+      }
     }
 
     return success();
@@ -3491,41 +3924,50 @@ LogicalResult TPrefetchOp::verify() {
     Type dstElem;
 
     auto srcPart = dyn_cast<pto::PartitionTensorViewType>(srcTy);
-    if (!srcPart)
+    if (!srcPart) {
       return emitOpError("expects src to be !pto.partition_tensor_view");
+    }
     auto srcShape = srcPart.getShape();
     for (unsigned i = 0; i < srcShape.size(); ++i) {
-      if (srcShape[i] != ShapedType::kDynamic && srcShape[i] <= 0)
+      if (srcShape[i] != ShapedType::kDynamic && srcShape[i] <= 0) {
         return emitOpError() << "expects src shape[" << i << "] to be positive";
+      }
     }
     srcElem = srcPart.getElementType();
 
     auto dstTile = dyn_cast<pto::TileBufType>(dstTy);
-    if (!dstTile)
+    if (!dstTile) {
       return emitOpError("expects dst to be !pto.tile_buf");
-    if (failed(verifyTileBufCommon(*this, dstTile, "dst", allowLowPrecision)))
+    }
+    if (failed(verifyTileBufCommon(*this, dstTile, "dst", allowLowPrecision))) {
       return failure();
+    }
     auto dstValid = dstTile.getValidShape();
     for (unsigned i = 0; i < dstValid.size(); ++i) {
-      if (dstValid[i] != ShapedType::kDynamic && dstValid[i] < 0)
+      if (dstValid[i] != ShapedType::kDynamic && dstValid[i] < 0) {
         return emitOpError()
                << "expects dst valid_shape[" << i << "] to be non-negative";
+      }
     }
     auto dstSpace = getPTOMemorySpaceEnum(dstTile);
     if (!dstSpace || (*dstSpace != pto::AddressSpace::VEC &&
-                      *dstSpace != pto::AddressSpace::MAT))
+                      *dstSpace != pto::AddressSpace::MAT)) {
       return emitOpError("expects dst to use loc=vec or loc=mat");
+    }
     dstElem = dstTile.getElementType();
 
-    if (getElemByteSize(srcElem) != getElemByteSize(dstElem))
+    if (getElemByteSize(srcElem) != getElemByteSize(dstElem)) {
       return emitOpError("expects src and dst element types to have the same element size");
+    }
     if (!allowLowPrecision &&
-        (isPTOLowPrecisionType(srcElem) || isPTOLowPrecisionType(dstElem)))
+        (isPTOLowPrecisionType(srcElem) || isPTOLowPrecisionType(dstElem))) {
       return emitOpError("expects A2/A3 tprefetch low-precision element types to be unsupported");
+    }
     if (allowLowPrecision &&
         (!isA5TLoadStoreTransferElemType(srcElem) ||
-         !isA5TLoadStoreTransferElemType(dstElem)))
+         !isA5TLoadStoreTransferElemType(dstElem))) {
       return emitOpError("expects A5 tprefetch element types to be i8/i16/i32/i64/f16/bf16/f32/f8/hif8/fp4");
+    }
     return success();
   };
 
@@ -3546,29 +3988,34 @@ LogicalResult TPrefetchOp::verify() {
 
 LogicalResult MakePrefetchAsyncContextOp::verify() {
   auto ptrTy = dyn_cast<pto::PtrType>(getWorkspace().getType());
-  if (!ptrTy)
+  if (!ptrTy) {
     return emitOpError("expects workspace to be !pto.ptr<i8>");
+  }
   Type elemTy = ptrTy.getElementType();
-  if (!isByteIntegerType(elemTy))
+  if (!isByteIntegerType(elemTy)) {
     return emitOpError("expects workspace element type to be an 8-bit integer");
+  }
   return success();
 }
 
 LogicalResult TPrefetchAsyncOp::verify() {
   if (failed(verifyAsyncFlatContiguous1DGMViewLike(getOperation(), getSrc(),
-                                                   "src")))
+                                                   "src"))) {
     return failure();
+  }
   return success();
 }
 
 LogicalResult mlir::pto::SetFFTsOp::verify() {
   auto ptrTy = llvm::dyn_cast<mlir::pto::PtrType>(getFfts().getType());
-  if (!ptrTy)
+  if (!ptrTy) {
     return emitOpError("expects a !pto.ptr operand");
+  }
 
   if (!ptrTy.getElementType().isInteger(64) &&
-      !ptrTy.getElementType().isInteger(8))
+      !ptrTy.getElementType().isInteger(8)) {
     return emitOpError("expects element type i64 (or i8)");
+  }
 
   return mlir::success();
 }
@@ -3589,14 +4036,16 @@ void mlir::pto::SyncSetOp::print(OpAsmPrinter &p) {
 LogicalResult mlir::pto::SyncSetOp::verify() {
   bool hasStatic = getEventIdAttr() != nullptr;
   bool hasDynamic = static_cast<bool>(getEventIdDyn());
-  if (hasStatic == hasDynamic)
+  if (hasStatic == hasDynamic) {
     return emitOpError()
            << "expects exactly one event-id form: static attr or dynamic index operand";
+  }
   if (IntegerAttr fftsModeAttr = getFftsModeAttr()) {
     int64_t fftsMode = fftsModeAttr.getInt();
-    if (fftsMode < 0 || fftsMode > 2)
+    if (fftsMode < 0 || fftsMode > 2) {
       return emitOpError() << "requires ffts_mode in range [0, 2], but got "
                            << fftsMode;
+    }
   }
 
   auto verifyA2A3 = [&]() -> LogicalResult { return success(); };
@@ -3645,39 +4094,46 @@ ParseResult mlir::pto::SyncAllOp::parse(OpAsmParser &parser,
   Attribute modeAttr;
   Attribute coreTypeAttr;
 
-  if (parser.parseLParen())
+  if (parser.parseLParen()) {
     return failure();
+  }
 
   if (failed(parser.parseOptionalRParen())) {
     if (parser.parseOperandList(operands) || parser.parseColonTypeList(operandTypes) ||
-        parser.parseRParen())
+        parser.parseRParen()) {
       return failure();
-    if (operands.size() != operandTypes.size())
+    }
+    if (operands.size() != operandTypes.size()) {
       return parser.emitError(parser.getCurrentLocation())
              << "expects the same number of operands and operand types";
+    }
   }
 
   if (parser.parseKeyword("mode") || parser.parseEqual() ||
       parser.parseAttribute(modeAttr) || parser.parseComma() ||
       parser.parseKeyword("core_type") || parser.parseEqual() ||
-      parser.parseAttribute(coreTypeAttr))
+      parser.parseAttribute(coreTypeAttr)) {
     return failure();
+  }
 
   auto mode = dyn_cast<pto::SyncAllModeAttr>(modeAttr);
-  if (!mode)
+  if (!mode) {
     return parser.emitError(parser.getCurrentLocation())
            << "expects mode to be #pto.sync_all_mode<...>";
+  }
 
   auto coreType = dyn_cast<pto::SyncCoreTypeAttr>(coreTypeAttr);
-  if (!coreType)
+  if (!coreType) {
     return parser.emitError(parser.getCurrentLocation())
            << "expects core_type to be #pto.sync_core_type<...>";
+  }
 
   result.addAttribute("mode", mode);
   result.addAttribute("core_type", coreType);
 
-  if (parser.parseOptionalAttrDict(result.attributes))
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
   auto addSegmentSizes = [&](int32_t gm, int32_t used) {
     result.addAttribute("operandSegmentSizes",
@@ -3686,34 +4142,40 @@ ParseResult mlir::pto::SyncAllOp::parse(OpAsmParser &parser,
 
   switch (mode.getValue()) {
   case pto::SyncAllMode::Hard:
-    if (!operands.empty())
+    if (!operands.empty()) {
       return parser.emitError(parser.getCurrentLocation())
              << "expects hard syncall to have no operands";
+    }
     addSegmentSizes(0, 0);
     return success();
   case pto::SyncAllMode::Soft:
     break;
   }
 
-  if (operands.size() != 1 && operands.size() != 2)
+  if (operands.size() != 1 && operands.size() != 2) {
     return parser.emitError(parser.getCurrentLocation())
            << "expects soft syncall to have gm_workspace and optional "
               "used_cores";
-  if (parser.resolveOperand(operands[0], operandTypes[0], result.operands))
+  }
+  if (parser.resolveOperand(operands[0], operandTypes[0], result.operands)) {
     return failure();
+  }
   if (operands.size() == 2 &&
-      parser.resolveOperand(operands[1], operandTypes[1], result.operands))
+      parser.resolveOperand(operands[1], operandTypes[1], result.operands)) {
     return failure();
+  }
   addSegmentSizes(1, operands.size() == 2 ? 1 : 0);
   return success();
 }
 
 void mlir::pto::SyncAllOp::print(OpAsmPrinter &p) {
   SmallVector<Value, 2> operands;
-  if (getGmWorkspace())
+  if (getGmWorkspace()) {
     operands.push_back(getGmWorkspace());
-  if (getUsedCores())
+  }
+  if (getUsedCores()) {
     operands.push_back(getUsedCores());
+  }
 
   p << "(";
   if (!operands.empty()) {
@@ -3731,18 +4193,20 @@ void mlir::pto::SyncAllOp::print(OpAsmPrinter &p) {
 LogicalResult mlir::pto::SyncWaitOp::verify() {
   bool hasStatic = getEventIdAttr() != nullptr;
   bool hasDynamic = static_cast<bool>(getEventIdDyn());
-  if (hasStatic == hasDynamic)
+  if (hasStatic == hasDynamic) {
     return emitOpError()
            << "expects exactly one event-id form: static attr or dynamic index operand";
+  }
 
   auto verifyA2A3 = [&]() -> LogicalResult { return success(); };
   auto verifyA5 = [&]() -> LogicalResult {
     if (IntegerAttr eventIdAttr = getEventIdAttr()) {
       int64_t eventId = eventIdAttr.getInt();
-      if (eventId < 0 || eventId > 31)
+      if (eventId < 0 || eventId > 31) {
         return emitOpError()
                << "A5 sync.wait expects static physical event_id in [0, 31], but got "
                << eventId;
+      }
     }
     switch (getPipe().getPipe()) {
     case PIPE::PIPE_FIX:
@@ -3763,10 +4227,12 @@ LogicalResult mlir::pto::SyncWaitOp::verify() {
 LogicalResult TStoreOp::verify() {
   const bool hasFp = static_cast<bool>(getFp());
   const bool hasPreQuant = static_cast<bool>(getPreQuantScalar());
-  if (hasFp && hasPreQuant)
+  if (hasFp && hasPreQuant) {
     return emitOpError("expects fp and preQuantScalar to be mutually exclusive");
-  if (hasFp && getStPhase() != pto::STPhase::Unspecified)
+  }
+  if (hasFp && getStPhase() != pto::STPhase::Unspecified) {
     return emitOpError("expects fp form to use the default stPhase");
+  }
 
   auto verifyCommon =
       [&](bool allowLowPrecision)
@@ -3777,12 +4243,14 @@ LogicalResult TStoreOp::verify() {
       emitOpError("expects src to be !pto.tile_buf and dst to be !pto.partition_tensor_view");
       return failure();
     }
-    if (failed(verifyTileBufCommon(*this, srcTile, "src", allowLowPrecision)))
+    if (failed(verifyTileBufCommon(*this, srcTile, "src", allowLowPrecision))) {
       return failure();
+    }
     if (hasFp) {
       Type fpTy = getFp().getType();
-      if (failed(verifyTileBufCommon(*this, fpTy, "fp", allowLowPrecision)))
+      if (failed(verifyTileBufCommon(*this, fpTy, "fp", allowLowPrecision))) {
         return failure();
+      }
       auto fpSpace = getPTOMemorySpaceEnum(fpTy);
       if (!fpSpace || *fpSpace != pto::AddressSpace::SCALING) {
         emitOpError("expects fp to use loc=scaling");
@@ -3810,12 +4278,15 @@ LogicalResult TStoreOp::verify() {
     auto getStaticElemCount = [](ArrayRef<int64_t> shape) -> std::optional<int64_t> {
       int64_t total = 1;
       for (int64_t dim : shape) {
-        if (dim == ShapedType::kDynamic)
+        if (dim == ShapedType::kDynamic) {
           return std::nullopt;
-        if (dim <= 0)
+        }
+        if (dim <= 0) {
           return std::nullopt;
-        if (total > std::numeric_limits<int64_t>::max() / dim)
+        }
+        if (total > std::numeric_limits<int64_t>::max() / dim) {
           return std::nullopt;
+        }
         total *= dim;
       }
       return total;
@@ -3842,83 +4313,104 @@ LogicalResult TStoreOp::verify() {
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     auto common = verifyCommon(/*allowLowPrecision=*/false);
-    if (failed(common))
+    if (failed(common)) {
       return failure();
+    }
     auto [srcTile, dstPart] = *common;
     auto srcSpace = getPTOMemorySpaceEnum(srcTile);
     if (!srcSpace || (*srcSpace != pto::AddressSpace::VEC &&
                       *srcSpace != pto::AddressSpace::MAT &&
-                      *srcSpace != pto::AddressSpace::ACC))
+                      *srcSpace != pto::AddressSpace::ACC)) {
       return emitOpError("expects A2/A3 tstore src to use loc=vec, loc=mat, or loc=acc");
-    if ((hasFp || hasPreQuant) && *srcSpace != pto::AddressSpace::ACC)
+    }
+    if ((hasFp || hasPreQuant) && *srcSpace != pto::AddressSpace::ACC) {
       return emitOpError("expects fp/preQuantScalar form to use loc=acc src");
-    if (reluMode != pto::ReluPreMode::NoRelu && *srcSpace != pto::AddressSpace::ACC)
+    }
+    if (reluMode != pto::ReluPreMode::NoRelu && *srcSpace != pto::AddressSpace::ACC) {
       return emitOpError("expects reluPreMode form to use loc=acc src");
+    }
 
     Type srcElem = srcTile.getElementType();
     Type dstElem = dstPart.getElementType();
     if (*srcSpace == pto::AddressSpace::VEC || *srcSpace == pto::AddressSpace::MAT) {
-      if (hasFp || hasPreQuant)
+      if (hasFp || hasPreQuant) {
         return emitOpError("expects fp/preQuantScalar form to use loc=acc src");
-      if (isPTOLowPrecisionType(dstElem))
+      }
+      if (isPTOLowPrecisionType(dstElem)) {
         return emitOpError("expects A2/A3 vec/mat tstore low-precision dst element types to be unsupported");
-      if (!isLoadStoreElemType(srcElem))
+      }
+      if (!isLoadStoreElemType(srcElem)) {
         return emitOpError("expects A2/A3 vec/mat tstore src element type to be i8/i16/i32/i64/u64/f16/bf16/f32");
-      if (getElemByteSize(srcElem) != getElemByteSize(dstElem))
+      }
+      if (getElemByteSize(srcElem) != getElemByteSize(dstElem)) {
         return emitOpError("expects A2/A3 vec/mat tstore src and dst element types to have the same bitwidth");
+      }
       return success();
     }
 
-    if (!(srcElem.isInteger(32) || srcElem.isF32()))
+    if (!(srcElem.isInteger(32) || srcElem.isF32())) {
       return emitOpError("expects A2/A3 acc tstore src element type to be i32 or f32");
+    }
     if (hasPreQuant) {
       if (srcElem.isInteger(32)) {
-        if (!(isI8Like(dstElem) || dstElem.isF16()))
+        if (!(isI8Like(dstElem) || dstElem.isF16())) {
           return emitOpError("expects A2/A3 acc preQuantScalar tstore dst type to be i8/ui8/f16");
+        }
       } else if (srcElem.isF32()) {
-        if (!isI8Like(dstElem))
+        if (!isI8Like(dstElem)) {
           return emitOpError("expects A2/A3 acc preQuantScalar tstore dst type to be i8/ui8");
+        }
       }
     } else if (!hasFp) {
       if (!(dstElem.isInteger(32) || dstElem.isF32() || dstElem.isF16() ||
-            dstElem.isBF16()))
+            dstElem.isBF16())) {
         return emitOpError("expects A2/A3 acc tstore dst element type to be i32/f32/f16/bf16");
+      }
     }
 
     auto srcShape = srcTile.getShape();
     if (srcShape[1] != ShapedType::kDynamic &&
-        (srcShape[1] < 1 || srcShape[1] > 4095))
+        (srcShape[1] < 1 || srcShape[1] > 4095)) {
       return emitOpError("expects A2/A3 acc tstore src cols to be in [1, 4095]");
+    }
     auto srcValid = srcTile.getValidShape();
     if (srcValid[1] != ShapedType::kDynamic &&
-        (srcValid[1] < 0 || srcValid[1] > 4095))
+        (srcValid[1] < 0 || srcValid[1] > 4095)) {
       return emitOpError("expects A2/A3 acc tstore src valid_shape[1] to be in [0, 4095]");
+    }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     auto common = verifyCommon(/*allowLowPrecision=*/true);
-    if (failed(common))
+    if (failed(common)) {
       return failure();
+    }
     auto [srcTile, dstPart] = *common;
     auto srcSpace = getPTOMemorySpaceEnum(srcTile);
     if (!srcSpace || (*srcSpace != pto::AddressSpace::VEC &&
-                      *srcSpace != pto::AddressSpace::ACC))
+                      *srcSpace != pto::AddressSpace::ACC)) {
       return emitOpError("expects A5 tstore src to use loc=vec or loc=acc");
-    if ((hasFp || hasPreQuant) && *srcSpace != pto::AddressSpace::ACC)
+    }
+    if ((hasFp || hasPreQuant) && *srcSpace != pto::AddressSpace::ACC) {
       return emitOpError("expects fp/preQuantScalar form to use loc=acc src");
-    if (reluMode != pto::ReluPreMode::NoRelu && *srcSpace != pto::AddressSpace::ACC)
+    }
+    if (reluMode != pto::ReluPreMode::NoRelu && *srcSpace != pto::AddressSpace::ACC) {
       return emitOpError("expects reluPreMode form to use loc=acc src");
+    }
 
     Type srcElem = srcTile.getElementType();
     Type dstElem = dstPart.getElementType();
     if (*srcSpace == pto::AddressSpace::VEC) {
-      if (hasFp || hasPreQuant)
+      if (hasFp || hasPreQuant) {
         return emitOpError("expects fp/preQuantScalar form to use loc=acc src");
-      if (!isA5TLoadStoreTransferElemType(srcElem))
+      }
+      if (!isA5TLoadStoreTransferElemType(srcElem)) {
         return emitOpError("expects A5 vec tstore src element type to be i8/i16/i32/i64/f16/bf16/f32/f8/hif8/fp4");
-      if (getElemByteSize(srcElem) != getElemByteSize(dstElem))
+      }
+      if (getElemByteSize(srcElem) != getElemByteSize(dstElem)) {
         return emitOpError("expects A5 vec tstore src and dst element types to have the same bitwidth");
+      }
 
       int32_t bl = srcTile.getBLayoutValueI32();
       int32_t sl = srcTile.getSLayoutValueI32();
@@ -3930,20 +4422,24 @@ LogicalResult TStoreOp::verify() {
                    sl == static_cast<int32_t>(pto::SLayout::RowMajor));
       auto srcShape = srcTile.getShape();
       bool isSpecialCase = (srcShape.size() == 2 && (srcShape[0] == 1 || srcShape[1] == 1));
-      if (!isSpecialCase && !isND && !isDN && !isNZ)
+      if (!isSpecialCase && !isND && !isDN && !isNZ) {
         return emitOpError("expects A5 vec tstore src layout to be ND, DN, or NZ (or special case with 1 row/col)");
+      }
       return success();
     }
 
-    if (!(srcElem.isInteger(32) || srcElem.isF32()))
+    if (!(srcElem.isInteger(32) || srcElem.isF32())) {
       return emitOpError("expects A5 acc tstore src element type to be i32 or f32");
+    }
     if (hasPreQuant) {
-      if (!isA5AccStorePreQuantDstType(srcElem, dstElem))
+      if (!isA5AccStorePreQuantDstType(srcElem, dstElem)) {
         return emitOpError("expects A5 acc preQuantScalar tstore dst type to be i8/ui8/f16/bf16/f32/hif8/f8E4M3");
+      }
     } else if (!hasFp) {
       if (!(dstElem.isInteger(32) || dstElem.isF32() || dstElem.isF16() ||
-            dstElem.isBF16()))
+            dstElem.isBF16())) {
         return emitOpError("expects A5 acc tstore dst element type to be i32/f32/f16/bf16");
+      }
     }
     return success();
   };
@@ -3955,17 +4451,21 @@ LogicalResult pto::TAbsOp::verify() {
   Type srcTy = getSrc().getType();
   Type dstTy = getDst().getType();
   if (failed(verifyVecTileCommon(*this, srcTy, "src")) ||
-      failed(verifyVecTileCommon(*this, dstTy, "dst")))
+      failed(verifyVecTileCommon(*this, dstTy, "dst"))) {
     return failure();
+  }
   if (failed(verifyTileBufSameElemType(*this, srcTy, dstTy, "src", "dst")) ||
-      failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+      failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
     return failure();
+  }
 
   Type elemTy;
-  if (auto tb = dyn_cast<pto::TileBufType>(srcTy))
+  if (auto tb = dyn_cast<pto::TileBufType>(srcTy)) {
     elemTy = tb.getElementType();
-  if (!(elemTy.isF16() || elemTy.isF32()))
+  }
+  if (!(elemTy.isF16() || elemTy.isF32())) {
     return emitOpError() << "expects element type to be f16 or f32";
+  }
 
   return success();
 }
@@ -3998,36 +4498,43 @@ static Type getElemTy(Type ty) {
 
 static SmallVector<int64_t, 4> getShapeVec(Type ty) {
   SmallVector<int64_t, 4> s;
-  if (auto tt = mlir::dyn_cast<RankedTensorType>(ty))
-    return SmallVector<int64_t,4>(tt.getShape().begin(), tt.getShape().end());
-  if (auto tv = mlir::dyn_cast<pto::TensorViewType>(ty))
-    return SmallVector<int64_t,4>(tv.getShape().begin(), tv.getShape().end());
-  if (auto tb = mlir::dyn_cast<pto::TileBufType>(ty))
-    return SmallVector<int64_t,4>(tb.getShape().begin(), tb.getShape().end());
-  if (auto tv = mlir::dyn_cast<pto::PartitionTensorViewType>(ty))
-    return SmallVector<int64_t,4>(tv.getShape().begin(), tv.getShape().end());
+  if (auto tt = mlir::dyn_cast<RankedTensorType>(ty)) {
+    return SmallVector<int64_t, 4>(tt.getShape().begin(), tt.getShape().end());
+  }
+  if (auto tv = mlir::dyn_cast<pto::TensorViewType>(ty)) {
+    return SmallVector<int64_t, 4>(tv.getShape().begin(), tv.getShape().end());
+  }
+  if (auto tb = mlir::dyn_cast<pto::TileBufType>(ty)) {
+    return SmallVector<int64_t, 4>(tb.getShape().begin(), tb.getShape().end());
+  }
+  if (auto tv = mlir::dyn_cast<pto::PartitionTensorViewType>(ty)) {
+    return SmallVector<int64_t, 4>(tv.getShape().begin(), tv.getShape().end());
+  }
   return {};
 }
 
 static SmallVector<int64_t, 4> getValidShapeVec(Type ty) {
-  if (auto tb = dyn_cast<pto::TileBufType>(ty))
+  if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
     return SmallVector<int64_t, 4>(tb.getValidShape().begin(), tb.getValidShape().end());
+  }
   return getShapeVec(ty);
 }
 
 static int64_t getLogicalTileDim(int64_t rawDim, Type elemTy,
                                  std::optional<pto::BLayout> blayout,
                                  unsigned dimIdx) {
-  if (rawDim == ShapedType::kDynamic || !isPTOFloat4PackedType(elemTy))
+  if (rawDim == ShapedType::kDynamic || !isPTOFloat4PackedType(elemTy)) {
     return rawDim;
+  }
   pto::BLayout layout = blayout.value_or(pto::BLayout::RowMajor);
   unsigned packedDim = layout == pto::BLayout::ColMajor ? 0 : 1;
   return dimIdx == packedDim ? rawDim * 2 : rawDim;
 }
 
 static std::optional<pto::BLayout> getTileBufBLayout(Type ty) {
-  if (auto tb = dyn_cast<pto::TileBufType>(ty))
+  if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
     return static_cast<pto::BLayout>(tb.getBLayoutValueI32());
+  }
   return std::nullopt;
 }
 
@@ -4035,19 +4542,22 @@ static SmallVector<int64_t, 4> getLogicalTileExtentVec(Type ty,
                                                        bool useValidShape) {
   SmallVector<int64_t, 4> dims =
       useValidShape ? getValidShapeVec(ty) : getShapeVec(ty);
-  if (!isTileLikeType(ty) || dims.size() != 2)
+  if (!isTileLikeType(ty) || dims.size() != 2) {
     return dims;
+  }
 
   Type elemTy = getElemTy(ty);
   auto blayout = getTileBufBLayout(ty);
-  for (unsigned i = 0; i < dims.size(); ++i)
+  for (unsigned i = 0; i < dims.size(); ++i) {
     dims[i] = getLogicalTileDim(dims[i], elemTy, blayout, i);
+  }
   return dims;
 }
 
 static SmallVector<int64_t, 4> getValidShapeVec(Value value) {
-  if (!value)
+  if (!value) {
     return {};
+  }
   auto valid = getValidShapeVec(value.getType());
   return valid;
 }
@@ -4055,12 +4565,14 @@ static SmallVector<int64_t, 4> getValidShapeVec(Value value) {
 static SmallVector<int64_t, 4> getMatmulLogicalShapeVec(Type ty) {
   auto shape = getShapeVec(ty);
   auto valid = getValidShapeVec(ty);
-  if (!isa<pto::TileBufType>(ty) || shape.size() != valid.size())
+  if (!isa<pto::TileBufType>(ty) || shape.size() != valid.size()) {
     return shape;
+  }
 
   for (size_t i = 0, e = shape.size(); i < e; ++i) {
-    if (valid[i] != ShapedType::kDynamic)
+    if (valid[i] != ShapedType::kDynamic) {
       shape[i] = valid[i];
+    }
   }
   return shape;
 }
@@ -4074,27 +4586,31 @@ static LogicalResult verifyAsyncFlatContiguous1DGMViewLike(Operation *op,
                                                            Value value,
                                                            StringRef name) {
   Type ty = value.getType();
-  if (!isa<pto::TensorViewType, pto::PartitionTensorViewType>(ty))
+  if (!isa<pto::TensorViewType, pto::PartitionTensorViewType>(ty)) {
     return op->emitOpError()
            << "expects " << name << " to be a tensor_view or partition_view";
+  }
 
   SmallVector<int64_t, 4> shape = getShapeVec(ty);
-  if (shape.empty())
+  if (shape.empty()) {
     return op->emitOpError() << "expects " << name << " to have rank >= 1";
+  }
   for (int64_t dim : shape) {
-    if (dim == ShapedType::kDynamic)
+    if (dim == ShapedType::kDynamic) {
       return op->emitOpError() << "expects " << name
                                << " to have a static shape";
+    }
   }
 
   bool logical1D = true;
   for (int i = 0, e = static_cast<int>(shape.size()) - 1; i < e; ++i) {
     logical1D &= shape[i] == 1;
   }
-  if (!logical1D)
+  if (!logical1D) {
     return op->emitOpError()
            << "expects " << name
            << " to be a static flat contiguous logical 1D GM view";
+  }
 
   return success();
 }
@@ -4112,77 +4628,91 @@ static LogicalResult verifyCommGlobalLike(
     Operation *op, Value value, StringRef name,
     CommGlobalShapePolicy policy = CommGlobalShapePolicy::StaticOnly) {
   Type ty = value.getType();
-  if (!isCommGlobalLikeType(ty))
+  if (!isCommGlobalLikeType(ty)) {
     return op->emitOpError()
            << "expects " << name << " to be a tensor_view or partition_view";
+  }
 
   SmallVector<int64_t, 4> shape = getShapeVec(ty);
-  if (shape.empty())
+  if (shape.empty()) {
     return op->emitOpError() << "expects " << name << " to have rank >= 1";
+  }
 
   bool opAllowsDynamic =
       policy == CommGlobalShapePolicy::AllowDynamicPartitionView;
   bool isAllowedDynamicType = isa<pto::PartitionTensorViewType>(ty);
   for (int64_t dim : shape) {
     if (dim == ShapedType::kDynamic) {
-      if (!opAllowsDynamic)
+      if (!opAllowsDynamic) {
         return op->emitOpError()
                << "does not support dynamic dimensions on " << name;
-      if (!isAllowedDynamicType)
+      }
+      if (!isAllowedDynamicType) {
         return op->emitOpError() << "allows dynamic dimensions on " << name
                                  << " only for partition_tensor_view";
+      }
       continue;
     }
-    if (dim <= 0)
+    if (dim <= 0) {
       return op->emitOpError() << "expects every static dimension of " << name
                                << " to be positive";
+    }
   }
   return success();
 }
 
 static LogicalResult verifyCommSignalLike(Operation *op, Value value,
                                           StringRef name) {
-  if (failed(verifyCommGlobalLike(op, value, name)))
+  if (failed(verifyCommGlobalLike(op, value, name))) {
     return failure();
+  }
   Type elemTy = getElemTy(value.getType());
-  if (!elemTy || !elemTy.isSignlessInteger(32))
+  if (!elemTy || !elemTy.isSignlessInteger(32)) {
     return op->emitOpError() << "expects " << name
                              << " element type to be i32";
+  }
   return success();
 }
 
 static LogicalResult verifyCommStagingTileLike(Operation *op, Value value,
                                                StringRef name) {
   Type ty = value.getType();
-  if (!isa<pto::TileBufType>(ty))
+  if (!isa<pto::TileBufType>(ty)) {
     return op->emitOpError() << "expects " << name << " to be a tile_buf";
+  }
   auto as = getPTOMemorySpaceEnum(ty);
-  if (!as || *as != pto::AddressSpace::VEC)
+  if (!as || *as != pto::AddressSpace::VEC) {
     return op->emitOpError() << "expects " << name
                              << " to be in vec address space";
+  }
   SmallVector<int64_t, 4> shape = getShapeVec(ty);
-  if (shape.empty())
+  if (shape.empty()) {
     return op->emitOpError() << "expects " << name << " to have rank >= 1";
+  }
   for (int64_t dim : shape) {
-    if (dim == ShapedType::kDynamic || dim <= 0)
+    if (dim == ShapedType::kDynamic || dim <= 0) {
       return op->emitOpError() << "expects " << name
                                << " to have a positive static shape";
+    }
   }
   return success();
 }
 
 static LogicalResult verifyCommGlobalGroup(Operation *op, ValueRange group,
                                            StringRef name) {
-  if (group.empty())
+  if (group.empty()) {
     return op->emitOpError() << "expects at least one " << name << " operand";
+  }
   Type groupTy = group.front().getType();
   for (auto it : llvm::enumerate(group)) {
     if (failed(verifyCommGlobalLike(op, it.value(),
-                                    (name + "[" + Twine(it.index()) + "]").str())))
+                                    (name + "[" + Twine(it.index()) + "]").str()))) {
       return failure();
-    if (it.value().getType() != groupTy)
+    }
+    if (it.value().getType() != groupTy) {
       return op->emitOpError() << "expects all " << name
                                << " operands to have identical types";
+    }
   }
   return success();
 }
@@ -4190,30 +4720,36 @@ static LogicalResult verifyCommGlobalGroup(Operation *op, ValueRange group,
 static LogicalResult verifyCommPingPongSameType(Operation *op, Value ping,
                                                 Value pong, StringRef pingName,
                                                 StringRef pongName) {
-  if (!pong)
+  if (!pong) {
     return success();
+  }
   if (failed(verifyCommStagingTileLike(op, ping, pingName)) ||
-      failed(verifyCommStagingTileLike(op, pong, pongName)))
+      failed(verifyCommStagingTileLike(op, pong, pongName))) {
     return failure();
-  if (ping.getType() != pong.getType())
+  }
+  if (ping.getType() != pong.getType()) {
     return op->emitOpError() << "expects " << pingName << " and " << pongName
                              << " to have identical types";
+  }
   return success();
 }
 
 static std::optional<uint64_t> getStaticByteSize(Type ty) {
   SmallVector<int64_t, 4> shape = getShapeVec(ty);
-  if (shape.empty())
+  if (shape.empty()) {
     return std::nullopt;
+  }
   for (int64_t dim : shape) {
-    if (dim == ShapedType::kDynamic || dim < 0)
+    if (dim == ShapedType::kDynamic || dim < 0) {
       return std::nullopt;
+    }
   }
 
   Type elemTy = getElemTy(ty);
   uint64_t elemBytes = getElemByteSize(elemTy);
-  if (elemBytes == 0)
+  if (elemBytes == 0) {
     return std::nullopt;
+  }
 
   uint64_t total = elemBytes;
   for (int64_t dim : shape) {
@@ -4226,22 +4762,26 @@ static LogicalResult verifyTmpCapacityAtLeast(Operation *op, Type tmpTy,
                                               uint64_t requiredBytes,
                                               StringRef tmpName) {
   auto actualBytes = getStaticByteSize(tmpTy);
-  if (!actualBytes)
+  if (!actualBytes) {
     return op->emitOpError()
            << "expects " << tmpName << " to have statically known byte capacity";
-  if (*actualBytes < requiredBytes)
+  }
+  if (*actualBytes < requiredBytes) {
     return op->emitOpError()
            << "expects " << tmpName << " capacity to be at least "
            << requiredBytes << " bytes, but got " << *actualBytes << " bytes";
+  }
   return success();
 }
 
 static std::optional<pto::AddressSpace> getPTOMemorySpaceEnum(Type ty) {
-  if (auto ptr = dyn_cast<pto::PtrType>(ty))
+  if (auto ptr = dyn_cast<pto::PtrType>(ty)) {
     return ptr.getMemorySpace().getAddressSpace();
+  }
   if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
-    if (auto as = dyn_cast_or_null<pto::AddressSpaceAttr>(tb.getMemorySpace()))
+    if (auto as = dyn_cast_or_null<pto::AddressSpaceAttr>(tb.getMemorySpace())) {
       return as.getAddressSpace();
+    }
     return std::nullopt;
   }
   return std::nullopt;
@@ -4264,10 +4804,12 @@ TMovForm mlir::pto::classifyTMovForm(Value fp) {
 
 static bool isSupportedVecElemType(Type ty, bool allowBf16,
                                    bool allowInt8) {
-  if (ty.isF16() || ty.isF32())
+  if (ty.isF16() || ty.isF32()) {
     return true;
-  if (allowBf16 && ty.isBF16())
+  }
+  if (allowBf16 && ty.isBF16()) {
     return true;
+  }
   if (auto it = dyn_cast<IntegerType>(ty)) {
     switch (it.getWidth()) {
     case 32:
@@ -4284,16 +4826,19 @@ static bool isSupportedVecElemType(Type ty, bool allowBf16,
 
 static bool isSupportedMGatherMScatterIndexElemType(Type ty) {
   auto it = dyn_cast<IntegerType>(ty);
-  if (!it || it.getWidth() != 32)
+  if (!it || it.getWidth() != 32) {
     return false;
+  }
   return true;
 }
 
 static bool isSupportedMGatherMScatterPayloadElemType(Operation *op, Type ty) {
-  if (isSupportedVecElemType(ty, /*allowBf16=*/true, /*allowInt8=*/true))
+  if (isSupportedVecElemType(ty, /*allowBf16=*/true, /*allowInt8=*/true)) {
     return true;
-  if (!isTargetArchA5(op))
+  }
+  if (!isTargetArchA5(op)) {
     return false;
+  }
   return isPTOHiFloat8Type(ty) || isPTOFloat8Type(ty);
 }
 
@@ -4320,17 +4865,20 @@ static LogicalResult verifyMGatherMScatterMemOperand(Operation *op,
                                                      StringRef dataOperandLabel) {
   Type memTy = memValue.getType();
   Type memElem = getElemTy(memTy);
-  if (!memElem || memElem != dataElemTy)
+  if (!memElem || memElem != dataElemTy) {
     return op->emitOpError() << "expects mem element type to match "
                              << dataOperandLabel << " element type";
+  }
 
-  if (!isa<pto::PartitionTensorViewType>(memTy))
+  if (!isa<pto::PartitionTensorViewType>(memTy)) {
     return op->emitOpError("expects mem to be !pto.partition_tensor_view");
+  }
   if (auto layout = getLogicalViewLayout(memValue)) {
-    if (*layout != pto::Layout::ND)
+    if (*layout != pto::Layout::ND) {
       return op->emitOpError(
           "expects mem partition view to use ND logical layout when layout "
           "can be inferred");
+    }
   }
   return success();
 }
@@ -4346,13 +4894,15 @@ static LogicalResult verifyMGatherMScatterTileShape(Operation *op, Type dataTy,
                                                     std::optional<pto::Coalesce> coalesce) {
   auto dataValid = getValidShapeVec(dataTy);
   auto idxValid = getValidShapeVec(idxTy);
-  if (dataValid.size() != 2 || idxValid.size() != 2)
+  if (dataValid.size() != 2 || idxValid.size() != 2) {
     return op->emitOpError() << "expects " << dataName
                              << " and idx to have rank-2 valid_shape";
+  }
 
   auto idxTile = dyn_cast<pto::TileBufType>(idxTy);
-  if (!idxTile)
+  if (!idxTile) {
     return op->emitOpError("expects idx to be a tile_buf type");
+  }
 
   const bool idxRowMajor =
       idxTile.getBLayoutValueI32() ==
@@ -4375,24 +4925,28 @@ static LogicalResult verifyMGatherMScatterTileShape(Operation *op, Type dataTy,
       hasCompatibleKnownExtent(idxValid[1], dataValid[1]);
 
   if (!coalesce) {
-    if (baseRowCoalesce || elemCoalesce)
+    if (baseRowCoalesce || elemCoalesce) {
       return success();
+    }
     return op->emitOpError()
            << "expects idx valid_shape to be [" << dataName
            << ".valid_row, 0|1] or match " << dataName
            << " valid_shape when coalesce is omitted";
   }
 
-  if (*coalesce == pto::Coalesce::Row && (rowCoalesce1xR || rowCoalesceRx1))
+  if (*coalesce == pto::Coalesce::Row && (rowCoalesce1xR || rowCoalesceRx1)) {
     return success();
+  }
 
-  if (*coalesce == pto::Coalesce::Elem && elemCoalesce)
+  if (*coalesce == pto::Coalesce::Elem && elemCoalesce) {
     return success();
+  }
 
-  if (*coalesce == pto::Coalesce::Row)
+  if (*coalesce == pto::Coalesce::Row) {
     return op->emitOpError()
            << "expects row-coalesce idx valid_shape to be [0|1, " << dataName
            << ".valid_row] or [" << dataName << ".valid_row, 0|1]";
+  }
 
   return op->emitOpError()
          << "expects elem-coalesce idx valid_shape to match " << dataName
@@ -4403,8 +4957,9 @@ template <typename AttrT>
 static AttrT getPTOOpAttr(Operation *op, StringRef name) {
   if (Attribute propsAttr = op->getPropertiesAsAttribute()) {
     if (auto props = dyn_cast<DictionaryAttr>(propsAttr)) {
-      if (auto attr = dyn_cast_or_null<AttrT>(props.get(name)))
+      if (auto attr = dyn_cast_or_null<AttrT>(props.get(name))) {
         return attr;
+      }
     }
   }
   return dyn_cast_or_null<AttrT>(op->getRawDictionaryAttrs().get(name));
@@ -4416,8 +4971,9 @@ static ParseResult parsePTOInherentAttrs(OpAsmParser &parser,
                                          NamedAttrList &parsedAttrs,
                                          ArrayRef<StringRef> inherentAttrNames) {
   auto attrLoc = parser.getCurrentLocation();
-  if (parser.parseOptionalAttrDict(parsedAttrs))
+  if (parser.parseOptionalAttrDict(parsedAttrs)) {
     return failure();
+  }
 
   auto &properties = result.getOrAddProperties<typename OpTy::Properties>();
   OpTy::populateDefaultProperties(result.name, properties);
@@ -4425,11 +4981,13 @@ static ParseResult parsePTOInherentAttrs(OpAsmParser &parser,
           properties, parsedAttrs.getDictionary(parser.getContext()), [&] {
             return parser.emitError(attrLoc)
                    << "'" << result.name.getStringRef() << "' op ";
-          })))
+          }))) {
     return failure();
+  }
 
-  for (StringRef attrName : inherentAttrNames)
+  for (StringRef attrName : inherentAttrNames) {
     parsedAttrs.erase(attrName);
+  }
   result.attributes = parsedAttrs;
   return success();
 }
@@ -4438,8 +4996,9 @@ static NamedAttrList getNonInherentAttrs(Operation *op,
                                          ArrayRef<StringRef> inherentAttrNames) {
   NamedAttrList attrs;
   for (NamedAttribute attr : op->getRawDictionaryAttrs()) {
-    if (llvm::is_contained(inherentAttrNames, attr.getName().getValue()))
+    if (llvm::is_contained(inherentAttrNames, attr.getName().getValue())) {
       continue;
+    }
     attrs.append(attr);
   }
   return attrs;
@@ -4454,8 +5013,9 @@ static pto::GatherOOBAttr getMGatherGatherOobAttrIfPresent(pto::MGatherOp op) {
 }
 
 static pto::GatherOOB getGatherOobOrDefault(pto::MGatherOp op) {
-  if (auto attr = getMGatherGatherOobAttrIfPresent(op))
+  if (auto attr = getMGatherGatherOobAttrIfPresent(op)) {
     return attr.getValue();
+  }
   return pto::GatherOOB::Undefined;
 }
 
@@ -4481,26 +5041,30 @@ static pto::ScatterConflictAttr getMScatterScatterConflictAttrIfPresent(
 }
 
 static std::optional<pto::Coalesce> getCoalesceIfPresent(pto::MGatherOp op) {
-  if (auto attr = getMGatherCoalesceAttrIfPresent(op))
+  if (auto attr = getMGatherCoalesceAttrIfPresent(op)) {
     return attr.getValue();
+  }
   return std::nullopt;
 }
 
 static std::optional<pto::Coalesce> getCoalesceIfPresent(pto::MScatterOp op) {
-  if (auto attr = getMScatterCoalesceAttrIfPresent(op))
+  if (auto attr = getMScatterCoalesceAttrIfPresent(op)) {
     return attr.getValue();
+  }
   return std::nullopt;
 }
 
 static pto::ScatterAtomicOp getScatterAtomicOpOrDefault(pto::MScatterOp op) {
-  if (auto attr = getMScatterScatterAtomicOpAttrIfPresent(op))
+  if (auto attr = getMScatterScatterAtomicOpAttrIfPresent(op)) {
     return attr.getValue();
+  }
   return pto::ScatterAtomicOp::None;
 }
 
 static pto::ScatterOOB getScatterOobOrDefault(pto::MScatterOp op) {
-  if (auto attr = getMScatterScatterOobAttrIfPresent(op))
+  if (auto attr = getMScatterScatterOobAttrIfPresent(op)) {
     return attr.getValue();
+  }
   return pto::ScatterOOB::Undefined;
 }
 
@@ -4515,23 +5079,28 @@ static Value getTPrintTmpIfPresent(pto::TPrintOp op) {
 
 static LogicalResult verifyMGatherMScatterIdxTile(Operation *op, Type ty,
                                                   StringRef name) {
-  if (failed(verifyTileBufCommon(op, ty, name)))
+  if (failed(verifyTileBufCommon(op, ty, name))) {
     return failure();
+  }
   auto as = getPTOMemorySpaceEnum(ty);
-  if (!as || *as != pto::AddressSpace::VEC)
+  if (!as || *as != pto::AddressSpace::VEC) {
     return op->emitOpError() << "expects " << name
                              << " to be in the vec address space";
+  }
   auto tb = dyn_cast<pto::TileBufType>(ty);
-  if (!tb)
+  if (!tb) {
     return op->emitOpError() << "expects " << name << " to be a tile_buf type";
+  }
   int32_t blayout = tb.getBLayoutValueI32();
   if (blayout != static_cast<int32_t>(pto::BLayout::RowMajor) &&
-      blayout != static_cast<int32_t>(pto::BLayout::ColMajor))
+      blayout != static_cast<int32_t>(pto::BLayout::ColMajor)) {
     return op->emitOpError() << "expects " << name
                              << " to use row_major or col_major blayout";
-  if (tb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
+  }
+  if (tb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox)) {
     return op->emitOpError() << "expects " << name
                              << " to use the none_box slayout";
+  }
   return success();
 }
 
@@ -4542,32 +5111,40 @@ static bool isA5TLoadStoreTransferElemType(Type ty) {
 }
 
 static bool isA5AccStorePreQuantDstType(Type srcElem, Type dstElem) {
-  if (srcElem.isInteger(32))
+  if (srcElem.isInteger(32)) {
     return dstElem.isInteger(8) || dstElem.isF16() || dstElem.isBF16();
-  if (!srcElem.isF32())
+  }
+  if (!srcElem.isF32()) {
     return false;
+  }
   return dstElem.isInteger(8) || dstElem.isF16() || dstElem.isBF16() ||
          dstElem.isF32() || isPTOHiFloat8Type(dstElem) ||
          isPTOFloat8E4M3LikeType(dstElem);
 }
 
 static bool isA5LowPrecisionTCvtPair(Type srcElem, Type dstElem) {
-  if (srcElem.isF32())
+  if (srcElem.isF32()) {
     return isPTOFloat8Type(dstElem) || isPTOHiFloat8Type(dstElem);
-  if (srcElem.isF16())
+  }
+  if (srcElem.isF16()) {
     return isPTOHiFloat8Type(dstElem);
-  if (srcElem.isBF16())
+  }
+  if (srcElem.isBF16()) {
     return isPTOFloat4PackedType(dstElem);
-  if (isPTOFloat4PackedType(srcElem))
+  }
+  if (isPTOFloat4PackedType(srcElem)) {
     return dstElem.isBF16();
-  if (isPTOFloat8Type(srcElem) || isPTOHiFloat8Type(srcElem))
+  }
+  if (isPTOFloat8Type(srcElem) || isPTOHiFloat8Type(srcElem)) {
     return dstElem.isF32();
+  }
   return false;
 }
 
 static bool isA5SupportedTCvtPair(Type srcElem, Type dstElem) {
-  if (isPTOLowPrecisionType(srcElem) || isPTOLowPrecisionType(dstElem))
+  if (isPTOLowPrecisionType(srcElem) || isPTOLowPrecisionType(dstElem)) {
     return isA5LowPrecisionTCvtPair(srcElem, dstElem);
+  }
   return true;
 }
 
@@ -4575,25 +5152,29 @@ static LogicalResult verifyTileBufCommon(Operation *op, Type ty, StringRef name,
                                          bool allowLowPrecision) {
   auto tb = dyn_cast<pto::TileBufType>(ty);
   if (tb) {
-    if (tb.getRank() != 2)
+    if (tb.getRank() != 2) {
       return op->emitOpError() << "expects " << name << " to be a rank-2 tile_buf";
+    }
     Type elemTy = tb.getElementType();
-    if (!allowLowPrecision && isPTOLowPrecisionType(elemTy))
+    if (!allowLowPrecision && isPTOLowPrecisionType(elemTy)) {
       return op->emitOpError() << name << ": dtype " << elemTy
                                << " is not supported by this op yet";
+    }
   } else {
     return op->emitOpError() << "expects " << name << " to be a !pto.tile_buf";
   }
 
   auto validShape = getValidShapeVec(ty);
-  if (validShape.size() != 2)
+  if (validShape.size() != 2) {
     return op->emitOpError() << "expects " << name << " to have a rank-2 valid_shape";
+  }
   auto shape = getShapeVec(ty);
   for (unsigned i = 0; i < 2; ++i) {
     if (shape[i] != ShapedType::kDynamic && validShape[i] != ShapedType::kDynamic &&
-        validShape[i] > shape[i])
+        validShape[i] > shape[i]) {
       return op->emitOpError() << "expects " << name << " to satisfy valid_shape[" << i
                                << "] <= shape[" << i << "]";
+    }
   }
   return success();
 }
@@ -4601,30 +5182,35 @@ static LogicalResult verifyTileBufCommon(Operation *op, Type ty, StringRef name,
 static LogicalResult verifyTileBufSameElemType(Operation *op, Type lhs, Type rhs,
                                                StringRef lhsName,
                                                StringRef rhsName) {
-  if (!isTileLikeType(lhs) || !isTileLikeType(rhs))
+  if (!isTileLikeType(lhs) || !isTileLikeType(rhs)) {
     return op->emitOpError() << "expects " << lhsName << " and " << rhsName
                              << " to be !pto.tile_buf";
-  if (getElemTy(lhs) != getElemTy(rhs))
+  }
+  if (getElemTy(lhs) != getElemTy(rhs)) {
     return op->emitOpError() << "expects " << lhsName << " and " << rhsName
                              << " to have the same element type";
+  }
   return success();
 }
 
 static LogicalResult verifyTileBufSameValidShape(Operation *op, Type lhs, Type rhs,
                                                  StringRef lhsName, StringRef rhsName) {
-  if (!isTileLikeType(lhs) || !isTileLikeType(rhs))
+  if (!isTileLikeType(lhs) || !isTileLikeType(rhs)) {
     return success();
+  }
   auto lhsValid = getValidShapeVec(lhs);
   auto rhsValid = getValidShapeVec(rhs);
   for (size_t i = 0; i < lhsValid.size() && i < rhsValid.size(); ++i) {
     if (lhsValid[i] != ShapedType::kDynamic && rhsValid[i] != ShapedType::kDynamic &&
-        lhsValid[i] != rhsValid[i])
+        lhsValid[i] != rhsValid[i]) {
       return op->emitOpError() << "expects " << lhsName << " and " << rhsName
                                << " to have the same valid_shape";
+    }
   }
-  if (lhsValid.size() != rhsValid.size())
+  if (lhsValid.size() != rhsValid.size()) {
     return op->emitOpError() << "expects " << lhsName << " and " << rhsName
                              << " to have the same valid_shape";
+  }
   return success();
 }
 
@@ -4632,25 +5218,29 @@ static LogicalResult verifyTileBufSameLogicalExtent(Operation *op, Type lhs,
                                                     Type rhs, StringRef lhsName,
                                                     StringRef rhsName,
                                                     bool compareValidShape) {
-  if (!isTileLikeType(lhs) || !isTileLikeType(rhs))
+  if (!isTileLikeType(lhs) || !isTileLikeType(rhs)) {
     return success();
+  }
 
   auto lhsExtent = getLogicalTileExtentVec(lhs, compareValidShape);
   auto rhsExtent = getLogicalTileExtentVec(rhs, compareValidShape);
   auto emitMismatch = [&]() -> LogicalResult {
-    if (compareValidShape)
+    if (compareValidShape) {
       return op->emitOpError() << "expects " << lhsName << " and " << rhsName
                                << " to have the same valid_shape";
+    }
     return op->emitOpError() << "expects " << lhsName << " and " << rhsName
                              << " to have compatible shapes";
   };
-  if (lhsExtent.size() != rhsExtent.size())
+  if (lhsExtent.size() != rhsExtent.size()) {
     return emitMismatch();
+  }
 
   for (size_t i = 0, e = lhsExtent.size(); i < e; ++i) {
     if (lhsExtent[i] != ShapedType::kDynamic &&
-        rhsExtent[i] != ShapedType::kDynamic && lhsExtent[i] != rhsExtent[i])
+        rhsExtent[i] != ShapedType::kDynamic && lhsExtent[i] != rhsExtent[i]) {
       return emitMismatch();
+    }
   }
   return success();
 }
@@ -4660,29 +5250,33 @@ static LogicalResult verifyPartialValidPattern(Operation *op, Type src0Ty,
   auto src0Valid = getValidShapeVec(src0Ty);
   auto src1Valid = getValidShapeVec(src1Ty);
   auto dstValid = getValidShapeVec(dstTy);
-  if (src0Valid.size() != 2 || src1Valid.size() != 2 || dstValid.size() != 2)
+  if (src0Valid.size() != 2 || src1Valid.size() != 2 || dstValid.size() != 2) {
     return op->emitOpError("expects src0, src1, and dst to have rank-2 valid_shape");
+  }
 
   auto lessEqualKnown = [](int64_t lhs, int64_t rhs) {
     return lhs == ShapedType::kDynamic || rhs == ShapedType::kDynamic || lhs <= rhs;
   };
   auto equalsKnown = [](ArrayRef<int64_t> lhs, ArrayRef<int64_t> rhs) {
     for (auto [a, b] : llvm::zip(lhs, rhs)) {
-      if (a != ShapedType::kDynamic && b != ShapedType::kDynamic && a != b)
+      if (a != ShapedType::kDynamic && b != ShapedType::kDynamic && a != b) {
         return false;
+      }
     }
     return true;
   };
 
   for (unsigned i = 0; i < 2; ++i) {
     if (!lessEqualKnown(src0Valid[i], dstValid[i]) ||
-        !lessEqualKnown(src1Valid[i], dstValid[i]))
+        !lessEqualKnown(src1Valid[i], dstValid[i])) {
       return op->emitOpError(
           "expects src0/src1 valid_shape to be less than or equal to dst valid_shape");
+    }
   }
-  if (!equalsKnown(src0Valid, dstValid) && !equalsKnown(src1Valid, dstValid))
+  if (!equalsKnown(src0Valid, dstValid) && !equalsKnown(src1Valid, dstValid)) {
     return op->emitOpError(
         "expects at least one of src0/src1 valid_shape to match dst valid_shape");
+  }
   return success();
 }
 
@@ -4691,8 +5285,9 @@ static LogicalResult verifyPartialValidPatternLoose(Operation *op, Type src0Ty,
   auto src0Valid = getValidShapeVec(src0Ty);
   auto src1Valid = getValidShapeVec(src1Ty);
   auto dstValid = getValidShapeVec(dstTy);
-  if (src0Valid.size() != 2 || src1Valid.size() != 2 || dstValid.size() != 2)
+  if (src0Valid.size() != 2 || src1Valid.size() != 2 || dstValid.size() != 2) {
     return op->emitOpError("expects src0, src1, and dst to have rank-2 valid_shape");
+  }
 
   auto lessEqualKnown = [](int64_t lhs, int64_t rhs) {
     return lhs == ShapedType::kDynamic || rhs == ShapedType::kDynamic || lhs <= rhs;
@@ -4700,17 +5295,19 @@ static LogicalResult verifyPartialValidPatternLoose(Operation *op, Type src0Ty,
 
   for (unsigned i = 0; i < 2; ++i) {
     if (!lessEqualKnown(src0Valid[i], dstValid[i]) ||
-        !lessEqualKnown(src1Valid[i], dstValid[i]))
+        !lessEqualKnown(src1Valid[i], dstValid[i])) {
       return op->emitOpError(
           "expects src0/src1 valid_shape to be less than or equal to dst valid_shape");
+    }
   }
   return success();
 }
 
 [[maybe_unused]] static bool hasKnownZeroValidRegion(Type ty) {
   auto valid = getValidShapeVec(ty);
-  if (valid.size() != 2)
+  if (valid.size() != 2) {
     return false;
+  }
   return valid[0] == 0 || valid[1] == 0;
 }
 
@@ -4719,37 +5316,44 @@ static LogicalResult verifyScalarTileOp(Operation *op, Type srcTy, Type dstTy,
                                         bool requireValidRowsEqual,
                                         bool requireValidColsEqual) {
   if (failed(verifyTileBufCommon(op, srcTy, srcName)) ||
-      failed(verifyTileBufCommon(op, dstTy, dstName)))
+      failed(verifyTileBufCommon(op, dstTy, dstName))) {
     return failure();
+  }
   auto srcSpace = getPTOMemorySpaceEnum(srcTy);
   auto dstSpace = getPTOMemorySpaceEnum(dstTy);
-  if (!srcSpace || *srcSpace != pto::AddressSpace::VEC)
+  if (!srcSpace || *srcSpace != pto::AddressSpace::VEC) {
     return op->emitOpError() << "expects " << srcName
                              << " to be in the vec address space";
-  if (!dstSpace || *dstSpace != pto::AddressSpace::VEC)
+  }
+  if (!dstSpace || *dstSpace != pto::AddressSpace::VEC) {
     return op->emitOpError() << "expects " << dstName
                              << " to be in the vec address space";
-  if (failed(verifyTileBufSameElemType(op, srcTy, dstTy, srcName, dstName)))
+  }
+  if (failed(verifyTileBufSameElemType(op, srcTy, dstTy, srcName, dstName))) {
     return failure();
+  }
 
   auto srcValid = getValidShapeVec(srcTy);
   auto dstValid = getValidShapeVec(dstTy);
-  if (srcValid.size() != 2 || dstValid.size() != 2)
+  if (srcValid.size() != 2 || dstValid.size() != 2) {
     return op->emitOpError()
            << "expects " << srcName << " and " << dstName
            << " to have rank-2 valid_shape";
+  }
   if (requireValidRowsEqual &&
       srcValid[0] != ShapedType::kDynamic && dstValid[0] != ShapedType::kDynamic &&
-      srcValid[0] != dstValid[0])
+      srcValid[0] != dstValid[0]) {
     return op->emitOpError()
            << "expects " << srcName << " and " << dstName
            << " to have the same valid_shape[0]";
+  }
   if (requireValidColsEqual &&
       srcValid[1] != ShapedType::kDynamic && dstValid[1] != ShapedType::kDynamic &&
-      srcValid[1] != dstValid[1])
+      srcValid[1] != dstValid[1]) {
     return op->emitOpError()
            << "expects " << srcName << " and " << dstName
            << " to have the same valid_shape[1]";
+  }
   return success();
 }
 
@@ -4758,13 +5362,15 @@ verifyMatchingRowMajorBinaryTileOpCommon(Operation *op, Type src0Ty, Type src1Ty
                                          Type dstTy) {
   if (failed(verifyTileBufCommon(op, src0Ty, "src0")) ||
       failed(verifyTileBufCommon(op, src1Ty, "src1")) ||
-      failed(verifyTileBufCommon(op, dstTy, "dst")))
+      failed(verifyTileBufCommon(op, dstTy, "dst"))) {
     return failure();
+  }
   if (failed(verifyTileBufSameElemType(op, src0Ty, src1Ty, "src0", "src1")) ||
       failed(verifyTileBufSameElemType(op, src0Ty, dstTy, "src0", "dst")) ||
       failed(verifyTileBufSameValidShape(op, src0Ty, src1Ty, "src0", "src1")) ||
-      failed(verifyTileBufSameValidShape(op, src0Ty, dstTy, "src0", "dst")))
+      failed(verifyTileBufSameValidShape(op, src0Ty, dstTy, "src0", "dst"))) {
     return failure();
+  }
   if (!isRowMajorTileBuf(src0Ty) || !isRowMajorTileBuf(src1Ty) ||
       !isRowMajorTileBuf(dstTy)) {
     op->emitOpError("expects src0, src1, and dst to use row-major layout");
@@ -4778,8 +5384,9 @@ verifyNumericScalarTileOpCommon(Operation *op, Type srcTy, Type dstTy,
                                 Type scalarTy, bool requireValidRowsEqual) {
   if (failed(verifyScalarTileOp(op, srcTy, dstTy, "src", "dst",
                                 requireValidRowsEqual,
-                                /*requireValidColsEqual=*/true)))
+                                /*requireValidColsEqual=*/true))) {
     return failure();
+  }
   if (!mlir::isa<IntegerType, FloatType>(scalarTy)) {
     op->emitOpError("scalar must be a scalar type (integer/float)");
     return failure();
@@ -4792,8 +5399,9 @@ verifyShiftLikeBinaryTileOpCommon(Operation *op, Type src0Ty, Type src1Ty,
                                    Type dstTy) {
   if (failed(verifyTileBufCommon(op, src0Ty, "src0")) ||
       failed(verifyTileBufCommon(op, src1Ty, "src1")) ||
-      failed(verifyTileBufCommon(op, dstTy, "dst")))
+      failed(verifyTileBufCommon(op, dstTy, "dst"))) {
     return failure();
+  }
   Type e0 = getElemTy(src0Ty);
   Type e1 = getElemTy(src1Ty);
   Type ed = getElemTy(dstTy);
@@ -4811,8 +5419,9 @@ verifyShiftLikeBinaryTileOpCommon(Operation *op, Type src0Ty, Type src1Ty,
     return failure();
   }
   if (failed(verifyTileBufSameValidShape(op, src0Ty, dstTy, "src0", "dst")) ||
-      failed(verifyTileBufSameValidShape(op, src1Ty, dstTy, "src1", "dst")))
+      failed(verifyTileBufSameValidShape(op, src1Ty, dstTy, "src1", "dst"))) {
     return failure();
+  }
   return e0;
 }
 
@@ -4826,8 +5435,9 @@ static FailureOr<Type> verifyDistinctRowMajorUnaryTileOpCommon(
   Type srcTy = src.getType();
   Type dstTy = dst.getType();
   if (failed(verifyTileBufCommon(op, srcTy, srcName)) ||
-      failed(verifyTileBufCommon(op, dstTy, dstName)))
+      failed(verifyTileBufCommon(op, dstTy, dstName))) {
     return failure();
+  }
 
   Type srcElem = getElemTy(srcTy);
   Type dstElem = getElemTy(dstTy);
@@ -4843,8 +5453,9 @@ static FailureOr<Type> verifyDistinctRowMajorUnaryTileOpCommon(
     op->emitOpError("expects src and dst to use row-major layout");
     return failure();
   }
-  if (failed(verifyTileBufSameValidShape(op, srcTy, dstTy, srcName, dstName)))
+  if (failed(verifyTileBufSameValidShape(op, srcTy, dstTy, srcName, dstName))) {
     return failure();
+  }
   return srcElem;
 }
 
@@ -4853,11 +5464,13 @@ static LogicalResult verifyArithmeticElemTypeForArch(
     bool allowBf16OnA5, StringRef a2a3Error, StringRef a5Error) {
   bool supported = elemTy.isInteger(32) || elemTy.isInteger(16) ||
                    elemTy.isF16() || elemTy.isF32();
-  if (targetArch == PTOArch::A5)
+  if (targetArch == PTOArch::A5) {
     supported = supported || (allowInt8OnA5 && elemTy.isInteger(8)) ||
                 (allowBf16OnA5 && elemTy.isBF16());
-  if (supported)
+  }
+  if (supported) {
     return success();
+  }
   return op->emitOpError(targetArch == PTOArch::A5 ? a5Error : a2a3Error);
 }
 
@@ -4867,8 +5480,9 @@ static LogicalResult verifyArithmeticBinaryTileOpWithArchDispatch(
   auto verifyByArch = [&](PTOArch targetArch) -> LogicalResult {
     FailureOr<Type> elemOr =
         verifyMatchingRowMajorBinaryTileOpCommon(op, src0Ty, src1Ty, dstTy);
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     return verifyArithmeticElemTypeForArch(op, *elemOr, targetArch,
                                            allowInt8OnA5, allowBf16OnA5,
                                            a2a3Error, a5Error);
@@ -4887,8 +5501,9 @@ static LogicalResult verifyArithmeticScalarTileOpWithArchDispatch(
                           bool requireValidRowsEqual) -> LogicalResult {
     FailureOr<Type> elemOr = verifyNumericScalarTileOpCommon(
         op, srcTy, dstTy, scalarTy, requireValidRowsEqual);
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     return verifyArithmeticElemTypeForArch(op, *elemOr, targetArch,
                                            allowInt8OnA5, allowBf16OnA5,
                                            a2a3Error, a5Error);
@@ -4907,11 +5522,13 @@ static LogicalResult verifyTColReductionElemTypeForArch(
     bool allowBf16OnA5, StringRef a2a3Error, StringRef a5Error) {
   bool ok = elemTy.isF16() || elemTy.isF32() || elemTy.isInteger(16) ||
             elemTy.isInteger(32);
-  if (targetArch == PTOArch::A5)
+  if (targetArch == PTOArch::A5) {
     ok = ok || (allowInt8OnA5 && elemTy.isInteger(8)) ||
          (allowBf16OnA5 && elemTy.isBF16());
-  if (ok)
+  }
+  if (ok) {
     return success();
+  }
   return op->emitOpError(targetArch == PTOArch::A5 ? a5Error : a2a3Error);
 }
 
@@ -4922,12 +5539,15 @@ static LogicalResult verifyTColReductionOpWithArchDispatch(
   auto verifyByArch = [&](PTOArch targetArch,
                           bool requireNonZeroSrc) -> LogicalResult {
     if (failed(verifyNDStyleVecTile(op, srcTy, "src")) ||
-        failed(verifyNDStyleVecTile(op, dstTy, "dst")))
+        failed(verifyNDStyleVecTile(op, dstTy, "dst"))) {
       return failure();
-    if (getElemTy(srcTy) != getElemTy(dstTy))
+    }
+    if (getElemTy(srcTy) != getElemTy(dstTy)) {
       return op->emitOpError("expects src and dst to have the same element type");
-    if (failed(verifyColReductionValidRegion(op, srcTy, dstTy, requireNonZeroSrc)))
+    }
+    if (failed(verifyColReductionValidRegion(op, srcTy, dstTy, requireNonZeroSrc))) {
       return failure();
+    }
     Type elem = getElemTy(srcTy);
     return verifyTColReductionElemTypeForArch(op, elem, targetArch, allowInt8OnA5,
                                               allowBf16OnA5, a2a3Error, a5Error);
@@ -4959,23 +5579,28 @@ static bool hasCompatibleKnownExtentOrZero(int64_t lhs, int64_t rhs) {
 }
 
 static LogicalResult verifyVecTileStorage(Operation *op, Type ty, StringRef name) {
-  if (failed(verifyTileBufCommon(op, ty, name)))
+  if (failed(verifyTileBufCommon(op, ty, name))) {
     return failure();
+  }
   auto as = getPTOMemorySpaceEnum(ty);
-  if (!as || *as != pto::AddressSpace::VEC)
+  if (!as || *as != pto::AddressSpace::VEC) {
     return op->emitOpError() << "expects " << name << " to be in the vec address space";
+  }
   return success();
 }
 static LogicalResult verifyVecTileCommonA2A3(Operation *op, Type ty,
                                              StringRef name) {
-  if (failed(verifyTileBufCommon(op, ty, name)))
+  if (failed(verifyTileBufCommon(op, ty, name))) {
     return failure();
+  }
   auto tb = dyn_cast<pto::TileBufType>(ty);
   auto as = getPTOMemorySpaceEnum(ty);
-  if (as && *as != pto::AddressSpace::VEC)
+  if (as && *as != pto::AddressSpace::VEC) {
     return op->emitOpError() << "expects " << name << " to be in the vec address space";
-  if (tb && tb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor))
+  }
+  if (tb && tb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor)) {
     return op->emitOpError() << "expects " << name << " to use the row_major blayout";
+  }
   return success();
 }
 
@@ -5000,22 +5625,27 @@ static LogicalResult verifyVecTileUnaryOp(Operation *op, Type srcTy, Type dstTy,
                                           bool allowBf16,
                                           bool allowInt8) {
   if (failed(verifyVecTileCommon(op, srcTy, srcName)) ||
-      failed(verifyVecTileCommon(op, dstTy, dstName)))
+      failed(verifyVecTileCommon(op, dstTy, dstName))) {
     return failure();
-  if (failed(verifyTileBufSameElemType(op, srcTy, dstTy, srcName, dstName)))
+  }
+  if (failed(verifyTileBufSameElemType(op, srcTy, dstTy, srcName, dstName))) {
     return failure();
-  if (!isSupportedVecElemType(getElemTy(srcTy), allowBf16, allowInt8))
+  }
+  if (!isSupportedVecElemType(getElemTy(srcTy), allowBf16, allowInt8)) {
     return op->emitOpError() << "expects vec tile element types to be supported";
+  }
   return success();
 }
 
 static LogicalResult verifyAccTileCommonA2A3(Operation *op, Type ty,
                                              StringRef name) {
-  if (failed(verifyTileBufCommon(op, ty, name)))
+  if (failed(verifyTileBufCommon(op, ty, name))) {
     return failure();
+  }
   auto as = getPTOMemorySpaceEnum(ty);
-  if (!as || *as != pto::AddressSpace::ACC)
+  if (!as || *as != pto::AddressSpace::ACC) {
     return op->emitOpError() << "expects " << name << " to be in the acc address space";
+  }
   return success();
 }
 
@@ -5039,23 +5669,27 @@ static LogicalResult verifyMatTileOperandsA2A3(Operation *op, Type lhsTy,
                                                bool allowLowPrecision) {
   if (failed(verifyTileBufCommon(op, lhsTy, "lhs", allowLowPrecision)) ||
       failed(verifyTileBufCommon(op, rhsTy, "rhs", allowLowPrecision)) ||
-      failed(verifyAccTileCommon(op, dstTy, "dst")))
+      failed(verifyAccTileCommon(op, dstTy, "dst"))) {
     return failure();
+  }
   auto lhsSpace = getPTOMemorySpaceEnum(lhsTy);
   auto rhsSpace = getPTOMemorySpaceEnum(rhsTy);
   auto dstSpace = getPTOMemorySpaceEnum(dstTy);
-  if (!lhsSpace || !rhsSpace || !dstSpace)
+  if (!lhsSpace || !rhsSpace || !dstSpace) {
     return op->emitOpError("expects lhs, rhs, and dst to have explicit address spaces");
+  }
   if (*lhsSpace != pto::AddressSpace::LEFT || *rhsSpace != pto::AddressSpace::RIGHT ||
-      *dstSpace != pto::AddressSpace::ACC)
+      *dstSpace != pto::AddressSpace::ACC) {
     return op->emitOpError(
         "expects lhs, rhs, and dst to use the left, right, and acc address spaces");
+  }
   auto lhsShape = getMatmulLogicalShapeVec(lhsTy);
   auto rhsShape = getMatmulLogicalShapeVec(rhsTy);
   auto dstShape = getMatmulLogicalShapeVec(dstTy);
-  if ((lhsShape[0] != dstShape[0] || rhsShape[1] != dstShape[1] || lhsShape[1] != rhsShape[0]))
+  if ((lhsShape[0] != dstShape[0] || rhsShape[1] != dstShape[1] || lhsShape[1] != rhsShape[0])) {
     return op->emitOpError(
         "expects static matmul tile shapes lhs[M,K], rhs[K,N], and dst[M,N]");
+  }
   auto lhsValid = getValidShapeVec(lhsTy);
   auto rhsValid = getValidShapeVec(rhsTy);
   if (lhsValid.size() == 2 && rhsValid.size() == 2) {
@@ -5064,8 +5698,9 @@ static LogicalResult verifyMatTileOperandsA2A3(Operation *op, Type lhsTy,
     int64_t n = rhsValid[1];
     if ((m != ShapedType::kDynamic && (m < 0 || m > 4095)) ||
         (k != ShapedType::kDynamic && (k < 0 || k > 4095)) ||
-        (n != ShapedType::kDynamic && (n < 0 || n > 4095)))
+        (n != ShapedType::kDynamic && (n < 0 || n > 4095))) {
       return op->emitOpError("expects m, k, and n valid sizes to be in [0, 4095]");
+    }
   }
   return success();
 }
@@ -5074,28 +5709,36 @@ static LogicalResult verifyMatTileOperandsA5(Operation *op, Type lhsTy,
                                              Type rhsTy, Type dstTy,
                                              bool allowLowPrecision) {
   if (failed(verifyMatTileOperandsA2A3(op, lhsTy, rhsTy, dstTy,
-                                       allowLowPrecision)))
+                                       allowLowPrecision))) {
     return failure();
+  }
 
   auto lhsTb = mlir::dyn_cast<pto::TileBufType>(lhsTy);
   auto rhsTb = mlir::dyn_cast<pto::TileBufType>(rhsTy);
   auto dstTb = mlir::dyn_cast<pto::TileBufType>(dstTy);
-  if (!lhsTb || !rhsTb || !dstTb)
+  if (!lhsTb || !rhsTb || !dstTb) {
     return success();
+  }
 
-  if (lhsTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor))
+  if (lhsTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor)) {
     return op->emitOpError("expects lhs to use the col_major blayout on A5");
-  if (rhsTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor))
+  }
+  if (rhsTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor)) {
     return op->emitOpError("expects rhs to use the row_major blayout on A5");
-  if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor))
+  }
+  if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor)) {
     return op->emitOpError("expects dst to use the col_major blayout on A5");
+  }
 
-  if (lhsTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))
+  if (lhsTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor)) {
     return op->emitOpError("expects lhs to use the row_major slayout on A5");
-  if (rhsTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor))
+  }
+  if (rhsTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor)) {
     return op->emitOpError("expects rhs to use the col_major slayout on A5");
-  if (dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))
+  }
+  if (dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor)) {
     return op->emitOpError("expects dst to use the row_major slayout on A5");
+  }
   return success();
 }
 
@@ -5117,42 +5760,50 @@ static LogicalResult verifyGemvTileOperandsA2A3(Operation *op, Type lhsTy,
                                                 Type rhsTy, Type dstTy) {
   if (failed(verifyTileBufCommon(op, lhsTy, "lhs")) ||
       failed(verifyTileBufCommon(op, rhsTy, "rhs")) ||
-      failed(verifyAccTileCommon(op, dstTy, "dst")))
+      failed(verifyAccTileCommon(op, dstTy, "dst"))) {
     return failure();
+  }
 
   auto lhsSpace = getPTOMemorySpaceEnum(lhsTy);
   auto rhsSpace = getPTOMemorySpaceEnum(rhsTy);
-  if (!lhsSpace || !rhsSpace)
+  if (!lhsSpace || !rhsSpace) {
     return op->emitOpError("expects lhs and rhs to have explicit address spaces");
-  if (*lhsSpace != pto::AddressSpace::LEFT || *rhsSpace != pto::AddressSpace::RIGHT)
+  }
+  if (*lhsSpace != pto::AddressSpace::LEFT || *rhsSpace != pto::AddressSpace::RIGHT) {
     return op->emitOpError(
         "expects lhs and rhs to use the left and right address spaces");
+  }
 
   auto lhsValid = getValidShapeVec(lhsTy);
   auto rhsValid = getValidShapeVec(rhsTy);
   auto dstValid = getValidShapeVec(dstTy);
-  if (lhsValid[0] != ShapedType::kDynamic && lhsValid[0] != 1)
+  if (lhsValid[0] != ShapedType::kDynamic && lhsValid[0] != 1) {
     return op->emitOpError("expects lhs valid_shape[0] to be 1 for tgemv");
+  }
   if (isa<pto::TileBufType>(dstTy) && dstValid[0] != ShapedType::kDynamic &&
-      dstValid[0] != 1)
+      dstValid[0] != 1) {
     return op->emitOpError("expects dst valid_shape[0] to be 1 for tgemv");
+  }
   if (lhsValid[1] != ShapedType::kDynamic && rhsValid[0] != ShapedType::kDynamic &&
-      lhsValid[1] != rhsValid[0])
+      lhsValid[1] != rhsValid[0]) {
     return op->emitOpError()
            << "expects lhs valid_shape[1] to equal rhs valid_shape[0], but got "
            << lhsValid[1] << " vs " << rhsValid[0];
+  }
   if (rhsValid[1] != ShapedType::kDynamic && dstValid[1] != ShapedType::kDynamic &&
-      rhsValid[1] != dstValid[1])
+      rhsValid[1] != dstValid[1]) {
     return op->emitOpError()
            << "expects rhs valid_shape[1] to equal dst valid_shape[1], but got "
            << rhsValid[1] << " vs " << dstValid[1];
+  }
   return success();
 }
 
 static LogicalResult verifyGemvTileOperandsA5(Operation *op, Type lhsTy,
                                               Type rhsTy, Type dstTy) {
-  if (failed(verifyGemvTileOperandsA2A3(op, lhsTy, rhsTy, dstTy)))
+  if (failed(verifyGemvTileOperandsA2A3(op, lhsTy, rhsTy, dstTy))) {
     return failure();
+  }
   return verifyMatTileOperandsA5(op, lhsTy, rhsTy, dstTy);
 }
 
@@ -5170,8 +5821,9 @@ static LogicalResult verifyGemvTileOperands(Operation *op, Type lhsTy, Type rhsT
 static LogicalResult verifyA5MxMatTileOperands(Operation *op, Type lhsTy,
                                                Type rhsTy, Type dstTy) {
   if (failed(verifyMatTileOperandsA5(op, lhsTy, rhsTy, dstTy,
-                                     /*allowLowPrecision=*/true)))
+                                     /*allowLowPrecision=*/true))) {
     return failure();
+  }
 
   auto lhsShape = getShapeVec(lhsTy);
   auto rhsShape = getShapeVec(rhsTy);
@@ -5179,15 +5831,18 @@ static LogicalResult verifyA5MxMatTileOperands(Operation *op, Type lhsTy,
     int64_t lhsK = lhsShape[1];
     int64_t rhsK = rhsShape[0];
     auto checkPhysicalK = [&](int64_t value, StringRef name) -> LogicalResult {
-      if (value != ShapedType::kDynamic && (value < 1 || (value % 64) != 0))
+      if (value != ShapedType::kDynamic && (value < 1 || (value % 64) != 0)) {
         return op->emitOpError() << "expects " << name
                                  << " physical K shape to be a positive multiple of 64 on A5";
+      }
       return success();
     };
-    if (failed(checkPhysicalK(lhsK, "lhs")))
+    if (failed(checkPhysicalK(lhsK, "lhs"))) {
       return failure();
-    if (failed(checkPhysicalK(rhsK, "rhs")))
+    }
+    if (failed(checkPhysicalK(rhsK, "rhs"))) {
       return failure();
+    }
   }
 
   auto lhsValid = getValidShapeVec(lhsTy);
@@ -5198,15 +5853,17 @@ static LogicalResult verifyA5MxMatTileOperands(Operation *op, Type lhsTy,
     int64_t n = rhsValid[1];
     if ((m != ShapedType::kDynamic && (m < 1 || m > 4095)) ||
         (k != ShapedType::kDynamic && (k < 1 || k > 4095)) ||
-        (n != ShapedType::kDynamic && (n < 1 || n > 4095)))
+        (n != ShapedType::kDynamic && (n < 1 || n > 4095))) {
       return op->emitOpError("expects m, k, and n valid sizes to be in [1, 4095]");
+    }
   }
   return success();
 }
 
 static int64_t ceilDivKnown(int64_t value, int64_t divisor) {
-  if (value == ShapedType::kDynamic)
+  if (value == ShapedType::kDynamic) {
     return ShapedType::kDynamic;
+  }
   return (value + divisor - 1) / divisor;
 }
 
@@ -5215,18 +5872,21 @@ static LogicalResult verifyA5MxMatScaleTile(Operation *op, Type scaleTy,
                                             StringRef scaleName,
                                             bool isLeftScale) {
   if (failed(verifyTileBufCommon(op, scaleTy, scaleName,
-                                 /*allowLowPrecision=*/true)))
+                                 /*allowLowPrecision=*/true))) {
     return failure();
+  }
   auto scaleSpace = getPTOMemorySpaceEnum(scaleTy);
-  if (!scaleSpace || *scaleSpace != pto::AddressSpace::SCALING)
+  if (!scaleSpace || *scaleSpace != pto::AddressSpace::SCALING) {
     return op->emitOpError() << "expects " << scaleName
                              << " to be in the scaling address space";
+  }
 
   auto checkDims = [&](ArrayRef<int64_t> scaleDims, ArrayRef<int64_t> lhsDims,
                        ArrayRef<int64_t> rhsDims, StringRef dimsName) -> LogicalResult {
-    if (scaleDims.size() != 2 || lhsDims.size() != 2 || rhsDims.size() != 2)
+    if (scaleDims.size() != 2 || lhsDims.size() != 2 || rhsDims.size() != 2) {
       return op->emitOpError() << "expects " << scaleName << ", lhs, and rhs to have rank-2 "
                                << dimsName;
+    }
 
     int64_t m = lhsDims[0];
     int64_t k = lhsDims[1];
@@ -5244,15 +5904,18 @@ static LogicalResult verifyA5MxMatScaleTile(Operation *op, Type scaleTy,
   };
 
   if (failed(checkDims(getShapeVec(scaleTy), getShapeVec(lhsTy), getShapeVec(rhsTy),
-                       "shape")))
+                       "shape"))) {
     return failure();
+  }
   if (failed(checkDims(getValidShapeVec(scaleTy), getValidShapeVec(lhsTy),
-                       getValidShapeVec(rhsTy), "valid_shape")))
+                       getValidShapeVec(rhsTy), "valid_shape"))) {
     return failure();
+  }
 
   auto scaleTb = dyn_cast<pto::TileBufType>(scaleTy);
-  if (!scaleTb)
+  if (!scaleTb) {
     return success();
+  }
   if (scaleTb.getBLayoutValueI32() !=
       static_cast<int32_t>(isLeftScale ? pto::BLayout::RowMajor
                                        : pto::BLayout::ColMajor)) {
@@ -5269,9 +5932,10 @@ static LogicalResult verifyA5MxMatScaleTile(Operation *op, Type scaleTy,
            << (isLeftScale ? "row_major" : "col_major")
            << " slayout on A5";
   }
-  if (scaleTb.getSFractalSizeI32() != 32)
+  if (scaleTb.getSFractalSizeI32() != 32) {
     return op->emitOpError() << "expects " << scaleName
                              << " to use fractal=32 on A5";
+  }
   return success();
 }
 
@@ -5279,8 +5943,9 @@ static LogicalResult verifyA5MxMatScaleTiles(Operation *op, Type lhsScaleTy,
                                              Type rhsScaleTy, Type lhsTy,
                                              Type rhsTy) {
   if (failed(verifyA5MxMatScaleTile(op, lhsScaleTy, lhsTy, rhsTy, "a_scale",
-                                    /*isLeftScale=*/true)))
+                                    /*isLeftScale=*/true))) {
     return failure();
+  }
   return verifyA5MxMatScaleTile(op, rhsScaleTy, lhsTy, rhsTy, "b_scale",
                                 /*isLeftScale=*/false);
 }
@@ -5289,26 +5954,30 @@ static LogicalResult verifyA5MxGemvTileOperands(Operation *op, Type lhsTy,
                                                 Type rhsTy, Type dstTy) {
   if (failed(verifyTileBufCommon(op, lhsTy, "lhs", /*allowLowPrecision=*/true)) ||
       failed(verifyTileBufCommon(op, rhsTy, "rhs", /*allowLowPrecision=*/true)) ||
-      failed(verifyAccTileCommon(op, dstTy, "dst")))
+      failed(verifyAccTileCommon(op, dstTy, "dst"))) {
     return failure();
+  }
 
   auto lhsSpace = getPTOMemorySpaceEnum(lhsTy);
   auto rhsSpace = getPTOMemorySpaceEnum(rhsTy);
   auto dstSpace = getPTOMemorySpaceEnum(dstTy);
-  if (!lhsSpace || !rhsSpace || !dstSpace)
+  if (!lhsSpace || !rhsSpace || !dstSpace) {
     return op->emitOpError("expects lhs, rhs, and dst to have explicit address spaces");
+  }
   if (*lhsSpace != pto::AddressSpace::LEFT || *rhsSpace != pto::AddressSpace::RIGHT ||
-      *dstSpace != pto::AddressSpace::ACC)
+      *dstSpace != pto::AddressSpace::ACC) {
     return op->emitOpError(
         "expects lhs, rhs, and dst to use the left, right, and acc address spaces");
+  }
 
   auto lhsShape = getMatmulLogicalShapeVec(lhsTy);
   auto rhsShape = getMatmulLogicalShapeVec(rhsTy);
   auto dstShape = getMatmulLogicalShapeVec(dstTy);
   if ((lhsShape[0] != dstShape[0] || rhsShape[1] != dstShape[1] ||
-       lhsShape[1] != rhsShape[0]))
+       lhsShape[1] != rhsShape[0])) {
     return op->emitOpError(
         "expects static matmul tile shapes lhs[M,K], rhs[K,N], and dst[M,N]");
+  }
 
   auto lhsValid = getValidShapeVec(lhsTy);
   auto rhsValid = getValidShapeVec(rhsTy);
@@ -5319,44 +5988,56 @@ static LogicalResult verifyA5MxGemvTileOperands(Operation *op, Type lhsTy,
     int64_t n = rhsValid[1];
     if ((m != ShapedType::kDynamic && (m < 1 || m > 4095)) ||
         (k != ShapedType::kDynamic && (k < 1 || k > 4095)) ||
-        (n != ShapedType::kDynamic && (n < 1 || n > 4095)))
+        (n != ShapedType::kDynamic && (n < 1 || n > 4095))) {
       return op->emitOpError("expects m, k, and n valid sizes to be in [1, 4095]");
+    }
   }
 
-  if (lhsValid[0] != ShapedType::kDynamic && lhsValid[0] != 1)
+  if (lhsValid[0] != ShapedType::kDynamic && lhsValid[0] != 1) {
     return op->emitOpError("expects lhs valid_shape[0] to be 1 for tgemv");
-  if (dstValid[0] != ShapedType::kDynamic && dstValid[0] != 1)
+  }
+  if (dstValid[0] != ShapedType::kDynamic && dstValid[0] != 1) {
     return op->emitOpError("expects dst valid_shape[0] to be 1 for tgemv");
+  }
   if (lhsValid[1] != ShapedType::kDynamic && rhsValid[0] != ShapedType::kDynamic &&
-      lhsValid[1] != rhsValid[0])
+      lhsValid[1] != rhsValid[0]) {
     return op->emitOpError()
            << "expects lhs valid_shape[1] to equal rhs valid_shape[0], but got "
            << lhsValid[1] << " vs " << rhsValid[0];
+  }
   if (rhsValid[1] != ShapedType::kDynamic && dstValid[1] != ShapedType::kDynamic &&
-      rhsValid[1] != dstValid[1])
+      rhsValid[1] != dstValid[1]) {
     return op->emitOpError()
            << "expects rhs valid_shape[1] to equal dst valid_shape[1], but got "
            << rhsValid[1] << " vs " << dstValid[1];
+  }
 
   auto lhsTb = dyn_cast<pto::TileBufType>(lhsTy);
   auto rhsTb = dyn_cast<pto::TileBufType>(rhsTy);
   auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
-  if (!lhsTb || !rhsTb || !dstTb)
+  if (!lhsTb || !rhsTb || !dstTb) {
     return success();
+  }
 
-  if (lhsTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor))
+  if (lhsTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor)) {
     return op->emitOpError("expects lhs to use the col_major blayout on A5");
-  if (rhsTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor))
+  }
+  if (rhsTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor)) {
     return op->emitOpError("expects rhs to use the row_major blayout on A5");
-  if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor))
+  }
+  if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor)) {
     return op->emitOpError("expects dst to use the col_major blayout on A5");
+  }
 
-  if (lhsTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))
+  if (lhsTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor)) {
     return op->emitOpError("expects lhs to use the row_major slayout on A5");
-  if (rhsTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor))
+  }
+  if (rhsTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor)) {
     return op->emitOpError("expects rhs to use the col_major slayout on A5");
-  if (dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))
+  }
+  if (dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor)) {
     return op->emitOpError("expects dst to use the row_major slayout on A5");
+  }
   return success();
 }
 
@@ -5365,12 +6046,14 @@ static LogicalResult verifyA5MxGemvScaleTile(Operation *op, Type scaleTy,
                                              StringRef scaleName,
                                              bool isLeftScale) {
   if (failed(verifyTileBufCommon(op, scaleTy, scaleName,
-                                 /*allowLowPrecision=*/true)))
+                                 /*allowLowPrecision=*/true))) {
     return failure();
+  }
   auto scaleSpace = getPTOMemorySpaceEnum(scaleTy);
-  if (!scaleSpace || *scaleSpace != pto::AddressSpace::SCALING)
+  if (!scaleSpace || *scaleSpace != pto::AddressSpace::SCALING) {
     return op->emitOpError() << "expects " << scaleName
                              << " to be in the scaling address space";
+  }
 
   auto scaleShape = getShapeVec(scaleTy);
   auto scaleValid = getValidShapeVec(scaleTy);
@@ -5380,9 +6063,10 @@ static LogicalResult verifyA5MxGemvScaleTile(Operation *op, Type scaleTy,
   auto rhsValid = getValidShapeVec(rhsTy);
   if (scaleShape.size() != 2 || scaleValid.size() != 2 ||
       lhsShape.size() != 2 || rhsShape.size() != 2 || lhsValid.size() != 2 ||
-      rhsValid.size() != 2)
+      rhsValid.size() != 2) {
     return op->emitOpError() << "expects " << scaleName
                              << ", lhs, and rhs to have rank-2 shape/valid_shape";
+  }
 
   int64_t logicalM = lhsValid[0];
   int64_t logicalK = lhsValid[1];
@@ -5398,10 +6082,11 @@ static LogicalResult verifyA5MxGemvScaleTile(Operation *op, Type scaleTy,
       !hasCompatibleKnownExtent(scaleShape[1], expectedShapeCols) ||
       !hasCompatibleKnownExtent(scaleValid[0], expectedValidRows) ||
       !hasCompatibleKnownExtent(scaleValid[1], expectedValidCols)) {
-    if (isLeftScale)
+    if (isLeftScale) {
       return op->emitOpError()
              << "expects " << scaleName
              << " shape/valid_shape to be [M, ceil(K/32)]";
+    }
     return op->emitOpError()
            << "expects " << scaleName
            << " shape/valid_shape to be [ceil(K/32), aligned_N]/[ceil(K/32), N]";
@@ -5411,17 +6096,21 @@ static LogicalResult verifyA5MxGemvScaleTile(Operation *op, Type scaleTy,
 
 static LogicalResult verifyMatBiasTileA2A3(Operation *op, Type biasTy, Type dstTy,
                                            bool requireFloatBias) {
-  if (failed(verifyTileBufCommon(op, biasTy, "bias")))
+  if (failed(verifyTileBufCommon(op, biasTy, "bias"))) {
     return failure();
+  }
   auto biasSpace = getPTOMemorySpaceEnum(biasTy);
-  if (!biasSpace || *biasSpace != pto::AddressSpace::BIAS)
+  if (!biasSpace || *biasSpace != pto::AddressSpace::BIAS) {
     return op->emitOpError("expects bias to be in the bias address space");
+  }
   auto biasShape = getShapeVec(biasTy);
-  if (biasShape[0] != ShapedType::kDynamic && biasShape[0] != 1)
+  if (biasShape[0] != ShapedType::kDynamic && biasShape[0] != 1) {
     return op->emitOpError("expects bias to have 1 row");
+  }
   if (requireFloatBias) {
-    if (!getElemTy(biasTy).isF32())
+    if (!getElemTy(biasTy).isF32()) {
       return op->emitOpError("expects bias to have element type f32");
+    }
   } else if (getElemTy(biasTy) != getElemTy(dstTy)) {
     return op->emitOpError("expects bias and dst to have the same element type");
   }
@@ -5430,11 +6119,13 @@ static LogicalResult verifyMatBiasTileA2A3(Operation *op, Type biasTy, Type dstT
 
 static LogicalResult verifyMatBiasTileA5(Operation *op, Type biasTy, Type dstTy,
                                          bool requireFloatBias) {
-  if (failed(verifyMatBiasTileA2A3(op, biasTy, dstTy, requireFloatBias)))
+  if (failed(verifyMatBiasTileA2A3(op, biasTy, dstTy, requireFloatBias))) {
     return failure();
+  }
   if (auto biasTb = dyn_cast<pto::TileBufType>(biasTy)) {
-    if (biasTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor))
+    if (biasTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor)) {
       return op->emitOpError("expects bias to use the row_major blayout on A5");
+    }
   }
   return success();
 }
@@ -5456,23 +6147,27 @@ static LogicalResult verifyMatmulTypeTriple(Operation *op, Type lhsElemTy,
   auto isInt8 = [](Type ty) {
     return ty.isInteger(8);
   };
-  if (dstElemTy.isInteger(32) && isInt8(lhsElemTy) && isInt8(rhsElemTy))
+  if (dstElemTy.isInteger(32) && isInt8(lhsElemTy) && isInt8(rhsElemTy)) {
     return success();
+  }
 
   auto isSupportedFpInput = [](Type ty) {
     return ty.isF16() || ty.isBF16() || ty.isF32();
   };
-  if (dstElemTy.isF32() && lhsElemTy == rhsElemTy && isSupportedFpInput(lhsElemTy))
+  if (dstElemTy.isF32() && lhsElemTy == rhsElemTy && isSupportedFpInput(lhsElemTy)) {
     return success();
+  }
 
   auto isA5TMatmulFp8Type = [](Type ty) {
     return isPTOFloat8Type(ty);
   };
   if (isA5 && dstElemTy.isF32()) {
-    if (isA5TMatmulFp8Type(lhsElemTy) && isA5TMatmulFp8Type(rhsElemTy))
+    if (isA5TMatmulFp8Type(lhsElemTy) && isA5TMatmulFp8Type(rhsElemTy)) {
       return success();
-    if (isPTOHiFloat8Type(lhsElemTy) && lhsElemTy == rhsElemTy)
+    }
+    if (isPTOHiFloat8Type(lhsElemTy) && lhsElemTy == rhsElemTy) {
       return success();
+    }
   }
 
   return op->emitOpError()
@@ -5493,11 +6188,13 @@ LogicalResult pto::TAddReluOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyMatchingRowMajorBinaryTileOpCommon(
         getOperation(), getSrc0().getType(), getSrc1().getType(), getDst().getType());
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     Type elemTy = *elemOr;
-    if (elemTy.isInteger(16) || elemTy.isF16() || elemTy.isF32())
+    if (elemTy.isInteger(16) || elemTy.isF16() || elemTy.isF32()) {
       return success();
+    }
     return emitOpError("expects element type to be i16/f16/f32");
   };
   auto verifyA5 = [&]() -> LogicalResult {
@@ -5513,15 +6210,17 @@ LogicalResult pto::TAddCOp::verify() {
   Type td = getDst().getType();
 
   if (!isPTOShapedLike(t0) || !isPTOShapedLike(t1) ||
-      !isPTOShapedLike(t2) || !isPTOShapedLike(td))
+      !isPTOShapedLike(t2) || !isPTOShapedLike(td)) {
     return emitOpError("expects src0/src1/src2/dst to be PTO shaped-like types");
+  }
 
   auto s0 = getShapeVec(t0);
   auto s1 = getShapeVec(t1);
   auto s2 = getShapeVec(t2);
   auto sd = getShapeVec(td);
-  if (s0 != s1 || s0 != s2 || s0 != sd)
+  if (s0 != s1 || s0 != s2 || s0 != sd) {
     return emitOpError("expects src0/src1/src2/dst to have the same shape");
+  }
   return success();
 }
 LogicalResult pto::TAddSOp::verify() {
@@ -5539,51 +6238,63 @@ LogicalResult pto::TAxpyOp::verify() {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyVecTileCommon(*this, srcTy, "src")) ||
-        failed(verifyVecTileCommon(*this, dstTy, "dst")))
+        failed(verifyVecTileCommon(*this, dstTy, "dst"))) {
       return failure();
-    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+    }
+    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
       return failure();
+    }
 
     Type scalarTy = getScalar().getType();
     Type srcElem = getElemTy(srcTy);
-    if (scalarTy != srcElem)
+    if (scalarTy != srcElem) {
       return emitOpError("expects scalar type to match src element type");
-    if (getShapeVec(srcTy) != getShapeVec(dstTy))
+    }
+    if (getShapeVec(srcTy) != getShapeVec(dstTy)) {
       return emitOpError("expects src and dst to have the same shape");
+    }
     return success();
   };
 
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (failed(verifyCommon()))
+    if (failed(verifyCommon())) {
       return failure();
+    }
     Type srcElem = getElemTy(getSrc().getType());
     Type dstElem = getElemTy(getDst().getType());
     bool sameType = srcElem == dstElem;
     bool widenF16ToF32 = srcElem.isF16() && dstElem.isF32();
-    if (!(sameType || widenF16ToF32))
+    if (!(sameType || widenF16ToF32)) {
       return emitOpError(
           "expects dst/src element types to match, or dst=f32 and src=f16");
-    if (!(dstElem.isF16() || dstElem.isF32()))
+    }
+    if (!(dstElem.isF16() || dstElem.isF32())) {
       return emitOpError("expects A2/A3 taxpy dst element type to be f16/f32");
-    if (!(srcElem.isF16() || srcElem.isF32()))
+    }
+    if (!(srcElem.isF16() || srcElem.isF32())) {
       return emitOpError("expects A2/A3 taxpy src element type to be f16/f32");
+    }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
-    if (failed(verifyCommon()))
+    if (failed(verifyCommon())) {
       return failure();
+    }
     Type srcElem = getElemTy(getSrc().getType());
     Type dstElem = getElemTy(getDst().getType());
     bool sameType = srcElem == dstElem;
     bool widenF16ToF32 = srcElem.isF16() && dstElem.isF32();
-    if (!(sameType || widenF16ToF32))
+    if (!(sameType || widenF16ToF32)) {
       return emitOpError(
           "expects dst/src element types to match, or dst=f32 and src=f16");
-    if (!(dstElem.isF16() || dstElem.isF32() || dstElem.isBF16()))
+    }
+    if (!(dstElem.isF16() || dstElem.isF32() || dstElem.isBF16())) {
       return emitOpError("expects A5 taxpy dst element type to be f16/bf16/f32");
-    if (!(srcElem.isF16() || srcElem.isF32() || srcElem.isBF16()))
+    }
+    if (!(srcElem.isF16() || srcElem.isF32() || srcElem.isBF16())) {
       return emitOpError("expects A5 taxpy src element type to be f16/bf16/f32");
+    }
     return success();
   };
 
@@ -5594,14 +6305,16 @@ LogicalResult pto::TAddSCOp::verify() {
   Type ts0 = getSrc0().getType();
   Type ts1 = getSrc1().getType();
   Type td = getDst().getType();
-  if (!isPTOShapedLike(ts0) || !isPTOShapedLike(ts1) || !isPTOShapedLike(td))
+  if (!isPTOShapedLike(ts0) || !isPTOShapedLike(ts1) || !isPTOShapedLike(td)) {
     return emitOpError("expects src0/src1/dst to be PTO shaped-like types");
+  }
 
   auto s0 = getShapeVec(ts0);
   auto s1 = getShapeVec(ts1);
   auto sd = getShapeVec(td);
-  if (s0 != s1 || s0 != sd)
+  if (s0 != s1 || s0 != sd) {
     return emitOpError("expects src0/src1/dst to have the same shape");
+  }
   return success();
 }
 
@@ -5614,25 +6327,29 @@ LogicalResult pto::TAndOp::verify() {
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
     if (!it || (it.getWidth() != 8 && it.getWidth() != 16 &&
-                it.getWidth() != 32))
+                it.getWidth() != 32)) {
       return emitOpError(
           "expects A2/A3 tand src0, src1, and dst element type to be i8/i16/i32");
+    }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
     if (!it || (it.getWidth() != 8 && it.getWidth() != 16 &&
-                it.getWidth() != 32))
+                it.getWidth() != 32)) {
       return emitOpError(
           "expects A5 tand src0, src1, and dst element type to be i8/i16/i32");
+    }
     return success();
   };
 
@@ -5646,8 +6363,9 @@ mlir::LogicalResult mlir::pto::TConcatOp::verify() {
     Type td = getDst().getType();
     if (failed(verifyTileBufCommon(*this, t0, "src0")) ||
         failed(verifyTileBufCommon(*this, t1, "src1")) ||
-        failed(verifyTileBufCommon(*this, td, "dst")))
+        failed(verifyTileBufCommon(*this, td, "dst"))) {
       return failure();
+    }
 
     Type e0 = getElemTy(t0);
     Type e1 = getElemTy(t1);
@@ -5664,65 +6382,77 @@ mlir::LogicalResult mlir::pto::TConcatOp::verify() {
     auto v0 = getValidShapeVec(getSrc0());
     auto v1 = getValidShapeVec(getSrc1());
     auto vd = getValidShapeVec(getDst());
-    if (v0.size() != 2 || v1.size() != 2 || vd.size() != 2)
+    if (v0.size() != 2 || v1.size() != 2 || vd.size() != 2) {
       return emitOpError("expects src0, src1, and dst to have rank-2 valid_shape");
+    }
 
     // validRow must match dst (when known).
-    if (v0[0] != ShapedType::kDynamic && vd[0] != ShapedType::kDynamic && v0[0] != vd[0])
+    if (v0[0] != ShapedType::kDynamic && vd[0] != ShapedType::kDynamic && v0[0] != vd[0]) {
       return emitOpError("expects src0 valid row to match dst valid row");
-    if (v1[0] != ShapedType::kDynamic && vd[0] != ShapedType::kDynamic && v1[0] != vd[0])
+    }
+    if (v1[0] != ShapedType::kDynamic && vd[0] != ShapedType::kDynamic && v1[0] != vd[0]) {
       return emitOpError("expects src1 valid row to match dst valid row");
+    }
 
     // Total valid columns must fit within dst static cols (when known).
     auto sd = getShapeVec(td);
     if (sd.size() == 2 && sd[1] != ShapedType::kDynamic &&
         v0[1] != ShapedType::kDynamic && v1[1] != ShapedType::kDynamic) {
-      if (v0[1] + v1[1] > sd[1])
+      if (v0[1] + v1[1] > sd[1]) {
         return emitOpError("expects src0.valid_col + src1.valid_col <= dst.cols");
+      }
     }
 
     return e0;
   };
 
   auto verifyElemType = [&](Type elem) -> LogicalResult {
-    if (elem.isF16() || elem.isF32() || elem.isBF16())
+    if (elem.isF16() || elem.isF32() || elem.isBF16()) {
       return success();
+    }
     auto it = mlir::dyn_cast<IntegerType>(elem);
     if (!it ||
-        (it.getWidth() != 8 && it.getWidth() != 16 && it.getWidth() != 32))
+        (it.getWidth() != 8 && it.getWidth() != 16 && it.getWidth() != 32)) {
       return emitOpError("expects element type to be i8, i16, i32, f16, f32, or bf16");
+    }
     return success();
   };
 
   auto verifyLocVec = [&](Type ty, StringRef name) -> LogicalResult {
     auto as = getPTOMemorySpaceEnum(ty);
-    if (!as || *as != pto::AddressSpace::VEC)
+    if (!as || *as != pto::AddressSpace::VEC) {
       return emitOpError() << "expects " << name << " to use loc=vec";
+    }
     return success();
   };
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     if (failed(verifyLocVec(getSrc0().getType(), "src0")) ||
         failed(verifyLocVec(getSrc1().getType(), "src1")) ||
-        failed(verifyLocVec(getDst().getType(), "dst")))
+        failed(verifyLocVec(getDst().getType(), "dst"))) {
       return failure();
+    }
     return verifyElemType(*elemOr);
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     if (failed(verifyLocVec(getSrc0().getType(), "src0")) ||
         failed(verifyLocVec(getSrc1().getType(), "src1")) ||
-        failed(verifyLocVec(getDst().getType(), "dst")))
+        failed(verifyLocVec(getDst().getType(), "dst"))) {
       return failure();
+    }
     if (!isRowMajorTileBuf(getSrc0().getType()) || !isRowMajorTileBuf(getSrc1().getType()) ||
-        !isRowMajorTileBuf(getDst().getType()))
+        !isRowMajorTileBuf(getDst().getType())) {
       return emitOpError("expects src0, src1, and dst to use row-major layout");
+    }
     return verifyElemType(*elemOr);
   };
 
@@ -5740,8 +6470,9 @@ LogicalResult pto::TConcatidxOp::verify() {
         failed(verifyTileBufCommon(*this, t1, "src1")) ||
         failed(verifyTileBufCommon(*this, ti0, "src0Idx")) ||
         failed(verifyTileBufCommon(*this, ti1, "src1Idx")) ||
-        failed(verifyTileBufCommon(*this, td, "dst")))
+        failed(verifyTileBufCommon(*this, td, "dst"))) {
       return failure();
+    }
 
     // Check data element type consistency.
     Type e0 = getElemTy(t0);
@@ -5775,27 +6506,32 @@ LogicalResult pto::TConcatidxOp::verify() {
     auto vi1 = getValidShapeVec(getSrc1Idx());
     auto vd  = getValidShapeVec(getDst());
     if (v0.size() != 2 || v1.size() != 2 || vi0.size() != 2 ||
-        vi1.size() != 2 || vd.size() != 2)
+        vi1.size() != 2 || vd.size() != 2) {
       return emitOpError("expects all operands to have rank-2 valid_shape");
+    }
 
     // validRow must match dst (when known).
     auto checkValidRow = [&](const auto &v, StringRef name) -> LogicalResult {
       if (v[0] != ShapedType::kDynamic && vd[0] != ShapedType::kDynamic &&
-          v[0] != vd[0])
+          v[0] != vd[0]) {
         return emitOpError("expects ") << name << " valid row to match dst valid row";
+      }
       return success();
     };
     if (failed(checkValidRow(v0, "src0")) ||
         failed(checkValidRow(v1, "src1")) ||
         failed(checkValidRow(vi0, "src0Idx")) ||
-        failed(checkValidRow(vi1, "src1Idx")))
+        failed(checkValidRow(vi1, "src1Idx"))) {
       return failure();
+    }
 
     // Index tile must have cols >= 1 (when known).
-    if (vi0[1] != ShapedType::kDynamic && vi0[1] < 1)
+    if (vi0[1] != ShapedType::kDynamic && vi0[1] < 1) {
       return emitOpError("expects src0Idx valid_col >= 1");
-    if (vi1[1] != ShapedType::kDynamic && vi1[1] < 1)
+    }
+    if (vi1[1] != ShapedType::kDynamic && vi1[1] < 1) {
       return emitOpError("expects src1Idx valid_col >= 1");
+    }
 
     return std::make_pair(e0, ei0);
   };
@@ -5805,57 +6541,65 @@ LogicalResult pto::TConcatidxOp::verify() {
     if (!dataElem.isF16() && !dataElem.isF32() && !dataElem.isBF16()) {
       auto it = mlir::dyn_cast<IntegerType>(dataElem);
       if (!it || !it.isSignless() ||
-          (it.getWidth() != 8 && it.getWidth() != 16 && it.getWidth() != 32))
+          (it.getWidth() != 8 && it.getWidth() != 16 && it.getWidth() != 32)) {
         return emitOpError()
                << "expects data element type to be i8, i16, i32, f16, f32, or bf16";
+      }
     }
 
     // Index element type: i8, i16, i32 (signless).
     auto it = mlir::dyn_cast<IntegerType>(idxElem);
     if (!it || !it.isSignless() ||
-        (it.getWidth() != 8 && it.getWidth() != 16 && it.getWidth() != 32))
+        (it.getWidth() != 8 && it.getWidth() != 16 && it.getWidth() != 32)) {
       return emitOpError()
              << "expects index element type to be i8, i16, or i32";
+    }
     return success();
   };
 
   auto verifyLocVec = [&](Type ty, StringRef name) -> LogicalResult {
     auto as = getPTOMemorySpaceEnum(ty);
-    if (!as || *as != pto::AddressSpace::VEC)
+    if (!as || *as != pto::AddressSpace::VEC) {
       return emitOpError() << "expects " << name << " to use loc=vec";
+    }
     return success();
   };
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     auto elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     if (failed(verifyLocVec(getSrc0().getType(), "src0")) ||
         failed(verifyLocVec(getSrc1().getType(), "src1")) ||
         failed(verifyLocVec(getSrc0Idx().getType(), "src0Idx")) ||
         failed(verifyLocVec(getSrc1Idx().getType(), "src1Idx")) ||
-        failed(verifyLocVec(getDst().getType(), "dst")))
+        failed(verifyLocVec(getDst().getType(), "dst"))) {
       return failure();
+    }
     return verifyElementTypes(elemOr->first, elemOr->second);
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     auto elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     if (failed(verifyLocVec(getSrc0().getType(), "src0")) ||
         failed(verifyLocVec(getSrc1().getType(), "src1")) ||
         failed(verifyLocVec(getSrc0Idx().getType(), "src0Idx")) ||
         failed(verifyLocVec(getSrc1Idx().getType(), "src1Idx")) ||
-        failed(verifyLocVec(getDst().getType(), "dst")))
+        failed(verifyLocVec(getDst().getType(), "dst"))) {
       return failure();
+    }
     if (!isRowMajorTileBuf(getSrc0().getType()) ||
         !isRowMajorTileBuf(getSrc1().getType()) ||
         !isRowMajorTileBuf(getSrc0Idx().getType()) ||
         !isRowMajorTileBuf(getSrc1Idx().getType()) ||
-        !isRowMajorTileBuf(getDst().getType()))
+        !isRowMajorTileBuf(getDst().getType())) {
       return emitOpError(
           "expects all operands to use row-major layout");
+    }
     return verifyElementTypes(elemOr->first, elemOr->second);
   };
 
@@ -5870,24 +6614,28 @@ LogicalResult pto::TAndSOp::verify() {
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
-    if (!it || (it.getWidth() != 8 && it.getWidth() != 16))
+    if (!it || (it.getWidth() != 8 && it.getWidth() != 16)) {
       return emitOpError(
           "expects A2/A3 tands src, scalar, and dst element type to be i8/i16");
+    }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
     if (!it || (it.getWidth() != 8 && it.getWidth() != 16 &&
-                it.getWidth() != 32))
+                it.getWidth() != 32)) {
       return emitOpError(
           "expects A5 tands src, scalar, and dst element type to be i8/i16/i32");
+    }
     return success();
   };
 
@@ -5898,30 +6646,38 @@ static ParseResult parseTCILikeOp(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::UnresolvedOperand s, tmp, dst;
   Type sTy, tmpTy, dstTy;
 
-  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(s))
+  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(s)) {
     return failure();
+  }
 
   bool hasTmp = succeeded(parser.parseOptionalComma());
-  if (hasTmp && parser.parseOperand(tmp))
+  if (hasTmp && parser.parseOperand(tmp)) {
     return failure();
+  }
 
-  if (parser.parseColonType(sTy))
+  if (parser.parseColonType(sTy)) {
     return failure();
+  }
   if (hasTmp) {
-    if (parser.parseComma() || parser.parseType(tmpTy))
+    if (parser.parseComma() || parser.parseType(tmpTy)) {
       return failure();
+    }
   }
   if (parser.parseRParen() || parser.parseKeyword("outs") || parser.parseLParen() ||
       parser.parseOperand(dst) || parser.parseColonType(dstTy) || parser.parseRParen() ||
-      parser.parseOptionalAttrDict(result.attributes))
+      parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
-  if (parser.resolveOperand(s, sTy, result.operands))
+  if (parser.resolveOperand(s, sTy, result.operands)) {
     return failure();
-  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands))
+  }
+  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands)) {
     return failure();
-  if (parser.resolveOperand(dst, dstTy, result.operands))
+  }
+  if (parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
+  }
 
   result.addAttribute(
       "operandSegmentSizes",
@@ -5932,11 +6688,13 @@ static ParseResult parseTCILikeOp(OpAsmParser &parser, OperationState &result) {
 static void printTCILikeOp(OpAsmPrinter &p, Operation *op, Value s, Value tmp,
                            Value dst) {
   p << " ins(" << s;
-  if (tmp)
+  if (tmp) {
     p << ", " << tmp;
+  }
   p << " : " << s.getType();
-  if (tmp)
+  if (tmp) {
     p << ", " << tmp.getType();
+  }
   p << ") outs(" << dst << " : " << dst.getType() << ")";
   p.printOptionalAttrDict(op->getAttrs(), /*elidedAttrs=*/{"operandSegmentSizes"});
 }
@@ -5951,89 +6709,110 @@ void mlir::pto::TCIOp::print(OpAsmPrinter &p) {
 
 LogicalResult pto::TCIOp::verify() {
   Type dstTy = getDst().getType();
-  if (failed(verifyTileBufCommon(*this, dstTy, "dst")))
+  if (failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
     return failure();
-  if (getTmp() && failed(verifyTileBufCommon(*this, getTmp().getType(), "tmp")))
+  }
+  if (getTmp() && failed(verifyTileBufCommon(*this, getTmp().getType(), "tmp"))) {
     return failure();
+  }
 
   auto elemTy = mlir::dyn_cast<IntegerType>(getElemTy(dstTy));
-  if (!elemTy)
+  if (!elemTy) {
     return emitOpError("expects dst element type to be integer");
+  }
 
   unsigned bw = elemTy.getWidth();
-  if (bw != 16 && bw != 32)
+  if (bw != 16 && bw != 32) {
     return emitOpError("expects dst element type to be i16/i32");
+  }
 
   if (getTmp() && getTargetArch(getOperation()) != PTOArch::A5) {
     auto tmpTy = mlir::dyn_cast<TileBufType>(getTmp().getType());
-    if (!tmpTy)
+    if (!tmpTy) {
       return emitOpError("expects tmp to be a tile buffer");
+    }
     auto tmpSpace =
         mlir::dyn_cast_or_null<AddressSpaceAttr>(tmpTy.getMemorySpace());
-    if (!tmpSpace || tmpSpace.getAddressSpace() != AddressSpace::VEC)
+    if (!tmpSpace || tmpSpace.getAddressSpace() != AddressSpace::VEC) {
       return emitOpError("expects tmp to be in vec address space");
+    }
     Type tmpElemTy = tmpTy.getElementType();
-    if (!(tmpElemTy.isF32() || tmpElemTy.isInteger(32)))
+    if (!(tmpElemTy.isF32() || tmpElemTy.isInteger(32))) {
       return emitOpError("expects A2/A3 tmp element type to be a 4-byte type");
-    if (tmpTy.getBLayoutValueI32() != static_cast<int32_t>(BLayout::RowMajor))
+    }
+    if (tmpTy.getBLayoutValueI32() != static_cast<int32_t>(BLayout::RowMajor)) {
       return emitOpError("expects tmp blayout to be row_major");
-    if (tmpTy.getSLayoutValueI32() != static_cast<int32_t>(SLayout::NoneBox))
+    }
+    if (tmpTy.getSLayoutValueI32() != static_cast<int32_t>(SLayout::NoneBox)) {
       return emitOpError("expects tmp slayout to be none_box");
-    if (tmpTy.getSFractalSizeI32() != 512)
+    }
+    if (tmpTy.getSFractalSizeI32() != 512) {
       return emitOpError("expects tmp fractal size to be 512");
+    }
     auto tmpBytes = getStaticByteSize(tmpTy);
-    if (!tmpBytes)
+    if (!tmpBytes) {
       return emitOpError("expects tmp to have static byte size");
+    }
     uint64_t minTmpBytes = bw == 32 ? 768 : 1792;
-    if (*tmpBytes < minTmpBytes)
+    if (*tmpBytes < minTmpBytes) {
       return emitOpError("expects A2/A3 tmp capacity to be at least ")
              << minTmpBytes << " bytes for " << bw
              << "-bit dst element type";
+    }
   }
 
   auto sTy = mlir::dyn_cast<IntegerType>(getOperand(0).getType());
-  if (!sTy)
+  if (!sTy) {
     return emitOpError("expects S to be integer");
+  }
 
-  if (sTy != elemTy)
+  if (sTy != elemTy) {
     return emitOpError("expects S and dst element type to be exactly the same type");
+  }
   auto shape = getShapeVec(dstTy);
-  if (shape.size() != 2)
+  if (shape.size() != 2) {
     return emitOpError("expects dst to be rank-2");
-  if (shape[1] != ShapedType::kDynamic && shape[1] == 1)
+  }
+  if (shape[1] != ShapedType::kDynamic && shape[1] == 1) {
     return emitOpError("expects dst cols to be different from 1");
+  }
 
   return success();
 }
 
 LogicalResult pto::TTriOp::verify() {
   Type dstTy = getDst().getType();
-  if (failed(verifyVecTileCommon(*this, dstTy, "dst")))
+  if (failed(verifyVecTileCommon(*this, dstTy, "dst"))) {
     return failure();
+  }
 
   auto diagonalTy = mlir::dyn_cast<IntegerType>(getDiagonal().getType());
-  if (!diagonalTy)
+  if (!diagonalTy) {
     return emitOpError("expects diagonal to be an integer operand");
+  }
 
   int32_t upperOrLower = getUpperOrLower();
-  if (upperOrLower != 0 && upperOrLower != 1)
+  if (upperOrLower != 0 && upperOrLower != 1) {
     return emitOpError("expects upperOrLower to be 0 (lower) or 1 (upper)");
+  }
 
   Type elemTy = getElemTy(dstTy);
   return dispatchVerifierByArch(
       getOperation(),
       [&]() -> LogicalResult {
         if (!isSupportedVecElemType(elemTy, /*allowBf16=*/false,
-                                    /*allowInt8=*/false))
+                                    /*allowInt8=*/false)) {
           return emitOpError()
                  << "expects A2/A3 dst element type to be f16/f32/i16/i32/u16/u32";
+        }
         return success();
       },
       [&]() -> LogicalResult {
         if (!isSupportedVecElemType(elemTy, /*allowBf16=*/true,
-                                    /*allowInt8=*/true))
+                                    /*allowInt8=*/true)) {
           return emitOpError()
                  << "expects A5 dst element type to be f16/f32/bf16/i8/i16/i32/u8/u16/u32";
+        }
         return success();
       });
 }
@@ -6045,32 +6824,41 @@ LogicalResult pto::TCmpOp::verify() {
     Type td = getDst().getType();
     if (failed(verifyVecTileStorage(*this, t0, "src0")) ||
         failed(verifyVecTileStorage(*this, t1, "src1")) ||
-        failed(verifyVecTileStorage(*this, td, "dst")))
+        failed(verifyVecTileStorage(*this, td, "dst"))) {
       return failure();
+    }
 
     Type e0 = getElemTy(t0);
     Type e1 = getElemTy(t1);
     Type ed = getElemTy(td);
-    if (!e0 || !e1 || !ed)
+    if (!e0 || !e1 || !ed) {
       return emitOpError("failed to get element type for src0/src1/dst");
-    if (e0 != e1)
+    }
+    if (e0 != e1) {
       return emitOpError("expects src0 and src1 to have the same element type");
-    if (!(e0.isInteger(32) || e0.isF16() || e0.isF32()))
+    }
+    if (!(e0.isInteger(32) || e0.isF16() || e0.isF32())) {
       return emitOpError("expects A2/A3 tcmp input element type to be i32/f16/f32");
-    if (!ed.isInteger(8))
+    }
+    if (!ed.isInteger(8)) {
       return emitOpError("expects dst element type to be i8");
+    }
 
     auto valid0 = getValidShapeVec(t0);
     auto valid1 = getValidShapeVec(t1);
     auto validd = getValidShapeVec(td);
-    if (valid0.size() != 2 || valid1.size() != 2 || validd.size() != 2)
+    if (valid0.size() != 2 || valid1.size() != 2 || validd.size() != 2) {
       return emitOpError("expects src0, src1, and dst to have rank-2 valid_shape");
-    if (!hasCompatibleKnownExtent(valid0[0], valid1[0]))
+    }
+    if (!hasCompatibleKnownExtent(valid0[0], valid1[0])) {
       return emitOpError("expects src0 and src1 to have the same valid row");
-    if (!hasCompatibleKnownExtent(valid0[1], valid1[1]))
+    }
+    if (!hasCompatibleKnownExtent(valid0[1], valid1[1])) {
       return emitOpError("expects src0 and src1 to have the same valid column");
-    if (!hasCompatibleKnownExtent(valid0[0], validd[0]))
+    }
+    if (!hasCompatibleKnownExtent(valid0[0], validd[0])) {
       return emitOpError("expects src0 valid row to equal dst valid row");
+    }
     return success();
   };
 
@@ -6080,29 +6868,35 @@ LogicalResult pto::TCmpOp::verify() {
     Type td = getDst().getType();
     if (failed(verifyTileBufCommon(*this, t0, "src0")) ||
         failed(verifyTileBufCommon(*this, t1, "src1")) ||
-        failed(verifyTileBufCommon(*this, td, "dst")))
+        failed(verifyTileBufCommon(*this, td, "dst"))) {
       return failure();
+    }
 
     Type e0 = getElemTy(t0);
     Type e1 = getElemTy(t1);
     Type ed = getElemTy(td);
-    if (!e0 || !e1 || !ed)
+    if (!e0 || !e1 || !ed) {
       return emitOpError("failed to get element type for src0/src1/dst");
-    if (e0 != e1)
+    }
+    if (e0 != e1) {
       return emitOpError("expects src0 and src1 to have the same element type");
+    }
     bool inputOk = e0.isF16() || e0.isF32() || e0.isBF16() ||
                    e0.isInteger(8) || e0.isInteger(16) || e0.isInteger(32);
-    if (!inputOk)
+    if (!inputOk) {
       return emitOpError("expects A5 tcmp input element type to be i8/i16/i32/f16/bf16/f32");
+    }
     if (auto it = dyn_cast<IntegerType>(ed)) {
-      if (it.getWidth() != 8)
+      if (it.getWidth() != 8) {
         return emitOpError("expects dst element type to be i8");
+      }
     } else {
       return emitOpError("expects dst element type to be i8");
     }
 
-    if (getShapeVec(t0) != getShapeVec(t1) || getShapeVec(t0) != getShapeVec(td))
+    if (getShapeVec(t0) != getShapeVec(t1) || getShapeVec(t0) != getShapeVec(td)) {
       return emitOpError("expects src0, src1, and dst to have the same shape");
+    }
     return success();
   };
 
@@ -6115,25 +6909,30 @@ LogicalResult pto::TCmpSOp::verify() {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyVecTileStorage(*this, srcTy, "src")) ||
-        failed(verifyVecTileStorage(*this, dstTy, "dst")))
+        failed(verifyVecTileStorage(*this, dstTy, "dst"))) {
       return failure();
+    }
 
     Type elemTy = getElemTy(srcTy);
     if (!(elemTy.isInteger(16) || elemTy.isInteger(32) ||
-          elemTy.isF16() || elemTy.isF32()))
+          elemTy.isF16() || elemTy.isF32())) {
       return emitOpError("expects A2/A3 tcmps input element type to be i16/i32/f16/f32");
+    }
 
     auto scalarTy = getScalar().getType();
-    if (!(scalarTy.isIntOrIndexOrFloat()))
+    if (!(scalarTy.isIntOrIndexOrFloat())) {
       return emitOpError("expects scalar to be integer, index, or float");
+    }
 
     auto srcValid = getValidShapeVec(srcTy);
     auto dstValid = getValidShapeVec(dstTy);
-    if (srcValid.size() != 2 || dstValid.size() != 2)
+    if (srcValid.size() != 2 || dstValid.size() != 2) {
       return emitOpError("expects src and dst to have rank-2 valid_shape");
+    }
     if (srcValid[0] != ShapedType::kDynamic && dstValid[0] != ShapedType::kDynamic &&
-        srcValid[0] != dstValid[0])
+        srcValid[0] != dstValid[0]) {
       return emitOpError("expects src and dst to have the same valid_shape[0]");
+    }
     return success();
   };
 
@@ -6141,25 +6940,30 @@ LogicalResult pto::TCmpSOp::verify() {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyVecTileStorage(*this, srcTy, "src")) ||
-        failed(verifyVecTileStorage(*this, dstTy, "dst")))
+        failed(verifyVecTileStorage(*this, dstTy, "dst"))) {
       return failure();
+    }
 
     Type elemTy = getElemTy(srcTy);
     if (!(elemTy.isInteger(8) || elemTy.isInteger(16) || elemTy.isInteger(32) ||
-          elemTy.isF16() || elemTy.isF32()))
+          elemTy.isF16() || elemTy.isF32())) {
       return emitOpError("expects A5 tcmps input element type to be i8/i16/i32/f16/f32");
+    }
 
     auto scalarTy = getScalar().getType();
-    if (!(scalarTy.isIntOrIndexOrFloat()))
+    if (!(scalarTy.isIntOrIndexOrFloat())) {
       return emitOpError("expects scalar to be integer, index, or float");
+    }
 
     auto srcValid = getValidShapeVec(srcTy);
     auto dstValid = getValidShapeVec(dstTy);
-    if (srcValid.size() != 2 || dstValid.size() != 2)
+    if (srcValid.size() != 2 || dstValid.size() != 2) {
       return emitOpError("expects src and dst to have rank-2 valid_shape");
+    }
     if (srcValid[0] != ShapedType::kDynamic && dstValid[0] != ShapedType::kDynamic &&
-        srcValid[0] != dstValid[0])
+        srcValid[0] != dstValid[0]) {
       return emitOpError("expects src and dst to have the same valid_shape[0]");
+    }
     return success();
   };
 
@@ -6169,80 +6973,98 @@ LogicalResult pto::TColExpandOp::verify() {
   Type srcTy = getSrc().getType();
   Type dstTy = getDst().getType();
   if (failed(verifyNDStyleVecTile(*this, srcTy, "src")) ||
-      failed(verifyNDStyleVecTile(*this, dstTy, "dst")))
+      failed(verifyNDStyleVecTile(*this, dstTy, "dst"))) {
     return failure();
-  if (getElemTy(srcTy) != getElemTy(dstTy))
+  }
+  if (getElemTy(srcTy) != getElemTy(dstTy)) {
     return emitOpError("expects src and dst to have the same element type");
+  }
   if (!isSupportedVecElemType(getElemTy(srcTy), /*allowBf16=*/true,
-                              /*allowInt8=*/true))
+                              /*allowInt8=*/true)) {
     return emitOpError("expects tcolexpand element type to be supported");
+  }
   auto srcValid = getValidShapeVec(getSrc());
   auto dstValid = getValidShapeVec(getDst());
-  if (srcValid.size() != 2 || dstValid.size() != 2)
+  if (srcValid.size() != 2 || dstValid.size() != 2) {
     return emitOpError("expects src and dst to have rank-2 valid_shape");
+  }
   if (srcValid[1] != ShapedType::kDynamic && dstValid[1] != ShapedType::kDynamic &&
-      srcValid[1] != dstValid[1])
+      srcValid[1] != dstValid[1]) {
     return emitOpError("expects src and dst to have the same valid_shape[1]");
+  }
   return success();
 }
 static LogicalResult verifyTColExpandBinaryLikeOp(Operation *op, Type t0, Type t1,
                                                   Type td, PTOArch targetArch,
                                                   StringRef opName,
                                                   bool allowIntegerTypes) {
-  if (!isPTOShapedLike(t0) || !isPTOShapedLike(t1) || !isPTOShapedLike(td))
+  if (!isPTOShapedLike(t0) || !isPTOShapedLike(t1) || !isPTOShapedLike(td)) {
     return op->emitOpError("expects src0/src1/dst to be PTO shaped-like types");
+  }
 
   Type e0 = getElemTy(t0);
   Type e1 = getElemTy(t1);
   Type ed = getElemTy(td);
-  if (!e0 || !e1 || !ed)
+  if (!e0 || !e1 || !ed) {
     return op->emitOpError("failed to get element type for src0/src1/dst");
+  }
 
-  auto isSupportedElem = [&](Type elemTy) {
-    if (elemTy.isF16() || elemTy.isF32())
+  auto isSupportedElem = [allowIntegerTypes, targetArch](Type elemTy) {
+    if (elemTy.isF16() || elemTy.isF32()) {
       return true;
-    if (!allowIntegerTypes)
+    }
+    if (!allowIntegerTypes) {
       return false;
-    if (elemTy.isInteger(16) || elemTy.isInteger(32))
+    }
+    if (elemTy.isInteger(16) || elemTy.isInteger(32)) {
       return true;
+    }
     return targetArch == PTOArch::A5 && elemTy.isInteger(8);
   };
   if (!isSupportedElem(e0) || !isSupportedElem(e1) || !isSupportedElem(ed)) {
-    if (!allowIntegerTypes)
+    if (!allowIntegerTypes) {
       return op->emitOpError() << "expects " << opName
                                << " element type to be f16 or f32";
-    if (targetArch == PTOArch::A5)
+    }
+    if (targetArch == PTOArch::A5) {
       return op->emitOpError() << "expects A5 " << opName
                                << " element type to be i8/i16/i32/f16/f32";
+    }
     return op->emitOpError() << "expects A2/A3 " << opName
                              << " element type to be i16/i32/f16/f32";
   }
 
-  if (getShapeVec(t0) != getShapeVec(td))
+  if (getShapeVec(t0) != getShapeVec(td)) {
     return op->emitOpError("expects src0/dst to have same shape");
-  if (failed(verifyTileBufSameValidShape(op, t0, td, "src0", "dst")))
+  }
+  if (failed(verifyTileBufSameValidShape(op, t0, td, "src0", "dst"))) {
     return failure();
+  }
 
   if (auto src0TileTy = dyn_cast<TileBufType>(t0)) {
-    if (src0TileTy.getBLayoutValueI32() != 0)
+    if (src0TileTy.getBLayoutValueI32() != 0) {
       return op->emitOpError("expects src0 to use row-major layout");
+    }
   }
 
   if (auto src1TileTy = dyn_cast<TileBufType>(t1)) {
-    if (src1TileTy.getBLayoutValueI32() != 0)
+    if (src1TileTy.getBLayoutValueI32() != 0) {
       return op->emitOpError("expects src1 to use row-major layout");
+    }
   }
   if (auto dstTileTy = dyn_cast<TileBufType>(td)) {
-    if (dstTileTy.getBLayoutValueI32() != 0)
+    if (dstTileTy.getBLayoutValueI32() != 0) {
       return op->emitOpError("expects dst to use row-major layout");
+    }
   }
 
   auto src1Valid = getValidShapeVec(t1);
   auto dstValid = getValidShapeVec(td);
   if (src1Valid.size() == 2 && dstValid.size() == 2 &&
       src1Valid[1] != ShapedType::kDynamic && dstValid[1] != ShapedType::kDynamic &&
-      src1Valid[1] != dstValid[1])
+      src1Valid[1] != dstValid[1]) {
     return op->emitOpError("expects src1 valid_shape[1] to equal dst valid_shape[1]");
+  }
 
   return success();
 }
@@ -6310,9 +7132,10 @@ LogicalResult pto::TColMaxOp::verify() {
 }
 
 LogicalResult pto::TColArgMaxOp::verify() {
-  if (!getTmp())
+  if (!getTmp()) {
     return verifyTColArgReductionNoTmp(getOperation(), getSrc().getType(),
                                        getDst().getType());
+  }
   auto verifyA2A3 = [&]() -> LogicalResult {
     return verifyTColArgReductionOpA2A3(*this, getSrc().getType(),
                                         getTmp().getType(), getDst().getType());
@@ -6335,9 +7158,10 @@ LogicalResult pto::TColMinOp::verify() {
 }
 
 LogicalResult pto::TColArgMinOp::verify() {
-  if (!getTmp())
+  if (!getTmp()) {
     return verifyTColArgReductionNoTmp(getOperation(), getSrc().getType(),
                                        getDst().getType());
+  }
   auto verifyA2A3 = [&]() -> LogicalResult {
     return verifyTColArgReductionOpA2A3(*this, getSrc().getType(),
                                         getTmp().getType(), getDst().getType());
@@ -6360,55 +7184,66 @@ ParseResult mlir::pto::TColSumOp::parse(OpAsmParser &parser, OperationState &res
   bool hasTmp = false;
 
   // Parse: ins(%src : type) or ins(%src, %tmp {isBinary = ...}: type, type)
-  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src))
+  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src)) {
     return failure();
+  }
 
   // Check for optional tmp operand (format 2)
   if (succeeded(parser.parseOptionalComma())) {
     // Format 2: ins(%src, %tmp {isBinary = ...}: type, type)
-    if (parser.parseOperand(tmp))
+    if (parser.parseOperand(tmp)) {
       return failure();
+    }
     hasTmp = true;
 
     // Parse attributes (isBinary)
-    if (parser.parseOptionalAttrDict(result.attributes))
+    if (parser.parseOptionalAttrDict(result.attributes)) {
       return failure();
+    }
 
     // Parse types: : type, type
-    if (parser.parseColonType(srcTy) || parser.parseComma() || parser.parseType(tmpTy))
+    if (parser.parseColonType(srcTy) || parser.parseComma() || parser.parseType(tmpTy)) {
       return failure();
+    }
   } else {
     // Format 1: ins(%src : type)
-    if (parser.parseColonType(srcTy))
+    if (parser.parseColonType(srcTy)) {
       return failure();
+    }
   }
 
-  if (parser.parseRParen())
+  if (parser.parseRParen()) {
     return failure();
+  }
 
   // Parse: outs(%dst : type)
   if (parser.parseKeyword("outs") || parser.parseLParen() ||
       parser.parseOperand(dst) || parser.parseColonType(dstTy) ||
-      parser.parseRParen())
+      parser.parseRParen()) {
     return failure();
+  }
 
   // Parse any remaining attributes (for format 1)
   if (!hasTmp) {
-    if (parser.parseOptionalAttrDict(result.attributes))
+    if (parser.parseOptionalAttrDict(result.attributes)) {
       return failure();
+    }
   }
 
   // Resolve operands
-  if (parser.resolveOperand(src, srcTy, result.operands))
+  if (parser.resolveOperand(src, srcTy, result.operands)) {
     return failure();
-
-  if (hasTmp) {
-    if (parser.resolveOperand(tmp, tmpTy, result.operands))
-      return failure();
   }
 
-  if (parser.resolveOperand(dst, dstTy, result.operands))
+  if (hasTmp) {
+    if (parser.resolveOperand(tmp, tmpTy, result.operands)) {
+      return failure();
+    }
+  }
+
+  if (parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
+  }
 
   return success();
 }
@@ -6443,85 +7278,105 @@ LogicalResult pto::TColSumOp::verify() {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyNDStyleVecTile(*this, srcTy, "src")) ||
-        failed(verifyNDStyleVecTile(*this, dstTy, "dst")))
+        failed(verifyNDStyleVecTile(*this, dstTy, "dst"))) {
       return failure();
+    }
     bool hasTmp = (bool)getTmp();
     bool hasIsBinary = (bool)getIsBinaryAttr();
-    if (hasTmp && !hasIsBinary)
+    if (hasTmp && !hasIsBinary) {
       return emitOpError("tmp operand requires isBinary attribute");
+    }
     if (getTmp()) {
       Type tmpTy = getTmp().getType();
-      if (failed(verifyNDStyleVecTile(*this, tmpTy, "tmp")))
+      if (failed(verifyNDStyleVecTile(*this, tmpTy, "tmp"))) {
         return failure();
-      if (getElemTy(srcTy) != getElemTy(dstTy) || getElemTy(srcTy) != getElemTy(tmpTy))
+      }
+      if (getElemTy(srcTy) != getElemTy(dstTy) || getElemTy(srcTy) != getElemTy(tmpTy)) {
         return emitOpError("expects src/tmp/dst element types to match");
-      if (failed(verifyTColSumTmpStride(*this, srcTy, tmpTy, getIsBinary())))
+      }
+      if (failed(verifyTColSumTmpStride(*this, srcTy, tmpTy, getIsBinary()))) {
         return failure();
+      }
       if (getIsBinary()) {
         auto srcValid = getValidShapeVec(srcTy);
         auto elemBytes = getElemByteSize(getElemTy(srcTy));
         if (srcValid.size() != 2 || srcValid[0] == ShapedType::kDynamic ||
-            srcValid[1] == ShapedType::kDynamic || elemBytes == 0)
+            srcValid[1] == ShapedType::kDynamic || elemBytes == 0) {
           return emitOpError(
               "expects static src valid_shape and element size to verify tcolsum tmp");
+        }
         uint64_t requiredBytes =
             static_cast<uint64_t>(ceilDivInt64(srcValid[0], 2)) *
             static_cast<uint64_t>(srcValid[1]) * elemBytes;
-        if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, requiredBytes)))
+        if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, requiredBytes))) {
           return failure();
+        }
       }
     }
-    if (getElemTy(srcTy) != getElemTy(dstTy))
+    if (getElemTy(srcTy) != getElemTy(dstTy)) {
       return emitOpError("expects src/dst element types to match");
+    }
     if (failed(verifyColReductionValidRegion(*this, srcTy, dstTy,
-                                             /*requireNonZeroSrc=*/false)))
+                                             /*requireNonZeroSrc=*/false))) {
       return failure();
+    }
     Type elem = getElemTy(srcTy);
-    if (!(elem.isF16() || elem.isF32() || elem.isInteger(16) || elem.isInteger(32)))
+    if (!(elem.isF16() || elem.isF32() || elem.isInteger(16) || elem.isInteger(32))) {
       return emitOpError("expects A2/A3 tcolsum element type to be f16/f32/i16/i32");
+    }
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyNDStyleVecTile(*this, srcTy, "src")) ||
-        failed(verifyNDStyleVecTile(*this, dstTy, "dst")))
+        failed(verifyNDStyleVecTile(*this, dstTy, "dst"))) {
       return failure();
+    }
     bool hasTmp = (bool)getTmp();
     bool hasIsBinary = (bool)getIsBinaryAttr();
-    if (hasTmp && !hasIsBinary)
+    if (hasTmp && !hasIsBinary) {
       return emitOpError("tmp operand requires isBinary attribute");
+    }
     if (getTmp()) {
       Type tmpTy = getTmp().getType();
-      if (failed(verifyNDStyleVecTile(*this, tmpTy, "tmp")))
+      if (failed(verifyNDStyleVecTile(*this, tmpTy, "tmp"))) {
         return failure();
-      if (getElemTy(srcTy) != getElemTy(dstTy) || getElemTy(srcTy) != getElemTy(tmpTy))
+      }
+      if (getElemTy(srcTy) != getElemTy(dstTy) || getElemTy(srcTy) != getElemTy(tmpTy)) {
         return emitOpError("expects src/tmp/dst element types to match");
-      if (failed(verifyTColSumTmpStride(*this, srcTy, tmpTy, getIsBinary())))
+      }
+      if (failed(verifyTColSumTmpStride(*this, srcTy, tmpTy, getIsBinary()))) {
         return failure();
+      }
       if (getIsBinary()) {
         auto srcValid = getValidShapeVec(srcTy);
         auto elemBytes = getElemByteSize(getElemTy(srcTy));
         if (srcValid.size() != 2 || srcValid[0] == ShapedType::kDynamic ||
-            srcValid[1] == ShapedType::kDynamic || elemBytes == 0)
+            srcValid[1] == ShapedType::kDynamic || elemBytes == 0) {
           return emitOpError(
               "expects static src valid_shape and element size to verify tcolsum tmp");
+        }
         uint64_t requiredBytes =
             static_cast<uint64_t>(ceilDivInt64(srcValid[0], 2)) *
             static_cast<uint64_t>(srcValid[1]) * elemBytes;
-        if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, requiredBytes)))
+        if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, requiredBytes))) {
           return failure();
+        }
       }
     }
-    if (getElemTy(srcTy) != getElemTy(dstTy))
+    if (getElemTy(srcTy) != getElemTy(dstTy)) {
       return emitOpError("expects src/dst element types to match");
+    }
     if (failed(verifyColReductionValidRegion(*this, srcTy, dstTy,
-                                             /*requireNonZeroSrc=*/true)))
+                                             /*requireNonZeroSrc=*/true))) {
       return failure();
+    }
     Type elem = getElemTy(srcTy);
     if (!(elem.isF16() || elem.isF32() || elem.isBF16() || elem.isInteger(8) ||
-          elem.isInteger(16) || elem.isInteger(32)))
+          elem.isInteger(16) || elem.isInteger(32))) {
       return emitOpError("expects A5 tcolsum element type to be i8/i16/i32/f16/bf16/f32");
+    }
     return success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -6540,8 +7395,9 @@ llvm::LogicalResult mlir::pto::TCvtOp::verify() {
   Type srcTy = getSrc().getType();
   Type dstTy = getDst().getType();
   if (failed(verifyTileBufCommon(*this, srcTy, "src", /*allowLowPrecision=*/true)) ||
-      failed(verifyTileBufCommon(*this, dstTy, "dst", /*allowLowPrecision=*/true)))
+      failed(verifyTileBufCommon(*this, dstTy, "dst", /*allowLowPrecision=*/true))) {
     return failure();
+  }
   auto isResolvedSubview = [](Value value) {
     auto alloc = value.getDefiningOp<pto::AllocTileOp>();
     auto semantics =
@@ -6554,35 +7410,42 @@ llvm::LogicalResult mlir::pto::TCvtOp::verify() {
   // extent, so comparing physical shapes would reject a valid sliced tile.
   if (!isResolvedSubview(getSrc()) && !isResolvedSubview(getDst()) &&
       failed(verifyTileBufSameLogicalExtent(*this, srcTy, dstTy, "src", "dst",
-                                            /*compareValidShape=*/false)))
+                                            /*compareValidShape=*/false))) {
     return failure();
+  }
   if (failed(verifyTileBufSameLogicalExtent(*this, srcTy, dstTy, "src", "dst",
-                                            /*compareValidShape=*/true)))
+                                            /*compareValidShape=*/true))) {
     return failure();
+  }
   Type srcElem = getElemTy(srcTy);
   Type dstElem = getElemTy(dstTy);
   auto needsTmp = [&]() {
-    if (getSatMode() != pto::SaturationMode::OFF)
+    if (getSatMode() != pto::SaturationMode::OFF) {
       return false;
+    }
     return (srcElem.isF32() && dstElem.isInteger(16)) ||
            (srcElem.isF16() &&
             (dstElem.isInteger(16) || dstElem.isInteger(8)));
   };
   auto verifyTmp = [&]() -> LogicalResult {
-    if (!getTmp())
+    if (!getTmp()) {
       return success();
+    }
     Type tmpTy = getTmp().getType();
-    if (failed(verifyVecTileCommon(*this, tmpTy, "tmp")))
+    if (failed(verifyVecTileCommon(*this, tmpTy, "tmp"))) {
       return failure();
-    if (!needsTmp())
+    }
+    if (!needsTmp()) {
       return success();
+    }
     auto srcShape = getShapeVec(srcTy);
     auto dstValid = getValidShapeVec(dstTy);
     if (srcShape.size() != 2 || dstValid.size() != 2 ||
         llvm::is_contained(srcShape, ShapedType::kDynamic) ||
-        llvm::is_contained(dstValid, ShapedType::kDynamic))
+        llvm::is_contained(dstValid, ShapedType::kDynamic)) {
       return emitOpError(
           "expects static src shape and dst valid_shape to verify tcvt tmp");
+    }
     int64_t rows = dstValid[0], cols = dstValid[1];
     int64_t requiredBytes = 0;
     if (rows > 0 && cols > 0 && srcElem.isF32()) {
@@ -6604,22 +7467,26 @@ llvm::LogicalResult mlir::pto::TCvtOp::verify() {
       requiredBytes = dstElem.isInteger(8) ? halfToI8 : halfToI16;
     }
     auto tmpBytes = getStaticByteSize(tmpTy);
-    if (!tmpBytes || *tmpBytes < static_cast<uint64_t>(requiredBytes))
+    if (!tmpBytes || *tmpBytes < static_cast<uint64_t>(requiredBytes)) {
       return emitOpError()
              << "expects tcvt tmp capacity to be at least " << requiredBytes
              << " bytes";
+    }
     return success();
   };
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (isPTOLowPrecisionType(srcElem) || isPTOLowPrecisionType(dstElem))
+    if (isPTOLowPrecisionType(srcElem) || isPTOLowPrecisionType(dstElem)) {
       return emitOpError("expects A2/A3 tcvt low-precision element types to be unsupported");
+    }
     return verifyTmp();
   };
   auto verifyA5 = [&]() -> LogicalResult {
-    if (!isA5SupportedTCvtPair(srcElem, dstElem))
+    if (!isA5SupportedTCvtPair(srcElem, dstElem)) {
       return emitOpError("expects A5 tcvt low-precision type pairs to match PTO-ISA support");
-    if (getTmp() && failed(verifyVecTileCommon(*this, getTmp().getType(), "tmp")))
+    }
+    if (getTmp() && failed(verifyVecTileCommon(*this, getTmp().getType(), "tmp"))) {
       return failure();
+    }
     return success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -6631,19 +7498,23 @@ llvm::LogicalResult mlir::pto::TRandomOp::verify() {
   };
   auto verifyA5 = [&]() -> LogicalResult {
     Type dstTy = getDst().getType();
-    if (failed(verifyTileBufCommon(*this, dstTy, "dst")))
+    if (failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
       return failure();
-    if (!isRowMajorTileBuf(dstTy))
+    }
+    if (!isRowMajorTileBuf(dstTy)) {
       return emitOpError("expects dst to use row-major layout");
+    }
 
     Type elemTy = getElemTy(dstTy);
-    if (!elemTy.isInteger(32))
+    if (!elemTy.isInteger(32)) {
       return emitOpError("expects dst element type to be i32 or ui32");
+    }
 
     auto checkWord = [&](Value v, StringRef name) -> LogicalResult {
       auto ty = dyn_cast<IntegerType>(v.getType());
-      if (!ty || ty.getWidth() != 32)
+      if (!ty || ty.getWidth() != 32) {
         return emitOpError() << "expects " << name << " to be i32/ui32";
+      }
       return success();
     };
     if (failed(checkWord(getKey0(), "key0")) ||
@@ -6651,12 +7522,14 @@ llvm::LogicalResult mlir::pto::TRandomOp::verify() {
         failed(checkWord(getCounter0(), "counter0")) ||
         failed(checkWord(getCounter1(), "counter1")) ||
         failed(checkWord(getCounter2(), "counter2")) ||
-        failed(checkWord(getCounter3(), "counter3")))
+        failed(checkWord(getCounter3(), "counter3"))) {
       return failure();
+    }
 
     int32_t rounds = getRounds();
-    if (rounds != 7 && rounds != 10)
+    if (rounds != 7 && rounds != 10) {
       return emitOpError("expects rounds to be 7 or 10");
+    }
 
     return success();
   };
@@ -6668,22 +7541,26 @@ LogicalResult mlir::pto::TDivOp::verify() {
     FailureOr<Type> elemOr = verifyMatchingRowMajorBinaryTileOpCommon(
         getOperation(), getSrc0().getType(), getSrc1().getType(),
         getDst().getType());
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto elem0 = *elemOr;
-    if (!(elem0.isF16() || elem0.isF32()))
+    if (!(elem0.isF16() || elem0.isF32())) {
       return emitOpError("expects A2/A3 tdiv element type to be f16 or f32");
+    }
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyMatchingRowMajorBinaryTileOpCommon(
         getOperation(), getSrc0().getType(), getSrc1().getType(),
         getDst().getType());
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto elem0 = *elemOr;
-    if (!(elem0.isF16() || elem0.isF32() || elem0.isInteger(16) || elem0.isInteger(32)))
+    if (!(elem0.isF16() || elem0.isF32() || elem0.isInteger(16) || elem0.isInteger(32))) {
       return emitOpError("expects A5 tdiv element type to be i32/i16/f16/f32");
+    }
     return success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -6708,27 +7585,32 @@ mlir::LogicalResult mlir::pto::TDivSOp::verify() {
     bool srcScalar = isScalarLike(srcTy);
     bool rhsScalar = isScalarLike(rhsTy);
 
-    if (!(srcTile && rhsScalar) && !(srcScalar && rhsTile))
+    if (!(srcTile && rhsScalar) && !(srcScalar && rhsTile)) {
       return emitOpError("expects one tile-like operand and one scalar operand in ins(...)");
+    }
 
     Type tileTy = srcTile ? srcTy : rhsTy;
     Type scalarTy = srcTile ? rhsTy : srcTy;
 
     if (failed(verifyScalarTileOp(*this, tileTy, dstTy, "src", "dst",
                                   /*requireValidRowsEqual=*/true,
-                                  /*requireValidColsEqual=*/true)))
+                                  /*requireValidColsEqual=*/true))) {
       return failure();
-    if (!mlir::isa<IntegerType, FloatType>(scalarTy))
+    }
+    if (!mlir::isa<IntegerType, FloatType>(scalarTy)) {
       return emitOpError("scalar must be a scalar type (integer/float)");
+    }
     Type elem = getElemTy(tileTy);
     if (targetArch == PTOArch::A3 &&
         !(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() ||
-          elem.isF32()))
+          elem.isF32())) {
       return emitOpError("expects A2/A3 tdivs element type to be i32/i16/f16/f32");
+    }
     if (targetArch == PTOArch::A5 &&
         !(elem.isInteger(32) || elem.isInteger(16) || elem.isInteger(8) ||
-          elem.isF16() || elem.isF32()))
+          elem.isF16() || elem.isF32())) {
       return emitOpError("expects A5 tdivs element type to be i32/i16/i8/f16/f32");
+    }
     return success();
   };
   auto verifyA2A3 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A3); };
@@ -6741,13 +7623,16 @@ mlir::LogicalResult mlir::pto::TExpOp::verify() {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyVecTileUnaryOp(*this, srcTy, dstTy, "src", "dst",
-                                    /*allowBf16=*/false, /*allowInt8=*/false)))
+                                    /*allowBf16=*/false, /*allowInt8=*/false))) {
       return failure();
-    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+    }
+    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
       return failure();
+    }
     Type srcElem = getElemTy(srcTy);
-    if (!srcElem.isF16() && !srcElem.isF32())
+    if (!srcElem.isF16() && !srcElem.isF32()) {
       return emitOpError("expects element type to be f16 or f32");
+    }
     return mlir::success();
   };
   auto verifyA5 = [&]() -> LogicalResult { return verifyA2A3(); };
@@ -6757,45 +7642,56 @@ mlir::LogicalResult mlir::pto::TExpOp::verify() {
 mlir::LogicalResult mlir::pto::TExpandsOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult {
     Type dstTy = getDst().getType();
-    if (failed(verifyTileBufCommon(*this, dstTy, "dst")))
+    if (failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
       return failure();
+    }
     auto dstSpace = getPTOMemorySpaceEnum(dstTy);
     if (!dstSpace || (*dstSpace != pto::AddressSpace::VEC &&
-                      *dstSpace != pto::AddressSpace::MAT))
+                      *dstSpace != pto::AddressSpace::MAT)) {
       return emitOpError("expects dst to be in the vec or mat address space");
+    }
     Type dstElem = getElemTy(dstTy);
     Type scalarTy = getScalar().getType();
-    if (scalarTy != dstElem)
+    if (scalarTy != dstElem) {
       return emitOpError("expects scalar type == dst element type");
-    if (*dstSpace == pto::AddressSpace::VEC && !isRowMajorTileBuf(dstTy))
+    }
+    if (*dstSpace == pto::AddressSpace::VEC && !isRowMajorTileBuf(dstTy)) {
       return emitOpError("expects vec dst to use row-major layout on A2/A3");
-    if (dstElem.isF16() || dstElem.isBF16() || dstElem.isF32())
+    }
+    if (dstElem.isF16() || dstElem.isBF16() || dstElem.isF32()) {
       return mlir::success();
+    }
     if (auto it = mlir::dyn_cast<mlir::IntegerType>(dstElem)) {
       unsigned w = it.getWidth();
-      if (w == 16 || w == 32)
+      if (w == 16 || w == 32) {
         return mlir::success();
+      }
     }
     return emitOpError("expects A2/A3 texpands dst element type to be i16/i32/f16/bf16/f32");
   };
   auto verifyA5 = [&]() -> LogicalResult {
     Type dstTy = getDst().getType();
-    if (failed(verifyTileBufCommon(*this, dstTy, "dst")))
+    if (failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
       return failure();
+    }
     auto dstSpace = getPTOMemorySpaceEnum(dstTy);
     if (!dstSpace || (*dstSpace != pto::AddressSpace::VEC &&
-                      *dstSpace != pto::AddressSpace::MAT))
+                      *dstSpace != pto::AddressSpace::MAT)) {
       return emitOpError("expects dst to be in the vec or mat address space");
+    }
     Type dstElem = getElemTy(dstTy);
     Type scalarTy = getScalar().getType();
-    if (scalarTy != dstElem)
+    if (scalarTy != dstElem) {
       return emitOpError("expects scalar type == dst element type");
-    if (dstElem.isF16() || dstElem.isBF16() || dstElem.isF32())
+    }
+    if (dstElem.isF16() || dstElem.isBF16() || dstElem.isF32()) {
       return mlir::success();
+    }
     if (auto it = mlir::dyn_cast<mlir::IntegerType>(dstElem)) {
       unsigned w = it.getWidth();
-      if (w == 8 || w == 16 || w == 32)
+      if (w == 8 || w == 16 || w == 32) {
         return mlir::success();
+      }
     }
     return emitOpError("expects A5 texpands dst element type to be i8/i16/i32/f16/bf16/f32");
   };
@@ -6807,27 +7703,33 @@ mlir::LogicalResult mlir::pto::TExtractOp::verify() {
     return srcElem.isF32() && (dstElem.isF16() || dstElem.isBF16());
   };
   auto isA2A3AccQuantExtractTypePair = [&](Type srcElem, Type dstElem) -> bool {
-    if (srcElem.isF32())
+    if (srcElem.isF32()) {
       return dstElem.isInteger(8);
-    if (srcElem.isInteger(32))
+    }
+    if (srcElem.isInteger(32)) {
       return dstElem.isInteger(8) || dstElem.isF16() || dstElem.isInteger(16);
+    }
     return false;
   };
   auto isA5AccCastExtractTypePair = [&](Type srcElem, Type dstElem) -> bool {
-    if (srcElem.isF32())
+    if (srcElem.isF32()) {
       return dstElem.isF16() || dstElem.isBF16() || dstElem.isF32();
-    if (srcElem.isInteger(32))
+    }
+    if (srcElem.isInteger(32)) {
       return dstElem.isInteger(32);
+    }
     return false;
   };
   auto isA5AccQuantExtractTypePair = [&](Type srcElem, Type dstElem) -> bool {
-    if (srcElem.isF32())
+    if (srcElem.isF32()) {
       return dstElem.isInteger(8) || dstElem.isF16() || dstElem.isBF16() ||
              dstElem.isF32() ||
              (llvm::isa<FloatType>(dstElem) &&
               llvm::cast<FloatType>(dstElem).getWidth() == 8);
-    if (srcElem.isInteger(32))
+    }
+    if (srcElem.isInteger(32)) {
       return dstElem.isInteger(8) || dstElem.isF16() || dstElem.isBF16();
+    }
     return false;
   };
   auto hasMatExtractSourceLayoutA2A3 = [&](pto::TileBufType srcTy) -> bool {
@@ -6858,12 +7760,15 @@ mlir::LogicalResult mlir::pto::TExtractOp::verify() {
   };
   auto isA5ExtractElemType = [&](Type ty) -> bool {
     if (isPTOFloat8Type(ty) || isPTOHiFloat8Type(ty) ||
-        isPTOFloat4PackedType(ty))
+        isPTOFloat4PackedType(ty)) {
       return true;
-    if (auto it = dyn_cast<IntegerType>(ty))
+    }
+    if (auto it = dyn_cast<IntegerType>(ty)) {
       return it.getWidth() == 8;
-    if (auto ft = dyn_cast<FloatType>(ty))
+    }
+    if (auto ft = dyn_cast<FloatType>(ty)) {
       return ft.getWidth() == 8 || ft.isF16() || ft.isBF16() || ft.isF32();
+    }
     return false;
   };
   auto isRowMajorNoneBoxND = [&](pto::TileBufType ty) -> bool {
@@ -6887,8 +7792,9 @@ mlir::LogicalResult mlir::pto::TExtractOp::verify() {
     Type dstTy = getDst().getType();
     auto srcTb = dyn_cast<pto::TileBufType>(srcTy);
     auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
-    if (!srcTb || !dstTb)
+    if (!srcTb || !dstTb) {
       return emitOpError("expects src and dst to be !pto.tile_buf");
+    }
     if (failed(verifyTileBufCommon(*this, srcTy, "src", allowLowPrecision)) ||
         failed(verifyTileBufCommon(*this, dstTy, "dst", allowLowPrecision)) ||
         failed(verifyNonNegativeIndexRowCol(
@@ -6896,116 +7802,148 @@ mlir::LogicalResult mlir::pto::TExtractOp::verify() {
             /*includeIndexAndIntOpsInConstFold=*/hasFp)) ||
         failed(verifyExtractStaticBoundsCommon(
             *getOperation(), getIndexRow(), getIndexCol(), srcTy, dstTy,
-            /*includeIndexAndIntOpsInConstFold=*/hasFp)))
+            /*includeIndexAndIntOpsInConstFold=*/hasFp))) {
       return failure();
+    }
     if (hasFp) {
       Type fpTy = fp.getType();
-      if (failed(verifyTileBufCommon(*this, fpTy, "fp", allowLowPrecision)))
+      if (failed(verifyTileBufCommon(*this, fpTy, "fp", allowLowPrecision))) {
         return failure();
+      }
       auto fpSpace = getPTOMemorySpaceEnum(fpTy);
-      if (!fpSpace || *fpSpace != pto::AddressSpace::SCALING)
+      if (!fpSpace || *fpSpace != pto::AddressSpace::SCALING) {
         return emitOpError("expects fp to use loc=scaling");
+      }
     }
     auto srcSpace = getPTOMemorySpaceEnum(srcTy);
     auto dstSpace = getPTOMemorySpaceEnum(dstTy);
     Type srcElem = getElemTy(srcTy);
     Type dstElem = getElemTy(dstTy);
-    if (!srcElem || !dstElem)
+    if (!srcElem || !dstElem) {
       return emitOpError("expects src and dst to have element types");
-    if ((!srcSpace || *srcSpace != pto::AddressSpace::ACC) && srcElem != dstElem)
+    }
+    if ((!srcSpace || *srcSpace != pto::AddressSpace::ACC) && srcElem != dstElem) {
       return emitOpError("expects src and dst to have the same element type");
+    }
     return std::make_tuple(srcTy, dstTy, srcTb, dstTb, srcElem, dstElem,
                            srcSpace, dstSpace);
   };
   auto verifyA2A3 = [&]() -> LogicalResult {
     auto common = verifyCommon(/*allowLowPrecision=*/false);
-    if (failed(common))
+    if (failed(common)) {
       return failure();
+    }
     auto [srcTy, dstTy, srcTb, dstTb, srcElem, dstElem, srcSpace, dstSpace] =
         *common;
     if (!isA2A3ExtractElemType(dstElem) &&
-        !(hasFp && dstElem.isInteger(16)))
+        !(hasFp && dstElem.isInteger(16))) {
       return emitOpError("expects A2/A3 textract element type to be i8/f16/bf16/f32");
-    if (hasFp && hasPreQuantScalar)
+    }
+    if (hasFp && hasPreQuantScalar) {
       return emitOpError("expects fp and preQuantScalar to be mutually exclusive");
-    if (hasFp && (!srcSpace || *srcSpace != pto::AddressSpace::ACC))
+    }
+    if (hasFp && (!srcSpace || *srcSpace != pto::AddressSpace::ACC)) {
       return emitOpError("expects fp form to use loc=acc src");
-    if (hasPreQuantScalar && (!srcSpace || *srcSpace != pto::AddressSpace::ACC))
+    }
+    if (hasPreQuantScalar && (!srcSpace || *srcSpace != pto::AddressSpace::ACC)) {
       return emitOpError("expects preQuantScalar form to use loc=acc src");
-    if (hasRelu && (!srcSpace || *srcSpace != pto::AddressSpace::ACC))
+    }
+    if (hasRelu && (!srcSpace || *srcSpace != pto::AddressSpace::ACC)) {
       return emitOpError("expects reluPreMode form to use loc=acc src");
-    if (hasAccToVecMode)
+    }
+    if (hasAccToVecMode) {
       return emitOpError("expects accToVecMode only on A5 acc->vec textract forms");
+    }
     if (srcSpace && dstSpace && *srcSpace == pto::AddressSpace::VEC &&
         *dstSpace == pto::AddressSpace::VEC) {
-      if (hasPreQuantScalar || hasRelu)
+      if (hasPreQuantScalar || hasRelu) {
         return emitOpError("expects vec->vec textract to use the base form without preQuantScalar or reluPreMode");
+      }
       return mlir::success();
     }
-    if (!srcSpace || !dstSpace)
+    if (!srcSpace || !dstSpace) {
       return emitOpError("expects src and dst to have explicit loc");
+    }
     if (*srcSpace == pto::AddressSpace::ACC) {
-      if (*dstSpace != pto::AddressSpace::MAT)
+      if (*dstSpace != pto::AddressSpace::MAT) {
         return emitOpError("expects A2/A3 acc-source textract dst to use loc=mat");
+      }
       if (srcTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor) ||
-          srcTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))
+          srcTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor)) {
         return emitOpError("expects A2/A3 acc-source textract src to use blayout=col_major and slayout=row_major");
+      }
       if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor) ||
-          dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))
+          dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor)) {
         return emitOpError("expects A2/A3 acc-source textract dst to use blayout=col_major and slayout=row_major");
-      if (dstTb.getSFractalSizeI32() != 512)
+      }
+      if (dstTb.getSFractalSizeI32() != 512) {
         return emitOpError("expects A2/A3 acc-source textract dst fractal size to be 512");
+      }
       if (hasFp || hasPreQuantScalar) {
-        if (!isA2A3AccQuantExtractTypePair(srcElem, dstElem))
+        if (!isA2A3AccQuantExtractTypePair(srcElem, dstElem)) {
           return emitOpError(
               "expects A2/A3 acc preQuantScalar textract element types to be "
               "(src=f32,dst=i8) or (src=i32,dst=i8/f16/i16)");
+        }
       } else if (!isA2A3AccCastExtractTypePair(srcElem, dstElem)) {
         return emitOpError(
             "expects A2/A3 acc textract element types to be src=f32, dst=f16/bf16");
       }
       return mlir::success();
     }
-    if (*srcSpace != pto::AddressSpace::MAT)
+    if (*srcSpace != pto::AddressSpace::MAT) {
       return emitOpError("expects A2/A3 textract src to use loc=mat, loc=acc, or loc=vec");
+    }
     if (*dstSpace != pto::AddressSpace::LEFT &&
-        *dstSpace != pto::AddressSpace::RIGHT)
+        *dstSpace != pto::AddressSpace::RIGHT) {
       return emitOpError("expects A2/A3 textract dst to use loc=left, loc=right, loc=mat, or loc=vec");
-    if (!hasMatExtractSourceLayoutA2A3(srcTb))
+    }
+    if (!hasMatExtractSourceLayoutA2A3(srcTb)) {
       return emitOpError("expects A2/A3 textract src to use a supported mat blayout/slayout combination");
+    }
     if (*dstSpace == pto::AddressSpace::LEFT) {
       if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
-          dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))
+          dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor)) {
         return emitOpError("expects A2/A3 left dst to use row_major blayout and row_major slayout");
+      }
     } else {
       if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
-          dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor))
+          dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor)) {
         return emitOpError("expects A2/A3 right dst to use row_major blayout and col_major slayout");
+      }
     }
     return mlir::success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
     auto common = verifyCommon(/*allowLowPrecision=*/true);
-    if (failed(common))
+    if (failed(common)) {
       return failure();
+    }
     auto [srcTy, dstTy, srcTb, dstTb, srcElem, dstElem, srcSpace, dstSpace] =
         *common;
-    if (!isA5ExtractElemType(dstElem))
+    if (!isA5ExtractElemType(dstElem)) {
       return emitOpError("expects A5 textract element type to be an fp8/f16/bf16/f32 or int8 family type");
-    if (hasFp && hasPreQuantScalar)
+    }
+    if (hasFp && hasPreQuantScalar) {
       return emitOpError("expects fp and preQuantScalar to be mutually exclusive");
-    if (hasFp && (!srcSpace || *srcSpace != pto::AddressSpace::ACC))
+    }
+    if (hasFp && (!srcSpace || *srcSpace != pto::AddressSpace::ACC)) {
       return emitOpError("expects fp form to use loc=acc src");
-    if (hasPreQuantScalar && (!srcSpace || *srcSpace != pto::AddressSpace::ACC))
+    }
+    if (hasPreQuantScalar && (!srcSpace || *srcSpace != pto::AddressSpace::ACC)) {
       return emitOpError("expects preQuantScalar form to use loc=acc src");
-    if (hasRelu && (!srcSpace || *srcSpace != pto::AddressSpace::ACC))
+    }
+    if (hasRelu && (!srcSpace || *srcSpace != pto::AddressSpace::ACC)) {
       return emitOpError("expects reluPreMode form to use loc=acc src");
+    }
     if (hasAccToVecMode &&
         (!srcSpace || !dstSpace || *srcSpace != pto::AddressSpace::ACC ||
-         *dstSpace != pto::AddressSpace::VEC))
+         *dstSpace != pto::AddressSpace::VEC)) {
       return emitOpError("expects accToVecMode only on A5 acc->vec textract forms");
-    if (!srcSpace || !dstSpace)
+    }
+    if (!srcSpace || !dstSpace) {
       return emitOpError("expects src and dst to have explicit loc");
+    }
     bool okPair =
         (*srcSpace == pto::AddressSpace::MAT &&
          (*dstSpace == pto::AddressSpace::LEFT ||
@@ -7017,47 +7955,58 @@ mlir::LogicalResult mlir::pto::TExtractOp::verify() {
         (*srcSpace == pto::AddressSpace::ACC &&
          (*dstSpace == pto::AddressSpace::MAT ||
           *dstSpace == pto::AddressSpace::VEC));
-    if (!okPair)
+    if (!okPair) {
       return emitOpError("expects A5 textract to use a supported src/dst loc pair");
+    }
     if (*srcSpace == pto::AddressSpace::MAT) {
-      if (hasPreQuantScalar || hasRelu)
+      if (hasPreQuantScalar || hasRelu) {
         return emitOpError("expects mat-source textract to use the base form without preQuantScalar or reluPreMode");
-      if (!hasMatExtractSourceLayoutA5(srcTb, *dstSpace))
+      }
+      if (!hasMatExtractSourceLayoutA5(srcTb, *dstSpace)) {
         return emitOpError("expects A5 textract src to use a supported mat blayout/slayout combination");
+      }
       if (*dstSpace == pto::AddressSpace::LEFT) {
         if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor) ||
-            dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))
+            dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor)) {
           return emitOpError("expects A5 left dst to use col_major blayout and row_major slayout");
+        }
       } else if (*dstSpace == pto::AddressSpace::RIGHT) {
         if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
-          dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor))
+            dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor)) {
           return emitOpError("expects A5 right dst to use row_major blayout and col_major slayout");
+        }
       }
     } else if (*srcSpace == pto::AddressSpace::VEC &&
                *dstSpace == pto::AddressSpace::VEC) {
-      if (hasPreQuantScalar || hasRelu)
+      if (hasPreQuantScalar || hasRelu) {
         return emitOpError("expects vec-source textract to use the base form without preQuantScalar or reluPreMode");
-      if (!isRowMajorNoneBoxND(srcTb) || !isRowMajorNoneBoxND(dstTb))
+      }
+      if (!isRowMajorNoneBoxND(srcTb) || !isRowMajorNoneBoxND(dstTb)) {
         return emitOpError(
             "expects A5 vec->vec textract src/dst to use ND layout "
             "(blayout=row_major, slayout=none_box)");
+      }
     } else if (*srcSpace == pto::AddressSpace::ACC) {
       if (srcTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor) ||
-          srcTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))
+          srcTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor)) {
         return emitOpError("expects A5 acc-source textract src to use blayout=col_major and slayout=row_major");
+      }
       if (*dstSpace == pto::AddressSpace::MAT) {
         if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor) ||
-            dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))
+            dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor)) {
           return emitOpError("expects A5 acc-source textract dst to use blayout=col_major and slayout=row_major");
+        }
       } else {
-        if (!isRowMajorNoneBoxND(dstTb))
+        if (!isRowMajorNoneBoxND(dstTb)) {
           return emitOpError("expects A5 acc->vec textract dst to use ND layout (blayout=row_major, slayout=none_box)");
+        }
       }
       if (hasFp || hasPreQuantScalar) {
-        if (!isA5AccQuantExtractTypePair(srcElem, dstElem))
+        if (!isA5AccQuantExtractTypePair(srcElem, dstElem)) {
           return emitOpError(
               "expects A5 acc preQuantScalar textract element types to be "
               "(src=f32,dst=i8/fp8/f16/bf16/f32) or (src=i32,dst=i8/f16/bf16)");
+        }
       } else if (!isA5AccCastExtractTypePair(srcElem, dstElem)) {
         return emitOpError(
             "expects A5 acc textract element types to be "
@@ -7074,10 +8023,12 @@ mlir::LogicalResult mlir::pto::TInsertOp::verify() {
     return srcElem.isF32() && (dstElem.isF16() || dstElem.isBF16());
   };
   auto isA2A3AccQuantInsertTypePair = [&](Type srcElem, Type dstElem) -> bool {
-    if (srcElem.isF32())
+    if (srcElem.isF32()) {
       return dstElem.isInteger(8);
-    if (srcElem.isInteger(32))
+    }
+    if (srcElem.isInteger(32)) {
       return dstElem.isInteger(8) || dstElem.isF16() || dstElem.isInteger(16);
+    }
     return false;
   };
   auto isColMajorRowMajorNZ = [&](pto::TileBufType ty) -> bool {
@@ -7090,12 +8041,15 @@ mlir::LogicalResult mlir::pto::TInsertOp::verify() {
   };
   auto isA5SupportedVecElemType = [&](Type ty) -> bool {
     if (isPTOFloat8Type(ty) || isPTOHiFloat8Type(ty) ||
-        isPTOFloat4PackedType(ty))
+        isPTOFloat4PackedType(ty)) {
       return true;
-    if (auto it = dyn_cast<IntegerType>(ty))
+    }
+    if (auto it = dyn_cast<IntegerType>(ty)) {
       return it.getWidth() == 8 || it.getWidth() == 32;
-    if (auto ft = dyn_cast<FloatType>(ty))
+    }
+    if (auto ft = dyn_cast<FloatType>(ty)) {
       return ft.getWidth() == 8 || ft.isF16() || ft.isBF16() || ft.isF32();
+    }
     return false;
   };
   auto isA2A3VecInsertElemType = [&](Type ty) -> bool {
@@ -7118,8 +8072,9 @@ mlir::LogicalResult mlir::pto::TInsertOp::verify() {
     Type dstTy = getDst().getType();
     auto srcTb = dyn_cast<pto::TileBufType>(srcTy);
     auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
-    if (!srcTb || !dstTb)
+    if (!srcTb || !dstTb) {
       return emitOpError("expects src and dst to be !pto.tile_buf");
+    }
     if (failed(verifyTileBufCommon(*this, srcTy, "src", allowLowPrecision)) ||
         failed(verifyTileBufCommon(*this, dstTy, "dst", allowLowPrecision)) ||
         failed(verifyNonNegativeIndexRowCol(
@@ -7127,8 +8082,9 @@ mlir::LogicalResult mlir::pto::TInsertOp::verify() {
             /*includeIndexAndIntOpsInConstFold=*/true)) ||
         failed(verifyInsertStaticBoundsCommon(
             *getOperation(), getIndexRow(), getIndexCol(), srcTy, dstTy,
-            /*includeIndexAndIntOpsInConstFold=*/true)))
+            /*includeIndexAndIntOpsInConstFold=*/true))) {
       return failure();
+    }
     Type srcElem = getElemTy(srcTy);
     Type dstElem = getElemTy(dstTy);
     auto srcSpace = getPTOMemorySpaceEnum(srcTy);
@@ -7146,13 +8102,15 @@ mlir::LogicalResult mlir::pto::TInsertOp::verify() {
     const bool hasInsertMode = static_cast<bool>(getTinsertModeAttr());
     const bool reluNonDefault = getReluPreMode() != pto::ReluPreMode::NoRelu;
 
-    if (hasFp && hasPreQuantScalar)
+    if (hasFp && hasPreQuantScalar) {
       return emitOpError("fp and preQuantScalar are mutually exclusive");
+    }
 
     // fp tile is only valid with Acc source.
     if (hasFp) {
-      if (!srcSpace || *srcSpace != pto::AddressSpace::ACC)
+      if (!srcSpace || *srcSpace != pto::AddressSpace::ACC) {
         return emitOpError("fp is only valid with src loc=acc");
+      }
       auto fpTy = getFp().getType();
       auto fpTb = dyn_cast<pto::TileBufType>(fpTy);
       if (!fpTb) {
@@ -7163,86 +8121,103 @@ mlir::LogicalResult mlir::pto::TInsertOp::verify() {
         return failure();
       }
       auto fpSpace = getSpace(fpTy);
-      if (!fpSpace || *fpSpace != pto::AddressSpace::SCALING)
+      if (!fpSpace || *fpSpace != pto::AddressSpace::SCALING) {
         return emitOpError("expects fp to be loc=scaling");
+      }
     }
 
     // preQuantScalar is only valid with Acc source.
     if (hasPreQuantScalar) {
-      if (!srcSpace || *srcSpace != pto::AddressSpace::ACC)
+      if (!srcSpace || *srcSpace != pto::AddressSpace::ACC) {
         return emitOpError("preQuantScalar is only valid with src loc=acc");
+      }
     }
 
     // reluPreMode is only valid with Acc source.
     if (reluNonDefault) {
-      if (!srcSpace || *srcSpace != pto::AddressSpace::ACC)
+      if (!srcSpace || *srcSpace != pto::AddressSpace::ACC) {
         return emitOpError("reluPreMode is only valid with src loc=acc");
+      }
     }
 
     // accToVecMode is only valid with Acc->Vec (A5 only).
     if (hasAccToVecMode) {
-      if (!isA5)
+      if (!isA5) {
         return emitOpError("accToVecMode is only supported on A5");
+      }
       if (!srcSpace || !dstSpace ||
           *srcSpace != pto::AddressSpace::ACC ||
-          *dstSpace != pto::AddressSpace::VEC)
+          *dstSpace != pto::AddressSpace::VEC) {
         return emitOpError("accToVecMode is only valid with src=acc, dst=vec");
+      }
     }
 
     // tinsertMode (SPLIT2/SPLIT4) is only valid with Vec(NZ)->Mat on A5.
     if (hasInsertMode) {
-      if (!isA5)
+      if (!isA5) {
         return emitOpError("tinsertMode is only supported on A5");
+      }
       if (!srcSpace || !dstSpace ||
           *srcSpace != pto::AddressSpace::VEC ||
-          *dstSpace != pto::AddressSpace::MAT)
+          *dstSpace != pto::AddressSpace::MAT) {
         return emitOpError(
             "tinsertMode (SPLIT2/SPLIT4) is only valid with src=vec, dst=mat");
+      }
       auto srcTb = dyn_cast<pto::TileBufType>(getSrc().getType());
-      if (!srcTb || !isColMajorRowMajorNZ(srcTb))
+      if (!srcTb || !isColMajorRowMajorNZ(srcTb)) {
         return emitOpError(
             "tinsertMode (SPLIT2/SPLIT4) requires src NZ layout "
             "(blayout=col_major, slayout=row_major)");
+      }
     }
 
     return success();
   };
   auto verifyA2A3 = [&]() -> LogicalResult {
     auto common = verifyCommon(/*allowLowPrecision=*/false);
-    if (failed(common))
+    if (failed(common)) {
       return failure();
+    }
     auto [srcTy, dstTy, srcTb, dstTb, srcElem, dstElem, srcSpace, dstSpace] =
         *common;
-    if (failed(verifyOptionalArgs(srcSpace, dstSpace, /*isA5=*/false)))
+    if (failed(verifyOptionalArgs(srcSpace, dstSpace, /*isA5=*/false))) {
       return failure();
+    }
     if (srcSpace && dstSpace && *srcSpace == pto::AddressSpace::VEC &&
         *dstSpace == pto::AddressSpace::VEC) {
-      if (hasPreQuantScalar || hasRelu)
+      if (hasPreQuantScalar || hasRelu) {
         return emitOpError(
             "expects vec->vec tinsert to use the base form without "
             "preQuantScalar or reluPreMode");
-      if (srcElem != dstElem || !isA2A3VecInsertElemType(srcElem))
+      }
+      if (srcElem != dstElem || !isA2A3VecInsertElemType(srcElem)) {
         return emitOpError(
             "expects A2/A3 vec->vec tinsert src/dst to have same supported dtype "
             "(i8/f16/bf16/f32)");
+      }
       return success();
     }
     if (!srcSpace || !dstSpace || *srcSpace != pto::AddressSpace::ACC ||
-        *dstSpace != pto::AddressSpace::MAT)
+        *dstSpace != pto::AddressSpace::MAT) {
       return emitOpError("expects A2/A3 tinsert to use acc->mat or vec->vec");
+    }
 
-    if (!isColMajorRowMajorNZ(srcTb))
+    if (!isColMajorRowMajorNZ(srcTb)) {
       return emitOpError("expects A2/A3 tinsert src to use blayout=col_major and slayout=row_major");
-    if (!isColMajorRowMajorNZ(dstTb))
+    }
+    if (!isColMajorRowMajorNZ(dstTb)) {
       return emitOpError("expects A2/A3 tinsert dst to use blayout=col_major and slayout=row_major");
-    if (dstTb.getSFractalSizeI32() != 512)
+    }
+    if (dstTb.getSFractalSizeI32() != 512) {
       return emitOpError("expects A2/A3 tinsert dst fractal size to be 512");
+    }
 
     if (hasFp || hasPreQuantScalar) {
-      if (!isA2A3AccQuantInsertTypePair(srcElem, dstElem))
+      if (!isA2A3AccQuantInsertTypePair(srcElem, dstElem)) {
         return emitOpError(
             "expects A2/A3 acc fp/preQuantScalar tinsert element types to be "
             "(src=f32,dst=i8) or (src=i32,dst=i8/f16/i16)");
+      }
     } else if (!isA2A3AccCastInsertTypePair(srcElem, dstElem)) {
       return emitOpError(
           "expects A2/A3 tinsert element types to be src=f32, dst=f16/bf16");
@@ -7251,41 +8226,51 @@ mlir::LogicalResult mlir::pto::TInsertOp::verify() {
   };
   auto verifyA5 = [&]() -> LogicalResult {
     auto common = verifyCommon(/*allowLowPrecision=*/true);
-    if (failed(common))
+    if (failed(common)) {
       return failure();
+    }
     auto [srcTy, dstTy, srcTb, dstTb, srcElem, dstElem, srcSpace, dstSpace] =
         *common;
-    if (hasPreQuantScalar && (!srcSpace || *srcSpace != pto::AddressSpace::ACC))
+    if (hasPreQuantScalar && (!srcSpace || *srcSpace != pto::AddressSpace::ACC)) {
       return emitOpError("expects preQuantScalar form to use loc=acc src");
-    if (hasRelu && (!srcSpace || *srcSpace != pto::AddressSpace::ACC))
+    }
+    if (hasRelu && (!srcSpace || *srcSpace != pto::AddressSpace::ACC)) {
       return emitOpError("expects reluPreMode form to use loc=acc src");
+    }
     if (hasAccToVecMode &&
         (!srcSpace || !dstSpace || *srcSpace != pto::AddressSpace::ACC ||
-         *dstSpace != pto::AddressSpace::VEC))
+         *dstSpace != pto::AddressSpace::VEC)) {
       return emitOpError("expects accToVecMode only on A5 acc->vec tinsert forms");
+    }
     if (hasTInsertMode &&
         (!srcSpace || !dstSpace || *srcSpace != pto::AddressSpace::VEC ||
-         *dstSpace != pto::AddressSpace::MAT))
+         *dstSpace != pto::AddressSpace::MAT)) {
       return emitOpError("expects tinsertMode only on A5 vec->mat tinsert forms");
-    if (!srcSpace || !dstSpace)
+    }
+    if (!srcSpace || !dstSpace) {
       return emitOpError("expects A5 tinsert src/dst to have explicit loc");
-    if (failed(verifyOptionalArgs(srcSpace, dstSpace, /*isA5=*/true)))
+    }
+    if (failed(verifyOptionalArgs(srcSpace, dstSpace, /*isA5=*/true))) {
       return failure();
+    }
 
     // A5 regular acc->mat/acc->vec path.
     if (*srcSpace == pto::AddressSpace::ACC &&
         (*dstSpace == pto::AddressSpace::MAT || *dstSpace == pto::AddressSpace::VEC)) {
-      if (!isColMajorRowMajorNZ(srcTb))
+      if (!isColMajorRowMajorNZ(srcTb)) {
         return emitOpError("expects A5 acc->mat tinsert src to use blayout=col_major and slayout=row_major");
+      }
       if (*dstSpace == pto::AddressSpace::MAT) {
-        if (!isColMajorRowMajorNZ(dstTb))
+        if (!isColMajorRowMajorNZ(dstTb)) {
           return emitOpError("expects A5 acc->mat tinsert dst to use blayout=col_major and slayout=row_major");
+        }
       } else {
         bool dstIsND = isRowMajorNoneBoxND(dstTb);
         bool dstIsNZ = isColMajorRowMajorNZ(dstTb);
-        if (!dstIsND && !dstIsNZ)
+        if (!dstIsND && !dstIsNZ) {
           return emitOpError(
               "expects A5 acc->vec tinsert dst to use ND(row_major/none_box) or NZ(col_major/row_major) layout");
+        }
       }
       const bool hasQuant = hasFp || hasPreQuantScalar;
       bool okTypes;
@@ -7297,42 +8282,49 @@ mlir::LogicalResult mlir::pto::TInsertOp::verify() {
                    (dstElem.isF16() || dstElem.isBF16() || dstElem.isF32())) ||
                   (srcElem.isInteger(32) && dstElem.isInteger(32));
       }
-      if (!okTypes)
+      if (!okTypes) {
         return emitOpError(
             "expects A5 acc-source tinsert element types to be "
-            "(src=f32,dst=f16/bf16/f32) or (src=i32,dst=i32)"
-            + (hasQuant ? std::string("; with fp/scalar: (src=f32,dst=i8/fp8/f16/bf16/f32) or (src=i32,dst=i8/f16/bf16)") : std::string()));
+            "(src=f32,dst=f16/bf16/f32) or (src=i32,dst=i32)" +
+            (hasQuant ? std::string("; with fp/scalar: (src=f32,dst=i8/fp8/f16/bf16/f32) or (src=i32,dst=i8/f16/bf16)") : std::string()));
+      }
       return success();
     }
 
     // A5 vec->mat path (ND/NZ modes in pto-isa).
     if (*srcSpace == pto::AddressSpace::VEC && *dstSpace == pto::AddressSpace::MAT) {
-      if (hasPreQuantScalar || hasRelu)
+      if (hasPreQuantScalar || hasRelu) {
         return emitOpError(
             "expects vec->mat tinsert to use the base form without "
             "preQuantScalar or reluPreMode");
-      if (!isColMajorRowMajorNZ(dstTb))
+      }
+      if (!isColMajorRowMajorNZ(dstTb)) {
         return emitOpError("expects A5 vec->mat tinsert dst to use blayout=col_major and slayout=row_major");
+      }
       bool srcIsND = isRowMajorNoneBoxND(srcTb);
       bool srcIsNZ = isColMajorRowMajorNZ(srcTb);
-      if (!srcIsND && !srcIsNZ)
+      if (!srcIsND && !srcIsNZ) {
         return emitOpError(
             "expects A5 vec->mat tinsert src to use ND(row_major/none_box) or NZ(col_major/row_major) layout");
-      if (hasTInsertMode && !srcIsNZ)
+      }
+      if (hasTInsertMode && !srcIsNZ) {
         return emitOpError("expects tinsertMode vec->mat tinsert src to use NZ(col_major/row_major) layout");
-      if (srcElem != dstElem || !isA5SupportedVecElemType(srcElem))
+      }
+      if (srcElem != dstElem || !isA5SupportedVecElemType(srcElem)) {
         return emitOpError(
             "expects A5 vec->mat tinsert src/dst to have same supported dtype "
             "(fp8/f16/bf16/f32/i8/i32)");
+      }
       return success();
     }
 
     // A5 vec->vec path: supports ND->ND and NZ->NZ.
     if (*srcSpace == pto::AddressSpace::VEC && *dstSpace == pto::AddressSpace::VEC) {
-      if (hasPreQuantScalar || hasRelu)
+      if (hasPreQuantScalar || hasRelu) {
         return emitOpError(
             "expects vec->vec tinsert to use the base form without "
             "preQuantScalar or reluPreMode");
+      }
       bool srcIsND = isRowMajorNoneBoxND(srcTb);
       bool dstIsND = isRowMajorNoneBoxND(dstTb);
       bool srcIsNZ = isColMajorRowMajorNZ(srcTb);
@@ -7346,10 +8338,11 @@ mlir::LogicalResult mlir::pto::TInsertOp::verify() {
             "expects A5 vec->vec tinsert src/dst layouts to match: "
             "both ND(row_major/none_box) or both NZ(col_major/row_major)");
       }
-      if (srcElem != dstElem || !isA5SupportedVecElemType(srcElem))
+      if (srcElem != dstElem || !isA5SupportedVecElemType(srcElem)) {
         return emitOpError(
             "expects A5 vec->vec tinsert src/dst to have same supported dtype "
             "(fp8/f16/bf16/f32/i8/i32)");
+      }
       return success();
     }
 
@@ -7366,8 +8359,9 @@ static bool isColMajorRowMajorNZTileBuf(pto::TileBufType ty) {
 }
 
 static bool isA5Fp8LikeType(Type ty) {
-  if (auto ft = dyn_cast<FloatType>(ty))
+  if (auto ft = dyn_cast<FloatType>(ty)) {
     return ft.getWidth() == 8;
+  }
   return false;
 }
 
@@ -7387,37 +8381,43 @@ static LogicalResult verifyA5MxTypeTriple(Operation *op, Type lhsTy, Type rhsTy,
   Type rhsElem = getElemTy(rhsTy);
   Type dstElem = getElemTy(dstTy);
 
-  if (!isA5MxInputTypePair(lhsElem, rhsElem))
+  if (!isA5MxInputTypePair(lhsElem, rhsElem)) {
     return op->emitOpError()
            << "expects A5 mx " << lhsName << "/" << rhsName
            << " element types to be a supported fp8/fp8 or fp4/fp4 pair";
+  }
 
-  if (!dstElem.isF32())
+  if (!dstElem.isF32()) {
     return op->emitOpError()
            << "expects A5 mx result " << dstName << " to use f32 element type";
+  }
 
   return success();
 }
 
 static bool isA5VectorPreQuantTypePair(Type srcElem, Type dstElem) {
-  if (srcElem.isF32())
+  if (srcElem.isF32()) {
     return dstElem.isInteger(8) || isA5Fp8LikeType(dstElem) ||
            isPTOHiFloat8Type(dstElem) || dstElem.isF16() ||
            dstElem.isBF16() || dstElem.isF32();
-  if (srcElem.isInteger(32))
+  }
+  if (srcElem.isInteger(32)) {
     return dstElem.isInteger(8) || dstElem.isF16() || dstElem.isBF16();
+  }
   return false;
 }
 
 static mlir::LogicalResult verifyTFillPadLike(Operation *op, Type srcTy,
                                               Type dstTy) {
-  if (!isPTOShapedLike(srcTy) || !isPTOShapedLike(dstTy))
+  if (!isPTOShapedLike(srcTy) || !isPTOShapedLike(dstTy)) {
     return op->emitError("expects src/dst to be PTO shaped-like types");
+  }
 
   auto srcShape = getShapeVec(srcTy);
   auto dstShape = getShapeVec(dstTy);
-  if (srcShape.size() != 2 || dstShape.size() != 2)
+  if (srcShape.size() != 2 || dstShape.size() != 2) {
     return op->emitError("expects rank-2 shaped types for src/dst");
+  }
 
   auto srcElem = getElemTy(srcTy);
   auto dstElem = getElemTy(dstTy);
@@ -7429,32 +8429,39 @@ static mlir::LogicalResult verifyTFillPadLike(Operation *op, Type srcTy,
 
   int64_t srcB = getElemBytes(srcElem);
   int64_t dstB = getElemBytes(dstElem);
-  if (srcB < 0 || dstB < 0)
+  if (srcB < 0 || dstB < 0) {
     return op->emitError("unsupported element type (expects int/float element types)");
-  if (srcB != dstB)
+  }
+  if (srcB != dstB) {
     return op->emitError("expects sizeof(src element) == sizeof(dst element)");
-  if (!(srcB == 1 || srcB == 2 || srcB == 4))
+  }
+  if (!(srcB == 1 || srcB == 2 || srcB == 4)) {
     return op->emitError("expects element size to be 1, 2, or 4 bytes");
+  }
 
   auto srcSpace = getPTOMemorySpaceEnum(srcTy);
   auto dstSpace = getPTOMemorySpaceEnum(dstTy);
 
   bool expanded = false;
   for (auto [srcDim, dstDim] : llvm::zip_equal(srcShape, dstShape)) {
-    if (srcDim == dstDim)
+    if (srcDim == dstDim) {
       continue;
-    if (ShapedType::isDynamic(srcDim) || ShapedType::isDynamic(dstDim))
+    }
+    if (ShapedType::isDynamic(srcDim) || ShapedType::isDynamic(dstDim)) {
       return op->emitError("cannot infer TFILLPAD lowering from mismatched "
                            "dynamic physical shapes");
-    if (srcDim > dstDim)
+    }
+    if (srcDim > dstDim) {
       return op->emitError(
           "expects each dst physical shape dimension to be >= src");
+    }
     expanded = true;
   }
   if (expanded &&
       (!srcSpace || !dstSpace || *srcSpace != pto::AddressSpace::VEC ||
-       *dstSpace != pto::AddressSpace::VEC))
+       *dstSpace != pto::AddressSpace::VEC)) {
     return op->emitError("expects expanded TFILLPAD only for loc=vec");
+  }
 
   // pto.tfillpad lowers to TFILLPAD(dst, src). For loc=mat, pto-isa only
   // exposes the homogeneous overload, so src/dst must use the same Tile<...>
@@ -7471,23 +8478,27 @@ static mlir::LogicalResult verifyTFillPadLike(Operation *op, Type srcTy,
     auto srcValid = getValidShapeVec(srcTy);
     auto dstValid = getValidShapeVec(dstTy);
     if (srcValid.size() == 2 && dstValid.size() == 2) {
-      if (srcValid[0] != dstValid[0])
+      if (srcValid[0] != dstValid[0]) {
         mismatchFields.push_back("v_row (" + dimToStr(srcValid[0]) + " vs " +
                                  dimToStr(dstValid[0]) + ")");
-      if (srcValid[1] != dstValid[1])
+      }
+      if (srcValid[1] != dstValid[1]) {
         mismatchFields.push_back("v_col (" + dimToStr(srcValid[1]) + " vs " +
                                  dimToStr(dstValid[1]) + ")");
+      }
     }
-    if (srcTb.getPadValueI32() != dstTb.getPadValueI32())
+    if (srcTb.getPadValueI32() != dstTb.getPadValueI32()) {
       mismatchFields.push_back("pad (" + std::to_string(srcTb.getPadValueI32()) +
                                " vs " + std::to_string(dstTb.getPadValueI32()) +
                                ")");
+    }
 
     auto diag = op->emitError()
                 << "expects src/dst tile types to be lowerable to TFILLPAD "
                    "for loc=mat";
-    if (!mismatchFields.empty())
+    if (!mismatchFields.empty()) {
       diag << "; mismatching fields: " << llvm::join(mismatchFields, ", ");
+    }
     diag << "\n  src: " << srcTy;
     diag << "\n  dst: " << dstTy;
     diag << "\n  note: heterogeneous TFILLPAD overload is only available for loc=vec";
@@ -7496,31 +8507,37 @@ static mlir::LogicalResult verifyTFillPadLike(Operation *op, Type srcTy,
 
   if (auto dstTileTy = mlir::dyn_cast<mlir::pto::TileBufType>(dstTy)) {
     auto padAttr = mlir::dyn_cast<mlir::pto::PadValueAttr>(dstTileTy.getPadValueAttr());
-    if (!padAttr || padAttr.getValue() == mlir::pto::PadValue::Null)
+    if (!padAttr || padAttr.getValue() == mlir::pto::PadValue::Null) {
       return op->emitError("expects dst PadVal != Null for tfillpad");
+    }
   }
 
   return mlir::success();
 }
 
 mlir::LogicalResult mlir::pto::TFillPadOp::verify() {
-  if (getOperation()->getAttr("mode"))
+  if (getOperation()->getAttr("mode")) {
     return emitOpError("does not accept 'mode'; PTOAS infers TFILLPAD lowering "
                        "from physical shape and planned addresses");
+  }
 
   if (failed(verifyTFillPadLike(getOperation(), getSrc().getType(),
-                                getDst().getType())))
+                                getDst().getType()))) {
     return failure();
+  }
 
   if (auto padValueAttr = getPadValueAttr()) {
     auto dstSpace = getPTOMemorySpaceEnum(getDst().getType());
-    if (!dstSpace || *dstSpace != pto::AddressSpace::MAT)
+    if (!dstSpace || *dstSpace != pto::AddressSpace::MAT) {
       return emitOpError("expects padValue attribute only for loc=mat tfillpad");
+    }
     auto dstTileTy = dyn_cast<pto::TileBufType>(getDst().getType());
-    if (!dstTileTy)
+    if (!dstTileTy) {
       return emitOpError("expects dst to be tile_buf when padValue is specified");
-    if (dstTileTy.getPadValueI32() != static_cast<int32_t>(padValueAttr.getValue()))
+    }
+    if (dstTileTy.getPadValueI32() != static_cast<int32_t>(padValueAttr.getValue())) {
       return emitOpError("expects padValue attribute to match dst tile pad configuration");
+    }
   }
 
   return success();
@@ -7529,10 +8546,12 @@ mlir::LogicalResult mlir::pto::TFillPadOp::verify() {
 
 llvm::LogicalResult mlir::pto::TGatherOp::verify() {
   auto isSupportedGatherElemTypeA5Index = [&](Type ty) -> bool {
-    if (isPTOFloat8Type(ty))
+    if (isPTOFloat8Type(ty)) {
       return true;
-    if (ty.isF16() || ty.isF32())
+    }
+    if (ty.isF16() || ty.isF32()) {
       return true;
+    }
     if (auto it = dyn_cast<IntegerType>(ty)) {
       unsigned width = it.getWidth();
       return width == 8 || width == 16 || width == 32;
@@ -7544,26 +8563,32 @@ llvm::LogicalResult mlir::pto::TGatherOp::verify() {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyTileBufCommon(*this, srcTy, "src", allowA5MaskTypes)) ||
-        failed(verifyTileBufCommon(*this, dstTy, "dst", allowA5MaskTypes)))
+        failed(verifyTileBufCommon(*this, dstTy, "dst", allowA5MaskTypes))) {
       return failure();
+    }
 
     Type srcElem = getElemTy(srcTy);
     Type dstElem = getElemTy(dstTy);
-    if (!srcElem || !dstElem)
+    if (!srcElem || !dstElem) {
       return emitOpError("failed to get element type for src/dst");
-    if (!isRowMajorTileBuf(srcTy) || !isRowMajorTileBuf(dstTy))
+    }
+    if (!isRowMajorTileBuf(srcTy) || !isRowMajorTileBuf(dstTy)) {
       return emitOpError("expects src and dst to use row-major layout");
+    }
     auto srcSpace = getPTOMemorySpaceEnum(srcTy);
     auto dstSpace = getPTOMemorySpaceEnum(dstTy);
     if (!srcSpace || !dstSpace || *srcSpace != pto::AddressSpace::VEC ||
-        *dstSpace != pto::AddressSpace::VEC)
+        *dstSpace != pto::AddressSpace::VEC) {
       return emitOpError("expects src and dst to be in the vec address space");
+    }
     unsigned srcElemBytes = getPTOStorageElemByteSize(srcElem);
     unsigned dstElemBytes = getPTOStorageElemByteSize(dstElem);
-    if (srcElemBytes == 0 || dstElemBytes == 0)
+    if (srcElemBytes == 0 || dstElemBytes == 0) {
       return emitOpError("failed to get element size for src/dst");
-    if (srcElemBytes != dstElemBytes)
+    }
+    if (srcElemBytes != dstElemBytes) {
       return emitOpError("expects src and dst element sizes to match");
+    }
 
     auto dstValid = getValidShapeVec(dstTy);
     auto dstShape = getShapeVec(dstTy);
@@ -7574,12 +8599,14 @@ llvm::LogicalResult mlir::pto::TGatherOp::verify() {
     }
 
     auto axisAttr = getAxisAttr();
-    if (!axisAttr)
+    if (!axisAttr) {
       return emitOpError("expects mask-pattern tgather to provide axis attribute");
+    }
     StringRef axisVal = axisAttr.getValue();
     auto mp = getMaskPatternAttr();
-    if (!mp)
+    if (!mp) {
       return emitOpError("expects mask-pattern tgather to provide maskPattern");
+    }
     auto getMaskGatherTimes = [](mlir::pto::MaskPatternAttr mp) -> unsigned {
       switch (mp.getValue()) {
       case mlir::pto::MaskPattern::P1111:
@@ -7593,35 +8620,43 @@ llvm::LogicalResult mlir::pto::TGatherOp::verify() {
     };
     const unsigned times = getMaskGatherTimes(mp);
     auto srcValid = getValidShapeVec(srcTy);
-    if (srcValid.size() != 2 || dstValid.size() != 2)
+    if (srcValid.size() != 2 || dstValid.size() != 2) {
       return emitOpError("expects src and dst to have rank-2 valid_shape");
+    }
     if (axisVal == "row") {
       if (srcValid[0] != ShapedType::kDynamic && dstValid[0] != ShapedType::kDynamic &&
-          dstValid[0] != srcValid[0])
+          dstValid[0] != srcValid[0]) {
         return emitOpError("expects dst valid rows to equal src valid rows for row direction");
+      }
       if (srcValid[1] != ShapedType::kDynamic && dstValid[1] != ShapedType::kDynamic &&
-          srcValid[1] != static_cast<int64_t>(dstValid[1] * times))
+          srcValid[1] != static_cast<int64_t>(dstValid[1] * times)) {
         return emitOpError("expects src valid cols to equal dst valid cols times the mask expansion factor for row direction");
+      }
     } else if (axisVal == "col") {
       if (srcValid[1] != ShapedType::kDynamic && dstValid[1] != ShapedType::kDynamic &&
-          dstValid[1] != srcValid[1])
+          dstValid[1] != srcValid[1]) {
         return emitOpError("expects dst valid cols to equal src valid cols for col direction");
+      }
       if (srcValid[0] != ShapedType::kDynamic && dstValid[0] != ShapedType::kDynamic &&
-          srcValid[0] != static_cast<int64_t>(dstValid[0] * times))
+          srcValid[0] != static_cast<int64_t>(dstValid[0] * times)) {
         return emitOpError("expects src valid rows to equal dst valid rows times the mask expansion factor for col direction");
+      }
     } else {
       return emitOpError("Invalid axis value, expected \"row\" or \"col\"");
     }
 
     if (allowA5MaskTypes) {
-      if (!(srcElemBytes == 1 || srcElemBytes == 2 || srcElemBytes == 4))
+      if (!(srcElemBytes == 1 || srcElemBytes == 2 || srcElemBytes == 4)) {
         return emitOpError("expects A5 mask-pattern gather element size to be 1, 2, or 4 bytes");
-      if (!isSupportedGatherElemTypeA5(srcElem) || !isSupportedGatherElemTypeA5(dstElem))
+      }
+      if (!isSupportedGatherElemTypeA5(srcElem) || !isSupportedGatherElemTypeA5(dstElem)) {
         return emitOpError(
             "expects A5 mask-pattern gather src/dst element type to be i8/i16/i32/f16/bf16/f32/fp8-like");
+      }
     } else {
-      if (!(srcElemBytes == 2 || srcElemBytes == 4))
+      if (!(srcElemBytes == 2 || srcElemBytes == 4)) {
         return emitOpError("expects A2/A3 mask-pattern gather element size to be 2 or 4 bytes");
+      }
     }
     return success();
   };
@@ -7632,33 +8667,39 @@ llvm::LogicalResult mlir::pto::TGatherOp::verify() {
     Type idxTy = getIndices().getType();
     if (failed(verifyTileBufCommon(*this, srcTy, "src", allowA5ElemTypes)) ||
         failed(verifyTileBufCommon(*this, dstTy, "dst", allowA5ElemTypes)) ||
-        failed(verifyTileBufCommon(*this, idxTy, "indices")))
+        failed(verifyTileBufCommon(*this, idxTy, "indices"))) {
       return failure();
+    }
     if (getTmp()) {
       Type tmpTy = getTmp().getType();
-      if (failed(verifyTileBufCommon(*this, tmpTy, "tmp")))
+      if (failed(verifyTileBufCommon(*this, tmpTy, "tmp"))) {
         return failure();
+      }
     }
 
     Type srcElem = getElemTy(srcTy);
     Type dstElem = getElemTy(dstTy);
-    if (!srcElem || !dstElem)
+    if (!srcElem || !dstElem) {
       return emitOpError("failed to get element type for src/dst");
-    if (srcElem != dstElem)
+    }
+    if (srcElem != dstElem) {
       return emitOpError("expects src and dst to have the same element type");
+    }
     if (allowA5ElemTypes) {
       if (!isSupportedGatherElemTypeA5Index(srcElem) ||
-          !isSupportedGatherElemTypeA5Index(dstElem))
+          !isSupportedGatherElemTypeA5Index(dstElem)) {
         return emitOpError(
             "expects A5 gather src/dst element type to be i8/i16/i32/f16/f32");
+      }
     } else if (!isSupportedGatherElemTypeA2A3(srcElem) ||
                !isSupportedGatherElemTypeA2A3(dstElem)) {
       return emitOpError("expects gather src/dst element type to be i16/i32/f16/f32");
     }
 
     auto idxElem = dyn_cast<IntegerType>(getElemTy(idxTy));
-    if (!idxElem)
+    if (!idxElem) {
       return emitOpError("indices element type must be integer");
+    }
     unsigned width = idxElem.getWidth();
     if (!(width == 32 || (allow16BitIndices && width == 16))) {
       return emitOpError() << "expects indices element type to be i32"
@@ -7683,10 +8724,12 @@ llvm::LogicalResult mlir::pto::TGatherOp::verify() {
 
     if (!allowA5ElemTypes) {
       Type tmpElem = getElemTy(getTmp().getType());
-      if (tmpElem != idxElem)
+      if (tmpElem != idxElem) {
         return emitOpError("expects tmp and indices to have the same element type");
-      if (failed(verifyTileBufSameValidShape(*this, idxTy, getTmp().getType(), "indices", "tmp")))
+      }
+      if (failed(verifyTileBufSameValidShape(*this, idxTy, getTmp().getType(), "indices", "tmp"))) {
         return failure();
+      }
     }
     return success();
   };
@@ -7699,26 +8742,32 @@ llvm::LogicalResult mlir::pto::TGatherOp::verify() {
     if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
         failed(verifyTileBufCommon(*this, dstTy, "dst")) ||
         failed(verifyTileBufCommon(*this, cdstTy, "cdst")) ||
-        failed(verifyTileBufCommon(*this, tmpTy, "tmp")))
+        failed(verifyTileBufCommon(*this, tmpTy, "tmp"))) {
       return failure();
+    }
 
     Type srcElem = getElemTy(srcTy);
     Type dstElem = getElemTy(dstTy);
     Type cdstElem = getElemTy(cdstTy);
-    if (!srcElem || !dstElem || !cdstElem)
+    if (!srcElem || !dstElem || !cdstElem) {
       return emitOpError("failed to get element type for src/dst/cdst");
+    }
     auto dstInt = dyn_cast<IntegerType>(dstElem);
-    if (!dstInt || dstInt.getWidth() != 32)
+    if (!dstInt || dstInt.getWidth() != 32) {
       return emitOpError("expects dst element type to be i32");
-    if (cdstElem != dstElem)
+    }
+    if (cdstElem != dstElem) {
       return emitOpError("expects cdst to have the same element type as dst");
-    if (getKValue().getType() != srcElem)
+    }
+    if (getKValue().getType() != srcElem) {
       return emitOpError("expects kValue to have the same type as src element type");
+    }
 
     auto cmpAttr = getCmpModeAttr();
     auto cmpMode = cmpAttr ? cmpAttr.getValue() : pto::CmpMode::EQ;
-    if (cmpMode != pto::CmpMode::EQ && cmpMode != pto::CmpMode::GT)
+    if (cmpMode != pto::CmpMode::EQ && cmpMode != pto::CmpMode::GT) {
       return emitOpError("expects compare-form tgather cmpMode to be eq or gt");
+    }
 
     if (allowA5SrcTypes) {
       if (!(srcElem.isF16() || srcElem.isF32() || srcElem.isInteger(16) ||
@@ -7737,48 +8786,59 @@ llvm::LogicalResult mlir::pto::TGatherOp::verify() {
     if (failed(verifyVecTileCommonA2A3(*this, srcTy, "src")) ||
         failed(verifyVecTileCommonA2A3(*this, dstTy, "dst")) ||
         failed(verifyVecTileCommonA2A3(*this, cdstTy, "cdst")) ||
-        failed(verifyVecTileCommonA2A3(*this, tmpTy, "tmp")))
+        failed(verifyVecTileCommonA2A3(*this, tmpTy, "tmp"))) {
       return failure();
+    }
     return success();
   };
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     if (getMaskPatternAttr()) {
-      if (getCdst() || getIndices() || getTmp() || getKValue())
+      if (getCdst() || getIndices() || getTmp() || getKValue()) {
         return emitOpError("mask-pattern tgather only allows src and dst operands");
+      }
       return verifyMaskForm(/*allowA5MaskTypes=*/false);
     }
-    if (getAxisAttr())
+    if (getAxisAttr()) {
       return emitOpError("axis attribute must not be provided without maskPattern");
+    }
     if (getCdst() || getKValue()) {
-      if (!getCdst() || !getKValue() || !getTmp())
+      if (!getCdst() || !getKValue() || !getTmp()) {
         return emitOpError("compare-form tgather expects dst, cdst, kValue, and tmp");
-      if (getIndices())
+      }
+      if (getIndices()) {
         return emitOpError("compare-form tgather does not take indices");
+      }
       return verifyCompareForm(/*allowA5SrcTypes=*/false);
     }
-    if (!getIndices() || !getTmp())
+    if (!getIndices() || !getTmp()) {
       return emitOpError("index-form tgather expects both indices and tmp");
+    }
     return verifyIndexForm(/*allow16BitIndices=*/false, /*allowA5ElemTypes=*/false);
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     if (getMaskPatternAttr()) {
-      if (getCdst() || getIndices() || getTmp() || getKValue())
+      if (getCdst() || getIndices() || getTmp() || getKValue()) {
         return emitOpError("mask-pattern tgather only allows src and dst operands");
+      }
       return verifyMaskForm(/*allowA5MaskTypes=*/true);
     }
-    if (getAxisAttr())
+    if (getAxisAttr()) {
       return emitOpError("axis attribute must not be provided without maskPattern");
+    }
     if (getCdst() || getKValue()) {
-      if (!getCdst() || !getKValue() || !getTmp())
+      if (!getCdst() || !getKValue() || !getTmp()) {
         return emitOpError("compare-form tgather expects dst, cdst, kValue, and tmp");
-      if (getIndices())
+      }
+      if (getIndices()) {
         return emitOpError("compare-form tgather does not take indices");
+      }
       return verifyCompareForm(/*allowA5SrcTypes=*/true);
     }
-    if (!getIndices())
+    if (!getIndices()) {
       return emitOpError("index-form tgather expects indices");
+    }
     return verifyIndexForm(/*allow16BitIndices=*/true, /*allowA5ElemTypes=*/true);
   };
 
@@ -7791,44 +8851,52 @@ mlir::LogicalResult mlir::pto::TGatherBOp::verify() {
     Type dstTy = getDst().getType();
     if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
         failed(verifyTileBufCommon(*this, offTy, "offsets")) ||
-        failed(verifyTileBufCommon(*this, dstTy, "dst")))
+        failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
       return failure();
+    }
     auto srcElemTy = getElemTy(srcTy);
     auto dstElemTy = getElemTy(dstTy);
-    if (!srcElemTy || !dstElemTy)
+    if (!srcElemTy || !dstElemTy) {
       return emitOpError() << "failed to get element type for src/dst";
+    }
     return std::make_pair(srcElemTy, dstElemTy);
   };
 
   auto getElemBytes = [](Type ty) -> std::optional<unsigned> {
     unsigned elemBytes = getPTOStorageElemByteSize(ty);
-    if (elemBytes == 0)
+    if (elemBytes == 0) {
       return std::nullopt;
+    }
     return elemBytes;
   };
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     FailureOr<std::pair<Type, Type>> elems = verifyCommon();
-    if (failed(elems))
+    if (failed(elems)) {
       return failure();
+    }
     Type dstTy = getDst().getType();
     Type dstElemTy = elems->second;
-    if (!isRowMajorTileBuf(dstTy))
+    if (!isRowMajorTileBuf(dstTy)) {
       return emitOpError() << "expects dst to use row-major layout";
+    }
     auto dstBytes = getElemBytes(dstElemTy);
-    if (!dstBytes || (*dstBytes != 1 && *dstBytes != 2 && *dstBytes != 4))
+    if (!dstBytes || (*dstBytes != 1 && *dstBytes != 2 && *dstBytes != 4)) {
       return emitOpError() << "expects dst element size to be 1, 2, or 4 bytes";
+    }
     return mlir::success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     FailureOr<std::pair<Type, Type>> elems = verifyCommon();
-    if (failed(elems))
+    if (failed(elems)) {
       return failure();
+    }
     Type dstElemTy = elems->second;
     auto dstBytes = getElemBytes(dstElemTy);
-    if (!dstBytes || (*dstBytes != 1 && *dstBytes != 2 && *dstBytes != 4))
+    if (!dstBytes || (*dstBytes != 1 && *dstBytes != 2 && *dstBytes != 4)) {
       return emitOpError() << "expects dst element size to be 1, 2, or 4 bytes";
+    }
     return mlir::success();
   };
 
@@ -7839,13 +8907,16 @@ mlir::LogicalResult mlir::pto::TLogOp::verify() {
   Type srcTy = getSrc().getType();
   Type dstTy = getDst().getType();
   if (failed(verifyVecTileUnaryOp(*this, srcTy, dstTy, "src", "dst",
-                                  /*allowBf16=*/false, /*allowInt8=*/false)))
+                                  /*allowBf16=*/false, /*allowInt8=*/false))) {
     return failure();
-  if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+  }
+  if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
     return failure();
+  }
   auto elemTy = getElemTy(srcTy);
-  if (!(elemTy.isF16() || elemTy.isF32()))
+  if (!(elemTy.isF16() || elemTy.isF32())) {
     return emitOpError() << "expects element type to be f16 or f32";
+  }
   return success();
 }
 
@@ -7854,35 +8925,45 @@ mlir::LogicalResult mlir::pto::TLReluOp::verify() {
   Type dstTy = getDst().getType();
   auto verifyA2A3 = [&]() -> LogicalResult {
     if (failed(verifyVecTileStorage(*this, srcTy, "src")) ||
-        failed(verifyVecTileStorage(*this, dstTy, "dst")))
+        failed(verifyVecTileStorage(*this, dstTy, "dst"))) {
       return failure();
+    }
     if (failed(verifyTileBufSameElemType(*this, srcTy, dstTy, "src", "dst")) ||
-        failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+        failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
       return failure();
+    }
     auto valid = getValidShapeVec(srcTy);
-    if (valid.size() != 2)
+    if (valid.size() != 2) {
       return emitOpError("expects src to have rank-2 valid_shape");
-    if (valid[0] != ShapedType::kDynamic && valid[0] < 0)
+    }
+    if (valid[0] != ShapedType::kDynamic && valid[0] < 0) {
       return emitOpError("expects src valid_shape[0] to be non-negative");
-    if (valid[1] != ShapedType::kDynamic && valid[1] < 0)
+    }
+    if (valid[1] != ShapedType::kDynamic && valid[1] < 0) {
       return emitOpError("expects src valid_shape[1] to be non-negative");
+    }
     Type elemTy = getElemTy(srcTy);
-    if (!(elemTy.isF16() || elemTy.isF32()))
+    if (!(elemTy.isF16() || elemTy.isF32())) {
       return emitOpError() << "expects A2/A3 tlrelu element type to be f16 or f32";
+    }
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
     if (failed(verifyVecTileStorage(*this, srcTy, "src")) ||
-        failed(verifyVecTileStorage(*this, dstTy, "dst")))
+        failed(verifyVecTileStorage(*this, dstTy, "dst"))) {
       return failure();
+    }
     if (failed(verifyTileBufSameElemType(*this, srcTy, dstTy, "src", "dst")) ||
-        failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+        failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
       return failure();
+    }
     Type elemTy = getElemTy(srcTy);
-    if (!(elemTy.isF16() || elemTy.isF32()))
+    if (!(elemTy.isF16() || elemTy.isF32())) {
       return emitOpError() << "expects A5 tlrelu element type to be f16 or f32";
-    if (!getSlope().getType().isF32())
+    }
+    if (!getSlope().getType().isF32()) {
       return emitOpError() << "expects slope to have type f32";
+    }
     return success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -8077,25 +9158,31 @@ mlir::LogicalResult mlir::pto::TMovOp::verify() {
       return emitOpError("expects grpAxis only on the X-to-ZZ form with a non-scaling third tile");
 
     if (failed(verifyTileBufCommon(*this, srcTy, "src", /*allowLowPrecision=*/isA5)) ||
-        failed(verifyTileBufCommon(*this, dstTy, "dst", /*allowLowPrecision=*/isA5)))
+        failed(verifyTileBufCommon(*this, dstTy, "dst", /*allowLowPrecision=*/isA5))) {
       return failure();
+    }
     if (hasFp && failed(verifyTileBufCommon(*this, fp.getType(), "fp",
-                                            /*allowLowPrecision=*/isA5)))
+                                            /*allowLowPrecision=*/isA5))) {
       return failure();
-    if (hasFp && hasPreQuantScalar)
+    }
+    if (hasFp && hasPreQuantScalar) {
       return emitOpError() << "expects fp and preQuantScalar forms to be mutually exclusive";
+    }
 
     auto srcSpace = getPTOMemorySpaceEnum(srcTy);
     auto dstSpace = getPTOMemorySpaceEnum(dstTy);
-    if (!srcSpace || !dstSpace)
+    if (!srcSpace || !dstSpace) {
       return emitOpError() << "expects src and dst to have explicit address spaces";
+    }
 
     auto srcShape = getShapeVec(srcTy);
     auto dstShape = getShapeVec(dstTy);
-    if (*srcSpace == pto::AddressSpace::MAT && srcShape != dstShape)
+    if (*srcSpace == pto::AddressSpace::MAT && srcShape != dstShape) {
       return emitOpError() << "expects mat-source tmov to use matching src/dst shapes";
-    if (!isA5 && *srcSpace != pto::AddressSpace::MAT && srcShape != dstShape)
+    }
+    if (!isA5 && *srcSpace != pto::AddressSpace::MAT && srcShape != dstShape) {
       return emitOpError() << "expects A2/A3 non-mat tmov to use matching src/dst shapes";
+    }
 
     const bool isMatToTile =
         *srcSpace == pto::AddressSpace::MAT &&
@@ -8117,36 +9204,44 @@ mlir::LogicalResult mlir::pto::TMovOp::verify() {
         *dstSpace == pto::AddressSpace::VEC;
 
     bool okPair = isMatToTile || isVecToVec || isAccToMat || isAccToVec;
-    if (isA5)
+    if (isA5) {
       okPair = okPair || isVecToMat;
-    if (!okPair)
+    }
+    if (!okPair) {
       return emitOpError()
              << "expects a supported tmov address-space pair for this target";
+    }
 
-    if (accToVecModeAttr && !isAccToVec)
+    if (accToVecModeAttr && !isAccToVec) {
       return emitOpError()
              << "expects accToVecMode to be used only for acc-to-vec tmov";
+    }
 
-    if (reluMode != pto::ReluPreMode::NoRelu && !(isAccToMat || isAccToVec))
+    if (reluMode != pto::ReluPreMode::NoRelu && !(isAccToMat || isAccToVec)) {
       return emitOpError()
              << "expects reluPreMode form to use loc=acc src";
+    }
 
-    if (hasPreQuantScalar && !(isAccToMat || isAccToVec))
+    if (hasPreQuantScalar && !(isAccToMat || isAccToVec)) {
       return emitOpError()
              << "expects preQuantScalar form to use loc=acc src";
+    }
 
     if (hasFp) {
       auto fpTy = fp.getType();
       auto fpSpace = getPTOMemorySpaceEnum(fpTy);
-      if (!fpSpace || *fpSpace != pto::AddressSpace::SCALING)
+      if (!fpSpace || *fpSpace != pto::AddressSpace::SCALING) {
         return emitOpError() << "expects fp to be in the scaling address space";
+      }
       auto srcElemTy = getElemTy(srcTy);
       auto srcIntTy = dyn_cast<IntegerType>(srcElemTy);
-      if (!(srcElemTy.isF32() || (srcIntTy && srcIntTy.getWidth() == 32)))
+      if (!(srcElemTy.isF32() || (srcIntTy && srcIntTy.getWidth() == 32))) {
         return emitOpError()
                << "expects fp form src to have element type f32, i32";
-      if (!(isAccToMat || isAccToVec))
+      }
+      if (!(isAccToMat || isAccToVec)) {
         return emitOpError() << "expects fp form to use loc=acc src";
+      }
     }
 
     if ((hasFp || hasPreQuantScalar) && accToVecModeAttr) {
@@ -8166,20 +9261,23 @@ mlir::LogicalResult mlir::pto::TMovOp::verify() {
     if (srcTb && *srcSpace == pto::AddressSpace::ACC &&
         (hasFp || reluMode != pto::ReluPreMode::NoRelu)) {
       if (srcTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor) ||
-          srcTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))
+          srcTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor)) {
         return emitOpError()
                << "expects acc-source fp/relu tmov src to use blayout=col_major and slayout=row_major";
+      }
     }
     if (hasFp && !isA5 && dstTb && isAccToMat &&
         (dstTb.getBLayoutValueI32() !=
              static_cast<int32_t>(pto::BLayout::ColMajor) ||
          dstTb.getSLayoutValueI32() !=
-             static_cast<int32_t>(pto::SLayout::RowMajor)))
+             static_cast<int32_t>(pto::SLayout::RowMajor))) {
       return emitOpError()
              << "expects fp tmov dst to use blayout=col_major and slayout=row_major";
+    }
     if (srcTb && dstTb && isAccToMat && !isA5 &&
-        dstTb.getSFractalSizeI32() != 512)
+        dstTb.getSFractalSizeI32() != 512) {
       return emitOpError() << "expects A2/A3 acc-to-mat tmov destination fractal to be 512";
+    }
 
     return success();
   };
@@ -8208,8 +9306,9 @@ static LogicalResult verifyMatmulLike(Operation *op, Type aTy, Type bTy, Type ds
   bool bValid = isa<RankedTensorType, pto::TileBufType, pto::PartitionTensorViewType>(bTy);
   bool dValid = isa<RankedTensorType, pto::TileBufType, pto::PartitionTensorViewType>(dstTy);
 
-  if (!aValid || !bValid || !dValid)
+  if (!aValid || !bValid || !dValid) {
     return op->emitOpError("expects inputs/outputs to be tensors or PTO tile types");
+  }
 
   if (checkRank) {
     int64_t aRank = getRankHelper(aTy);
@@ -8217,10 +9316,12 @@ static LogicalResult verifyMatmulLike(Operation *op, Type aTy, Type bTy, Type ds
     int64_t dRank = getRankHelper(dstTy);
 
     // 检查 Rank 一致性
-    if (aRank != -1 && dRank != -1 && aRank != dRank)
+    if (aRank != -1 && dRank != -1 && aRank != dRank) {
       return op->emitOpError("expects a and dst to have the same rank");
-    if (bRank != -1 && dRank != -1 && bRank != dRank)
+    }
+    if (bRank != -1 && dRank != -1 && bRank != dRank) {
       return op->emitOpError("expects b and dst to have the same rank");
+    }
   }
 
   return success();
@@ -8236,8 +9337,9 @@ LogicalResult LoadScalarOp::verify() {
     return emitOpError("expects ptr to be !pto.ptr type");
   }
 
-  if (getValue().getType() != elemTy)
+  if (getValue().getType() != elemTy) {
     return emitOpError("expects result type to match ptr element type");
+  }
 
   return success();
 }
@@ -8251,8 +9353,9 @@ LogicalResult StoreScalarOp::verify() {
     return emitOpError("expects ptr to be !pto.ptr type");
   }
 
-  if (getValue().getType() != elemTy)
+  if (getValue().getType() != elemTy) {
     return emitOpError("expects value type to match ptr element type");
+  }
 
   return success();
 }
@@ -8263,10 +9366,12 @@ static bool isGmOrDefaultAddressSpace(pto::AddressSpace space) {
 }
 
 static bool isGmOrDefaultCmoAddressType(Type type) {
-  if (auto ptrTy = dyn_cast<mlir::pto::PtrType>(type))
+  if (auto ptrTy = dyn_cast<mlir::pto::PtrType>(type)) {
     return isGmOrDefaultAddressSpace(ptrTy.getMemorySpace().getAddressSpace());
-  if (isa<mlir::pto::TensorViewType, mlir::pto::PartitionTensorViewType>(type))
+  }
+  if (isa<mlir::pto::TensorViewType, mlir::pto::PartitionTensorViewType>(type)) {
     return true;
+  }
   return false;
 }
 
@@ -8275,8 +9380,9 @@ ParseResult CmoCacheInvalidOp::parse(OpAsmParser &parser,
   if (succeeded(parser.parseOptionalKeyword("all"))) {
     AddressSpaceAttr spaceAttr;
     if (parser.parseAttribute(spaceAttr, "space", result.attributes) ||
-        parser.parseOptionalAttrDict(result.attributes))
+        parser.parseOptionalAttrDict(result.attributes)) {
       return failure();
+    }
     return success();
   }
 
@@ -8285,11 +9391,13 @@ ParseResult CmoCacheInvalidOp::parse(OpAsmParser &parser,
   if (parser.parseOperand(addr) ||
       parser.parseKeyword("single_cache_line") ||
       parser.parseColonType(addrTy) ||
-      parser.parseOptionalAttrDict(result.attributes))
+      parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
-  if (parser.resolveOperand(addr, addrTy, result.operands))
+  if (parser.resolveOperand(addr, addrTy, result.operands)) {
     return failure();
+  }
 
   if (!result.attributes.get("space")) {
     result.addAttribute(
@@ -8313,12 +9421,14 @@ void CmoCacheInvalidOp::print(OpAsmPrinter &p) {
 }
 
 LogicalResult CmoCacheInvalidOp::verify() {
-  if (!isGmOrDefaultAddressSpace(getSpace().getAddressSpace()))
+  if (!isGmOrDefaultAddressSpace(getSpace().getAddressSpace())) {
     return emitOpError("only supports GM cache maintenance");
+  }
 
   if (Value addr = getAddr()) {
-    if (!isGmOrDefaultCmoAddressType(addr.getType()))
+    if (!isGmOrDefaultCmoAddressType(addr.getType())) {
       return emitOpError("single_cache_line address expects a GM pointer or GM tensor view");
+    }
   }
 
   return success();
@@ -8328,8 +9438,9 @@ LogicalResult CmoCacheInvalidOp::verify() {
 static LogicalResult verifyBufSyncOp(Operation *op, Attribute opTypeAttr,
                                      IntegerAttr bufIdAttr,
                                      IntegerAttr modeAttr) {
-  if (!opTypeAttr)
+  if (!opTypeAttr) {
     return op->emitOpError("expects 'op_type' attribute");
+  }
 
   pto::PIPE pipe = pto::PIPE::PIPE_UNASSIGNED;
   if (auto pipeAttr = dyn_cast<PipeAttr>(opTypeAttr)) {
@@ -8344,19 +9455,23 @@ static LogicalResult verifyBufSyncOp(Operation *op, Attribute opTypeAttr,
     }
     pipe = mapSyncOpTypeToPipe(*opTypeOr);
   }
-  if (!isConcreteSyncPipe(pipe))
+  if (!isConcreteSyncPipe(pipe)) {
     return op->emitOpError("expects 'op_type' to map to a concrete pipe, not PIPE_ALL/PIPE_UNASSIGNED");
+  }
 
-  if (!bufIdAttr)
+  if (!bufIdAttr) {
     return op->emitOpError("expects 'buf_id' attribute");
+  }
   int64_t bufId = bufIdAttr.getInt();
-  if (bufId < 0 || bufId > 31)
+  if (bufId < 0 || bufId > 31) {
     return op->emitOpError("expects 'buf_id' in range [0, 31]");
+  }
 
   if (modeAttr) {
     int64_t mode = modeAttr.getInt();
-    if (mode < 0)
+    if (mode < 0) {
       return op->emitOpError("expects 'mode' to be non-negative");
+    }
   }
 
   return success();
@@ -8375,8 +9490,9 @@ LogicalResult RlsBufOp::verify() {
 // ---- GetBufDynOp / RlsBufDynOp ----
 static LogicalResult verifyBufDynSyncOp(Operation *op, Attribute opTypeAttr,
                                         Value bufId, IntegerAttr modeAttr) {
-  if (!opTypeAttr)
+  if (!opTypeAttr) {
     return op->emitOpError("expects 'op_type' attribute");
+  }
 
   pto::PIPE pipe = pto::PIPE::PIPE_UNASSIGNED;
   if (auto pipeAttr = dyn_cast<PipeAttr>(opTypeAttr)) {
@@ -8391,16 +9507,19 @@ static LogicalResult verifyBufDynSyncOp(Operation *op, Attribute opTypeAttr,
     }
     pipe = mapSyncOpTypeToPipe(*opTypeOr);
   }
-  if (!isConcreteSyncPipe(pipe))
+  if (!isConcreteSyncPipe(pipe)) {
     return op->emitOpError("expects 'op_type' to map to a concrete pipe, not PIPE_ALL/PIPE_UNASSIGNED");
+  }
 
-  if (!bufId)
+  if (!bufId) {
     return op->emitOpError("expects 'buf_id' operand");
+  }
 
   if (modeAttr) {
     int64_t mode = modeAttr.getInt();
-    if (mode < 0)
+    if (mode < 0) {
       return op->emitOpError("expects 'mode' to be non-negative");
+    }
   }
 
   return success();
@@ -8422,18 +9541,21 @@ static ParseResult parseLegacyOrAttrMemBar(OpAsmParser &parser,
   std::string token;
   if (succeeded(parser.parseOptionalString(&token))) {
     auto kind = symbolizeMemBarKind(token);
-    if (!kind)
+    if (!kind) {
       return parser.emitError(loc) << "invalid membar token: " << token;
+    }
     attr = MemBarAttr::get(parser.getContext(), *kind);
     return success();
   }
 
   Attribute parsed;
-  if (failed(parser.parseAttribute(parsed)))
+  if (failed(parser.parseAttribute(parsed))) {
     return failure();
+  }
   auto memBarAttr = dyn_cast<MemBarAttr>(parsed);
-  if (!memBarAttr)
+  if (!memBarAttr) {
     return parser.emitError(loc, "expected membar attribute");
+  }
   attr = memBarAttr;
   return success();
 }
@@ -8450,18 +9572,21 @@ static ParseResult parseLegacyOrAttrDsbMem(OpAsmParser &parser,
   std::string token;
   if (succeeded(parser.parseOptionalString(&token))) {
     auto kind = symbolizeDsbMem(token);
-    if (!kind)
+    if (!kind) {
       return parser.emitError(loc) << "invalid dsb memory token: " << token;
+    }
     attr = DsbMemAttr::get(parser.getContext(), *kind);
     return success();
   }
 
   Attribute parsed;
-  if (failed(parser.parseAttribute(parsed)))
+  if (failed(parser.parseAttribute(parsed))) {
     return failure();
+  }
   auto dsbMemAttr = dyn_cast<DsbMemAttr>(parsed);
-  if (!dsbMemAttr)
+  if (!dsbMemAttr) {
     return parser.emitError(loc, "expected dsb_mem attribute");
+  }
   attr = dsbMemAttr;
   return success();
 }
@@ -8478,18 +9603,21 @@ static ParseResult parseLegacyOrAttrDcciCacheLine(OpAsmParser &parser,
   std::string token;
   if (succeeded(parser.parseOptionalString(&token))) {
     auto kind = symbolizeDcciCacheLine(token);
-    if (!kind)
+    if (!kind) {
       return parser.emitError(loc) << "invalid dcci cache token: " << token;
+    }
     attr = DcciCacheLineAttr::get(parser.getContext(), *kind);
     return success();
   }
 
   Attribute parsed;
-  if (failed(parser.parseAttribute(parsed)))
+  if (failed(parser.parseAttribute(parsed))) {
     return failure();
+  }
   auto cacheAttr = dyn_cast<DcciCacheLineAttr>(parsed);
-  if (!cacheAttr)
+  if (!cacheAttr) {
     return parser.emitError(loc, "expected dcci_cache_line attribute");
+  }
   attr = cacheAttr;
   return success();
 }
@@ -8502,25 +9630,29 @@ static void printLegacyOrAttrDcciCacheLine(OpAsmPrinter &printer, Operation *op,
 
 static ParseResult parseOptionalDcciDst(OpAsmParser &parser,
                                         DcciDstAttr &attr) {
-  if (failed(parser.parseOptionalComma()))
+  if (failed(parser.parseOptionalComma())) {
     return success();
+  }
 
   auto loc = parser.getCurrentLocation();
   std::string token;
   if (succeeded(parser.parseOptionalString(&token))) {
     auto kind = symbolizeDcciDst(token);
-    if (!kind)
+    if (!kind) {
       return parser.emitError(loc) << "invalid dcci dst token: " << token;
+    }
     attr = DcciDstAttr::get(parser.getContext(), *kind);
     return success();
   }
 
   Attribute parsed;
-  if (failed(parser.parseAttribute(parsed)))
+  if (failed(parser.parseAttribute(parsed))) {
     return failure();
+  }
   auto dstAttr = dyn_cast<DcciDstAttr>(parsed);
-  if (!dstAttr)
+  if (!dstAttr) {
     return parser.emitError(loc, "expected dcci_dst attribute");
+  }
   attr = dstAttr;
   return success();
 }
@@ -8528,17 +9660,20 @@ static ParseResult parseOptionalDcciDst(OpAsmParser &parser,
 static void printOptionalDcciDst(OpAsmPrinter &printer, Operation *op,
                                  DcciDstAttr dst) {
   (void)op;
-  if (!dst)
+  if (!dst) {
     return;
+  }
   printer << ", \"" << stringifyDcciDst(dst.getKind()) << '"';
 }
 
 LogicalResult DcciOp::verify() {
   auto space = getPTOMemorySpaceEnum(getPtr().getType());
-  if (!space)
+  if (!space) {
     return emitOpError("expects ptr to have a PTO memory space");
-  if (*space != pto::AddressSpace::GM && *space != pto::AddressSpace::VEC)
+  }
+  if (*space != pto::AddressSpace::GM && *space != pto::AddressSpace::VEC) {
     return emitOpError("expects ptr memory space to be gm or ub/vec");
+  }
 
   return success();
 }
@@ -8548,29 +9683,34 @@ static ParseResult parseLegacyOrAttrPipe(OpAsmParser &parser, PipeAttr &attr) {
   std::string token;
   if (succeeded(parser.parseOptionalString(&token))) {
     auto pipe = symbolizePIPE(token);
-    if (!pipe)
+    if (!pipe) {
       return parser.emitError(loc) << "invalid pipe token: " << token;
+    }
     attr = PipeAttr::get(parser.getContext(), *pipe);
     return success();
   }
 
   if (succeeded(parser.parseOptionalLess())) {
     StringRef keyword;
-    if (parser.parseKeyword(&keyword) || parser.parseGreater())
+    if (parser.parseKeyword(&keyword) || parser.parseGreater()) {
       return failure();
+    }
     auto pipe = symbolizePIPE(keyword);
-    if (!pipe)
+    if (!pipe) {
       return parser.emitError(loc) << "invalid pipe token: " << keyword;
+    }
     attr = PipeAttr::get(parser.getContext(), *pipe);
     return success();
   }
 
   Attribute parsed;
-  if (failed(parser.parseAttribute(parsed)))
+  if (failed(parser.parseAttribute(parsed))) {
     return failure();
+  }
   auto pipeAttr = dyn_cast<PipeAttr>(parsed);
-  if (!pipeAttr)
+  if (!pipeAttr) {
     return parser.emitError(loc, "expected pipe attribute");
+  }
   attr = pipeAttr;
   return success();
 }
@@ -8580,29 +9720,34 @@ static ParseResult parseLegacyOrAttrEvent(OpAsmParser &parser, EventAttr &attr) 
   std::string token;
   if (succeeded(parser.parseOptionalString(&token))) {
     auto event = symbolizeEVENT(token);
-    if (!event)
+    if (!event) {
       return parser.emitError(loc) << "invalid event token: " << token;
+    }
     attr = EventAttr::get(parser.getContext(), *event);
     return success();
   }
 
   if (succeeded(parser.parseOptionalLess())) {
     StringRef keyword;
-    if (parser.parseKeyword(&keyword) || parser.parseGreater())
+    if (parser.parseKeyword(&keyword) || parser.parseGreater()) {
       return failure();
+    }
     auto event = symbolizeEVENT(keyword);
-    if (!event)
+    if (!event) {
       return parser.emitError(loc) << "invalid event token: " << keyword;
+    }
     attr = EventAttr::get(parser.getContext(), *event);
     return success();
   }
 
   Attribute parsed;
-  if (failed(parser.parseAttribute(parsed)))
+  if (failed(parser.parseAttribute(parsed))) {
     return failure();
+  }
   auto eventAttr = dyn_cast<EventAttr>(parsed);
-  if (!eventAttr)
+  if (!eventAttr) {
     return parser.emitError(loc, "expected event attribute");
+  }
   attr = eventAttr;
   return success();
 }
@@ -8610,11 +9755,13 @@ static ParseResult parseLegacyOrAttrEvent(OpAsmParser &parser, EventAttr &attr) 
 static ParseResult parseI32LiteralAttr(OpAsmParser &parser, IntegerAttr &attr) {
   auto loc = parser.getCurrentLocation();
   int64_t value = 0;
-  if (failed(parser.parseInteger(value)))
+  if (failed(parser.parseInteger(value))) {
     return failure();
+  }
   if (value < std::numeric_limits<int32_t>::min() ||
-      value > std::numeric_limits<int32_t>::max())
+      value > std::numeric_limits<int32_t>::max()) {
     return parser.emitError(loc, "expected 32-bit integer literal");
+  }
   attr = IntegerAttr::get(IntegerType::get(parser.getContext(), 32), value);
   return success();
 }
@@ -8635,10 +9782,12 @@ ParseResult SetFlagOp::parse(OpAsmParser &parser, OperationState &result) {
   if (parser.parseLSquare() || parseLegacyOrAttrPipe(parser, srcPipe) ||
       parser.parseComma() || parseLegacyOrAttrPipe(parser, dstPipe) ||
       parser.parseComma() || parseLegacyOrAttrEvent(parser, eventId) ||
-      parser.parseRSquare())
+      parser.parseRSquare()) {
     return failure();
-  if (parser.parseOptionalAttrDict(result.attributes))
+  }
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
   result.addAttribute("src_pipe", srcPipe);
   result.addAttribute("dst_pipe", dstPipe);
   result.addAttribute("event_id", eventId);
@@ -8657,10 +9806,12 @@ ParseResult WaitFlagOp::parse(OpAsmParser &parser, OperationState &result) {
   if (parser.parseLSquare() || parseLegacyOrAttrPipe(parser, srcPipe) ||
       parser.parseComma() || parseLegacyOrAttrPipe(parser, dstPipe) ||
       parser.parseComma() || parseLegacyOrAttrEvent(parser, eventId) ||
-      parser.parseRSquare())
+      parser.parseRSquare()) {
     return failure();
-  if (parser.parseOptionalAttrDict(result.attributes))
+  }
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
   result.addAttribute("src_pipe", srcPipe);
   result.addAttribute("dst_pipe", dstPipe);
   result.addAttribute("event_id", eventId);
@@ -8674,10 +9825,12 @@ void WaitFlagOp::print(OpAsmPrinter &p) {
 
 ParseResult MemBarOp::parse(OpAsmParser &parser, OperationState &result) {
   MemBarAttr kind;
-  if (parseLegacyOrAttrMemBar(parser, kind))
+  if (parseLegacyOrAttrMemBar(parser, kind)) {
     return failure();
-  if (parser.parseOptionalAttrDict(result.attributes))
+  }
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
   result.addAttribute("kind", kind);
   return success();
 }
@@ -8694,39 +9847,46 @@ static ParseResult parseBufSyncOp(OpAsmParser &parser, OperationState &result) {
   auto loc = parser.getCurrentLocation();
   std::string token;
   if (succeeded(parser.parseOptionalString(&token))) {
-    if (auto pipe = symbolizePIPE(token))
+    if (auto pipe = symbolizePIPE(token)) {
       opTypeAttr = PipeAttr::get(parser.getContext(), *pipe);
-    else if (auto opType = symbolizeSyncOpType(token))
+    } else if (auto opType = symbolizeSyncOpType(token)) {
       opTypeAttr = PipeEventTypeAttr::get(parser.getContext(), *opType);
-    else
+    } else {
       return parser.emitError(loc) << "invalid get_buf/rls_buf token: " << token;
+}
 
-    if (parser.parseComma() || parseI32LiteralAttr(parser, bufIdAttr))
+    if (parser.parseComma() || parseI32LiteralAttr(parser, bufIdAttr)) {
       return failure();
+    }
     if (succeeded(parser.parseOptionalComma())) {
-      if (parseI32LiteralAttr(parser, modeAttr))
+      if (parseI32LiteralAttr(parser, modeAttr)) {
         return failure();
+      }
     } else {
       modeAttr = IntegerAttr::get(IntegerType::get(parser.getContext(), 32), 0);
     }
   } else if (succeeded(parser.parseOptionalLSquare())) {
     if (parser.parseAttribute(opTypeAttr) || parser.parseComma() ||
-        parseI32LiteralAttr(parser, bufIdAttr))
+        parseI32LiteralAttr(parser, bufIdAttr)) {
       return failure();
+    }
     if (succeeded(parser.parseOptionalComma())) {
-      if (parseI32LiteralAttr(parser, modeAttr))
+      if (parseI32LiteralAttr(parser, modeAttr)) {
         return failure();
+      }
     } else {
       modeAttr = IntegerAttr::get(IntegerType::get(parser.getContext(), 32), 0);
     }
-    if (parser.parseRSquare())
+    if (parser.parseRSquare()) {
       return failure();
+    }
   } else {
     return parser.emitError(loc, "expected string pipe/op_type or '['");
   }
 
-  if (parser.parseOptionalAttrDict(result.attributes))
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
   result.addAttribute("op_type", opTypeAttr);
   result.addAttribute("buf_id", bufIdAttr);
   result.addAttribute("mode", modeAttr);
@@ -8779,57 +9939,68 @@ static ParseResult parseBufDynSyncOp(OpAsmParser &parser,
   auto loc = parser.getCurrentLocation();
   std::string token;
   if (succeeded(parser.parseOptionalString(&token))) {
-    if (auto pipe = symbolizePIPE(token))
+    if (auto pipe = symbolizePIPE(token)) {
       opTypeAttr = PipeAttr::get(parser.getContext(), *pipe);
-    else if (auto opType = symbolizeSyncOpType(token))
+    } else if (auto opType = symbolizeSyncOpType(token)) {
       opTypeAttr = PipeEventTypeAttr::get(parser.getContext(), *opType);
-    else
+    } else {
       return parser.emitError(loc)
              << "invalid get_buf_dyn/rls_buf_dyn token: " << token;
+}
 
-    if (parser.parseComma())
+    if (parser.parseComma()) {
       return failure();
+    }
 
     OpAsmParser::UnresolvedOperand bufOperand;
-    if (parser.parseOperand(bufOperand))
+    if (parser.parseOperand(bufOperand)) {
       return failure();
+    }
     if (parser.resolveOperand(bufOperand,
                               parser.getBuilder().getIndexType(),
-                              result.operands))
+                              result.operands)) {
       return failure();
+    }
 
     if (succeeded(parser.parseOptionalComma())) {
-      if (parseI32LiteralAttr(parser, modeAttr))
+      if (parseI32LiteralAttr(parser, modeAttr)) {
         return failure();
+      }
     } else {
       modeAttr = IntegerAttr::get(IntegerType::get(parser.getContext(), 32), 0);
     }
   } else if (succeeded(parser.parseOptionalLSquare())) {
-    if (parser.parseAttribute(opTypeAttr) || parser.parseComma())
+    if (parser.parseAttribute(opTypeAttr) || parser.parseComma()) {
       return failure();
+    }
 
     OpAsmParser::UnresolvedOperand bufOperand;
-    if (parser.parseOperand(bufOperand))
+    if (parser.parseOperand(bufOperand)) {
       return failure();
+    }
     if (parser.resolveOperand(bufOperand,
                               parser.getBuilder().getIndexType(),
-                              result.operands))
+                              result.operands)) {
       return failure();
+    }
 
     if (succeeded(parser.parseOptionalComma())) {
-      if (parseI32LiteralAttr(parser, modeAttr))
+      if (parseI32LiteralAttr(parser, modeAttr)) {
         return failure();
+      }
     } else {
       modeAttr = IntegerAttr::get(IntegerType::get(parser.getContext(), 32), 0);
     }
-    if (parser.parseRSquare())
+    if (parser.parseRSquare()) {
       return failure();
+    }
   } else {
     return parser.emitError(loc, "expected string pipe/op_type or '['");
   }
 
-  if (parser.parseOptionalAttrDict(result.attributes))
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
   result.addAttribute("op_type", opTypeAttr);
   result.addAttribute("mode", modeAttr);
   return success();
@@ -8870,12 +10041,14 @@ LogicalResult TGemvBiasOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult {
     if (failed(verifyGemvTileOperands(*this, getA().getType(), getB().getType(),
                                       getDst().getType())) ||
-        failed(verifyMatBiasTile(*this, getBias().getType(), getDst().getType())))
+        failed(verifyMatBiasTile(*this, getBias().getType(), getDst().getType()))) {
       return failure();
+    }
     if (failed(verifyMatmulTypeTriple(*this, getElemTy(getA().getType()),
                                       getElemTy(getB().getType()),
-                                      getElemTy(getDst().getType()))))
+                                      getElemTy(getDst().getType())))) {
       return failure();
+    }
     return verifyMatmulLike(*this, getA().getType(), getB().getType(),
                             getDst().getType());
   };
@@ -8895,11 +10068,13 @@ LogicalResult TGemvMxOp::verify() {
                                        "a_scale", /*isLeftScale=*/true)) ||
         failed(verifyA5MxGemvScaleTile(*this, getBScale().getType(),
                                        getA().getType(), getB().getType(),
-                                       "b_scale", /*isLeftScale=*/false)))
+                                       "b_scale", /*isLeftScale=*/false))) {
       return failure();
+    }
     if (failed(verifyA5MxTypeTriple(*this, getA().getType(), getB().getType(),
-                                    getDst().getType(), "lhs", "rhs", "dst")))
+                                    getDst().getType(), "lhs", "rhs", "dst"))) {
       return failure();
+    }
     return verifyMatmulLike(*this, getA().getType(), getB().getType(),
                             getDst().getType());
   };
@@ -8919,16 +10094,19 @@ LogicalResult TGemvMxAccOp::verify() {
                                        "a_scale", /*isLeftScale=*/true)) ||
         failed(verifyA5MxGemvScaleTile(*this, getBScale().getType(),
                                        getA().getType(), getB().getType(),
-                                       "b_scale", /*isLeftScale=*/false)))
+                                       "b_scale", /*isLeftScale=*/false))) {
       return failure();
+    }
     if (failed(verifyA5MxTypeTriple(*this, getA().getType(), getB().getType(),
-                                    getDst().getType(), "lhs", "rhs", "dst")))
+                                    getDst().getType(), "lhs", "rhs", "dst"))) {
       return failure();
+    }
     if (failed(verifyTileBufSameElemType(*this, getCIn().getType(),
-                                             getDst().getType(), "c_in", "dst")) ||
+                                         getDst().getType(), "c_in", "dst")) ||
         failed(verifyTileBufSameValidShape(*this, getCIn().getType(),
-                                           getDst().getType(), "c_in", "dst")))
+                                           getDst().getType(), "c_in", "dst"))) {
       return failure();
+    }
     return verifyMatmulLike(*this, getA().getType(), getB().getType(),
                             getDst().getType());
   };
@@ -8949,21 +10127,26 @@ LogicalResult TGemvMxBiasOp::verify() {
                                        getA().getType(), getB().getType(),
                                        "b_scale", /*isLeftScale=*/false)) ||
         failed(verifyMatBiasTile(*this, getBias().getType(), getDst().getType(),
-                                 /*requireFloatBias=*/true)))
+                                 /*requireFloatBias=*/true))) {
       return failure();
+    }
     if (failed(verifyA5MxTypeTriple(*this, getA().getType(), getB().getType(),
-                                    getDst().getType(), "lhs", "rhs", "dst")))
+                                    getDst().getType(), "lhs", "rhs", "dst"))) {
       return failure();
+    }
     auto biasShape = getShapeVec(getBias().getType());
     auto dstShape = getShapeVec(getDst().getType());
-    if (biasShape.size() != 2 || dstShape.size() != 2)
+    if (biasShape.size() != 2 || dstShape.size() != 2) {
       return emitOpError("expects bias and dst to be rank-2 for tgemv.mx.bias");
+    }
     if (biasShape[1] != ShapedType::kDynamic && dstShape[1] != ShapedType::kDynamic &&
-        biasShape[1] != dstShape[1])
+        biasShape[1] != dstShape[1]) {
       return emitOpError("expects bias and dst to have the same column shape");
+    }
     if (failed(verifyTileBufSameValidShape(*this, getBias().getType(),
-                                           getDst().getType(), "bias", "dst")))
+                                           getDst().getType(), "bias", "dst"))) {
       return failure();
+    }
     return verifyMatmulLike(*this, getA().getType(), getB().getType(),
                             getDst().getType());
   };
@@ -8973,26 +10156,30 @@ LogicalResult TGemvMxBiasOp::verify() {
 LogicalResult TMatmulBiasOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult {
     if (failed(verifyMatTileOperands(*this, getA().getType(), getB().getType(),
-                                         getDst().getType())) ||
-        failed(verifyMatBiasTile(*this, getBias().getType(), getDst().getType())))
+                                     getDst().getType())) ||
+        failed(verifyMatBiasTile(*this, getBias().getType(), getDst().getType()))) {
       return failure();
+    }
     if (failed(verifyMatmulTypeTriple(*this, getElemTy(getA().getType()),
                                       getElemTy(getB().getType()),
-                                      getElemTy(getDst().getType()))))
+                                      getElemTy(getDst().getType())))) {
       return failure();
+    }
     return verifyMatmulLike(*this, getA().getType(), getB().getType(),
                             getDst().getType());
   };
   auto verifyA5 = [&]() -> LogicalResult {
     if (failed(verifyMatmulTypeTriple(*this, getElemTy(getA().getType()),
                                       getElemTy(getB().getType()),
-                                      getElemTy(getDst().getType()))))
+                                      getElemTy(getDst().getType())))) {
       return failure();
+    }
     if (failed(verifyMatTileOperands(*this, getA().getType(), getB().getType(),
                                      getDst().getType(),
                                      /*allowLowPrecision=*/true)) ||
-        failed(verifyMatBiasTile(*this, getBias().getType(), getDst().getType())))
+        failed(verifyMatBiasTile(*this, getBias().getType(), getDst().getType()))) {
       return failure();
+    }
     return verifyMatmulLike(*this, getA().getType(), getB().getType(),
                             getDst().getType());
   };
@@ -9008,11 +10195,13 @@ LogicalResult TMatmulMxOp::verify() {
                                          getDst().getType())) ||
         failed(verifyA5MxMatScaleTiles(*this, getAScale().getType(),
                                        getBScale().getType(), getA().getType(),
-                                       getB().getType())))
+                                       getB().getType()))) {
       return failure();
+    }
     if (failed(verifyA5MxTypeTriple(*this, getA().getType(), getB().getType(),
-                                    getDst().getType(), "lhs", "rhs", "dst")))
+                                    getDst().getType(), "lhs", "rhs", "dst"))) {
       return failure();
+    }
     return verifyMatmulLike(*this, getA().getType(), getB().getType(),
                             getDst().getType());
   };
@@ -9029,16 +10218,19 @@ LogicalResult TMatmulMxAccOp::verify() {
                                          getDst().getType())) ||
         failed(verifyA5MxMatScaleTiles(*this, getAScale().getType(),
                                        getBScale().getType(), getA().getType(),
-                                       getB().getType())))
+                                       getB().getType()))) {
       return failure();
+    }
     if (failed(verifyA5MxTypeTriple(*this, getA().getType(), getB().getType(),
-                                    getDst().getType(), "lhs", "rhs", "dst")))
+                                    getDst().getType(), "lhs", "rhs", "dst"))) {
       return failure();
+    }
     if (failed(verifyTileBufSameElemType(*this, getCIn().getType(),
-                                             getDst().getType(), "c_in", "dst")) ||
+                                         getDst().getType(), "c_in", "dst")) ||
         failed(verifyTileBufSameValidShape(*this, getCIn().getType(),
-                                           getDst().getType(), "c_in", "dst")))
+                                           getDst().getType(), "c_in", "dst"))) {
       return failure();
+    }
     return verifyMatmulLike(*this, getA().getType(), getB().getType(),
                             getDst().getType());
   };
@@ -9055,11 +10247,13 @@ LogicalResult TMatmulMxBiasOp::verify() {
                                        getBScale().getType(), getA().getType(),
                                        getB().getType())) ||
         failed(verifyMatBiasTile(*this, getBias().getType(), getDst().getType(),
-                              /*requireFloatBias=*/true)))
+                                 /*requireFloatBias=*/true))) {
       return failure();
+    }
     if (failed(verifyA5MxTypeTriple(*this, getA().getType(), getB().getType(),
-                                    getDst().getType(), "lhs", "rhs", "dst")))
+                                    getDst().getType(), "lhs", "rhs", "dst"))) {
       return failure();
+    }
     return verifyMatmulLike(*this, getA().getType(), getB().getType(),
                             getDst().getType());
   };
@@ -9069,16 +10263,18 @@ LogicalResult TMatmulMxBiasOp::verify() {
 LogicalResult TSetValOp::verify() {
   // dst can be tile/tensor/tilebuf (PTODpsType). Keep checks minimal.
   if (auto shaped = dyn_cast<ShapedType>(getDst().getType())) {
-    if (shaped.getElementType() != getVal().getType())
+    if (shaped.getElementType() != getVal().getType()) {
       return emitOpError("expects val type to match dst element type");
+    }
   }
   return success();
 }
 // ---- TGetValOp ----
 LogicalResult TGetValOp::verify() {
   Type srcTy = getSrc().getType();
-  if (!mlir::isa<pto::TileBufType>(srcTy))
+  if (!mlir::isa<pto::TileBufType>(srcTy)) {
     return emitOpError("expects src to be tile_buf type");
+  }
 
   // Memory space must be vec (Ascend does not support getval from MAT etc.).
   Attribute memSpace = cast<pto::TileBufType>(srcTy).getMemorySpace();
@@ -9086,14 +10282,16 @@ LogicalResult TGetValOp::verify() {
   if (!addrSpaceAttr ||
       addrSpaceAttr.getAddressSpace() != pto::AddressSpace::VEC) {
     if (addrSpaceAttr &&
-        addrSpaceAttr.getAddressSpace() == pto::AddressSpace::MAT)
+        addrSpaceAttr.getAddressSpace() == pto::AddressSpace::MAT) {
       return emitOpError(
           "Ascend hardware does not support reading from Mat tile_buf to Scalar unit");
+    }
     return emitOpError("expects src memory space to be vec");
   }
 
-  if (getElemTy(srcTy) != getDst().getType())
+  if (getElemTy(srcTy) != getDst().getType()) {
     return emitOpError("expects dst type to match src element type");
+  }
   return success();
 }
 
@@ -9104,16 +10302,19 @@ LogicalResult THistogramOp::verify() {
   };
   int64_t byte = 1;
   auto byteAttr = getByteAttr();
-  if (byteAttr)
+  if (byteAttr) {
     byte = byteAttr.getInt();
+  }
   if (auto legacyIsMSB = (*this)->getAttrOfType<BoolAttr>("isMSB")) {
     int64_t legacyByte = legacyIsMSB.getValue() ? 1 : 0;
-    if (byteAttr && byte != legacyByte)
+    if (byteAttr && byte != legacyByte) {
       return emitOpError("does not allow conflicting 'byte' and legacy 'isMSB' attributes");
+    }
     byte = legacyByte;
   }
-  if (byte < 0 || byte > 3)
+  if (byte < 0 || byte > 3) {
     return emitOpError("expects byte to be in range [0, 3]");
+  }
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     return emitOpError("thistogram is only supported on A5");
@@ -9124,40 +10325,50 @@ LogicalResult THistogramOp::verify() {
     Type dstTy = getDst().getType();
     if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
         failed(verifyTileBufCommon(*this, idxTy, "idx")) ||
-        failed(verifyTileBufCommon(*this, dstTy, "dst")))
+        failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
       return failure();
+    }
 
     auto srcSpace = getPTOMemorySpaceEnum(srcTy);
     auto idxSpace = getPTOMemorySpaceEnum(idxTy);
     auto dstSpace = getPTOMemorySpaceEnum(dstTy);
-    if (!srcSpace || *srcSpace != pto::AddressSpace::VEC)
+    if (!srcSpace || *srcSpace != pto::AddressSpace::VEC) {
       return emitOpError("expects src to be in the vec address space");
-    if (!idxSpace || *idxSpace != pto::AddressSpace::VEC)
+    }
+    if (!idxSpace || *idxSpace != pto::AddressSpace::VEC) {
       return emitOpError("expects idx to be in the vec address space");
-    if (!dstSpace || *dstSpace != pto::AddressSpace::VEC)
+    }
+    if (!dstSpace || *dstSpace != pto::AddressSpace::VEC) {
       return emitOpError("expects dst to be in the vec address space");
+    }
 
     auto srcTB = dyn_cast<pto::TileBufType>(srcTy);
     auto idxTB = dyn_cast<pto::TileBufType>(idxTy);
     auto dstTB = dyn_cast<pto::TileBufType>(dstTy);
-    if (!srcTB || !idxTB || !dstTB)
+    if (!srcTB || !idxTB || !dstTB) {
       return emitOpError("expects src, idx, and dst to be tile_buf types");
+    }
 
     if (srcTB.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
-        srcTB.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
+        srcTB.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox)) {
       return emitOpError("expects src to use row_major + none_box layout");
+    }
     if (dstTB.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
-        dstTB.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
+        dstTB.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox)) {
       return emitOpError("expects dst to use row_major + none_box layout");
+    }
 
     bool srcIsUi16 = isIntegerWidth(getElemTy(srcTy), 16);
     bool srcIsUi32 = isIntegerWidth(getElemTy(srcTy), 32);
-    if (!srcIsUi16 && !srcIsUi32)
+    if (!srcIsUi16 && !srcIsUi32) {
       return emitOpError("expects src element type to be ui16 or ui32");
-    if (!isIntegerWidth(getElemTy(idxTy), 8))
+    }
+    if (!isIntegerWidth(getElemTy(idxTy), 8)) {
       return emitOpError("expects idx element type to be ui8");
-    if (!isIntegerWidth(getElemTy(dstTy), 32))
+    }
+    if (!isIntegerWidth(getElemTy(dstTy), 32)) {
       return emitOpError("expects dst element type to be ui32");
+    }
 
     auto srcShape = getShapeVec(srcTy);
     auto idxShape = getShapeVec(idxTy);
@@ -9166,53 +10377,65 @@ LogicalResult THistogramOp::verify() {
     auto idxValid = getValidShapeVec(idxTy);
     auto dstValid = getValidShapeVec(dstTy);
     if (srcShape.size() != 2 || idxShape.size() != 2 || dstShape.size() != 2 ||
-        srcValid.size() != 2 || idxValid.size() != 2 || dstValid.size() != 2)
+        srcValid.size() != 2 || idxValid.size() != 2 || dstValid.size() != 2) {
       return emitOpError(
           "expects src, idx, and dst to have rank-2 shape and valid_shape");
+    }
 
     if (!hasCompatibleKnownExtent(srcShape[0], dstShape[0]) ||
-        !hasCompatibleKnownExtent(srcValid[0], dstValid[0]))
+        !hasCompatibleKnownExtent(srcValid[0], dstValid[0])) {
       return emitOpError("expects dst rows and valid rows to match src");
+    }
 
     if (srcIsUi16) {
-      if (byte > 1)
+      if (byte > 1) {
         return emitOpError("expects byte to be 0 or 1 when src element type is ui16");
+      }
       if (idxTB.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor) ||
-          idxTB.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
+          idxTB.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox)) {
         return emitOpError(
             "expects idx to use DN layout (col_major + none_box) when src element type is ui16");
+      }
       if (!hasCompatibleKnownExtent(srcShape[0], idxShape[0]) ||
-          !hasCompatibleKnownExtent(srcValid[0], idxValid[0]))
+          !hasCompatibleKnownExtent(srcValid[0], idxValid[0])) {
         return emitOpError("expects idx rows and valid rows to match src when src element type is ui16");
-      if (!isKnownUnitExtent(idxShape[1]) || !isKnownZeroOrUnitExtent(idxValid[1]))
+      }
+      if (!isKnownUnitExtent(idxShape[1]) || !isKnownZeroOrUnitExtent(idxValid[1])) {
         return emitOpError("expects idx to have exactly one physical column and 0 or 1 valid column when src element type is ui16");
+      }
     } else {
       if (byte != 3) {
         if (idxTB.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
-            idxTB.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
+            idxTB.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox)) {
           return emitOpError(
               "expects idx to use row_major + none_box layout when src element type is ui32 and byte is 0, 1, or 2");
+        }
         if (!hasCompatibleKnownExtent(srcShape[1], idxShape[1]) ||
-            !hasCompatibleKnownExtent(srcValid[1], idxValid[1]))
+            !hasCompatibleKnownExtent(srcValid[1], idxValid[1])) {
           return emitOpError(
               "expects idx cols and valid cols to match src when src element type is ui32 and byte is 0, 1, or 2");
+        }
 
         int64_t expectedIdxRows = 1;
-        if (byte == 1)
+        if (byte == 1) {
           expectedIdxRows = 2;
-        else if (byte == 0)
+        } else if (byte == 0) {
           expectedIdxRows = 3;
+        }
         if (!hasCompatibleKnownExtent(idxShape[0], expectedIdxRows) ||
-            !hasCompatibleKnownExtentOrZero(idxValid[0], expectedIdxRows))
+            !hasCompatibleKnownExtentOrZero(idxValid[0], expectedIdxRows)) {
           return emitOpError(
               "expects idx rows to match the byte-selected filter depth and idx valid rows to be 0 or match it when src element type is ui32 and byte is 0, 1, or 2");
+        }
       }
     }
-    if (dstShape[1] != ShapedType::kDynamic && dstShape[1] < 256)
+    if (dstShape[1] != ShapedType::kDynamic && dstShape[1] < 256) {
       return emitOpError("expects dst shape[1] to be at least 256");
+    }
     if (dstValid[1] != ShapedType::kDynamic && dstValid[1] != 0 &&
-        dstValid[1] < 256)
+        dstValid[1] < 256) {
       return emitOpError("expects dst valid_shape[1] to be 0 or at least 256");
+    }
     return success();
   };
 
@@ -9226,25 +10449,30 @@ LogicalResult TGetScaleAddrOp::verify() {
   auto verifyA5 = [&]() -> LogicalResult {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
-    if (failed(verifyTileBufCommon(*this, srcTy, "src", /*allowLowPrecision=*/true)))
+    if (failed(verifyTileBufCommon(*this, srcTy, "src", /*allowLowPrecision=*/true))) {
       return failure();
-    if (failed(verifyTileBufCommon(*this, dstTy, "dst", /*allowLowPrecision=*/true)))
+    }
+    if (failed(verifyTileBufCommon(*this, dstTy, "dst", /*allowLowPrecision=*/true))) {
       return failure();
+    }
     auto srcSpace = getPTOMemorySpaceEnum(srcTy);
     if (!srcSpace ||
-        (*srcSpace != pto::AddressSpace::LEFT && *srcSpace != pto::AddressSpace::RIGHT))
+        (*srcSpace != pto::AddressSpace::LEFT && *srcSpace != pto::AddressSpace::RIGHT)) {
       return emitOpError("expects src to be in the left or right address space");
+    }
     auto dstSpace = getPTOMemorySpaceEnum(dstTy);
-    if (!dstSpace || *dstSpace != pto::AddressSpace::SCALING)
+    if (!dstSpace || *dstSpace != pto::AddressSpace::SCALING) {
       return emitOpError("expects dst to be in the scaling address space");
+    }
     auto dstShape = getShapeVec(dstTy);
     auto srcShape = getShapeVec(srcTy);
     auto dstValid = getValidShapeVec(dstTy);
     auto srcValid = getValidShapeVec(srcTy);
     if (dstShape.size() != 2 || srcShape.size() != 2 || dstValid.size() != 2 ||
-        srcValid.size() != 2)
+        srcValid.size() != 2) {
       return emitOpError(
           "expects src/dst to have rank-2 shape and valid_shape");
+    }
     if (*srcSpace == pto::AddressSpace::LEFT) {
       int64_t mShape = srcShape[0];
       int64_t vk = srcValid[1];
@@ -9252,8 +10480,9 @@ LogicalResult TGetScaleAddrOp::verify() {
       if (!hasCompatibleKnownExtent(dstShape[0], mShape) ||
           !hasCompatibleKnownExtent(dstShape[1], expectedScaleK) ||
           !hasCompatibleKnownExtent(dstValid[0], srcValid[0]) ||
-          !hasCompatibleKnownExtent(dstValid[1], expectedScaleK))
+          !hasCompatibleKnownExtent(dstValid[1], expectedScaleK)) {
         return emitOpError("expects dst shape/valid_shape to be [M, ceil(K/32)]");
+      }
     } else {
       int64_t k = srcValid[0];
       int64_t n = srcShape[1];
@@ -9262,8 +10491,9 @@ LogicalResult TGetScaleAddrOp::verify() {
       if (!hasCompatibleKnownExtent(dstShape[0], ceilDivKnown(k, 32)) ||
           !hasCompatibleKnownExtent(dstShape[1], n) ||
           !hasCompatibleKnownExtent(dstValid[0], ceilDivKnown(vk, 32)) ||
-          !hasCompatibleKnownExtent(dstValid[1], vn))
+          !hasCompatibleKnownExtent(dstValid[1], vn)) {
         return emitOpError("expects dst shape/valid_shape to be [ceil(K/32), N]");
+      }
     }
     return success();
   };
@@ -9288,13 +10518,15 @@ ParseResult mlir::pto::MScatterOp::parse(OpAsmParser &parser,
       parser.parseRParen() ||
       parsePTOInherentAttrs<MScatterOp>(
           parser, result, parsedAttrs,
-          {"coalesce", "scatterAtomicOp", "scatterOob", "scatterConflict"}))
+          {"coalesce", "scatterAtomicOp", "scatterOob", "scatterConflict"})) {
     return failure();
+  }
 
   if (parser.resolveOperand(src, srcTy, result.operands) ||
       parser.resolveOperand(idx, idxTy, result.operands) ||
-      parser.resolveOperand(mem, memTy, result.operands))
+      parser.resolveOperand(mem, memTy, result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -9309,19 +10541,23 @@ void mlir::pto::MScatterOp::print(OpAsmPrinter &p) {
   NamedAttrList attrs = getNonInherentAttrs(
       getOperation(),
       {"coalesce", "scatterAtomicOp", "scatterOob", "scatterConflict"});
-  if (auto coalesceAttr = getMScatterCoalesceAttrIfPresent(*this))
+  if (auto coalesceAttr = getMScatterCoalesceAttrIfPresent(*this)) {
     attrs.append("coalesce", coalesceAttr);
+  }
   if (auto scatterAtomicAttr = getMScatterScatterAtomicOpAttrIfPresent(*this);
       scatterAtomicAttr &&
-      scatterAtomicAttr.getValue() != pto::ScatterAtomicOp::None)
+      scatterAtomicAttr.getValue() != pto::ScatterAtomicOp::None) {
     attrs.append("scatterAtomicOp", scatterAtomicAttr);
+  }
   if (auto scatterOobAttr = getMScatterScatterOobAttrIfPresent(*this);
       scatterOobAttr &&
-      scatterOobAttr.getValue() != pto::ScatterOOB::Undefined)
+      scatterOobAttr.getValue() != pto::ScatterOOB::Undefined) {
     attrs.append("scatterOob", scatterOobAttr);
+  }
   if (auto scatterConflictAttr =
-          getMScatterScatterConflictAttrIfPresent(*this))
+          getMScatterScatterConflictAttrIfPresent(*this)) {
     attrs.append("scatterConflict", scatterConflictAttr);
+  }
   p.printOptionalAttrDict(attrs.getAttrs());
 }
 
@@ -9331,14 +10567,16 @@ LogicalResult MScatterOp::verify() {
   Type memTy = getMem().getType();
 
   if (getPTOTypeRank(srcTy) == -1 || getPTOTypeRank(idxTy) == -1 ||
-      getPTOTypeRank(memTy) == -1)
+      getPTOTypeRank(memTy) == -1) {
     return emitOpError("expects src, idx, and mem to use supported PTO shapes");
+  }
 
   if (failed(verifyNDStyleVecTile(
           *this, srcTy, "src",
           /*allowLowPrecision=*/isTargetArchA5(getOperation()))) ||
-      failed(verifyMGatherMScatterIdxTile(getOperation(), idxTy, "idx")))
+      failed(verifyMGatherMScatterIdxTile(getOperation(), idxTy, "idx"))) {
     return failure();
+  }
 
   auto coalesce = getCoalesceIfPresent(*this);
 
@@ -9346,39 +10584,47 @@ LogicalResult MScatterOp::verify() {
   Type idxElem = getElemTy(idxTy);
   pto::ScatterAtomicOp scatterAtomicOp = getScatterAtomicOpOrDefault(*this);
   pto::ScatterOOB scatterOob = getScatterOobOrDefault(*this);
-  if (!srcElem || !idxElem)
+  if (!srcElem || !idxElem) {
     return emitOpError("failed to resolve element types for src or idx");
+  }
 
-  if (!isSupportedMGatherMScatterPayloadElemType(getOperation(), srcElem))
+  if (!isSupportedMGatherMScatterPayloadElemType(getOperation(), srcElem)) {
     return emitOpError(
         "expects src element type to be i8/ui8/i16/ui16/i32/ui32/f16/bf16/f32 "
         "(and on A5 targets also float8_e4m3/float8_e5m2 family types)");
+  }
 
-  if (!isSupportedMGatherMScatterIndexElemType(idxElem))
+  if (!isSupportedMGatherMScatterIndexElemType(idxElem)) {
     return emitOpError("expects idx element type to be signless i32");
+  }
 
   if (failed(verifyMGatherMScatterMemOperand(getOperation(), getMem(), srcElem,
-                                             "src")))
+                                             "src"))) {
     return failure();
+  }
 
   if (failed(verifyMGatherMScatterTileShape(getOperation(), srcTy, idxTy, "src",
-                                            coalesce)))
+                                            coalesce))) {
     return failure();
+  }
 
   if (!coalesce &&
       (scatterAtomicOp != pto::ScatterAtomicOp::None ||
        scatterOob != pto::ScatterOOB::Undefined ||
-       getScatterConflictAttrIfPresent(*this)))
+       getScatterConflictAttrIfPresent(*this))) {
     return emitOpError(
         "expects coalesce when scatterAtomicOp/scatterOob/scatterConflict is specified");
+  }
 
-  if (getScatterConflictAttrIfPresent(*this) && !isTargetArchA5(getOperation()))
+  if (getScatterConflictAttrIfPresent(*this) && !isTargetArchA5(getOperation())) {
     return emitOpError("expects scatterConflict only on A5 targets");
+  }
 
-  if (!isSupportedMScatterAtomicPayloadElemType(srcElem, scatterAtomicOp))
+  if (!isSupportedMScatterAtomicPayloadElemType(srcElem, scatterAtomicOp)) {
     return emitOpError(
         "expects scatterAtomicOp-compatible src element type: add supports "
         "i32/ui32/f16/f32, max/min support signless i32/f32");
+  }
 
   return success();
 }
@@ -9393,25 +10639,30 @@ static LogicalResult verifyMGatherGm2L1(Operation *op, Value mem, Value idx,
                                         std::optional<pto::Coalesce> coalesce) {
   Type dstTy = dst.getType();
   auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
-  if (!dstTb)
+  if (!dstTb) {
     return op->emitOpError("expects GM->L1 mgather dst to be a tile_buf");
+  }
 
   // dst must be an L1 / cube Mat tile in NZ layout (col_major + row_major sub +
   // fractal 512), matching the matmul A/NZ operand a TLOAD would produce.
-  if (!isColMajorRowMajorNZTileBuf(dstTb))
+  if (!isColMajorRowMajorNZTileBuf(dstTb)) {
     return op->emitOpError("expects GM->L1 mgather dst (loc=mat) to use "
                            "blayout=col_major and slayout=row_major (NZ)");
-  if (dstTb.getSFractalSizeI32() != 512)
+  }
+  if (dstTb.getSFractalSizeI32() != 512) {
     return op->emitOpError("expects GM->L1 mgather dst fractal size to be 512");
+  }
 
   Type dstElem = getElemTy(dstTy);
-  if (!dstElem)
+  if (!dstElem) {
     return op->emitOpError("failed to resolve GM->L1 mgather dst element type");
-  if (!isSupportedMGatherMScatterPayloadElemType(op, dstElem))
+  }
+  if (!isSupportedMGatherMScatterPayloadElemType(op, dstElem)) {
     return op->emitOpError(
         "expects GM->L1 mgather dst element type to be "
         "i8/ui8/i16/ui16/i32/ui32/f16/bf16/f32 (and on A5 targets also "
         "float8_e4m3/float8_e5m2 family types)");
+  }
 
   // NZ tile shape: padded Cols a multiple of C0 (= 32 / sizeof(elem)) and padded
   // Rows a multiple of FRACTAL_NZ_ROW (= 16).
@@ -9421,54 +10672,65 @@ static LogicalResult verifyMGatherGm2L1(Operation *op, Value mem, Value idx,
   auto dstShape = getShapeVec(dstTy);
   if (dstShape.size() == 2) {
     if (kC0 > 0 && dstShape[1] != ShapedType::kDynamic &&
-        dstShape[1] % kC0 != 0)
+        dstShape[1] % kC0 != 0) {
       return op->emitOpError()
              << "expects GM->L1 mgather dst padded cols to be a multiple of "
              << kC0 << " (C0 = 32 / sizeof(elem))";
-    if (dstShape[0] != ShapedType::kDynamic && dstShape[0] % 16 != 0)
+    }
+    if (dstShape[0] != ShapedType::kDynamic && dstShape[0] % 16 != 0) {
       return op->emitOpError("expects GM->L1 mgather dst padded rows to be a "
                              "multiple of 16 (FRACTAL_NZ_ROW)");
+    }
   }
 
   // mem table: GM, element type matches dst.
-  if (failed(verifyMGatherMScatterMemOperand(op, mem, dstElem, "dst")))
+  if (failed(verifyMGatherMScatterMemOperand(op, mem, dstElem, "dst"))) {
     return failure();
+  }
 
   // idx: GM partition tensor view of i32 -- NOT a UB tile.
   Type idxTy = idx.getType();
-  if (isa<pto::TileBufType>(idxTy))
+  if (isa<pto::TileBufType>(idxTy)) {
     return op->emitOpError("expects GM->L1 mgather idx to be a GM tensor "
                            "partition_tensor_view, not a tile_buf");
-  if (!isa<pto::PartitionTensorViewType>(idxTy))
+  }
+  if (!isa<pto::PartitionTensorViewType>(idxTy)) {
     return op->emitOpError(
         "expects GM->L1 mgather idx to be a partition_tensor_view");
+  }
   Type idxElem = getElemTy(idxTy);
-  if (!idxElem || !isSupportedMGatherMScatterIndexElemType(idxElem))
+  if (!idxElem || !isSupportedMGatherMScatterIndexElemType(idxElem)) {
     return op->emitOpError("expects GM->L1 mgather idx element type to be i32");
+  }
 
   // Coalesce must be explicit: the GM index has no UB tile shape to infer from.
-  if (!coalesce)
+  if (!coalesce) {
     return op->emitOpError("expects GM->L1 mgather to specify an explicit "
                            "coalesce attribute (row or elem)");
+  }
 
   if (*coalesce == pto::Coalesce::Elem) {
     // Elem mode stages discrete elements into NZ layout through a GM scratch
     // workspace before the bulk GM -> L1 copy.
-    if (!scratch)
+    if (!scratch) {
       return op->emitOpError("expects GM->L1 mgather with coalesce=elem to "
                              "provide a GM scratch operand");
+    }
     Type scTy = scratch.getType();
-    if (!isa<pto::PartitionTensorViewType>(scTy))
+    if (!isa<pto::PartitionTensorViewType>(scTy)) {
       return op->emitOpError(
           "expects GM->L1 mgather scratch to be a partition_tensor_view");
+    }
     Type scElem = getElemTy(scTy);
-    if (!scElem || scElem != dstElem)
+    if (!scElem || scElem != dstElem) {
       return op->emitOpError("expects GM->L1 mgather scratch element type to "
                              "match dst element type");
+    }
   } else { // Row
-    if (scratch)
+    if (scratch) {
       return op->emitOpError("expects GM->L1 mgather with coalesce=row to omit "
                              "the scratch operand");
+    }
   }
 
   return success();
@@ -9481,55 +10743,65 @@ ParseResult mlir::pto::MGatherOp::parse(OpAsmParser &parser,
   Type dstTy;
   NamedAttrList parsedAttrs;
 
-  if (parser.parseKeyword("ins") || parser.parseLParen())
+  if (parser.parseKeyword("ins") || parser.parseLParen()) {
     return failure();
+  }
 
   do {
     OpAsmParser::UnresolvedOperand operand;
-    if (parser.parseOperand(operand))
+    if (parser.parseOperand(operand)) {
       return failure();
+    }
     insOperands.push_back(operand);
   } while (succeeded(parser.parseOptionalComma()));
 
-  if (insOperands.size() < 2 || insOperands.size() > 3)
+  if (insOperands.size() < 2 || insOperands.size() > 3) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expects mgather ins(mem, idx[, scratch])");
+  }
 
-  if (parser.parseColon())
+  if (parser.parseColon()) {
     return failure();
+  }
 
   do {
     Type type;
-    if (parser.parseType(type))
+    if (parser.parseType(type)) {
       return failure();
+    }
     insTypes.push_back(type);
   } while (succeeded(parser.parseOptionalComma()));
 
-  if (insOperands.size() != insTypes.size())
+  if (insOperands.size() != insTypes.size()) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expects the number of ins operands to match the number of ins types");
+  }
 
   if (parser.parseRParen() || parser.parseKeyword("outs") ||
       parser.parseLParen() || parser.parseOperand(dst) ||
       parser.parseColonType(dstTy) || parser.parseRParen() ||
       parsePTOInherentAttrs<MGatherOp>(
-          parser, result, parsedAttrs, {"coalesce", "gatherOob"}))
+          parser, result, parsedAttrs, {"coalesce", "gatherOob"})) {
     return failure();
+  }
 
   if (parser.resolveOperand(insOperands[0], insTypes[0], result.operands) ||
       parser.resolveOperand(insOperands[1], insTypes[1], result.operands) ||
-      parser.resolveOperand(dst, dstTy, result.operands))
+      parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
+  }
   if (insOperands.size() == 3 &&
-      parser.resolveOperand(insOperands[2], insTypes[2], result.operands))
+      parser.resolveOperand(insOperands[2], insTypes[2], result.operands)) {
     return failure();
+  }
   return success();
 }
 
 void mlir::pto::MGatherOp::print(OpAsmPrinter &p) {
   p << " ins(" << getMem() << ", " << getIdx();
-  if (auto scratch = getScratch())
+  if (auto scratch = getScratch()) {
     p << ", " << scratch;
+  }
   p << " : ";
   p.printStrippedAttrOrType(getMem().getType());
   p << ", ";
@@ -9542,12 +10814,14 @@ void mlir::pto::MGatherOp::print(OpAsmPrinter &p) {
 
   NamedAttrList attrs =
       getNonInherentAttrs(getOperation(), {"coalesce", "gatherOob"});
-  if (auto coalesceAttr = getMGatherCoalesceAttrIfPresent(*this))
+  if (auto coalesceAttr = getMGatherCoalesceAttrIfPresent(*this)) {
     attrs.append("coalesce", coalesceAttr);
+  }
   if (auto gatherOobAttr = getMGatherGatherOobAttrIfPresent(*this);
       gatherOobAttr &&
-      gatherOobAttr.getValue() != pto::GatherOOB::Undefined)
+      gatherOobAttr.getValue() != pto::GatherOOB::Undefined) {
     attrs.append("gatherOob", gatherOobAttr);
+  }
   p.printOptionalAttrDict(attrs.getAttrs());
 }
 
@@ -9557,8 +10831,9 @@ LogicalResult MGatherOp::verify() {
   Type dstTy = getDst().getType();
 
   if (getPTOTypeRank(memTy) == -1 || getPTOTypeRank(idxTy) == -1 ||
-      getPTOTypeRank(dstTy) == -1)
+      getPTOTypeRank(dstTy) == -1) {
     return emitOpError("expects mem, idx, and dst to use supported PTO shapes");
+  }
 
   // GM -> L1 (cube Mat) gather: dst is an L1 (loc=mat) tile; idx comes from GM
   // and Coalesce::Elem carries a GM scratch operand.
@@ -9566,8 +10841,9 @@ LogicalResult MGatherOp::verify() {
     if (auto as = getPTOMemorySpaceEnum(dstTy);
         as && *as == pto::AddressSpace::MAT) {
       std::optional<pto::Coalesce> coalesce;
-      if (auto coalesceAttr = getCoalesceAttr())
+      if (auto coalesceAttr = getCoalesceAttr()) {
         coalesce = coalesceAttr.getValue();
+      }
       return verifyMGatherGm2L1(getOperation(), getMem(), getIdx(), getDst(),
                                 getScratch(), coalesce);
     }
@@ -9575,50 +10851,59 @@ LogicalResult MGatherOp::verify() {
 
   // GM -> UB (VEC) gather: the default path. A GM scratch operand is only valid
   // for the GM -> L1 path above.
-  if (getScratch())
+  if (getScratch()) {
     return emitOpError("expects scratch operand only on GM->L1 (loc=mat) "
                        "mgather");
+  }
 
   if (failed(verifyNDStyleVecTile(
           *this, dstTy, "dst",
           /*allowLowPrecision=*/isTargetArchA5(getOperation()))) ||
-      failed(verifyMGatherMScatterIdxTile(getOperation(), idxTy, "idx")))
+      failed(verifyMGatherMScatterIdxTile(getOperation(), idxTy, "idx"))) {
     return failure();
+  }
 
   auto coalesce = getCoalesceIfPresent(*this);
 
   Type dstElem = getElemTy(dstTy);
   Type idxElem = getElemTy(idxTy);
   pto::GatherOOB gatherOob = getGatherOobOrDefault(*this);
-  if (!dstElem || !idxElem)
+  if (!dstElem || !idxElem) {
     return emitOpError("failed to resolve element types for dst or idx");
+  }
 
-  if (!isSupportedMGatherMScatterPayloadElemType(getOperation(), dstElem))
+  if (!isSupportedMGatherMScatterPayloadElemType(getOperation(), dstElem)) {
     return emitOpError(
         "expects dst element type to be i8/ui8/i16/ui16/i32/ui32/f16/bf16/f32 "
         "(and on A5 targets also float8_e4m3/float8_e5m2 family types)");
+  }
 
-  if (!isSupportedMGatherMScatterIndexElemType(idxElem))
+  if (!isSupportedMGatherMScatterIndexElemType(idxElem)) {
     return emitOpError("expects idx element type to be signless i32");
+  }
 
   if (failed(verifyMGatherMScatterMemOperand(getOperation(), getMem(), dstElem,
-                                             "dst")))
+                                             "dst"))) {
     return failure();
+  }
 
   if (failed(verifyMGatherMScatterTileShape(getOperation(), dstTy, idxTy, "dst",
-                                            coalesce)))
+                                            coalesce))) {
     return failure();
+  }
 
-  if (gatherOob != pto::GatherOOB::Undefined && !coalesce)
+  if (gatherOob != pto::GatherOOB::Undefined && !coalesce) {
     return emitOpError("expects coalesce when gatherOob is specified");
+  }
 
   return success();
 }
 
 void mlir::pto::TCvtOp::print(OpAsmPrinter &p) {
   p << " ins(" << getSrc();
-  if (getTmp())
+  if (getTmp()) {
     p << ", " << getTmp();
+  }
   Builder builder(getContext());
   NamedAttrList attrs;
   for (auto attr : (*this)->getAttrs()) {
@@ -9631,8 +10916,9 @@ void mlir::pto::TCvtOp::print(OpAsmPrinter &p) {
   p.printOptionalAttrDict(attrs.getAttrs(),
                           /*elidedAttrs=*/{"operandSegmentSizes"});
   p << " : " << getSrc().getType();
-  if (getTmp())
+  if (getTmp()) {
     p << ", " << getTmp().getType();
+  }
   p << ") outs(" << getDst() << " : " << getDst().getType() << ")";
 }
 
@@ -9641,34 +10927,41 @@ ParseResult mlir::pto::TCvtOp::parse(OpAsmParser &parser, OperationState &result
   Type srcTy, tmpTy, dstTy;
   bool hasTmp = false;
 
-  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src))
+  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(tmp))
+    if (parser.parseOperand(tmp)) {
       return failure();
+    }
     hasTmp = true;
   }
   NamedAttrList attrs;
-  if (parser.parseOptionalAttrDict(attrs) || parser.parseColonType(srcTy))
+  if (parser.parseOptionalAttrDict(attrs) || parser.parseColonType(srcTy)) {
     return failure();
-  if (hasTmp && (parser.parseComma() || parser.parseType(tmpTy)))
+  }
+  if (hasTmp && (parser.parseComma() || parser.parseType(tmpTy))) {
     return failure();
+  }
   if (auto satmode = attrs.get("satmode")) {
     attrs.erase("satmode");
-    if (attrs.get("sat_mode"))
+    if (attrs.get("sat_mode")) {
       return parser.emitError(parser.getCurrentLocation(),
                               "cannot specify both satmode and sat_mode");
+    }
     attrs.set("sat_mode", satmode);
   }
   result.attributes = attrs;
   if (parser.parseRParen() || parser.parseKeyword("outs") || parser.parseLParen() ||
-      parser.parseOperand(dst) || parser.parseColonType(dstTy) || parser.parseRParen())
+      parser.parseOperand(dst) || parser.parseColonType(dstTy) || parser.parseRParen()) {
     return failure();
+  }
 
   if (parser.resolveOperand(src, srcTy, result.operands) ||
       (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands)) ||
-      parser.resolveOperand(dst, dstTy, result.operands))
+      parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
+  }
   result.addAttribute(
       "operandSegmentSizes",
       parser.getBuilder().getDenseI32ArrayAttr({1, hasTmp ? 1 : 0, 1}));
@@ -9683,14 +10976,16 @@ void mlir::pto::TMrgSortOp::print(OpAsmPrinter &p) {
   } else if (isFormat2() || isFormat2WithoutTmp()) {
     p << " ins(";
     llvm::interleaveComma(getSrcs(), p, [&](Value src) { p << src; });
-    if (getTmp())
+    if (getTmp()) {
       p << ", " << getTmp();
-    else
+    } else {
       p << " no_tmp";
+}
     p << " {exhausted = " << (getExhausted() ? "true" : "false") << "} : ";
     llvm::interleaveComma(getSrcs().getTypes(), p, [&](Type ty) { p << ty; });
-    if (getTmp())
+    if (getTmp()) {
       p << ", " << getTmp().getType();
+    }
     p << ") outs(" << getDst() << ", " << getExcuted()
       << " : " << getDst().getType() << ", " << getExcuted().getType() << ")";
   } else {
@@ -9700,86 +10995,104 @@ void mlir::pto::TMrgSortOp::print(OpAsmPrinter &p) {
 }
 
 ParseResult mlir::pto::TMrgSortOp::parse(OpAsmParser &parser, OperationState &result) {
-  if (parser.parseKeyword("ins") || parser.parseLParen())
+  if (parser.parseKeyword("ins") || parser.parseLParen()) {
     return failure();
+  }
   OpAsmParser::UnresolvedOperand first, second;
-  if (parser.parseOperand(first) || parser.parseComma() || parser.parseOperand(second))
+  if (parser.parseOperand(first) || parser.parseComma() || parser.parseOperand(second)) {
     return failure();
+  }
 
   if (parser.parseOptionalColon().succeeded()) {
     Type srcTy, blockLenTy, dstTy;
     if (parser.parseType(srcTy) || parser.parseComma() || parser.parseType(blockLenTy) ||
-        parser.parseRParen() || parser.parseKeyword("outs") || parser.parseLParen())
+        parser.parseRParen() || parser.parseKeyword("outs") || parser.parseLParen()) {
       return failure();
+    }
     OpAsmParser::UnresolvedOperand dstOp;
     if (parser.parseOperand(dstOp) || parser.parseColon() || parser.parseType(dstTy) ||
-        parser.parseRParen())
+        parser.parseRParen()) {
       return failure();
+    }
     result.addAttribute("operandSegmentSizes",
                         parser.getBuilder().getDenseI32ArrayAttr({1, 1, 1, 0, 0}));
     if (parser.resolveOperand(first, srcTy, result.operands) ||
         parser.resolveOperand(second, blockLenTy, result.operands) ||
-        parser.resolveOperand(dstOp, dstTy, result.operands))
+        parser.resolveOperand(dstOp, dstTy, result.operands)) {
       return failure();
-    if (parser.parseOptionalAttrDict(result.attributes))
+    }
+    if (parser.parseOptionalAttrDict(result.attributes)) {
       return failure();
-    if (!result.attributes.get("exhausted"))
+    }
+    if (!result.attributes.get("exhausted")) {
       result.addAttribute("exhausted", parser.getBuilder().getBoolAttr(false));
+    }
     return success();
   }
 
   SmallVector<OpAsmParser::UnresolvedOperand, 4> srcs = {first, second};
   while (parser.parseOptionalComma().succeeded()) {
     OpAsmParser::UnresolvedOperand next;
-    if (parser.parseOperand(next))
+    if (parser.parseOperand(next)) {
       return failure();
+    }
     srcs.push_back(next);
   }
   bool noTmp = succeeded(parser.parseOptionalKeyword("no_tmp"));
   if ((noTmp && (srcs.size() < 2 || srcs.size() > 4)) ||
-      (!noTmp && (srcs.size() < 3 || srcs.size() > 5)))
+      (!noTmp && (srcs.size() < 3 || srcs.size() > 5))) {
     return parser.emitError(
         parser.getCurrentLocation(),
         "tmrgsort format2 expects 2 to 4 src operands and optional no_tmp marker");
+  }
   OpAsmParser::UnresolvedOperand tmpOp;
-  if (!noTmp)
+  if (!noTmp) {
     tmpOp = srcs.pop_back_val();
+  }
   bool exhaustedVal = false;
   if (parser.parseOptionalLBrace().succeeded()) {
-    if (parser.parseKeyword("exhausted") || parser.parseEqual())
+    if (parser.parseKeyword("exhausted") || parser.parseEqual()) {
       return failure();
+    }
     StringRef kw;
-    if (parser.parseKeyword(&kw) || parser.parseRBrace())
+    if (parser.parseKeyword(&kw) || parser.parseRBrace()) {
       return failure();
+    }
     exhaustedVal = (kw == "true");
   }
   SmallVector<Type, 4> srcTypes;
   srcTypes.reserve(srcs.size());
-  if (parser.parseColon())
+  if (parser.parseColon()) {
     return failure();
+  }
   Type firstSrcTy;
-  if (parser.parseType(firstSrcTy))
+  if (parser.parseType(firstSrcTy)) {
     return failure();
+  }
   srcTypes.push_back(firstSrcTy);
   while (parser.parseOptionalComma().succeeded()) {
     Type nextTy;
-    if (parser.parseType(nextTy))
+    if (parser.parseType(nextTy)) {
       return failure();
+    }
     srcTypes.push_back(nextTy);
   }
   if (srcTypes.size() != srcs.size() + (noTmp ? 0 : 1) ||
       parser.parseRParen() ||
-      parser.parseKeyword("outs") || parser.parseLParen())
+      parser.parseKeyword("outs") || parser.parseLParen()) {
     return failure();
+  }
   Type tmpTy;
-  if (!noTmp)
+  if (!noTmp) {
     tmpTy = srcTypes.pop_back_val();
+  }
   OpAsmParser::UnresolvedOperand dstOp, excutedOp;
   Type dstTy, excutedTy;
   if (parser.parseOperand(dstOp) || parser.parseComma() || parser.parseOperand(excutedOp) ||
       parser.parseColon() || parser.parseType(dstTy) || parser.parseComma() ||
-      parser.parseType(excutedTy) || parser.parseRParen())
+      parser.parseType(excutedTy) || parser.parseRParen()) {
     return failure();
+  }
   result.addAttribute("operandSegmentSizes",
                       parser.getBuilder().getDenseI32ArrayAttr(
                           {static_cast<int32_t>(srcs.size()), 0, 1,
@@ -9787,12 +11100,15 @@ ParseResult mlir::pto::TMrgSortOp::parse(OpAsmParser &parser, OperationState &re
   if (parser.resolveOperands(srcs, srcTypes, parser.getCurrentLocation(), result.operands) ||
       parser.resolveOperand(dstOp, dstTy, result.operands) ||
       (!noTmp && parser.resolveOperand(tmpOp, tmpTy, result.operands)) ||
-      parser.resolveOperand(excutedOp, excutedTy, result.operands))
+      parser.resolveOperand(excutedOp, excutedTy, result.operands)) {
     return failure();
-  if (parser.parseOptionalAttrDict(result.attributes))
+  }
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
-  if (!result.attributes.get("exhausted"))
+  }
+  if (!result.attributes.get("exhausted")) {
     result.addAttribute("exhausted", parser.getBuilder().getBoolAttr(exhaustedVal));
+  }
   return success();
 }
 
@@ -9800,87 +11116,110 @@ mlir::LogicalResult mlir::pto::TMrgSortOp::verify() {
   if (isFormat1()) {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
-    if (!isPTOShapedLike(srcTy) || !isPTOShapedLike(dstTy))
+    if (!isPTOShapedLike(srcTy) || !isPTOShapedLike(dstTy)) {
       return emitOpError() << "format1 expects PTO shaped-like types for src/dst";
-    if (getElemTy(srcTy) != getElemTy(dstTy))
+    }
+    if (getElemTy(srcTy) != getElemTy(dstTy)) {
       return emitOpError() << "expects src/dst to have the same element type";
-    if (!getElemTy(srcTy).isF16() && !getElemTy(srcTy).isF32())
+    }
+    if (!getElemTy(srcTy).isF16() && !getElemTy(srcTy).isF32()) {
       return emitOpError() << "expects element type to be f16 or f32";
+    }
     auto ss = getShapeVec(srcTy);
     auto ds = getShapeVec(dstTy);
-    if (ss.size() != 2 || ds.size() != 2)
+    if (ss.size() != 2 || ds.size() != 2) {
       return emitOpError() << "expects src/dst to be rank-2 tile-shaped";
-    if (ss[0] != mlir::ShapedType::kDynamic && ss[0] != 1)
+    }
+    if (ss[0] != mlir::ShapedType::kDynamic && ss[0] != 1) {
       return emitOpError() << "expects src rows == 1";
-    if (ds[0] != mlir::ShapedType::kDynamic && ds[0] != 1)
+    }
+    if (ds[0] != mlir::ShapedType::kDynamic && ds[0] != 1) {
       return emitOpError() << "expects dst rows == 1";
-    if (ss[1] != mlir::ShapedType::kDynamic && ds[1] != mlir::ShapedType::kDynamic && ss[1] != ds[1])
+    }
+    if (ss[1] != mlir::ShapedType::kDynamic && ds[1] != mlir::ShapedType::kDynamic && ss[1] != ds[1]) {
       return emitOpError() << "expects src/dst cols to match";
+    }
     if (getBlockLen()) {
       if (auto cstOp = getBlockLen().getDefiningOp<arith::ConstantOp>()) {
         if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(cstOp.getValue())) {
           int64_t v = intAttr.getValue().getSExtValue();
-          if (v <= 0 || (v % 64) != 0)
+          if (v <= 0 || (v % 64) != 0) {
             return emitOpError() << "expects blockLen > 0 and multiple of 64";
+          }
         }
       }
     }
     return mlir::success();
   }
   if (isFormat2() || isFormat2WithoutTmp()) {
-    for (Value v : getSrcs())
-      if (!isPTOShapedLike(v.getType()))
+    for (Value v : getSrcs()) {
+      if (!isPTOShapedLike(v.getType())) {
         return emitOpError() << "format2 expects PTO shaped-like type for each src";
-    if (getSrcs().size() < 2u || getSrcs().size() > 4u)
+      }
+    }
+    if (getSrcs().size() < 2u || getSrcs().size() > 4u) {
       return emitOpError() << "format2 expects 2 to 4 srcs";
-    if (getDsts().size() != 1u || !getExcuted())
+    }
+    if (getDsts().size() != 1u || !getExcuted()) {
       return emitOpError()
              << "format2 expects 2 to 4 srcs, one dst, and excuted=vector";
+    }
     Type dstTy = getDst().getType();
     Type tmpTy = getTmp() ? getTmp().getType() : Type{};
     if (!isPTOShapedLike(dstTy) ||
-        (tmpTy && !isPTOShapedLike(tmpTy)))
+        (tmpTy && !isPTOShapedLike(tmpTy))) {
       return emitOpError() << "format2 dst/tmp must be PTO shaped-like";
+    }
     auto excutedTy = mlir::dyn_cast<mlir::VectorType>(getExcuted().getType());
     if (!excutedTy || excutedTy.getRank() != 1 || excutedTy.getNumElements() != 4 ||
-        !excutedTy.getElementType().isInteger(16))
+        !excutedTy.getElementType().isInteger(16)) {
       return emitOpError() << "format2 excuted must be vector<4xi16>";
+    }
     Type elemTy = getElemTy(dstTy);
-    if (tmpTy && elemTy != getElemTy(tmpTy))
+    if (tmpTy && elemTy != getElemTy(tmpTy)) {
       return emitOpError() << "format2 expects dst/tmp element types to match";
+    }
     auto dstShape = getShapeVec(dstTy);
     auto tmpShape = tmpTy ? getShapeVec(tmpTy) : SmallVector<int64_t, 4>{};
-    if (dstShape.size() != 2 || (tmpTy && tmpShape.size() != 2))
+    if (dstShape.size() != 2 || (tmpTy && tmpShape.size() != 2)) {
       return emitOpError() << "format2 expects dst/tmp to be rank-2 tile-shaped";
+    }
     if ((dstShape[0] != mlir::ShapedType::kDynamic && dstShape[0] != 1) ||
         (tmpTy && tmpShape[0] != mlir::ShapedType::kDynamic &&
-         tmpShape[0] != 1))
+         tmpShape[0] != 1)) {
       return emitOpError() << "format2 expects dst/tmp rows == 1";
+    }
     if (tmpTy && dstShape[1] != mlir::ShapedType::kDynamic &&
         tmpShape[1] != mlir::ShapedType::kDynamic &&
-        tmpShape[1] < dstShape[1])
+        tmpShape[1] < dstShape[1]) {
       return emitOpError() << "format2 expects tmp.cols >= dst.cols";
+    }
     int64_t requiredTmpCols = 0;
     for (Value src : getSrcs()) {
       Type srcTy = src.getType();
       auto srcShape = getShapeVec(srcTy);
-      if (srcShape.size() != 2)
+      if (srcShape.size() != 2) {
         return emitOpError() << "format2 expects src to be rank-2 tile-shaped";
-      if (srcShape[0] != mlir::ShapedType::kDynamic && srcShape[0] != 1)
+      }
+      if (srcShape[0] != mlir::ShapedType::kDynamic && srcShape[0] != 1) {
         return emitOpError() << "format2 expects src rows == 1";
-      if (getElemTy(srcTy) != elemTy)
+      }
+      if (getElemTy(srcTy) != elemTy) {
         return emitOpError() << "format2 expects src/dst/tmp element types to match";
-      if (srcShape[1] == mlir::ShapedType::kDynamic)
+      }
+      if (srcShape[1] == mlir::ShapedType::kDynamic) {
         requiredTmpCols = mlir::ShapedType::kDynamic;
-      else if (requiredTmpCols != mlir::ShapedType::kDynamic)
+      } else if (requiredTmpCols != mlir::ShapedType::kDynamic) {
         requiredTmpCols += srcShape[1];
+      }
     }
     if (tmpTy && requiredTmpCols != mlir::ShapedType::kDynamic &&
         tmpShape[1] != mlir::ShapedType::kDynamic &&
-        tmpShape[1] < requiredTmpCols)
+        tmpShape[1] < requiredTmpCols) {
       return emitOpError()
              << "format2 expects tmp.cols >= sum(src.cols) = "
              << requiredTmpCols;
+    }
     return mlir::success();
   }
   return emitOpError() << "tmrgsort expects format1 (1 src + blockLen + 1 dst) or "
@@ -9909,19 +11248,24 @@ mlir::LogicalResult mlir::pto::TShlSOp::verify() {
   Type srcTy = getSrc().getType();
   Type dstTy = getDst().getType();
   if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
-      failed(verifyTileBufCommon(*this, dstTy, "dst")))
+      failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
     return failure();
+  }
 
   Type srcElem = getElemTy(srcTy);
   Type dstElem = getElemTy(dstTy);
-  if (!srcElem || !dstElem)
+  if (!srcElem || !dstElem) {
     return emitOpError() << "failed to get element type for src/dst";
-  if (srcElem != dstElem)
+  }
+  if (srcElem != dstElem) {
     return emitOpError() << "expects src and dst to have the same element type";
-  if (!mlir::isa<IntegerType>(srcElem))
+  }
+  if (!mlir::isa<IntegerType>(srcElem)) {
     return emitOpError() << "expects integral element types";
-  if (auto scalarValue = getConstantIntegerValue(getScalar()); scalarValue && *scalarValue < 0)
+  }
+  if (auto scalarValue = getConstantIntegerValue(getScalar()); scalarValue && *scalarValue < 0) {
     return emitOpError("expects tshls scalar to be non-negative");
+  }
   return mlir::success();
 }
 
@@ -9930,10 +11274,12 @@ mlir::LogicalResult mlir::pto::TShrSOp::verify() {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyVecTileCommon(*this, srcTy, "src")) ||
-        failed(verifyVecTileCommon(*this, dstTy, "dst")))
+        failed(verifyVecTileCommon(*this, dstTy, "dst"))) {
       return failure();
-    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+    }
+    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
       return failure();
+    }
 
     Type srcElem = getElemTy(srcTy);
     Type dstElem = getElemTy(dstTy);
@@ -9950,24 +11296,28 @@ mlir::LogicalResult mlir::pto::TShrSOp::verify() {
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
-    if (!it || (it.getWidth() != 16 && it.getWidth() != 32))
+    if (!it || (it.getWidth() != 16 && it.getWidth() != 32)) {
       return emitOpError(
           "expects A2/A3 tshrs src and dst element type to be i16/i32");
+    }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
     if (!it || (it.getWidth() != 8 && it.getWidth() != 16 &&
-                it.getWidth() != 32))
+                it.getWidth() != 32)) {
       return emitOpError(
           "expects A5 tshrs src and dst element type to be i8/i16/i32");
+    }
     return success();
   };
 
@@ -9979,17 +11329,20 @@ mlir::LogicalResult mlir::pto::TNegOp::verify() {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyVecTileStorage(*this, srcTy, "src")) ||
-        failed(verifyVecTileStorage(*this, dstTy, "dst")))
+        failed(verifyVecTileStorage(*this, dstTy, "dst"))) {
       return failure();
+    }
     if (failed(verifyTileBufSameElemType(*this, srcTy, dstTy, "src", "dst")) ||
-        failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+        failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
       return failure();
+    }
 
     Type elemTy = getElemTy(srcTy);
     if (!(elemTy.isInteger(16) || elemTy.isInteger(32) || elemTy.isF16() ||
-          elemTy.isF32()))
+          elemTy.isF32())) {
       return emitOpError()
              << "expects A2/A3 tneg element type to be i16/i32/f16/f32";
+    }
     return success();
   };
 
@@ -9997,26 +11350,31 @@ mlir::LogicalResult mlir::pto::TNegOp::verify() {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyVecTileStorage(*this, srcTy, "src")) ||
-        failed(verifyVecTileStorage(*this, dstTy, "dst")))
+        failed(verifyVecTileStorage(*this, dstTy, "dst"))) {
       return failure();
-    if (failed(verifyTileBufSameElemType(*this, srcTy, dstTy, "src", "dst")))
+    }
+    if (failed(verifyTileBufSameElemType(*this, srcTy, dstTy, "src", "dst"))) {
       return failure();
+    }
 
     auto srcValid = getValidShapeVec(srcTy);
     auto dstValid = getValidShapeVec(dstTy);
-    if (srcValid.size() != 2 || dstValid.size() != 2)
+    if (srcValid.size() != 2 || dstValid.size() != 2) {
       return emitOpError() << "expects src and dst to have rank-2 valid_shape";
+    }
     if (srcValid[1] != ShapedType::kDynamic &&
         dstValid[1] != ShapedType::kDynamic &&
-        srcValid[1] != dstValid[1])
+        srcValid[1] != dstValid[1]) {
       return emitOpError()
              << "expects src and dst to have the same valid_shape[1]";
+    }
 
     Type elemTy = getElemTy(srcTy);
     if (!(elemTy.isInteger(8) || elemTy.isInteger(16) || elemTy.isInteger(32) ||
-          elemTy.isF16() || elemTy.isF32() || elemTy.isBF16()))
+          elemTy.isF16() || elemTy.isF32() || elemTy.isBF16())) {
       return emitOpError()
              << "expects A5 tneg element type to be i8/i16/i32/f16/f32/bf16";
+    }
     return success();
   };
 
@@ -10028,30 +11386,38 @@ mlir::LogicalResult mlir::pto::TNotOp::verify() {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyVecTileCommon(*this, srcTy, "src")) ||
-        failed(verifyVecTileCommon(*this, dstTy, "dst")))
+        failed(verifyVecTileCommon(*this, dstTy, "dst"))) {
       return failure();
-    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+    }
+    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
       return failure();
+    }
     auto elemTy = getElemTy(srcTy);
-    if (elemTy != getElemTy(dstTy))
+    if (elemTy != getElemTy(dstTy)) {
       return emitOpError() << "expects src and dst to have the same element type";
-    if (!elemTy.isInteger(16))
+    }
+    if (!elemTy.isInteger(16)) {
       return emitOpError() << "expects A2/A3 tnot element type to be i16";
+    }
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyVecTileCommon(*this, srcTy, "src")) ||
-        failed(verifyVecTileCommon(*this, dstTy, "dst")))
+        failed(verifyVecTileCommon(*this, dstTy, "dst"))) {
       return failure();
-    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+    }
+    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
       return failure();
+    }
     auto elemTy = getElemTy(srcTy);
-    if (elemTy != getElemTy(dstTy))
+    if (elemTy != getElemTy(dstTy)) {
       return emitOpError() << "expects src and dst to have the same element type";
-    if (!(elemTy.isInteger(8) || elemTy.isInteger(16) || elemTy.isInteger(32)))
+    }
+    if (!(elemTy.isInteger(8) || elemTy.isInteger(16) || elemTy.isInteger(32))) {
       return emitOpError() << "expects A5 tnot element type to be i8/i16/i32";
+    }
     return success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -10066,25 +11432,29 @@ mlir::LogicalResult mlir::pto::TOrOp::verify() {
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
     if (!it || (it.getWidth() != 8 && it.getWidth() != 16 &&
-                it.getWidth() != 32))
+                it.getWidth() != 32)) {
       return emitOpError(
           "expects A2/A3 tor src0, src1, and dst element type to be i8/i16/i32");
+    }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
     if (!it || (it.getWidth() != 8 && it.getWidth() != 16 &&
-                it.getWidth() != 32))
+                it.getWidth() != 32)) {
       return emitOpError(
           "expects A5 tor src0, src1, and dst element type to be i8/i16/i32");
+    }
     return success();
   };
 
@@ -10099,24 +11469,28 @@ mlir::LogicalResult mlir::pto::TOrSOp::verify() {
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
-    if (!it || (it.getWidth() != 8 && it.getWidth() != 16))
+    if (!it || (it.getWidth() != 8 && it.getWidth() != 16)) {
       return emitOpError(
           "expects A2/A3 tors src and dst element type to be i8/i16");
+    }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
     if (!it || (it.getWidth() != 8 && it.getWidth() != 16 &&
-                it.getWidth() != 32))
+                it.getWidth() != 32)) {
       return emitOpError(
           "expects A5 tors src and dst element type to be i8/i16/i32");
+    }
     return success();
   };
 
@@ -10128,20 +11502,24 @@ static FailureOr<Type> verifyPTOShapedBinarySameElemAndShape(Operation *op,
                                                               Type src1Ty,
                                                               Type dstTy) {
   if (!isPTOShapedLike(src0Ty) || !isPTOShapedLike(src1Ty) ||
-      !isPTOShapedLike(dstTy))
+      !isPTOShapedLike(dstTy)) {
     return op->emitOpError(
                "expects src0/src1/dst to be tensor/tile_buf/tile_view types"),
            failure();
+  }
   Type e0 = getElemTy(src0Ty), e1 = getElemTy(src1Ty), ed = getElemTy(dstTy);
-  if (!e0 || !e1 || !ed)
+  if (!e0 || !e1 || !ed) {
     return op->emitOpError("failed to get element type for operands"), failure();
-  if (e0 != e1 || e0 != ed)
+  }
+  if (e0 != e1 || e0 != ed) {
     return op->emitOpError("expects src0/src1/dst to have the same element type"),
            failure();
+  }
   auto s0 = getShapeVec(src0Ty), s1 = getShapeVec(src1Ty), sd = getShapeVec(dstTy);
-  if (s0 != s1 || s0 != sd)
+  if (s0 != s1 || s0 != sd) {
     return op->emitOpError("expects src0/src1/dst to have the same shape"),
            failure();
+  }
   return e0;
 }
 
@@ -10151,21 +11529,26 @@ mlir::LogicalResult mlir::pto::TPartAddOp::verify() {
     Type src1Ty = getSrc1().getType();
     Type dstTy = getDst().getType();
     if (!isPTOShapedLike(src0Ty) || !isPTOShapedLike(src1Ty) ||
-        !isPTOShapedLike(dstTy))
+        !isPTOShapedLike(dstTy)) {
       return emitOpError() << "expects PTO shaped-like src0/src1/dst";
+    }
     if (getElemTy(src0Ty) != getElemTy(src1Ty) ||
-        getElemTy(src0Ty) != getElemTy(dstTy))
+        getElemTy(src0Ty) != getElemTy(dstTy)) {
       return emitOpError() << "expects src0/src1/dst to have the same element type";
+    }
     auto s0 = getShapeVec(src0Ty);
     auto s1 = getShapeVec(src1Ty);
     auto d = getShapeVec(dstTy);
-    if (s0.size() != 2 || s1.size() != 2 || d.size() != 2)
+    if (s0.size() != 2 || s1.size() != 2 || d.size() != 2) {
       return emitOpError() << "expects src0/src1/dst to be rank-2 (tile-shaped)";
-    if (failed(verifyPartialValidPattern(*this, src0Ty, src1Ty, dstTy)))
+    }
+    if (failed(verifyPartialValidPattern(*this, src0Ty, src1Ty, dstTy))) {
       return failure();
+    }
     Type elem = getElemTy(src0Ty);
-    if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32()))
+    if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32())) {
       return emitOpError("expects A2/A3 tpartadd element type to be i32/i16/f16/f32");
+    }
     return mlir::success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
@@ -10173,22 +11556,27 @@ mlir::LogicalResult mlir::pto::TPartAddOp::verify() {
     Type src1Ty = getSrc1().getType();
     Type dstTy = getDst().getType();
     if (!isPTOShapedLike(src0Ty) || !isPTOShapedLike(src1Ty) ||
-        !isPTOShapedLike(dstTy))
+        !isPTOShapedLike(dstTy)) {
       return emitOpError() << "expects PTO shaped-like src0/src1/dst";
+    }
     if (getElemTy(src0Ty) != getElemTy(src1Ty) ||
-        getElemTy(src0Ty) != getElemTy(dstTy))
+        getElemTy(src0Ty) != getElemTy(dstTy)) {
       return emitOpError() << "expects src0/src1/dst to have the same element type";
+    }
     Type elem = getElemTy(src0Ty);
     if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isInteger(8) ||
-          elem.isF16() || elem.isBF16() || elem.isF32()))
+          elem.isF16() || elem.isBF16() || elem.isF32())) {
       return emitOpError("expects A5 tpartadd element type to be i32/i16/i8/f16/bf16/f32");
+    }
     auto s0 = getShapeVec(src0Ty);
     auto s1 = getShapeVec(src1Ty);
     auto d = getShapeVec(dstTy);
-    if (s0.size() != 2 || s1.size() != 2 || d.size() != 2)
+    if (s0.size() != 2 || s1.size() != 2 || d.size() != 2) {
       return emitOpError() << "expects src0/src1/dst to be rank-2 (tile-shaped)";
-    if (failed(verifyPartialValidPatternLoose(*this, src0Ty, src1Ty, dstTy)))
+    }
+    if (failed(verifyPartialValidPatternLoose(*this, src0Ty, src1Ty, dstTy))) {
       return failure();
+    }
     return mlir::success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -10201,13 +11589,16 @@ mlir::LogicalResult mlir::pto::TPartMaxOp::verify() {
     Type td = getDst().getType();
     FailureOr<Type> elemOr =
         verifyPTOShapedBinarySameElemAndShape(getOperation(), t0, t1, td);
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
-    if (failed(verifyPartialValidPattern(*this, t0, t1, td)))
+    }
+    if (failed(verifyPartialValidPattern(*this, t0, t1, td))) {
       return failure();
+    }
     Type e0 = *elemOr;
-    if (!(e0.isInteger(32) || e0.isInteger(16) || e0.isF16() || e0.isF32()))
+    if (!(e0.isInteger(32) || e0.isInteger(16) || e0.isF16() || e0.isF32())) {
       return emitOpError("expects A2/A3 tpartmax element type to be i32/i16/f16/f32");
+    }
     return mlir::success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
@@ -10216,14 +11607,17 @@ mlir::LogicalResult mlir::pto::TPartMaxOp::verify() {
     Type td = getDst().getType();
     FailureOr<Type> elemOr =
         verifyPTOShapedBinarySameElemAndShape(getOperation(), t0, t1, td);
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     Type e0 = *elemOr;
     if (!(e0.isInteger(32) || e0.isInteger(16) || e0.isInteger(8) ||
-          e0.isF16() || e0.isBF16() || e0.isF32()))
+          e0.isF16() || e0.isBF16() || e0.isF32())) {
       return emitOpError("expects A5 tpartmax element type to be i32/i16/i8/f16/bf16/f32");
-    if (failed(verifyPartialValidPatternLoose(*this, t0, t1, td)))
+    }
+    if (failed(verifyPartialValidPatternLoose(*this, t0, t1, td))) {
       return failure();
+    }
     return mlir::success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -10236,13 +11630,16 @@ mlir::LogicalResult mlir::pto::TPartMinOp::verify() {
     Type td = getDst().getType();
     FailureOr<Type> elemOr =
         verifyPTOShapedBinarySameElemAndShape(getOperation(), t0, t1, td);
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
-    if (failed(verifyPartialValidPattern(*this, t0, t1, td)))
+    }
+    if (failed(verifyPartialValidPattern(*this, t0, t1, td))) {
       return failure();
+    }
     Type e0 = *elemOr;
-    if (!(e0.isInteger(32) || e0.isInteger(16) || e0.isF16() || e0.isF32()))
+    if (!(e0.isInteger(32) || e0.isInteger(16) || e0.isF16() || e0.isF32())) {
       return emitOpError("expects A2/A3 tpartmin element type to be i32/i16/f16/f32");
+    }
     return mlir::success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
@@ -10251,14 +11648,17 @@ mlir::LogicalResult mlir::pto::TPartMinOp::verify() {
     Type td = getDst().getType();
     FailureOr<Type> elemOr =
         verifyPTOShapedBinarySameElemAndShape(getOperation(), t0, t1, td);
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     Type e0 = *elemOr;
     if (!(e0.isInteger(32) || e0.isInteger(16) || e0.isInteger(8) ||
-          e0.isF16() || e0.isBF16() || e0.isF32()))
+          e0.isF16() || e0.isBF16() || e0.isF32())) {
       return emitOpError("expects A5 tpartmin element type to be i32/i16/i8/f16/bf16/f32");
-    if (failed(verifyPartialValidPatternLoose(*this, t0, t1, td)))
+    }
+    if (failed(verifyPartialValidPatternLoose(*this, t0, t1, td))) {
       return failure();
+    }
     return mlir::success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -10270,48 +11670,57 @@ static LogicalResult verifyTPartArgOpCommon(Operation *op, Type src0Ty,
                                             Type dstIdxTy, StringRef opName) {
   FailureOr<Type> dataElemOr =
       verifyPTOShapedBinarySameElemAndShape(op, src0Ty, src1Ty, dstTy);
-  if (failed(dataElemOr))
+  if (failed(dataElemOr)) {
     return failure();
-  if (failed(verifyPartialValidPattern(op, src0Ty, src1Ty, dstTy)))
+  }
+  if (failed(verifyPartialValidPattern(op, src0Ty, src1Ty, dstTy))) {
     return failure();
+  }
 
   if (!isPTOShapedLike(src0IdxTy) || !isPTOShapedLike(src1IdxTy) ||
-      !isPTOShapedLike(dstIdxTy))
+      !isPTOShapedLike(dstIdxTy)) {
     return op->emitOpError("expects PTO shaped-like src0Idx/src1Idx/dstIdx");
+  }
   Type idxElem = getElemTy(src0IdxTy);
   if (!idxElem || idxElem != getElemTy(src1IdxTy) ||
-      idxElem != getElemTy(dstIdxTy))
+      idxElem != getElemTy(dstIdxTy)) {
     return op->emitOpError(
         "expects src0Idx/src1Idx/dstIdx to have the same element type");
+  }
   auto idxInt = dyn_cast<IntegerType>(idxElem);
-  if (!idxInt || idxInt.getWidth() != 32)
+  if (!idxInt || idxInt.getWidth() != 32) {
     return op->emitOpError(
         "expects src0Idx/src1Idx/dstIdx element type to be i32 or ui32");
+  }
 
   auto dataShape = getShapeVec(src0Ty);
   if (dataShape != getShapeVec(src0IdxTy) ||
       dataShape != getShapeVec(src1IdxTy) ||
-      dataShape != getShapeVec(dstIdxTy))
+      dataShape != getShapeVec(dstIdxTy)) {
     return op->emitOpError(
         "expects data and index operands to have the same shape");
+  }
   if (getValidShapeVec(src0Ty) != getValidShapeVec(src0IdxTy) ||
       getValidShapeVec(src1Ty) != getValidShapeVec(src1IdxTy) ||
-      getValidShapeVec(dstTy) != getValidShapeVec(dstIdxTy))
+      getValidShapeVec(dstTy) != getValidShapeVec(dstIdxTy)) {
     return op->emitOpError(
         "expects each data operand and its index operand to have the same valid_shape");
+  }
 
   Type elem = *dataElemOr;
   PTOArch arch = getTargetArch(op);
   if (arch == PTOArch::A5) {
     if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isInteger(8) ||
-          elem.isF16() || elem.isBF16() || elem.isF32()))
+          elem.isF16() || elem.isBF16() || elem.isF32())) {
       return op->emitOpError() << "expects A5 " << opName
                                << " element type to be i32/i16/i8/f16/bf16/f32";
+    }
   } else {
     if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() ||
-          elem.isF32()))
+          elem.isF32())) {
       return op->emitOpError() << "expects A2/A3 " << opName
                                << " element type to be i32/i16/f16/f32";
+    }
   }
   return success();
 }
@@ -10342,25 +11751,30 @@ mlir::LogicalResult mlir::pto::TPartMulOp::verify() {
     Type src1Ty = getSrc1().getType();
     Type dstTy = getDst().getType();
     if (!isPTOShapedLike(src0Ty) || !isPTOShapedLike(src1Ty) ||
-        !isPTOShapedLike(dstTy))
+        !isPTOShapedLike(dstTy)) {
       return emitOpError() << "expects PTO shaped-like src0/src1/dst";
+    }
     if (getElemTy(src0Ty) != getElemTy(src1Ty) ||
-        getElemTy(src0Ty) != getElemTy(dstTy))
+        getElemTy(src0Ty) != getElemTy(dstTy)) {
       return emitOpError()
              << "expects src0/src1/dst to have the same element type";
+    }
     auto s0 = getShapeVec(src0Ty);
     auto s1 = getShapeVec(src1Ty);
     auto d = getShapeVec(dstTy);
-    if (s0.size() != 2 || s1.size() != 2 || d.size() != 2)
+    if (s0.size() != 2 || s1.size() != 2 || d.size() != 2) {
       return emitOpError()
              << "expects src0/src1/dst to be rank-2 (tile-shaped)";
-    if (failed(verifyPartialValidPattern(*this, src0Ty, src1Ty, dstTy)))
+    }
+    if (failed(verifyPartialValidPattern(*this, src0Ty, src1Ty, dstTy))) {
       return failure();
+    }
     Type elem = getElemTy(src0Ty);
     if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() ||
-          elem.isF32()))
+          elem.isF32())) {
       return emitOpError(
           "expects A2/A3 tpartmul element type to be i32/i16/f16/f32");
+    }
     return mlir::success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
@@ -10368,25 +11782,30 @@ mlir::LogicalResult mlir::pto::TPartMulOp::verify() {
     Type src1Ty = getSrc1().getType();
     Type dstTy = getDst().getType();
     if (!isPTOShapedLike(src0Ty) || !isPTOShapedLike(src1Ty) ||
-        !isPTOShapedLike(dstTy))
+        !isPTOShapedLike(dstTy)) {
       return emitOpError() << "expects PTO shaped-like src0/src1/dst";
+    }
     if (getElemTy(src0Ty) != getElemTy(src1Ty) ||
-        getElemTy(src0Ty) != getElemTy(dstTy))
+        getElemTy(src0Ty) != getElemTy(dstTy)) {
       return emitOpError()
              << "expects src0/src1/dst to have the same element type";
+    }
     Type elem = getElemTy(src0Ty);
     if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isInteger(8) ||
-          elem.isF16() || elem.isBF16() || elem.isF32()))
+          elem.isF16() || elem.isBF16() || elem.isF32())) {
       return emitOpError(
           "expects A5 tpartmul element type to be i32/i16/i8/f16/bf16/f32");
+    }
     auto s0 = getShapeVec(src0Ty);
     auto s1 = getShapeVec(src1Ty);
     auto d = getShapeVec(dstTy);
-    if (s0.size() != 2 || s1.size() != 2 || d.size() != 2)
+    if (s0.size() != 2 || s1.size() != 2 || d.size() != 2) {
       return emitOpError()
              << "expects src0/src1/dst to be rank-2 (tile-shaped)";
-    if (failed(verifyPartialValidPatternLoose(*this, src0Ty, src1Ty, dstTy)))
+    }
+    if (failed(verifyPartialValidPatternLoose(*this, src0Ty, src1Ty, dstTy))) {
       return failure();
+    }
     return mlir::success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -10400,10 +11819,12 @@ mlir::LogicalResult mlir::pto::TPReluOp::verify() {
     Type td = getDst().getType();
     if (failed(verifyTileBufCommon(*this, t0, "src0")) ||
         failed(verifyTileBufCommon(*this, t1, "src1")) ||
-        failed(verifyTileBufCommon(*this, td, "dst")))
+        failed(verifyTileBufCommon(*this, td, "dst"))) {
       return failure();
-    if (tt && failed(verifyTileBufCommon(*this, tt, "tmp")))
+    }
+    if (tt && failed(verifyTileBufCommon(*this, tt, "tmp"))) {
       return failure();
+    }
 
     Type e0 = getElemTy(t0), e1 = getElemTy(t1), ed = getElemTy(td);
     if (!e0 || !e1 || !ed) {
@@ -10423,8 +11844,9 @@ mlir::LogicalResult mlir::pto::TPReluOp::verify() {
       return failure();
     }
     if (failed(verifyTileBufSameValidShape(*this, t0, td, "src0", "dst")) ||
-        failed(verifyTileBufSameValidShape(*this, t1, td, "src1", "dst")))
+        failed(verifyTileBufSameValidShape(*this, t1, td, "src1", "dst"))) {
       return failure();
+    }
 
     auto s0 = getShapeVec(t0), s1 = getShapeVec(t1), sd = getShapeVec(td);
     if (s0 != s1 || s0 != sd) {
@@ -10436,66 +11858,77 @@ mlir::LogicalResult mlir::pto::TPReluOp::verify() {
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     auto tysOr = verifyCommon();
-    if (failed(tysOr))
+    if (failed(tysOr)) {
       return failure();
+    }
     auto [t0, t1, tt, td] = *tysOr;
-    if (!tt)
+    if (!tt) {
       return success();
+    }
     Type tmpElem = getElemTy(tt);
     auto tmpIntTy = mlir::dyn_cast<IntegerType>(tmpElem);
-    if (!tmpIntTy || tmpIntTy.getWidth() != 8)
+    if (!tmpIntTy || tmpIntTy.getWidth() != 8) {
       return emitOpError("expects A2/A3 tmp element type to be u8");
-    if (failed(verifyVecTileCommon(*this, tt, "tmp")))
+    }
+    if (failed(verifyVecTileCommon(*this, tt, "tmp"))) {
       return failure();
+    }
     auto tmpShape = getShapeVec(tt);
     auto dstValid = getValidShapeVec(td);
     auto tmpValid = getValidShapeVec(tt);
-    if (tmpShape.size() != 2 || dstValid.size() != 2 || tmpValid.size() != 2)
+    if (tmpShape.size() != 2 || dstValid.size() != 2 || tmpValid.size() != 2) {
       return emitOpError("expects tmp and dst to be rank-2 tiles");
+    }
     if (dstValid[0] != ShapedType::kDynamic && tmpShape[0] != ShapedType::kDynamic &&
-        tmpShape[0] < dstValid[0] + 1)
-        return emitOpError()
+        tmpShape[0] < dstValid[0] + 1) {
+      return emitOpError()
              << "expects A2/A3 tmp shape[0] to be at least dst valid_shape[0] + 1 ("
              << (dstValid[0] + 1) << ")";
+    }
     if (dstValid[1] != ShapedType::kDynamic && tmpValid[1] != ShapedType::kDynamic) {
       int64_t packedMaskCols = llvm::divideCeil(dstValid[1], int64_t{8});
-      if (tmpValid[1] < packedMaskCols)
+      if (tmpValid[1] < packedMaskCols) {
         return emitOpError()
                << "expects A2/A3 tmp valid_shape[1] to be at least ceil(dst valid_shape[1] / 8) ("
                << packedMaskCols << ")";
+      }
     }
     if (dstValid[0] == ShapedType::kDynamic ||
-        dstValid[1] == ShapedType::kDynamic)
+        dstValid[1] == ShapedType::kDynamic) {
       return emitOpError(
           "expects A2/A3 tprelu dst valid_shape to be static when tmp is provided");
+    }
     int64_t packedCols = std::max<int64_t>(
         32, llvm::divideCeil(llvm::divideCeil(dstValid[1], int64_t{8}),
                              int64_t{32}) *
                 32);
     if (failed(verifyTmpCapacityAtLeast(
-            *this, tt, static_cast<uint64_t>(dstValid[0] + 1) *
-                          static_cast<uint64_t>(packedCols))))
+            *this, tt, static_cast<uint64_t>(dstValid[0] + 1) * static_cast<uint64_t>(packedCols)))) {
       return failure();
+    }
     if (auto arch = getVerifierArchName(getOperation());
         arch && arch->equals_insensitive("a3")) {
       if (getSrc0() == getSrc1() || getSrc0() == getTmp() || getSrc0() == getDst() ||
-          getSrc1() == getTmp() || getSrc1() == getDst() || getTmp() == getDst())
+          getSrc1() == getTmp() || getSrc1() == getDst() || getTmp() == getDst()) {
         return emitOpError(
             "expects A3 src0, src1, tmp, and dst to use different storage");
+      }
     }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     auto tysOr = verifyCommon();
-    if (failed(tysOr))
+    if (failed(tysOr)) {
       return failure();
+    }
     auto [t0, t1, tt, td] = *tysOr;
     (void)t0;
     (void)t1;
     (void)td;
-    if (tt && failed(verifyVecTileCommon(*this, tt, "tmp")))
+    if (tt && failed(verifyVecTileCommon(*this, tt, "tmp"))) {
       return failure();
+    }
     return success();
   };
 
@@ -10511,56 +11944,72 @@ ParseResult mlir::pto::TQuantOp::parse(OpAsmParser &parser,
   NamedAttrList parsedAttrs;
 
   if (parser.parseKeyword("ins") || parser.parseLParen() ||
-      parser.parseOperand(src) || parser.parseComma() || parser.parseOperand(fp))
+      parser.parseOperand(src) || parser.parseComma() || parser.parseOperand(fp)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(offset))
+    if (parser.parseOperand(offset)) {
       return failure();
+    }
     hasOffset = true;
   }
-  if (parser.parseColon())
+  if (parser.parseColon()) {
     return failure();
-  if (parser.parseType(srcTy) || parser.parseComma() || parser.parseType(fpTy))
-    return failure();
-  if (hasOffset) {
-    if (parser.parseComma() || parser.parseType(offsetTy))
-      return failure();
   }
-  if (parser.parseRParen())
+  if (parser.parseType(srcTy) || parser.parseComma() || parser.parseType(fpTy)) {
     return failure();
-  if (parser.parseKeyword("outs") || parser.parseLParen() ||
-      parser.parseOperand(dst))
-    return failure();
-  if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(tmp))
+  }
+  if (hasOffset) {
+    if (parser.parseComma() || parser.parseType(offsetTy)) {
       return failure();
+    }
+  }
+  if (parser.parseRParen()) {
+    return failure();
+  }
+  if (parser.parseKeyword("outs") || parser.parseLParen() ||
+      parser.parseOperand(dst)) {
+    return failure();
+  }
+  if (succeeded(parser.parseOptionalComma())) {
+    if (parser.parseOperand(tmp)) {
+      return failure();
+    }
     hasTmp = true;
   }
-  if (parser.parseColonType(dstTy))
+  if (parser.parseColonType(dstTy)) {
     return failure();
-  if (hasTmp) {
-    if (parser.parseComma() || parser.parseType(tmpTy))
-      return failure();
   }
-  if (parser.parseRParen())
+  if (hasTmp) {
+    if (parser.parseComma() || parser.parseType(tmpTy)) {
+      return failure();
+    }
+  }
+  if (parser.parseRParen()) {
     return failure();
+  }
   if (failed(parsePTOInherentAttrs<TQuantOp>(
-          parser, result, parsedAttrs, {"quant_type", "operandSegmentSizes"})))
+          parser, result, parsedAttrs, {"quant_type", "operandSegmentSizes"}))) {
     return failure();
+  }
 
   if (parser.resolveOperand(src, srcTy, result.operands) ||
-      parser.resolveOperand(fp, fpTy, result.operands))
+      parser.resolveOperand(fp, fpTy, result.operands)) {
     return failure();
+  }
   if (hasOffset) {
-    if (parser.resolveOperand(offset, offsetTy, result.operands))
+    if (parser.resolveOperand(offset, offsetTy, result.operands)) {
       return failure();
+    }
   }
   if (hasTmp) {
-    if (parser.resolveOperand(tmp, tmpTy, result.operands))
+    if (parser.resolveOperand(tmp, tmpTy, result.operands)) {
       return failure();
+    }
   }
-  if (parser.resolveOperand(dst, dstTy, result.operands))
+  if (parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
+  }
 
   auto &properties = result.getOrAddProperties<TQuantOp::Properties>();
   llvm::copy(ArrayRef<int32_t>({1, 1, hasOffset ? 1 : 0, hasTmp ? 1 : 0, 1}),
@@ -10598,52 +12047,64 @@ ParseResult mlir::pto::TQuantMxOp::parse(OpAsmParser &parser,
 
   if (parser.parseKeyword("ins") || parser.parseLParen() ||
       parser.parseOperand(src) || parser.parseColonType(srcTy) ||
-      parser.parseRParen())
+      parser.parseRParen()) {
     return failure();
+  }
 
-  if (parser.parseKeyword("outs") || parser.parseLParen())
+  if (parser.parseKeyword("outs") || parser.parseLParen()) {
     return failure();
+  }
 
   do {
     OpAsmParser::UnresolvedOperand operand;
-    if (parser.parseOperand(operand))
+    if (parser.parseOperand(operand)) {
       return failure();
+    }
     outOperands.push_back(operand);
   } while (succeeded(parser.parseOptionalComma()));
 
-  if (parser.parseColon())
+  if (parser.parseColon()) {
     return failure();
+  }
 
   do {
     Type type;
-    if (parser.parseType(type))
+    if (parser.parseType(type)) {
       return failure();
+    }
     outTypes.push_back(type);
   } while (succeeded(parser.parseOptionalComma()));
 
-  if (parser.parseRParen())
+  if (parser.parseRParen()) {
     return failure();
+  }
 
-  if (outOperands.size() != outTypes.size())
+  if (outOperands.size() != outTypes.size()) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expects the number of outs operands to match the number of outs types");
-  if (outOperands.size() != 4 && outOperands.size() != 5)
+  }
+  if (outOperands.size() != 4 && outOperands.size() != 5) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expects 4 or 5 operands in outs(...)");
+  }
 
-  if (parser.parseOptionalAttrDict(result.attributes))
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
   if (!llvm::isa_and_nonnull<pto::QuantTypeAttr>(
-          result.attributes.get("quant_type")))
+          result.attributes.get("quant_type"))) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expects quant_type attribute");
+  }
 
-  if (parser.resolveOperand(src, srcTy, result.operands))
+  if (parser.resolveOperand(src, srcTy, result.operands)) {
     return failure();
+  }
   for (auto [operand, type] : llvm::zip_equal(outOperands, outTypes)) {
-    if (parser.resolveOperand(operand, type, result.operands))
+    if (parser.resolveOperand(operand, type, result.operands)) {
       return failure();
+    }
   }
 
   return success();
@@ -10653,12 +12114,14 @@ void mlir::pto::TQuantMxOp::print(OpAsmPrinter &p) {
   p << " ins(" << getSrc() << " : " << getSrc().getType() << ")";
   p << " outs(" << getDst() << ", " << getExp() << ", " << getMax() << ", "
     << getScaling();
-  if (auto expZz = getExpZz())
+  if (auto expZz = getExpZz()) {
     p << ", " << expZz;
+  }
   p << " : " << getDst().getType() << ", " << getExp().getType() << ", "
     << getMax().getType() << ", " << getScaling().getType();
-  if (auto expZz = getExpZz())
+  if (auto expZz = getExpZz()) {
     p << ", " << expZz.getType();
+  }
   p << ")";
   p.printOptionalAttrDict((*this)->getAttrs());
 }
@@ -10668,33 +12131,40 @@ mlir::LogicalResult mlir::pto::TQuantOp::verify() {
     Type dstElemTy = getElemTy(getDst().getType());
     auto dstIntTy = dyn_cast<IntegerType>(dstElemTy);
     if (getQuantType() == mlir::pto::QuantType::INT8_SYM) {
-      if (!getFp())
+      if (!getFp()) {
         return emitOpError()
                << "INT8_SYM quantization requires an fp operand";
-      if (getOffset())
+      }
+      if (getOffset()) {
         return emitOpError()
                << "INT8_SYM quantization must not have an offset operand";
-      if (!dstIntTy || dstIntTy.getWidth() != 8)
+      }
+      if (!dstIntTy || dstIntTy.getWidth() != 8) {
         return emitOpError()
                << "expects dst element type i8/ui8 for INT8_SYM quantization";
+      }
     } else if (getQuantType() == mlir::pto::QuantType::INT8_ASYM) {
-      if (!getFp())
+      if (!getFp()) {
         return emitOpError()
                << "INT8_ASYM quantization requires an fp operand";
-      if (!getOffset())
+      }
+      if (!getOffset()) {
         return emitOpError()
                << "INT8_ASYM quantization requires an offset operand";
-      if (!dstIntTy || dstIntTy.getWidth() != 8)
+      }
+      if (!dstIntTy || dstIntTy.getWidth() != 8) {
         return emitOpError()
                << "expects dst element type i8/ui8 for INT8_ASYM quantization";
+      }
     } else {
       return emitOpError("expects plain tquant quant_type to be INT8_SYM or INT8_ASYM; use tquant.mx for MX quantization");
     }
     return success();
   };
 
-  if (failed(verifyStructural()))
+  if (failed(verifyStructural())) {
     return failure();
+  }
 
   auto verifyInt8Common = [&]() -> LogicalResult {
     Type srcTy = getSrc().getType();
@@ -10702,77 +12172,98 @@ mlir::LogicalResult mlir::pto::TQuantOp::verify() {
     Type dstTy = getDst().getType();
     if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
         failed(verifyTileBufCommon(*this, fpTy, "fp")) ||
-        failed(verifyTileBufCommon(*this, dstTy, "dst")))
+        failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
       return failure();
-    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+    }
+    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
       return failure();
-    if (getTmp() && failed(verifyTileBufCommon(*this, getTmp().getType(), "tmp")))
+    }
+    if (getTmp() && failed(verifyTileBufCommon(*this, getTmp().getType(), "tmp"))) {
       return failure();
-    if (!getElemTy(srcTy).isF32())
+    }
+    if (!getElemTy(srcTy).isF32()) {
       return emitOpError() << "expects src to have element type f32";
+    }
     if (getOffset()) {
       Type offsetTy = getOffset().getType();
-      if (failed(verifyTileBufCommon(*this, offsetTy, "offset")))
+      if (failed(verifyTileBufCommon(*this, offsetTy, "offset"))) {
         return failure();
-      if (!getElemTy(offsetTy).isF32())
+      }
+      if (!getElemTy(offsetTy).isF32()) {
         return emitOpError() << "expects offset to have element type f32";
+      }
     }
     if (getTmp()) {
       Type tmpTy = getTmp().getType();
-      if (!getElemTy(tmpTy).isF32())
+      if (!getElemTy(tmpTy).isF32()) {
         return emitOpError() << "expects tmp to have element type f32";
+      }
     }
     return success();
   };
 
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (failed(verifyInt8Common()))
+    if (failed(verifyInt8Common())) {
       return failure();
+    }
     Type srcTy = getSrc().getType();
     Type fpTy = getFp().getType();
     Type dstTy = getDst().getType();
-    if (!isRowMajorTileBuf(srcTy) || !isRowMajorTileBuf(dstTy))
+    if (!isRowMajorTileBuf(srcTy) || !isRowMajorTileBuf(dstTy)) {
       return emitOpError()
              << "expects A2/A3 src and dst to use row-major layout";
+    }
     auto verifyA2A3Tmp = [&](Type tmpTy) -> LogicalResult {
-      if (failed(verifyTileBufSameElemType(*this, srcTy, tmpTy, "src", "tmp")))
+      if (failed(verifyTileBufSameElemType(*this, srcTy, tmpTy, "src", "tmp"))) {
         return failure();
-      if (!isRowMajorTileBuf(tmpTy))
+      }
+      if (!isRowMajorTileBuf(tmpTy)) {
         return emitOpError() << "expects A2/A3 tmp to use row-major layout";
-      if (getShapeVec(srcTy) != getShapeVec(tmpTy))
+      }
+      if (getShapeVec(srcTy) != getShapeVec(tmpTy)) {
         return emitOpError() << "expects A2/A3 tmp to have the same shape as src";
-      if (failed(verifyTileBufSameValidShape(*this, srcTy, tmpTy, "src", "tmp")))
+      }
+      if (failed(verifyTileBufSameValidShape(*this, srcTy, tmpTy, "src", "tmp"))) {
         return failure();
+      }
       auto requiredBytes = getStaticByteSize(srcTy);
-      if (!requiredBytes)
+      if (!requiredBytes) {
         return emitOpError(
             "expects A2/A3 tquant src shape to be static when tmp is provided");
+      }
       return verifyTmpCapacityAtLeast(*this, tmpTy, *requiredBytes);
     };
-    if (getTmp() && failed(verifyA2A3Tmp(getTmp().getType())))
+    if (getTmp() && failed(verifyA2A3Tmp(getTmp().getType()))) {
       return failure();
+    }
     auto verifyA2A3Param = [&](Type paramTy, StringRef paramName) -> LogicalResult {
-      if (isRowMajorTileBuf(paramTy))
+      if (isRowMajorTileBuf(paramTy)) {
         return emitOpError() << "expects A2/A3 " << paramName
                              << " to use non-row-major layout";
+      }
       auto paramValid = getValidShapeVec(paramTy);
       auto dstValid = getValidShapeVec(dstTy);
-      if (paramValid.size() != 2 || dstValid.size() != 2)
+      if (paramValid.size() != 2 || dstValid.size() != 2) {
         return emitOpError() << "expects A2/A3 " << paramName
                              << " and dst to have rank-2 valid_shape";
+      }
       if (paramValid[0] != ShapedType::kDynamic &&
-          dstValid[0] != ShapedType::kDynamic && paramValid[0] != dstValid[0])
+          dstValid[0] != ShapedType::kDynamic && paramValid[0] != dstValid[0]) {
         return emitOpError() << "expects A2/A3 " << paramName
                              << " valid_shape[0] to equal dst valid_shape[0]";
-      if (paramValid[1] != ShapedType::kDynamic && paramValid[1] != 1)
+      }
+      if (paramValid[1] != ShapedType::kDynamic && paramValid[1] != 1) {
         return emitOpError() << "expects A2/A3 " << paramName
                              << " valid_shape[1] to be 1";
+      }
       return success();
     };
-    if (failed(verifyA2A3Param(fpTy, "fp")))
+    if (failed(verifyA2A3Param(fpTy, "fp"))) {
       return failure();
-    if (getOffset() && failed(verifyA2A3Param(getOffset().getType(), "offset")))
+    }
+    if (getOffset() && failed(verifyA2A3Param(getOffset().getType(), "offset"))) {
       return failure();
+    }
     return success();
   };
 
@@ -10798,11 +12289,13 @@ mlir::LogicalResult mlir::pto::TQuantMxOp::verify() {
         failed(verifyNDStyleVecTile(*this, dstTy, "dst", /*allowLowPrecision=*/true)) ||
         failed(verifyNDStyleVecTile(*this, expTy, "exp")) ||
         failed(verifyNDStyleVecTile(*this, maxTy, "max")) ||
-        failed(verifyNDStyleVecTile(*this, scalingTy, "scaling")))
+        failed(verifyNDStyleVecTile(*this, scalingTy, "scaling"))) {
       return failure();
+    }
     if (getExpZz() &&
-        failed(verifyNDStyleVecTile(*this, getExpZz().getType(), "exp_zz")))
+        failed(verifyNDStyleVecTile(*this, getExpZz().getType(), "exp_zz"))) {
       return failure();
+    }
 
     const bool isDn = getGrpAxis() == pto::MxGroupAxis::Axis0;
     if (getInterleave() && !isDn)
@@ -10813,15 +12306,19 @@ mlir::LogicalResult mlir::pto::TQuantMxOp::verify() {
 
     auto quantType = getQuantType();
     if (quantType != mlir::pto::QuantType::MXFP8 &&
-        quantType != mlir::pto::QuantType::MXFP4_E2M1)
+        quantType != mlir::pto::QuantType::MXFP4_E2M1) {
       return emitOpError("expects quant_type to be MXFP8 or MXFP4_E2M1");
-    if (getExpZz() && !getStoreMode())
+    }
+    if (getExpZz() && !getStoreMode()) {
       return emitOpError("expects storeMode when exp_zz is present");
-    if (getStoreMode() && !getExpZz())
+    }
+    if (getStoreMode() && !getExpZz()) {
       return emitOpError("expects exp_zz when storeMode is present");
+    }
     if (getStoreMode() &&
-        getQuantScaleAlg() != mlir::pto::QuantScaleAlg::OCP)
+        getQuantScaleAlg() != mlir::pto::QuantScaleAlg::OCP) {
       return emitOpError("storeMode form must not override quantScaleAlg");
+    }
 
     Type srcElem = getElemTy(srcTy);
     Type dstElem = getElemTy(dstTy);
@@ -10829,25 +12326,33 @@ mlir::LogicalResult mlir::pto::TQuantMxOp::verify() {
     Type maxElem = getElemTy(maxTy);
     Type scalingElem = getElemTy(scalingTy);
 
-    if (!(srcElem.isF32() || srcElem.isF16() || srcElem.isBF16()))
+    if (!(srcElem.isF32() || srcElem.isF16() || srcElem.isBF16())) {
       return emitOpError("expects src element type to be f32/f16/bf16");
-    if (!expElem.isInteger(8))
+    }
+    if (!expElem.isInteger(8)) {
       return emitOpError("expects exp element type to be i8/ui8");
-    if (getExpZz() && !getElemTy(getExpZz().getType()).isInteger(8))
+    }
+    if (getExpZz() && !getElemTy(getExpZz().getType()).isInteger(8)) {
       return emitOpError("expects exp_zz element type to be i8/ui8");
-    if (maxElem != srcElem)
+    }
+    if (maxElem != srcElem) {
       return emitOpError("expects max element type to match src element type");
-    if (scalingElem != srcElem)
+    }
+    if (scalingElem != srcElem) {
       return emitOpError("expects scaling element type to match src element type");
+    }
 
     if (quantType == mlir::pto::QuantType::MXFP8) {
-      if (!dstElem.isInteger(8))
+      if (!dstElem.isInteger(8)) {
         return emitOpError("expects MXFP8 dst element type to be i8/ui8");
+      }
     } else {
-      if (!isa<pto::F4E2M1x2Type>(dstElem))
+      if (!isa<pto::F4E2M1x2Type>(dstElem)) {
         return emitOpError("expects MXFP4_E2M1 dst element type to be !pto.f4E2M1x2");
-      if (!(srcElem.isF16() || srcElem.isBF16()))
+      }
+      if (!(srcElem.isF16() || srcElem.isBF16())) {
         return emitOpError("expects MXFP4_E2M1 src element type to be f16/bf16");
+      }
     }
 
     auto srcValid = getValidShapeVec(srcTy);
@@ -11163,37 +12668,45 @@ mlir::LogicalResult mlir::pto::TDequantOp::verify() {
   auto verifyStructural = [&]() -> LogicalResult {
     Type srcElemTy = getElemTy(getSrc().getType());
     auto srcIntTy = dyn_cast<IntegerType>(srcElemTy);
-    if (!srcIntTy || !(srcIntTy.getWidth() == 8 || srcIntTy.getWidth() == 16))
+    if (!srcIntTy || !(srcIntTy.getWidth() == 8 || srcIntTy.getWidth() == 16)) {
       return emitOpError()
              << "expects src element type i8 or i16";
-    if (!getElemTy(getDst().getType()).isF32())
+    }
+    if (!getElemTy(getDst().getType()).isF32()) {
       return emitOpError() << "expects dst element type f32";
-    if (!getElemTy(getScale().getType()).isF32())
+    }
+    if (!getElemTy(getScale().getType()).isF32()) {
       return emitOpError() << "expects scale element type f32";
-    if (!getElemTy(getOffset().getType()).isF32())
+    }
+    if (!getElemTy(getOffset().getType()).isF32()) {
       return emitOpError() << "expects offset element type f32";
+    }
     return success();
   };
 
-  if (failed(verifyStructural()))
+  if (failed(verifyStructural())) {
     return failure();
+  }
 
   auto verifyCommon = [&]() -> LogicalResult {
     if (failed(verifyTileBufCommon(*this, getSrc().getType(), "src")) ||
         failed(verifyTileBufCommon(*this, getScale().getType(), "scale")) ||
         failed(verifyTileBufCommon(*this, getOffset().getType(), "offset")) ||
-        failed(verifyTileBufCommon(*this, getDst().getType(), "dst")))
+        failed(verifyTileBufCommon(*this, getDst().getType(), "dst"))) {
       return failure();
+    }
     return success();
   };
 
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (failed(verifyCommon()))
+    if (failed(verifyCommon())) {
       return failure();
+    }
     if (!isRowMajorTileBuf(getSrc().getType()) ||
-        !isRowMajorTileBuf(getDst().getType()))
+        !isRowMajorTileBuf(getDst().getType())) {
       return emitOpError()
              << "expects A2/A3 src and dst to use row-major layout";
+    }
     return success();
   };
 
@@ -11206,16 +12719,20 @@ mlir::LogicalResult mlir::pto::TRecipOp::verify() {
   Type ts = getSrc().getType();
   Type td = getDst().getType();
   if (failed(verifyVecTileUnaryOp(*this, ts, td, "src", "dst",
-                                  /*allowBf16=*/false, /*allowInt8=*/false)))
+                                  /*allowBf16=*/false, /*allowInt8=*/false))) {
     return failure();
-  if (failed(verifyTileBufSameValidShape(*this, ts, td, "src", "dst")))
+  }
+  if (failed(verifyTileBufSameValidShape(*this, ts, td, "src", "dst"))) {
     return failure();
+  }
   Type elemTy = getElemTy(ts);
-  if (!(elemTy.isF16() || elemTy.isF32()))
+  if (!(elemTy.isF16() || elemTy.isF32())) {
     return emitOpError() << "expects element type to be f16 or f32";
+  }
   if (auto arch = getVerifierArchName(getOperation());
-      arch && arch->equals_insensitive("a3") && getSrc() == getDst())
+      arch && arch->equals_insensitive("a3") && getSrc() == getDst()) {
     return emitOpError("expects A3 trecip src and dst to use different storage");
+  }
   return mlir::success();
 }
 
@@ -11224,14 +12741,17 @@ mlir::LogicalResult mlir::pto::TReluOp::verify() {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyVecTileCommon(*this, srcTy, "src")) ||
-        failed(verifyVecTileCommon(*this, dstTy, "dst")))
+        failed(verifyVecTileCommon(*this, dstTy, "dst"))) {
       return failure();
+    }
     if (failed(verifyTileBufSameElemType(*this, srcTy, dstTy, "src", "dst")) ||
-        failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+        failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
       return failure();
+    }
     Type elemTy = getElemTy(srcTy);
-    if (!(elemTy.isInteger(32) || elemTy.isF16() || elemTy.isF32()))
+    if (!(elemTy.isInteger(32) || elemTy.isF16() || elemTy.isF32())) {
       return emitOpError() << errorMessage;
+    }
     return success();
   };
   auto verifyA2A3 = [&]() -> LogicalResult {
@@ -11250,70 +12770,85 @@ mlir::LogicalResult mlir::pto::TRemOp::verify() {
   Type dstTy = getDst().getType();
   if (failed(verifyTileBufCommon(*this, src0Ty, "src0")) ||
       failed(verifyTileBufCommon(*this, src1Ty, "src1")) ||
-      failed(verifyTileBufCommon(*this, dstTy, "dst")))
+      failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
     return failure();
+  }
   if (failed(verifyTileBufSameElemType(*this, src0Ty, src1Ty, "src0", "src1")) ||
       failed(verifyTileBufSameElemType(*this, src0Ty, dstTy, "src0", "dst")) ||
       failed(verifyTileBufSameValidShape(*this, src0Ty, src1Ty, "src0", "src1")) ||
-      failed(verifyTileBufSameValidShape(*this, src0Ty, dstTy, "src0", "dst")))
+      failed(verifyTileBufSameValidShape(*this, src0Ty, dstTy, "src0", "dst"))) {
     return failure();
+  }
   if (!isRowMajorTileBuf(src0Ty) || !isRowMajorTileBuf(src1Ty) ||
-      !isRowMajorTileBuf(dstTy))
+      !isRowMajorTileBuf(dstTy)) {
     return emitOpError("expects src0, src1, and dst to use row-major layout");
+  }
   auto dstValid = getValidShapeVec(dstTy);
 
   Type elem = getElemTy(src0Ty);
   if (!getTmp()) {
     auto verifyA2A3NoTmp = [&]() -> LogicalResult {
-      if (!(elem.isInteger(32) || elem.isF32()))
+      if (!(elem.isInteger(32) || elem.isF32())) {
         return emitOpError("expects A2/A3 trem element type to be i32/f32");
+      }
       return success();
     };
     auto verifyA5NoTmp = [&]() -> LogicalResult {
       if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() ||
-            elem.isF32()))
+            elem.isF32())) {
         return emitOpError(
             "expects A5 trem element type to be i32/i16/f16/f32");
+      }
       return success();
     };
     return dispatchVerifierByArch(getOperation(), verifyA2A3NoTmp,
                                   verifyA5NoTmp);
   }
   Type tmpTy = getTmp().getType();
-  if (failed(verifyTileBufCommon(*this, tmpTy, "tmp")))
+  if (failed(verifyTileBufCommon(*this, tmpTy, "tmp"))) {
     return failure();
+  }
   auto tmpValid = getValidShapeVec(tmpTy);
-  if (dstValid.size() != 2 || tmpValid.size() != 2)
+  if (dstValid.size() != 2 || tmpValid.size() != 2) {
     return emitOpError("expects tmp and dst to be rank-2 tiles");
+  }
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (failed(verifyVecTileCommon(*this, tmpTy, "tmp")))
+    if (failed(verifyVecTileCommon(*this, tmpTy, "tmp"))) {
       return failure();
-    if (getElemTy(tmpTy) != getElemTy(dstTy))
+    }
+    if (getElemTy(tmpTy) != getElemTy(dstTy)) {
       return emitOpError("expects tmp and dst to have the same element type");
-    if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 2)
+    }
+    if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 2) {
       return emitOpError("expects A2/A3 tmp valid_shape[0] to be at least 2");
+    }
     if (dstValid[1] != ShapedType::kDynamic && tmpValid[1] != ShapedType::kDynamic &&
-        tmpValid[1] < dstValid[1])
+        tmpValid[1] < dstValid[1]) {
       return emitOpError("expects A2/A3 tmp valid columns to cover dst valid columns");
+    }
     auto dstShape = getShapeVec(dstTy);
     auto elemBytes = getElemByteSize(elem);
     if (dstShape.size() != 2 || dstShape[1] == ShapedType::kDynamic ||
-        elemBytes == 0)
+        elemBytes == 0) {
       return emitOpError(
           "expects A2/A3 trem dst shape and element size to be static when tmp is provided");
+    }
     if (failed(verifyTmpCapacityAtLeast(
-            *this, tmpTy, static_cast<uint64_t>(2) *
-                              static_cast<uint64_t>(dstShape[1]) * elemBytes)))
+            *this, tmpTy, static_cast<uint64_t>(2) * static_cast<uint64_t>(dstShape[1]) * elemBytes))) {
       return failure();
-    if (!(elem.isInteger(32) || elem.isF32()))
+    }
+    if (!(elem.isInteger(32) || elem.isF32())) {
       return emitOpError("expects A2/A3 trem element type to be i32/f32");
+    }
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
-    if (failed(verifyVecTileCommon(*this, tmpTy, "tmp")))
+    if (failed(verifyVecTileCommon(*this, tmpTy, "tmp"))) {
       return failure();
-    if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32()))
+    }
+    if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32())) {
       return emitOpError("expects A5 trem element type to be i32/i16/f16/f32");
+    }
     return success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -11332,67 +12867,84 @@ mlir::LogicalResult mlir::pto::TRemSOp::verify() {
   Type td = getDst().getType();
   Type scalarTy = getScalar().getType();
   if (failed(verifyTileBufCommon(*this, ts, "src")) ||
-      failed(verifyTileBufCommon(*this, td, "dst")))
+      failed(verifyTileBufCommon(*this, td, "dst"))) {
     return failure();
+  }
   if (failed(verifyTileBufSameElemType(*this, ts, td, "src", "dst")) ||
-      failed(verifyTileBufSameValidShape(*this, ts, td, "src", "dst")))
+      failed(verifyTileBufSameValidShape(*this, ts, td, "src", "dst"))) {
     return failure();
-  if (!isRowMajorTileBuf(ts) || !isRowMajorTileBuf(td))
+  }
+  if (!isRowMajorTileBuf(ts) || !isRowMajorTileBuf(td)) {
     return emitOpError("expects src and dst to use row-major layout");
+  }
   Type elem = getElemTy(ts);
-  if (scalarTy != elem)
+  if (scalarTy != elem) {
     return emitOpError("expects scalar type to match the tile element type");
+  }
   auto dstValid = getValidShapeVec(td);
   if (!getTmp()) {
     auto verifyA2A3NoTmp = [&]() -> LogicalResult {
-      if (!(elem.isInteger(32) || elem.isF32()))
+      if (!(elem.isInteger(32) || elem.isF32())) {
         return emitOpError("expects A2/A3 trems element type to be i32/f32");
+      }
       return success();
     };
     auto verifyA5NoTmp = [&]() -> LogicalResult {
       if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() ||
-            elem.isF32()))
+            elem.isF32())) {
         return emitOpError(
             "expects A5 trems element type to be i32/i16/f16/f32");
+      }
       return success();
     };
     return dispatchVerifierByArch(getOperation(), verifyA2A3NoTmp,
                                   verifyA5NoTmp);
   }
   Type tt = getTmp().getType();
-  if (failed(verifyTileBufCommon(*this, tt, "tmp")))
+  if (failed(verifyTileBufCommon(*this, tt, "tmp"))) {
     return failure();
+  }
   auto tmpValid = getValidShapeVec(tt);
-  if (dstValid.size() != 2 || tmpValid.size() != 2)
+  if (dstValid.size() != 2 || tmpValid.size() != 2) {
     return emitOpError("expects tmp and dst to be rank-2 tiles");
+  }
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (failed(verifyVecTileCommon(*this, tt, "tmp")))
+    if (failed(verifyVecTileCommon(*this, tt, "tmp"))) {
       return failure();
-    if (getElemTy(tt) != getElemTy(td))
+    }
+    if (getElemTy(tt) != getElemTy(td)) {
       return emitOpError("expects tmp and dst to have the same element type");
-    if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 1)
+    }
+    if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 1) {
       return emitOpError("expects A2/A3 tmp valid_shape[0] to be at least 1");
+    }
     if (dstValid[1] != ShapedType::kDynamic && tmpValid[1] != ShapedType::kDynamic &&
-        tmpValid[1] < dstValid[1])
+        tmpValid[1] < dstValid[1]) {
       return emitOpError("expects A2/A3 tmp valid columns to cover dst valid columns");
+    }
     auto dstShape = getShapeVec(td);
     auto elemBytes = getElemByteSize(elem);
     if (dstShape.size() != 2 || dstShape[1] == ShapedType::kDynamic ||
-        elemBytes == 0)
+        elemBytes == 0) {
       return emitOpError(
           "expects A2/A3 trems dst shape and element size to be static when tmp is provided");
+    }
     if (failed(verifyTmpCapacityAtLeast(
-            *this, tt, static_cast<uint64_t>(dstShape[1]) * elemBytes)))
+            *this, tt, static_cast<uint64_t>(dstShape[1]) * elemBytes))) {
       return failure();
-    if (!(elem.isInteger(32) || elem.isF32()))
+    }
+    if (!(elem.isInteger(32) || elem.isF32())) {
       return emitOpError("expects A2/A3 trems element type to be i32/f32");
+    }
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
-    if (failed(verifyVecTileCommon(*this, tt, "tmp")))
+    if (failed(verifyVecTileCommon(*this, tt, "tmp"))) {
       return failure();
-    if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32()))
+    }
+    if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32())) {
       return emitOpError("expects A5 trems element type to be i32/i16/f16/f32");
+    }
     return success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -11403,36 +12955,44 @@ mlir::LogicalResult mlir::pto::TFModSOp::verify() {
   Type dstTy = getDst().getType();
   Type scalarTy = getScalar().getType();
   if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
-      failed(verifyTileBufCommon(*this, dstTy, "dst")))
+      failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
     return failure();
+  }
   if (failed(verifyTileBufSameElemType(*this, srcTy, dstTy, "src", "dst")) ||
-      failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+      failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
     return failure();
-  if (!isRowMajorTileBuf(srcTy) || !isRowMajorTileBuf(dstTy))
+  }
+  if (!isRowMajorTileBuf(srcTy) || !isRowMajorTileBuf(dstTy)) {
     return emitOpError("expects src and dst to use row-major layout");
+  }
 
   Type elem = getElemTy(srcTy);
-  if (scalarTy != elem)
+  if (scalarTy != elem) {
     return emitOpError("expects scalar type to match the tile element type");
+  }
 
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32()))
+    if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32())) {
       return emitOpError("expects A2/A3 tfmods element type to be i32/i16/f16/f32");
+    }
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
-    if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32()))
+    if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32())) {
       return emitOpError("expects A5 tfmods element type to be i32/i16/f16/f32");
+    }
     return success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 
 static LogicalResult verifyTPowTmpShape(Operation *op, Type tmpTy, Type dstTy) {
-  if (failed(verifyTileBufSameElemType(op, tmpTy, dstTy, "tmp", "dst")))
+  if (failed(verifyTileBufSameElemType(op, tmpTy, dstTy, "tmp", "dst"))) {
     return failure();
-  if (!isRowMajorTileBuf(tmpTy))
+  }
+  if (!isRowMajorTileBuf(tmpTy)) {
     return op->emitOpError("expects tmp to use row-major layout");
+  }
   return verifyTileBufSameValidShape(op, tmpTy, dstTy, "tmp", "dst");
 }
 
@@ -11442,61 +13002,74 @@ mlir::LogicalResult mlir::pto::TPowOp::verify() {
   Type dstTy = getDst().getType();
   if (failed(verifyTileBufCommon(*this, baseTy, "base")) ||
       failed(verifyTileBufCommon(*this, expTy, "exp")) ||
-      failed(verifyTileBufCommon(*this, dstTy, "dst")))
+      failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
     return failure();
+  }
   if (failed(verifyTileBufSameElemType(*this, baseTy, expTy, "base", "exp")) ||
       failed(verifyTileBufSameElemType(*this, baseTy, dstTy, "base", "dst")) ||
       failed(verifyTileBufSameValidShape(*this, baseTy, expTy, "base", "exp")) ||
-      failed(verifyTileBufSameValidShape(*this, baseTy, dstTy, "base", "dst")))
+      failed(verifyTileBufSameValidShape(*this, baseTy, dstTy, "base", "dst"))) {
     return failure();
+  }
   if (!isRowMajorTileBuf(baseTy) || !isRowMajorTileBuf(expTy) ||
-      !isRowMajorTileBuf(dstTy))
+      !isRowMajorTileBuf(dstTy)) {
     return emitOpError("expects base, exp, and dst to use row-major layout");
+  }
 
   Type elem = getElemTy(baseTy);
   bool isIntElem = elem.isInteger(32) || elem.isInteger(16) || elem.isInteger(8);
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (getPrecisionType() == pto::PowPrecision::HighPrecision)
+    if (getPrecisionType() == pto::PowPrecision::HighPrecision) {
       return emitOpError(
           "A2/A3 does not support precisionType=high_precision");
-    if (!(isIntElem || elem.isF32()))
+    }
+    if (!(isIntElem || elem.isF32())) {
       return emitOpError(
           "expects A2/A3 tpow element type to be i8/i16/i32 or f32");
+    }
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
     if (getPrecisionType() == pto::PowPrecision::HighPrecision) {
-      if (!(elem.isF16() || elem.isF32() || elem.isBF16()))
+      if (!(elem.isF16() || elem.isF32() || elem.isBF16())) {
         return emitOpError("expects A5 tpow element type to be f16/f32/bf16 "
                            "when precisionType=high_precision");
+      }
     } else {
-      if (!(isIntElem || elem.isF16() || elem.isF32()))
+      if (!(isIntElem || elem.isF16() || elem.isF32())) {
         return emitOpError(
             "expects A5 tpow element type to be i8/i16/i32/f16/f32 "
             "when precisionType=default");
+      }
     }
     return success();
   };
-  if (failed(dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5)))
+  if (failed(dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5))) {
     return failure();
+  }
 
-  if (isIntElem && getTmp())
+  if (isIntElem && getTmp()) {
     return emitOpError(
         "does not accept tmp when element type is integer (the integer pow "
         "lowering uses the 3-operand form TPOW(dst, base, exp))");
+  }
   if (auto tmp = getTmp()) {
     Type tmpTy = tmp.getType();
-    if (failed(verifyTileBufCommon(*this, tmpTy, "tmp")))
+    if (failed(verifyTileBufCommon(*this, tmpTy, "tmp"))) {
       return failure();
-    if (failed(verifyTPowTmpShape(getOperation(), tmpTy, dstTy)))
+    }
+    if (failed(verifyTPowTmpShape(getOperation(), tmpTy, dstTy))) {
       return failure();
+    }
     if (getTargetArch(getOperation()) != PTOArch::A5) {
       auto requiredBytes = getStaticByteSize(dstTy);
-      if (!requiredBytes)
+      if (!requiredBytes) {
         return emitOpError(
             "expects A2/A3 tpow dst shape to be static when tmp is provided");
-      if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, *requiredBytes)))
+      }
+      if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, *requiredBytes))) {
         return failure();
+      }
     }
   }
   return success();
@@ -11507,61 +13080,75 @@ mlir::LogicalResult mlir::pto::TPowSOp::verify() {
   Type dstTy = getDst().getType();
   Type scalarTy = getScalar().getType();
   if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
-      failed(verifyTileBufCommon(*this, dstTy, "dst")))
+      failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
     return failure();
+  }
   if (failed(verifyTileBufSameElemType(*this, srcTy, dstTy, "src", "dst")) ||
-      failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+      failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
     return failure();
-  if (!isRowMajorTileBuf(srcTy) || !isRowMajorTileBuf(dstTy))
+  }
+  if (!isRowMajorTileBuf(srcTy) || !isRowMajorTileBuf(dstTy)) {
     return emitOpError("expects src and dst to use row-major layout");
+  }
   Type elem = getElemTy(srcTy);
-  if (scalarTy != elem)
+  if (scalarTy != elem) {
     return emitOpError("expects scalar type to match the tile element type");
+  }
 
   // Same dtype matrix as TPowOp; see comment in TPowOp::verify.
   bool isIntElem = elem.isInteger(32) || elem.isInteger(16) || elem.isInteger(8);
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (getPrecisionType() == pto::PowPrecision::HighPrecision)
+    if (getPrecisionType() == pto::PowPrecision::HighPrecision) {
       return emitOpError(
           "A2/A3 does not support precisionType=high_precision");
-    if (!(isIntElem || elem.isF32()))
+    }
+    if (!(isIntElem || elem.isF32())) {
       return emitOpError(
           "expects A2/A3 tpows element type to be i8/i16/i32 or f32");
+    }
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
     if (getPrecisionType() == pto::PowPrecision::HighPrecision) {
-      if (!(elem.isF16() || elem.isF32() || elem.isBF16()))
+      if (!(elem.isF16() || elem.isF32() || elem.isBF16())) {
         return emitOpError("expects A5 tpows element type to be f16/f32/bf16 "
                            "when precisionType=high_precision");
+      }
     } else {
-      if (!(isIntElem || elem.isF16() || elem.isF32()))
+      if (!(isIntElem || elem.isF16() || elem.isF32())) {
         return emitOpError(
             "expects A5 tpows element type to be i8/i16/i32/f16/f32 "
             "when precisionType=default");
+      }
     }
     return success();
   };
-  if (failed(dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5)))
+  if (failed(dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5))) {
     return failure();
+  }
 
-  if (isIntElem && getTmp())
+  if (isIntElem && getTmp()) {
     return emitOpError(
         "does not accept tmp when element type is integer (the integer pows "
         "lowering uses the 3-operand form TPOWS(dst, src, scalar))");
+  }
   if (auto tmp = getTmp()) {
     Type tmpTy = tmp.getType();
-    if (failed(verifyTileBufCommon(*this, tmpTy, "tmp")))
+    if (failed(verifyTileBufCommon(*this, tmpTy, "tmp"))) {
       return failure();
-    if (failed(verifyTPowTmpShape(getOperation(), tmpTy, dstTy)))
+    }
+    if (failed(verifyTPowTmpShape(getOperation(), tmpTy, dstTy))) {
       return failure();
+    }
     if (getTargetArch(getOperation()) != PTOArch::A5) {
       auto requiredBytes = getStaticByteSize(dstTy);
-      if (!requiredBytes)
+      if (!requiredBytes) {
         return emitOpError(
             "expects A2/A3 tpows dst shape to be static when tmp is provided");
-      if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, *requiredBytes)))
+      }
+      if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, *requiredBytes))) {
         return failure();
+      }
     }
   }
   return success();
@@ -11571,120 +13158,149 @@ mlir::LogicalResult mlir::pto::TPowSOp::verify() {
 static std::optional<int64_t> getStaticNumElements(ArrayRef<int64_t> shape) {
   int64_t numel = 1;
   for (int64_t d : shape) {
-    if (d == ShapedType::kDynamic)
+    if (d == ShapedType::kDynamic) {
       return std::nullopt;
-    if (d < 0)
+    }
+    if (d < 0) {
       return std::nullopt;
+    }
     numel *= d;
   }
   return numel;
 }
 
 static std::optional<int64_t> getElemBytes(Type elemTy) {
-  if (!elemTy)
+  if (!elemTy) {
     return std::nullopt;
+  }
   if (auto ft = dyn_cast<FloatType>(elemTy)) {
-    if (ft.isF16() || ft.isBF16())
+    if (ft.isF16() || ft.isBF16()) {
       return 2;
-    if (ft.isF32())
+    }
+    if (ft.isF32()) {
       return 4;
-    if (ft.isF64())
+    }
+    if (ft.isF64()) {
       return 8;
+    }
     return std::nullopt;
   }
   if (auto it = dyn_cast<IntegerType>(elemTy)) {
     int64_t bits = it.getWidth();
-    if (bits <= 0)
+    if (bits <= 0) {
       return std::nullopt;
+    }
     return std::max<int64_t>(1, bits / 8);
   }
   return std::nullopt;
 }
 
 static bool isLocallyBoundTileSource(Value value) {
-  if (!value || isa<BlockArgument>(value))
+  if (!value || isa<BlockArgument>(value)) {
     return false;
+  }
 
-  if (isa<AllocTileOp, DeclareTileOp>(value.getDefiningOp()))
+  if (isa<AllocTileOp, DeclareTileOp>(value.getDefiningOp())) {
     return true;
+  }
 
-  if (auto bitcast = value.getDefiningOp<BitcastOp>())
+  if (auto bitcast = value.getDefiningOp<BitcastOp>()) {
     return isLocallyBoundTileSource(bitcast.getSrc());
-  if (auto reshape = value.getDefiningOp<TReshapeOp>())
+  }
+  if (auto reshape = value.getDefiningOp<TReshapeOp>()) {
     return isLocallyBoundTileSource(reshape.getSrc());
+  }
 
   return false;
 }
 
 static std::optional<int64_t> getConstIndexLike(Value v) {
-  if (auto cOp = v.getDefiningOp<arith::ConstantIndexOp>())
+  if (auto cOp = v.getDefiningOp<arith::ConstantIndexOp>()) {
     return cOp.value();
-  if (auto cInt = v.getDefiningOp<arith::ConstantIntOp>())
-    return cInt.value();
-  if (auto cOp = v.getDefiningOp<arith::ConstantOp>()) {
-    if (auto ia = dyn_cast<IntegerAttr>(cOp.getValue()))
-      return ia.getInt();
   }
-  if (auto castOp = v.getDefiningOp<arith::IndexCastOp>())
+  if (auto cInt = v.getDefiningOp<arith::ConstantIntOp>()) {
+    return cInt.value();
+  }
+  if (auto cOp = v.getDefiningOp<arith::ConstantOp>()) {
+    if (auto ia = dyn_cast<IntegerAttr>(cOp.getValue())) {
+      return ia.getInt();
+    }
+  }
+  if (auto castOp = v.getDefiningOp<arith::IndexCastOp>()) {
     return getConstIndexLike(castOp.getIn());
-  if (auto extOp = v.getDefiningOp<arith::ExtSIOp>())
+  }
+  if (auto extOp = v.getDefiningOp<arith::ExtSIOp>()) {
     return getConstIndexLike(extOp.getIn());
-  if (auto extOp = v.getDefiningOp<arith::ExtUIOp>())
+  }
+  if (auto extOp = v.getDefiningOp<arith::ExtUIOp>()) {
     return getConstIndexLike(extOp.getIn());
-  if (auto truncOp = v.getDefiningOp<arith::TruncIOp>())
+  }
+  if (auto truncOp = v.getDefiningOp<arith::TruncIOp>()) {
     return getConstIndexLike(truncOp.getIn());
+  }
   return std::nullopt;
 }
 
 mlir::LogicalResult mlir::pto::SetValidShapeOp::verify() {
   SmallVector<int64_t> shape;
   auto srcTy = getSource().getType();
-  if (srcTy.getRank() != 2)
+  if (srcTy.getRank() != 2) {
     return emitOpError("expects rank-2 tile_buf source");
+  }
 
   ArrayRef<int64_t> validShape = srcTy.getValidShape();
-  if (validShape.size() != 2)
+  if (validShape.size() != 2) {
     return emitOpError("expects source validShape to be rank-2");
-  if (!srcTy.hasDynamicValid())
+  }
+  if (!srcTy.hasDynamicValid()) {
     return emitOpError("expects source tile_buf to have dynamic validShape (?, ?)");
+  }
 
   shape.assign(srcTy.getShape().begin(), srcTy.getShape().end());
 
-  if (!isLocallyBoundTileSource(getSource()))
+  if (!isLocallyBoundTileSource(getSource())) {
     return emitOpError(
         "requires a locally bound tile source; function arguments/results "
         "are unsupported");
+  }
 
   auto checkDim = [&](Value operand, unsigned dimIdx,
                       StringRef dimName) -> LogicalResult {
     int64_t maxStatic = shape[dimIdx];
 
     auto constVal = getConstIndexLike(operand);
-    if (!constVal)
+    if (!constVal) {
       return success();
+    }
 
-    if (*constVal < 0)
+    if (*constVal < 0) {
       return emitOpError() << "expects " << dimName << " operand to be non-negative";
-    if (maxStatic != ShapedType::kDynamic && *constVal > maxStatic)
+    }
+    if (maxStatic != ShapedType::kDynamic && *constVal > maxStatic) {
       return emitOpError() << "expects " << dimName << " operand <= shape dim ("
                            << maxStatic << ")";
+    }
     return success();
   };
 
-  if (failed(checkDim(getValidRow(), /*dimIdx=*/0, "row")))
+  if (failed(checkDim(getValidRow(), /*dimIdx=*/0, "row"))) {
     return failure();
-  if (failed(checkDim(getValidCol(), /*dimIdx=*/1, "col")))
+  }
+  if (failed(checkDim(getValidCol(), /*dimIdx=*/1, "col"))) {
     return failure();
+  }
 
   return success();
 }
 
 mlir::LogicalResult mlir::pto::GetValidShapeOp::verify() {
   auto srcTy = getSource().getType();
-  if (srcTy.getRank() != 2)
+  if (srcTy.getRank() != 2) {
     return emitOpError("expects rank-2 tile_buf source");
-  if (srcTy.getValidShape().size() != 2)
+  }
+  if (srcTy.getValidShape().size() != 2) {
     return emitOpError("expects source validShape to be rank-2");
+  }
   return success();
 }
 
@@ -11694,38 +13310,45 @@ mlir::LogicalResult mlir::pto::TReshapeOp::verify() {
   Type tr = getResult().getType();
   auto srcTb = dyn_cast<pto::TileBufType>(ts);
   auto dstTb = dyn_cast<pto::TileBufType>(tr);
-  if (!srcTb || !dstTb)
+  if (!srcTb || !dstTb) {
     return emitOpError("expects src/result to be !pto.tile_buf types");
+  }
 
   if (failed(verifyTileBufCommon(*this, ts, "src")) ||
-      failed(verifyTileBufCommon(*this, tr, "dst")))
+      failed(verifyTileBufCommon(*this, tr, "dst"))) {
     return failure();
+  }
 
-  if (srcTb.getMemorySpace() != dstTb.getMemorySpace())
+  if (srcTb.getMemorySpace() != dstTb.getMemorySpace()) {
     return emitOpError("expects src and dst to use the same loc");
+  }
 
   Type srcElem = srcTb.getElementType();
   Type dstElem = dstTb.getElementType();
   auto srcElemBytes = getElemBytes(srcElem);
   auto dstElemBytes = getElemBytes(dstElem);
-  if (!srcElem || !dstElem || !srcElemBytes.has_value() || !dstElemBytes.has_value())
+  if (!srcElem || !dstElem || !srcElemBytes.has_value() || !dstElemBytes.has_value()) {
     return emitOpError("failed to get element byte width for src/dst");
+  }
 
   auto srcNumel = getStaticNumElements(getShapeVec(ts));
   auto dstNumel = getStaticNumElements(getShapeVec(tr));
-  if (!srcNumel.has_value() || !dstNumel.has_value())
+  if (!srcNumel.has_value() || !dstNumel.has_value()) {
     return emitOpError("expects static shapes for treshape");
+  }
 
   if (srcElemBytes.value() * srcNumel.value() !=
-      dstElemBytes.value() * dstNumel.value())
+      dstElemBytes.value() * dstNumel.value()) {
     return emitOpError("expects src and dst to have the same total byte size");
+  }
 
   bool srcBoxed =
       srcTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox);
   bool dstBoxed =
       dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox);
-  if (srcBoxed != dstBoxed)
+  if (srcBoxed != dstBoxed) {
     return emitOpError("cannot reshape between boxed and non-boxed tile layouts");
+  }
 
   return success();
 }
@@ -11733,41 +13356,50 @@ mlir::LogicalResult mlir::pto::TReshapeOp::verify() {
 mlir::LogicalResult mlir::pto::BitcastOp::verify() {
   auto srcTy = llvm::dyn_cast<TileBufType>(getSrc().getType());
   auto dstTy = llvm::dyn_cast<TileBufType>(getResult().getType());
-  if (!srcTy || !dstTy)
+  if (!srcTy || !dstTy) {
     return emitOpError("expects tile_buf src and tile_buf result");
+  }
 
-  if (srcTy.getMemorySpace() != dstTy.getMemorySpace())
+  if (srcTy.getMemorySpace() != dstTy.getMemorySpace()) {
     return emitOpError("expects src/result to have the same memorySpace");
+  }
 
-  if (srcTy.getElementType() == dstTy.getElementType())
+  if (srcTy.getElementType() == dstTy.getElementType()) {
     return emitOpError(
         "expects src/result to have different element types; use "
         "pto.treshape for shape/config changes");
+  }
 
-  if (srcTy.getShape() != dstTy.getShape())
+  if (srcTy.getShape() != dstTy.getShape()) {
     return emitOpError("expects src/result to have the same shape; use pto.treshape for shape changes");
+  }
 
-  if (srcTy.getValidShape() != dstTy.getValidShape())
+  if (srcTy.getValidShape() != dstTy.getValidShape()) {
     return emitOpError("expects src/result to have the same validShape");
+  }
 
   auto srcCfg = srcTy.getConfigAttr();
   auto dstCfg = dstTy.getConfigAttr();
-  if (srcCfg != dstCfg)
+  if (srcCfg != dstCfg) {
     return emitOpError("expects src/result to have the same tile config");
+  }
 
   auto numel = getStaticNumElements(srcTy.getShape());
-  if (!numel.has_value())
+  if (!numel.has_value()) {
     return emitOpError("expects static shapes for bitcast");
+  }
 
   auto srcBytes = getElemBytes(srcTy.getElementType());
   auto dstBytes = getElemBytes(dstTy.getElementType());
-  if (!srcBytes.has_value() || !dstBytes.has_value())
+  if (!srcBytes.has_value() || !dstBytes.has_value()) {
     return emitOpError("unsupported element type for bitcast");
+  }
 
   int64_t srcTotalBytes = numel.value() * srcBytes.value();
   int64_t dstTotalBytes = numel.value() * dstBytes.value();
-  if (dstTotalBytes > srcTotalBytes)
+  if (dstTotalBytes > srcTotalBytes) {
     return emitOpError("bitcast result requires more bytes than source storage");
+  }
 
   return success();
 }
@@ -11778,40 +13410,52 @@ mlir::LogicalResult mlir::pto::TRowExpandOp::verify() {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
-        failed(verifyNDStyleVecTile(*this, dstTy, "dst")))
+        failed(verifyNDStyleVecTile(*this, dstTy, "dst"))) {
       return failure();
-    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
-    if (!srcSpace || *srcSpace != pto::AddressSpace::VEC)
-      return emitOpError("expects src to be in the vec address space");
-    if (auto srcTb = dyn_cast<pto::TileBufType>(srcTy)) {
-      if (srcTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
-        return emitOpError("expects src to use the none_box slayout");
     }
-    if (getElemTy(srcTy) != getElemTy(dstTy))
+    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
+    if (!srcSpace || *srcSpace != pto::AddressSpace::VEC) {
+      return emitOpError("expects src to be in the vec address space");
+    }
+    if (auto srcTb = dyn_cast<pto::TileBufType>(srcTy)) {
+      if (srcTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox)) {
+        return emitOpError("expects src to use the none_box slayout");
+      }
+    }
+    if (getElemTy(srcTy) != getElemTy(dstTy)) {
       return emitOpError("expects src and dst to have the same element type");
+    }
     if (!isSupportedVecElemType(getElemTy(srcTy), /*allowBf16=*/true,
-                                /*allowInt8=*/true))
+                                /*allowInt8=*/true)) {
       return emitOpError("expects trowexpand element type to be supported");
+    }
     auto srcValid = getValidShapeVec(getSrc());
     auto dstValid = getValidShapeVec(getDst());
-    if (srcValid.size() != 2 || dstValid.size() != 2)
+    if (srcValid.size() != 2 || dstValid.size() != 2) {
       return emitOpError("expects src and dst to have rank-2 valid_shape");
+    }
     // Fully-empty dst valid region (0x0): dual-AIV no-op replay marker. The op
     // writes no elements; accept and skip the non-empty constraints. One-sided
     // empties still fall through. See pto-isa#143 for hardware Rv=0 no-op.
-    if (dstValid[0] == 0 && dstValid[1] == 0)
+    if (dstValid[0] == 0 && dstValid[1] == 0) {
       return success();
+    }
     if (srcValid[0] != ShapedType::kDynamic && dstValid[0] != ShapedType::kDynamic &&
-        srcValid[0] != dstValid[0])
+        srcValid[0] != dstValid[0]) {
       return emitOpError("expects src and dst to have the same valid_shape[0]");
-    if (srcValid[0] != ShapedType::kDynamic && srcValid[0] == 0)
+    }
+    if (srcValid[0] != ShapedType::kDynamic && srcValid[0] == 0) {
       return emitOpError("expects src valid_shape[0] to be non-zero");
-    if (srcValid[1] != ShapedType::kDynamic && srcValid[1] == 0)
+    }
+    if (srcValid[1] != ShapedType::kDynamic && srcValid[1] == 0) {
       return emitOpError("expects src valid_shape[1] to be non-zero");
-    if (dstValid[0] != ShapedType::kDynamic && dstValid[0] == 0)
+    }
+    if (dstValid[0] != ShapedType::kDynamic && dstValid[0] == 0) {
       return emitOpError("expects dst valid_shape[0] to be non-zero");
-    if (dstValid[1] != ShapedType::kDynamic && dstValid[1] == 0)
+    }
+    if (dstValid[1] != ShapedType::kDynamic && dstValid[1] == 0) {
       return emitOpError("expects dst valid_shape[1] to be non-zero");
+    }
     return success();
   };
   auto verifyA2A3 = [&]() -> LogicalResult {
@@ -11829,44 +13473,55 @@ ParseResult mlir::pto::TSort32Op::parse(OpAsmParser &parser, OperationState &res
   Type srcTy, dstTy, idxTy, tmpTy;
   bool hasTmp = false;
 
-  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src))
+  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(idx))
+    if (parser.parseOperand(idx)) {
       return failure();
+    }
     if (succeeded(parser.parseOptionalComma())) {
-      if (parser.parseOperand(tmp))
+      if (parser.parseOperand(tmp)) {
         return failure();
+      }
       hasTmp = true;
     }
   } else {
     return failure();
   }
-  if (parser.parseColonType(srcTy) || parser.parseComma() || parser.parseType(idxTy))
+  if (parser.parseColonType(srcTy) || parser.parseComma() || parser.parseType(idxTy)) {
     return failure();
-  if (hasTmp) {
-    if (parser.parseComma() || parser.parseType(tmpTy))
-      return failure();
   }
-  if (parser.parseRParen())
+  if (hasTmp) {
+    if (parser.parseComma() || parser.parseType(tmpTy)) {
+      return failure();
+    }
+  }
+  if (parser.parseRParen()) {
     return failure();
+  }
 
   if (parser.parseKeyword("outs") || parser.parseLParen() ||
       parser.parseOperand(dst) || parser.parseColonType(dstTy) ||
-      parser.parseRParen())
+      parser.parseRParen()) {
     return failure();
-  if (parser.parseOptionalAttrDict(result.attributes))
+  }
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
   if (parser.resolveOperand(src, srcTy, result.operands) ||
-      parser.resolveOperand(idx, idxTy, result.operands))
+      parser.resolveOperand(idx, idxTy, result.operands)) {
     return failure();
-  if (hasTmp) {
-    if (parser.resolveOperand(tmp, tmpTy, result.operands))
-      return failure();
   }
-  if (parser.resolveOperand(dst, dstTy, result.operands))
+  if (hasTmp) {
+    if (parser.resolveOperand(tmp, tmpTy, result.operands)) {
+      return failure();
+    }
+  }
+  if (parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
+  }
 
   result.addAttribute(
       "operandSegmentSizes",
@@ -11892,45 +13547,56 @@ ParseResult mlir::pto::TRsqrtOp::parse(OpAsmParser &parser, OperationState &resu
   Type srcTy, tmpTy, dstTy;
   bool hasTmp = false;
 
-  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src))
+  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(tmp))
+    if (parser.parseOperand(tmp)) {
       return failure();
+    }
     hasTmp = true;
   }
-  if (parser.parseColonType(srcTy))
+  if (parser.parseColonType(srcTy)) {
     return failure();
-  if (hasTmp) {
-    if (parser.parseComma() || parser.parseType(tmpTy))
-      return failure();
   }
-  if (parser.parseRParen())
+  if (hasTmp) {
+    if (parser.parseComma() || parser.parseType(tmpTy)) {
+      return failure();
+    }
+  }
+  if (parser.parseRParen()) {
     return failure();
+  }
 
   if (parser.parseKeyword("outs") || parser.parseLParen() ||
       parser.parseOperand(dst) || parser.parseColonType(dstTy) ||
-      parser.parseRParen())
+      parser.parseRParen()) {
     return failure();
-  if (parser.parseOptionalAttrDict(result.attributes))
+  }
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
   if (parser.resolveOperand(src, srcTy, result.operands) ||
-      parser.resolveOperand(dst, dstTy, result.operands))
+      parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
-  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands))
+  }
+  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands)) {
     return failure();
+  }
 
   return success();
 }
 
 void mlir::pto::TRsqrtOp::print(OpAsmPrinter &p) {
   p << " ins(" << getSrc();
-  if (getTmp())
+  if (getTmp()) {
     p << ", " << getTmp();
+  }
   p << " : " << getSrc().getType();
-  if (getTmp())
+  if (getTmp()) {
     p << ", " << getTmp().getType();
+  }
   p << ")";
   p << " outs(" << getDst() << " : " << getDst().getType() << ")";
   p.printOptionalAttrDict((*this)->getAttrs());
@@ -11946,48 +13612,60 @@ ParseResult mlir::pto::TPowOp::parse(OpAsmParser &parser, OperationState &result
 
   if (parser.parseKeyword("ins") || parser.parseLParen() ||
       parser.parseOperand(base) || parser.parseComma() ||
-      parser.parseOperand(exp))
+      parser.parseOperand(exp)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(tmp))
+    if (parser.parseOperand(tmp)) {
       return failure();
+    }
     hasTmp = true;
   }
-  if (parser.parseColon())
+  if (parser.parseColon()) {
     return failure();
-  if (parser.parseType(baseTy) || parser.parseComma() || parser.parseType(expTy))
-    return failure();
-  if (hasTmp) {
-    if (parser.parseComma() || parser.parseType(tmpTy))
-      return failure();
   }
-  if (parser.parseRParen())
+  if (parser.parseType(baseTy) || parser.parseComma() || parser.parseType(expTy)) {
     return failure();
+  }
+  if (hasTmp) {
+    if (parser.parseComma() || parser.parseType(tmpTy)) {
+      return failure();
+    }
+  }
+  if (parser.parseRParen()) {
+    return failure();
+  }
 
   if (parser.parseKeyword("outs") || parser.parseLParen() ||
       parser.parseOperand(dst) || parser.parseColonType(dstTy) ||
-      parser.parseRParen())
+      parser.parseRParen()) {
     return failure();
-  if (parser.parseOptionalAttrDict(result.attributes))
+  }
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
   if (parser.resolveOperand(base, baseTy, result.operands) ||
       parser.resolveOperand(exp, expTy, result.operands) ||
-      parser.resolveOperand(dst, dstTy, result.operands))
+      parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
-  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands))
+  }
+  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands)) {
     return failure();
+  }
 
   return success();
 }
 
 void mlir::pto::TPowOp::print(OpAsmPrinter &p) {
   p << " ins(" << getBase() << ", " << getExp();
-  if (getTmp())
+  if (getTmp()) {
     p << ", " << getTmp();
+  }
   p << " : " << getBase().getType() << ", " << getExp().getType();
-  if (getTmp())
+  if (getTmp()) {
     p << ", " << getTmp().getType();
+  }
   p << ")";
   p << " outs(" << getDst() << " : " << getDst().getType() << ")";
   p.printOptionalAttrDict((*this)->getAttrs(),
@@ -12004,48 +13682,60 @@ ParseResult mlir::pto::TPowSOp::parse(OpAsmParser &parser, OperationState &resul
 
   if (parser.parseKeyword("ins") || parser.parseLParen() ||
       parser.parseOperand(src) || parser.parseComma() ||
-      parser.parseOperand(scalar))
+      parser.parseOperand(scalar)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(tmp))
+    if (parser.parseOperand(tmp)) {
       return failure();
+    }
     hasTmp = true;
   }
-  if (parser.parseColon())
+  if (parser.parseColon()) {
     return failure();
-  if (parser.parseType(srcTy) || parser.parseComma() || parser.parseType(scalarTy))
-    return failure();
-  if (hasTmp) {
-    if (parser.parseComma() || parser.parseType(tmpTy))
-      return failure();
   }
-  if (parser.parseRParen())
+  if (parser.parseType(srcTy) || parser.parseComma() || parser.parseType(scalarTy)) {
     return failure();
+  }
+  if (hasTmp) {
+    if (parser.parseComma() || parser.parseType(tmpTy)) {
+      return failure();
+    }
+  }
+  if (parser.parseRParen()) {
+    return failure();
+  }
 
   if (parser.parseKeyword("outs") || parser.parseLParen() ||
       parser.parseOperand(dst) || parser.parseColonType(dstTy) ||
-      parser.parseRParen())
+      parser.parseRParen()) {
     return failure();
-  if (parser.parseOptionalAttrDict(result.attributes))
+  }
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
   if (parser.resolveOperand(src, srcTy, result.operands) ||
       parser.resolveOperand(scalar, scalarTy, result.operands) ||
-      parser.resolveOperand(dst, dstTy, result.operands))
+      parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
-  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands))
+  }
+  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands)) {
     return failure();
+  }
 
   return success();
 }
 
 void mlir::pto::TPowSOp::print(OpAsmPrinter &p) {
   p << " ins(" << getSrc() << ", " << getScalar();
-  if (getTmp())
+  if (getTmp()) {
     p << ", " << getTmp();
+  }
   p << " : " << getSrc().getType() << ", " << getScalar().getType();
-  if (getTmp())
+  if (getTmp()) {
     p << ", " << getTmp().getType();
+  }
   p << ")";
   p << " outs(" << getDst() << " : " << getDst().getType() << ")";
   p.printOptionalAttrDict((*this)->getAttrs(),
@@ -12059,39 +13749,50 @@ static ParseResult parseTRowExpandBinaryLikeOp(OpAsmParser &parser,
   bool hasTmp = false;
 
   if (parser.parseKeyword("ins") || parser.parseLParen() ||
-      parser.parseOperand(src0) || parser.parseComma() || parser.parseOperand(src1))
+      parser.parseOperand(src0) || parser.parseComma() || parser.parseOperand(src1)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(tmp))
+    if (parser.parseOperand(tmp)) {
       return failure();
+    }
     hasTmp = true;
   }
-  if (parser.parseColon())
+  if (parser.parseColon()) {
     return failure();
-  if (parser.parseType(src0Ty) || parser.parseComma() || parser.parseType(src1Ty))
-    return failure();
-  if (hasTmp) {
-    if (parser.parseComma() || parser.parseType(tmpTy))
-      return failure();
   }
-  if (parser.parseRParen())
+  if (parser.parseType(src0Ty) || parser.parseComma() || parser.parseType(src1Ty)) {
     return failure();
+  }
+  if (hasTmp) {
+    if (parser.parseComma() || parser.parseType(tmpTy)) {
+      return failure();
+    }
+  }
+  if (parser.parseRParen()) {
+    return failure();
+  }
   if (parser.parseKeyword("outs") || parser.parseLParen() ||
       parser.parseOperand(dst) || parser.parseColonType(dstTy) ||
-      parser.parseRParen())
+      parser.parseRParen()) {
     return failure();
-  if (parser.parseOptionalAttrDict(result.attributes))
+  }
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
   if (parser.resolveOperand(src0, src0Ty, result.operands) ||
-      parser.resolveOperand(src1, src1Ty, result.operands))
+      parser.resolveOperand(src1, src1Ty, result.operands)) {
     return failure();
-  if (hasTmp) {
-    if (parser.resolveOperand(tmp, tmpTy, result.operands))
-      return failure();
   }
-  if (parser.resolveOperand(dst, dstTy, result.operands))
+  if (hasTmp) {
+    if (parser.resolveOperand(tmp, tmpTy, result.operands)) {
+      return failure();
+    }
+  }
+  if (parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
+  }
 
   result.addAttribute(
       "operandSegmentSizes",
@@ -12185,12 +13886,15 @@ static FailureOr<Type> verifyTRowExpandBinaryCore(Operation *op, Type src0Ty,
                                                   Type tmpTy, bool hasTmp) {
   if (failed(verifyTileBufCommon(op, src0Ty, "src0")) ||
       failed(verifyTileBufCommon(op, src1Ty, "src1")) ||
-      failed(verifyTileBufCommon(op, dstTy, "dst")))
+      failed(verifyTileBufCommon(op, dstTy, "dst"))) {
     return failure();
-  if (hasTmp && failed(verifyTileBufCommon(op, tmpTy, "tmp")))
+  }
+  if (hasTmp && failed(verifyTileBufCommon(op, tmpTy, "tmp"))) {
     return failure();
-  if (failed(verifyTileBufSameElemType(op, src0Ty, dstTy, "src0", "dst")))
+  }
+  if (failed(verifyTileBufSameElemType(op, src0Ty, dstTy, "src0", "dst"))) {
     return failure();
+  }
   if (getElemTy(src0Ty) != getElemTy(src1Ty)) {
     op->emitOpError("expects src0 and src1 to have the same element type");
     return failure();
@@ -12210,11 +13914,13 @@ enum class TRowExpandBinaryMode {
 
 static bool validShapesCompatibleForTRowExpand(ArrayRef<int64_t> lhs,
                                                ArrayRef<int64_t> rhs) {
-  if (lhs.size() != rhs.size())
+  if (lhs.size() != rhs.size()) {
     return false;
+  }
   for (auto [l, r] : llvm::zip(lhs, rhs)) {
-    if (l != ShapedType::kDynamic && r != ShapedType::kDynamic && l != r)
+    if (l != ShapedType::kDynamic && r != ShapedType::kDynamic && l != r) {
       return false;
+    }
   }
   return true;
 }
@@ -12225,8 +13931,9 @@ static TRowExpandBinaryMode classifyTRowExpandBinaryMode(Type src0Ty,
   auto src0Valid = getValidShapeVec(src0Ty);
   auto src1Valid = getValidShapeVec(src1Ty);
   auto dstValid = getValidShapeVec(dstTy);
-  if (src0Valid.size() != 2 || src1Valid.size() != 2 || dstValid.size() != 2)
+  if (src0Valid.size() != 2 || src1Valid.size() != 2 || dstValid.size() != 2) {
     return TRowExpandBinaryMode::Unknown;
+  }
 
   Type expandedTy;
   ArrayRef<int64_t> expandedValid;
@@ -12242,44 +13949,52 @@ static TRowExpandBinaryMode classifyTRowExpandBinaryMode(Type src0Ty,
 
   int64_t expandedCols = expandedValid[1];
   if (isColMajorTileBuf(expandedTy) &&
-      (expandedCols == ShapedType::kDynamic || expandedCols == 1))
+      (expandedCols == ShapedType::kDynamic || expandedCols == 1)) {
     return TRowExpandBinaryMode::Mode1ColMajorScalar;
+  }
 
   std::optional<int64_t> elemBytes = getElemBytes(getElemTy(dstTy));
-  if (!elemBytes || *elemBytes == 0)
+  if (!elemBytes || *elemBytes == 0) {
     return TRowExpandBinaryMode::Unknown;
+  }
   int64_t expectedMode2Cols = 32 / *elemBytes;
   if (isRowMajorTileBuf(expandedTy) &&
       (expandedCols == ShapedType::kDynamic ||
-       expandedCols == expectedMode2Cols))
+       expandedCols == expectedMode2Cols)) {
     return TRowExpandBinaryMode::Mode2RowMajorBlock;
+  }
 
   return TRowExpandBinaryMode::Unknown;
 }
 
 static int64_t getTRowExpandTmpMinBytes(int64_t dstValidRows) {
-  if (dstValidRows == ShapedType::kDynamic)
+  if (dstValidRows == ShapedType::kDynamic) {
     return 8192;
-  if (dstValidRows < 0)
+  }
+  if (dstValidRows < 0) {
     return 8192;
-  if (dstValidRows < 256)
+  }
+  if (dstValidRows < 256) {
     return ceilDivInt64(dstValidRows, 8) * 256;
+  }
   return 30 * 256;
 }
 
 static std::optional<int64_t> getStaticTileCapacityBytes(Type ty) {
   auto numElems = getStaticNumElements(getShapeVec(ty));
   auto elemBytes = getElemBytes(getElemTy(ty));
-  if (!numElems || !elemBytes)
+  if (!numElems || !elemBytes) {
     return std::nullopt;
+  }
   return *numElems * *elemBytes;
 }
 
 static LogicalResult verifyTRowExpandImplicitTmpContract(
     Operation *op, Type src0Ty, Type src1Ty, Type dstTy, Type tmpTy,
     bool hasTmp, PTOArch targetArch) {
-  if (!hasTmp || targetArch == PTOArch::A5)
+  if (!hasTmp || targetArch == PTOArch::A5) {
     return success();
+  }
 
   if (classifyTRowExpandBinaryMode(src0Ty, src1Ty, dstTy) !=
       TRowExpandBinaryMode::Mode1ColMajorScalar) {
@@ -12288,23 +14003,28 @@ static LogicalResult verifyTRowExpandImplicitTmpContract(
         "(ColMajor per-row scalar expanded operand)");
   }
 
-  if (failed(verifyVecTileStorage(op, tmpTy, "tmp")))
+  if (failed(verifyVecTileStorage(op, tmpTy, "tmp"))) {
     return failure();
-  if (getElemTy(tmpTy) != getElemTy(dstTy))
+  }
+  if (getElemTy(tmpTy) != getElemTy(dstTy)) {
     return op->emitOpError("expects tmp and dst to have the same element type");
+  }
 
   auto dstValid = getValidShapeVec(dstTy);
-  if (dstValid.size() != 2)
+  if (dstValid.size() != 2) {
     return op->emitOpError("expects dst to have rank-2 valid_shape");
+  }
   int64_t minBytes = getTRowExpandTmpMinBytes(dstValid[0]);
   std::optional<int64_t> tmpBytes = getStaticTileCapacityBytes(tmpTy);
-  if (!tmpBytes)
+  if (!tmpBytes) {
     return op->emitOpError(
         "expects A2/A3 trowexpand tmp capacity to be statically known");
-  if (*tmpBytes < minBytes)
+  }
+  if (*tmpBytes < minBytes) {
     return op->emitOpError()
            << "expects A2/A3 trowexpand tmp capacity to be at least "
            << minBytes << " bytes, but got " << *tmpBytes << " bytes";
+  }
   return success();
 }
 
@@ -12316,26 +14036,30 @@ mlir::LogicalResult mlir::pto::TRowExpandDivOp::verify() {
     FailureOr<Type> elemOr = verifyTRowExpandBinaryCore(
         *this, src0Ty, src1Ty, dstTy, getTmp() ? getTmp().getType() : Type{},
         static_cast<bool>(getTmp()));
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     Type elem = *elemOr;
     bool supported =
         elem.isF16() || elem.isF32() ||
         (targetArch == PTOArch::A5 &&
          (elem.isInteger(8) || elem.isInteger(16) || elem.isInteger(32)));
     if (!supported) {
-      if (targetArch == PTOArch::A5)
+      if (targetArch == PTOArch::A5) {
         return emitOpError(
             "expects A5 trowexpanddiv element type to be i8/i16/i32/f16/f32");
+      }
       return emitOpError("expects element type to be f16 or f32");
     }
-    if (getPrecisionType() == pto::DivPrecision::HighPrecision && !getTmp())
+    if (getPrecisionType() == pto::DivPrecision::HighPrecision && !getTmp()) {
       return emitOpError("expects tmp when precisionType is high_precision");
+    }
     if (failed(verifyTRowExpandImplicitTmpContract(
             getOperation(), src0Ty, src1Ty, dstTy,
             getTmp() ? getTmp().getType() : Type{}, static_cast<bool>(getTmp()),
-            targetArch)))
+            targetArch))) {
       return failure();
+    }
     return mlir::success();
   };
   auto verifyA2A3 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A3); };
@@ -12352,24 +14076,27 @@ mlir::LogicalResult mlir::pto::TRowExpandMulOp::verify() {
     FailureOr<Type> elemOr = verifyTRowExpandBinaryCore(
         *this, src0Ty, src1Ty, dstTy, getTmp() ? getTmp().getType() : Type{},
         static_cast<bool>(getTmp()));
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     Type elem = *elemOr;
     bool supported = elem.isF16() || elem.isF32() || elem.isInteger(16) ||
                      elem.isInteger(32) ||
                      (targetArch == PTOArch::A5 && elem.isInteger(8));
     if (!supported) {
-      if (targetArch == PTOArch::A5)
+      if (targetArch == PTOArch::A5) {
         return emitOpError(
             "expects A5 trowexpandmul element type to be i8/i16/i32/f16/f32");
+      }
       return emitOpError(
           "expects A2/A3 trowexpandmul element type to be i16/i32/f16/f32");
     }
     if (failed(verifyTRowExpandImplicitTmpContract(
             getOperation(), src0Ty, src1Ty, dstTy,
             getTmp() ? getTmp().getType() : Type{}, static_cast<bool>(getTmp()),
-            targetArch)))
+            targetArch))) {
       return failure();
+    }
     return mlir::success();
   };
   auto verifyA2A3 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A3); };
@@ -12386,24 +14113,27 @@ mlir::LogicalResult mlir::pto::TRowExpandSubOp::verify() {
     FailureOr<Type> elemOr = verifyTRowExpandBinaryCore(
         *this, src0Ty, src1Ty, dstTy, getTmp() ? getTmp().getType() : Type{},
         static_cast<bool>(getTmp()));
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     Type elem = *elemOr;
     bool supported = elem.isF16() || elem.isF32() || elem.isInteger(16) ||
                      elem.isInteger(32) ||
                      (targetArch == PTOArch::A5 && elem.isInteger(8));
     if (!supported) {
-      if (targetArch == PTOArch::A5)
+      if (targetArch == PTOArch::A5) {
         return emitOpError(
             "expects A5 trowexpandsub element type to be i8/i16/i32/f16/f32");
+      }
       return emitOpError(
           "expects A2/A3 trowexpandsub element type to be i16/i32/f16/f32");
     }
     if (failed(verifyTRowExpandImplicitTmpContract(
             getOperation(), src0Ty, src1Ty, dstTy,
             getTmp() ? getTmp().getType() : Type{}, static_cast<bool>(getTmp()),
-            targetArch)))
+            targetArch))) {
       return failure();
+    }
     return mlir::success();
   };
   auto verifyA2A3 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A3); };
@@ -12419,47 +14149,56 @@ mlir::LogicalResult mlir::pto::TRowExpandAddOp::verify() {
     FailureOr<Type> elemOr = verifyTRowExpandBinaryCore(
         *this, src0Ty, src1Ty, dstTy, getTmp() ? getTmp().getType() : Type{},
         static_cast<bool>(getTmp()));
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
-    if (failed(verifyTileBufSameValidShape(*this, src0Ty, dstTy, "src0", "dst")))
+    }
+    if (failed(verifyTileBufSameValidShape(*this, src0Ty, dstTy, "src0", "dst"))) {
       return failure();
-    if (!isRowMajorTileBuf(src0Ty))
+    }
+    if (!isRowMajorTileBuf(src0Ty)) {
       return emitOpError("expects src0 to use row-major layout");
+    }
     Type elem = *elemOr;
     bool supported = elem.isF16() || elem.isF32() || elem.isInteger(16) ||
                      elem.isInteger(32) ||
                      (targetArch == PTOArch::A5 && elem.isInteger(8));
     if (!supported) {
-      if (targetArch == PTOArch::A5)
+      if (targetArch == PTOArch::A5) {
         return emitOpError(
             "expects A5 trowexpandadd element type to be i8/i16/i32/f16/f32");
+      }
       return emitOpError(
           "expects A2/A3 trowexpandadd element type to be i16/i32/f16/f32");
     }
     auto src1Valid = getValidShapeVec(src1Ty);
     auto dstValid = getValidShapeVec(dstTy);
-    if (src1Valid.size() != 2 || dstValid.size() != 2)
+    if (src1Valid.size() != 2 || dstValid.size() != 2) {
       return emitOpError("expects src1 and dst to have rank-2 valid_shape");
+    }
     if (src1Valid[0] != ShapedType::kDynamic && dstValid[0] != ShapedType::kDynamic &&
-        src1Valid[0] != dstValid[0])
+        src1Valid[0] != dstValid[0]) {
       return emitOpError("expects src1 valid_shape[0] to equal dst valid_shape[0]");
+    }
     bool src1IsRowMajor = isRowMajorTileBuf(src1Ty);
     int64_t expectedCol = elem.isInteger(8)
                               ? 32
                               : ((elem.isF16() || elem.isInteger(16)) ? 16 : 8);
     int64_t src1Col = src1Valid[1];
     if (src1IsRowMajor) {
-      if (src1Col != ShapedType::kDynamic && src1Col != expectedCol)
+      if (src1Col != ShapedType::kDynamic && src1Col != expectedCol) {
         return emitOpError("expects row-major src1 valid_shape[1] to be 32/sizeof(dtype)");
+      }
     } else {
-      if (src1Col != ShapedType::kDynamic && src1Col != 1)
+      if (src1Col != ShapedType::kDynamic && src1Col != 1) {
         return emitOpError("expects non-row-major src1 valid_shape[1] to be 1");
+      }
     }
     if (failed(verifyTRowExpandImplicitTmpContract(
             getOperation(), src0Ty, src1Ty, dstTy,
             getTmp() ? getTmp().getType() : Type{}, static_cast<bool>(getTmp()),
-            targetArch)))
+            targetArch))) {
       return failure();
+    }
     return mlir::success();
   };
   auto verifyA2A3 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A3); };
@@ -12476,61 +14215,74 @@ static LogicalResult verifyTRowExpandReduceLikeOp(Operation *op, Type src0Ty,
                                                   bool allowIntegerTypes) {
   if (failed(verifyTileBufCommon(op, src0Ty, "src0")) ||
       failed(verifyTileBufCommon(op, src1Ty, "src1")) ||
-      failed(verifyTileBufCommon(op, dstTy, "dst")))
+      failed(verifyTileBufCommon(op, dstTy, "dst"))) {
     return failure();
+  }
   if (hasTmp) {
-    if (failed(verifyTileBufCommon(op, tmpTy, "tmp")))
+    if (failed(verifyTileBufCommon(op, tmpTy, "tmp"))) {
       return failure();
-    if (getElemTy(tmpTy) != getElemTy(dstTy))
+    }
+    if (getElemTy(tmpTy) != getElemTy(dstTy)) {
       return op->emitOpError() << "expects tmp and dst to have the same element type";
+    }
   }
 
   Type elem = getElemTy(dstTy);
-  if (!elem || getElemTy(src0Ty) != elem || getElemTy(src1Ty) != elem)
+  if (!elem || getElemTy(src0Ty) != elem || getElemTy(src1Ty) != elem) {
     return op->emitOpError("expects src0, src1, and dst to have the same element type");
+  }
   bool supported = elem.isF16() || elem.isF32() ||
                    (allowIntegerTypes &&
                     (elem.isInteger(16) || elem.isInteger(32) ||
                      (targetArch == PTOArch::A5 && elem.isInteger(8))));
   if (!supported) {
-    if (!allowIntegerTypes)
+    if (!allowIntegerTypes) {
       return op->emitOpError() << "expects " << opName
                                << " element type to be f16 or f32";
-    if (targetArch == PTOArch::A5)
+    }
+    if (targetArch == PTOArch::A5) {
       return op->emitOpError() << "expects A5 " << opName
                                << " element type to be i8/i16/i32/f16/f32";
+    }
     return op->emitOpError() << "expects A2/A3 " << opName
                              << " element type to be i16/i32/f16/f32";
   }
 
-  if (!isRowMajorTileBuf(dstTy))
+  if (!isRowMajorTileBuf(dstTy)) {
     return op->emitOpError("expects dst to use row-major layout");
+  }
 
   auto src0Valid = getValidShapeVec(src0Ty);
   auto src1Valid = getValidShapeVec(src1Ty);
   auto dstValid = getValidShapeVec(dstTy);
-  if (src0Valid.size() != 2 || src1Valid.size() != 2 || dstValid.size() != 2)
+  if (src0Valid.size() != 2 || src1Valid.size() != 2 || dstValid.size() != 2) {
     return op->emitOpError("expects src0, src1, and dst to have rank-2 valid_shape");
+  }
 
   // Fully-empty dst valid region (0x0): dual-AIV no-op replay marker. Element
   // type/layout were already checked above; the op writes no elements, so accept
   // and skip the non-empty broadcast/width constraints. One-sided empties still
   // fall through. See pto-isa#143 for hardware Rv=0 no-op.
-  if (dstValid[0] == 0 && dstValid[1] == 0)
+  if (dstValid[0] == 0 && dstValid[1] == 0) {
     return success();
+  }
 
-  if (dstValid[0] != ShapedType::kDynamic && dstValid[0] == 0)
+  if (dstValid[0] != ShapedType::kDynamic && dstValid[0] == 0) {
     return op->emitOpError("expects dst valid_shape[0] to be non-zero");
-  if (dstValid[1] != ShapedType::kDynamic && dstValid[1] == 0)
+  }
+  if (dstValid[1] != ShapedType::kDynamic && dstValid[1] == 0) {
     return op->emitOpError("expects dst valid_shape[1] to be non-zero");
+  }
 
   auto validShapeMatches = [](ArrayRef<int64_t> lhs,
                               ArrayRef<int64_t> rhs) -> bool {
-    if (lhs.size() != rhs.size())
+    if (lhs.size() != rhs.size()) {
       return false;
+    }
     for (auto [l, r] : llvm::zip(lhs, rhs)) {
-      if (l != ShapedType::kDynamic && r != ShapedType::kDynamic && l != r)
+      if (l != ShapedType::kDynamic && r != ShapedType::kDynamic && l != r) {
         return false;
+      }
     }
     return true;
   };
@@ -12572,17 +14324,20 @@ static LogicalResult verifyTRowExpandReduceLikeOp(Operation *op, Type src0Ty,
                                    StringRef fullName, Type broadcastTy,
                                    ArrayRef<int64_t> broadcastValid,
                                    StringRef broadcastName) -> LogicalResult {
-    if (!isRowMajorTileBuf(fullTy))
+    if (!isRowMajorTileBuf(fullTy)) {
       return op->emitOpError() << "expects " << fullName
                                << " to use row-major layout when it matches dst";
+    }
     if (fullValid[0] != ShapedType::kDynamic && dstValid[0] != ShapedType::kDynamic &&
-        fullValid[0] != dstValid[0])
+        fullValid[0] != dstValid[0]) {
       return op->emitOpError() << "expects " << fullName
                                << " valid_shape[0] to equal dst valid_shape[0]";
+    }
     if (fullValid[1] != ShapedType::kDynamic && dstValid[1] != ShapedType::kDynamic &&
-        fullValid[1] != dstValid[1])
+        fullValid[1] != dstValid[1]) {
       return op->emitOpError() << "expects " << fullName
                                << " valid_shape[1] to equal dst valid_shape[1]";
+    }
     return checkBroadcastOperand(broadcastTy, broadcastValid, broadcastName,
                                  /*requireNonRowMajor=*/hasTmp &&
                                      targetArch == PTOArch::A3);
@@ -12591,8 +14346,9 @@ static LogicalResult verifyTRowExpandReduceLikeOp(Operation *op, Type src0Ty,
   // (A5 tmp-form invariant is checked earlier, before the empty-marker accept.)
 
   auto verifyTmpContract = [&]() -> LogicalResult {
-    if (!enforceTmpContract)
+    if (!enforceTmpContract) {
       return success();
+    }
     return verifyTRowExpandImplicitTmpContract(op, src0Ty, src1Ty, dstTy,
                                                tmpTy, hasTmp, targetArch);
   };
@@ -12600,14 +14356,16 @@ static LogicalResult verifyTRowExpandReduceLikeOp(Operation *op, Type src0Ty,
   if (src0MatchesDst) {
     if (succeeded(checkFullAndBroadcast(src0Ty, src0Valid, "src0", src1Ty,
                                         src1Valid, "src1")) &&
-        succeeded(verifyTmpContract()))
+        succeeded(verifyTmpContract())) {
       return success();
+    }
   }
   if (src1MatchesDst) {
     if (succeeded(checkFullAndBroadcast(src1Ty, src1Valid, "src1", src0Ty,
                                         src0Valid, "src0")) &&
-        succeeded(verifyTmpContract()))
+        succeeded(verifyTmpContract())) {
       return success();
+    }
   }
 
   return op->emitOpError() << "expects one of src0/src1 to match dst valid_shape"
@@ -12688,29 +14446,37 @@ static ParseResult parseOptionalTmpRowReductionOp(OpAsmParser &parser,
   bool hasTmp = false;
 
   if (parser.parseKeyword("ins") || parser.parseLParen() ||
-      parser.parseOperand(src))
+      parser.parseOperand(src)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(tmp))
+    if (parser.parseOperand(tmp)) {
       return failure();
+    }
     hasTmp = true;
   }
-  if (parser.parseColonType(srcTy))
+  if (parser.parseColonType(srcTy)) {
     return failure();
-  if (hasTmp && (parser.parseComma() || parser.parseType(tmpTy)))
+  }
+  if (hasTmp && (parser.parseComma() || parser.parseType(tmpTy))) {
     return failure();
+  }
   if (parser.parseRParen() || parser.parseKeyword("outs") ||
       parser.parseLParen() || parser.parseOperand(dst) ||
       parser.parseColonType(dstTy) || parser.parseRParen() ||
-      parser.parseOptionalAttrDict(result.attributes))
+      parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
-  if (parser.resolveOperand(src, srcTy, result.operands))
+  if (parser.resolveOperand(src, srcTy, result.operands)) {
     return failure();
-  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands))
+  }
+  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands)) {
     return failure();
-  if (parser.resolveOperand(dst, dstTy, result.operands))
+  }
+  if (parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
+  }
   result.addAttribute(
       "operandSegmentSizes",
       parser.getBuilder().getDenseI32ArrayAttr({1, hasTmp ? 1 : 0, 1}));
@@ -12720,11 +14486,13 @@ static ParseResult parseOptionalTmpRowReductionOp(OpAsmParser &parser,
 static void printOptionalTmpRowReductionOp(OpAsmPrinter &p, Operation *op,
                                            Value src, Value tmp, Value dst) {
   p << " ins(" << src;
-  if (tmp)
+  if (tmp) {
     p << ", " << tmp;
+  }
   p << " : " << src.getType();
-  if (tmp)
+  if (tmp) {
     p << ", " << tmp.getType();
+  }
   p << ") outs(" << dst << " : " << dst.getType() << ")";
   p.printOptionalAttrDict(op->getAttrs(),
                           /*elidedAttrs=*/{"operandSegmentSizes"});
@@ -12738,22 +14506,27 @@ static ParseResult parseOptionalTmpFixedDpsOp(
   SmallVector<Type> inputTypes;
   OpAsmParser::UnresolvedOperand dst;
   Type dstType;
-  if (parser.parseKeyword("ins") || parser.parseLParen())
+  if (parser.parseKeyword("ins") || parser.parseLParen()) {
     return failure();
+  }
   do {
     inputs.emplace_back();
-    if (parser.parseOperand(inputs.back()))
+    if (parser.parseOperand(inputs.back())) {
       return failure();
+    }
   } while (succeeded(parser.parseOptionalComma()));
   if (inputs.size() < minInputs || inputs.size() > maxInputs ||
-      parser.parseColon())
+      parser.parseColon()) {
     return failure();
+  }
   for (unsigned i = 0; i < inputs.size(); ++i) {
-    if (i && parser.parseComma())
+    if (i && parser.parseComma()) {
       return failure();
+    }
     Type type;
-    if (parser.parseType(type))
+    if (parser.parseType(type)) {
       return failure();
+    }
     inputTypes.push_back(type);
   }
   if (parser.parseRParen() || parser.parseKeyword("outs") ||
@@ -12762,8 +14535,9 @@ static ParseResult parseOptionalTmpFixedDpsOp(
       parser.parseOptionalAttrDict(result.attributes) ||
       parser.resolveOperands(inputs, inputTypes, parser.getCurrentLocation(),
                              result.operands) ||
-      parser.resolveOperand(dst, dstType, result.operands))
+      parser.resolveOperand(dst, dstType, result.operands)) {
     return failure();
+  }
   result.addAttribute(
       "operandSegmentSizes",
       parser.getBuilder().getDenseI32ArrayAttr(
@@ -12790,8 +14564,9 @@ ParseResult mlir::pto::TTransOp::parse(OpAsmParser &parser,
 }
 void mlir::pto::TTransOp::print(OpAsmPrinter &p) {
   SmallVector<Value> inputs{getSrc()};
-  if (getTmp())
+  if (getTmp()) {
     inputs.push_back(getTmp());
+  }
   printOptionalTmpFixedDpsOp(p, getOperation(), inputs, getDst());
 }
 
@@ -12802,8 +14577,9 @@ ParseResult mlir::pto::TPReluOp::parse(OpAsmParser &parser,
 }
 void mlir::pto::TPReluOp::print(OpAsmPrinter &p) {
   SmallVector<Value> inputs{getSrc0(), getSrc1()};
-  if (getTmp())
+  if (getTmp()) {
     inputs.push_back(getTmp());
+  }
   printOptionalTmpFixedDpsOp(p, getOperation(), inputs, getDst());
 }
 
@@ -12814,8 +14590,9 @@ ParseResult mlir::pto::TRemOp::parse(OpAsmParser &parser,
 }
 void mlir::pto::TRemOp::print(OpAsmPrinter &p) {
   SmallVector<Value> inputs{getSrc0(), getSrc1()};
-  if (getTmp())
+  if (getTmp()) {
     inputs.push_back(getTmp());
+  }
   printOptionalTmpFixedDpsOp(p, getOperation(), inputs, getDst());
 }
 
@@ -12826,8 +14603,9 @@ ParseResult mlir::pto::TRemSOp::parse(OpAsmParser &parser,
 }
 void mlir::pto::TRemSOp::print(OpAsmPrinter &p) {
   SmallVector<Value> inputs{getSrc(), getScalar()};
-  if (getTmp())
+  if (getTmp()) {
     inputs.push_back(getTmp());
+  }
   printOptionalTmpFixedDpsOp(p, getOperation(), inputs, getDst());
 }
 
@@ -12838,8 +14616,9 @@ ParseResult mlir::pto::TSelOp::parse(OpAsmParser &parser,
 }
 void mlir::pto::TSelOp::print(OpAsmPrinter &p) {
   SmallVector<Value> inputs{getMask(), getSrc0(), getSrc1()};
-  if (getTmp())
+  if (getTmp()) {
     inputs.push_back(getTmp());
+  }
   printOptionalTmpFixedDpsOp(p, getOperation(), inputs, getDst());
 }
 
@@ -12850,8 +14629,9 @@ ParseResult mlir::pto::TSelSOp::parse(OpAsmParser &parser,
 }
 void mlir::pto::TSelSOp::print(OpAsmPrinter &p) {
   SmallVector<Value> inputs{getMask(), getSrc()};
-  if (getTmp())
+  if (getTmp()) {
     inputs.push_back(getTmp());
+  }
   inputs.push_back(getScalar());
   printOptionalTmpFixedDpsOp(p, getOperation(), inputs, getDst());
 }
@@ -12938,10 +14718,11 @@ void mlir::pto::TRowProdOp::print(OpAsmPrinter &p) {
 
 mlir::LogicalResult mlir::pto::TRowMaxOp::verify() {
   auto verifyByArch = [&]() -> LogicalResult {
-    if (!getTmp())
+    if (!getTmp()) {
       return verifyTRowReductionNoTmpCommon(
           *this, getSrc().getType(), getDst().getType(),
           "expects element type to be i16/i32/f16/f32");
+    }
     return verifyTRowReductionWithTmpCommon(
         *this, getSrc().getType(), getTmp().getType(), getDst().getType(),
         "expects element type to be i16/i32/f16/f32");
@@ -12950,9 +14731,10 @@ mlir::LogicalResult mlir::pto::TRowMaxOp::verify() {
 }
 
 mlir::LogicalResult mlir::pto::TRowArgMaxOp::verify() {
-  if (!getTmp())
+  if (!getTmp()) {
     return verifyTRowArgReductionNoTmp(getOperation(), getSrc().getType(),
                                        getDst().getType());
+  }
   auto verifyA2A3 = [&]() -> LogicalResult {
     return verifyTRowArgReductionOpA2A3(*this, getSrc().getType(),
                                         getTmp().getType(), getDst().getType());
@@ -12968,10 +14750,11 @@ mlir::LogicalResult mlir::pto::TRowArgMaxOp::verify() {
 
 mlir::LogicalResult mlir::pto::TRowMinOp::verify() {
   auto verifyByArch = [&]() -> LogicalResult {
-    if (!getTmp())
+    if (!getTmp()) {
       return verifyTRowReductionNoTmpCommon(
           *this, getSrc().getType(), getDst().getType(),
           "expects element type to be i16/i32/f16/f32");
+    }
     return verifyTRowReductionWithTmpCommon(
         *this, getSrc().getType(), getTmp().getType(), getDst().getType(),
         "expects element type to be i16/i32/f16/f32");
@@ -12980,9 +14763,10 @@ mlir::LogicalResult mlir::pto::TRowMinOp::verify() {
 }
 
 mlir::LogicalResult mlir::pto::TRowArgMinOp::verify() {
-  if (!getTmp())
+  if (!getTmp()) {
     return verifyTRowArgReductionNoTmp(getOperation(), getSrc().getType(),
                                        getDst().getType());
+  }
   auto verifyA2A3 = [&]() -> LogicalResult {
     return verifyTRowArgReductionOpA2A3(*this, getSrc().getType(),
                                         getTmp().getType(), getDst().getType());
@@ -12998,10 +14782,11 @@ mlir::LogicalResult mlir::pto::TRowArgMinOp::verify() {
 
 mlir::LogicalResult mlir::pto::TRowSumOp::verify() {
   auto verifyByArch = [&]() -> LogicalResult {
-    if (!getTmp())
+    if (!getTmp()) {
       return verifyTRowReductionNoTmpCommon(
           *this, getSrc().getType(), getDst().getType(),
           "expects element type to be i16/i32/f16/f32");
+    }
     return verifyTRowReductionWithTmpCommon(
         *this, getSrc().getType(), getTmp().getType(), getDst().getType(),
         "expects element type to be i16/i32/f16/f32");
@@ -13011,19 +14796,21 @@ mlir::LogicalResult mlir::pto::TRowSumOp::verify() {
 
 mlir::LogicalResult mlir::pto::TRowProdOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (!getTmp())
+    if (!getTmp()) {
       return verifyTRowReductionNoTmpCommon(
           *this, getSrc().getType(), getDst().getType(),
           "expects A2/A3 trowprod element type to be i16/i32/f16/f32");
+    }
     return verifyTRowReductionWithTmpCommon(
         *this, getSrc().getType(), getTmp().getType(), getDst().getType(),
         "expects A2/A3 trowprod element type to be i16/i32/f16/f32");
   };
   auto verifyA5 = [&]() -> LogicalResult {
-    if (!getTmp())
+    if (!getTmp()) {
       return verifyTRowReductionNoTmpCommon(
           *this, getSrc().getType(), getDst().getType(),
           "expects A5 trowprod element type to be i16/i32/f16/f32");
+    }
     return verifyTRowReductionWithTmpCommon(
         *this, getSrc().getType(), getTmp().getType(), getDst().getType(),
         "expects A5 trowprod element type to be i16/i32/f16/f32");
@@ -13036,27 +14823,34 @@ mlir::LogicalResult mlir::pto::TRsqrtOp::verify() {
   Type ts = getSrc().getType();
   Type td = getDst().getType();
   if (failed(verifyVecTileUnaryOp(*this, ts, td, "src", "dst",
-                                  /*allowBf16=*/false, /*allowInt8=*/false)))
+                                  /*allowBf16=*/false, /*allowInt8=*/false))) {
     return failure();
-  if (failed(verifyTileBufSameValidShape(*this, ts, td, "src", "dst")))
+  }
+  if (failed(verifyTileBufSameValidShape(*this, ts, td, "src", "dst"))) {
     return failure();
+  }
   auto ft = mlir::dyn_cast<mlir::FloatType>(getElemTy(ts));
-  if (!ft || (!ft.isF16() && !ft.isF32()))
+  if (!ft || (!ft.isF16() && !ft.isF32())) {
     return emitOpError("expects element type to be f16 or f32");
-  if (getPrecisionType() == pto::RsqrtPrecision::HighPrecision && !getTmp())
+  }
+  if (getPrecisionType() == pto::RsqrtPrecision::HighPrecision && !getTmp()) {
     return emitOpError("expects tmp when precisionType is high_precision");
+  }
   if (auto tmp = getTmp()) {
     Type tt = tmp.getType();
-    if (failed(verifyVecTileCommon(*this, tt, "tmp")))
+    if (failed(verifyVecTileCommon(*this, tt, "tmp"))) {
       return failure();
+    }
 
     auto tmpElemTy = getElemTy(tt);
     auto tmpElemBytes = getElemBytes(tmpElemTy);
     auto tmpNumel = getStaticNumElements(getShapeVec(tt));
-    if (!tmpElemBytes.has_value() || !tmpNumel.has_value())
+    if (!tmpElemBytes.has_value() || !tmpNumel.has_value()) {
       return emitOpError("expects tmp to have a static, byte-addressable tile type");
-    if (tmpElemBytes.value() * tmpNumel.value() < 32)
+    }
+    if (tmpElemBytes.value() * tmpNumel.value() < 32) {
       return emitOpError("expects tmp to be at least 32 bytes when provided");
+    }
   }
   return mlir::success();
 }
@@ -13077,13 +14871,15 @@ mlir::LogicalResult mlir::pto::TScatterOp::verify() {
     if (t.isF16() || t.isF32() || t.isBF16()) {
       return true;
     }
-    if (auto it = mlir::dyn_cast<mlir::IntegerType>(t))
+    if (auto it = mlir::dyn_cast<mlir::IntegerType>(t)) {
       return (it.getWidth() == 8 || it.getWidth() == 16 || it.getWidth() == 32);
+    }
     return false;
   };
   auto isAllowedIndexElem = [&](mlir::Type t) -> bool {
-    if (auto it = mlir::dyn_cast<mlir::IntegerType>(t))
+    if (auto it = mlir::dyn_cast<mlir::IntegerType>(t)) {
       return (it.getWidth() == 16 || it.getWidth() == 32);
+    }
     return false;
   };
   auto getMaskScatterTimes = [&](mlir::pto::MaskPatternAttr mp) -> unsigned {
@@ -13104,44 +14900,54 @@ mlir::LogicalResult mlir::pto::TScatterOp::verify() {
     Type td = getDst().getType();
     if (failed(verifyVecTileCommon(*this, ts, "src")) ||
         failed(verifyVecTileCommon(*this, ti, "indexes")) ||
-        failed(verifyVecTileCommon(*this, td, "dst")))
+        failed(verifyVecTileCommon(*this, td, "dst"))) {
       return failure();
+    }
 
     Type srcElem = getElemTy(ts), dstElem = getElemTy(td), idxElem = getElemTy(ti);
-    if (!srcElem || !dstElem || !idxElem)
+    if (!srcElem || !dstElem || !idxElem) {
       return emitOpError("failed to get element type for operands");
-    if (srcElem != dstElem)
+    }
+    if (srcElem != dstElem) {
       return emitOpError("expects src/dst to have the same element type");
+    }
 
-    if (!isAllowedDataElem(srcElem))
+    if (!isAllowedDataElem(srcElem)) {
       return emitOpError("expects src/dst element type to be i8/i16/i32/f16/bf16/f32");
-    if (!isAllowedIndexElem(idxElem))
+    }
+    if (!isAllowedIndexElem(idxElem)) {
       return emitOpError("expects indexes element type to be i16/i32");
+    }
 
     auto bwData = getPTOStorageElemBitWidth(srcElem);
     auto bwIdx  = getPTOStorageElemBitWidth(idxElem);
-    if (bwData != 8 && bwData != 16 && bwData != 32)
+    if (bwData != 8 && bwData != 16 && bwData != 32) {
       return emitOpError("unexpected src/dst element bitwidth");
+    }
 
     unsigned dataBytes = bwData / 8;
     unsigned idxBytes  = bwIdx / 8;
     unsigned expectedIdxBytes = (dataBytes == 1) ? 2 : dataBytes;
-    if (idxBytes != expectedIdxBytes)
+    if (idxBytes != expectedIdxBytes) {
       return emitOpError("expects indexes element size to match the documented scatter rule");
+    }
 
     auto srcValid = getValidShapeVec(ts);
     auto idxValid = getValidShapeVec(ti);
     auto dstValid = getValidShapeVec(td);
-    if (srcValid.size() != 2 || idxValid.size() != 2 || dstValid.size() != 2)
+    if (srcValid.size() != 2 || idxValid.size() != 2 || dstValid.size() != 2) {
       return emitOpError("expects src, indexes and dst to have rank-2 valid_shape");
+    }
 
     for (unsigned d = 0; d < 2; ++d) {
       if (srcValid[d] != ShapedType::kDynamic && idxValid[d] != ShapedType::kDynamic &&
-          srcValid[d] != idxValid[d])
+          srcValid[d] != idxValid[d]) {
         return emitOpError("expects src and indexes to have the same valid_shape");
+      }
       if (srcValid[d] != ShapedType::kDynamic && dstValid[d] != ShapedType::kDynamic &&
-          dstValid[d] < srcValid[d])
+          dstValid[d] < srcValid[d]) {
         return emitOpError("expects dst valid_shape to be >= src valid_shape");
+      }
     }
     return mlir::success();
   };
@@ -13150,64 +14956,78 @@ mlir::LogicalResult mlir::pto::TScatterOp::verify() {
     Type ts = getSrc().getType();
     Type td = getDst().getType();
     if (failed(verifyVecTileCommon(*this, ts, "src")) ||
-        failed(verifyVecTileCommon(*this, td, "dst")))
+        failed(verifyVecTileCommon(*this, td, "dst"))) {
       return failure();
+    }
 
     auto srcTB = dyn_cast<pto::TileBufType>(ts);
     auto dstTB = dyn_cast<pto::TileBufType>(td);
-    if (!srcTB || !dstTB)
+    if (!srcTB || !dstTB) {
       return emitOpError("expects src and dst to be tile_buf types");
+    }
 
-    if (getElemTy(ts) != getElemTy(td))
+    if (getElemTy(ts) != getElemTy(td)) {
       return emitOpError("expects src and dst to have the same element type");
-    if (!isAllowedDataElem(getElemTy(ts)))
+    }
+    if (!isAllowedDataElem(getElemTy(ts))) {
       return emitOpError("expects src/dst element type to be i8/i16/i32/f16/bf16/f32");
+    }
 
     auto srcValid = getValidShapeVec(ts);
     auto dstValid = getValidShapeVec(td);
-    if (srcValid.size() != 2 || dstValid.size() != 2)
+    if (srcValid.size() != 2 || dstValid.size() != 2) {
       return emitOpError("expects src and dst to have rank-2 valid_shape");
+    }
 
     auto axisAttr = getAxisAttr();
-    if (!axisAttr)
+    if (!axisAttr) {
       return emitOpError("expects mask-pattern tscatter to provide axis attribute");
+    }
     StringRef axisVal = axisAttr.getValue();
     auto mp = getMaskPatternAttr();
-    if (!mp)
+    if (!mp) {
       return emitOpError("expects mask-pattern tscatter to provide maskPattern");
+    }
     const unsigned times = getMaskScatterTimes(mp);
     if (axisVal == "row") {
       if (srcValid[0] != ShapedType::kDynamic && dstValid[0] != ShapedType::kDynamic &&
-          dstValid[0] != srcValid[0])
+          dstValid[0] != srcValid[0]) {
         return emitOpError("expects dst valid rows to equal src valid rows for row direction");
+      }
       if (srcValid[1] != ShapedType::kDynamic && dstValid[1] != ShapedType::kDynamic &&
-          dstValid[1] != static_cast<int64_t>(srcValid[1] * times))
+          dstValid[1] != static_cast<int64_t>(srcValid[1] * times)) {
         return emitOpError("expects dst valid cols to equal src valid cols times the mask expansion factor for row direction");
+      }
     } else if (axisVal == "col") {
       if (srcValid[1] != ShapedType::kDynamic && dstValid[1] != ShapedType::kDynamic &&
-          dstValid[1] != srcValid[1])
+          dstValid[1] != srcValid[1]) {
         return emitOpError("expects dst valid cols to equal src valid cols for col direction");
+      }
       if (srcValid[0] != ShapedType::kDynamic && dstValid[0] != ShapedType::kDynamic &&
-          dstValid[0] != static_cast<int64_t>(srcValid[0] * times))
+          dstValid[0] != static_cast<int64_t>(srcValid[0] * times)) {
         return emitOpError("expects dst valid rows to equal src valid rows times the mask expansion factor for col direction");
+      }
     } else {
         return emitOpError("Invalid axis value, expected \"row\" or \"col\"");
     }
 
     if (srcTB.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
-        dstTB.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor))
+        dstTB.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor)) {
       return emitOpError("expects mask-pattern tscatter to use row_major blayout");
+    }
     return mlir::success();
   };
 
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (hasMaskPattern)
+    if (hasMaskPattern) {
       return verifyMaskForm();
+    }
     return verifyIndexedForm();
   };
   auto verifyA5 = [&]() -> LogicalResult {
-    if (hasMaskPattern)
+    if (hasMaskPattern) {
       return verifyMaskForm();
+    }
     return verifyIndexedForm();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -13221,11 +15041,13 @@ mlir::LogicalResult mlir::pto::TSelOp::verify() {
     Type td = getDst().getType();
     if (failed(verifyTileBufCommon(*this, t0, "src0")) ||
         failed(verifyTileBufCommon(*this, t1, "src1")) ||
-        failed(verifyTileBufCommon(*this, td, "dst")))
+        failed(verifyTileBufCommon(*this, td, "dst"))) {
       return failure();
+    }
     if (getTmp() &&
-        failed(verifyVecTileCommon(*this, getTmp().getType(), "tmp")))
+        failed(verifyVecTileCommon(*this, getTmp().getType(), "tmp"))) {
       return failure();
+    }
 
     Type srcElem = getElemTy(t0);
     Type src1Elem = getElemTy(t1);
@@ -13250,40 +15072,49 @@ mlir::LogicalResult mlir::pto::TSelOp::verify() {
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     FailureOr<Type> srcElem = verifyCommon();
-    if (failed(srcElem))
+    if (failed(srcElem)) {
       return failure();
+    }
     Type elem = *srcElem;
     bool ok = elem.isF16() || elem.isBF16() || elem.isF32();
-    if (auto it = dyn_cast<IntegerType>(elem))
+    if (auto it = dyn_cast<IntegerType>(elem)) {
       ok = it.getWidth() == 16 || it.getWidth() == 32;
-    if (!ok)
+    }
+    if (!ok) {
       return emitOpError(
           "expects A2/A3 tsel src0, src1, and dst element type to be i16/i32/f16/bf16/f32");
+    }
     if (getTmp()) {
       Type tmpTy = getTmp().getType();
-      if (getElemByteSize(getElemTy(tmpTy)) != 4)
+      if (getElemByteSize(getElemTy(tmpTy)) != 4) {
         return emitOpError("expects A2/A3 tsel tmp element type to be 4 bytes wide");
+      }
       unsigned elemBits = getPTOStorageElemBitWidth(elem);
-      if (elemBits != 16 && elemBits != 32)
+      if (elemBits != 16 && elemBits != 32) {
         return emitOpError("expects A2/A3 tsel data element type to be 16 or 32 bits");
+      }
       uint64_t minBytes = elemBits == 16 ? 16 : 8;
-      if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, minBytes)))
+      if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, minBytes))) {
         return failure();
+      }
     }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     FailureOr<Type> srcElem = verifyCommon();
-    if (failed(srcElem))
+    if (failed(srcElem)) {
       return failure();
+    }
     Type elem = *srcElem;
     bool ok = elem.isF16() || elem.isBF16() || elem.isF32();
-    if (auto it = dyn_cast<IntegerType>(elem))
+    if (auto it = dyn_cast<IntegerType>(elem)) {
       ok = it.getWidth() == 8 || it.getWidth() == 16 || it.getWidth() == 32;
-    if (!ok)
+    }
+    if (!ok) {
       return emitOpError(
           "expects A5 tsel src0, src1, and dst element type to be i8/i16/i32/f16/bf16/f32");
+    }
     return success();
   };
 
@@ -13302,73 +15133,89 @@ mlir::LogicalResult mlir::pto::TSelSOp::verify() {
     Type tDst = getDst().getType();
     if (failed(verifyTileBufCommon(*this, tMask, "mask")) ||
         failed(verifyTileBufCommon(*this, tSrc, "src")) ||
-        failed(verifyTileBufCommon(*this, tDst, "dst")))
+        failed(verifyTileBufCommon(*this, tDst, "dst"))) {
       return failure();
-    if (tTmp && failed(verifyTileBufCommon(*this, tTmp, "tmp")))
+    }
+    if (tTmp && failed(verifyTileBufCommon(*this, tTmp, "tmp"))) {
       return failure();
+    }
     Type eMask = getElemTy(tMask), eSrc = getElemTy(tSrc);
     Type eDst = getElemTy(tDst);
     if (!eMask || !eSrc || !eDst) {
       emitOpError("failed to get element type for operands");
       return failure();
     }
-    if (eSrc != eDst)
+    if (eSrc != eDst) {
       return emitOpError("expects src and dst to have the same element type");
-    if (failed(verifyTileBufSameValidShape(*this, tSrc, tDst, "src", "dst")))
+    }
+    if (failed(verifyTileBufSameValidShape(*this, tSrc, tDst, "src", "dst"))) {
       return failure();
+    }
     return eDst;
   };
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     Type tSrc = getSrc().getType();
     Type tDst = getDst().getType();
-    if (!isRowMajorTileBuf(tSrc) || !isRowMajorTileBuf(tDst))
+    if (!isRowMajorTileBuf(tSrc) || !isRowMajorTileBuf(tDst)) {
       return emitOpError("expects src and dst to use row-major layout");
+    }
     Type elem = *elemOr;
     if (getTmp()) {
       Type tmpTy = getTmp().getType();
-      if (getElemTy(tmpTy) != elem)
+      if (getElemTy(tmpTy) != elem) {
         return emitOpError("expects A2/A3 tsels tmp to have the same element type as src and dst");
-      if (!isRowMajorTileBuf(tmpTy))
+      }
+      if (!isRowMajorTileBuf(tmpTy)) {
         return emitOpError("expects A2/A3 tsels tmp to use row-major layout");
+      }
       auto srcShape = getShapeVec(tSrc);
-      if (srcShape.size() != 2 || srcShape[1] == ShapedType::kDynamic)
+      if (srcShape.size() != 2 || srcShape[1] == ShapedType::kDynamic) {
         return emitOpError(
             "expects A2/A3 tsels src shape to be static when tmp is provided");
+      }
       auto elemBytes = getElemByteSize(elem);
       if (elemBytes == 0 ||
           failed(verifyTmpCapacityAtLeast(
-              *this, tmpTy, static_cast<uint64_t>(srcShape[1]) * elemBytes)))
+              *this, tmpTy, static_cast<uint64_t>(srcShape[1]) * elemBytes))) {
         return failure();
+      }
     }
     bool ok = elem.isF16() || elem.isF32();
-    if (auto it = mlir::dyn_cast<mlir::IntegerType>(elem))
+    if (auto it = mlir::dyn_cast<mlir::IntegerType>(elem)) {
       ok = (it.getWidth() == 16 || it.getWidth() == 32);
-    if (!ok)
+    }
+    if (!ok) {
       return emitOpError(
           "expects A2/A3 tsels src and dst element type to be i16, i32, f16, or f32");
+    }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     Type tMask = getMask().getType();
     Type tSrc = getSrc().getType();
     Type tDst = getDst().getType();
-    if (!isRowMajorTileBuf(tMask) || !isRowMajorTileBuf(tSrc) || !isRowMajorTileBuf(tDst))
+    if (!isRowMajorTileBuf(tMask) || !isRowMajorTileBuf(tSrc) || !isRowMajorTileBuf(tDst)) {
       return emitOpError("expects mask, src, and dst to use row-major layout");
+    }
     Type elem = *elemOr;
     bool ok = elem.isF16() || elem.isF32();
-    if (auto it = mlir::dyn_cast<mlir::IntegerType>(elem))
+    if (auto it = mlir::dyn_cast<mlir::IntegerType>(elem)) {
       ok = (it.getWidth() == 8 || it.getWidth() == 16 || it.getWidth() == 32);
-    if (!ok)
+    }
+    if (!ok) {
       return emitOpError(
           "expects A5 tsels src and dst element type to be i8, i16, i32, f16, or f32");
+    }
     return success();
   };
 
@@ -13380,13 +15227,15 @@ mlir::LogicalResult mlir::pto::TShlOp::verify() {
   auto verify = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyShiftLikeBinaryTileOpCommon(
         *this, getSrc0().getType(), getSrc1().getType(), getDst().getType());
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
     if (!it || (it.getWidth() != 8 && it.getWidth() != 16 &&
-                it.getWidth() != 32))
+                it.getWidth() != 32)) {
       return emitOpError(
           "expects tshl src0 and src1 element type to be i8/i16/i32");
+    }
     return success();
   };
 
@@ -13398,13 +15247,15 @@ mlir::LogicalResult mlir::pto::TShrOp::verify() {
   auto verify = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyShiftLikeBinaryTileOpCommon(
         *this, getSrc0().getType(), getSrc1().getType(), getDst().getType());
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
     if (!it || (it.getWidth() != 8 && it.getWidth() != 16 &&
-                it.getWidth() != 32))
+                it.getWidth() != 32)) {
       return emitOpError(
           "expects tshr src0 and src1 element type to be i8/i16/i32");
+    }
     return success();
   };
 
@@ -13418,32 +15269,39 @@ mlir::LogicalResult mlir::pto::TSort32Op::verify() {
   Type idxTy = getIdx().getType();
   if (failed(verifyVecTileCommon(*this, srcTy, "src")) ||
       failed(verifyVecTileCommon(*this, dstTy, "dst")) ||
-      failed(verifyVecTileCommon(*this, idxTy, "idx")))
+      failed(verifyVecTileCommon(*this, idxTy, "idx"))) {
     return failure();
+  }
   if (getTmp() &&
-      failed(verifyVecTileCommon(*this, getTmp().getType(), "tmp")))
+      failed(verifyVecTileCommon(*this, getTmp().getType(), "tmp"))) {
     return failure();
+  }
   if (getTmp() && getTargetArch(getOperation()) != PTOArch::A5) {
     auto requiredBytes = getStaticByteSize(srcTy);
-    if (!requiredBytes)
+    if (!requiredBytes) {
       return emitOpError(
           "expects A2/A3 tsort32 src shape to be static when tmp is provided");
+    }
     if (failed(verifyTmpCapacityAtLeast(*this, getTmp().getType(),
-                                        *requiredBytes)))
+                                        *requiredBytes))) {
       return failure();
+    }
   }
 
   auto srcElem = getElemTy(srcTy);
   auto dstElem = getElemTy(dstTy);
-  if (!srcElem || !dstElem || srcElem != dstElem)
+  if (!srcElem || !dstElem || srcElem != dstElem) {
     return emitOpError() << "expects src and dst to have the same element type";
-  if (!(srcElem.isF16() || srcElem.isF32()))
+  }
+  if (!(srcElem.isF16() || srcElem.isF32())) {
     return emitOpError() << "expects src and dst element type to be f16 or f32";
+  }
 
   auto idxElem = getElemTy(idxTy);
   auto idxInt = dyn_cast<IntegerType>(idxElem);
-  if (!idxInt || idxInt.getWidth() != 32)
+  if (!idxInt || idxInt.getWidth() != 32) {
     return emitOpError() << "expects idx element type to be i32/u32";
+  }
   return mlir::success();
 }
 
@@ -13452,14 +15310,17 @@ mlir::LogicalResult mlir::pto::TSqrtOp::verify() {
   Type srcTy = getSrc().getType();
   Type dstTy = getDst().getType();
   if (failed(verifyVecTileUnaryOp(*this, srcTy, dstTy, "src", "dst",
-                                  /*allowBf16=*/false, /*allowInt8=*/false)))
+                                  /*allowBf16=*/false, /*allowInt8=*/false))) {
     return failure();
-  if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+  }
+  if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst"))) {
     return failure();
+  }
 
   auto srcElem = getElemTy(srcTy);
-  if (!(mlir::isa<mlir::FloatType>(srcElem) || mlir::isa<mlir::Float16Type>(srcElem)))
+  if (!(mlir::isa<mlir::FloatType>(srcElem) || mlir::isa<mlir::Float16Type>(srcElem))) {
     return emitOpError() << "expects src and dst element type to be float or half";
+  }
 
   return mlir::success();
 }
@@ -13478,12 +15339,14 @@ mlir::LogicalResult mlir::pto::TSubCOp::verify() {
   Type src1Ty = getSrc1().getType();
   Type src2Ty = getSrc2().getType();
   Type dstTy = getDst().getType();
-  if (!isPTOShapedLike(src0Ty) || !isPTOShapedLike(src1Ty) || !isPTOShapedLike(src2Ty) || !isPTOShapedLike(dstTy))
+  if (!isPTOShapedLike(src0Ty) || !isPTOShapedLike(src1Ty) || !isPTOShapedLike(src2Ty) || !isPTOShapedLike(dstTy)) {
     return emitOpError() << "expects PTO shaped-like src0, src1, src2, and dst";
+  }
 
   auto d = getShapeVec(dstTy);
-  if (getShapeVec(src0Ty).size() != d.size() || getShapeVec(src1Ty).size() != d.size() || getShapeVec(src2Ty).size() != d.size())
+  if (getShapeVec(src0Ty).size() != d.size() || getShapeVec(src1Ty).size() != d.size() || getShapeVec(src2Ty).size() != d.size()) {
     return emitOpError() << "expects all tensors to have the same rank";
+  }
   return mlir::success();
 }
 
@@ -13503,12 +15366,14 @@ mlir::LogicalResult mlir::pto::TSubSCOp::verify() {
   Type src0Ty = getSrc0().getType();
   Type src1Ty = getSrc1().getType();
   Type dstTy = getDst().getType();
-  if (!isPTOShapedLike(src0Ty) || !isPTOShapedLike(src1Ty) || !isPTOShapedLike(dstTy))
+  if (!isPTOShapedLike(src0Ty) || !isPTOShapedLike(src1Ty) || !isPTOShapedLike(dstTy)) {
     return emitOpError() << "expects PTO shaped-like src0, src1, and dst";
+  }
 
   auto d = getShapeVec(dstTy);
-  if (getShapeVec(src0Ty).size() != d.size() || getShapeVec(src1Ty).size() != d.size())
+  if (getShapeVec(src0Ty).size() != d.size() || getShapeVec(src1Ty).size() != d.size()) {
     return emitOpError() << "expects src0, src1, and dst to have the same rank";
+  }
   return mlir::success();
 }
 static bool ttransUsesTmp(Type srcTy, Type dstTy) {
@@ -13517,8 +15382,9 @@ static bool ttransUsesTmp(Type srcTy, Type dstTy) {
   unsigned elemBytes = getPTOStorageElemByteSize(getElemTy(srcTy));
   if (srcShape.size() != 2 || dstShape.size() != 2 || elemBytes == 0 ||
       llvm::is_contained(srcShape, ShapedType::kDynamic) ||
-      llvm::is_contained(dstShape, ShapedType::kDynamic))
+      llvm::is_contained(dstShape, ShapedType::kDynamic)) {
     return true;
+  }
   int64_t rowStride = elemBytes == 1 ? 32 : 16;
   int64_t elemPerBlock = 32 / elemBytes;
   int64_t srcStride = srcShape[1];
@@ -13533,44 +15399,55 @@ mlir::LogicalResult mlir::pto::TTransOp::verify() {
     Type tmpTy = getTmp() ? getTmp().getType() : Type{};
     Type dstTy = getDst().getType();
     if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
-        failed(verifyTileBufCommon(*this, dstTy, "dst")))
+        failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
       return failure();
-    if (tmpTy && failed(verifyTileBufCommon(*this, tmpTy, "tmp")))
+    }
+    if (tmpTy && failed(verifyTileBufCommon(*this, tmpTy, "tmp"))) {
       return failure();
+    }
     Type srcElem = getElemTy(srcTy);
     Type tmpElem = tmpTy ? getElemTy(tmpTy) : srcElem;
     Type dstElem = getElemTy(dstTy);
-    if (!srcElem || !tmpElem || !dstElem || srcElem != dstElem || srcElem != tmpElem)
+    if (!srcElem || !tmpElem || !dstElem || srcElem != dstElem || srcElem != tmpElem) {
       return emitOpError() << "expects src and dst to have the same element type";
+    }
     if (auto srcTb = dyn_cast<pto::TileBufType>(srcTy)) {
-      if (srcTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor))
+      if (srcTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor)) {
         return emitOpError() << "expects A2/A3 transpose src to use the row_major blayout";
+      }
     }
     unsigned elemBytes = getPTOStorageElemByteSize(srcElem);
-    if (elemBytes == 0)
+    if (elemBytes == 0) {
       return emitOpError() << "failed to get transpose element size";
-    if (elemBytes != 1 && elemBytes != 2 && elemBytes != 4)
+    }
+    if (elemBytes != 1 && elemBytes != 2 && elemBytes != 4) {
       return emitOpError() << "expects transpose element size to be 1, 2, or 4 bytes";
+    }
     auto isAllowedWidthType = [&](Type ty) {
-      if (elemBytes == 4)
+      if (elemBytes == 4) {
         return ty.isInteger(32) || ty.isF32();
-      if (elemBytes == 2)
+      }
+      if (elemBytes == 2) {
         return ty.isInteger(16) || ty.isF16() || ty.isBF16();
+      }
       return ty.isInteger(8);
     };
-    if (!isAllowedWidthType(srcElem))
+    if (!isAllowedWidthType(srcElem)) {
       return emitOpError() << "expects transpose element type to match the supported set for its width";
+    }
     if (tmpTy) {
       uint64_t requiredBytes = 32;
       if (ttransUsesTmp(srcTy, dstTy)) {
         auto srcBytes = getStaticByteSize(srcTy);
-        if (!srcBytes)
+        if (!srcBytes) {
           return emitOpError(
               "expects A2/A3 transpose src shape to be static when tmp is used");
+        }
         requiredBytes = *srcBytes;
       }
-      if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, requiredBytes)))
+      if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, requiredBytes))) {
         return failure();
+      }
     }
     return mlir::success();
   };
@@ -13579,46 +15456,59 @@ mlir::LogicalResult mlir::pto::TTransOp::verify() {
     Type tmpTy = getTmp() ? getTmp().getType() : Type{};
     Type dstTy = getDst().getType();
     if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
-        failed(verifyTileBufCommon(*this, dstTy, "dst")))
+        failed(verifyTileBufCommon(*this, dstTy, "dst"))) {
       return failure();
-    if (tmpTy && failed(verifyTileBufCommon(*this, tmpTy, "tmp")))
+    }
+    if (tmpTy && failed(verifyTileBufCommon(*this, tmpTy, "tmp"))) {
       return failure();
+    }
     Type srcElem = getElemTy(srcTy);
     Type tmpElem = tmpTy ? getElemTy(tmpTy) : srcElem;
     Type dstElem = getElemTy(dstTy);
-    if (!srcElem || !tmpElem || !dstElem || srcElem != dstElem || srcElem != tmpElem)
+    if (!srcElem || !tmpElem || !dstElem || srcElem != dstElem || srcElem != tmpElem) {
       return emitOpError() << "expects src, tmp, and dst to have the same element type";
+    }
     unsigned elemBytes = getPTOStorageElemByteSize(srcElem);
-    if (elemBytes == 0)
+    if (elemBytes == 0) {
       return emitOpError() << "failed to get transpose element size";
-    if (elemBytes != 1 && elemBytes != 2 && elemBytes != 4)
+    }
+    if (elemBytes != 1 && elemBytes != 2 && elemBytes != 4) {
       return emitOpError() << "expects transpose element size to be 1, 2, or 4 bytes";
+    }
     auto isAllowedWidthType = [&](Type ty) {
-      if (elemBytes == 4)
+      if (elemBytes == 4) {
         return ty.isInteger(32) || ty.isF32();
-      if (elemBytes == 2)
+      }
+      if (elemBytes == 2) {
         return ty.isInteger(16) || ty.isF16() || ty.isBF16();
+      }
       return ty.isInteger(8);
     };
-    if (!isAllowedWidthType(srcElem))
+    if (!isAllowedWidthType(srcElem)) {
       return emitOpError() << "expects transpose element type to match the supported set for its width";
-    if (tmpTy && failed(verifyTmpCapacityAtLeast(*this, tmpTy, 32)))
+    }
+    if (tmpTy && failed(verifyTmpCapacityAtLeast(*this, tmpTy, 32))) {
       return failure();
+    }
     auto checkAlignedMajor = [&](Type ty, StringRef name) -> LogicalResult {
       auto tb = mlir::dyn_cast<pto::TileBufType>(ty);
-      if (!tb)
+      if (!tb) {
         return success();
+      }
       auto shape = getShapeVec(ty);
-      if (shape.size() != 2)
+      if (shape.size() != 2) {
         return success();
+      }
       bool rowMajor = tb.getBLayoutValueI32() == static_cast<int32_t>(pto::BLayout::RowMajor);
       int64_t major = rowMajor ? shape[1] : shape[0];
-      if (major != ShapedType::kDynamic && (major * static_cast<int64_t>(elemBytes)) % 32 != 0)
+      if (major != ShapedType::kDynamic && (major * static_cast<int64_t>(elemBytes)) % 32 != 0) {
         return emitOpError() << "expects " << name << " major dimension times element size to be 32-byte aligned on A5";
+      }
       return success();
     };
-    if (failed(checkAlignedMajor(srcTy, "src")) || failed(checkAlignedMajor(dstTy, "dst")))
+    if (failed(checkAlignedMajor(srcTy, "src")) || failed(checkAlignedMajor(dstTy, "dst"))) {
       return failure();
+    }
     return mlir::success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -13631,28 +15521,34 @@ ParseResult mlir::pto::TXorOp::parse(OpAsmParser &parser,
   bool hasTmp = false;
   if (parser.parseKeyword("ins") || parser.parseLParen() ||
       parser.parseOperand(src0) || parser.parseComma() ||
-      parser.parseOperand(src1))
+      parser.parseOperand(src1)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(tmp))
+    if (parser.parseOperand(tmp)) {
       return failure();
+    }
     hasTmp = true;
   }
   if (parser.parseColonType(src0Ty) || parser.parseComma() ||
-      parser.parseType(src1Ty))
+      parser.parseType(src1Ty)) {
     return failure();
-  if (hasTmp && (parser.parseComma() || parser.parseType(tmpTy)))
+  }
+  if (hasTmp && (parser.parseComma() || parser.parseType(tmpTy))) {
     return failure();
+  }
   if (parser.parseRParen() || parser.parseKeyword("outs") ||
       parser.parseLParen() || parser.parseOperand(dst) ||
       parser.parseColonType(dstTy) || parser.parseRParen() ||
-      parser.parseOptionalAttrDict(result.attributes))
+      parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
   if (parser.resolveOperand(src0, src0Ty, result.operands) ||
       parser.resolveOperand(src1, src1Ty, result.operands) ||
       (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands)) ||
-      parser.resolveOperand(dst, dstTy, result.operands))
+      parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
+  }
   result.addAttribute(
       "operandSegmentSizes",
       parser.getBuilder().getDenseI32ArrayAttr({1, 1, hasTmp ? 1 : 0, 1}));
@@ -13661,11 +15557,13 @@ ParseResult mlir::pto::TXorOp::parse(OpAsmParser &parser,
 
 void mlir::pto::TXorOp::print(OpAsmPrinter &p) {
   p << " ins(" << getSrc0() << ", " << getSrc1();
-  if (getTmp())
+  if (getTmp()) {
     p << ", " << getTmp();
+  }
   p << " : " << getSrc0().getType() << ", " << getSrc1().getType();
-  if (getTmp())
+  if (getTmp()) {
     p << ", " << getTmp().getType();
+  }
   p << ") outs(" << getDst() << " : " << getDst().getType() << ")";
   p.printOptionalAttrDict((*this)->getAttrs(),
                           /*elidedAttrs=*/{"operandSegmentSizes"});
@@ -13678,28 +15576,34 @@ ParseResult mlir::pto::TXorSOp::parse(OpAsmParser &parser,
   bool hasTmp = false;
   if (parser.parseKeyword("ins") || parser.parseLParen() ||
       parser.parseOperand(src) || parser.parseComma() ||
-      parser.parseOperand(scalar))
+      parser.parseOperand(scalar)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(tmp))
+    if (parser.parseOperand(tmp)) {
       return failure();
+    }
     hasTmp = true;
   }
   if (parser.parseColonType(srcTy) || parser.parseComma() ||
-      parser.parseType(scalarTy))
+      parser.parseType(scalarTy)) {
     return failure();
-  if (hasTmp && (parser.parseComma() || parser.parseType(tmpTy)))
+  }
+  if (hasTmp && (parser.parseComma() || parser.parseType(tmpTy))) {
     return failure();
+  }
   if (parser.parseRParen() || parser.parseKeyword("outs") ||
       parser.parseLParen() || parser.parseOperand(dst) ||
       parser.parseColonType(dstTy) || parser.parseRParen() ||
-      parser.parseOptionalAttrDict(result.attributes))
+      parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
   if (parser.resolveOperand(src, srcTy, result.operands) ||
       parser.resolveOperand(scalar, scalarTy, result.operands) ||
       (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands)) ||
-      parser.resolveOperand(dst, dstTy, result.operands))
+      parser.resolveOperand(dst, dstTy, result.operands)) {
     return failure();
+  }
   result.addAttribute(
       "operandSegmentSizes",
       parser.getBuilder().getDenseI32ArrayAttr({1, 1, hasTmp ? 1 : 0, 1}));
@@ -13708,11 +15612,13 @@ ParseResult mlir::pto::TXorSOp::parse(OpAsmParser &parser,
 
 void mlir::pto::TXorSOp::print(OpAsmPrinter &p) {
   p << " ins(" << getSrc() << ", " << getScalar();
-  if (getTmp())
+  if (getTmp()) {
     p << ", " << getTmp();
+  }
   p << " : " << getSrc().getType() << ", " << getScalar().getType();
-  if (getTmp())
+  if (getTmp()) {
     p << ", " << getTmp().getType();
+  }
   p << ") outs(" << getDst() << " : " << getDst().getType() << ")";
   p.printOptionalAttrDict((*this)->getAttrs(),
                           /*elidedAttrs=*/{"operandSegmentSizes"});
@@ -13727,45 +15633,55 @@ mlir::LogicalResult mlir::pto::TXorOp::verify() {
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyBase();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     Type elem = *elemOr;
     if (getTmp()) {
       Type tmpTy = getTmp().getType();
-      if (failed(verifyTileBufCommon(*this, tmpTy, "tmp")))
+      if (failed(verifyTileBufCommon(*this, tmpTy, "tmp"))) {
         return failure();
-      if (getElemTy(tmpTy) != elem)
+      }
+      if (getElemTy(tmpTy) != elem) {
         return emitOpError(
             "expects tmp to have the same element type as src0, src1, and dst");
-      if (!isRowMajorTileBuf(tmpTy))
+      }
+      if (!isRowMajorTileBuf(tmpTy)) {
         return emitOpError("expects tmp to use row-major layout");
+      }
       if (failed(verifyTileBufSameValidShape(
-              *this, tmpTy, getDst().getType(), "tmp", "dst")))
+              *this, tmpTy, getDst().getType(), "tmp", "dst"))) {
         return failure();
+      }
       auto requiredBytes = getStaticByteSize(getDst().getType());
-      if (!requiredBytes)
+      if (!requiredBytes) {
         return emitOpError(
             "expects A2/A3 txor dst shape to be static when tmp is provided");
-      if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, *requiredBytes)))
+      }
+      if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, *requiredBytes))) {
         return failure();
+      }
     }
     auto it = mlir::dyn_cast<IntegerType>(elem);
     if (!it || (it.getWidth() != 8 && it.getWidth() != 16 &&
-                it.getWidth() != 32))
+                it.getWidth() != 32)) {
       return emitOpError(
           "expects A2/A3 txor src0, src1, tmp, and dst element type to be i8/i16/i32");
+    }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyBase();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
     if (!it || (it.getWidth() != 8 && it.getWidth() != 16 &&
-                it.getWidth() != 32))
+                it.getWidth() != 32)) {
       return emitOpError(
           "expects A5 txor src0, src1, and dst element type to be i8/i16/i32");
+    }
     return success();
   };
 
@@ -13781,41 +15697,50 @@ mlir::LogicalResult mlir::pto::TXorSOp::verify() {
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     Type elem = *elemOr;
     if (getTmp()) {
       Type tmpTy = getTmp().getType();
-      if (failed(verifyTileBufCommon(*this, tmpTy, "tmp")))
+      if (failed(verifyTileBufCommon(*this, tmpTy, "tmp"))) {
         return failure();
-      if (getElemTy(tmpTy) != elem)
+      }
+      if (getElemTy(tmpTy) != elem) {
         return emitOpError(
             "expects tmp to have the same element type as src and dst");
-      if (!isRowMajorTileBuf(tmpTy))
+      }
+      if (!isRowMajorTileBuf(tmpTy)) {
         return emitOpError("expects tmp to use row-major layout");
+      }
       auto requiredBytes = getStaticByteSize(getDst().getType());
-      if (!requiredBytes)
+      if (!requiredBytes) {
         return emitOpError(
             "expects A2/A3 txors dst shape to be static when tmp is provided");
-      if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, *requiredBytes)))
+      }
+      if (failed(verifyTmpCapacityAtLeast(*this, tmpTy, *requiredBytes))) {
         return failure();
+      }
     }
     auto it = mlir::dyn_cast<IntegerType>(elem);
-    if (!it || (it.getWidth() != 8 && it.getWidth() != 16))
+    if (!it || (it.getWidth() != 8 && it.getWidth() != 16)) {
       return emitOpError(
           "expects A2/A3 txors src and dst element type to be i8/i16");
+    }
     return success();
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
     FailureOr<Type> elemOr = verifyCommon();
-    if (failed(elemOr))
+    if (failed(elemOr)) {
       return failure();
+    }
     auto it = mlir::dyn_cast<IntegerType>(*elemOr);
     if (!it || (it.getWidth() != 8 && it.getWidth() != 16 &&
-                it.getWidth() != 32))
+                it.getWidth() != 32)) {
       return emitOpError(
           "expects A5 txors src and dst element type to be i8/i16/i32");
+    }
     return success();
   };
 
@@ -13831,29 +15756,37 @@ ParseResult mlir::pto::TPrintOp::parse(OpAsmParser &parser,
   NamedAttrList parsedAttrs;
 
   if (parser.parseKeyword("ins") || parser.parseLParen() ||
-      parser.parseOperand(src))
+      parser.parseOperand(src)) {
     return failure();
+  }
 
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(tmp))
+    if (parser.parseOperand(tmp)) {
       return failure();
+    }
     hasTmp = true;
   }
 
-  if (parser.parseColonType(srcTy))
+  if (parser.parseColonType(srcTy)) {
     return failure();
-  if (hasTmp && (parser.parseComma() || parser.parseType(tmpTy)))
+  }
+  if (hasTmp && (parser.parseComma() || parser.parseType(tmpTy))) {
     return failure();
-  if (parser.parseRParen())
+  }
+  if (parser.parseRParen()) {
     return failure();
+  }
   if (failed(parsePTOInherentAttrs<TPrintOp>(
-          parser, result, parsedAttrs, {"printFormat"})))
+          parser, result, parsedAttrs, {"printFormat"}))) {
     return failure();
+  }
 
-  if (parser.resolveOperand(src, srcTy, result.operands))
+  if (parser.resolveOperand(src, srcTy, result.operands)) {
     return failure();
-  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands))
+  }
+  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands)) {
     return failure();
+  }
 
   return success();
 }
@@ -13869,8 +15802,9 @@ void mlir::pto::TPrintOp::print(OpAsmPrinter &p) {
   p << ")";
   NamedAttrList attrs = getNonInherentAttrs(getOperation(), {"printFormat"});
   if (auto printFormatAttr =
-          dyn_cast_or_null<pto::PrintFormatAttr>(getProperties().printFormat))
+          dyn_cast_or_null<pto::PrintFormatAttr>(getProperties().printFormat)) {
     attrs.append("printFormat", printFormatAttr);
+  }
   p.printOptionalAttrDict(attrs.getAttrs());
 }
 
@@ -13880,30 +15814,38 @@ mlir::LogicalResult mlir::pto::TPrintOp::verify() {
   if (auto tb = mlir::dyn_cast<mlir::pto::TileBufType>(srcType)) {
     auto elem = tb.getElementType();
     if (!(elem.isF16() || elem.isF32() ||
-          elem.isInteger(8) || elem.isInteger(16) || elem.isInteger(32)))
+          elem.isInteger(8) || elem.isInteger(16) || elem.isInteger(32))) {
       return emitOpError() << "expects printable tile element type";
+}
     auto space = getPTOMemorySpaceEnum(srcType);
     if (!tmp) {
-      if (!space || *space != pto::AddressSpace::VEC)
+      if (!space || *space != pto::AddressSpace::VEC) {
         return emitOpError() << "expects printable tile_buf without tmp to be in vec address space";
+}
       return success();
     }
 
-    if (!space)
+    if (!space) {
       return emitOpError() << "expects printable tile_buf with tmp to use a supported address space";
-    if (*space == pto::AddressSpace::MAT && isTargetArchA5(getOperation()))
+}
+    if (*space == pto::AddressSpace::MAT && isTargetArchA5(getOperation())) {
       return emitOpError() << "expects mat tile printing with tmp only on A2/A3 targets";
+}
     if (*space != pto::AddressSpace::VEC && *space != pto::AddressSpace::MAT &&
-        *space != pto::AddressSpace::ACC)
+        *space != pto::AddressSpace::ACC) {
       return emitOpError() << "expects printable tile_buf with tmp to be in vec/mat/acc address space";
-    if (failed(verifyMGatherMScatterMemOperand(getOperation(), tmp, elem, "tmp")))
+}
+    if (failed(verifyMGatherMScatterMemOperand(getOperation(), tmp, elem, "tmp"))) {
       return failure();
+}
     return success();
   }
-  if (tmp)
+  if (tmp) {
     return emitOpError() << "expects tmp only when src is a tile_buf";
-  if (mlir::dyn_cast<mlir::pto::PartitionTensorViewType>(srcType))
+}
+  if (mlir::dyn_cast<mlir::pto::PartitionTensorViewType>(srcType)) {
     return mlir::success();
+}
   return emitOpError() << "expects tile_buf or partition_tensor_view for src";
 }
 
@@ -13915,33 +15857,39 @@ mlir::LogicalResult mlir::pto::TPrintOp::verify() {
   // ---- case A: tensor ----
   if (auto lhsTy = dyn_cast<RankedTensorType>(lhs.getType())) {
     auto rhsTy = dyn_cast<RankedTensorType>(rhs.getType());
-    if (!rhsTy)
+    if (!rhsTy) {
       return op->emitOpError("expects lhs and rhs to be ranked tensors");
+    }
 
-    if (lhsTy.getElementType() != rhsTy.getElementType())
+    if (lhsTy.getElementType() != rhsTy.getElementType()) {
       return op->emitOpError()
              << "expects lhs and rhs to have the same element type, but got lhs="
              << lhsTy.getElementType() << " rhs=" << rhsTy.getElementType();
+    }
 
     if (biasOpt) {
       auto biasTy = dyn_cast<RankedTensorType>(biasOpt.getType());
-      if (!biasTy)
+      if (!biasTy) {
         return op->emitOpError("expects bias to be a ranked tensor");
-      if (biasTy.getElementType() != lhsTy.getElementType())
+      }
+      if (biasTy.getElementType() != lhsTy.getElementType()) {
         return op->emitOpError()
                << "expects bias to have the same element type as lhs and rhs, but got bias="
                << biasTy.getElementType() << " vs " << lhsTy.getElementType();
+      }
     }
 
-    if (maybeDstElemTy && maybeDstElemTy != lhsTy.getElementType())
+    if (maybeDstElemTy && maybeDstElemTy != lhsTy.getElementType()) {
       return op->emitOpError()
              << "expects dst to have the same element type as lhs and rhs, but got dst="
              << maybeDstElemTy << " vs " << lhsTy.getElementType();
+    }
 
-    if (maybeResultElemTy && maybeResultElemTy != lhsTy.getElementType())
+    if (maybeResultElemTy && maybeResultElemTy != lhsTy.getElementType()) {
       return op->emitOpError()
              << "expects result to have the same element type as lhs and rhs, but got result="
              << maybeResultElemTy << " vs " << lhsTy.getElementType();
+    }
 
     return success();
   }
@@ -13949,33 +15897,41 @@ mlir::LogicalResult mlir::pto::TPrintOp::verify() {
   // ---- case B: tile ----
   auto lhsTile = dyn_cast<mlir::pto::TileType>(lhs.getType());
   auto rhsTile = dyn_cast<mlir::pto::TileType>(rhs.getType());
-  if (!lhsTile || !rhsTile)
+  if (!lhsTile || !rhsTile) {
     return op->emitOpError("expects lhs and rhs to be ranked tensors or !pto.tile");
+  }
 
-  if (lhsTile.getElementType() != rhsTile.getElementType())
+  if (lhsTile.getElementType() != rhsTile.getElementType()) {
     return op->emitOpError() << "expects lhs and rhs tiles to have the same element type, but got lhs="
                              << lhsTile.getElementType() << " rhs=" << rhsTile.getElementType();
+  }
 
-  if ((int64_t)lhsTile.getShape().size() != 2 || (int64_t)rhsTile.getShape().size() != 2)
+  if ((int64_t)lhsTile.getShape().size() != 2 || (int64_t)rhsTile.getShape().size() != 2) {
     return op->emitOpError("expects lhs and rhs tiles to be 2D");
+  }
 
-  if (lhsTile.getShape()[1] != rhsTile.getShape()[0])
+  if (lhsTile.getShape()[1] != rhsTile.getShape()[0]) {
     return op->emitOpError() << "expects lhs dim1 to equal rhs dim0, but got "
                              << lhsTile.getShape()[1] << " vs " << rhsTile.getShape()[0];
+  }
 
   if (biasOpt) {
     auto biasTile = dyn_cast<mlir::pto::TileType>(biasOpt.getType());
-    if (!biasTile)
+    if (!biasTile) {
       return op->emitOpError("expects bias to be !pto.tile when lhs and rhs are !pto.tile");
-    if (biasTile.getElementType() != lhsTile.getElementType())
+    }
+    if (biasTile.getElementType() != lhsTile.getElementType()) {
       return op->emitOpError("expects bias to have the same element type as lhs and rhs");
+    }
   }
 
-  if (maybeDstElemTy && maybeDstElemTy != lhsTile.getElementType())
+  if (maybeDstElemTy && maybeDstElemTy != lhsTile.getElementType()) {
     return op->emitOpError() << "expects dst to have the same element type as lhs and rhs";
+  }
 
-  if (maybeResultElemTy && maybeResultElemTy != lhsTile.getElementType())
+  if (maybeResultElemTy && maybeResultElemTy != lhsTile.getElementType()) {
     return op->emitOpError() << "expects result to have the same element type as lhs and rhs";
+  }
 
   return success();
 }
@@ -13983,24 +15939,28 @@ mlir::LogicalResult mlir::pto::TPrintOp::verify() {
 LogicalResult mlir::pto::TMatmulOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult {
     if (failed(verifyMatTileOperands(*this, getLhs().getType(), getRhs().getType(),
-                                     getDst().getType())))
+                                     getDst().getType()))) {
       return failure();
+    }
     if (failed(verifyMatmulTypeTriple(*this, getElemTy(getLhs().getType()),
                                       getElemTy(getRhs().getType()),
-                                      getElemTy(getDst().getType()))))
+                                      getElemTy(getDst().getType())))) {
       return failure();
+    }
     return verifyMatmulLike(*this, getLhs().getType(), getRhs().getType(),
                             getDst().getType());
   };
   auto verifyA5 = [&]() -> LogicalResult {
     if (failed(verifyMatmulTypeTriple(*this, getElemTy(getLhs().getType()),
                                       getElemTy(getRhs().getType()),
-                                      getElemTy(getDst().getType()))))
+                                      getElemTy(getDst().getType())))) {
       return failure();
+    }
     if (failed(verifyMatTileOperands(*this, getLhs().getType(), getRhs().getType(),
                                      getDst().getType(),
-                                     /*allowLowPrecision=*/true)))
+                                     /*allowLowPrecision=*/true))) {
       return failure();
+    }
     return verifyMatmulLike(*this, getLhs().getType(), getRhs().getType(),
                             getDst().getType());
   };
@@ -14010,12 +15970,14 @@ LogicalResult mlir::pto::TMatmulOp::verify() {
 LogicalResult mlir::pto::TGemvOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult {
     if (failed(verifyGemvTileOperands(*this, getLhs().getType(), getRhs().getType(),
-                                      getDst().getType())))
+                                      getDst().getType()))) {
       return failure();
+    }
     if (failed(verifyMatmulTypeTriple(*this, getElemTy(getLhs().getType()),
                                       getElemTy(getRhs().getType()),
-                                      getElemTy(getDst().getType()))))
+                                      getElemTy(getDst().getType())))) {
       return failure();
+    }
     return verifyMatmulLike(*this, getLhs().getType(), getRhs().getType(),
                             getDst().getType());
   };
@@ -14027,20 +15989,23 @@ LogicalResult mlir::pto::TMatmulAccOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult {
     if (failed(verifyAccTileCommon(*this, getAccIn().getType(), "acc_in")) ||
         failed(verifyMatTileOperands(*this, getLhs().getType(), getRhs().getType(),
-                                     getDst().getType())))
+                                     getDst().getType()))) {
       return failure();
+    }
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
     if (failed(verifyMatmulTypeTriple(*this, getElemTy(getLhs().getType()),
                                       getElemTy(getRhs().getType()),
-                                      getElemTy(getDst().getType()))))
+                                      getElemTy(getDst().getType())))) {
       return failure();
+    }
     if (failed(verifyAccTileCommon(*this, getAccIn().getType(), "acc_in")) ||
         failed(verifyMatTileOperands(*this, getLhs().getType(), getRhs().getType(),
                                      getDst().getType(),
-                                     /*allowLowPrecision=*/true)))
+                                     /*allowLowPrecision=*/true))) {
       return failure();
+    }
     return success();
   };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
@@ -14049,8 +16014,9 @@ LogicalResult mlir::pto::TMatmulAccOp::verify() {
 LogicalResult mlir::pto::TGemvAccOp::verify() {
   if (failed(verifyAccTileCommon(*this, getAccIn().getType(), "acc_in")) ||
       failed(verifyGemvTileOperands(*this, getLhs().getType(), getRhs().getType(),
-                                    getDst().getType())))
+                                    getDst().getType()))) {
     return failure();
+  }
   return success();
 }
 
@@ -14058,13 +16024,15 @@ LogicalResult mlir::pto::TGemvAccOp::verify() {
 // inferReturnTypes() for matmul ops (keep your existing code)
 //===----------------------------------------------------------------------===
 [[maybe_unused]] static mlir::Type inferMatmulTileResult2DFromAB(MLIRContext *context, ValueRange operands) {
-  if (operands.size() < 2)
+  if (operands.size() < 2) {
     return mlir::Type();
+  }
 
   auto lhsTile = dyn_cast<mlir::pto::TileType>(operands[0].getType());
   auto rhsTile = dyn_cast<mlir::pto::TileType>(operands[1].getType());
-  if (!lhsTile || !rhsTile)
+  if (!lhsTile || !rhsTile) {
     return mlir::Type();
+  }
 
   Type elemTy = lhsTile.getElementType();
 
@@ -14087,19 +16055,22 @@ LogicalResult mlir::pto::TGemvAccOp::verify() {
 }
 
 [[maybe_unused]] static RankedTensorType inferMatmulResult2DFromAB(ValueRange operands) {
-  if (operands.size() < 2)
+  if (operands.size() < 2) {
     return RankedTensorType();
+  }
 
   auto lhsTy = dyn_cast<RankedTensorType>(operands[0].getType());
   auto rhsTy = dyn_cast<RankedTensorType>(operands[1].getType());
-  if (!lhsTy || !rhsTy)
+  if (!lhsTy || !rhsTy) {
     return RankedTensorType();
+  }
 
   Type elemTy = lhsTy.getElementType();
 
   if (operands.size() >= 3) {
-    if (auto biasRT = dyn_cast<RankedTensorType>(operands[2].getType()))
+    if (auto biasRT = dyn_cast<RankedTensorType>(operands[2].getType())) {
       return RankedTensorType::get(biasRT.getShape(), elemTy);
+    }
   }
 
   if (lhsTy.getRank() >= 2 && rhsTy.getRank() >= 2) {
@@ -14112,10 +16083,12 @@ LogicalResult mlir::pto::TGemvAccOp::verify() {
 }
 
 [[maybe_unused]] static RankedTensorType inferAccReturnFromAccIn(ValueRange operands) {
-  if (operands.empty())
+  if (operands.empty()) {
     return RankedTensorType();
-  if (auto accRT = dyn_cast<RankedTensorType>(operands[0].getType()))
+  }
+  if (auto accRT = dyn_cast<RankedTensorType>(operands[0].getType())) {
     return accRT;
+  }
   return RankedTensorType();
 }
 
@@ -14125,17 +16098,21 @@ static LogicalResult parseShapeAndElem(AsmParser &parser,
                                        SmallVectorImpl<int64_t> &shape,
                                        Type &elementType,
                                        bool allowDynamic) {
-  if (parser.parseLess())
+  if (parser.parseLess()) {
     return failure();
+  }
 
-  if (parser.parseDimensionList(shape, allowDynamic))
+  if (parser.parseDimensionList(shape, allowDynamic)) {
     return failure();
+  }
 
-  if (parser.parseType(elementType))
+  if (parser.parseType(elementType)) {
     return failure();
+  }
 
-  if (parser.parseGreater())
+  if (parser.parseGreater()) {
     return failure();
+  }
 
   return success();
 }
@@ -14145,10 +16122,11 @@ static void printShapeAndElem(AsmPrinter &printer,
                               Type elementType) {
   printer << "<";
   for (auto d : shape) {
-    if (d == ShapedType::kDynamic)
+    if (d == ShapedType::kDynamic) {
       printer << "?";
-    else
+    } else {
       printer << d;
+}
     printer << "x";
   }
   printer.printType(elementType);
@@ -14162,9 +16140,10 @@ static void printShapeAndElem(AsmPrinter &printer,
 Type PartitionTensorViewType::parse(AsmParser &parser) {
   SmallVector<int64_t, 4> shape;
   Type elemTy;
-  if (failed(parseShapeAndElem(parser, shape, elemTy, /*allowDynamic=*/true)))
+  if (failed(parseShapeAndElem(parser, shape, elemTy, /*allowDynamic=*/true))) {
     return Type();
-  
+  }
+
   return PartitionTensorViewType::get(parser.getContext(), shape, elemTy);
 }
 
@@ -14176,8 +16155,9 @@ void PartitionTensorViewType::print(AsmPrinter &printer) const {
 Type TileType::parse(AsmParser &parser) {
   SmallVector<int64_t, 4> shape;
   Type elemTy;
-  if (failed(parseShapeAndElem(parser, shape, elemTy, /*allowDynamic=*/true)))
+  if (failed(parseShapeAndElem(parser, shape, elemTy, /*allowDynamic=*/true))) {
     return Type();
+  }
   return TileType::get(parser.getContext(), shape, elemTy);
 }
 
@@ -14192,8 +16172,9 @@ void TileType::print(AsmPrinter &printer) const {
 Type LocalArrayType::parse(AsmParser &parser) {
   SmallVector<int64_t, 4> shape;
   Type elemTy;
-  if (failed(parseShapeAndElem(parser, shape, elemTy, /*allowDynamic=*/false)))
+  if (failed(parseShapeAndElem(parser, shape, elemTy, /*allowDynamic=*/false))) {
     return Type();
+  }
   return LocalArrayType::getChecked(
       [&]() { return parser.emitError(parser.getNameLoc()); },
       parser.getContext(), shape, elemTy);
@@ -14206,19 +16187,22 @@ void LocalArrayType::print(AsmPrinter &printer) const {
 LogicalResult LocalArrayType::verify(
     llvm::function_ref<InFlightDiagnostic()> emitError,
     llvm::ArrayRef<int64_t> shape, Type elementType) {
-  if (shape.empty())
+  if (shape.empty()) {
     return emitError() << "'!pto.local_array' requires at least one dimension";
+  }
   for (auto [i, d] : llvm::enumerate(shape)) {
-    if (d <= 0)
+    if (d <= 0) {
       return emitError()
              << "'!pto.local_array' dimension " << i
              << " must be a positive static size, got " << d;
+    }
   }
-  if (!elementType.isIntOrFloat())
+  if (!elementType.isIntOrFloat()) {
     return emitError()
            << "'!pto.local_array' element type must be a scalar integer or "
               "float, got "
            << elementType;
+  }
   return success();
 }
 
@@ -14236,8 +16220,9 @@ LogicalResult LocalArrayType::verify(
 // vec/cube formats (f8/f4 variants) would otherwise be emitted as `float`,
 // silently changing the field's width and semantics, so reject them here.
 static bool isStructScalar(Type t) {
-  if (llvm::isa<Float16Type, BFloat16Type, Float32Type, Float64Type>(t))
+  if (llvm::isa<Float16Type, BFloat16Type, Float32Type, Float64Type>(t)) {
     return true;
+  }
   if (auto intTy = llvm::dyn_cast<IntegerType>(t)) {
     unsigned w = intTy.getWidth();
     return w == 8 || w == 16 || w == 32 || w == 64;
@@ -14259,12 +16244,14 @@ Type StructType::parse(AsmParser &parser) {
   if (parser.parseCommaSeparatedList(
           AsmParser::Delimiter::LessGreater, [&]() -> ParseResult {
             Type t;
-            if (parser.parseType(t))
+            if (parser.parseType(t)) {
               return failure();
+            }
             fields.push_back(t);
             return success();
-          }))
+          })) {
     return Type();
+  }
   return StructType::getChecked(
       [&]() { return parser.emitError(parser.getNameLoc()); },
       parser.getContext(), fields);
@@ -14274,8 +16261,9 @@ void StructType::print(AsmPrinter &printer) const {
   printer << "<";
   llvm::ArrayRef<Type> fields = getFieldTypes();
   for (size_t i = 0; i < fields.size(); ++i) {
-    if (i)
+    if (i) {
       printer << ", ";
+    }
     printer.printType(fields[i]);
   }
   printer << ">";
@@ -14284,10 +16272,11 @@ void StructType::print(AsmPrinter &printer) const {
 LogicalResult StructType::verify(
     llvm::function_ref<InFlightDiagnostic()> emitError,
     llvm::ArrayRef<Type> fieldTypes) {
-  if (fieldTypes.empty())
+  if (fieldTypes.empty()) {
     return emitError() << "'!pto.struct' requires at least one field";
+  }
   for (auto [i, f] : llvm::enumerate(fieldTypes)) {
-    if (!isStructStorable(f))
+    if (!isStructStorable(f)) {
       return emitError()
              << "'!pto.struct' field " << i << " type " << f
              << " is not scalar-storable; only i8/i16/i32/i64 (signed, "
@@ -14295,6 +16284,7 @@ LogicalResult StructType::verify(
                 "!pto.struct are allowed (!pto.local_array cannot be a field "
                 "because emitc.member cannot yield an array lvalue; tile_buf / "
                 "tensor_view belong to the vec/cube world)";
+    }
   }
   return success();
 }
@@ -14541,41 +16531,49 @@ ParseResult mlir::pto::SubViewOp::parse(OpAsmParser &parser,
 
   if (parser.parseOperand(source) || parser.parseLSquare() ||
       parser.parseOperandList(offsets) || parser.parseRSquare() ||
-      parser.parseKeyword("sizes"))
+      parser.parseKeyword("sizes")) {
     return failure();
+  }
 
   ArrayAttr sizesAttr;
-  if (parser.parseAttribute(sizesAttr, "sizes", result.attributes))
+  if (parser.parseAttribute(sizesAttr, "sizes", result.attributes)) {
     return failure();
+  }
 
   if (succeeded(parser.parseOptionalKeyword("valid"))) {
     OpAsmParser::UnresolvedOperand vrow, vcol;
     if (parser.parseLSquare() || parser.parseOperand(vrow) || parser.parseComma() ||
-        parser.parseOperand(vcol) || parser.parseRSquare())
+        parser.parseOperand(vcol) || parser.parseRSquare()) {
       return failure();
+    }
     valids.push_back(vrow);
     valids.push_back(vcol);
   }
 
   if (parser.parseOptionalAttrDict(result.attributes) ||
-      parser.parseColonType(sourceTy))
+      parser.parseColonType(sourceTy)) {
     return failure();
+  }
 
   if (succeeded(parser.parseOptionalArrow())) {
-    if (parser.parseType(resultTy))
+    if (parser.parseType(resultTy)) {
       return failure();
+    }
     hasExplicitResultTy = true;
   }
 
-  if (parser.resolveOperand(source, sourceTy, result.operands))
+  if (parser.resolveOperand(source, sourceTy, result.operands)) {
     return failure();
+  }
 
   Type indexTy = parser.getBuilder().getIndexType();
-  if (parser.resolveOperands(offsets, indexTy, result.operands))
+  if (parser.resolveOperands(offsets, indexTy, result.operands)) {
     return failure();
+  }
   if (!valids.empty() &&
-      parser.resolveOperands(valids, indexTy, result.operands))
+      parser.resolveOperands(valids, indexTy, result.operands)) {
     return failure();
+  }
 
   int32_t hasValid = valids.empty() ? 0 : 1;
   result.addAttribute(
@@ -14623,29 +16621,35 @@ void mlir::pto::SubViewOp::print(OpAsmPrinter &printer) {
 // operand to supply the runtime value. Every other difference (shape, element
 // type, address space, config) is still rejected as the default check would.
 bool SubViewOp::isCompatibleReturnTypes(TypeRange lhs, TypeRange rhs) {
-  if (lhs.size() != rhs.size())
+  if (lhs.size() != rhs.size()) {
     return false;
+  }
   for (auto [inferred, declared] : llvm::zip(lhs, rhs)) {
-    if (inferred == declared)
+    if (inferred == declared) {
       continue;
+    }
     auto inferredTb = dyn_cast<TileBufType>(inferred);
     auto declaredTb = dyn_cast<TileBufType>(declared);
-    if (!inferredTb || !declaredTb)
+    if (!inferredTb || !declaredTb) {
       return false;
+    }
     if (inferredTb.getShape() != declaredTb.getShape() ||
         inferredTb.getElementType() != declaredTb.getElementType() ||
         inferredTb.getMemorySpace() != declaredTb.getMemorySpace() ||
-        inferredTb.getConfigAttr() != declaredTb.getConfigAttr())
+        inferredTb.getConfigAttr() != declaredTb.getConfigAttr()) {
       return false;
+    }
     auto inferredValid = inferredTb.getValidShape();
     auto declaredValid = declaredTb.getValidShape();
-    if (inferredValid.size() != declaredValid.size())
+    if (inferredValid.size() != declaredValid.size()) {
       return false;
+    }
     for (auto [inferredDim, declaredDim] : llvm::zip(inferredValid, declaredValid)) {
       // Any static declared valid extent is accepted in place of the inferred
       // one; only a dynamic declared valid that disagrees is incompatible.
-      if (inferredDim != declaredDim && declaredDim == ShapedType::kDynamic)
+      if (inferredDim != declaredDim && declaredDim == ShapedType::kDynamic) {
         return false;
+      }
     }
   }
   return true;
@@ -14687,8 +16691,9 @@ LogicalResult SubViewOp::inferReturnTypes(
 
   // Design: subview 的结果 tile 类型显式表达逻辑子窗口 shape（sizes）。
   ArrayRef<int64_t> parentShape = sourceType.getShape();
-  if (subviewShape.size() != parentShape.size())
+  if (subviewShape.size() != parentShape.size()) {
     return failure();
+  }
 
   // Derive valid shape from explicit valid_row/valid_col when provided.
   // Otherwise default to subview shape (no parent valid-shape inheritance).
@@ -14712,10 +16717,12 @@ LogicalResult SubViewOp::inferReturnTypes(
         if (srcSeg == 1 && offSeg >= 0 && (vRowSeg == 0 || vRowSeg == 1) &&
             (vColSeg == 0 || vColSeg == 1)) {
           size_t idx = static_cast<size_t>(srcSeg + offSeg);
-          if (vRowSeg == 1 && idx < operands.size())
+          if (vRowSeg == 1 && idx < operands.size()) {
             explicitVRow = operands[idx++];
-          if (vColSeg == 1 && idx < operands.size())
+          }
+          if (vColSeg == 1 && idx < operands.size()) {
             explicitVCol = operands[idx];
+          }
         }
       }
     }
@@ -14774,14 +16781,18 @@ static bool getConstIndex(Value v, int64_t &out) {
       return true;
     }
   }
-  if (auto castOp = v.getDefiningOp<arith::IndexCastOp>())
+  if (auto castOp = v.getDefiningOp<arith::IndexCastOp>()) {
     return getConstIndex(castOp.getIn(), out);
-  if (auto extOp = v.getDefiningOp<arith::ExtSIOp>())
+  }
+  if (auto extOp = v.getDefiningOp<arith::ExtSIOp>()) {
     return getConstIndex(extOp.getIn(), out);
-  if (auto extOp = v.getDefiningOp<arith::ExtUIOp>())
+  }
+  if (auto extOp = v.getDefiningOp<arith::ExtUIOp>()) {
     return getConstIndex(extOp.getIn(), out);
-  if (auto truncOp = v.getDefiningOp<arith::TruncIOp>())
+  }
+  if (auto truncOp = v.getDefiningOp<arith::TruncIOp>()) {
     return getConstIndex(truncOp.getIn(), out);
+  }
   return false;
 }
 
@@ -14859,64 +16870,81 @@ static LogicalResult computeInnerShape(TileBufConfigAttr cfg, Type elemTy,
 mlir::LogicalResult mlir::pto::SubViewOp::verify() {
   auto srcTy = llvm::dyn_cast<TileBufType>(getSource().getType());
   auto dstTy = llvm::dyn_cast<TileBufType>(getResult().getType());
-  if (!srcTy || !dstTy)
+  if (!srcTy || !dstTy) {
     return emitOpError("expects tile_buf src and tile_buf result");
-  if (srcTy.getRank() != 2 || dstTy.getRank() != 2)
+  }
+  if (srcTy.getRank() != 2 || dstTy.getRank() != 2) {
     return emitOpError("expects rank-2 tilebuf for src/dst");
+  }
 
   auto sizesAttr = getSizes();
-  if (!sizesAttr || sizesAttr.size() != 2)
+  if (!sizesAttr || sizesAttr.size() != 2) {
     return emitOpError("subview expects 2D sizes");
+  }
   int64_t sizeR = cast<IntegerAttr>(sizesAttr[0]).getInt();
   int64_t sizeC = cast<IntegerAttr>(sizesAttr[1]).getInt();
-  if (sizeR <= 0 || sizeC <= 0)
+  if (sizeR <= 0 || sizeC <= 0) {
     return emitOpError("subview sizes must be positive");
-  if (getOffsets().size() != 2)
+  }
+  if (getOffsets().size() != 2) {
     return emitOpError("subview expects 2D offsets");
+  }
 
   int64_t offR = 0, offC = 0;
   bool offRConst = getConstIndex(getOffsets()[0], offR);
   bool offCConst = getConstIndex(getOffsets()[1], offC);
-  if (offRConst && offR < 0)
+  if (offRConst && offR < 0) {
     return emitOpError("subview offsets must be non-negative");
-  if (offCConst && offC < 0)
+  }
+  if (offCConst && offC < 0) {
     return emitOpError("subview offsets must be non-negative");
+  }
 
   bool hasValidRow = static_cast<bool>(getValidRow());
   bool hasValidCol = static_cast<bool>(getValidCol());
-  if (hasValidRow != hasValidCol)
+  if (hasValidRow != hasValidCol) {
     return emitOpError(
         "subview expects valid_row and valid_col to be both present or both absent");
+  }
 
   if (hasValidRow) {
     int64_t vRow = 0, vCol = 0;
     if (getConstIndex(getValidRow(), vRow)) {
-      if (vRow < 0)
+      if (vRow < 0) {
         return emitOpError("valid_row must be non-negative when constant");
-      if (vRow > sizeR)
+      }
+      if (vRow > sizeR) {
         return emitOpError("valid_row must be <= subview row size");
+      }
     }
     if (getConstIndex(getValidCol(), vCol)) {
-      if (vCol < 0)
+      if (vCol < 0) {
         return emitOpError("valid_col must be non-negative when constant");
-      if (vCol > sizeC)
+      }
+      if (vCol > sizeC) {
         return emitOpError("valid_col must be <= subview col size");
+      }
     }
   }
 
   auto dstShape = dstTy.getShape();
-  if (dstShape.size() != 2)
+  if (dstShape.size() != 2) {
     return emitOpError("expects result to be rank-2");
+  }
   auto srcShape = srcTy.getShape();
-  if (srcShape.size() != 2)
+  if (srcShape.size() != 2) {
     return emitOpError("expects source to be rank-2");
-  if (dstShape[0] != sizeR || dstShape[1] != sizeC)
+  }
+  if (dstShape[0] != sizeR || dstShape[1] != sizeC) {
     return emitOpError("expects result shape to match subview sizes");
+  }
 
-  if (dstTy.getElementType() != srcTy.getElementType())
+  if (dstTy.getElementType() != srcTy.getElementType()) {
     return emitOpError("expects result element type to match source");
-  if (dstTy.getMemorySpace() != srcTy.getMemorySpace())
+  }
+  if (dstTy.getMemorySpace() != srcTy.getMemorySpace()) {
     return emitOpError("expects result address space to match source");
+  }
   auto srcCfg = srcTy.getConfigAttr();
   if (!srcCfg) {
     srcCfg = TileBufConfigAttr::getDefault(getContext());
@@ -14925,26 +16953,30 @@ mlir::LogicalResult mlir::pto::SubViewOp::verify() {
   if (!dstCfg) {
     dstCfg = TileBufConfigAttr::getDefault(getContext());
   }
-  if (dstCfg != srcCfg)
+  if (dstCfg != srcCfg) {
     return emitOpError("expects result tile config to match source");
+  }
 
   // Design choice: when valid[...] is omitted, infer result valid_shape from
   // subview sizes directly. We intentionally do not constrain it by source
   // valid_shape to allow user-controlled subview semantics.
 
   auto expectedValidDim = [&](Value explicitValid, int64_t defaultSize) {
-    if (!explicitValid)
+    if (!explicitValid) {
       return defaultSize;
+    }
     int64_t c = 0;
-    if (getConstIndex(explicitValid, c))
+    if (getConstIndex(explicitValid, c)) {
       return std::min<int64_t>(c, defaultSize);
+    }
     return ShapedType::kDynamic;
   };
   int64_t expectedVRow = expectedValidDim(getValidRow(), sizeR);
   int64_t expectedVCol = expectedValidDim(getValidCol(), sizeC);
   auto dstValid = dstTy.getValidShape();
-  if (dstValid.size() != 2)
+  if (dstValid.size() != 2) {
     return emitOpError("expects result to have rank-2 valid_shape");
+  }
   // With the valid operand omitted, the result type is authoritative for the
   // valid extent: accept any static value in [0, size] (this subsumes both the
   // full-size default and the v=0 no-op-replay empty marker). A dynamic result valid still
@@ -14954,10 +16986,12 @@ mlir::LogicalResult mlir::pto::SubViewOp::verify() {
                      dstValid[0] >= 0 && dstValid[0] <= sizeR;
   bool colInferred = !getValidCol() && dstValid[1] != ShapedType::kDynamic &&
                      dstValid[1] >= 0 && dstValid[1] <= sizeC;
-  if (dstValid[0] != expectedVRow && !rowInferred)
+  if (dstValid[0] != expectedVRow && !rowInferred) {
     return emitOpError("expects result valid_shape[0] to match inferred/explicit valid_row");
-  if (dstValid[1] != expectedVCol && !colInferred)
+  }
+  if (dstValid[1] != expectedVCol && !colInferred) {
     return emitOpError("expects result valid_shape[1] to match inferred/explicit valid_col");
+  }
 
   auto cfg = srcTy.getConfigAttr();
   if (!cfg) {
@@ -14968,24 +17002,29 @@ mlir::LogicalResult mlir::pto::SubViewOp::verify() {
   bool boxed = false;
   int32_t bl = 0, sl = 0;
   if (failed(computeInnerShape(cfg, srcTy.getElementType(), innerRows, innerCols,
-                               boxed, bl, sl)))
+                               boxed, bl, sl))) {
     return emitOpError("unsupported tile layout for subview");
+  }
 
-  if (!boxed)
+  if (!boxed) {
     return success();
+  }
 
   // Boxed layout: require static 2D sizes with inner alignment. Offsets may be
   // dynamic, but static offsets must be aligned.
-  if (sizeR % innerRows != 0 || sizeC % innerCols != 0)
+  if (sizeR % innerRows != 0 || sizeC % innerCols != 0) {
     return emitOpError("boxed layout subview sizes must be multiples of inner shape");
+  }
 
   if (offRConst) {
-    if (offR % innerRows != 0)
+    if (offR % innerRows != 0) {
       return emitOpError("boxed layout subview offsets must be multiples of inner shape");
+    }
   }
   if (offCConst) {
-    if (offC % innerCols != 0)
+    if (offC % innerCols != 0) {
       return emitOpError("boxed layout subview offsets must be multiples of inner shape");
+    }
   }
 
   (void)bl;
@@ -15018,16 +17057,18 @@ using namespace mlir::pto;
 static void addEffect(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects,
     OpOperand *operand, MemoryEffects::Effect *effect) {
-  if (operand)
+  if (operand) {
     effects.emplace_back(effect, operand, SideEffects::DefaultResource::get());
+  }
 }
  
 // 针对结果 (Result) 的重载
 static void addEffect(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects,
     OpResult result, MemoryEffects::Effect *effect) {
-  if (result)
+  if (result) {
     effects.emplace_back(effect, result, SideEffects::DefaultResource::get());
+  }
 }
 
 // === TLoadOp ===
@@ -15058,11 +17099,13 @@ void TAbsOp::getEffects(
 void TStoreOp::getEffects(SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   addEffect(effects, &getSrcMutable(), MemoryEffects::Read::get());
   auto fpRange = getFpMutable();
-  if (!fpRange.empty())
+  if (!fpRange.empty()) {
     addEffect(effects, &*fpRange.begin(), MemoryEffects::Read::get());
+  }
   auto preQuantRange = getPreQuantScalarMutable();
-  if (!preQuantRange.empty())
+  if (!preQuantRange.empty()) {
     addEffect(effects, &*preQuantRange.begin(), MemoryEffects::Read::get());
+  }
   addEffect(effects, &getDstMutable(), MemoryEffects::Write::get());
 }
 
@@ -15089,11 +17132,13 @@ void TMovOp::getEffects(SmallVectorImpl<SideEffects::EffectInstance<MemoryEffect
   }
   addEffect(effects, &getSrcMutable(), MemoryEffects::Read::get());
   auto fpRange = getFpMutable();
-  if (!fpRange.empty())
+  if (!fpRange.empty()) {
     addEffect(effects, &*fpRange.begin(), MemoryEffects::Read::get());
+  }
   auto preQuantRange = getPreQuantScalarMutable();
-  if (!preQuantRange.empty())
+  if (!preQuantRange.empty()) {
     addEffect(effects, &*preQuantRange.begin(), MemoryEffects::Read::get());
+  }
   addEffect(effects, &getDstMutable(), MemoryEffects::Write::get());
 }
 
@@ -15155,8 +17200,9 @@ void MGatherOp::getEffects(
   // GM -> L1 Elem mode stages the gathered elements into the GM scratch buffer
   // before the bulk copy: the op clobbers scratch, so model it as a write.
   auto scratchRange = getScratchMutable();
-  if (!scratchRange.empty())
+  if (!scratchRange.empty()) {
     addEffect(effects, &*scratchRange.begin(), MemoryEffects::Write::get());
+  }
 }
 
 // MSCATTER: Read(src, idx) -> Write(mem)
@@ -15324,8 +17370,9 @@ void TExtractOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   addEffect(effects, &getSrcMutable(), MemoryEffects::Read::get());
   auto fpRange = getFpMutable();
-  if (!fpRange.empty())
+  if (!fpRange.empty()) {
     addEffect(effects, &*fpRange.begin(), MemoryEffects::Read::get());
+  }
   addEffect(effects, &getDstMutable(), MemoryEffects::Write::get());
 }
 
@@ -15334,8 +17381,9 @@ void TInsertOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   addEffect(effects, &getSrcMutable(), MemoryEffects::Read::get());
   auto fpRange = getFpMutable();
-  if (!fpRange.empty())
+  if (!fpRange.empty()) {
     addEffect(effects, &*fpRange.begin(), MemoryEffects::Read::get());
+  }
   addEffect(effects, &getDstMutable(), MemoryEffects::Write::get());
 }
 
@@ -15344,10 +17392,12 @@ PTO_DEFINE_UNARY_EFFECTS(TFillPadOp, getSrcMutable(), getDstMutable())
 void TGatherOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrcMutable());
-  if (auto cdst = getCdstMutable(); !cdst.empty())
+  if (auto cdst = getCdstMutable(); !cdst.empty()) {
     PTO_ADD_WRITE(cdst[0]);
-  if (auto indices = getIndicesMutable(); !indices.empty())
+  }
+  if (auto indices = getIndicesMutable(); !indices.empty()) {
     PTO_ADD_READ(indices[0]);
+  }
   if (auto tmp = getTmpMutable();
       !tmp.empty() && getTargetArch(getOperation()) != PTOArch::A5) {
     PTO_ADD_READ(tmp[0]);
@@ -15434,8 +17484,9 @@ void TQuantOp::getEffects(
   PTO_ADD_READ(getSrcMutable());
   PTO_ADD_READ(getFpMutable());
   auto offsetRange = getOffsetMutable();
-  if (!offsetRange.empty())
+  if (!offsetRange.empty()) {
     PTO_ADD_READ(offsetRange[0]);
+  }
   auto tmpRange = getTmpMutable();
   if (!tmpRange.empty() && getTargetArch(getOperation()) != PTOArch::A5) {
     PTO_ADD_READ(tmpRange[0]);
@@ -15462,8 +17513,9 @@ void TQuantMxOp::getEffects(
   PTO_ADD_WRITE(getMaxMutable());
   PTO_ADD_WRITE(getScalingMutable());
   auto expZzRange = getExpZzMutable();
-  if (!expZzRange.empty())
+  if (!expZzRange.empty()) {
     PTO_ADD_WRITE(expZzRange[0]);
+  }
 }
 PTO_DEFINE_TERNARY_EFFECTS(TDequantOp, getSrcMutable(), getScaleMutable(),
                            getOffsetMutable(), getDstMutable())
@@ -15571,8 +17623,9 @@ void TRowExpandExpdifOp::getEffects(
   PTO_ADD_READ(getSrc0Mutable());
   PTO_ADD_READ(getSrc1Mutable());
   auto tmp = getTmpMutable();
-  if (!tmp.empty() && getTargetArch(getOperation()) != PTOArch::A5)
+  if (!tmp.empty() && getTargetArch(getOperation()) != PTOArch::A5) {
     PTO_ADD_WRITE(tmp[0]);
+  }
   PTO_ADD_WRITE(getDstMutable());
 }
 
@@ -15688,8 +17741,9 @@ void TScatterOp::getEffects(
   PTO_ADD_READ(getSrcMutable());
   if (getIndexes()) {
     auto idx = getIndexesMutable();
-    if (!idx.empty())
+    if (!idx.empty()) {
       PTO_ADD_READ(idx[0]);
+    }
   }
   PTO_ADD_WRITE(getDstMutable());
 }
@@ -15738,8 +17792,9 @@ void TSort32Op::getEffects(
   PTO_ADD_READ(getSrcMutable());
   PTO_ADD_READ(getIdxMutable());
   auto tmp = getTmpMutable();
-  if (!tmp.empty())
+  if (!tmp.empty()) {
     PTO_ADD_WRITE(tmp[0]);
+  }
   PTO_ADD_WRITE(getDstMutable());
 }
 
@@ -15795,8 +17850,9 @@ void TTransOp::getEffects(
 void TPrintOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrcMutable());
-  if (!getTmpMutable().empty())
+  if (!getTmpMutable().empty()) {
     PTO_ADD_WRITE(getTmpMutable()[0]);
+  }
   PTO_ADD_WRITE(getSrcMutable());
 }
 
@@ -15940,14 +17996,16 @@ static bool isInsideTileOpHelper(Operation *op) {
 static std::optional<FunctionKernelKind>
 getEnclosingFunctionKernelKind(Operation *op) {
   auto funcOp = op->getParentOfType<func::FuncOp>();
-  if (!funcOp)
+  if (!funcOp) {
     return std::nullopt;
+  }
 
   auto kernelKindAttr =
       funcOp->getAttrOfType<FunctionKernelKindAttr>(
           FunctionKernelKindAttr::name);
-  if (!kernelKindAttr)
+  if (!kernelKindAttr) {
     return std::nullopt;
+  }
 
   return kernelKindAttr.getKernelKind();
 }
@@ -15958,8 +18016,9 @@ static bool isInsideSectionOrAttributedKernel(Operation *op) {
 }
 
 static LogicalResult verifySplitAttr(Operation *op, int64_t split) {
-  if (split < 0 || split > 4)
+  if (split < 0 || split > 4) {
     return op->emitOpError("expects 'split' to be 0, 1, 2, 3, or 4");
+  }
   return success();
 }
 
@@ -15968,15 +18027,17 @@ static bool isOddSplit(int64_t split) {
 }
 
 static bool isInsideCubeKernelOrSection(Operation *op) {
-  if (isInsideSectionCube(op))
+  if (isInsideSectionCube(op)) {
     return true;
+  }
   auto kernelKind = getEnclosingFunctionKernelKind(op);
   return kernelKind && *kernelKind == FunctionKernelKind::Cube;
 }
 
 static bool isInsideVectorKernelOrSection(Operation *op) {
-  if (isInsideSectionVector(op))
+  if (isInsideSectionVector(op)) {
     return true;
+  }
   auto kernelKind = getEnclosingFunctionKernelKind(op);
   return kernelKind && *kernelKind == FunctionKernelKind::Vector;
 }
@@ -15984,17 +18045,20 @@ static bool isInsideVectorKernelOrSection(Operation *op) {
 static LogicalResult verifyFrontendKernelKind(Operation *op,
                                               FunctionKernelKind expected,
                                               StringRef kernelName) {
-  if (isInsideTileOpHelper(op))
+  if (isInsideTileOpHelper(op)) {
     return success();
+  }
   if (isInsideSectionCube(op)) {
-    if (expected == FunctionKernelKind::Cube)
+    if (expected == FunctionKernelKind::Cube) {
       return success();
+    }
     return op->emitOpError("must be inside a ")
            << kernelName << " kernel function or section";
   }
   if (isInsideSectionVector(op)) {
-    if (expected == FunctionKernelKind::Vector)
+    if (expected == FunctionKernelKind::Vector) {
       return success();
+    }
     return op->emitOpError("must be inside a ")
            << kernelName << " kernel function or section";
   }
@@ -16019,93 +18083,114 @@ static ParseResult parseFrontendInitializePipeOp(OpAsmParser &parser,
   bool sawNoSplit = false;
   bool sawAccPushEpilogue = false;
 
-  if (parser.parseLBrace())
+  if (parser.parseLBrace()) {
     return failure();
+  }
 
   while (failed(parser.parseOptionalRBrace())) {
     StringRef keyword;
-    if (parser.parseKeyword(&keyword) || parser.parseEqual())
+    if (parser.parseKeyword(&keyword) || parser.parseEqual()) {
       return failure();
+    }
 
     if (keyword == "id") {
-      if (sawId)
+      if (sawId) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "duplicate 'id' clause");
+      }
       IntegerAttr idAttr;
       if (parser.parseAttribute(idAttr, parser.getBuilder().getI32Type(), "id",
-                                attrs))
+                                attrs)) {
         return failure();
+      }
       sawId = true;
     } else if (keyword == "dir_mask") {
-      if (sawDirMask)
+      if (sawDirMask) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "duplicate 'dir_mask' clause");
+      }
       IntegerAttr dirMaskAttr;
       if (parser.parseAttribute(dirMaskAttr, parser.getBuilder().getI8Type(),
-                                "dir_mask", attrs))
+                                "dir_mask", attrs)) {
         return failure();
+      }
       sawDirMask = true;
     } else if (keyword == "slot_size") {
-      if (sawSlotSize)
+      if (sawSlotSize) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "duplicate 'slot_size' clause");
+      }
       IntegerAttr slotSizeAttr;
       if (parser.parseAttribute(slotSizeAttr, parser.getBuilder().getI32Type(),
-                                "slot_size", attrs))
+                                "slot_size", attrs)) {
         return failure();
+      }
       sawSlotSize = true;
     } else if (keyword == "slot_num") {
-      if (sawSlotNum)
+      if (sawSlotNum) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "duplicate 'slot_num' clause");
+      }
       IntegerAttr slotNumAttr;
       if (parser.parseAttribute(slotNumAttr, parser.getBuilder().getI32Type(),
-                                "slot_num", attrs))
+                                "slot_num", attrs)) {
         return failure();
+      }
       sawSlotNum = true;
     } else if (keyword == "local_slot_num") {
-      if (sawLocalSlotNum)
+      if (sawLocalSlotNum) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "duplicate 'local_slot_num' clause");
+      }
       IntegerAttr localSlotNumAttr;
       if (parser.parseAttribute(localSlotNumAttr, parser.getBuilder().getI32Type(),
-                                "local_slot_num", attrs))
+                                "local_slot_num", attrs)) {
         return failure();
+      }
       sawLocalSlotNum = true;
     } else if (keyword == "nosplit") {
-      if (sawNoSplit)
+      if (sawNoSplit) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "duplicate 'nosplit' clause");
+      }
       BoolAttr noSplitAttr;
-      if (parser.parseAttribute(noSplitAttr, "nosplit", attrs))
+      if (parser.parseAttribute(noSplitAttr, "nosplit", attrs)) {
         return failure();
+      }
       sawNoSplit = true;
     } else if (keyword == "acc_push_epilogue") {
-      if (sawAccPushEpilogue)
+      if (sawAccPushEpilogue) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "duplicate 'acc_push_epilogue' clause");
+      }
       AccPushEpilogueAttr accPushEpilogueAttr;
       if (parser.parseAttribute(accPushEpilogueAttr, "acc_push_epilogue",
-                                attrs))
+                                attrs)) {
         return failure();
+      }
       sawAccPushEpilogue = true;
     } else {
       return parser.emitError(parser.getCurrentLocation())
              << "unexpected keyword '" << keyword << "'";
     }
 
-    if (succeeded(parser.parseOptionalRBrace()))
+    if (succeeded(parser.parseOptionalRBrace())) {
       break;
-    if (parser.parseComma())
+    }
+    if (parser.parseComma()) {
       return failure();
+    }
   }
 
-  if (!sawDirMask)
+  if (!sawDirMask) {
     return parser.emitError(parser.getNameLoc(), "expected 'dir_mask' clause");
-  if (!sawSlotSize)
+  }
+  if (!sawSlotSize) {
     return parser.emitError(parser.getNameLoc(), "expected 'slot_size' clause");
-  if (!sawId)
+  }
+  if (!sawId) {
     attrs.set("id", parser.getBuilder().getI32IntegerAttr(0));
+  }
 
   OpAsmParser::UnresolvedOperand gmSlotBuffer;
   OpAsmParser::UnresolvedOperand gmSlotTensor;
@@ -16120,58 +18205,71 @@ static ParseResult parseFrontendInitializePipeOp(OpAsmParser &parser,
   bool hasC2vConsumerBuf = false;
   bool hasV2cConsumerBuf = false;
 
-  if (parser.parseLParen())
+  if (parser.parseLParen()) {
     return failure();
+  }
   while (failed(parser.parseOptionalRParen())) {
     StringRef keyword;
-    if (parser.parseKeyword(&keyword) || parser.parseEqual())
+    if (parser.parseKeyword(&keyword) || parser.parseEqual()) {
       return failure();
+    }
 
     if (keyword == "gm_slot_buffer") {
-      if (hasGmSlotBuffer)
+      if (hasGmSlotBuffer) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "duplicate 'gm_slot_buffer' operand");
+      }
       if (parser.parseOperand(gmSlotBuffer) ||
-          parser.parseColonType(gmSlotBufferTy))
+          parser.parseColonType(gmSlotBufferTy)) {
         return failure();
+      }
       hasGmSlotBuffer = true;
     } else if (keyword == "gm_slot_tensor") {
-      if (hasGmSlotTensor)
+      if (hasGmSlotTensor) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "duplicate 'gm_slot_tensor' operand");
+      }
       if (parser.parseOperand(gmSlotTensor) ||
-          parser.parseColonType(gmSlotTensorTy))
+          parser.parseColonType(gmSlotTensorTy)) {
         return failure();
+      }
       hasGmSlotTensor = true;
     } else if (keyword == "c2v_consumer_buf") {
-      if (hasC2vConsumerBuf)
+      if (hasC2vConsumerBuf) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "duplicate 'c2v_consumer_buf' operand");
+      }
       if (parser.parseOperand(c2vConsumerBuf) ||
-          parser.parseColonType(c2vConsumerBufTy))
+          parser.parseColonType(c2vConsumerBufTy)) {
         return failure();
+      }
       hasC2vConsumerBuf = true;
     } else if (keyword == "v2c_consumer_buf") {
-      if (hasV2cConsumerBuf)
+      if (hasV2cConsumerBuf) {
         return parser.emitError(parser.getCurrentLocation(),
                                 "duplicate 'v2c_consumer_buf' operand");
+      }
       if (parser.parseOperand(v2cConsumerBuf) ||
-          parser.parseColonType(v2cConsumerBufTy))
+          parser.parseColonType(v2cConsumerBufTy)) {
         return failure();
+      }
       hasV2cConsumerBuf = true;
     } else {
       return parser.emitError(parser.getCurrentLocation())
              << "unexpected initialize_pipe operand '" << keyword << "'";
     }
 
-    if (succeeded(parser.parseOptionalRParen()))
+    if (succeeded(parser.parseOptionalRParen())) {
       break;
-    if (parser.parseComma())
+    }
+    if (parser.parseComma()) {
       return failure();
+    }
   }
 
-  if (parser.parseOptionalAttrDict(attrs))
+  if (parser.parseOptionalAttrDict(attrs)) {
     return failure();
+  }
 
   result.addAttributes(attrs);
   result.addAttribute("operandSegmentSizes",
@@ -16180,17 +18278,21 @@ static ParseResult parseFrontendInitializePipeOp(OpAsmParser &parser,
                            hasC2vConsumerBuf ? 1 : 0,
                            hasV2cConsumerBuf ? 1 : 0}));
   if (hasGmSlotBuffer &&
-      parser.resolveOperand(gmSlotBuffer, gmSlotBufferTy, result.operands))
+      parser.resolveOperand(gmSlotBuffer, gmSlotBufferTy, result.operands)) {
     return failure();
+  }
   if (hasGmSlotTensor &&
-      parser.resolveOperand(gmSlotTensor, gmSlotTensorTy, result.operands))
+      parser.resolveOperand(gmSlotTensor, gmSlotTensorTy, result.operands)) {
     return failure();
+  }
   if (hasC2vConsumerBuf &&
-      parser.resolveOperand(c2vConsumerBuf, c2vConsumerBufTy, result.operands))
+      parser.resolveOperand(c2vConsumerBuf, c2vConsumerBufTy, result.operands)) {
     return failure();
+  }
   if (hasV2cConsumerBuf &&
-      parser.resolveOperand(v2cConsumerBuf, v2cConsumerBufTy, result.operands))
+      parser.resolveOperand(v2cConsumerBuf, v2cConsumerBufTy, result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -16199,8 +18301,9 @@ static void printFrontendInitializePipeOp(InitOpT op, OpAsmPrinter &p) {
   p << " {";
   bool needsComma = false;
   auto printClause = [&](StringRef keyword, auto value) {
-    if (needsComma)
+    if (needsComma) {
       p << ", ";
+    }
     p << keyword << " = " << value;
     needsComma = true;
   };
@@ -16208,33 +18311,41 @@ static void printFrontendInitializePipeOp(InitOpT op, OpAsmPrinter &p) {
   printClause("id", op.getId());
   printClause("dir_mask", static_cast<int32_t>(op.getDirMask()));
   printClause("slot_size", op.getSlotSize());
-  if (auto slotNumAttr = op.getSlotNumAttr())
+  if (auto slotNumAttr = op.getSlotNumAttr()) {
     printClause("slot_num", slotNumAttr.getInt());
-  if (auto localSlotNumAttr = op.getLocalSlotNumAttr())
+  }
+  if (auto localSlotNumAttr = op.getLocalSlotNumAttr()) {
     printClause("local_slot_num", localSlotNumAttr.getInt());
-  if (auto noSplitAttr = op.getNosplitAttr())
+  }
+  if (auto noSplitAttr = op.getNosplitAttr()) {
     printClause("nosplit", noSplitAttr.getValue() ? "true" : "false");
-  if (auto accPushEpilogueAttr = op.getAccPushEpilogueAttr())
+  }
+  if (auto accPushEpilogueAttr = op.getAccPushEpilogueAttr()) {
     printClause("acc_push_epilogue", accPushEpilogueAttr);
+  }
   p << "}";
 
   p << "(";
   bool needsOperandComma = false;
   auto printOperandClause = [&](StringRef keyword, Value value) {
-    if (needsOperandComma)
+    if (needsOperandComma) {
       p << ", ";
+    }
     p << keyword << " = " << value << " : " << value.getType();
     needsOperandComma = true;
   };
   if (op.getGmSlotBuffer()) {
     printOperandClause("gm_slot_buffer", op.getGmSlotBuffer());
   }
-  if (op.getGmSlotTensor())
+  if (op.getGmSlotTensor()) {
     printOperandClause("gm_slot_tensor", op.getGmSlotTensor());
-  if (op.getC2vConsumerBuf())
+  }
+  if (op.getC2vConsumerBuf()) {
     printOperandClause("c2v_consumer_buf", op.getC2vConsumerBuf());
-  if (op.getV2cConsumerBuf())
+  }
+  if (op.getV2cConsumerBuf()) {
     printOperandClause("v2c_consumer_buf", op.getV2cConsumerBuf());
+  }
   p << ")";
   p.printOptionalAttrDict(
       op->getAttrs(),
@@ -16247,8 +18358,9 @@ static std::optional<uint64_t>
 getStaticElementCount(ArrayRef<int64_t> shape) {
   uint64_t count = 1;
   for (int64_t dim : shape) {
-    if (dim == ShapedType::kDynamic || dim < 0)
+    if (dim == ShapedType::kDynamic || dim < 0) {
       return std::nullopt;
+    }
     count *= static_cast<uint64_t>(dim);
   }
   return count;
@@ -16263,13 +18375,15 @@ static LogicalResult verifyFrontendGlobalSlotTensor(Operation *op, Value tensor,
                                                     int32_t slotSize) {
   (void)dirMask;
   auto tvTy = dyn_cast<TensorViewType>(tensor.getType());
-  if (!tvTy)
+  if (!tvTy) {
     return op->emitOpError("expects 'gm_slot_tensor' to be !pto.tensor_view");
+  }
 
   ArrayRef<int64_t> shape = tvTy.getShape();
-  if (shape.empty())
+  if (shape.empty()) {
     return op->emitOpError(
         "expects 'gm_slot_tensor' to describe one slot entry tensor");
+  }
 
   if (auto elemCount = getStaticElementCount(shape)) {
     uint64_t elemBytes = getElemByteSize(tvTy.getElementType());
@@ -16294,28 +18408,35 @@ template <typename InitOpT>
 static LogicalResult verifyFrontendInitCommon(InitOpT op,
                                               FunctionKernelKind expected,
                                               StringRef kernelName) {
-  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(op.getOperation())))
+  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(op.getOperation()))) {
     return failure();
-  if (failed(verifyFrontendKernelKind(op.getOperation(), expected, kernelName)))
+  }
+  if (failed(verifyFrontendKernelKind(op.getOperation(), expected, kernelName))) {
     return failure();
+  }
 
   auto funcOp = op->template getParentOfType<func::FuncOp>();
-  if (!funcOp)
+  if (!funcOp) {
     return op.emitOpError("must be nested under a func.func");
+  }
 
-  if (op.getId() < 0)
+  if (op.getId() < 0) {
     return op.emitOpError("expects 'id' to be non-negative");
+  }
 
   unsigned sameIdInitCount = 0;
   funcOp.walk([&](Operation *candidate) {
     if (auto aic = dyn_cast<AicInitializePipeOp>(candidate)) {
-      if (aic.getId() == op.getId())
+      if (aic.getId() == op.getId()) {
         ++sameIdInitCount;
+      }
       return;
     }
-    if (auto aiv = dyn_cast<AivInitializePipeOp>(candidate))
-      if (aiv.getId() == op.getId())
+    if (auto aiv = dyn_cast<AivInitializePipeOp>(candidate)) {
+      if (aiv.getId() == op.getId()) {
         ++sameIdInitCount;
+      }
+    }
   });
   if (sameIdInitCount > 1) {
     return op.emitOpError(
@@ -16323,15 +18444,18 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
   }
 
   int8_t dirMask = op.getDirMask();
-  if (dirMask != 1 && dirMask != 2 && dirMask != 3)
+  if (dirMask != 1 && dirMask != 2 && dirMask != 3) {
     return op.emitOpError("expects 'dir_mask' to be 1, 2, or 3");
-  if (op.getSlotSize() <= 0)
+  }
+  if (op.getSlotSize() <= 0) {
     return op.emitOpError("expects 'slot_size' to be greater than 0");
+  }
   int32_t slotNum = dirMask == 3 ? 4 : 8;
   if (auto slotNumAttr = op.getSlotNumAttr()) {
     slotNum = slotNumAttr.getInt();
-    if (slotNum <= 0)
+    if (slotNum <= 0) {
       return op.emitOpError("expects 'slot_num' to be greater than 0");
+    }
   }
   PTOArch arch = getTargetArch(op.getOperation());
 
@@ -16351,16 +18475,18 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
           "with 'gm_slot_tensor' and 'c2v_consumer_buf'");
     }
     if (!hasC2vConsumerBuf && !hasV2cConsumerBuf) {
-      if (op.getLocalSlotNumAttr())
+      if (op.getLocalSlotNumAttr()) {
         return op.emitOpError(
             "globaltensor pipe init does not use 'local_slot_num'");
+      }
       return verifyFrontendGlobalSlotTensor(
           op.getOperation(), op.getGmSlotTensor(), dirMask, op.getSlotSize());
     }
     if (failed(verifyFrontendGlobalSlotTensor(
             op.getOperation(), op.getGmSlotTensor(), dirMask,
-            op.getSlotSize())))
+            op.getSlotSize()))) {
       return failure();
+    }
   }
 
   if (!hasC2vConsumerBuf && !hasV2cConsumerBuf) {
@@ -16382,12 +18508,14 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
   }
 
   if (auto localSlotNumAttr = op.getLocalSlotNumAttr()) {
-    if (arch == PTOArch::A5)
+    if (arch == PTOArch::A5) {
       return op.emitOpError(
           "'local_slot_num' is only supported for a2/a3 frontend pipe lowering");
+    }
     int32_t localSlotNum = localSlotNumAttr.getInt();
-    if (localSlotNum <= 0)
+    if (localSlotNum <= 0) {
       return op.emitOpError("expects 'local_slot_num' to be greater than 0");
+    }
     if (localSlotNum > slotNum) {
       return op.emitOpError()
              << "expects 'local_slot_num' to be less than or equal to slot_num ("
@@ -16511,8 +18639,9 @@ ReserveBufferOp mlir::pto::findReserveBufferByName(func::FuncOp funcOp,
                                                    StringRef name) {
   ReserveBufferOp found;
   funcOp.walk([&](ReserveBufferOp reserveOp) {
-    if (reserveOp.getName() != name)
+    if (reserveOp.getName() != name) {
       return WalkResult::advance();
+    }
     found = reserveOp;
     return WalkResult::interrupt();
   });
@@ -16521,41 +18650,50 @@ ReserveBufferOp mlir::pto::findReserveBufferByName(func::FuncOp funcOp,
 
 LogicalResult ReserveBufferOp::verify() {
   auto funcOp = getOperation()->getParentOfType<func::FuncOp>();
-  if (!funcOp)
+  if (!funcOp) {
     return emitOpError("must be nested under a func.func");
+  }
 
-  if (getSize() <= 0)
+  if (getSize() <= 0) {
     return emitOpError("expects 'size' to be greater than 0");
+  }
 
   auto location = getLocation().getAddressSpace();
-  if (location != AddressSpace::VEC && location != AddressSpace::MAT)
+  if (location != AddressSpace::VEC && location != AddressSpace::MAT) {
     return emitOpError("expects 'location' to be #pto.address_space<vec> or #pto.address_space<mat>");
+  }
 
-  if (!getAutoAlloc() && !getBaseAttr())
+  if (!getAutoAlloc() && !getBaseAttr()) {
     return emitOpError("expects 'base' when 'auto' is false");
+  }
 
-  if (auto baseAttr = getBaseAttr(); baseAttr && baseAttr.getInt() < 0)
+  if (auto baseAttr = getBaseAttr(); baseAttr && baseAttr.getInt() < 0) {
     return emitOpError("expects 'base' to be non-negative when present");
+  }
 
   unsigned sameNameCount = 0;
   funcOp.walk([&](ReserveBufferOp reserveOp) {
-    if (reserveOp.getName() == getName())
+    if (reserveOp.getName() == getName()) {
       ++sameNameCount;
+    }
   });
-  if (sameNameCount > 1)
+  if (sameNameCount > 1) {
     return emitOpError("requires 'name' to be unique within the function");
+  }
 
   return success();
 }
 
 LogicalResult ImportReservedBufferOp::verify() {
   auto funcOp = getOperation()->getParentOfType<func::FuncOp>();
-  if (!funcOp)
+  if (!funcOp) {
     return emitOpError("must be nested under a func.func");
+  }
 
   auto peerFunc = lookupPeerFuncAcrossContainer(getOperation(), getPeerFuncAttr());
-  if (!peerFunc)
+  if (!peerFunc) {
     return emitOpError("expects 'peer_func' to reference an existing func.func");
+  }
 
   unsigned sameImportCount = 0;
   funcOp.walk([&](ImportReservedBufferOp importOp) {
@@ -16569,8 +18707,9 @@ LogicalResult ImportReservedBufferOp::verify() {
         "requires (name, peer_func) to be unique within the function");
   }
 
-  if (!findReserveBufferByName(peerFunc, getName()))
+  if (!findReserveBufferByName(peerFunc, getName())) {
     return emitOpError("expects matching peer reserve_buffer to exist");
+  }
 
   return success();
 }
@@ -16628,36 +18767,45 @@ static FailureOr<Operation *> lookupFrontendInitOpById(Operation *op,
 }
 
 static std::optional<int32_t> getFrontendPipeIdFromHandle(Value pipeHandle) {
-  if (!pipeHandle)
+  if (!pipeHandle) {
     return std::nullopt;
+  }
   Operation *defOp = pipeHandle.getDefiningOp();
-  if (!defOp)
+  if (!defOp) {
     return std::nullopt;
+  }
   auto frontendIdAttr = defOp->getAttrOfType<IntegerAttr>(kFrontendPipeIdAttrName);
-  if (!frontendIdAttr)
+  if (!frontendIdAttr) {
     return std::nullopt;
+  }
   return static_cast<int32_t>(frontendIdAttr.getInt());
 }
 
 static pto::AccPushEpilogueAttr getAccPushEpilogueFromInitOp(Operation *initOp) {
-  if (!initOp)
+  if (!initOp) {
     return {};
-  if (auto aicInit = dyn_cast<AicInitializePipeOp>(initOp))
+  }
+  if (auto aicInit = dyn_cast<AicInitializePipeOp>(initOp)) {
     return aicInit.getAccPushEpilogueAttr();
-  if (auto aivInit = dyn_cast<AivInitializePipeOp>(initOp))
+  }
+  if (auto aivInit = dyn_cast<AivInitializePipeOp>(initOp)) {
     return aivInit.getAccPushEpilogueAttr();
-  if (auto l2lInit = dyn_cast<InitializeL2LPipeOp>(initOp))
+  }
+  if (auto l2lInit = dyn_cast<InitializeL2LPipeOp>(initOp)) {
     return l2lInit.getAccPushEpilogueAttr();
-  if (auto l2g2lInit = dyn_cast<InitializeL2G2LPipeOp>(initOp))
+  }
+  if (auto l2g2lInit = dyn_cast<InitializeL2G2LPipeOp>(initOp)) {
     return l2g2lInit.getAccPushEpilogueAttr();
+  }
   return {};
 }
 
 static bool matchesLoweredFixpipePeerContract(Operation *initOp,
                                               func::FuncOp expectedOwnerFunc,
                                               StringRef expectedReserveName) {
-  if (!initOp || !isa<InitializeL2LPipeOp, InitializeL2G2LPipeOp>(initOp))
+  if (!initOp || !isa<InitializeL2LPipeOp, InitializeL2G2LPipeOp>(initOp)) {
     return false;
+  }
 
   auto ownerAttr =
       initOp->getAttrOfType<FlatSymbolRefAttr>(kPipePeerOwnerFuncAttrName);
@@ -16665,13 +18813,15 @@ static bool matchesLoweredFixpipePeerContract(Operation *initOp,
       initOp->getAttrOfType<StringAttr>(kPipePeerReserveNameAttrName);
   auto dirMaskAttr =
       initOp->getAttrOfType<IntegerAttr>(kPipePeerDirMaskAttrName);
-  if (!ownerAttr || !reserveAttr || !dirMaskAttr)
+  if (!ownerAttr || !reserveAttr || !dirMaskAttr) {
     return false;
+  }
 
   if (ownerAttr.getValue() != expectedOwnerFunc.getSymName() ||
       reserveAttr.getValue() != expectedReserveName ||
-      dirMaskAttr.getInt() != 1)
+      dirMaskAttr.getInt() != 1) {
     return false;
+  }
 
   return static_cast<bool>(getAccPushEpilogueFromInitOp(initOp));
 }
@@ -16681,46 +18831,53 @@ static FailureOr<Operation *> lookupFrontendOrLoweredInitOpById(
 
 static FailureOr<Operation *>
 lookupFixpipePeerConsumerInit(AicInitializePipeOp producerInit) {
-  if (!producerInit.getC2vConsumerBuf())
+  if (!producerInit.getC2vConsumerBuf()) {
     return failure();
+  }
   auto importOp = dyn_cast_or_null<ImportReservedBufferOp>(
       producerInit.getC2vConsumerBuf().getDefiningOp());
-  if (!importOp)
+  if (!importOp) {
     return failure();
+  }
 
   auto peerConsumerFunc =
       lookupPeerFuncAcrossContainer(importOp.getOperation(),
                                     importOp.getPeerFuncAttr());
-  if (!peerConsumerFunc)
+  if (!peerConsumerFunc) {
     return failure();
+  }
 
   StringRef bufferName = importOp.getName();
   Operation *matchedInit = nullptr;
   unsigned matchedInitCount = 0;
   peerConsumerFunc.walk([&](Operation *candidate) {
     if (auto aivInit = dyn_cast<AivInitializePipeOp>(candidate)) {
-      if (!aivInit.getC2vConsumerBuf())
+      if (!aivInit.getC2vConsumerBuf()) {
         return WalkResult::advance();
+      }
       auto reserveOp = dyn_cast_or_null<ReserveBufferOp>(
           aivInit.getC2vConsumerBuf().getDefiningOp());
-      if (!reserveOp || reserveOp.getName() != bufferName)
+      if (!reserveOp || reserveOp.getName() != bufferName) {
         return WalkResult::advance();
+      }
       matchedInit = candidate;
       ++matchedInitCount;
       return WalkResult::advance();
     }
 
     if (!matchesLoweredFixpipePeerContract(candidate, peerConsumerFunc,
-                                           bufferName))
+                                           bufferName)) {
       return WalkResult::advance();
+    }
 
     matchedInit = candidate;
     ++matchedInitCount;
     return WalkResult::advance();
   });
 
-  if (matchedInitCount != 1)
+  if (matchedInitCount != 1) {
     return failure();
+  }
   return matchedInit;
 }
 
@@ -16733,20 +18890,23 @@ lookupFixpipePeerProducerInit(AivInitializePipeOp consumerInit,
   unsigned matchedInitCount = 0;
   peerProducerFunc.walk([&](Operation *candidate) {
     if (auto aicInit = dyn_cast<AicInitializePipeOp>(candidate)) {
-      if (!aicInit.getC2vConsumerBuf())
+      if (!aicInit.getC2vConsumerBuf()) {
         return WalkResult::advance();
+      }
 
       auto importOp = dyn_cast_or_null<ImportReservedBufferOp>(
           aicInit.getC2vConsumerBuf().getDefiningOp());
-      if (!importOp)
+      if (!importOp) {
         return WalkResult::advance();
+      }
 
       auto peerConsumerFunc =
           lookupPeerFuncAcrossContainer(importOp.getOperation(),
                                         importOp.getPeerFuncAttr());
       if (importOp.getName() != bufferName ||
-          peerConsumerFunc != currentConsumerFunc)
+          peerConsumerFunc != currentConsumerFunc) {
         return WalkResult::advance();
+      }
 
       matchedInit = candidate;
       ++matchedInitCount;
@@ -16754,8 +18914,9 @@ lookupFixpipePeerProducerInit(AivInitializePipeOp consumerInit,
     }
 
     if (!matchesLoweredFixpipePeerContract(candidate, currentConsumerFunc,
-                                           bufferName))
+                                           bufferName)) {
       return WalkResult::advance();
+    }
 
     matchedInit = candidate;
     ++matchedInitCount;
@@ -16794,8 +18955,9 @@ static FailureOr<Operation *> lookupFrontendOrLoweredInitOpById(
     return WalkResult::advance();
   });
 
-  if (matchedFrontendInitCount == 1)
+  if (matchedFrontendInitCount == 1) {
     return matchedFrontendInit;
+  }
   if (matchedFrontendInitCount > 1) {
     op->emitOpError() << "expects 'id' = " << id
                       << " to match exactly one frontend initialize_pipe op in the same function";
@@ -16805,12 +18967,14 @@ static FailureOr<Operation *> lookupFrontendOrLoweredInitOpById(
   Operation *matchedInit = nullptr;
   unsigned matchedInitCount = 0;
   funcOp.walk([&](Operation *candidate) {
-    if (!isa<InitializeL2LPipeOp, InitializeL2G2LPipeOp>(candidate))
+    if (!isa<InitializeL2LPipeOp, InitializeL2G2LPipeOp>(candidate)) {
       return WalkResult::advance();
+    }
     auto frontendIdAttr =
         candidate->getAttrOfType<IntegerAttr>(kFrontendPipeIdAttrName);
-    if (!frontendIdAttr || frontendIdAttr.getInt() != id)
+    if (!frontendIdAttr || frontendIdAttr.getInt() != id) {
       return WalkResult::advance();
+    }
     matchedInit = candidate;
     ++matchedInitCount;
     return WalkResult::advance();
@@ -16835,14 +18999,18 @@ static LogicalResult verifyFrontendSplitOp(Operation *op,
                                            int32_t id,
                                            int64_t split,
                                            bool expectC2V) {
-  if (failed(verifyFrontendKernelKind(op, expected, kernelName)))
+  if (failed(verifyFrontendKernelKind(op, expected, kernelName))) {
     return failure();
-  if (id < 0)
+  }
+  if (id < 0) {
     return op->emitOpError("expects 'id' to be non-negative");
-  if (failed(verifySplitAttr(op, split)))
+  }
+  if (failed(verifySplitAttr(op, split))) {
     return failure();
-  if (!isOddSplit(split))
+  }
+  if (!isOddSplit(split)) {
     return success();
+  }
   if (!expectC2V) {
     return op->emitOpError(
         "supports odd split modes (split = 3 or 4) only for C2V "
@@ -16850,13 +19018,15 @@ static LogicalResult verifyFrontendSplitOp(Operation *op,
   }
 
   auto funcOp = op->getParentOfType<func::FuncOp>();
-  if (!funcOp)
+  if (!funcOp) {
     return op->emitOpError("must be nested under a func.func");
+  }
   auto initOr = lookupFrontendInitOpById(op, funcOp, id);
-  if (failed(initOr))
+  if (failed(initOr)) {
     return failure();
+  }
 
-  auto supportsOddC2V = [&](auto init) {
+  auto supportsOddC2V = [op](auto init) {
     PTOArch arch = getTargetArch(op);
     bool hasSupportedGmBacking =
         static_cast<bool>(init.getGmSlotTensor()) ||
@@ -16866,10 +19036,11 @@ static LogicalResult verifyFrontendSplitOp(Operation *op,
   };
 
   bool supported = false;
-  if (auto aic = dyn_cast<AicInitializePipeOp>(*initOr))
+  if (auto aic = dyn_cast<AicInitializePipeOp>(*initOr)) {
     supported = supportsOddC2V(aic);
-  else
+  } else {
     supported = supportsOddC2V(cast<AivInitializePipeOp>(*initOr));
+}
   if (!supported) {
     return op->emitOpError(
         "supports odd split modes (split = 3 or 4) only for a "
@@ -16891,23 +19062,27 @@ static LogicalResult verifyOddSplitTileEntry(Operation *op, int64_t split,
 
 static LogicalResult verifyC2VProducerSplitParity(Operation *op, int64_t split,
                                                   Type entryTy) {
-  if (split == 0)
+  if (split == 0) {
     return success();
+  }
 
   ArrayRef<int64_t> shape;
-  if (auto tileTy = dyn_cast<TileBufType>(entryTy))
+  if (auto tileTy = dyn_cast<TileBufType>(entryTy)) {
     shape = tileTy.getValidShape();
-  else if (auto viewTy = dyn_cast<TensorViewType>(entryTy))
+  } else if (auto viewTy = dyn_cast<TensorViewType>(entryTy)) {
     shape = viewTy.getShape();
-  else
+  } else {
     return success();
-  if (shape.size() != 2)
+}
+  if (shape.size() != 2) {
     return success();
+  }
 
   bool splitRows = split == 1 || split == 3;
   int64_t axisSize = shape[splitRows ? 0 : 1];
-  if (axisSize == ShapedType::kDynamic)
+  if (axisSize == ShapedType::kDynamic) {
     return success();
+  }
 
   bool expectOdd = isOddSplit(split);
   if ((axisSize % 2 != 0) != expectOdd) {
@@ -16923,8 +19098,9 @@ static LogicalResult verifyAivSubblockIdOperand(Operation *op,
                                                 Value aivSubblockId,
                                                 int64_t split,
                                                 Type pipeEntryType) {
-  if (!aivSubblockId)
+  if (!aivSubblockId) {
     return success();
+  }
 
   if (split == 0) {
     return op->emitOpError(
@@ -16949,22 +19125,26 @@ static FailureOr<int8_t> lookupFrontendInitDirMaskById(Operation *op,
                                                        func::FuncOp funcOp,
                                                        int32_t id) {
   auto initOr = lookupFrontendInitOpById(op, funcOp, id);
-  if (failed(initOr))
+  if (failed(initOr)) {
     return failure();
-  if (auto aic = dyn_cast<AicInitializePipeOp>(*initOr))
+  }
+  if (auto aic = dyn_cast<AicInitializePipeOp>(*initOr)) {
     return aic.getDirMask();
+  }
   return cast<AivInitializePipeOp>(*initOr).getDirMask();
 }
 
 static LogicalResult verifyFrontendDataOpDirection(Operation *op, int32_t id,
                                                    bool expectC2V) {
   auto funcOp = op->getParentOfType<func::FuncOp>();
-  if (!funcOp)
+  if (!funcOp) {
     return op->emitOpError("must be nested under a func.func");
+  }
 
   auto dirMaskOr = lookupFrontendInitDirMaskById(op, funcOp, id);
-  if (failed(dirMaskOr))
+  if (failed(dirMaskOr)) {
     return failure();
+  }
 
   int8_t dirMask = *dirMaskOr;
   if (expectC2V && dirMask != 1 && dirMask != 3) {
@@ -16981,8 +19161,9 @@ static LogicalResult verifyFrontendDataOpDirection(Operation *op, int32_t id,
 }
 
 static Value getFrontendInitGmSlotTensor(Operation *initOp) {
-  if (auto aic = dyn_cast<AicInitializePipeOp>(initOp))
+  if (auto aic = dyn_cast<AicInitializePipeOp>(initOp)) {
     return aic.getGmSlotTensor();
+  }
   return cast<AivInitializePipeOp>(initOp).getGmSlotTensor();
 }
 
@@ -16990,16 +19171,19 @@ static LogicalResult verifyFrontendTensorEntryMatchesInit(Operation *op,
                                                           int32_t id,
                                                           Type entryTy) {
   auto entryViewTy = dyn_cast<TensorViewType>(entryTy);
-  if (!entryViewTy)
+  if (!entryViewTy) {
     return success();
+  }
 
   auto funcOp = op->getParentOfType<func::FuncOp>();
-  if (!funcOp)
+  if (!funcOp) {
     return op->emitOpError("must be nested under a func.func");
+  }
 
   auto initOr = lookupFrontendInitOpById(op, funcOp, id);
-  if (failed(initOr))
+  if (failed(initOr)) {
     return failure();
+  }
   Value gmSlotTensor = getFrontendInitGmSlotTensor(*initOr);
   if (!gmSlotTensor) {
     return op->emitOpError()
@@ -17009,8 +19193,9 @@ static LogicalResult verifyFrontendTensorEntryMatchesInit(Operation *op,
   }
 
   auto slotTensorTy = dyn_cast<TensorViewType>(gmSlotTensor.getType());
-  if (!slotTensorTy)
+  if (!slotTensorTy) {
     return op->emitOpError("expects 'gm_slot_tensor' to be !pto.tensor_view");
+  }
   if (slotTensorTy.getElementType() != entryViewTy.getElementType()) {
     return op->emitOpError()
            << "expects pipe entry element type to match gm_slot_tensor element type";
@@ -17025,8 +19210,9 @@ static LogicalResult verifyFrontendTensorEntryMatchesInit(Operation *op,
   for (auto [idx, entryDim] : llvm::enumerate(entryShape)) {
     int64_t slotDim = slotShape[idx];
     if (slotDim == ShapedType::kDynamic ||
-        entryDim == ShapedType::kDynamic || slotDim == entryDim)
+        entryDim == ShapedType::kDynamic || slotDim == entryDim) {
       continue;
+    }
     return op->emitOpError()
            << "expects pipe entry dimension " << idx
            << " to match gm_slot_tensor dimension " << slotDim;
@@ -17041,43 +19227,52 @@ static LogicalResult verifyFrontendPopOp(FrontendPopOpT op,
                                          bool expectC2V) {
   if (failed(verifyFrontendSplitOp(op.getOperation(), expected, kernelName,
                                    op.getId(),
-                                   op.getSplit(), expectC2V)))
+                                   op.getSplit(), expectC2V))) {
     return failure();
+  }
   if (failed(verifyFrontendDataOpDirection(op.getOperation(), op.getId(),
-                                           expectC2V)))
+                                           expectC2V))) {
     return failure();
+  }
   if (failed(verifyOddSplitTileEntry(op.getOperation(), op.getSplit(),
-                                     op.getTile().getType())))
+                                     op.getTile().getType()))) {
     return failure();
+  }
   if (failed(verifyFrontendTensorEntryMatchesInit(op.getOperation(), op.getId(),
-                                                  op.getTile().getType())))
+                                                  op.getTile().getType()))) {
     return failure();
+  }
 
   bool hasValidRow = static_cast<bool>(op.getValidRow());
   bool hasValidCol = static_cast<bool>(op.getValidCol());
-  if (hasValidRow != hasValidCol)
+  if (hasValidRow != hasValidCol) {
     return op.emitOpError(
         "expects valid_row and valid_col operands to be provided together");
+  }
   if (isOddSplit(op.getSplit()) && !hasValidRow &&
       !isa<TensorViewType>(op.getTile().getType())) {
     return op.emitOpError(
         "expects odd C2V split tpop to provide per-sub-core valid_row and "
         "valid_col operands");
   }
-  if (!hasValidRow)
+  if (!hasValidRow) {
     return success();
+  }
 
-  if (isa<TensorViewType>(op.getTile().getType()))
+  if (isa<TensorViewType>(op.getTile().getType())) {
     return op.emitOpError(
         "does not accept valid_row/valid_col when result is !pto.tensor_view");
+  }
 
   auto tileTy = dyn_cast<TileBufType>(op.getTile().getType());
-  if (!tileTy)
+  if (!tileTy) {
     return op.emitOpError(
         "expects tile result to be !pto.tile_buf when valid_row/valid_col operands are provided");
-  if (!tileTy.hasDynamicValid())
+  }
+  if (!tileTy.hasDynamicValid()) {
     return op.emitOpError(
         "expects tile result to have dynamic validShape (?, ?) when valid_row/valid_col operands are provided");
+  }
   return success();
 }
 
@@ -17112,8 +19307,9 @@ static bool isVectorFixpipeQuant(FixpipeQuant quant) {
 static bool matchesFixpipeConsumerLayout(FixpipeLayout layout,
                                          TileBufType tileTy) {
   auto memorySpace = dyn_cast_or_null<AddressSpaceAttr>(tileTy.getMemorySpace());
-  if (!memorySpace || memorySpace.getAddressSpace() != AddressSpace::VEC)
+  if (!memorySpace || memorySpace.getAddressSpace() != AddressSpace::VEC) {
     return false;
+  }
 
   int32_t bLayout = tileTy.getBLayoutValueI32();
   int32_t sLayout = tileTy.getSLayoutValueI32();
@@ -17132,14 +19328,16 @@ static bool matchesFixpipeConsumerLayout(FixpipeLayout layout,
 }
 
 static bool isSignedOrUnsignedI8(Type ty) {
-  if (auto intTy = dyn_cast<IntegerType>(ty))
+  if (auto intTy = dyn_cast<IntegerType>(ty)) {
     return intTy.getWidth() == 8 && (intTy.isSigned() || intTy.isUnsigned());
+  }
   return false;
 }
 
 static bool isSignedI8(Type ty) {
-  if (auto intTy = dyn_cast<IntegerType>(ty))
+  if (auto intTy = dyn_cast<IntegerType>(ty)) {
     return intTy.isSignedInteger(8);
+  }
   return false;
 }
 
@@ -17173,11 +19371,13 @@ static bool matchesFixpipeConsumerElementType(FixpipeQuant quant,
 }
 
 static bool isFixpipeQuantPayloadElemType(Type elemTy, PTOArch arch) {
-  if (!elemTy)
+  if (!elemTy) {
     return false;
-  if (arch == PTOArch::A3)
+  }
+  if (arch == PTOArch::A3) {
     return elemTy.isUnsignedInteger(64) || elemTy.isSignlessInteger(64) ||
            elemTy.isSignedInteger(64);
+  }
   return elemTy.isF16() || elemTy.isBF16() || elemTy.isF32();
 }
 
@@ -17239,8 +19439,9 @@ static bool isUnpublishedFixpipeFrontendAttrName(StringRef name) {
 static LogicalResult verifyNoUnpublishedFixpipeFrontendAttrs(Operation *op) {
   for (NamedAttribute attr : op->getAttrs()) {
     StringRef name = attr.getName().getValue();
-    if (!isUnpublishedFixpipeFrontendAttrName(name))
+    if (!isUnpublishedFixpipeFrontendAttrName(name)) {
       continue;
+    }
     return op->emitOpError()
            << "does not allow unpublished fixpipe attr '" << name
            << "'; STPhase / AtomicType / SubBlockId / ClipReluMode / "
@@ -17253,8 +19454,9 @@ static std::optional<uint64_t> getStaticTileByteSize(TileBufType tileTy) {
   auto shape = getShapeVec(tileTy);
   auto elemCount = getStaticElementCount(shape);
   uint64_t elemBytes = getElemByteSize(tileTy.getElementType());
-  if (!elemCount || elemBytes == 0)
+  if (!elemCount || elemBytes == 0) {
     return std::nullopt;
+  }
   return *elemCount * elemBytes;
 }
 
@@ -17262,22 +19464,26 @@ static std::optional<uint64_t> getStaticTileByteSize(TileBufType tileTy) {
 static LogicalResult verifyFixpipeConsumerType(Operation *tpopOp, int32_t id,
                                                Type resultTileType) {
   auto funcOp = tpopOp->getParentOfType<func::FuncOp>();
-  if (!funcOp)
+  if (!funcOp) {
     return success(); // Already checked elsewhere
+  }
 
   // Look up the consumer-side init
   auto initOr = lookupFrontendInitOpById(tpopOp, funcOp, id);
-  if (failed(initOr))
+  if (failed(initOr)) {
     return failure();
+  }
 
   Operation *initOp = *initOr;
   auto aivInit = dyn_cast<AivInitializePipeOp>(initOp);
-  if (!aivInit)
+  if (!aivInit) {
     return success(); // Not consumer init, skip
+  }
 
   auto accPushEpilogue = aivInit.getAccPushEpilogueAttr();
-  if (!accPushEpilogue)
+  if (!accPushEpilogue) {
     return success(); // Not a fixpipe, skip
+  }
 
   if (auto tpop = dyn_cast<TPopFromAicOp>(tpopOp); tpop && tpop.getSplit() != 0) {
     return tpop.emitOpError("expects fixpipe TPOP to have split = 0");
@@ -17296,8 +19502,9 @@ static LogicalResult verifyFixpipeConsumerType(Operation *tpopOp, int32_t id,
   bool mismatchedPeerType = false;
   funcOp.walk([&](TPopFromAicOp otherPop) {
     if (otherPop.getOperation() == tpopOp ||
-        otherPop.getId() != static_cast<uint32_t>(id))
+        otherPop.getId() != static_cast<uint32_t>(id)) {
       return WalkResult::advance();
+    }
     if (otherPop.getTile().getType() != resultTileType) {
       mismatchedPeerType = true;
       tpopOp->emitOpError()
@@ -17307,8 +19514,9 @@ static LogicalResult verifyFixpipeConsumerType(Operation *tpopOp, int32_t id,
     }
     return WalkResult::advance();
   });
-  if (mismatchedPeerType)
+  if (mismatchedPeerType) {
     return failure();
+  }
 
   if (!matchesFixpipeConsumerElementType(quant, resultElemType)) {
     return tpopOp->emitOpError()
@@ -17330,14 +19538,18 @@ static LogicalResult verifyPipeShape(Operation *op, int8_t dirMask, int32_t slot
                                      int32_t slotNum,
                                      std::optional<int32_t> flagBase) {
   constexpr int32_t kMaxHardwareFlagIds = 16;
-  if (dirMask != 1 && dirMask != 2 && dirMask != 3)
+  if (dirMask != 1 && dirMask != 2 && dirMask != 3) {
     return op->emitOpError("expects 'dir_mask' to be 1, 2, or 3");
-  if (slotSize <= 0)
+  }
+  if (slotSize <= 0) {
     return op->emitOpError("expects 'slot_size' to be greater than 0");
-  if (slotNum <= 0)
+  }
+  if (slotNum <= 0) {
     return op->emitOpError("expects 'slot_num' to be greater than 0");
-  if (flagBase && *flagBase < 0)
+  }
+  if (flagBase && *flagBase < 0) {
     return op->emitOpError("expects 'flag_base' to be non-negative when present");
+  }
   if (flagBase) {
     int32_t flagWidth = dirMask == 3 ? 4 : 2;
     if (*flagBase + flagWidth > kMaxHardwareFlagIds) {
@@ -17351,8 +19563,9 @@ static LogicalResult verifyPipeShape(Operation *op, int8_t dirMask, int32_t slot
 }
 
 static LogicalResult verifyPipeHandleProducer(Operation *op, Value pipeHandle) {
-  if (!isa<pto::PipeType>(pipeHandle.getType()))
+  if (!isa<pto::PipeType>(pipeHandle.getType())) {
     return op->emitOpError("expects pipe operand type !pto.pipe");
+  }
   if (!pipeHandle.getDefiningOp<InitializeL2LPipeOp>() &&
       !pipeHandle.getDefiningOp<InitializeL2G2LPipeOp>()) {
     return op->emitOpError(
@@ -17366,8 +19579,9 @@ static LogicalResult verifyInternalOddSplitSupport(Operation *op,
                                                    Value pipeHandle,
                                                    int64_t split,
                                                    bool producerSide) {
-  if (!isOddSplit(split))
+  if (!isOddSplit(split)) {
     return success();
+  }
 
   bool isC2VSide = producerSide ? isInsideCubeKernelOrSection(op)
                                 : isInsideVectorKernelOrSection(op);
@@ -17396,8 +19610,9 @@ static LogicalResult verifyTensorEntryMatchesInternalPipeInit(Operation *op,
                                                               Value pipeHandle,
                                                               Type entryTy) {
   auto entryViewTy = dyn_cast<TensorViewType>(entryTy);
-  if (!entryViewTy)
+  if (!entryViewTy) {
     return success();
+  }
 
   auto initOp = pipeHandle.getDefiningOp<InitializeL2G2LPipeOp>();
   if (!initOp) {
@@ -17435,8 +19650,9 @@ slotElementType, slotShape)) {
   for (auto [idx, entryDim] : llvm::enumerate(entryShape)) {
     int64_t slotDim = slotShape[idx];
     if (slotDim == ShapedType::kDynamic ||
-        entryDim == ShapedType::kDynamic || slotDim == entryDim)
+        entryDim == ShapedType::kDynamic || slotDim == entryDim) {
       continue;
+    }
     return op->emitOpError()
            << "expects pipe entry dimension " << idx
            << " to match initialize_l2g2l_pipe gm_addr dimension "
@@ -17448,14 +19664,15 @@ slotElementType, slotShape)) {
     uint64_t entryBytes = *entryElemCount * elemBytes;
     if (elemBytes != 0) {
       int8_t split = 0;
-      if (auto alloc = dyn_cast<TAllocOp>(op))
+      if (auto alloc = dyn_cast<TAllocOp>(op)) {
         split = alloc.getSplit();
-      else if (auto push = dyn_cast<TPushOp>(op))
+      } else if (auto push = dyn_cast<TPushOp>(op)) {
         split = push.getSplit();
-      else if (auto pop = dyn_cast<TPopOp>(op))
+      } else if (auto pop = dyn_cast<TPopOp>(op)) {
         split = pop.getSplit();
-      else if (auto free = dyn_cast<TFreeOp>(op))
+      } else if (auto free = dyn_cast<TFreeOp>(op)) {
         split = free.getSplit();
+      }
 
       uint64_t slotBytes = static_cast<uint64_t>(initOp.getSlotSize());
       bool isSplitEntry = split != 0;
@@ -17477,57 +19694,71 @@ slotElementType, slotShape)) {
 
 LogicalResult BuildAsyncSessionOp::verify() {
   Type scratchTy = getScratch().getType();
-  if (!isa<pto::TileBufType>(scratchTy))
+  if (!isa<pto::TileBufType>(scratchTy)) {
     return emitOpError("expects scratch to be tile_buf type");
+  }
 
   auto scratchSpace = getPTOMemorySpaceEnum(scratchTy);
-  if (!scratchSpace || *scratchSpace != pto::AddressSpace::VEC)
+  if (!scratchSpace || *scratchSpace != pto::AddressSpace::VEC) {
     return emitOpError("expects scratch to be in vec address space");
+  }
 
   auto scratchShape = getShapeVec(scratchTy);
-  if (scratchShape.empty() || scratchShape.size() > 2)
+  if (scratchShape.empty() || scratchShape.size() > 2) {
     return emitOpError("expects scratch to be rank-1 or rank-2");
+  }
   for (int64_t dim : scratchShape) {
-    if (dim == ShapedType::kDynamic)
+    if (dim == ShapedType::kDynamic) {
       return emitOpError("expects scratch to have a static shape");
+    }
   }
 
   auto scratchBytes = getStaticByteSize(scratchTy);
-  if (!scratchBytes)
+  if (!scratchBytes) {
     return emitOpError("expects scratch byte size to be statically known");
-  if (*scratchBytes < sizeof(uint64_t))
+  }
+  if (*scratchBytes < sizeof(uint64_t)) {
     return emitOpError("expects scratch to provide at least 8 bytes");
+  }
 
   auto workspaceTy = dyn_cast<pto::PtrType>(getWorkspace().getType());
-  if (!workspaceTy)
+  if (!workspaceTy) {
     return emitOpError("expects workspace to be !pto.ptr type");
+  }
   Type workspaceElemTy = workspaceTy.getElementType();
-  if (!isByteIntegerType(workspaceElemTy))
+  if (!isByteIntegerType(workspaceElemTy)) {
     return emitOpError("expects workspace element type to be an 8-bit integer");
+  }
 
   if (auto syncIdAttr = getSyncIdAttr()) {
     int64_t syncId = syncIdAttr.getInt();
-    if (syncId < 0 || syncId > 7)
+    if (syncId < 0 || syncId > 7) {
       return emitOpError("expects sync_id in range [0, 7]");
+    }
   }
   if (auto blockBytesAttr = getBlockBytesAttr()) {
-    if (blockBytesAttr.getInt() <= 0)
+    if (blockBytesAttr.getInt() <= 0) {
       return emitOpError("expects block_bytes to be greater than 0");
+    }
   }
   if (auto commBlockOffsetAttr = getCommBlockOffsetAttr()) {
-    if (commBlockOffsetAttr.getInt() < 0)
+    if (commBlockOffsetAttr.getInt() < 0) {
       return emitOpError("expects comm_block_offset to be non-negative");
+    }
   }
   if (auto queueNumAttr = getQueueNumAttr()) {
-    if (queueNumAttr.getInt() <= 0)
+    if (queueNumAttr.getInt() <= 0) {
       return emitOpError("expects queue_num to be greater than 0");
+    }
   }
   if (auto channelGroupIdxAttr = getChannelGroupIdxAttr()) {
     APInt value = channelGroupIdxAttr.getValue();
-    if (value.isNegative())
+    if (value.isNegative()) {
       return emitOpError("expects channel_group_idx to be non-negative");
-    if (value.ugt(UINT32_MAX))
+    }
+    if (value.ugt(UINT32_MAX)) {
       return emitOpError("expects channel_group_idx to fit in uint32");
+    }
   }
 
   return success();
@@ -17536,15 +19767,19 @@ LogicalResult BuildAsyncSessionOp::verify() {
 static LogicalResult verifyAsyncTransferOp(Operation *op, Value dst, Value src) {
   Type dstElemTy = getElemTy(dst.getType());
   Type srcElemTy = getElemTy(src.getType());
-  if (!dstElemTy || !srcElemTy)
+  if (!dstElemTy || !srcElemTy) {
     return op->emitOpError("expects src and dst to have element types");
-  if (dstElemTy != srcElemTy)
+  }
+  if (dstElemTy != srcElemTy) {
     return op->emitOpError("expects src and dst to have the same element type");
+  }
   if (failed(verifyAsyncFlatContiguous1DGMViewLike(op, dst, "dst")) ||
-      failed(verifyAsyncFlatContiguous1DGMViewLike(op, src, "src")))
+      failed(verifyAsyncFlatContiguous1DGMViewLike(op, src, "src"))) {
     return failure();
-  if (getShapeVec(dst.getType()) != getShapeVec(src.getType()))
+  }
+  if (getShapeVec(dst.getType()) != getShapeVec(src.getType())) {
     return op->emitOpError("expects src and dst to have the same static shape");
+  }
   return success();
 }
 
@@ -17565,15 +19800,19 @@ LogicalResult TPutOp::verify() {
           CommGlobalShapePolicy::AllowDynamicPartitionView)) ||
       failed(verifyCommStagingTileLike(*this, getPing(), "ping")) ||
       failed(verifyCommPingPongSameType(*this, getPing(), getPong(), "ping",
-                                        "pong")))
+                                        "pong"))) {
     return failure();
-  if (getElemTy(getDst().getType()) != getElemTy(getSrc().getType()))
+  }
+  if (getElemTy(getDst().getType()) != getElemTy(getSrc().getType())) {
     return emitOpError("expects src and dst to have the same element type");
-  if (getShapeVec(getDst().getType()) != getShapeVec(getSrc().getType()))
+  }
+  if (getShapeVec(getDst().getType()) != getShapeVec(getSrc().getType())) {
     return emitOpError(
         "expects src and dst to have the same static/dynamic shape signature");
-  if (getElemTy(getPing().getType()) != getElemTy(getSrc().getType()))
+  }
+  if (getElemTy(getPing().getType()) != getElemTy(getSrc().getType())) {
     return emitOpError("expects staging tile element type to match src/dst");
+  }
   return success();
 }
 
@@ -17586,42 +19825,52 @@ LogicalResult TGetOp::verify() {
           CommGlobalShapePolicy::AllowDynamicPartitionView)) ||
       failed(verifyCommStagingTileLike(*this, getPing(), "ping")) ||
       failed(verifyCommPingPongSameType(*this, getPing(), getPong(), "ping",
-                                        "pong")))
+                                        "pong"))) {
     return failure();
-  if (getElemTy(getDst().getType()) != getElemTy(getSrc().getType()))
+  }
+  if (getElemTy(getDst().getType()) != getElemTy(getSrc().getType())) {
     return emitOpError("expects src and dst to have the same element type");
-  if (getShapeVec(getDst().getType()) != getShapeVec(getSrc().getType()))
+  }
+  if (getShapeVec(getDst().getType()) != getShapeVec(getSrc().getType())) {
     return emitOpError(
         "expects src and dst to have the same static/dynamic shape signature");
-  if (getElemTy(getPing().getType()) != getElemTy(getSrc().getType()))
+  }
+  if (getElemTy(getPing().getType()) != getElemTy(getSrc().getType())) {
     return emitOpError("expects staging tile element type to match src/dst");
+  }
   return success();
 }
 
 LogicalResult TNotifyOp::verify() {
-  if (failed(verifyCommSignalLike(*this, getSignal(), "signal")))
+  if (failed(verifyCommSignalLike(*this, getSignal(), "signal"))) {
     return failure();
+  }
   auto valueTy = dyn_cast<IntegerType>(getValue().getType());
-  if (!valueTy || valueTy.getWidth() != 32)
+  if (!valueTy || valueTy.getWidth() != 32) {
     return emitOpError("expects value to be i32");
+  }
   return success();
 }
 
 LogicalResult TWaitOp::verify() {
-  if (failed(verifyCommSignalLike(*this, getSignal(), "signal")))
+  if (failed(verifyCommSignalLike(*this, getSignal(), "signal"))) {
     return failure();
+  }
   auto cmpTy = dyn_cast<IntegerType>(getCmpValue().getType());
-  if (!cmpTy || cmpTy.getWidth() != 32)
+  if (!cmpTy || cmpTy.getWidth() != 32) {
     return emitOpError("expects cmp_value to be i32");
+  }
   return success();
 }
 
 LogicalResult TTestOp::verify() {
-  if (failed(verifyCommSignalLike(*this, getSignal(), "signal")))
+  if (failed(verifyCommSignalLike(*this, getSignal(), "signal"))) {
     return failure();
+  }
   auto cmpTy = dyn_cast<IntegerType>(getCmpValue().getType());
-  if (!cmpTy || cmpTy.getWidth() != 32)
+  if (!cmpTy || cmpTy.getWidth() != 32) {
     return emitOpError("expects cmp_value to be i32");
+  }
   return success();
 }
 
@@ -17631,9 +19880,10 @@ static LogicalResult verifySyncAllGmWorkspace(Operation *op, Value workspace,
   Type elemType;
   SmallVector<int64_t, 4> shape;
   if (auto ptrTy = dyn_cast<pto::PtrType>(ty)) {
-    if (ptrTy.getMemorySpace().getAddressSpace() != pto::AddressSpace::GM)
+    if (ptrTy.getMemorySpace().getAddressSpace() != pto::AddressSpace::GM) {
       return op->emitOpError() << "expects " << name
                                << " to be in GM address space";
+    }
     elemType = ptrTy.getElementType();
   } else if (isa<pto::TensorViewType, pto::PartitionTensorViewType>(ty)) {
     elemType = getElemTy(ty);
@@ -17645,20 +19895,24 @@ static LogicalResult verifySyncAllGmWorkspace(Operation *op, Value workspace,
   }
 
   auto elemTy = dyn_cast<IntegerType>(elemType);
-  if (!elemTy || elemTy.getWidth() != 32)
+  if (!elemTy || elemTy.getWidth() != 32) {
     return op->emitOpError() << "expects " << name << " element type to be i32";
+  }
 
   // A pointer does not carry capacity metadata. It is lowered as the fixed
   // 16 x i32 workspace required by PTO-ISA; allocation size remains a runtime
   // responsibility.
-  if (isa<pto::PtrType>(ty))
+  if (isa<pto::PtrType>(ty)) {
     return success();
+  }
 
-  if (shape.empty())
+  if (shape.empty()) {
     return op->emitOpError() << "expects " << name << " to have rank >= 1";
+  }
   for (int64_t dim : shape) {
-    if (dim != ShapedType::kDynamic && dim <= 0)
+    if (dim != ShapedType::kDynamic && dim <= 0) {
       return op->emitOpError() << "expects " << name << " shape to be positive";
+    }
   }
 
   constexpr int64_t kMinWorkspaceElements = 16;
@@ -17672,12 +19926,13 @@ static LogicalResult verifySyncAllGmWorkspace(Operation *op, Value workspace,
       }
       staticCapacity = product;
     }
-    if (staticCapacity < kMinWorkspaceElements)
+    if (staticCapacity < kMinWorkspaceElements) {
       return op->emitOpError()
              << "expects " << name << " to contain at least "
              << kMinWorkspaceElements
              << " i32 elements (64 bytes), but static capacity is "
              << staticCapacity;
+    }
   }
 
   return success();
@@ -17688,17 +19943,20 @@ LogicalResult SyncAllOp::verify() {
   auto mode = getMode().getValue();
 
   if (mode == pto::SyncAllMode::Hard) {
-    if (hasGm || getUsedCores())
+    if (hasGm || getUsedCores()) {
       return emitOpError(
           "expects hard syncall to have no gm_workspace or used_cores");
+    }
     return success();
   }
 
-  if (!hasGm)
+  if (!hasGm) {
     return emitOpError("expects soft syncall to provide gm_workspace");
+  }
   if (failed(verifySyncAllGmWorkspace(getOperation(), getGmWorkspace(),
-                                      "gm_workspace")))
+                                      "gm_workspace"))) {
     return failure();
+  }
 
   return success();
 }
@@ -17708,14 +19966,18 @@ LogicalResult TBroadcastOp::verify() {
       failed(verifyCommStagingTileLike(*this, getPing(), "ping")) ||
       failed(verifyCommPingPongSameType(*this, getPing(), getPong(), "ping",
                                         "pong")) ||
-      failed(verifyCommGlobalGroup(*this, getGroup(), "group")))
+      failed(verifyCommGlobalGroup(*this, getGroup(), "group"))) {
     return failure();
-  if (getRoot() >= static_cast<uint32_t>(getGroup().size()))
+  }
+  if (getRoot() >= static_cast<uint32_t>(getGroup().size())) {
     return emitOpError("expects root to index into group operands");
-  if (getSrc().getType() != getGroup().front().getType())
+  }
+  if (getSrc().getType() != getGroup().front().getType()) {
     return emitOpError("expects src type to match group member type");
-  if (getElemTy(getPing().getType()) != getElemTy(getSrc().getType()))
+  }
+  if (getElemTy(getPing().getType()) != getElemTy(getSrc().getType())) {
     return emitOpError("expects staging tile element type to match src");
+  }
   return success();
 }
 
@@ -17724,14 +19986,18 @@ LogicalResult CommTGatherOp::verify() {
       failed(verifyCommStagingTileLike(*this, getPing(), "ping")) ||
       failed(verifyCommPingPongSameType(*this, getPing(), getPong(), "ping",
                                         "pong")) ||
-      failed(verifyCommGlobalGroup(*this, getGroup(), "group")))
+      failed(verifyCommGlobalGroup(*this, getGroup(), "group"))) {
     return failure();
-  if (getRoot() >= static_cast<uint32_t>(getGroup().size()))
+  }
+  if (getRoot() >= static_cast<uint32_t>(getGroup().size())) {
     return emitOpError("expects root to index into group operands");
-  if (getElemTy(getDst().getType()) != getElemTy(getGroup().front().getType()))
+  }
+  if (getElemTy(getDst().getType()) != getElemTy(getGroup().front().getType())) {
     return emitOpError("expects dst element type to match group member type");
-  if (getElemTy(getPing().getType()) != getElemTy(getDst().getType()))
+  }
+  if (getElemTy(getPing().getType()) != getElemTy(getDst().getType())) {
     return emitOpError("expects staging tile element type to match dst");
+  }
   return success();
 }
 
@@ -17740,14 +20006,18 @@ LogicalResult CommTScatterOp::verify() {
       failed(verifyCommStagingTileLike(*this, getPing(), "ping")) ||
       failed(verifyCommPingPongSameType(*this, getPing(), getPong(), "ping",
                                         "pong")) ||
-      failed(verifyCommGlobalGroup(*this, getGroup(), "group")))
+      failed(verifyCommGlobalGroup(*this, getGroup(), "group"))) {
     return failure();
-  if (getRoot() >= static_cast<uint32_t>(getGroup().size()))
+  }
+  if (getRoot() >= static_cast<uint32_t>(getGroup().size())) {
     return emitOpError("expects root to index into group operands");
-  if (getElemTy(getSrc().getType()) != getElemTy(getGroup().front().getType()))
+  }
+  if (getElemTy(getSrc().getType()) != getElemTy(getGroup().front().getType())) {
     return emitOpError("expects src element type to match group member type");
-  if (getElemTy(getPing().getType()) != getElemTy(getSrc().getType()))
+  }
+  if (getElemTy(getPing().getType()) != getElemTy(getSrc().getType())) {
     return emitOpError("expects staging tile element type to match src");
+  }
   return success();
 }
 
@@ -17757,26 +20027,33 @@ LogicalResult TReduceOp::verify() {
       failed(verifyCommStagingTileLike(*this, getRecvPing(), "recv_ping")) ||
       failed(verifyCommPingPongSameType(*this, getRecvPing(), getRecvPong(),
                                         "recv_ping", "recv_pong")) ||
-      failed(verifyCommGlobalGroup(*this, getGroup(), "group")))
+      failed(verifyCommGlobalGroup(*this, getGroup(), "group"))) {
     return failure();
-  if (getRoot() >= static_cast<uint32_t>(getGroup().size()))
+  }
+  if (getRoot() >= static_cast<uint32_t>(getGroup().size())) {
     return emitOpError("expects root to index into group operands");
-  if (getElemTy(getDst().getType()) != getElemTy(getGroup().front().getType()))
+  }
+  if (getElemTy(getDst().getType()) != getElemTy(getGroup().front().getType())) {
     return emitOpError("expects dst element type to match group member type");
-  if (getAcc().getType() != getRecvPing().getType())
+  }
+  if (getAcc().getType() != getRecvPing().getType()) {
     return emitOpError("expects acc and recv_ping to have identical types");
-  if (getElemTy(getAcc().getType()) != getElemTy(getDst().getType()))
+  }
+  if (getElemTy(getAcc().getType()) != getElemTy(getDst().getType())) {
     return emitOpError("expects accumulator/receive tiles to match dst element type");
+  }
   return success();
 }
 
 LogicalResult AicInitializePipeOp::verify() {
-  if (failed(verifyFrontendInitCommon(*this, FunctionKernelKind::Cube, "cube")))
+  if (failed(verifyFrontendInitCommon(*this, FunctionKernelKind::Cube, "cube"))) {
     return failure();
+  }
 
   auto accPushEpilogue = getAccPushEpilogueAttr();
-  if (!accPushEpilogue)
+  if (!accPushEpilogue) {
     return success();
+  }
 
   auto peerConsumerInitOr = lookupFixpipePeerConsumerInit(*this);
   if (failed(peerConsumerInitOr)) {
@@ -17819,8 +20096,9 @@ LogicalResult AicInitializePipeOp::verify() {
 }
 
 LogicalResult AivInitializePipeOp::verify() {
-  if (failed(verifyFrontendInitCommon(*this, FunctionKernelKind::Vector, "vector")))
+  if (failed(verifyFrontendInitCommon(*this, FunctionKernelKind::Vector, "vector"))) {
     return failure();
+  }
 
   // Rule 3 & 22: Peer fixpipe contract verification
   auto accPushEpilogue = getAccPushEpilogueAttr();
@@ -17839,8 +20117,9 @@ LogicalResult AivInitializePipeOp::verify() {
 
     func::FuncOp peerProducerFunc;
     auto currentConsumerFunc = getOperation()->getParentOfType<func::FuncOp>();
-    if (!currentConsumerFunc)
+    if (!currentConsumerFunc) {
       return emitOpError("must be nested under a func.func");
+    }
     StringRef bufferName;
 
     if (auto importOp = dyn_cast_or_null<ImportReservedBufferOp>(bufDefOp)) {
@@ -17850,19 +20129,22 @@ LogicalResult AivInitializePipeOp::verify() {
       bufferName = reserveOp.getName();
 
       ModuleOp moduleOp = currentConsumerFunc->getParentOfType<ModuleOp>();
-      if (!moduleOp)
+      if (!moduleOp) {
         return emitOpError("must be nested under a module for fixpipe contract verification");
+      }
 
       ImportReservedBufferOp matchedImport;
       unsigned matchedImportCount = 0;
       moduleOp.walk([&](ImportReservedBufferOp candidateImport) {
-        if (candidateImport.getName() != bufferName)
+        if (candidateImport.getName() != bufferName) {
           return WalkResult::advance();
+        }
         auto peerConsumerFunc =
             lookupPeerFuncAcrossContainer(candidateImport.getOperation(),
                                           candidateImport.getPeerFuncAttr());
-        if (peerConsumerFunc != currentConsumerFunc)
+        if (peerConsumerFunc != currentConsumerFunc) {
           return WalkResult::advance();
+        }
         matchedImport = candidateImport;
         ++matchedImportCount;
         return WalkResult::advance();
@@ -17892,8 +20174,9 @@ LogicalResult AivInitializePipeOp::verify() {
 
     auto peerProducerInitOr = lookupFixpipePeerProducerInit(
         *this, peerProducerFunc, bufferName, currentConsumerFunc);
-    if (failed(peerProducerInitOr))
+    if (failed(peerProducerInitOr)) {
       return failure();
+    }
 
     Operation *peerProducerInitOp = *peerProducerInitOr;
     auto peerProducerFrontendInit =
@@ -17976,8 +20259,9 @@ LogicalResult AivInitializePipeOp::verify() {
 
     SmallVector<TPopFromAicOp> matchingPops;
     currentConsumerFunc.walk([&](TPopFromAicOp pop) {
-      if (pop.getId() == getId())
+      if (pop.getId() == getId()) {
         matchingPops.push_back(pop);
+      }
       return WalkResult::advance();
     });
 
@@ -18018,14 +20302,18 @@ LogicalResult AivInitializePipeOp::verify() {
     }
 
     auto getInitSlotSize = [](Operation *initOp) -> std::optional<uint32_t> {
-      if (auto aicInit = dyn_cast_or_null<AicInitializePipeOp>(initOp))
+      if (auto aicInit = dyn_cast_or_null<AicInitializePipeOp>(initOp)) {
         return aicInit.getSlotSize();
-      if (auto aivInit = dyn_cast_or_null<AivInitializePipeOp>(initOp))
+      }
+      if (auto aivInit = dyn_cast_or_null<AivInitializePipeOp>(initOp)) {
         return aivInit.getSlotSize();
-      if (auto l2lInit = dyn_cast_or_null<InitializeL2LPipeOp>(initOp))
+      }
+      if (auto l2lInit = dyn_cast_or_null<InitializeL2LPipeOp>(initOp)) {
         return l2lInit.getSlotSize();
-      if (auto l2g2lInit = dyn_cast_or_null<InitializeL2G2LPipeOp>(initOp))
+      }
+      if (auto l2g2lInit = dyn_cast_or_null<InitializeL2G2LPipeOp>(initOp)) {
         return l2g2lInit.getSlotSize();
+      }
       return std::nullopt;
     };
 
@@ -18048,11 +20336,13 @@ LogicalResult AivInitializePipeOp::verify() {
 
     bool producerConsumerTypeMismatch = false;
     peerProducerFunc.walk([&](TPushToAivOp push) {
-      if (push.getId() != *peerProducerId)
+      if (push.getId() != *peerProducerId) {
         return WalkResult::advance();
+      }
       auto srcTileTy = dyn_cast<pto::TileBufType>(push.getTile().getType());
-      if (!srcTileTy)
+      if (!srcTileTy) {
         return WalkResult::advance();
+      }
       if (!matchesFixpipeProducerAndConsumerTypes(
               quant, srcTileTy.getElementType(), resolvedConsumerElemTy)) {
         producerConsumerTypeMismatch = true;
@@ -18064,23 +20354,27 @@ LogicalResult AivInitializePipeOp::verify() {
       }
       return WalkResult::advance();
     });
-    if (producerConsumerTypeMismatch)
+    if (producerConsumerTypeMismatch) {
       return failure();
+    }
   }
 
   return success();
 }
 
 LogicalResult TAllocToAivOp::verify() {
-  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation())))
+  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation()))) {
     return failure();
+  }
   if (failed(verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Cube,
                                    "cube", getId(), getSplit(),
-                                   /*expectC2V=*/true)))
+                                   /*expectC2V=*/true))) {
     return failure();
+  }
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/true)))
+                                           /*expectC2V=*/true))) {
     return failure();
+  }
 
   // Fixpipe validation: check if this is a fixpipe pipe
   auto funcOp = getOperation()->getParentOfType<func::FuncOp>();
@@ -18100,63 +20394,77 @@ LogicalResult TAllocToAivOp::verify() {
   }
 
   if (failed(verifyOddSplitTileEntry(getOperation(), getSplit(),
-                                     getEntry().getType())))
+                                     getEntry().getType()))) {
     return failure();
+  }
   return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
                                               getEntry().getType());
 }
 
 LogicalResult TAllocToAicOp::verify() {
-  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation())))
+  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation()))) {
     return failure();
+  }
   if (failed(verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Vector,
                                    "vector", getId(), getSplit(),
-                                   /*expectC2V=*/false)))
+                                   /*expectC2V=*/false))) {
     return failure();
+  }
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/false)))
+                                           /*expectC2V=*/false))) {
     return failure();
+  }
   return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
                                               getEntry().getType());
 }
 
 LogicalResult TPushToAivOp::verify() {
-  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation())))
+  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation()))) {
     return failure();
+  }
   if (failed(verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Cube,
                                    "cube", getId(), getSplit(),
-                                   /*expectC2V=*/true)))
+                                   /*expectC2V=*/true))) {
     return failure();
+  }
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/true)))
+                                           /*expectC2V=*/true))) {
     return failure();
+  }
   if (failed(verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                              getTile().getType())))
+                                                  getTile().getType()))) {
     return failure();
+  }
   if (failed(verifyOddSplitTileEntry(getOperation(), getSplit(),
-                                     getTile().getType())))
+                                     getTile().getType()))) {
     return failure();
+  }
   if (failed(verifyC2VProducerSplitParity(getOperation(), getSplit(),
-                                          getTile().getType())))
+                                          getTile().getType()))) {
     return failure();
+  }
 
   // Fixpipe validation
   auto funcOp = getOperation()->getParentOfType<func::FuncOp>();
-  if (!funcOp)
+  if (!funcOp) {
     return emitOpError("must be nested under a func.func");
+  }
 
   auto initOr = lookupFrontendInitOpById(getOperation(), funcOp, getId());
-  if (failed(initOr))
+  if (failed(initOr)) {
     return failure();
+  }
 
   Operation *initOp = *initOr;
   auto aicInit = dyn_cast<AicInitializePipeOp>(initOp);
-  if (!aicInit)
+  if (!aicInit) {
     return success(); // Not an AIC init, no fixpipe check needed
+  }
 
   auto accPushEpilogue = aicInit.getAccPushEpilogueAttr();
-  if (!accPushEpilogue)
+  if (!accPushEpilogue) {
     return success(); // No fixpipe config, normal pipe
+  }
 
   // Rule 9: Source tile must be acc tile
   auto tileTy = dyn_cast<pto::TileBufType>(getTile().getType());
@@ -18223,18 +20531,21 @@ LogicalResult TPushToAivOp::verify() {
     Block *tpushBlock = getOperation()->getBlock();
     bool foundQuantConfig = false;
     for (Operation &op : tpushBlock->getOperations()) {
-      if (&op == getOperation())
+      if (&op == getOperation()) {
         break;
+      }
 
       if (isScalarQuant) {
         if (auto setQuant = dyn_cast<SetQuantScalarOp>(&op)) {
-          if (setQuant.getId() == getId())
+          if (setQuant.getId() == getId()) {
             foundQuantConfig = true;
+          }
         }
       } else if (isVectorQuant) {
         if (auto setQuant = dyn_cast<SetQuantVectorOp>(&op)) {
-          if (setQuant.getId() == getId())
+          if (setQuant.getId() == getId()) {
             foundQuantConfig = true;
+          }
         }
       }
     }
@@ -18255,51 +20566,62 @@ LogicalResult TPushToAivOp::verify() {
 }
 
 LogicalResult TPushToAicOp::verify() {
-  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation())))
+  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation()))) {
     return failure();
+  }
   if (failed(verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Vector,
                                    "vector", getId(), getSplit(),
-                                   /*expectC2V=*/false)))
+                                   /*expectC2V=*/false))) {
     return failure();
+  }
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/false)))
+                                           /*expectC2V=*/false))) {
     return failure();
+  }
   if (failed(verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
-                                                  getTile().getType())))
+                                                  getTile().getType()))) {
     return failure();
+  }
   return verifyAivSubblockIdOperand(getOperation(), getAivSubblockid(),
                                     getSplit(), getTile().getType());
 }
 
 LogicalResult TPopFromAicOp::verify() {
-  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation())))
+  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation()))) {
     return failure();
+  }
   if (failed(verifyFrontendPopOp(*this, FunctionKernelKind::Vector, "vector",
-                                 /*expectC2V=*/true)))
+                                 /*expectC2V=*/true))) {
     return failure();
+  }
   if (failed(verifyAivSubblockIdOperand(getOperation(), getAivSubblockid(),
-                                        getSplit(), getTile().getType())))
+                                        getSplit(), getTile().getType()))) {
     return failure();
+  }
   return verifyFixpipeConsumerType(getOperation(), getId(), getTile().getType());
 }
 
 LogicalResult TPopFromAivOp::verify() {
-  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation())))
+  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation()))) {
     return failure();
+  }
   return verifyFrontendPopOp(*this, FunctionKernelKind::Cube, "cube",
                              /*expectC2V=*/false);
 }
 
 LogicalResult TFreeFromAicOp::verify() {
-  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation())))
+  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation()))) {
     return failure();
+  }
   if (failed(verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Vector,
                                    "vector", getId(), getSplit(),
-                                   /*expectC2V=*/true)))
+                                   /*expectC2V=*/true))) {
     return failure();
+  }
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/true)))
+                                           /*expectC2V=*/true))) {
     return failure();
+  }
 
   // Fixpipe validation: check if this is a fixpipe pipe
   auto funcOp = getOperation()->getParentOfType<func::FuncOp>();
@@ -18320,24 +20642,29 @@ LogicalResult TFreeFromAicOp::verify() {
 
   if (getEntry() &&
       failed(verifyOddSplitTileEntry(getOperation(), getSplit(),
-                                     getEntry().getType())))
+                                     getEntry().getType()))) {
     return failure();
-  if (getEntry())
+  }
+  if (getEntry()) {
     return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
                                                 getEntry().getType());
+  }
   return success();
 }
 
 LogicalResult TFreeFromAivOp::verify() {
-  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation())))
+  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation()))) {
     return failure();
+  }
   if (failed(verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Cube,
                                    "cube", getId(), getSplit(),
-                                   /*expectC2V=*/false)))
+                                   /*expectC2V=*/false))) {
     return failure();
+  }
   if (failed(verifyFrontendDataOpDirection(getOperation(), getId(),
-                                           /*expectC2V=*/false)))
+                                           /*expectC2V=*/false))) {
     return failure();
+  }
 
   // Fixpipe validation: check if this is a fixpipe pipe
   auto funcOp = getOperation()->getParentOfType<func::FuncOp>();
@@ -18358,26 +20685,31 @@ LogicalResult TFreeFromAivOp::verify() {
 
   if (getEntry() &&
       failed(verifyOddSplitTileEntry(getOperation(), getSplit(),
-                                     getEntry().getType())))
+                                     getEntry().getType()))) {
     return failure();
-  if (getEntry())
+  }
+  if (getEntry()) {
     return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
                                                 getEntry().getType());
+  }
   return success();
 }
 
 LogicalResult SetQuantScalarOp::verify() {
-  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation())))
+  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation()))) {
     return failure();
+  }
   auto funcOp = getOperation()->getParentOfType<func::FuncOp>();
-  if (!funcOp)
+  if (!funcOp) {
     return emitOpError("must be nested under a func.func");
+  }
 
   // Look up the referenced pipe
   auto initOr =
       lookupFrontendOrLoweredInitOpById(getOperation(), funcOp, getId());
-  if (failed(initOr))
+  if (failed(initOr)) {
     return failure();
+  }
 
   Operation *initOp = *initOr;
   pto::AccPushEpilogueAttr accPushEpilogue;
@@ -18418,17 +20750,20 @@ LogicalResult SetQuantScalarOp::verify() {
 }
 
 LogicalResult SetQuantVectorOp::verify() {
-  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation())))
+  if (failed(verifyNoUnpublishedFixpipeFrontendAttrs(getOperation()))) {
     return failure();
+  }
   auto funcOp = getOperation()->getParentOfType<func::FuncOp>();
-  if (!funcOp)
+  if (!funcOp) {
     return emitOpError("must be nested under a func.func");
+  }
 
   // Look up the referenced pipe
   auto initOr =
       lookupFrontendOrLoweredInitOpById(getOperation(), funcOp, getId());
-  if (failed(initOr))
+  if (failed(initOr)) {
     return failure();
+  }
 
   Operation *initOp = *initOr;
   pto::AccPushEpilogueAttr accPushEpilogue;
@@ -18465,14 +20800,16 @@ LogicalResult SetQuantVectorOp::verify() {
     return emitOpError("expects 'scaling_tile' to be a tile type");
   }
   auto scalingSpace = getPTOMemorySpaceEnum(scalingTy);
-  if (!scalingSpace || *scalingSpace != pto::AddressSpace::SCALING)
+  if (!scalingSpace || *scalingSpace != pto::AddressSpace::SCALING) {
     return emitOpError("expects 'scaling_tile' to use loc=scaling");
+  }
   Type scalingElemTy = getElemTy(scalingTy);
   PTOArch arch = getTargetArch(getOperation());
   if (!isFixpipeQuantPayloadElemType(scalingElemTy, arch)) {
-    if (arch == PTOArch::A3)
+    if (arch == PTOArch::A3) {
       return emitOpError(
           "expects 'scaling_tile' element type to be packed i64/ui64 on A3");
+    }
     return emitOpError(
         "expects 'scaling_tile' element type to be f16, bf16, or f32 on A5");
   }
@@ -18485,144 +20822,183 @@ LogicalResult InitializeL2G2LPipeOp::verify() {
                              getSlotNum(),
                              getFlagBaseAttr()
                                  ? std::optional<int32_t>(getFlagBaseAttr().getInt())
-                                 : std::nullopt)))
+                                 : std::nullopt))) {
     return failure();
+  }
 
   if (!getLocalAddr()) {
-    if (getPeerLocalAddr())
+    if (getPeerLocalAddr()) {
       return emitOpError("'peer_local_addr' requires 'local_addr'");
-    if (getLocalSlotNumAttr())
+    }
+    if (getLocalSlotNumAttr()) {
       return emitOpError(
           "'local_slot_num' is only allowed when 'local_addr' is present");
+    }
     return success();
   }
 
   if (auto localSlotNumAttr = getLocalSlotNumAttr()) {
     int32_t localSlotNum = localSlotNumAttr.getInt();
-    if (localSlotNum <= 0)
+    if (localSlotNum <= 0) {
       return emitOpError("expects 'local_slot_num' to be greater than 0");
-    if (static_cast<uint32_t>(localSlotNum) > getSlotNum())
+    }
+    if (static_cast<uint32_t>(localSlotNum) > getSlotNum()) {
       return emitOpError(
           "expects 'local_slot_num' to be less than or equal to slot_num");
+    }
   }
 
-  if (getDirMask() == 3 && !getPeerLocalAddr())
+  if (getDirMask() == 3 && !getPeerLocalAddr()) {
     return emitOpError("expects 'peer_local_addr' when dir_mask is 3");
-  if (getDirMask() != 3 && getPeerLocalAddr())
+  }
+  if (getDirMask() != 3 && getPeerLocalAddr()) {
     return emitOpError("'peer_local_addr' is only allowed when dir_mask is 3");
+  }
   return success();
 }
 
 LogicalResult InitializeL2LPipeOp::verify() {
   if (failed(verifyPipeShape(getOperation(), getDirMask(), getSlotSize(),
-                              getSlotNum(),
-                              getFlagBaseAttr()
-                                  ? std::optional<int32_t>(getFlagBaseAttr().getInt())
-                                  : std::nullopt)))
+                             getSlotNum(),
+                             getFlagBaseAttr()
+                                 ? std::optional<int32_t>(getFlagBaseAttr().getInt())
+                                 : std::nullopt))) {
     return failure();
+  }
 
-  if (getDirMask() == 3 && !getPeerLocalAddr())
+  if (getDirMask() == 3 && !getPeerLocalAddr()) {
     return emitOpError("expects 'peer_local_addr' when dir_mask is 3");
-  if (getDirMask() != 3 && getPeerLocalAddr())
+  }
+  if (getDirMask() != 3 && getPeerLocalAddr()) {
     return emitOpError("'peer_local_addr' is only allowed when dir_mask is 3");
+  }
   return success();
 }
 
 LogicalResult TPushOp::verify() {
-  if (!isInsideSectionOrAttributedKernel(getOperation()))
+  if (!isInsideSectionOrAttributedKernel(getOperation())) {
     return emitOpError("must be inside pto.section.cube/vector or a kernel_kind function");
-  if (failed(verifyPipeHandleProducer(getOperation(), getPipeHandle())))
+  }
+  if (failed(verifyPipeHandleProducer(getOperation(), getPipeHandle()))) {
     return failure();
-  if (failed(verifySplitAttr(getOperation(), getSplit())))
+  }
+  if (failed(verifySplitAttr(getOperation(), getSplit()))) {
     return failure();
+  }
   if (failed(verifyInternalOddSplitSupport(
           getOperation(), getPipeHandle(), getSplit(),
-          /*producerSide=*/true)))
+          /*producerSide=*/true))) {
     return failure();
+  }
   if (failed(verifyOddSplitTileEntry(getOperation(), getSplit(),
-                                     getTile().getType())))
+                                     getTile().getType()))) {
     return failure();
+  }
   if (failed(verifyC2VProducerSplitParity(getOperation(), getSplit(),
-                                          getTile().getType())))
+                                          getTile().getType()))) {
     return failure();
+  }
   if (failed(verifyAivSubblockIdOperand(getOperation(), getAivSubblockid(),
-                                        getSplit(), getTile().getType())))
+                                        getSplit(), getTile().getType()))) {
     return failure();
+  }
   if (failed(verifyTensorEntryMatchesInternalPipeInit(
-          getOperation(), getPipeHandle(), getTile().getType())))
+          getOperation(), getPipeHandle(), getTile().getType()))) {
     return failure();
+  }
   if (!isa<TensorViewType>(getTile().getType()) &&
-      getPipe() == pto::PIPE::PIPE_UNASSIGNED)
+      getPipe() == pto::PIPE::PIPE_UNASSIGNED) {
     return emitOpError("tile type must map to a supported producer pipe");
+  }
   return success();
 }
 
 LogicalResult TAllocOp::verify() {
-  if (!isInsideSectionOrAttributedKernel(getOperation()))
+  if (!isInsideSectionOrAttributedKernel(getOperation())) {
     return emitOpError("must be inside pto.section.cube/vector or a kernel_kind function");
-  if (failed(verifyPipeHandleProducer(getOperation(), getPipeHandle())))
+  }
+  if (failed(verifyPipeHandleProducer(getOperation(), getPipeHandle()))) {
     return failure();
-  if (failed(verifySplitAttr(getOperation(), getSplit())))
+  }
+  if (failed(verifySplitAttr(getOperation(), getSplit()))) {
     return failure();
+  }
   if (failed(verifyInternalOddSplitSupport(
           getOperation(), getPipeHandle(), getSplit(),
-          /*producerSide=*/true)))
+          /*producerSide=*/true))) {
     return failure();
+  }
   if (failed(verifyOddSplitTileEntry(getOperation(), getSplit(),
-                                     getEntry().getType())))
+                                     getEntry().getType()))) {
     return failure();
+  }
   if (failed(verifyTensorEntryMatchesInternalPipeInit(
-          getOperation(), getPipeHandle(), getEntry().getType())))
+          getOperation(), getPipeHandle(), getEntry().getType()))) {
     return failure();
+  }
   return success();
 }
 
 LogicalResult TPopOp::verify() {
-  if (!isInsideSectionOrAttributedKernel(getOperation()))
+  if (!isInsideSectionOrAttributedKernel(getOperation())) {
     return emitOpError("must be inside pto.section.cube/vector or a kernel_kind function");
-  if (failed(verifyPipeHandleProducer(getOperation(), getPipeHandle())))
+  }
+  if (failed(verifyPipeHandleProducer(getOperation(), getPipeHandle()))) {
     return failure();
-  if (failed(verifySplitAttr(getOperation(), getSplit())))
+  }
+  if (failed(verifySplitAttr(getOperation(), getSplit()))) {
     return failure();
+  }
   if (failed(verifyInternalOddSplitSupport(
           getOperation(), getPipeHandle(), getSplit(),
-          /*producerSide=*/false)))
+          /*producerSide=*/false))) {
     return failure();
+  }
   if (failed(verifyOddSplitTileEntry(getOperation(), getSplit(),
-                                     getTile().getType())))
+                                     getTile().getType()))) {
     return failure();
+  }
   if (failed(verifyAivSubblockIdOperand(getOperation(), getAivSubblockid(),
-                                        getSplit(), getTile().getType())))
+                                        getSplit(), getTile().getType()))) {
     return failure();
+  }
   if (failed(verifyTensorEntryMatchesInternalPipeInit(
-          getOperation(), getPipeHandle(), getTile().getType())))
+          getOperation(), getPipeHandle(), getTile().getType()))) {
     return failure();
+  }
   if (!isa<TensorViewType>(getTile().getType()) &&
-      getPipe() == pto::PIPE::PIPE_UNASSIGNED)
+      getPipe() == pto::PIPE::PIPE_UNASSIGNED) {
     return emitOpError(
         "tile type and target arch must map to a supported consumer pipe");
+  }
   return success();
 }
 
 LogicalResult TFreeOp::verify() {
-  if (!isInsideSectionOrAttributedKernel(getOperation()))
+  if (!isInsideSectionOrAttributedKernel(getOperation())) {
     return emitOpError("must be inside pto.section.cube/vector or a kernel_kind function");
-  if (failed(verifyPipeHandleProducer(getOperation(), getPipeHandle())))
+  }
+  if (failed(verifyPipeHandleProducer(getOperation(), getPipeHandle()))) {
     return failure();
-  if (failed(verifySplitAttr(getOperation(), getSplit())))
+  }
+  if (failed(verifySplitAttr(getOperation(), getSplit()))) {
     return failure();
+  }
   if (failed(verifyInternalOddSplitSupport(
           getOperation(), getPipeHandle(), getSplit(),
-          /*producerSide=*/false)))
+          /*producerSide=*/false))) {
     return failure();
+  }
   if (getEntry() &&
       failed(verifyOddSplitTileEntry(getOperation(), getSplit(),
-                                     getEntry().getType())))
+                                     getEntry().getType()))) {
     return failure();
+  }
   if (getEntry() &&
       failed(verifyTensorEntryMatchesInternalPipeInit(
-          getOperation(), getPipeHandle(), getEntry().getType())))
+          getOperation(), getPipeHandle(), getEntry().getType()))) {
     return failure();
+  }
   return success();
 }
 
@@ -18633,36 +21009,43 @@ ParseResult TFreeOp::parse(OpAsmParser &parser, OperationState &result) {
   Type pipeTy;
   bool hasEntry = false;
 
-  if (parser.parseLParen() || parser.parseOperand(first))
+  if (parser.parseLParen() || parser.parseOperand(first)) {
     return failure();
+  }
 
   if (succeeded(parser.parseOptionalComma())) {
     hasEntry = true;
     if (parser.parseOperand(pipe) || parser.parseColonType(firstTy) ||
-        parser.parseComma() || parser.parseType(pipeTy) || parser.parseRParen())
+        parser.parseComma() || parser.parseType(pipeTy) || parser.parseRParen()) {
       return failure();
+    }
   } else {
-    if (parser.parseColonType(pipeTy) || parser.parseRParen())
+    if (parser.parseColonType(pipeTy) || parser.parseRParen()) {
       return failure();
+    }
     pipe = first;
   }
 
   NamedAttrList attrs;
   if (parser.parseLBrace() || parser.parseKeyword("split") ||
-      parser.parseEqual())
+      parser.parseEqual()) {
     return failure();
+  }
   IntegerAttr splitAttr;
   if (parser.parseAttribute(splitAttr, parser.getBuilder().getI8Type(),
                             "split", attrs) ||
-      parser.parseRBrace() || parser.parseOptionalAttrDict(attrs))
+      parser.parseRBrace() || parser.parseOptionalAttrDict(attrs)) {
     return failure();
+  }
 
   result.addAttributes(attrs);
   if (hasEntry &&
-      parser.resolveOperand(first, firstTy, result.operands))
+      parser.resolveOperand(first, firstTy, result.operands)) {
     return failure();
-  if (parser.resolveOperand(pipe, pipeTy, result.operands))
+  }
+  if (parser.resolveOperand(pipe, pipeTy, result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -18840,17 +21223,19 @@ static bool isInsideSimtExecutionScope(Operation *op) {
 }
 
 static LogicalResult verifyInsideSimtExecutionScope(Operation *op) {
-  if (!isInsideSimtExecutionScope(op))
+  if (!isInsideSimtExecutionScope(op)) {
     return op->emitOpError("must appear inside a function marked with '")
            << pto::kPTOSimtEntryAttrName
            << "' or inside pto.section.simt";
+  }
   return success();
 }
 
 static LogicalResult verifySimtKeepResumeCommon(Operation *op, int64_t slot) {
-  if (!isInsideSimtExecutionScope(op))
+  if (!isInsideSimtExecutionScope(op)) {
     return op->emitOpError("must appear inside a function marked with '")
            << pto::kPTOSimtEntryAttrName << "' or inside pto.section.simt";
+  }
   if (slot < 0 || slot >= kSimtKeepResumeSlotLimit) {
     return op->emitOpError("requires slot in range [0, ")
            << (kSimtKeepResumeSlotLimit - 1) << "]";
@@ -18898,89 +21283,107 @@ void ThreadfenceBlockOp::getEffects(
 }
 
 LogicalResult KeepOp::verify() {
-  if (failed(verifySimtKeepResumeCommon(getOperation(), getSlot())))
+  if (failed(verifySimtKeepResumeCommon(getOperation(), getSlot()))) {
     return failure();
-  if (!isSupportedSimtKeepResumeType(getPayload().getType()))
+  }
+  if (!isSupportedSimtKeepResumeType(getPayload().getType())) {
     return emitOpError()
            << "supports integer scalar payloads up to 64 bits and "
               "f16/bf16/f32 payloads";
-  if (failed(verifySimtKeepResumeSlotRange(*this)))
+  }
+  if (failed(verifySimtKeepResumeSlotRange(*this))) {
     return failure();
+  }
 
   Block *block = getOperation()->getBlock();
   bool insideSection =
       getOperation()->getParentOfType<SectionSimtOp>() != nullptr;
   Operation *lastPayloadOp = nullptr;
   if (insideSection) {
-    if (!block->empty())
+    if (!block->empty()) {
       lastPayloadOp = &block->back();
+    }
   } else {
     Operation *terminator = block->getTerminator();
-    if (isa<func::ReturnOp>(terminator))
+    if (isa<func::ReturnOp>(terminator)) {
       lastPayloadOp = terminator->getPrevNode();
+    }
   }
-  if (!lastPayloadOp)
+  if (!lastPayloadOp) {
     return emitOpError(
         "must be placed in the SIMT epilogue before func.return or the end "
         "of pto.section.simt");
+  }
 
   Operation *cur = lastPayloadOp;
-  while (cur && isa<SyncthreadsOp>(cur))
+  while (cur && isa<SyncthreadsOp>(cur)) {
     cur = cur->getPrevNode();
+  }
   Operation *lastKeep = cur;
-  if (!lastKeep || !isa<KeepOp>(lastKeep))
+  if (!lastKeep || !isa<KeepOp>(lastKeep)) {
     return emitOpError()
            << "must be placed in the SIMT epilogue before func.return; only "
               "'pto.syncthreads' may appear between the final 'pto.keep' group "
               "and func.return or the end of pto.section.simt";
+  }
 
   Operation *firstKeep = lastKeep;
   while (Operation *prev = firstKeep->getPrevNode()) {
-    if (!isa<KeepOp>(prev))
+    if (!isa<KeepOp>(prev)) {
       break;
+    }
     firstKeep = prev;
   }
-  if (!isOpInRange(getOperation(), firstKeep, lastKeep))
+  if (!isOpInRange(getOperation(), firstKeep, lastKeep)) {
     return emitOpError()
            << "must be in the contiguous SIMT keep epilogue group immediately "
               "before optional 'pto.syncthreads' and func.return or the end "
               "of pto.section.simt";
-  if (failed(verifyUniqueKeepGroupSlots(*this, firstKeep, lastKeep)))
+  }
+  if (failed(verifyUniqueKeepGroupSlots(*this, firstKeep, lastKeep))) {
     return failure();
+  }
   return success();
 }
 
 LogicalResult ResumeOp::verify() {
-  if (failed(verifySimtKeepResumeCommon(getOperation(), getSlot())))
+  if (failed(verifySimtKeepResumeCommon(getOperation(), getSlot()))) {
     return failure();
-  if (!isSupportedSimtKeepResumeType(getResult().getType()))
+  }
+  if (!isSupportedSimtKeepResumeType(getResult().getType())) {
     return emitOpError()
            << "supports integer scalar results up to 64 bits and "
               "f16/bf16/f32 results";
-  if (failed(verifySimtKeepResumeSlotRange(*this)))
+  }
+  if (failed(verifySimtKeepResumeSlotRange(*this))) {
     return failure();
+  }
   Block *block = getOperation()->getBlock();
   Operation *first = getFirstNonConstantLikeOp(block);
-  if (!first || !isa<ResumeOp>(first))
+  if (!first || !isa<ResumeOp>(first)) {
     return emitOpError()
            << "must be in the contiguous SIMT resume prologue group after "
               "constant-like operations";
+  }
 
   bool found = false;
   for (Operation *cur = first; cur; cur = cur->getNextNode()) {
-    if (!isa<ResumeOp>(cur))
+    if (!isa<ResumeOp>(cur)) {
       break;
+    }
     if (cur == getOperation()) {
       found = true;
       break;
     }
   }
-  if (!found)
+  if (!found) {
     return emitOpError()
            << "must be in the contiguous SIMT resume prologue group after "
               "constant-like operations";
-  if (failed(verifyUniqueResumeGroupSlots(*this, first)))
+  }
+  if (failed(verifyUniqueResumeGroupSlots(*this, first))) {
     return failure();
+  }
   return success();
 }
 
@@ -19077,8 +21480,9 @@ void TBroadcastOp::getEffects(
       addEffect(effects, &*it, MemoryEffects::Write::get());
     }
   }
-  for (OpOperand &operand : getGroupMutable())
+  for (OpOperand &operand : getGroupMutable()) {
     addEffect(effects, &operand, MemoryEffects::Write::get());
+  }
 }
 
 void CommTGatherOp::getEffects(
@@ -19094,8 +21498,9 @@ void CommTGatherOp::getEffects(
       addEffect(effects, &*it, MemoryEffects::Write::get());
     }
   }
-  for (OpOperand &operand : getGroupMutable())
+  for (OpOperand &operand : getGroupMutable()) {
     addEffect(effects, &operand, MemoryEffects::Read::get());
+  }
 }
 
 void CommTScatterOp::getEffects(
@@ -19111,8 +21516,9 @@ void CommTScatterOp::getEffects(
       addEffect(effects, &*it, MemoryEffects::Write::get());
     }
   }
-  for (OpOperand &operand : getGroupMutable())
+  for (OpOperand &operand : getGroupMutable()) {
     addEffect(effects, &operand, MemoryEffects::Write::get());
+  }
 }
 
 void TReduceOp::getEffects(
@@ -19130,8 +21536,9 @@ void TReduceOp::getEffects(
       addEffect(effects, &*it, MemoryEffects::Write::get());
     }
   }
-  for (OpOperand &operand : getGroupMutable())
+  for (OpOperand &operand : getGroupMutable()) {
     addEffect(effects, &operand, MemoryEffects::Read::get());
+  }
 }
 
 void WaitAsyncEventOp::getEffects(
@@ -19155,11 +21562,13 @@ void InitializeL2G2LPipeOp::getEffects(
         &effects) {
   addEffect(effects, &getGmAddrMutable(), MemoryEffects::Read::get());
   auto localAddr = getLocalAddrMutable();
-  if (!localAddr.empty())
+  if (!localAddr.empty()) {
     addEffect(effects, &*localAddr.begin(), MemoryEffects::Read::get());
+  }
   auto peerLocalAddr = getPeerLocalAddrMutable();
-  if (!peerLocalAddr.empty())
+  if (!peerLocalAddr.empty()) {
     addEffect(effects, &*peerLocalAddr.begin(), MemoryEffects::Read::get());
+  }
   addEffect(effects, getOperation()->getOpResult(0), MemoryEffects::Write::get());
 }
 
@@ -19175,8 +21584,9 @@ void TPushOp::getEffects(
         &effects) {
   addEffect(effects, &getTileMutable(), MemoryEffects::Read::get());
   auto aivSubblockId = getAivSubblockidMutable();
-  if (!aivSubblockId.empty())
+  if (!aivSubblockId.empty()) {
     addEffect(effects, &*aivSubblockId.begin(), MemoryEffects::Read::get());
+  }
   addEffect(effects, &getPipeHandleMutable(), MemoryEffects::Read::get());
   addEffect(effects, &getPipeHandleMutable(), MemoryEffects::Write::get());
   effects.emplace_back(MemoryEffects::Read::get(),
@@ -19203,20 +21613,24 @@ void TPushToAivOp::getEffects(
   addEffect(effects, &getTileMutable(), MemoryEffects::Read::get());
 
   auto funcOp = getOperation()->getParentOfType<func::FuncOp>();
-  if (!funcOp)
+  if (!funcOp) {
     return;
+  }
 
   auto initOr = lookupFrontendInitOpById(getOperation(), funcOp, getId());
-  if (failed(initOr))
+  if (failed(initOr)) {
     return;
+  }
 
   auto aicInit = dyn_cast<AicInitializePipeOp>(*initOr);
-  if (!aicInit)
+  if (!aicInit) {
     return;
+  }
 
   auto accPushEpilogue = aicInit.getAccPushEpilogueAttr();
-  if (!accPushEpilogue)
+  if (!accPushEpilogue) {
     return;
+  }
 
   auto quant = accPushEpilogue.getQuant();
   if (isScalarFixpipeQuant(quant) || isVectorFixpipeQuant(quant)) {
@@ -19240,8 +21654,9 @@ void TPopOp::getEffects(
   addEffect(effects, &getPipeHandleMutable(), MemoryEffects::Read::get());
   addEffect(effects, &getPipeHandleMutable(), MemoryEffects::Write::get());
   auto aivSubblockId = getAivSubblockidMutable();
-  if (!aivSubblockId.empty())
+  if (!aivSubblockId.empty()) {
     addEffect(effects, &*aivSubblockId.begin(), MemoryEffects::Read::get());
+  }
   addEffect(effects, &getTileMutable(), MemoryEffects::Write::get());
 }
 
@@ -19249,8 +21664,9 @@ void TFreeOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   auto entry = getEntryMutable();
-  if (!entry.empty())
+  if (!entry.empty()) {
     addEffect(effects, &*entry.begin(), MemoryEffects::Read::get());
+  }
   addEffect(effects, &getPipeHandleMutable(), MemoryEffects::Read::get());
   addEffect(effects, &getPipeHandleMutable(), MemoryEffects::Write::get());
 }
@@ -19279,13 +21695,15 @@ static ParseResult parseConvertRounding(OpAsmParser &parser,
                                         RoundingAttr &roundingAttr) {
   StringRef roundingKeyword;
   if (parser.parseKeyword("round") || parser.parseLParen() ||
-      parser.parseKeyword(&roundingKeyword) || parser.parseRParen())
+      parser.parseKeyword(&roundingKeyword) || parser.parseRParen()) {
     return failure();
+  }
   std::optional<Rounding> rounding = symbolizeRounding(roundingKeyword);
-  if (!rounding)
+  if (!rounding) {
     return parser.emitError(parser.getCurrentLocation())
            << "expected convert rounding to be one of "
            << kConvertRoundingKeywords;
+  }
   roundingAttr = RoundingAttr::get(parser.getContext(), *rounding);
   return success();
 }
@@ -19298,13 +21716,15 @@ static void printConvertRounding(OpAsmPrinter &printer, Operation *op,
 static ParseResult parseConvertSaturation(OpAsmParser &parser,
                                           SaturationAttr &saturationAttr) {
   StringRef saturationKeyword;
-  if (parser.parseKeyword(&saturationKeyword))
+  if (parser.parseKeyword(&saturationKeyword)) {
     return failure();
+  }
   std::optional<Saturation> saturation =
       symbolizeSaturation(saturationKeyword);
-  if (!saturation)
+  if (!saturation) {
     return parser.emitError(parser.getCurrentLocation())
            << "expected convert saturation to be sat or nosat";
+  }
   saturationAttr = SaturationAttr::get(parser.getContext(), *saturation);
   return success();
 }
@@ -19317,12 +21737,14 @@ static void printConvertSaturation(OpAsmPrinter &printer, Operation *op,
 static ParseResult parseSignedness(OpAsmParser &parser,
                                    SignednessAttr &signedness) {
   StringRef signednessKeyword;
-  if (parser.parseKeyword(&signednessKeyword))
+  if (parser.parseKeyword(&signednessKeyword)) {
     return failure();
+  }
   std::optional<Signedness> parsed = symbolizeSignedness(signednessKeyword);
-  if (!parsed)
+  if (!parsed) {
     return parser.emitError(parser.getCurrentLocation())
            << "expected signedness to be signed or unsigned";
+  }
   signedness = SignednessAttr::get(parser.getContext(), *parsed);
   return success();
 }
@@ -19367,20 +21789,23 @@ static ParseResult parseL1Cache(OpAsmParser &parser, L1CacheAttr &l1cache) {
 
   StringRef keyword;
   if (parser.parseLParen() || parser.parseKeyword(&keyword) ||
-      parser.parseRParen())
+      parser.parseRParen()) {
     return failure();
+  }
   std::optional<L1Cache> parsed = symbolizeL1Cache(keyword);
-  if (!parsed)
+  if (!parsed) {
     return parser.emitError(parser.getCurrentLocation())
            << "expected memory l1cache to be cache or uncache";
+  }
   l1cache = L1CacheAttr::get(parser.getContext(), *parsed);
   return success();
 }
 
 static void printL1Cache(OpAsmPrinter &printer, Operation *op,
                          L1CacheAttr l1cache) {
-  if (!l1cache)
+  if (!l1cache) {
     return;
+  }
   printer << "l1cache(" << stringifyL1Cache(l1cache.getValue()) << ")";
 }
 
@@ -19393,21 +21818,24 @@ static ParseResult parseLdL2Cache(OpAsmParser &parser,
 
   StringRef keyword;
   if (parser.parseLParen() || parser.parseKeyword(&keyword) ||
-      parser.parseRParen())
+      parser.parseRParen()) {
     return failure();
+  }
   std::optional<LdL2Cache> parsed = symbolizeLdL2Cache(keyword);
-  if (!parsed)
+  if (!parsed) {
     return parser.emitError(parser.getCurrentLocation())
            << "expected load L2 cache control to be one of "
            << kLdL2CacheKeywords;
+  }
   l2cache = LdL2CacheAttr::get(parser.getContext(), *parsed);
   return success();
 }
 
 static void printLdL2Cache(OpAsmPrinter &printer, Operation *op,
                            LdL2CacheAttr l2cache) {
-  if (!l2cache)
+  if (!l2cache) {
     return;
+  }
   printer << "l2cache(" << stringifyLdL2Cache(l2cache.getValue()) << ")";
 }
 
@@ -19420,21 +21848,24 @@ static ParseResult parseStL2Cache(OpAsmParser &parser,
 
   StringRef keyword;
   if (parser.parseLParen() || parser.parseKeyword(&keyword) ||
-      parser.parseRParen())
+      parser.parseRParen()) {
     return failure();
+  }
   std::optional<StL2Cache> parsed = symbolizeStL2Cache(keyword);
-  if (!parsed)
+  if (!parsed) {
     return parser.emitError(parser.getCurrentLocation())
            << "expected store L2 cache control to be one of "
            << kStL2CacheKeywords;
+  }
   l2cache = StL2CacheAttr::get(parser.getContext(), *parsed);
   return success();
 }
 
 static void printStL2Cache(OpAsmPrinter &printer, Operation *op,
                            StL2CacheAttr l2cache) {
-  if (!l2cache)
+  if (!l2cache) {
     return;
+  }
   printer << "l2cache(" << stringifyStL2Cache(l2cache.getValue()) << ")";
 }
 
@@ -19443,17 +21874,20 @@ static void printStL2Cache(OpAsmPrinter &printer, Operation *op,
 static ParseResult parseStructPath(OpAsmParser &parser,
                                    DenseI64ArrayAttr &path) {
   SmallVector<int64_t> indices;
-  if (parser.parseLSquare())
+  if (parser.parseLSquare()) {
     return failure();
+  }
   if (failed(parser.parseOptionalRSquare())) {
     do {
       int64_t idx = 0;
-      if (parser.parseInteger(idx))
+      if (parser.parseInteger(idx)) {
         return failure();
+      }
       indices.push_back(idx);
     } while (succeeded(parser.parseOptionalComma()));
-    if (parser.parseRSquare())
+    if (parser.parseRSquare()) {
       return failure();
+    }
   }
   path = DenseI64ArrayAttr::get(parser.getContext(), indices);
   return success();
@@ -19464,8 +21898,9 @@ static void printStructPath(OpAsmPrinter &printer, Operation *op,
   printer << "[";
   llvm::ArrayRef<int64_t> indices = path.asArrayRef();
   for (size_t i = 0; i < indices.size(); ++i) {
-    if (i)
+    if (i) {
       printer << ", ";
+    }
     printer << indices[i];
   }
   printer << "]";

--- a/lib/PTO/IR/PTOAttrs.cpp
+++ b/lib/PTO/IR/PTOAttrs.cpp
@@ -79,43 +79,54 @@ LogicalResult TileBufConfigAttr::verify(function_ref<InFlightDiagnostic()> emitE
                                        IntegerAttr sFractalSize,
                                        Attribute pad,
                                        Attribute compactMode) {
-  if (!bLayout || (!mlir::isa<BLayoutAttr>(bLayout) && !mlir::isa<IntegerAttr>(bLayout)))
+  if (!bLayout || (!mlir::isa<BLayoutAttr>(bLayout) && !mlir::isa<IntegerAttr>(bLayout))) {
     return emitError() << "blayout must be BLayoutAttr or i32 integer attr", failure();
-  if (!sLayout || (!mlir::isa<SLayoutAttr>(sLayout) && !mlir::isa<IntegerAttr>(sLayout)))
+  }
+  if (!sLayout || (!mlir::isa<SLayoutAttr>(sLayout) && !mlir::isa<IntegerAttr>(sLayout))) {
     return emitError() << "slayout must be SLayoutAttr or i32 integer attr", failure();
-  if (!pad || (!mlir::isa<PadValueAttr>(pad) && !mlir::isa<IntegerAttr>(pad)))
+  }
+  if (!pad || (!mlir::isa<PadValueAttr>(pad) && !mlir::isa<IntegerAttr>(pad))) {
     return emitError() << "pad must be PadValueAttr or i32 integer attr", failure();
+  }
   if (!compactMode ||
       (!mlir::isa<CompactModeAttr>(compactMode) &&
-       !mlir::isa<IntegerAttr>(compactMode)))
+       !mlir::isa<IntegerAttr>(compactMode))) {
     return emitError() << "compact_mode must be CompactModeAttr or i32 integer attr", failure();
+  }
 
-  if (!sFractalSize || !sFractalSize.getType().isInteger(kI32BitWidth))
+  if (!sFractalSize || !sFractalSize.getType().isInteger(kI32BitWidth)) {
     return emitError() << "s_fractal_size must be i32", failure();
+  }
 
   int32_t s = static_cast<int32_t>(sFractalSize.getInt());
-  if (s != kFractalMxSize && s != kFractalABSize && s != kFractalCSize)
+  if (s != kFractalMxSize && s != kFractalABSize && s != kFractalCSize) {
     return emitError() << "unsupported s_fractal_size: " << s
                        << ", must be one of {"
                        << kFractalMxSize << ", "
                        << kFractalABSize << ", "
-                       << kFractalCSize << "}", failure();
+                       << kFractalCSize << "}",
+           failure();
+  }
 
   int32_t blv = getLayoutInt(bLayout, -1);
-  if (blv != kBLayoutRowMajor && blv != kBLayoutColMajor)
+  if (blv != kBLayoutRowMajor && blv != kBLayoutColMajor) {
     return emitError() << "unsupported blayout value: " << blv, failure();
+  }
 
   int32_t slv = getLayoutInt(sLayout, -1);
-  if (slv < kSLayoutNoneBox || slv > kSLayoutColMajor)
+  if (slv < kSLayoutNoneBox || slv > kSLayoutColMajor) {
     return emitError() << "unsupported slayout value: " << slv, failure();
+  }
 
   int32_t pvv = getLayoutInt(pad, -1);
-  if (pvv < kPadValueNull || pvv > kPadValueMin)
+  if (pvv < kPadValueNull || pvv > kPadValueMin) {
     return emitError() << "unsupported pad value: " << pvv, failure();
+  }
 
   int32_t cmv = getLayoutInt(compactMode, -1);
-  if (cmv < kCompactModeNull || cmv > kCompactModeRowPlusOne)
+  if (cmv < kCompactModeNull || cmv > kCompactModeRowPlusOne) {
     return emitError() << "unsupported compact_mode value: " << cmv, failure();
+  }
 
   return success();
 }

--- a/lib/PTO/IR/PTOSyncUtils.cpp
+++ b/lib/PTO/IR/PTOSyncUtils.cpp
@@ -15,10 +15,12 @@ using namespace mlir;
 using namespace mlir::pto;
 
 FailureOr<SyncOpType> mlir::pto::parseSyncOpTypeLikeAttr(Attribute attr) {
-  if (auto a = dyn_cast_or_null<PipeEventTypeAttr>(attr))
+  if (auto a = dyn_cast_or_null<PipeEventTypeAttr>(attr)) {
     return a.getOpType();
-  if (auto a = dyn_cast_or_null<SyncOpTypeAttr>(attr))
+  }
+  if (auto a = dyn_cast_or_null<SyncOpTypeAttr>(attr)) {
     return a.getOpType();
+  }
   return failure();
 }
 

--- a/lib/PTO/IR/PTOTypeDefs.cpp
+++ b/lib/PTO/IR/PTOTypeDefs.cpp
@@ -7,12 +7,13 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 //===- PTOTypeDefs.cpp --------------------------------------------*- C++ -*-===//
-#include "PTO/IR/PTO.h"
-#include "PTO/IR/PTOMultiBuffer.h"
-#include "mlir/IR/DialectImplementation.h"
 #include <limits>
 #include <mutex>
 #include <unordered_map>
+#include "PTO/IR/PTO.h"
+#include "PTO/IR/PTOMultiBuffer.h"
+#include "mlir/IR/DialectImplementation.h"
+
 
 using namespace mlir;
 using namespace mlir::pto;
@@ -80,8 +81,9 @@ canonicalizeTileBufValidShape(ArrayRef<int64_t> validShape) {
 
 static LogicalResult parseTileBufKeyEq(AsmParser &parser,
                                        StringRef expectedKey) {
-  if (failed(parser.parseKeyword(expectedKey)))
+  if (failed(parser.parseKeyword(expectedKey))) {
     return failure();
+  }
   return parser.parseEqual();
 }
 
@@ -91,43 +93,51 @@ static LogicalResult parseTileBufComma(AsmParser &parser) {
 
 static LogicalResult parseTileBufKeywordField(AsmParser &parser, StringRef key,
                                               std::string &value) {
-  if (failed(parseTileBufKeyEq(parser, key)))
+  if (failed(parseTileBufKeyEq(parser, key))) {
     return failure();
-  if (failed(parser.parseKeywordOrString(&value)))
+  }
+  if (failed(parser.parseKeywordOrString(&value))) {
     return failure();
+  }
   return parseTileBufComma(parser);
 }
 
 static LogicalResult parseTileBufTypeField(AsmParser &parser, StringRef key,
                                            Type &value) {
-  if (failed(parseTileBufKeyEq(parser, key)))
+  if (failed(parseTileBufKeyEq(parser, key))) {
     return failure();
-  if (failed(parser.parseType(value)))
+  }
+  if (failed(parser.parseType(value))) {
     return failure();
+  }
   return parseTileBufComma(parser);
 }
 
 static LogicalResult parseTileBufIntegerField(AsmParser &parser, StringRef key,
                                               int64_t &value) {
-  if (failed(parseTileBufKeyEq(parser, key)))
+  if (failed(parseTileBufKeyEq(parser, key))) {
     return failure();
-  if (failed(parser.parseInteger(value)))
+  }
+  if (failed(parser.parseInteger(value))) {
     return failure();
+  }
   return parseTileBufComma(parser);
 }
 
 static LogicalResult parseTileBufValidDim(AsmParser &parser, StringRef key,
                                           int64_t &value) {
-  if (failed(parseTileBufKeyEq(parser, key)))
+  if (failed(parseTileBufKeyEq(parser, key))) {
     return failure();
+  }
 
   if (succeeded(parser.parseOptionalQuestion())) {
     value = -1;
     return success();
   }
 
-  if (failed(parser.parseInteger(value)))
+  if (failed(parser.parseInteger(value))) {
     return failure();
+  }
   if (value < -1) {
     parser.emitError(parser.getCurrentLocation(),
                      key + " must be '?', -1, or a non-negative integer");
@@ -139,21 +149,26 @@ static LogicalResult parseTileBufValidDim(AsmParser &parser, StringRef key,
 static LogicalResult parseTileBufValidShapeFields(AsmParser &parser,
                                                   int64_t &vrow,
                                                   int64_t &vcol) {
-  if (failed(parseTileBufValidDim(parser, "v_row", vrow)))
+  if (failed(parseTileBufValidDim(parser, "v_row", vrow))) {
     return failure();
-  if (failed(parseTileBufComma(parser)))
+  }
+  if (failed(parseTileBufComma(parser))) {
     return failure();
-  if (failed(parseTileBufValidDim(parser, "v_col", vcol)))
+  }
+  if (failed(parseTileBufValidDim(parser, "v_col", vcol))) {
     return failure();
+  }
   return parseTileBufComma(parser);
 }
 
 static LogicalResult parseTileBufPadField(AsmParser &parser, uint32_t &padInt) {
   int64_t parsedPad = 0;
-  if (failed(parseTileBufKeyEq(parser, "pad")))
+  if (failed(parseTileBufKeyEq(parser, "pad"))) {
     return failure();
-  if (failed(parser.parseInteger(parsedPad)))
+  }
+  if (failed(parser.parseInteger(parsedPad))) {
     return failure();
+  }
   if (parsedPad < 0 || parsedPad > std::numeric_limits<uint32_t>::max()) {
     parser.emitError(parser.getCurrentLocation(),
                      "pad must be a non-negative 32-bit integer");
@@ -227,26 +242,30 @@ int32_t TileBufType::getSFractalSizeI32() const {
 }
 
 int32_t TileBufType::getBLayoutValueI32() const {
-  if (auto a = llvm::dyn_cast<BLayoutAttr>(getBLayoutAttr()))
+  if (auto a = llvm::dyn_cast<BLayoutAttr>(getBLayoutAttr())) {
     return static_cast<int32_t>(a.getValue());
+  }
   return 0;
 }
 
 int32_t TileBufType::getSLayoutValueI32() const {
-  if (auto a = llvm::dyn_cast<SLayoutAttr>(getSLayoutAttr()))
+  if (auto a = llvm::dyn_cast<SLayoutAttr>(getSLayoutAttr())) {
     return static_cast<int32_t>(a.getValue());
+  }
   return 0;
 }
 
 int32_t TileBufType::getPadValueI32() const {
-  if (auto a = llvm::dyn_cast<PadValueAttr>(getPadValueAttr()))
+  if (auto a = llvm::dyn_cast<PadValueAttr>(getPadValueAttr())) {
     return static_cast<int32_t>(a.getValue());
+  }
   return 0;
 }
 
 int32_t TileBufType::getCompactModeI32() const {
-  if (auto a = llvm::dyn_cast<CompactModeAttr>(getCompactModeAttr()))
+  if (auto a = llvm::dyn_cast<CompactModeAttr>(getCompactModeAttr())) {
     return static_cast<int32_t>(a.getValue());
+  }
   return 0;
 }
 
@@ -269,8 +288,9 @@ struct ParsedTileBufFields {
 static LogicalResult parseTileBufUInt32Value(AsmParser &parser, StringRef key,
                                              uint32_t &value) {
   int64_t parsedValue = 0;
-  if (failed(parser.parseInteger(parsedValue)))
+  if (failed(parser.parseInteger(parsedValue))) {
     return failure();
+  }
   if (parsedValue < 0 ||
       parsedValue > std::numeric_limits<uint32_t>::max()) {
     parser.emitError(parser.getCurrentLocation())
@@ -283,12 +303,15 @@ static LogicalResult parseTileBufUInt32Value(AsmParser &parser, StringRef key,
 
 static LogicalResult parseLegacyTileBufFields(AsmParser &parser,
                                               ParsedTileBufFields &fields) {
-  if (failed(parser.parseEqual()))
+  if (failed(parser.parseEqual())) {
     return failure();
-  if (failed(parser.parseKeywordOrString(&fields.locStr)))
+  }
+  if (failed(parser.parseKeywordOrString(&fields.locStr))) {
     return failure();
-  if (failed(parser.parseComma()))
+  }
+  if (failed(parser.parseComma())) {
     return failure();
+  }
 
   if (failed(parseTileBufTypeField(parser, "dtype", fields.dtype)) ||
       failed(parseTileBufIntegerField(parser, "rows", fields.rows)) ||
@@ -316,14 +339,17 @@ static LogicalResult parseCompactTileBufFields(AsmParser &parser,
                                                uint32_t *outMultiCount = nullptr) {
   fields.locStr = firstToken.str();
 
-  if (failed(parser.parseComma()))
+  if (failed(parser.parseComma())) {
     return failure();
+  }
 
   TileBufShape shape;
-  if (failed(parser.parseDimensionList(shape, /*allowDynamic=*/false)))
+  if (failed(parser.parseDimensionList(shape, /*allowDynamic=*/false))) {
     return failure();
-  if (failed(parser.parseType(fields.dtype)))
+  }
+  if (failed(parser.parseType(fields.dtype))) {
     return failure();
+  }
   if (shape.size() != kTileBufRank2D) {
     parser.emitError(parser.getCurrentLocation(),
                      "tile_buf compact syntax expects exactly two shape dims");
@@ -361,8 +387,9 @@ static LogicalResult parseCompactTileBufFields(AsmParser &parser,
 
   while (succeeded(parser.parseOptionalComma())) {
     StringRef key;
-    if (failed(parser.parseKeyword(&key)) || failed(parser.parseEqual()))
+    if (failed(parser.parseKeyword(&key)) || failed(parser.parseEqual())) {
       return failure();
+    }
 
     if (key == "valid") {
       if (seenValid) {
@@ -394,8 +421,9 @@ static LogicalResult parseCompactTileBufFields(AsmParser &parser,
         return failure();
       }
       seenBLayout = true;
-      if (failed(parser.parseKeywordOrString(&fields.blayoutStr)))
+      if (failed(parser.parseKeywordOrString(&fields.blayoutStr))) {
         return failure();
+      }
       continue;
     }
 
@@ -406,8 +434,9 @@ static LogicalResult parseCompactTileBufFields(AsmParser &parser,
         return failure();
       }
       seenSLayout = true;
-      if (failed(parser.parseKeywordOrString(&fields.slayoutStr)))
+      if (failed(parser.parseKeywordOrString(&fields.slayoutStr))) {
         return failure();
+      }
       continue;
     }
 
@@ -418,8 +447,9 @@ static LogicalResult parseCompactTileBufFields(AsmParser &parser,
         return failure();
       }
       seenFractal = true;
-      if (failed(parser.parseInteger(fields.fractal)))
+      if (failed(parser.parseInteger(fields.fractal))) {
         return failure();
+      }
       continue;
     }
 
@@ -430,8 +460,9 @@ static LogicalResult parseCompactTileBufFields(AsmParser &parser,
         return failure();
       }
       seenPad = true;
-      if (failed(parseTileBufUInt32Value(parser, key, fields.padInt)))
+      if (failed(parseTileBufUInt32Value(parser, key, fields.padInt))) {
         return failure();
+      }
       continue;
     }
 
@@ -442,16 +473,18 @@ static LogicalResult parseCompactTileBufFields(AsmParser &parser,
         return failure();
       }
       seenCompact = true;
-      if (failed(parseTileBufUInt32Value(parser, key, fields.compactInt)))
+      if (failed(parseTileBufUInt32Value(parser, key, fields.compactInt))) {
         return failure();
+      }
       continue;
     }
 
     if (outMultiCount && key == "count") {
       // Tail field belonging to a wrapping multi_tile_buf<...>. Consume the
       // integer and return success; the wrapper finishes the parse.
-      if (failed(parseTileBufUInt32Value(parser, key, *outMultiCount)))
+      if (failed(parseTileBufUInt32Value(parser, key, *outMultiCount))) {
         return failure();
+      }
       return success();
     }
 
@@ -557,21 +590,25 @@ static Type buildTileBufType(AsmParser &parser,
 // !pto.tile_buf<<loc=.., dtype=.., rows=.., cols=.., blayout=.., valid=..x..,
 //                slayout=.., fractal=.., pad=.., compact=..>>
 Type TileBufType::parse(AsmParser &parser) {
-  if (failed(parser.parseLess()))
+  if (failed(parser.parseLess())) {
     return Type();
+  }
 
   std::string firstToken;
-  if (failed(parser.parseKeywordOrString(&firstToken)))
+  if (failed(parser.parseKeywordOrString(&firstToken))) {
     return Type();
+  }
 
   ParsedTileBufFields fields;
   const bool isLegacySyntax = firstToken == "loc";
   if (isLegacySyntax) {
-    if (failed(parseLegacyTileBufFields(parser, fields)))
+    if (failed(parseLegacyTileBufFields(parser, fields))) {
       return Type();
+    }
   } else {
-    if (failed(parseCompactTileBufFields(parser, firstToken, fields)))
+    if (failed(parseCompactTileBufFields(parser, firstToken, fields))) {
       return Type();
+    }
   }
 
   if (isLegacySyntax && succeeded(parser.parseOptionalComma())) {
@@ -581,8 +618,9 @@ Type TileBufType::parse(AsmParser &parser) {
     }
   }
 
-  if (failed(parser.parseGreater()))
+  if (failed(parser.parseGreater())) {
     return Type();
+  }
 
   return buildTileBufType(parser, fields);
 }
@@ -606,7 +644,9 @@ static llvm::StringRef stringifyLocFromMemorySpace(mlir::Attribute memorySpace) 
 
 static llvm::StringRef stringifyLocFromPad(mlir::Attribute pad) {
   auto padAttr = llvm::dyn_cast_or_null<PadValueAttr>(pad);
-  if (!padAttr) return "9999";
+  if (!padAttr) {
+    return "9999";
+  }
 
   switch (padAttr.getValue()) {
     case PadValue::Null: return "0";
@@ -619,8 +659,9 @@ static llvm::StringRef stringifyLocFromPad(mlir::Attribute pad) {
 
 static llvm::StringRef stringifyCompactModeInt(mlir::Attribute compactMode) {
   auto compactAttr = llvm::dyn_cast_or_null<CompactModeAttr>(compactMode);
-  if (!compactAttr)
+  if (!compactAttr) {
     return "9999";
+  }
 
   switch (compactAttr.getValue()) {
   case CompactMode::Null:
@@ -634,10 +675,11 @@ static llvm::StringRef stringifyCompactModeInt(mlir::Attribute compactMode) {
 }
 
 static void printTileBufDim(AsmPrinter &printer, int64_t dim) {
-  if (dim == ShapedType::kDynamic)
+  if (dim == ShapedType::kDynamic) {
     printer << "?";
-  else
+  } else {
     printer << dim;
+}
 }
 
 void mlir::pto::TileBufType::print(mlir::AsmPrinter &printer) const {
@@ -696,16 +738,21 @@ void mlir::pto::TileBufType::print(mlir::AsmPrinter &printer) const {
     printer << "x";
     printTileBufDim(printer, vcol);
   }
-  if (printBLayout)
+  if (printBLayout) {
     printer << ", blayout=" << stringifyBLayout(blayout.getValue());
-  if (printSLayout)
+  }
+  if (printSLayout) {
     printer << ", slayout=" << stringifySLayout(slayout.getValue());
-  if (printFractal)
+  }
+  if (printFractal) {
     printer << ", fractal=" << cfg.getSFractalSize().getInt();
-  if (printPad)
+  }
+  if (printPad) {
     printer << ", pad=" << stringifyLocFromPad(cfg.getPad());
-  if (printCompact)
+  }
+  if (printCompact) {
     printer << ", compact=" << stringifyCompactModeInt(cfg.getCompactMode());
+  }
 
   printer << ">";
 }
@@ -734,23 +781,28 @@ namespace {
 // closing `>`.
 static LogicalResult parseMultiTileBufCount(AsmParser &parser,
                                             uint32_t &count) {
-  if (failed(parser.parseComma()))
+  if (failed(parser.parseComma())) {
     return failure();
-  if (failed(parser.parseKeyword("count")))
+  }
+  if (failed(parser.parseKeyword("count"))) {
     return failure();
-  if (failed(parser.parseEqual()))
+  }
+  if (failed(parser.parseEqual())) {
     return failure();
+  }
   uint32_t parsed = 0;
-  if (failed(parseTileBufUInt32Value(parser, "count", parsed)))
+  if (failed(parseTileBufUInt32Value(parser, "count", parsed))) {
     return failure();
+  }
   count = parsed;
   return success();
 }
 } // namespace
 
 Type MultiTileBufType::parse(AsmParser &parser) {
-  if (failed(parser.parseLess()))
+  if (failed(parser.parseLess())) {
     return Type();
+  }
 
   MLIRContext *ctx = parser.getContext();
   TileBufType slotType;
@@ -762,8 +814,9 @@ Type MultiTileBufType::parse(AsmParser &parser) {
   Type maybeType;
   OptionalParseResult typeRes = parser.parseOptionalType(maybeType);
   if (typeRes.has_value()) {
-    if (failed(*typeRes))
+    if (failed(*typeRes)) {
       return Type();
+    }
     slotType = llvm::dyn_cast<TileBufType>(maybeType);
     if (!slotType) {
       parser.emitError(parser.getCurrentLocation(),
@@ -774,27 +827,32 @@ Type MultiTileBufType::parse(AsmParser &parser) {
     // Compact form: parse via the same compact path used by tile_buf, but
     // tell it to consume the trailing `, count=N` on our behalf.
     std::string firstToken;
-    if (failed(parser.parseKeywordOrString(&firstToken)))
+    if (failed(parser.parseKeywordOrString(&firstToken))) {
       return Type();
+    }
 
     ParsedTileBufFields fields;
-    if (failed(parseCompactTileBufFields(parser, firstToken, fields, &count)))
+    if (failed(parseCompactTileBufFields(parser, firstToken, fields, &count))) {
       return Type();
+    }
 
     Type built = buildTileBufType(parser, fields);
-    if (!built)
+    if (!built) {
       return Type();
+    }
     slotType = llvm::cast<TileBufType>(built);
     countConsumedByCompact = (count != 0);
   }
 
   if (!countConsumedByCompact) {
-    if (failed(parseMultiTileBufCount(parser, count)))
+    if (failed(parseMultiTileBufCount(parser, count))) {
       return Type();
+    }
   }
 
-  if (failed(parser.parseGreater()))
+  if (failed(parser.parseGreater())) {
     return Type();
+  }
 
   return getChecked(
       [&]() { return parser.emitError(parser.getNameLoc()); }, ctx, slotType,

--- a/lib/PTO/IR/PTOTypeUtils.cpp
+++ b/lib/PTO/IR/PTOTypeUtils.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTOTypeUtils.h"
 
 #include "PTO/IR/PTO.h"
@@ -15,6 +16,9 @@ using namespace mlir::pto;
 
 namespace {
 constexpr unsigned kBitsPerByte = 8;
+constexpr unsigned kPackedLdgStgBitWidth16 = 16;
+constexpr unsigned kPackedLdgStgBitWidth32 = 32;
+constexpr unsigned kPackedLdgStgBitWidth64 = 64;
 } // namespace
 
 bool mlir::pto::isPTOFloat8Type(Type t) {
@@ -48,22 +52,23 @@ bool mlir::pto::isPTOPackedLdgStgVectorType(Type t) {
     return true;
   }
   auto vecType = dyn_cast<VectorType>(t);
-  if (!vecType || vecType.isScalable() || vecType.getRank() != 1)
+  if (!vecType || vecType.isScalable() || vecType.getRank() != 1) {
     return false;
+  }
   int64_t lanes = vecType.getDimSize(0);
   Type elemType = vecType.getElementType();
   bool validElem = false;
   if (isPTOFloat8Type(elemType)) {
-    validElem = lanes == 2 || lanes == 4 || lanes == 8;
+    validElem = lanes == mlir::pto::kValue2 || lanes == 4 || lanes == 8;
   } else {
     validElem =
-        lanes == 2 &&
+        lanes == mlir::pto::kValue2 &&
         (elemType.isF16() || elemType.isBF16() || elemType.isF32());
   }
   if (!validElem) {
     if (auto intTy = dyn_cast<IntegerType>(elemType)) {
       unsigned w = intTy.getWidth();
-      validElem = lanes == 2 && (w == 8 || w == 16 || w == 32);
+      validElem = lanes == mlir::pto::kValue2 && (w == 8 || w == 16 || w == 32);
     }
   }
   if (!validElem) {
@@ -71,12 +76,15 @@ bool mlir::pto::isPTOPackedLdgStgVectorType(Type t) {
   }
   unsigned totalBits =
       vecType.getDimSize(0) * getPTOStorageElemBitWidth(elemType);
-  return totalBits == 16 || totalBits == 32 || totalBits == 64;
+  return totalBits == kPackedLdgStgBitWidth16 ||
+         totalBits == kPackedLdgStgBitWidth32 ||
+         totalBits == kPackedLdgStgBitWidth64;
 }
 
 unsigned mlir::pto::getPTOPackedLdgStgTotalBits(Type t) {
-  if (isPTOHiFloat8x2Type(t))
+  if (isPTOHiFloat8x2Type(t)) {
     return getPTOStorageElemBitWidth(t); // 16
+  }
   auto vecType = cast<VectorType>(t);
   return vecType.getDimSize(0) *
          getPTOStorageElemBitWidth(vecType.getElementType());
@@ -97,12 +105,15 @@ unsigned mlir::pto::getPTOStorageElemBitWidth(Type t) {
   if (isPTOBF16x2Type(t)) {
     return 32;
   }
-  if (isPTOLowPrecisionType(t))
+  if (isPTOLowPrecisionType(t)) {
     return kBitsPerByte;
-  if (auto floatTy = dyn_cast<FloatType>(t))
+}
+  if (auto floatTy = dyn_cast<FloatType>(t)) {
     return floatTy.getWidth();
-  if (auto intTy = dyn_cast<IntegerType>(t))
+}
+  if (auto intTy = dyn_cast<IntegerType>(t)) {
     return intTy.getWidth();
+}
   return 0;
 }
 

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -9,18 +9,19 @@
 //===- VMI.cpp - PTO VMI type and attribute support -----------------------===//
 //===----------------------------------------------------------------------===//
 
+#include <optional>
+#include <set>
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/IR/VMIUtils.h"
-
+#include "PTO/Support/CodeConstants.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/Types.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
-#include <optional>
-#include <set>
+
 
 using namespace mlir;
 using namespace mlir::pto;
@@ -76,9 +77,10 @@ static bool involvesVMIPackedFloatCarrier(Type sourceType, Type resultType) {
 }
 
 static LogicalResult verifyBF16x2ComputeElementType(Operation *op, Type type) {
-  if (pto::isPTOBF16x2Type(type))
+  if (pto::isPTOBF16x2Type(type)) {
     return op->emitOpError(
         "does not support bf16x2 VMI element type; bf16x2 is conversion-only");
+}
   return success();
 }
 
@@ -96,7 +98,7 @@ static bool isVMIF16BF16OrF32Type(Type type) {
 
 static bool isVMIPredicateMaskableElementType(Type type) {
   unsigned elementBits = pto::getPTOStorageElemBitWidth(type);
-  return elementBits == 8 || elementBits == 16 || elementBits == 32;
+  return elementBits == mlir::pto::kValue8 || elementBits == 16 || elementBits == 32;
 }
 
 static bool isVMIAnyI8I16I32Type(Type type) {
@@ -104,8 +106,8 @@ static bool isVMIAnyI8I16I32Type(Type type) {
   if (!integerType) {
     return false;
   }
-  return integerType.getWidth() == 8 || integerType.getWidth() == 16 ||
-         integerType.getWidth() == 32;
+  return integerType.getWidth() == mlir::pto::kValue8 || integerType.getWidth() == 16 ||
+         integerType.getWidth() == mlir::pto::kValue32;
 }
 
 static bool isVMII8I16I32OrF16BF16F32Type(Type type) {
@@ -128,8 +130,8 @@ static bool isVMISignedI8I16I32Type(Type type) {
   if (!integerType || !integerType.isSigned()) {
     return false;
   }
-  return integerType.getWidth() == 8 || integerType.getWidth() == 16 ||
-         integerType.getWidth() == 32;
+  return integerType.getWidth() == mlir::pto::kValue8 || integerType.getWidth() == 16 ||
+         integerType.getWidth() == mlir::pto::kValue32;
 }
 
 static bool isVMISignedIntegerType(Type type) {
@@ -175,9 +177,10 @@ static bool matchesVMIIntSemantics(IntegerType intType,
 }
 
 static bool isVMIIotaElementType(Type type) {
-  if (auto intType = dyn_cast<IntegerType>(type))
-    return intType.getWidth() == 8 || intType.getWidth() == 16 ||
-           intType.getWidth() == 32;
+  if (auto intType = dyn_cast<IntegerType>(type)) {
+    return intType.getWidth() == mlir::pto::kValue8 || intType.getWidth() == 16 ||
+           intType.getWidth() == mlir::pto::kValue32;
+  }
   return type.isF16() || type.isF32();
 }
 
@@ -190,8 +193,9 @@ static bool isCompatibleScalarForSemanticType(Type semanticType,
   auto semanticInt = dyn_cast<IntegerType>(semanticType);
   auto scalarInt = dyn_cast<IntegerType>(scalarType);
   if (!semanticInt || !scalarInt ||
-      semanticInt.getWidth() != scalarInt.getWidth())
+      semanticInt.getWidth() != scalarInt.getWidth()) {
     return false;
+  }
 
   if (semanticInt.isSigned()) {
     return scalarInt.isSigned() || scalarInt.isSignless();
@@ -204,7 +208,7 @@ static bool isCompatibleScalarForSemanticType(Type semanticType,
 
 static unsigned getVMIElementBitWidth(Type type) {
   if (isa<IndexType>(type)) {
-    return 64;
+    return mlir::pto::kValue64;
   }
   return pto::getPTOStorageElemBitWidth(type);
 }
@@ -222,9 +226,10 @@ static LogicalResult parseOptionalVMILayout(AsmParser &parser,
   if (failed(parser.parseAttribute(layout))) {
     return failure();
   }
-  if (!mlir::isa<VMILayoutAttr>(layout))
+  if (!mlir::isa<VMILayoutAttr>(layout)) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expected #pto.vmi.layout attribute");
+  }
   return success();
 }
 
@@ -271,24 +276,24 @@ static FailureOr<int64_t> getLayoutBlockElems(Type type) {
 
 static int64_t getMaskGranularityBitWidth(StringRef granularity) {
   if (granularity == "b8") {
-    return 8;
+    return mlir::pto::kValue8;
   }
   if (granularity == "b16") {
-    return 16;
+    return mlir::pto::kValue16;
   }
   if (granularity == "b32") {
-    return 32;
+    return mlir::pto::kValue32;
   }
   return 0;
 }
 
 static StringRef getMaskGranularityForBitWidth(int64_t bits) {
   switch (bits) {
-  case 8:
+  case mlir::pto::kValue8:
     return "b8";
-  case 16:
+  case mlir::pto::kValue16:
     return "b16";
-  case 32:
+  case mlir::pto::kValue32:
     return "b32";
   default:
     return "";
@@ -358,18 +363,22 @@ verifyAllSameVRegShapeAndLayout(Operation *op, ArrayRef<VMIVRegType> types,
       types, [](VMIVRegType type) { return isLayoutAssigned(type); });
 
   for (VMIVRegType type : types) {
-    if (type.getElementCount() != first.getElementCount())
+    if (type.getElementCount() != first.getElementCount()) {
       return op->emitOpError(
           "requires all VMI data values to have the same logical lane count");
-    if (requireSameElement && type.getElementType() != first.getElementType())
+    }
+    if (requireSameElement && type.getElementType() != first.getElementType()) {
       return op->emitOpError(
           "requires all VMI data values to have the same element type");
-    if (anyLayout && !isLayoutAssigned(type))
+    }
+    if (anyLayout && !isLayoutAssigned(type)) {
       return op->emitOpError(
           "requires either all or no VMI data values to carry layout");
-    if (anyLayout && type.getLayout() != first.getLayout())
+    }
+    if (anyLayout && type.getLayout() != first.getLayout()) {
       return op->emitOpError("requires all layout-assigned VMI data values to "
                              "have the same layout");
+    }
   }
   return success();
 }
@@ -385,15 +394,18 @@ static LogicalResult verifyAllSameVRegShapeAndLayoutPresence(
       types, [](VMIVRegType type) { return isLayoutAssigned(type); });
 
   for (VMIVRegType type : types) {
-    if (type.getElementCount() != first.getElementCount())
+    if (type.getElementCount() != first.getElementCount()) {
       return op->emitOpError(
           "requires all VMI data values to have the same logical lane count");
-    if (requireSameElement && type.getElementType() != first.getElementType())
+    }
+    if (requireSameElement && type.getElementType() != first.getElementType()) {
       return op->emitOpError(
           "requires all VMI data values to have the same element type");
-    if (anyLayout && !isLayoutAssigned(type))
+    }
+    if (anyLayout && !isLayoutAssigned(type)) {
       return op->emitOpError(
           "requires either all or no VMI data values to carry layout");
+    }
   }
   return success();
 }
@@ -443,33 +455,39 @@ verifyAllSameMaskShapeLayoutAndGranularity(Operation *op,
       types, [](VMIMaskType type) { return isLayoutAssigned(type); });
 
   for (VMIMaskType type : types) {
-    if (type.getElementCount() != first.getElementCount())
+    if (type.getElementCount() != first.getElementCount()) {
       return op->emitOpError(
           "requires all VMI mask values to have the same logical lane count");
-    if (type.getGranularity() != first.getGranularity())
+    }
+    if (type.getGranularity() != first.getGranularity()) {
       return op->emitOpError(
           "requires all VMI mask values to have the same granularity");
-    if (anyLayout && !isLayoutAssigned(type))
+    }
+    if (anyLayout && !isLayoutAssigned(type)) {
       return op->emitOpError(
           "requires either all or no VMI mask values to carry layout");
-    if (anyLayout && type.getLayout() != first.getLayout())
+    }
+    if (anyLayout && type.getLayout() != first.getLayout()) {
       return op->emitOpError(
           "requires all layout-assigned VMI mask values to have the same "
           "layout");
+    }
   }
   return success();
 }
 
 static LogicalResult verifyMaskMatchesData(Operation *op, VMIMaskType maskType,
                                            VMIVRegType dataType) {
-  if (maskType.getElementCount() != dataType.getElementCount())
+  if (maskType.getElementCount() != dataType.getElementCount()) {
     return op->emitOpError(
         "requires mask logical lane count to match data lane count");
+  }
 
   if (isLayoutAssigned(maskType) || isLayoutAssigned(dataType)) {
-    if (!isLayoutAssigned(maskType) || !isLayoutAssigned(dataType))
+    if (!isLayoutAssigned(maskType) || !isLayoutAssigned(dataType)) {
       return op->emitOpError("requires either both mask and data to carry "
                              "layout or neither to carry layout");
+    }
     if (maskType.getLayout() != dataType.getLayout()) {
       return op->emitOpError("requires mask layout to match data layout");
     }
@@ -482,9 +500,10 @@ static LogicalResult verifyMaskMatchesData(Operation *op, VMIMaskType maskType,
   unsigned elementBitWidth = getVMIElementBitWidth(dataType.getElementType());
   int64_t maskBitWidth = getMaskGranularityBitWidth(maskType.getGranularity());
   if (elementBitWidth != 0 && maskBitWidth != 0 &&
-      elementBitWidth != static_cast<unsigned>(maskBitWidth))
+      elementBitWidth != static_cast<unsigned>(maskBitWidth)) {
     return op->emitOpError(
         "requires mask granularity to match data element width");
+  }
 
   return success();
 }
@@ -536,9 +555,10 @@ static LogicalResult verifyMemoryElementMatches(Operation *op, Type memoryType,
   if (!memoryElementType) {
     return success();
   }
-  if (memoryElementType != dataType.getElementType())
+  if (memoryElementType != dataType.getElementType()) {
     return op->emitOpError() << "requires memory " << role
                              << " element type to match VMI data element type";
+  }
   return success();
 }
 
@@ -546,10 +566,11 @@ static LogicalResult verifyContiguousIfLayoutAssigned(Operation *op,
                                                       VMIVRegType type,
                                                       StringRef role) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (layout && !layout.isContiguous())
+  if (layout && !layout.isContiguous()) {
     return op->emitOpError()
            << "requires layout-assigned " << role
            << " to use #pto.vmi.layout<contiguous>";
+  }
   return success();
 }
 
@@ -561,7 +582,7 @@ static bool isPackedByteGroupStore(Type memoryType, VMIVRegType dataType) {
   auto memoryIntegerType = dyn_cast<IntegerType>(memoryElementType);
   auto dataIntegerType = dyn_cast<IntegerType>(dataType.getElementType());
   return memoryIntegerType && dataIntegerType &&
-         memoryIntegerType.getWidth() == 8 && dataIntegerType.getWidth() == 32;
+         memoryIntegerType.getWidth() == mlir::pto::kValue8 && dataIntegerType.getWidth() == 32;
 }
 
 static LogicalResult verifyNumGroups(Operation *op, VMIVRegType type,
@@ -569,39 +590,44 @@ static LogicalResult verifyNumGroups(Operation *op, VMIVRegType type,
   if (numGroups <= 0) {
     return op->emitOpError("requires num_groups to be positive");
   }
-  if (type.getElementCount() % numGroups != 0)
+  if (type.getElementCount() % numGroups != 0) {
     return op->emitOpError()
            << "requires num_groups to evenly divide VMI logical lane count "
            << type.getElementCount();
+  }
   return success();
 }
 
 static LogicalResult verifyPhysicalParts(Operation *op, Type vmiType,
                                          TypeRange physicalTypes) {
   FailureOr<int64_t> expectedArity = getVMIPhysicalArity(vmiType);
-  if (failed(expectedArity))
+  if (failed(expectedArity)) {
     return op->emitOpError(
         "requires a layout-assigned VMI type with computable physical arity");
-  if (static_cast<int64_t>(physicalTypes.size()) != *expectedArity)
+  }
+  if (static_cast<int64_t>(physicalTypes.size()) != *expectedArity) {
     return op->emitOpError() << "requires " << *expectedArity
                              << " physical parts, got " << physicalTypes.size();
+  }
 
   if (auto vregType = dyn_cast<VMIVRegType>(vmiType)) {
     FailureOr<int64_t> lanesPerPart =
         getPhysicalLanesPerPart(vregType);
     Type physicalElementType = getVMIPhysicalDataElementType(vregType);
-    if (failed(lanesPerPart))
+    if (failed(lanesPerPart)) {
       return op->emitOpError(
           "requires data element type with known physical lane count");
+    }
     for (Type physicalType : physicalTypes) {
       auto partType = dyn_cast<VRegType>(physicalType);
       if (!partType) {
         return op->emitOpError("requires physical data parts to be !pto.vreg");
       }
       if (partType.getElementCount() != *lanesPerPart ||
-          partType.getElementType() != physicalElementType)
+          partType.getElementType() != physicalElementType) {
         return op->emitOpError(
             "requires physical data part type to match VMI lane-map helper");
+      }
     }
     return success();
   }
@@ -610,23 +636,26 @@ static LogicalResult verifyPhysicalParts(Operation *op, Type vmiType,
   if (!maskType) {
     return op->emitOpError("requires VMI data or mask type");
   }
-  if (maskType.isPred())
+  if (maskType.isPred()) {
     return op->emitOpError(
         "requires layout-assigned mask with concrete granularity");
+  }
   FailureOr<StringRef> physicalGranularity =
       getVMIMaskPhysicalGranularity(maskType);
-  if (failed(physicalGranularity))
+  if (failed(physicalGranularity)) {
     return op->emitOpError(
         "requires mask type with supported physical carrier granularity");
+  }
 
   for (Type physicalType : physicalTypes) {
     auto partType = dyn_cast<MaskType>(physicalType);
     if (!partType) {
       return op->emitOpError("requires physical mask parts to be !pto.mask");
     }
-    if (partType.getGranularity() != *physicalGranularity)
+    if (partType.getGranularity() != *physicalGranularity) {
       return op->emitOpError(
           "requires physical mask part granularity to match VMI mask carrier");
+    }
   }
   return success();
 }
@@ -636,8 +665,9 @@ mapDenseLogicalLaneToPartIndex(int64_t elementCount, int64_t factor,
                                int64_t blockElems, int64_t logicalLane,
                                int64_t &part) {
   if (logicalLane < 0 || logicalLane >= elementCount || factor <= 0 ||
-      blockElems <= 0)
+      blockElems <= 0) {
     return std::nullopt;
+  }
   int64_t block = logicalLane / blockElems;
   int64_t inBlockLane = logicalLane % blockElems;
   part = block % factor;
@@ -650,8 +680,9 @@ mapDensePartIndexToLogicalLane(int64_t elementCount, int64_t factor,
                                int64_t blockElems, int64_t part,
                                int64_t indexInPart) {
   if (part < 0 || part >= factor || indexInPart < 0 || factor <= 0 ||
-      blockElems <= 0)
+      blockElems <= 0) {
     return std::nullopt;
+  }
   int64_t partBlock = indexInPart / blockElems;
   int64_t inBlockLane = indexInPart % blockElems;
   int64_t logicalBlock = partBlock * factor + part;
@@ -698,25 +729,30 @@ lookupVMIFpToSiContract(Type srcElem, Type dstElem) {
   bool srcF16 = srcElem.isF16();
   bool srcBF16 = srcElem.isBF16();
   unsigned dstBits = dstInt.getWidth();
-
   // f32 → s32: same width, rnd, sat, no part
-  if (srcF32 && dstBits == 32)
+  if (srcF32 && dstBits == 32) {
     return VMIFpToSiContract{/*requiresSat=*/true, /*requiresPart=*/false};
+  }
   // f32 → s16: narrow 2×, rnd, sat, part (EvenOdd)
-  if (srcF32 && dstBits == 16)
+  if (srcF32 && dstBits == 16) {
     return VMIFpToSiContract{/*requiresSat=*/true, /*requiresPart=*/true};
+  }
   // f16 → s32: widen 2×, rnd, NO sat, part (EvenOdd)
-  if (srcF16 && dstBits == 32)
+  if (srcF16 && dstBits == 32) {
     return VMIFpToSiContract{/*requiresSat=*/false, /*requiresPart=*/true};
+  }
   // f16 → s16: same width, rnd, sat, no part
-  if (srcF16 && dstBits == 16)
+  if (srcF16 && dstBits == 16) {
     return VMIFpToSiContract{/*requiresSat=*/true, /*requiresPart=*/false};
+  }
   // f16 → s8: narrow 2×, rnd, sat, part (EvenOdd)
-  if (srcF16 && dstBits == 8)
+  if (srcF16 && dstBits == 8) {
     return VMIFpToSiContract{/*requiresSat=*/true, /*requiresPart=*/true};
+  }
   // bf16 → s32: widen 2×, rnd, sat, part (EvenOdd)
-  if (srcBF16 && dstBits == 32)
+  if (srcBF16 && dstBits == 32) {
     return VMIFpToSiContract{/*requiresSat=*/true, /*requiresPart=*/true};
+  }
 
   return std::nullopt;
 }
@@ -739,10 +775,10 @@ lookupVMIFpToUIContract(Type srcElem, Type dstElem) {
 
   bool srcF16 = srcElem.isF16();
   unsigned dstBits = dstInt.getWidth();
-
   // f16 → u8: narrow 2×, rnd, sat, part (EvenOdd)
-  if (srcF16 && dstBits == 8)
+  if (srcF16 && dstBits == 8) {
     return VMIFpToUiContract{/*requiresSat=*/true, /*requiresPart=*/true};
+  }
 
   return std::nullopt;
 }
@@ -764,26 +800,29 @@ lookupVMIFpToFpContract(Type srcElem, Type dstElem) {
   // bf16x2 -> f4x2 (32->8 narrow): Packed4, rnd, NO sat. Mirrors the VPTO
   // bf16->f4 contract row (requiresSat=false) so the VMI verifier does not
   // force a saturate attribute that the physical pto.vcvt would reject.
-  if (pto::isPTOBF16x2Type(srcElem) && pto::isPTOFloat4PackedType(dstElem))
+  if (pto::isPTOBF16x2Type(srcElem) && pto::isPTOFloat4PackedType(dstElem)) {
     return VMIFpToFpContract{/*requiresRnd=*/true, /*requiresSat=*/false,
                             /*requiresPart=*/true,
                             /*allowedRndModes=*/"RAFZC"};
+}
   // f4x2 -> bf16x2 (8->32 widen): Packed4, no rnd, no sat. Mirrors the VPTO
   // f4->bf16 contract row (requiresSat=false, requiresRnd=false). Widen has
   // no rounding/saturate semantics by construction; the contract exists so
   // the involvesBF16x2 / packed-carrier gates in the VMI verifiers pass.
-  if (pto::isPTOFloat4PackedType(srcElem) && pto::isPTOBF16x2Type(dstElem))
+  if (pto::isPTOFloat4PackedType(srcElem) && pto::isPTOBF16x2Type(dstElem)) {
     return VMIFpToFpContract{/*requiresRnd=*/false, /*requiresSat=*/false,
                             /*requiresPart=*/true,
                             /*allowedRndModes=*/StringRef()};
+}
   if (srcBits != dstBits) {
     return std::nullopt;
   }
   // bf16 -> f16: same-width, rnd, sat, no part.
-  if (srcElem.isBF16() && dstElem.isF16())
+  if (srcElem.isBF16() && dstElem.isF16()) {
     return VMIFpToFpContract{/*requiresRnd=*/true, /*requiresSat=*/true,
                             /*requiresPart=*/false,
                             /*allowedRndModes=*/StringRef()};
+}
   return std::nullopt;
 }
 
@@ -929,54 +968,64 @@ LogicalResult
 VMILayoutAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                       StringRef kind, int64_t factor, int64_t blockElems,
                       int64_t slots, int64_t laneStride) {
-  if (laneStride <= 0)
+  if (laneStride <= 0) {
     return emitError() << "#pto.vmi.layout<" << kind
                        << "> requires lane_stride to be positive";
+  }
 
   if (kind == "contiguous") {
-    if (factor != 1 || blockElems != 1 || slots != 0)
+    if (factor != 1 || blockElems != 1 || slots != 0) {
       return emitError()
              << "#pto.vmi.layout<contiguous> requires factor, block_elems, "
                 "and slots to be their defaults";
+    }
     return success();
   }
 
   if (kind == "deinterleaved") {
-    if (factor != 2 && factor != 4)
+    if (factor != mlir::pto::kValue2 && factor != 4) {
       return emitError() << "#pto.vmi.layout<deinterleaved = " << factor
                          << "> expected factor to be 2 or 4";
-    if (blockElems != 1)
+    }
+    if (blockElems != 1) {
       return emitError() << "#pto.vmi.layout<deinterleaved = " << factor
                          << ", block_elems = " << blockElems
                          << "> requires block_elems to be omitted";
-    if (slots != 0)
+    }
+    if (slots != 0) {
       return emitError() << "#pto.vmi.layout<deinterleaved = " << factor
                          << "> requires slots to be omitted";
+    }
     return success();
   }
 
   if (kind == "block_deinterleaved") {
-    if (factor != 2 && factor != 4)
+    if (factor != mlir::pto::kValue2 && factor != 4) {
       return emitError() << "#pto.vmi.layout<block_deinterleaved = " << factor
                          << "> expected factor to be 2 or 4";
-    if (blockElems != 1 || slots != 0 || laneStride != 1)
+    }
+    if (blockElems != 1 || slots != 0 || laneStride != 1) {
       return emitError()
              << "#pto.vmi.layout<block_deinterleaved = " << factor
              << "> does not accept block_elems, slots, or lane_stride";
+    }
     return success();
   }
 
   if (kind == "num_groups") {
-    if (factor <= 0)
+    if (factor <= 0) {
       return emitError() << "#pto.vmi.layout<num_groups = " << factor
                          << "> requires num_groups to be positive";
-    if (blockElems != 1)
+    }
+    if (blockElems != 1) {
       return emitError() << "#pto.vmi.layout<num_groups = " << factor
                          << "> requires block_elems to be omitted";
-    if (slots < 0)
+    }
+    if (slots < 0) {
       return emitError() << "#pto.vmi.layout<num_groups = " << factor
                          << ", slots = " << slots
                          << "> requires slots to be omitted or positive";
+    }
     return success();
   }
 
@@ -996,8 +1045,9 @@ Type VMIVRegType::parse(AsmParser &parser) {
                                        /*withTrailingX=*/true)) ||
       shape.size() != 1 || failed(parser.parseType(elementType)) ||
       failed(parseOptionalVMILayout(parser, layout)) ||
-      failed(parser.parseGreater()))
+      failed(parser.parseGreater())) {
     return {};
+  }
 
   return parser.getChecked<VMIVRegType>(loc, parser.getContext(), shape.front(),
                                         elementType, layout);
@@ -1015,32 +1065,37 @@ void VMIVRegType::print(AsmPrinter &printer) const {
 LogicalResult VMIVRegType::verify(function_ref<InFlightDiagnostic()> emitError,
                                   int64_t elementCount, Type elementType,
                                   Attribute layout) {
-  if (elementCount <= 0)
+  if (elementCount <= 0) {
     return emitError() << "'"
                        << formatVMIVRegType(elementCount, elementType, layout)
                        << "' expected a positive element count";
+}
 
-  if (!isSupportedVMIElementType(elementType))
+  if (!isSupportedVMIElementType(elementType)) {
     return emitError() << "'"
                        << formatVMIVRegType(elementCount, elementType, layout)
                        << "' expected an integer, index, floating-point, or "
                           "PTO low-precision element type";
-  if (!isVMIPredicateMaskableElementType(elementType))
+}
+  if (!isVMIPredicateMaskableElementType(elementType)) {
     return emitError() << "'"
                        << formatVMIVRegType(elementCount, elementType, layout)
                        << "' expected an 8-bit, 16-bit, or 32-bit logical "
                           "element type";
-  if (layout && !mlir::isa<VMILayoutAttr>(layout))
+}
+  if (layout && !mlir::isa<VMILayoutAttr>(layout)) {
     return emitError() << "'"
                        << formatVMIVRegType(elementCount, elementType, layout)
                        << "' expected layout to be #pto.vmi.layout";
+}
   if (auto layoutAttr = llvm::dyn_cast_or_null<VMILayoutAttr>(layout)) {
     if (layoutAttr.isGroupSlots() &&
-        elementCount != layoutAttr.getNumGroups())
+        elementCount != layoutAttr.getNumGroups()) {
       return emitError() << "'"
                          << formatVMIVRegType(elementCount, elementType, layout)
                          << "' expected num_groups layout to describe exactly "
                             "one logical result lane per group";
+}
   }
 
   return success();
@@ -1065,8 +1120,9 @@ Type VMIMaskType::parse(AsmParser &parser) {
                                        /*withTrailingX=*/true)) ||
       shape.size() != 1 || failed(parser.parseKeyword(&granularity)) ||
       failed(parseOptionalVMILayout(parser, layout)) ||
-      failed(parser.parseGreater()))
+      failed(parser.parseGreater())) {
     return {};
+  }
 
   return parser.getChecked<VMIMaskType>(loc, parser.getContext(), shape.front(),
                                         granularity, layout);
@@ -1083,26 +1139,30 @@ void VMIMaskType::print(AsmPrinter &printer) const {
 LogicalResult VMIMaskType::verify(function_ref<InFlightDiagnostic()> emitError,
                                   int64_t elementCount, StringRef granularity,
                                   Attribute layout) {
-  if (elementCount <= 0)
+  if (elementCount <= 0) {
     return emitError() << "'"
                        << formatVMIMaskType(elementCount, granularity, layout)
                        << "' expected a positive element count";
+  }
 
-  if (!isSupportedGranularity(granularity))
+  if (!isSupportedGranularity(granularity)) {
     return emitError() << "'"
                        << formatVMIMaskType(elementCount, granularity, layout)
                        << "' expected granularity to be one of pred, b8, b16, "
                           "b32";
+  }
 
-  if (layout && !mlir::isa<VMILayoutAttr>(layout))
+  if (layout && !mlir::isa<VMILayoutAttr>(layout)) {
     return emitError() << "'"
                        << formatVMIMaskType(elementCount, granularity, layout)
                        << "' expected layout to be #pto.vmi.layout";
+  }
 
-  if (granularity == "pred" && layout)
+  if (granularity == "pred" && layout) {
     return emitError() << "'"
                        << formatVMIMaskType(elementCount, granularity, layout)
                        << "' pred mask must not carry layout";
+  }
 
   return success();
 }
@@ -1119,12 +1179,14 @@ LogicalResult VMIConstantOp::verify() {
   if (!denseAttr) {
     return emitOpError("requires dense elements constant attribute");
   }
-  if (denseAttr.getElementType() != resultType.getElementType())
+  if (denseAttr.getElementType() != resultType.getElementType()) {
     return emitOpError(
         "requires dense constant element type to match result element type");
-  if (denseAttr.getNumElements() != resultType.getElementCount())
+  }
+  if (denseAttr.getNumElements() != resultType.getElementCount()) {
     return emitOpError("requires dense constant element count to match result "
                        "logical lane count");
+  }
   return success();
 }
 
@@ -1138,9 +1200,10 @@ LogicalResult VMIBroadcastOp::verify() {
     if (vregType.getElementCount() != 1) {
       return emitOpError("requires VMI vector input to have one logical lane");
     }
-    if (vregType.getElementType() != resultType.getElementType())
+    if (vregType.getElementType() != resultType.getElementType()) {
       return emitOpError("requires VMI vector input element type to match "
                          "result element type");
+    }
     return success();
   }
   return emitOpError("requires scalar or VMI vector input element type to "
@@ -1150,9 +1213,10 @@ LogicalResult VMIBroadcastOp::verify() {
 LogicalResult VMIIotaOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   Type elementType = resultType.getElementType();
-  if (!isVMIIotaElementType(elementType))
+  if (!isVMIIotaElementType(elementType)) {
     return emitOpError("requires result element type to be integer 8/16/32 "
                        "or f16/f32");
+  }
   if (!isCompatibleScalarForSemanticType(elementType, getBase().getType())) {
     return emitOpError("requires base type to match result element type");
   }
@@ -1168,9 +1232,10 @@ LogicalResult VMIIotaOp::verify() {
 LogicalResult VMIGroupIotaOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   Type elementType = resultType.getElementType();
-  if (!isVMIIotaElementType(elementType))
+  if (!isVMIIotaElementType(elementType)) {
     return emitOpError("requires result element type to be integer 8/16/32 "
                        "or f16/f32");
+  }
   if (!isCompatibleScalarForSemanticType(elementType, getBase().getType())) {
     return emitOpError("requires base type to match result element type");
   }
@@ -1184,19 +1249,22 @@ LogicalResult VMIGroupIotaOp::verify() {
   if (numGroups <= 1) {
     return emitOpError("requires group greater than one");
   }
-  if (resultType.getElementCount() % numGroups != 0)
+  if (resultType.getElementCount() % numGroups != 0) {
     return emitOpError("requires group to evenly divide result logical lane "
                        "count");
+  }
   int64_t groupSize = resultType.getElementCount() / numGroups;
   FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(elementType);
   if (succeeded(lanesPerPart) && groupSize % *lanesPerPart != 0 &&
-      *lanesPerPart % groupSize != 0)
+      *lanesPerPart % groupSize != 0) {
     return emitOpError("requires group_size to divide or be a multiple of "
                        "physical lanes per part (")
            << *lanesPerPart << ")";
+  }
   if (VMILayoutAttr layout = resultType.getLayoutAttr();
-      layout && !layout.isContiguous())
+      layout && !layout.isContiguous()) {
     return emitOpError("requires contiguous result layout");
+  }
   return success();
 }
 
@@ -1214,9 +1282,10 @@ LogicalResult VMICreateGroupMaskOp::verify() {
   if (groupSize <= 0) {
     return emitOpError("requires positive group_size");
   }
-  if (resultType.getElementCount() != numGroups * groupSize)
+  if (resultType.getElementCount() != numGroups * groupSize) {
     return emitOpError("requires result lane count to equal num_groups * "
                        "group_size");
+  }
   return success();
 }
 
@@ -1229,9 +1298,10 @@ LogicalResult VMIConstantMaskOp::verify() {
   if (!denseAttr.getElementType().isInteger(1)) {
     return emitOpError("requires dense mask constant element type to be i1");
   }
-  if (denseAttr.getNumElements() != resultType.getElementCount())
+  if (denseAttr.getNumElements() != resultType.getElementCount()) {
     return emitOpError("requires dense mask constant element count to match "
                        "result logical lane count");
+  }
   return success();
 }
 
@@ -1407,8 +1477,9 @@ LogicalResult VMIMinIOp::verify() {
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   if (!isVMIIntegerLikeType(lhsType.getElementType()) ||
-      !isVMIAnyI8I16I32Type(lhsType.getElementType()))
+      !isVMIAnyI8I16I32Type(lhsType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 integer-like VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1417,8 +1488,9 @@ LogicalResult VMIMaxIOp::verify() {
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   if (!isVMIIntegerLikeType(lhsType.getElementType()) ||
-      !isVMIAnyI8I16I32Type(lhsType.getElementType()))
+      !isVMIAnyI8I16I32Type(lhsType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 integer-like VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1567,9 +1639,10 @@ LogicalResult VMIShRUIOp::verify() {
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   auto integerType = dyn_cast<IntegerType>(lhsType.getElementType());
-  if (!integerType || integerType.isSigned())
+  if (!integerType || integerType.isSigned()) {
     return emitOpError(
         "requires signless or unsigned integer VMI element type");
+  }
   if (!isVMIAnyI8I16I32Type(lhsType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 VMI element type");
   }
@@ -1614,8 +1687,9 @@ LogicalResult VMICmpFOp::verify() {
     return emitOpError("requires f16, bf16, or f32 VMI element type");
   }
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(), {lhsType, rhsType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+  }
   return verifyMaskMatchesData(getOperation(), resultType, lhsType);
 }
 
@@ -1630,8 +1704,9 @@ LogicalResult VMICmpIOp::verify() {
     return emitOpError("requires i8, i16, or i32 VMI element type");
   }
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(), {lhsType, rhsType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+  }
   return verifyMaskMatchesData(getOperation(), resultType, lhsType);
 }
 
@@ -1642,8 +1717,9 @@ LogicalResult VMISelectOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                              {trueType, falseType, resultType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+  }
   return verifyMaskMatchesData(getOperation(), maskType, resultType);
 }
 
@@ -1655,7 +1731,7 @@ LogicalResult VMIActivePrefixIndexOp::verify() {
     return emitOpError("requires signless integer result element type");
   }
   unsigned resultWidth = resultIntType.getWidth();
-  if (resultWidth != 8 && resultWidth != 16 && resultWidth != 32) {
+  if (resultWidth != mlir::pto::kValue8 && resultWidth != 16 && resultWidth != 32) {
     return emitOpError("requires i8, i16, or i32 result element type");
   }
   return verifyMaskMatchesData(getOperation(), maskType, resultType);
@@ -1667,8 +1743,9 @@ LogicalResult VMICompressOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                              {sourceType, resultType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+  }
   return verifyMaskMatchesData(getOperation(), maskType, sourceType);
 }
 
@@ -1677,11 +1754,13 @@ LogicalResult VMICompressStoreOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   if (failed(verifyMemoryElementMatches(getOperation(),
                                         getDestination().getType(), valueType,
-                                        "destination")))
+                                        "destination"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getDestination().getType(),
-                                  "destination")))
+                                  "destination"))) {
     return failure();
+  }
   return verifyMaskMatchesData(getOperation(), maskType, valueType);
 }
 
@@ -1699,7 +1778,7 @@ LogicalResult VMIReduceAddIOp::verify() {
     return emitOpError("requires integer-like VMI source element type");
   }
   auto sourceIntegerType = dyn_cast<IntegerType>(sourceType.getElementType());
-  if (!sourceIntegerType || sourceIntegerType.getWidth() != 32) {
+  if (!sourceIntegerType || sourceIntegerType.getWidth() != mlir::pto::kValue32) {
     return emitOpError("requires 32-bit integer source element type");
   }
   if (sourceType.getElementType() != resultType.getElementType()) {
@@ -1715,10 +1794,11 @@ LogicalResult VMIReduceAddFOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!getOperation()->hasAttr("reassoc"))
+  if (!getOperation()->hasAttr("reassoc")) {
     return emitOpError(
         "requires reassoc attr because VPTO vcadd performs pair-wise "
         "floating-point reduction");
+  }
   if (!isVMIFloatLikeType(sourceType.getElementType())) {
     return emitOpError("requires floating-point-like VMI source element type");
   }
@@ -1738,9 +1818,10 @@ template <typename OpTy> LogicalResult verifyReduceMinMaxFOp(OpTy op) {
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
-  if (!isVMIFloatLikeType(sourceType.getElementType()))
+  if (!isVMIFloatLikeType(sourceType.getElementType())) {
     return op.emitOpError(
         "requires floating-point-like VMI source element type");
+  }
   if (!isVMIF16OrF32Type(sourceType.getElementType())) {
     return op.emitOpError("requires f16 or f32 source element type");
   }
@@ -1763,9 +1844,10 @@ template <typename OpTy> LogicalResult verifyReduceMinMaxIOp(OpTy op) {
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   auto sourceIntegerType = dyn_cast<IntegerType>(sourceType.getElementType());
   if (!sourceIntegerType ||
-      !isVMIAnyI8I16I32Type(sourceType.getElementType()))
+      !isVMIAnyI8I16I32Type(sourceType.getElementType())) {
     return op.emitOpError(
         "requires 8-bit, 16-bit, or 32-bit integer source element type");
+  }
   if (sourceType.getElementType() != resultType.getElementType()) {
     return op.emitOpError("requires source and result element types to match");
   }
@@ -1784,19 +1866,22 @@ static LogicalResult verifyGroupReduceFloatOp(OpTy op, bool requiresReassoc) {
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
-  if (requiresReassoc && !op->hasAttr("reassoc"))
+  if (requiresReassoc && !op->hasAttr("reassoc")) {
     return op.emitOpError(
         "requires reassoc attr because grouped lowering uses pair-wise "
         "floating-point reductions");
-  if (!isVMIFloatLikeType(sourceType.getElementType()))
+  }
+  if (!isVMIFloatLikeType(sourceType.getElementType())) {
     return op.emitOpError(
         "requires floating-point-like VMI source element type");
+  }
   if (!isVMIF16OrF32Type(sourceType.getElementType())) {
     return op.emitOpError("requires f16 or f32 source element type");
   }
-  if (resultType.getElementCount() != op.getNumGroupsAttr().getInt())
+  if (resultType.getElementCount() != op.getNumGroupsAttr().getInt()) {
     return op.emitOpError(
         "requires result logical lane count to match num_groups");
+  }
   if (sourceType.getElementType() != resultType.getElementType()) {
     return op.emitOpError("requires source and result element types to match");
   }
@@ -1805,17 +1890,19 @@ static LogicalResult verifyGroupReduceFloatOp(OpTy op, bool requiresReassoc) {
         sourceLayout.isContiguous() ||
         (sourceLayout.isDenseSplit() &&
          (sourceLayout.getFactor() == 2 || sourceLayout.getFactor() == 4));
-    if (!supportedSourceLayout)
+    if (!supportedSourceLayout) {
       return op.emitOpError(
           "requires layout-assigned source to use contiguous layout or "
           "deinterleaved=2/4 or block_deinterleaved=2/4 layout");
+    }
   }
   if (auto resultLayout = resultType.getLayoutAttr()) {
     if (!resultLayout.isGroupSlots() ||
-        resultLayout.getNumGroups() != op.getNumGroupsAttr().getInt())
+        resultLayout.getNumGroups() != op.getNumGroupsAttr().getInt()) {
       return op.emitOpError() << "requires layout-assigned result to use "
                                  "#pto.vmi.layout<num_groups = "
                               << op.getNumGroupsAttr().getInt() << ">";
+    }
   }
   if (failed(verifyMaskMatchesData(op.getOperation(), maskType, sourceType))) {
     return failure();
@@ -1845,12 +1932,14 @@ static LogicalResult verifyGroupReduceIntegerOp(OpTy op) {
     return op.emitOpError("requires integer-like VMI source element type");
   }
   auto intType = dyn_cast<IntegerType>(sourceType.getElementType());
-  if (!intType || !isVMIAnyI8I16I32Type(sourceType.getElementType()))
+  if (!intType || !isVMIAnyI8I16I32Type(sourceType.getElementType())) {
     return op.emitOpError(
         "requires 8-bit, 16-bit, or 32-bit integer source element type");
-  if (resultType.getElementCount() != op.getNumGroupsAttr().getInt())
+  }
+  if (resultType.getElementCount() != op.getNumGroupsAttr().getInt()) {
     return op.emitOpError(
         "requires result logical lane count to match num_groups");
+  }
   if (sourceType.getElementType() != resultType.getElementType()) {
     return op.emitOpError("requires source and result element types to match");
   }
@@ -1859,17 +1948,19 @@ static LogicalResult verifyGroupReduceIntegerOp(OpTy op) {
         sourceLayout.isContiguous() ||
         (sourceLayout.isDenseSplit() &&
          (sourceLayout.getFactor() == 2 || sourceLayout.getFactor() == 4));
-    if (!supportedSourceLayout)
+    if (!supportedSourceLayout) {
       return op.emitOpError(
           "requires layout-assigned source to use contiguous layout or "
           "deinterleaved=2/4 or block_deinterleaved=2/4 layout");
+    }
   }
   if (auto resultLayout = resultType.getLayoutAttr()) {
     if (!resultLayout.isGroupSlots() ||
-        resultLayout.getNumGroups() != op.getNumGroupsAttr().getInt())
+        resultLayout.getNumGroups() != op.getNumGroupsAttr().getInt()) {
       return op.emitOpError() << "requires layout-assigned result to use "
                                  "#pto.vmi.layout<num_groups = "
                               << op.getNumGroupsAttr().getInt() << ">";
+    }
   }
   if (failed(verifyMaskMatchesData(op.getOperation(), maskType, sourceType))) {
     return failure();
@@ -1898,26 +1989,30 @@ LogicalResult VMIGroupBroadcastOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   int64_t numGroups = getNumGroupsAttr().getInt();
-  if (sourceType.getElementCount() != numGroups)
+  if (sourceType.getElementCount() != numGroups) {
     return emitOpError(
         "requires source logical lane count to match num_groups");
-  if (resultType.getElementCount() % numGroups != 0)
+  }
+  if (resultType.getElementCount() % numGroups != 0) {
     return emitOpError(
         "requires num_groups to evenly divide result logical lane count");
+  }
   if (sourceType.getElementType() != resultType.getElementType()) {
     return emitOpError("requires source and result element types to match");
   }
   if (auto sourceLayout = sourceType.getLayoutAttr()) {
     if (!sourceLayout.isGroupSlots() ||
-        sourceLayout.getNumGroups() != numGroups)
+        sourceLayout.getNumGroups() != numGroups) {
       return emitOpError() << "requires layout-assigned source to use "
                               "#pto.vmi.layout<num_groups = "
                            << numGroups << ">";
+    }
   }
   if (auto resultLayout = resultType.getLayoutAttr()) {
-    if (resultLayout.isGroupSlots())
+    if (resultLayout.isGroupSlots()) {
       return emitOpError(
           "requires layout-assigned result to use a dense VMI layout");
+    }
   }
   return verifyNumGroups(getOperation(), resultType, numGroups);
 }
@@ -1931,50 +2026,58 @@ template <typename OpTy> static LogicalResult verifyVMIHistogramOp(OpTy op) {
   auto accElemType = dyn_cast<IntegerType>(accType.getElementType());
   auto sourceElemType = dyn_cast<IntegerType>(sourceType.getElementType());
   int64_t bins = accType.getElementCount();
-  if (!accElemType || accElemType.getWidth() != 16 ||
+  if (!accElemType || accElemType.getWidth() != mlir::pto::kValue16 ||
       !matchesVMIIntSemantics(accElemType, VMIIntSignSemantics::Unsigned) ||
-      (bins != 128 && bins != 256))
+      (bins != mlir::pto::kValue128 && bins != 256)) {
     return op.emitOpError("requires acc type to be "
                           "!pto.vmi.vreg<128x{ui16|i16}> (Bin_N0-only) or "
                           "!pto.vmi.vreg<256x{ui16|i16}>");
-  if (resultType.getElementCount() != bins)
+  }
+  if (resultType.getElementCount() != bins) {
     return op.emitOpError("requires result element count to match acc "
                           "(bins must be identical)");
+  }
   if (resultType.getLayoutAttr() != accType.getLayoutAttr()) {
     return op.emitOpError("requires result layout attribute to match acc");
   }
   auto resultElemType = dyn_cast<IntegerType>(resultType.getElementType());
-  if (!resultElemType || resultElemType.getWidth() != 16 ||
-      !matchesVMIIntSemantics(resultElemType, VMIIntSignSemantics::Unsigned))
+  if (!resultElemType || resultElemType.getWidth() != mlir::pto::kValue16 ||
+      !matchesVMIIntSemantics(resultElemType, VMIIntSignSemantics::Unsigned)) {
     return op.emitOpError("requires result element type to be ui16 or i16 "
                           "(interpreted as unsigned)");
-  if (!sourceElemType || sourceElemType.getWidth() != 8 ||
-      !matchesVMIIntSemantics(sourceElemType, VMIIntSignSemantics::Unsigned))
+  }
+  if (!sourceElemType || sourceElemType.getWidth() != mlir::pto::kValue8 ||
+      !matchesVMIIntSemantics(sourceElemType, VMIIntSignSemantics::Unsigned)) {
     return op.emitOpError("requires source type to be "
                           "!pto.vmi.vreg<Nx{ui8|i8}> (interpreted as unsigned)");
+  }
   if (maskType.getElementCount() != sourceType.getElementCount()) {
     return op.emitOpError("requires mask logical lane count to match source");
   }
 
   if (auto accLayout = accType.getLayoutAttr()) {
-    if (!accLayout.isContiguous())
+    if (!accLayout.isContiguous()) {
       return op.emitOpError("requires layout-assigned acc to use contiguous "
                             "layout");
+    }
   }
   if (auto sourceLayout = sourceType.getLayoutAttr()) {
-    if (!sourceLayout.isContiguous())
+    if (!sourceLayout.isContiguous()) {
       return op.emitOpError("requires layout-assigned source to use contiguous "
                             "layout");
+    }
   }
   if (auto resultLayout = resultType.getLayoutAttr()) {
-    if (!resultLayout.isContiguous())
+    if (!resultLayout.isContiguous()) {
       return op.emitOpError("requires layout-assigned result to use "
                             "contiguous layout");
+    }
   }
   if (auto maskLayout = maskType.getLayoutAttr()) {
-    if (!maskLayout.isContiguous())
+    if (!maskLayout.isContiguous()) {
       return op.emitOpError("requires layout-assigned mask to use contiguous "
                             "layout");
+    }
     if (maskType.getGranularity() != "b8") {
       return op.emitOpError("requires layout-assigned mask granularity b8");
     }
@@ -2007,13 +2110,15 @@ LogicalResult VMIExtFOp::verify() {
         "requires floating-point-like source and result element types");
   }
   if (involvesBF16x2(sourceElementType, resultElementType) &&
-      !lookupVMIFpToFpContract(sourceElementType, resultElementType))
+      !lookupVMIFpToFpContract(sourceElementType, resultElementType)) {
     return emitOpError(
         "unsupported bf16x2 fp-to-fp conversion element type pair");
+}
   if (getVMIElementBitWidth(sourceElementType) >=
-      getVMIElementBitWidth(resultElementType))
+      getVMIElementBitWidth(resultElementType)) {
     return emitOpError(
         "requires result element type to be wider than source element type");
+}
   return success();
 }
 
@@ -2024,46 +2129,54 @@ LogicalResult VMITruncFOp::verify() {
   Type resultElementType = resultType.getElementType();
   auto fpContract =
       lookupVMIFpToFpContract(sourceElementType, resultElementType);
-  if (sourceType.getElementCount() != resultType.getElementCount())
+  if (sourceType.getElementCount() != resultType.getElementCount()) {
     return emitOpError(
         "requires source and result logical lane counts to match");
+}
   if (!isVMIFloatLikeType(sourceElementType) ||
-      !isVMIFloatLikeType(resultElementType))
+      !isVMIFloatLikeType(resultElementType)) {
     return emitOpError(
         "requires floating-point-like source and result element types");
-  if (involvesBF16x2(sourceElementType, resultElementType) && !fpContract)
+}
+  if (involvesBF16x2(sourceElementType, resultElementType) && !fpContract) {
     return emitOpError(
         "unsupported bf16x2 fp-to-fp conversion element type pair");
+}
   if (involvesVMIPackedFloatCarrier(sourceElementType, resultElementType) &&
-      !fpContract)
+      !fpContract) {
     return emitOpError(
         "unsupported packed fp-to-fp conversion element type pair");
+}
   unsigned srcBits = getVMIElementBitWidth(sourceElementType);
   unsigned dstBits = getVMIElementBitWidth(resultElementType);
-  if (srcBits < dstBits)
+  if (srcBits < dstBits) {
     return emitOpError(
         "requires result element type to be narrower than or same-width "
         "as source element type");
+}
   if (srcBits == dstBits) {
     // Same-width fp→fp (e.g. bf16→f16): only allowed for supported VMI
     // fp-to-fp contract pairs.
-    if (!fpContract)
+    if (!fpContract) {
       return emitOpError("same-width fp-to-fp conversion is not supported "
                          "for this type pair; see lookupVMIFpToFpContract");
+}
   }
   if (auto roundingAttr = (*this)->getAttrOfType<StringAttr>("rounding")) {
     StringRef rounding = roundingAttr.getValue();
-    if (rounding.size() != 1)
+    if (rounding.size() != 1) {
       return emitOpError(
           "rounding attr must be a single-character mode token");
+}
     StringRef allowedRndModes =
         fpContract && !fpContract->allowedRndModes.empty()
             ? fpContract->allowedRndModes
             : StringRef("RAHZ");
     if (!allowedRndModes.contains(rounding)) {
-      if (fpContract && !fpContract->allowedRndModes.empty())
+      if (fpContract && !fpContract->allowedRndModes.empty()) {
         return emitOpError("rounding attr is not valid for this fp-to-fp "
                            "conversion type pair");
+}
       return emitOpError("rounding attr must be R, A, H, or Z");
     }
   }
@@ -2090,9 +2203,10 @@ LogicalResult VMITruncFOp::verify() {
 LogicalResult VMIFPToSIOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (sourceType.getElementCount() != resultType.getElementCount())
+  if (sourceType.getElementCount() != resultType.getElementCount()) {
     return emitOpError(
         "requires source and result logical lane counts to match");
+  }
   if (!isVMIFloatLikeType(sourceType.getElementType())) {
     return emitOpError("requires floating-point-like source element type");
   }
@@ -2114,17 +2228,19 @@ LogicalResult VMIFPToSIOp::verify() {
   }
   if (contract->requiresSat) {
     auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
-    if (!satAttr)
+    if (!satAttr) {
       return emitOpError("'saturate' attribute is required for this fp-to-si "
                          "conversion (SAT or NOSAT)");
+    }
     StringRef satVal = satAttr.getValue();
     if (satVal != "SAT" && satVal != "NOSAT") {
       return emitOpError("saturate attr must be 'SAT' or 'NOSAT'");
     }
   } else {
-    if ((*this)->getAttrOfType<StringAttr>("saturate"))
+    if ((*this)->getAttrOfType<StringAttr>("saturate")) {
       return emitOpError("'saturate' attribute is not valid for this fp-to-si "
                          "conversion (no overflow possible)");
+    }
   }
   return success();
 }
@@ -2132,9 +2248,10 @@ LogicalResult VMIFPToSIOp::verify() {
 LogicalResult VMIFPToUIOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (sourceType.getElementCount() != resultType.getElementCount())
+  if (sourceType.getElementCount() != resultType.getElementCount()) {
     return emitOpError(
         "requires source and result logical lane counts to match");
+  }
   if (!isVMIFloatLikeType(sourceType.getElementType())) {
     return emitOpError("requires floating-point-like source element type");
   }
@@ -2157,17 +2274,19 @@ LogicalResult VMIFPToUIOp::verify() {
   }
   if (contract->requiresSat) {
     auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
-    if (!satAttr)
+    if (!satAttr) {
       return emitOpError("'saturate' attribute is required for this fp-to-ui "
                          "conversion (SAT or NOSAT)");
+    }
     StringRef satVal = satAttr.getValue();
     if (satVal != "SAT" && satVal != "NOSAT") {
       return emitOpError("saturate attr must be 'SAT' or 'NOSAT'");
     }
   } else {
-    if ((*this)->getAttrOfType<StringAttr>("saturate"))
+    if ((*this)->getAttrOfType<StringAttr>("saturate")) {
       return emitOpError("'saturate' attribute is not valid for this fp-to-ui "
                          "conversion (no overflow possible)");
+    }
   }
   return success();
 }
@@ -2175,16 +2294,17 @@ LogicalResult VMIFPToUIOp::verify() {
 LogicalResult VMISIToFPOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (sourceType.getElementCount() != resultType.getElementCount())
+  if (sourceType.getElementCount() != resultType.getElementCount()) {
     return emitOpError(
         "requires source and result logical lane counts to match");
+  }
   if (!isVMISignedIntegerType(sourceType.getElementType())) {
     return emitOpError("requires signed integer source element type");
   }
   if (!isVMIFloatLikeType(resultType.getElementType())) {
     return emitOpError("requires floating-point-like result element type");
   }
-  if (getVMIElementBitWidth(sourceType.getElementType()) != 32) {
+  if (getVMIElementBitWidth(sourceType.getElementType()) != mlir::pto::kValue32) {
     return emitOpError("requires 32-bit integer source element type");
   }
   if (!resultType.getElementType().isF32()) {
@@ -2245,16 +2365,19 @@ LogicalResult VMIExtUIOp::verify() {
 LogicalResult VMITruncIOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (sourceType.getElementCount() != resultType.getElementCount())
+  if (sourceType.getElementCount() != resultType.getElementCount()) {
     return emitOpError(
         "requires source and result logical lane counts to match");
+  }
   if (!isVMIIntegerLikeType(sourceType.getElementType()) ||
-      !isVMIIntegerLikeType(resultType.getElementType()))
+      !isVMIIntegerLikeType(resultType.getElementType())) {
     return emitOpError("requires integer source and result element types");
+  }
   if (getVMIElementBitWidth(sourceType.getElementType()) <=
-      getVMIElementBitWidth(resultType.getElementType()))
+      getVMIElementBitWidth(resultType.getElementType())) {
     return emitOpError(
         "requires result element type to be narrower than source element type");
+  }
   auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
   if (!satAttr) {
     return emitOpError("'saturate' attribute is required (SAT or NOSAT)");
@@ -2273,19 +2396,22 @@ LogicalResult VMIBitcastOp::verify() {
       pto::getPTOStorageElemBitWidth(sourceType.getElementType());
   unsigned resultBits =
       pto::getPTOStorageElemBitWidth(resultType.getElementType());
-  if (sourceBits == 0 || resultBits == 0)
+  if (sourceBits == 0 || resultBits == 0) {
     return emitOpError(
         "requires integer or floating-point source and result element types");
+}
   if (sourceType.getElementCount() * static_cast<int64_t>(sourceBits) !=
-      resultType.getElementCount() * static_cast<int64_t>(resultBits))
+      resultType.getElementCount() * static_cast<int64_t>(resultBits)) {
     return emitOpError(
         "requires source and result to carry the same total number of bits");
+}
 
   if (isLayoutAssigned(sourceType) || isLayoutAssigned(resultType)) {
-    if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType))
+    if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType)) {
       return emitOpError(
           "requires either both source and result to carry layout or neither "
           "to carry layout");
+}
     if (sourceType.getLayout() != resultType.getLayout()) {
       return emitOpError("requires source and result layouts to match");
     }
@@ -2297,8 +2423,9 @@ LogicalResult VMIBitcastOp::verify() {
 LogicalResult VMILoadOp::verify() {
   if (failed(verifyMemoryElementMatches(
           getOperation(), getSource().getType(),
-          cast<VMIVRegType>(getResult().getType()), "source")))
+          cast<VMIVRegType>(getResult().getType()), "source"))) {
     return failure();
+  }
   return verifyUBBackedMemory(getOperation(), getSource().getType(), "source");
 }
 
@@ -2313,19 +2440,23 @@ LogicalResult VMIDeinterleaveLoadOp::verify() {
   auto highType = cast<VMIVRegType>(getHigh().getType());
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                              {lowType, highType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+  }
   if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
-                                        lowType, "source")))
+                                        lowType, "source"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getSource().getType(),
-                                  "source")))
+                                  "source"))) {
     return failure();
+  }
   if (failed(verifyContiguousIfLayoutAssigned(getOperation(), lowType,
                                               "low result")) ||
       failed(verifyContiguousIfLayoutAssigned(getOperation(), highType,
-                                              "high result")))
+                                              "high result"))) {
     return failure();
+  }
   return success();
 }
 
@@ -2338,11 +2469,13 @@ void VMIDeinterleaveLoadOp::getEffects(
 LogicalResult VMIGroupLoadOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
-                                        resultType, "source")))
+                                        resultType, "source"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getSource().getType(),
-                                  "source")))
+                                  "source"))) {
     return failure();
+  }
   return verifyNumGroups(getOperation(), resultType,
                          getNumGroupsAttr().getInt());
 }
@@ -2356,21 +2489,25 @@ void VMIGroupLoadOp::getEffects(
 LogicalResult VMIGroupSlotLoadOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   int64_t numGroups = getNumGroupsAttr().getInt();
-  if (resultType.getElementCount() != numGroups)
+  if (resultType.getElementCount() != numGroups) {
     return emitOpError(
         "requires result logical lane count to match num_groups");
+  }
   if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
-                                        resultType, "source")))
+                                        resultType, "source"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getSource().getType(),
-                                  "source")))
+                                  "source"))) {
     return failure();
+  }
   if (auto resultLayout = resultType.getLayoutAttr()) {
     if (!resultLayout.isGroupSlots() ||
-        resultLayout.getNumGroups() != numGroups)
+        resultLayout.getNumGroups() != numGroups) {
       return emitOpError() << "requires layout-assigned result to use "
                               "#pto.vmi.layout<num_groups = "
                            << numGroups << ">";
+    }
   }
   return verifyNumGroups(getOperation(), resultType, numGroups);
 }
@@ -2387,19 +2524,23 @@ LogicalResult VMIGroupBroadcastLoadOp::verify() {
   if (numGroups <= 0) {
     return emitOpError("requires num_groups to be positive");
   }
-  if (resultType.getElementCount() % numGroups != 0)
+  if (resultType.getElementCount() % numGroups != 0) {
     return emitOpError(
         "requires num_groups to evenly divide result logical lane count");
+  }
   if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
-                                        resultType, "source")))
+                                        resultType, "source"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getSource().getType(),
-                                  "source")))
+                                  "source"))) {
     return failure();
+  }
   if (auto resultLayout = resultType.getLayoutAttr()) {
-    if (resultLayout.isGroupSlots())
+    if (resultLayout.isGroupSlots()) {
       return emitOpError(
           "requires layout-assigned result to use a dense VMI layout");
+    }
   }
   return verifyNumGroups(getOperation(), resultType, numGroups);
 }
@@ -2415,15 +2556,18 @@ LogicalResult VMIMaskedLoadOp::verify() {
   auto passthruType = cast<VMIVRegType>(getPassthru().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
-                                        resultType, "source")))
+                                        resultType, "source"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getSource().getType(),
-                                  "source")))
+                                  "source"))) {
     return failure();
+  }
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                              {passthruType, resultType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+  }
   return verifyMaskMatchesData(getOperation(), maskType, resultType);
 }
 
@@ -2439,34 +2583,40 @@ LogicalResult VMIGatherOp::verify() {
   auto passthruType = cast<VMIVRegType>(getPassthru().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
-                                        resultType, "source")))
+                                        resultType, "source"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getSource().getType(),
-                                  "source")))
+                                  "source"))) {
     return failure();
+  }
 
   auto indexElementType = dyn_cast<IntegerType>(indicesType.getElementType());
   if (!indexElementType || indexElementType.isSigned() ||
-      (indexElementType.getWidth() != 16 && indexElementType.getWidth() != 32))
+      (indexElementType.getWidth() != mlir::pto::kValue16 && indexElementType.getWidth() != 32)) {
     return emitOpError(
         "requires signless or unsigned 16-bit or 32-bit integer indices");
+  }
 
   if (failed(verifyAllSameVRegShapeAndLayout(
           getOperation(), {indicesType, passthruType, resultType},
-          /*requireSameElement=*/false)))
+          /*requireSameElement=*/false))) {
     return failure();
+  }
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                              {passthruType, resultType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+  }
 
   auto resultIntegerType = dyn_cast<IntegerType>(resultType.getElementType());
-  if (indexElementType.getWidth() == 16 &&
+  if (indexElementType.getWidth() == mlir::pto::kValue16 &&
       (!resultIntegerType || !resultIntegerType.isUnsigned() ||
-       resultIntegerType.getWidth() != 16))
+       resultIntegerType.getWidth() != mlir::pto::kValue16)) {
     return emitOpError(
         "requires ui16 result and passthru element type when using ui16 "
         "indices");
+  }
   return verifyMaskMatchesData(getOperation(), maskType, resultType);
 }
 
@@ -2481,15 +2631,18 @@ LogicalResult VMIExpandLoadOp::verify() {
   auto passthruType = cast<VMIVRegType>(getPassthru().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
-                                        resultType, "source")))
+                                        resultType, "source"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getSource().getType(),
-                                  "source")))
+                                  "source"))) {
     return failure();
+  }
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                              {passthruType, resultType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+  }
   return verifyMaskMatchesData(getOperation(), maskType, resultType);
 }
 
@@ -2502,8 +2655,9 @@ void VMIExpandLoadOp::getEffects(
 LogicalResult VMIStoreOp::verify() {
   if (failed(verifyMemoryElementMatches(
           getOperation(), getDestination().getType(),
-          cast<VMIVRegType>(getValue().getType()), "destination")))
+          cast<VMIVRegType>(getValue().getType()), "destination"))) {
     return failure();
+  }
   return verifyUBBackedMemory(getOperation(), getDestination().getType(),
                               "destination");
 }
@@ -2519,20 +2673,24 @@ LogicalResult VMIInterleaveStoreOp::verify() {
   auto highType = cast<VMIVRegType>(getHigh().getType());
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                              {lowType, highType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+  }
   if (failed(verifyMemoryElementMatches(getOperation(),
                                         getDestination().getType(), lowType,
-                                        "destination")))
+                                        "destination"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getDestination().getType(),
-                                  "destination")))
+                                  "destination"))) {
     return failure();
+  }
   if (failed(verifyContiguousIfLayoutAssigned(getOperation(), lowType,
                                               "low input")) ||
       failed(verifyContiguousIfLayoutAssigned(getOperation(), highType,
-                                              "high input")))
+                                              "high input"))) {
     return failure();
+  }
   return success();
 }
 
@@ -2547,11 +2705,13 @@ LogicalResult VMIGroupStoreOp::verify() {
   if (!isPackedByteGroupStore(getDestination().getType(), valueType) &&
       failed(verifyMemoryElementMatches(getOperation(),
                                         getDestination().getType(), valueType,
-                                        "destination")))
+                                        "destination"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getDestination().getType(),
-                                  "destination")))
+                                  "destination"))) {
     return failure();
+  }
   return verifyNumGroups(getOperation(), valueType,
                          getNumGroupsAttr().getInt());
 }
@@ -2566,11 +2726,13 @@ LogicalResult VMIStrideLoadOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   auto maskType = cast<VMIMaskType>(getMask().getType());
   if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
-                                        resultType, "source")))
+                                        resultType, "source"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getSource().getType(),
-                                  "source")))
+                                  "source"))) {
     return failure();
+  }
   return verifyMaskMatchesData(getOperation(), maskType, resultType);
 }
 
@@ -2585,11 +2747,13 @@ LogicalResult VMIMaskedStoreOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   if (failed(verifyMemoryElementMatches(getOperation(),
                                         getDestination().getType(), valueType,
-                                        "destination")))
+                                        "destination"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getDestination().getType(),
-                                  "destination")))
+                                  "destination"))) {
     return failure();
+  }
   return verifyMaskMatchesData(getOperation(), maskType, valueType);
 }
 
@@ -2604,11 +2768,13 @@ LogicalResult VMIStrideStoreOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   if (failed(verifyMemoryElementMatches(getOperation(),
                                         getDestination().getType(), valueType,
-                                        "destination")))
+                                        "destination"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getDestination().getType(),
-                                  "destination")))
+                                  "destination"))) {
     return failure();
+  }
   return verifyMaskMatchesData(getOperation(), maskType, valueType);
 }
 
@@ -2626,23 +2792,27 @@ LogicalResult VMIScatterOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   if (failed(verifyMemoryElementMatches(getOperation(),
                                         getDestination().getType(), valueType,
-                                        "destination")))
+                                        "destination"))) {
     return failure();
+  }
   if (failed(verifyUBBackedMemory(getOperation(), getDestination().getType(),
-                                  "destination")))
+                                  "destination"))) {
     return failure();
+  }
 
   auto indexElementType = dyn_cast<IntegerType>(indicesType.getElementType());
   if (!indexElementType || indexElementType.isSigned() ||
-      (indexElementType.getWidth() != 32 &&
-       indexElementType.getWidth() != 16))
+      (indexElementType.getWidth() != mlir::pto::kValue32 &&
+       indexElementType.getWidth() != mlir::pto::kValue16)) {
     return emitOpError(
         "requires signless or unsigned 16-bit or 32-bit integer indices");
+  }
 
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                              {valueType, indicesType},
-                                             /*requireSameElement=*/false)))
+                                             /*requireSameElement=*/false))) {
     return failure();
+  }
   return verifyMaskMatchesData(getOperation(), maskType, valueType);
 }
 
@@ -2655,75 +2825,85 @@ void VMIScatterOp::getEffects(
 LogicalResult VMIShuffleOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (sourceType.getElementType() != resultType.getElementType())
+  if (sourceType.getElementType() != resultType.getElementType()) {
     return emitOpError(
         "requires result element type to match source element type");
-  if (static_cast<int64_t>(getIndices().size()) != resultType.getElementCount())
+  }
+  if (static_cast<int64_t>(getIndices().size()) != resultType.getElementCount()) {
     return emitOpError(
         "requires shuffle index count to match result logical lane count");
+  }
   for (int64_t index : getIndices()) {
-    if (index < 0 || index >= sourceType.getElementCount())
+    if (index < 0 || index >= sourceType.getElementCount()) {
       return emitOpError("requires every shuffle index to select an existing "
                          "source logical lane");
+    }
   }
   if (isLayoutAssigned(sourceType) || isLayoutAssigned(resultType)) {
-    if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType))
+    if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType)) {
       return emitOpError("requires either both source and result to carry "
                          "layout or neither to carry layout");
+    }
   }
   return success();
 }
 
 LogicalResult VMIChannelSplitOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
-  if (getResults().size() < 2) {
+  if (getResults().size() < mlir::pto::kValue2) {
     return emitOpError("requires at least two channel results");
   }
   auto firstResultType = cast<VMIVRegType>(getResults().front().getType());
   if (sourceType.getElementCount() !=
       static_cast<int64_t>(getResults().size()) *
-          firstResultType.getElementCount())
+          firstResultType.getElementCount()) {
     return emitOpError("requires source lane count to equal result count times "
                        "per-channel lane count");
+  }
   for (Value result : getResults()) {
     auto resultType = cast<VMIVRegType>(result.getType());
     if (resultType.getElementCount() != firstResultType.getElementCount() ||
-        resultType.getElementType() != sourceType.getElementType())
+        resultType.getElementType() != sourceType.getElementType()) {
       return emitOpError("requires every channel result to have equal lane "
                          "count and source element type");
+    }
   }
   bool anyLayout = isLayoutAssigned(sourceType);
   for (Value result : getResults()) {
     anyLayout |= isLayoutAssigned(cast<VMIVRegType>(result.getType()));
   }
   if (anyLayout) {
-    if (!isLayoutAssigned(sourceType))
+    if (!isLayoutAssigned(sourceType)) {
       return emitOpError("requires layout-assigned channel_split source when "
                          "any channel result has layout");
+    }
     for (Value result : getResults()) {
       auto resultType = cast<VMIVRegType>(result.getType());
-      if (!isLayoutAssigned(resultType))
+      if (!isLayoutAssigned(resultType)) {
         return emitOpError("requires every channel_split result to carry "
                            "layout when source has layout");
-      if (!cast<VMILayoutAttr>(resultType.getLayout()).isContiguous())
+      }
+      if (!cast<VMILayoutAttr>(resultType.getLayout()).isContiguous()) {
         return emitOpError(
             "requires layout-assigned channel_split results to be contiguous");
+      }
     }
     int64_t channels = getResults().size();
-    if (channels == 2 || channels == 4) {
+    if (channels == mlir::pto::kValue2 || channels == 4) {
       auto sourceLayout = cast<VMILayoutAttr>(sourceType.getLayout());
       auto expectedLayout =
           VMILayoutAttr::getDeinterleaved(getContext(), channels);
-      if (!sourceLayout.isContiguous() && sourceLayout != expectedLayout)
+      if (!sourceLayout.isContiguous() && sourceLayout != expectedLayout) {
         return emitOpError("requires layout-assigned channel_split source to "
                            "be contiguous or deinterleaved by result count");
+      }
     }
   }
   return success();
 }
 
 LogicalResult VMIChannelMergeOp::verify() {
-  if (getInputs().size() < 2) {
+  if (getInputs().size() < mlir::pto::kValue2) {
     return emitOpError("requires at least two channel inputs");
   }
   auto firstInputType = cast<VMIVRegType>(getInputs().front().getType());
@@ -2731,40 +2911,46 @@ LogicalResult VMIChannelMergeOp::verify() {
   for (Value input : getInputs()) {
     auto inputType = cast<VMIVRegType>(input.getType());
     if (inputType.getElementCount() != firstInputType.getElementCount() ||
-        inputType.getElementType() != firstInputType.getElementType())
+        inputType.getElementType() != firstInputType.getElementType()) {
       return emitOpError("requires all channel inputs to have the same lane "
                          "count and element type");
+    }
   }
   if (resultType.getElementCount() != static_cast<int64_t>(getInputs().size()) *
                                           firstInputType.getElementCount() ||
-      resultType.getElementType() != firstInputType.getElementType())
+      resultType.getElementType() != firstInputType.getElementType()) {
     return emitOpError(
         "requires result lane count and element type to match merged channels");
+  }
   bool anyLayout = isLayoutAssigned(resultType);
   for (Value input : getInputs()) {
     anyLayout |= isLayoutAssigned(cast<VMIVRegType>(input.getType()));
   }
   if (anyLayout) {
-    if (!isLayoutAssigned(resultType))
+    if (!isLayoutAssigned(resultType)) {
       return emitOpError("requires layout-assigned channel_merge result when "
                          "any channel input has layout");
+    }
     for (Value input : getInputs()) {
       auto inputType = cast<VMIVRegType>(input.getType());
-      if (!isLayoutAssigned(inputType))
+      if (!isLayoutAssigned(inputType)) {
         return emitOpError("requires every channel_merge input to carry layout "
                            "when result has layout");
-      if (!cast<VMILayoutAttr>(inputType.getLayout()).isContiguous())
+      }
+      if (!cast<VMILayoutAttr>(inputType.getLayout()).isContiguous()) {
         return emitOpError(
             "requires layout-assigned channel_merge inputs to be contiguous");
+      }
     }
     int64_t channels = getInputs().size();
-    if (channels == 2 || channels == 4) {
+    if (channels == mlir::pto::kValue2 || channels == 4) {
       auto resultLayout = cast<VMILayoutAttr>(resultType.getLayout());
       auto expectedLayout =
           VMILayoutAttr::getDeinterleaved(getContext(), channels);
-      if (!resultLayout.isContiguous() && resultLayout != expectedLayout)
+      if (!resultLayout.isContiguous() && resultLayout != expectedLayout) {
         return emitOpError("requires layout-assigned channel_merge result to "
                            "be contiguous or deinterleaved by input count");
+      }
     }
   }
   return success();
@@ -2774,9 +2960,10 @@ LogicalResult VMIEnsureLayoutOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   if (sourceType.getElementCount() != resultType.getElementCount() ||
-      sourceType.getElementType() != resultType.getElementType())
+      sourceType.getElementType() != resultType.getElementType()) {
     return emitOpError("requires source and result to preserve VMI data shape "
                        "and element type");
+  }
   if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType)) {
     return emitOpError("requires source and result to be layout-assigned");
   }
@@ -2787,9 +2974,10 @@ LogicalResult VMIEnsureMaskLayoutOp::verify() {
   auto sourceType = cast<VMIMaskType>(getSource().getType());
   auto resultType = cast<VMIMaskType>(getResult().getType());
   if (sourceType.getElementCount() != resultType.getElementCount() ||
-      sourceType.getGranularity() != resultType.getGranularity())
+      sourceType.getGranularity() != resultType.getGranularity()) {
     return emitOpError("requires source and result to preserve VMI mask shape "
                        "and granularity");
+  }
   if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType)) {
     return emitOpError("requires source and result to be layout-assigned");
   }
@@ -2799,16 +2987,19 @@ LogicalResult VMIEnsureMaskLayoutOp::verify() {
 LogicalResult VMIEnsureMaskGranularityOp::verify() {
   auto sourceType = cast<VMIMaskType>(getSource().getType());
   auto resultType = cast<VMIMaskType>(getResult().getType());
-  if (sourceType.getElementCount() != resultType.getElementCount())
+  if (sourceType.getElementCount() != resultType.getElementCount()) {
     return emitOpError(
         "requires source and result to preserve VMI mask lane count");
-  if (sourceType.isPred() || resultType.isPred())
+  }
+  if (sourceType.isPred() || resultType.isPred()) {
     return emitOpError(
         "requires concrete source and result mask granularities");
+  }
   if (isLayoutAssigned(sourceType) || isLayoutAssigned(resultType)) {
-    if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType))
+    if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType)) {
       return emitOpError("requires either both source and result to carry "
                          "layout or neither to carry layout");
+    }
   }
   return success();
 }
@@ -2836,9 +3027,10 @@ static LogicalResult verifyVMIPmodeMask(Operation *op, VMIMaskType maskType,
   }
   if (pmode.has_value()) {
     StringRef mode = pmode.value();
-    if (mode != "merge" && mode != "zero")
+    if (mode != "merge" && mode != "zero") {
       return op->emitOpError("pmode must be \"merge\" or \"zero\", got \"")
              << mode << "\"";
+    }
   }
   return success();
 }
@@ -2850,9 +3042,10 @@ static LogicalResult verifyVMIVariadicPmodeMask(Operation *op,
                                                 std::optional<StringRef> pmode) {
   if (pmode.has_value()) {
     StringRef mode = pmode.value();
-    if (mode != "merge" && mode != "zero")
+    if (mode != "merge" && mode != "zero") {
       return op->emitOpError("pmode must be \"merge\" or \"zero\", got \"")
              << mode << "\"";
+    }
   }
   if (maskParts.empty()) {
     return success();
@@ -2875,20 +3068,24 @@ verifyVMIVectorScalarOp(Operation *op, VMIVRegType srcType,
                         VMIMaskType maskType,
                         std::optional<StringRef> pmode) {
   Type eltTy = srcType.getElementType();
-  if (failed(verifyBF16x2ComputeElementType(op, eltTy)))
+  if (failed(verifyBF16x2ComputeElementType(op, eltTy))) {
     return failure();
-  if (!isVMIFloatLikeType(eltTy) && !isVMIIntegerLikeType(eltTy))
+}
+  if (!isVMIFloatLikeType(eltTy) && !isVMIIntegerLikeType(eltTy)) {
     return op->emitOpError(
         "requires floating-point-like or integer-like VMI element type");
+}
 
-  if (scalarType != eltTy)
+  if (scalarType != eltTy) {
     return op->emitOpError(
         "requires scalar type to match vector element type, got scalar ")
            << scalarType << " vs vector element " << eltTy;
+}
 
   if (failed(verifyAllSameVRegShapeAndLayout(op, {srcType, resultType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+}
 
   if (failed(verifyMaskMatchesData(op, maskType, resultType))) {
     return failure();
@@ -2896,9 +3093,10 @@ verifyVMIVectorScalarOp(Operation *op, VMIVRegType srcType,
 
   if (pmode.has_value()) {
     StringRef mode = pmode.value();
-    if (mode != "merge" && mode != "zero")
+    if (mode != "merge" && mode != "zero") {
       return op->emitOpError("unsupported pmode '")
              << mode << "'; expected \"merge\" or \"zero\"";
+    }
   }
 
   return success();
@@ -2911,23 +3109,26 @@ verifyVMIVectorScalarShiftOp(Operation *op, VMIVRegType srcType,
                              VMIMaskType maskType,
                              std::optional<StringRef> pmode) {
   Type eltTy = srcType.getElementType();
-  if (!isVMIIntegerLikeType(eltTy))
+  if (!isVMIIntegerLikeType(eltTy)) {
     return op->emitOpError(
         "requires integer-like VMI element type for shift");
-  if (!scalarType.isSignlessInteger(16)) {
+  }
+  if (!scalarType.isSignlessInteger(mlir::pto::kValue16)) {
     return op->emitOpError("requires signless i16 shift amount");
   }
   if (failed(verifyAllSameVRegShapeAndLayout(op, {srcType, resultType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+  }
   if (failed(verifyMaskMatchesData(op, maskType, resultType))) {
     return failure();
   }
   if (pmode.has_value()) {
     StringRef mode = pmode.value();
-    if (mode != "merge" && mode != "zero")
+    if (mode != "merge" && mode != "zero") {
       return op->emitOpError("unsupported pmode '")
              << mode << "'; expected \"merge\" or \"zero\"";
+    }
   }
   return success();
 }
@@ -3041,24 +3242,27 @@ LogicalResult VMIVbrcOp::verify() {
     if (!vregType) {
       return emitOpError("requires VMI vector input when num_groups is set");
     }
-    if (vregType.getElementCount() != numGroupsVal)
+    if (vregType.getElementCount() != numGroupsVal) {
       return emitOpError()
              << "requires source logical lane count " << vregType.getElementCount()
              << " to match num_groups " << numGroupsVal;
+    }
     if (vregType.getElementType() != resultType.getElementType()) {
       return emitOpError("requires source and result element types to match");
     }
     if (auto sourceLayout = vregType.getLayoutAttr()) {
       if (!sourceLayout.isGroupSlots() ||
-          sourceLayout.getNumGroups() != numGroupsVal)
+          sourceLayout.getNumGroups() != numGroupsVal) {
         return emitOpError() << "requires layout-assigned source to use "
                                 "#pto.vmi.layout<num_groups = "
                              << numGroupsVal << ">";
+      }
     }
     if (auto resultLayout = resultType.getLayoutAttr()) {
-      if (resultLayout.isGroupSlots())
+      if (resultLayout.isGroupSlots()) {
         return emitOpError(
             "requires layout-assigned result to use a dense VMI layout");
+      }
     }
     return verifyNumGroups(getOperation(), resultType, numGroupsVal);
   }
@@ -3071,9 +3275,10 @@ LogicalResult VMIVbrcOp::verify() {
     if (vregType.getElementCount() != 1) {
       return emitOpError("requires VMI vector input to have one logical lane");
     }
-    if (vregType.getElementType() != resultType.getElementType())
+    if (vregType.getElementType() != resultType.getElementType()) {
       return emitOpError("requires VMI vector input element type to match "
                          "result element type");
+    }
     return success();
   }
   return emitOpError("requires scalar or VMI vector input element type to "
@@ -3083,9 +3288,10 @@ LogicalResult VMIVbrcOp::verify() {
 LogicalResult VMIVciOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   Type elementType = resultType.getElementType();
-  if (!isVMIIotaElementType(elementType))
+  if (!isVMIIotaElementType(elementType)) {
     return emitOpError("requires result element type to be integer 8/16/32 "
                        "or f16/f32");
+  }
   if (!isCompatibleScalarForSemanticType(elementType, getBase().getType())) {
     return emitOpError("requires base type to match result element type");
   }
@@ -3100,17 +3306,19 @@ LogicalResult VMIVciOp::verify() {
     if (numGroups <= 0) {
       return emitOpError("requires group to be positive");
     }
-    if (resultType.getElementCount() % numGroups != 0)
+    if (resultType.getElementCount() % numGroups != 0) {
       return emitOpError("requires group to evenly divide result logical lane "
                          "count");
+    }
     if (numGroups > 1) {
       int64_t groupSize = resultType.getElementCount() / numGroups;
       FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(elementType);
       if (succeeded(lanesPerPart) && groupSize % *lanesPerPart != 0 &&
-          *lanesPerPart % groupSize != 0)
+          *lanesPerPart % groupSize != 0) {
         return emitOpError("requires group_size to divide or be a multiple of "
                            "physical lanes per part (")
                << *lanesPerPart << ")";
+      }
     }
   }
   return success();
@@ -3135,15 +3343,16 @@ LogicalResult VMIPgeOp::verify() {
     return emitOpError("requires pattern to start with \"PAT_VL\"");
   }
   int64_t activeLanes;
-  if (pattern.drop_front(6).getAsInteger(10, activeLanes)) {
+  if (pattern.drop_front(mlir::pto::kValue6).getAsInteger(10, activeLanes)) {
     return emitOpError("requires pattern \"PAT_VL<n>\" with integer n");
   }
   if (activeLanes <= 0) {
     return emitOpError("requires positive n in pattern \"PAT_VL<n>\"");
   }
-  if (activeLanes > resultType.getElementCount())
+  if (activeLanes > resultType.getElementCount()) {
     return emitOpError("PAT_VL active lanes ") << activeLanes
-        << " exceeds mask element count " << resultType.getElementCount();
+                                               << " exceeds mask element count " << resultType.getElementCount();
+  }
   if (!resultType.isPred() && !isLayoutAssigned(resultType)) {
     return emitOpError("requires concrete mask result to carry layout");
   }
@@ -3153,11 +3362,11 @@ LogicalResult VMIPgeOp::verify() {
 LogicalResult VMIPltOp::verify() {
   auto resultType = cast<VMIMaskType>(getMask().getType());
   auto scalarType = dyn_cast<IntegerType>(getScalar().getType());
-  if (!scalarType || scalarType.getWidth() != 32) {
+  if (!scalarType || scalarType.getWidth() != mlir::pto::kValue32) {
     return emitOpError("requires i32 scalar input");
   }
   auto scalarOutType = dyn_cast<IntegerType>(getScalarOut().getType());
-  if (!scalarOutType || scalarOutType.getWidth() != 32) {
+  if (!scalarOutType || scalarOutType.getWidth() != mlir::pto::kValue32) {
     return emitOpError("requires i32 scalar_out result");
   }
   if (!resultType.isPred() && !isLayoutAssigned(resultType)) {
@@ -3183,8 +3392,9 @@ LogicalResult VMIVaddOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3205,8 +3415,9 @@ LogicalResult VMIVsubOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3227,8 +3438,9 @@ LogicalResult VMIVmulOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3248,8 +3460,9 @@ LogicalResult VMIVdivOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3258,18 +3471,21 @@ LogicalResult VMIVminOp::verify() {
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   Type elementType = lhsType.getElementType();
-  if (failed(verifyBF16x2ComputeElementType(getOperation(), elementType)))
+  if (failed(verifyBF16x2ComputeElementType(getOperation(), elementType))) {
     return failure();
+  }
   if (!isVMII8I16I32OrF16BF16F32Type(elementType)) {
     return emitOpError(
         "requires i8, i16, i32, f16, bf16, or f32 VMI element type");
   }
   if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType,
-                                     resultType)))
+                                     resultType))) {
     return failure();
+}
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(), resultType,
-                                        getPmode())))
+                                        getPmode()))) {
     return failure();
+}
   return success();
 }
 
@@ -3278,18 +3494,21 @@ LogicalResult VMIVmaxOp::verify() {
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   Type elementType = lhsType.getElementType();
-  if (failed(verifyBF16x2ComputeElementType(getOperation(), elementType)))
+  if (failed(verifyBF16x2ComputeElementType(getOperation(), elementType))) {
     return failure();
+  }
   if (!isVMII8I16I32OrF16BF16F32Type(elementType)) {
     return emitOpError(
         "requires i8, i16, i32, f16, bf16, or f32 VMI element type");
   }
   if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType,
-                                     resultType)))
+                                     resultType))) {
     return failure();
+}
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(), resultType,
-                                        getPmode())))
+                                        getPmode()))) {
     return failure();
+}
   return success();
 }
 
@@ -3305,8 +3524,9 @@ LogicalResult VMIVnegOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3315,8 +3535,9 @@ LogicalResult VMIVabsOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
 
   Type eltTy = sourceType.getElementType();
-  if (failed(verifyBF16x2ComputeElementType(getOperation(), eltTy)))
+  if (failed(verifyBF16x2ComputeElementType(getOperation(), eltTy))) {
     return failure();
+  }
   bool supportedInteger = isVMISignedI8I16I32Type(eltTy);
   if (!supportedInteger && !isVMIF16BF16OrF32Type(eltTy)) {
     return emitOpError(
@@ -3325,12 +3546,14 @@ LogicalResult VMIVabsOp::verify() {
 
   if (failed(verifyAllSameVRegShapeAndLayout(
           getOperation(), {sourceType, resultType},
-          /*requireSameElement=*/true)))
+          /*requireSameElement=*/true))) {
     return failure();
+}
 
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                      resultType, getPmode()))) {
     return failure();
+}
   return success();
 }
 
@@ -3344,8 +3567,9 @@ LogicalResult VMIVsqrtOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3363,8 +3587,9 @@ LogicalResult VMIVexpOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3378,8 +3603,9 @@ LogicalResult VMIVlnOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3402,8 +3628,9 @@ LogicalResult VMIVreluOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3433,8 +3660,9 @@ LogicalResult VMIVandOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3464,8 +3692,9 @@ LogicalResult VMIVorOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3495,8 +3724,9 @@ LogicalResult VMIVxorOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3511,8 +3741,9 @@ LogicalResult VMIVshlOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3528,8 +3759,9 @@ LogicalResult VMIVshrOp::verify() {
     return failure();
   }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3555,11 +3787,13 @@ LogicalResult VMIVnotOp::verify() {
   }
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                              {sourceType, resultType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                      resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -3570,16 +3804,18 @@ LogicalResult VMIvSelOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                              {trueType, falseType, resultType},
-                                             /*requireSameElement=*/true)))
+                                             /*requireSameElement=*/true))) {
     return failure();
+  }
   if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
     return failure();
   }
   if (auto pmode = getPmode(); pmode.has_value()) {
     StringRef mode = pmode.value();
-    if (mode != "merge" && mode != "zero")
+    if (mode != "merge" && mode != "zero") {
       return emitOpError("pmode must be \"merge\" or \"zero\", got \"")
              << mode << "\"";
+    }
   }
   return success();
 }
@@ -3590,15 +3826,17 @@ LogicalResult VMIvcaddOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   auto elemTy = sourceType.getElementType();
 
-  if (failed(verifyBF16x2ComputeElementType(getOperation(), elemTy)))
+  if (failed(verifyBF16x2ComputeElementType(getOperation(), elemTy))) {
     return failure();
+}
 
   // Element type must be integer-like or float-like
   bool isFloat = isVMIFloatLikeType(elemTy);
   bool isInt = isVMIIntegerLikeType(elemTy);
-  if (!isFloat && !isInt)
+  if (!isFloat && !isInt) {
     return emitOpError("requires integer-like or floating-point-like VMI "
                        "source element type");
+  }
 
   // Floating-point vcadd MUST carry reassoc
   if (isFloat && !getReassoc()) {
@@ -3612,24 +3850,28 @@ LogicalResult VMIvcaddOp::verify() {
   // Validate group vs result lane count
   if (auto groupAttr = getGroupAttr()) {
     int64_t C = groupAttr.getInt();
-    if (sourceType.getElementCount() % C != 0)
+    if (sourceType.getElementCount() % C != 0) {
       return emitOpError("group count ") << C << " must divide source lane count "
                                          << sourceType.getElementCount();
-    if (resultType.getElementCount() != C)
+    }
+    if (resultType.getElementCount() != C) {
       return emitOpError("result lane count must equal group count ")
              << C << ", got " << resultType.getElementCount();
+    }
     if (auto resultLayout = resultType.getLayoutAttr()) {
       if (!resultLayout.isGroupSlots() ||
-          resultLayout.getNumGroups() != C)
+          resultLayout.getNumGroups() != C) {
         return emitOpError()
                << "layout-assigned result must use "
                   "#pto.vmi.layout<num_groups = "
                << C << ">";
+      }
     }
   } else {
-    if (resultType.getElementCount() != 1)
+    if (resultType.getElementCount() != 1) {
       return emitOpError("full reduction (no group) requires 1-lane result, got ")
              << resultType.getElementCount();
+    }
   }
 
   // Element types must match
@@ -3654,14 +3896,16 @@ LogicalResult VMIvcmaxOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   auto elemTy = sourceType.getElementType();
 
-  if (failed(verifyBF16x2ComputeElementType(getOperation(), elemTy)))
+  if (failed(verifyBF16x2ComputeElementType(getOperation(), elemTy))) {
     return failure();
+}
 
   bool isFloat = isVMIFloatLikeType(elemTy);
   bool isInt = isVMIIntegerLikeType(elemTy);
-  if (!isFloat && !isInt)
+  if (!isFloat && !isInt) {
     return emitOpError("requires integer-like or floating-point-like VMI "
                        "source element type");
+  }
 
   if (failed(verifyMaskMatchesData(getOperation(), maskType, sourceType))) {
     return failure();
@@ -3669,24 +3913,28 @@ LogicalResult VMIvcmaxOp::verify() {
 
   if (auto groupAttr = getGroupAttr()) {
     int64_t C = groupAttr.getInt();
-    if (sourceType.getElementCount() % C != 0)
+    if (sourceType.getElementCount() % C != 0) {
       return emitOpError("group count ") << C << " must divide source lane count "
                                          << sourceType.getElementCount();
-    if (resultType.getElementCount() != C)
+    }
+    if (resultType.getElementCount() != C) {
       return emitOpError("result lane count must equal group count ")
              << C << ", got " << resultType.getElementCount();
+    }
     if (auto resultLayout = resultType.getLayoutAttr()) {
       if (!resultLayout.isGroupSlots() ||
-          resultLayout.getNumGroups() != C)
+          resultLayout.getNumGroups() != C) {
         return emitOpError()
                << "layout-assigned result must use "
                   "#pto.vmi.layout<num_groups = "
                << C << ">";
+      }
     }
   } else {
-    if (resultType.getElementCount() != 1)
+    if (resultType.getElementCount() != 1) {
       return emitOpError("full reduction (no group) requires 1-lane result, got ")
              << resultType.getElementCount();
+    }
   }
 
   if (sourceType.getElementType() != resultType.getElementType()) {
@@ -3709,14 +3957,16 @@ LogicalResult VMIvcminOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   auto elemTy = sourceType.getElementType();
 
-  if (failed(verifyBF16x2ComputeElementType(getOperation(), elemTy)))
+  if (failed(verifyBF16x2ComputeElementType(getOperation(), elemTy))) {
     return failure();
+}
 
   bool isFloat = isVMIFloatLikeType(elemTy);
   bool isInt = isVMIIntegerLikeType(elemTy);
-  if (!isFloat && !isInt)
+  if (!isFloat && !isInt) {
     return emitOpError("requires integer-like or floating-point-like VMI "
                        "source element type");
+  }
 
   if (failed(verifyMaskMatchesData(getOperation(), maskType, sourceType))) {
     return failure();
@@ -3724,24 +3974,28 @@ LogicalResult VMIvcminOp::verify() {
 
   if (auto groupAttr = getGroupAttr()) {
     int64_t C = groupAttr.getInt();
-    if (sourceType.getElementCount() % C != 0)
+    if (sourceType.getElementCount() % C != 0) {
       return emitOpError("group count ") << C << " must divide source lane count "
                                          << sourceType.getElementCount();
-    if (resultType.getElementCount() != C)
+    }
+    if (resultType.getElementCount() != C) {
       return emitOpError("result lane count must equal group count ")
              << C << ", got " << resultType.getElementCount();
+    }
     if (auto resultLayout = resultType.getLayoutAttr()) {
       if (!resultLayout.isGroupSlots() ||
-          resultLayout.getNumGroups() != C)
+          resultLayout.getNumGroups() != C) {
         return emitOpError()
                << "layout-assigned result must use "
                   "#pto.vmi.layout<num_groups = "
                << C << ">";
+      }
     }
   } else {
-    if (resultType.getElementCount() != 1)
+    if (resultType.getElementCount() != 1) {
       return emitOpError("full reduction (no group) requires 1-lane result, got ")
              << resultType.getElementCount();
+    }
   }
 
   if (sourceType.getElementType() != resultType.getElementType()) {
@@ -3764,24 +4018,28 @@ LogicalResult VMIVgatherOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
 
   if (failed(verifyUBBackedMemory(getOperation(), getSource().getType(),
-                                  "source")))
+                                  "source"))) {
     return failure();
+  }
 
   if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
-                                        resultType, "source")))
+                                        resultType, "source"))) {
     return failure();
+  }
 
   auto indexElementType =
       dyn_cast<IntegerType>(offsetsType.getElementType());
   if (!indexElementType || indexElementType.isSigned() ||
-      (indexElementType.getWidth() != 32 && indexElementType.getWidth() != 16))
+      (indexElementType.getWidth() != mlir::pto::kValue32 && indexElementType.getWidth() != 16)) {
     return emitOpError(
         "requires signless or unsigned 16-bit or 32-bit integer offsets");
+  }
 
   if (failed(verifyAllSameVRegShapeAndLayout(
           getOperation(), {offsetsType, resultType},
-          /*requireSameElement=*/false)))
+          /*requireSameElement=*/false))) {
     return failure();
+  }
   if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
     return failure();
   }
@@ -3791,11 +4049,12 @@ LogicalResult VMIVgatherOp::verify() {
   // results here so the error surfaces at the vgather op rather than later in
   // the legacy gather it lowers to.
   auto resultIntegerType = dyn_cast<IntegerType>(resultType.getElementType());
-  if (indexElementType.getWidth() == 16 &&
+  if (indexElementType.getWidth() == mlir::pto::kValue16 &&
       (!resultIntegerType || !resultIntegerType.isUnsigned() ||
-       resultIntegerType.getWidth() != 16))
+       resultIntegerType.getWidth() != mlir::pto::kValue16)) {
     return emitOpError(
         "requires ui16 result element type when using ui16 offsets");
+  }
 
   if (auto pmode = getPmode()) {
     if (pmode.value() != "merge" && pmode.value() != "zero") {
@@ -3817,19 +4076,22 @@ LogicalResult VMIVgatherbOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
 
   if (failed(verifyUBBackedMemory(getOperation(), getSource().getType(),
-                                  "source")))
+                                  "source"))) {
     return failure();
+  }
 
   if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
-                                        resultType, "source")))
+                                        resultType, "source"))) {
     return failure();
+  }
 
   auto indexElementType =
       dyn_cast<IntegerType>(offsetsType.getElementType());
   if (!indexElementType || indexElementType.isSigned() ||
-      (indexElementType.getWidth() != 32 && indexElementType.getWidth() != 16))
+      (indexElementType.getWidth() != mlir::pto::kValue32 && indexElementType.getWidth() != 16)) {
     return emitOpError(
         "requires signless or unsigned 16-bit or 32-bit integer offsets");
+  }
 
   if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
     return failure();
@@ -3855,26 +4117,30 @@ LogicalResult VMIVscatterOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
 
   if (failed(verifyUBBackedMemory(getOperation(),
-                                  getDestination().getType(), "destination")))
+                                  getDestination().getType(), "destination"))) {
     return failure();
+  }
 
   if (failed(verifyMemoryElementMatches(getOperation(),
                                         getDestination().getType(), valueType,
-                                        "destination")))
+                                        "destination"))) {
     return failure();
+  }
 
   auto indexElementType =
       dyn_cast<IntegerType>(offsetsType.getElementType());
   if (!indexElementType || indexElementType.isSigned() ||
-      (indexElementType.getWidth() != 32 &&
-       indexElementType.getWidth() != 16))
+      (indexElementType.getWidth() != mlir::pto::kValue32 &&
+       indexElementType.getWidth() != mlir::pto::kValue16)) {
     return emitOpError(
         "requires signless or unsigned 16-bit or 32-bit integer offsets");
+  }
 
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                              {valueType, offsetsType},
-                                             /*requireSameElement=*/false)))
+                                             /*requireSameElement=*/false))) {
     return failure();
+  }
   if (failed(verifyMaskMatchesData(getOperation(), maskType, valueType))) {
     return failure();
   }
@@ -3908,14 +4174,15 @@ LogicalResult VMIVexpdifOp::verify() {
   }
 
   auto resultElemType = dyn_cast<FloatType>(resultType.getElementType());
-  if (!resultElemType || resultElemType.getWidth() != 32) {
+  if (!resultElemType || resultElemType.getWidth() != mlir::pto::kValue32) {
     return emitOpError("requires result element type to be f32");
   }
 
   if (xType.getElementCount() != maxType.getElementCount() ||
-      xType.getElementCount() != resultType.getElementCount())
+      xType.getElementCount() != resultType.getElementCount()) {
     return emitOpError(
         "requires x, max, and result logical lane counts to match");
+  }
 
   if (failed(verifyMaskMatchesData(getOperation(), maskType, xType))) {
     return failure();
@@ -3943,9 +4210,10 @@ LogicalResult VMIVaxpyOp::verify() {
     return emitOpError("requires vector element type to be f16 or f32");
   }
 
-  if (xType != accType || accType != resultType)
+  if (xType != accType || accType != resultType) {
     return emitOpError(
         "requires x, acc, and result to have identical VMI vreg types");
+  }
 
   auto alphaType = cast<FloatType>(getAlpha().getType());
   if (alphaType != xType.getElementType()) {
@@ -3982,9 +4250,10 @@ LogicalResult VMIVlreluOp::verify() {
   }
 
   auto slopeType = cast<FloatType>(getSlope().getType());
-  if (slopeType != xType.getElementType())
+  if (slopeType != xType.getElementType()) {
     return emitOpError(
         "requires slope scalar type to match vector element type");
+  }
 
   if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
     return failure();
@@ -4013,9 +4282,10 @@ LogicalResult VMIVpreluOp::verify() {
     return emitOpError("requires vector element type to be f16 or f32");
   }
 
-  if (xType != alphaType || alphaType != resultType)
+  if (xType != alphaType || alphaType != resultType) {
     return emitOpError(
         "requires x, alpha, and result to have identical VMI vreg types");
+  }
 
   if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
     return failure();
@@ -4039,23 +4309,28 @@ static LogicalResult verifyVMIAddCarryOp(CarryOp op, VMIMaskType carryInType,
   auto carryType = cast<VMIMaskType>(op.getCarry().getType());
 
   auto integerType = dyn_cast<IntegerType>(lhsType.getElementType());
-  if (!integerType || integerType.getWidth() != 32)
+  if (!integerType || integerType.getWidth() != mlir::pto::kValue32) {
     return op.emitOpError("requires 32-bit integer vector element types");
+  }
 
   if (failed(verifyAllSameVRegShapeAndLayout(
           op.getOperation(), {lhsType, rhsType, resultType},
-          /*requireSameElement=*/true)))
+          /*requireSameElement=*/true))) {
     return failure();
+  }
   if (failed(verifyMaskMatchesData(op.getOperation(), maskType, lhsType)) ||
-      failed(verifyMaskMatchesData(op.getOperation(), carryType, lhsType)))
+      failed(verifyMaskMatchesData(op.getOperation(), carryType, lhsType))) {
     return failure();
+  }
   if (hasCarryIn &&
-      failed(verifyMaskMatchesData(op.getOperation(), carryInType, lhsType)))
+      failed(verifyMaskMatchesData(op.getOperation(), carryInType, lhsType))) {
     return failure();
+  }
 
   SmallVector<VMIMaskType> masks{maskType, carryType};
-  if (hasCarryIn)
+  if (hasCarryIn) {
     masks.push_back(carryInType);
+  }
   return verifyAllSameMaskShapeLayoutAndGranularity(op.getOperation(), masks);
 }
 
@@ -4083,16 +4358,18 @@ LogicalResult VMIVmullOp::verify() {
   if (!isLegalElementType(aType.getElementType()) ||
       !isLegalElementType(bType.getElementType()) ||
       !isLegalElementType(lowType.getElementType()) ||
-      !isLegalElementType(highType.getElementType()))
+      !isLegalElementType(highType.getElementType())) {
     return emitOpError(
         "requires a, b, low, and high element types to be exactly i32 or ui32");
+  }
 
-  if (aType != bType || aType != lowType || aType != highType)
+  if (aType != bType || aType != lowType || aType != highType) {
     return emitOpError(
         "requires a, b, low, and high to have identical VMI vreg types");
+  }
 
   int64_t lanes = aType.getElementCount();
-  if (lanes != 64 && lanes != 128 && lanes != 256) {
+  if (lanes != mlir::pto::kValue64 && lanes != 128 && lanes != 256) {
     return emitOpError("requires logical lane count to be 64, 128, or 256");
   }
 
@@ -4113,19 +4390,23 @@ LogicalResult VMIVmulaOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
 
   Type eltTy = accType.getElementType();
-  if (failed(verifyBF16x2ComputeElementType(getOperation(), eltTy)))
+  if (failed(verifyBF16x2ComputeElementType(getOperation(), eltTy))) {
     return failure();
-  if (!isVMIFloatLikeType(eltTy) && !isVMIIntegerLikeType(eltTy))
+}
+  if (!isVMIFloatLikeType(eltTy) && !isVMIIntegerLikeType(eltTy)) {
     return emitOpError(
         "requires floating-point-like or integer-like VMI element type");
+}
 
-  if (accType != lhsType || lhsType != rhsType || rhsType != resultType)
+  if (accType != lhsType || lhsType != rhsType || rhsType != resultType) {
     return emitOpError(
         "requires acc, lhs, rhs, and result to have identical VMI vreg types");
+}
 
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
-                                        resultType, getPmode())))
+                                        resultType, getPmode()))) {
     return failure();
+}
   return success();
 }
 
@@ -4134,9 +4415,10 @@ LogicalResult VMICvtOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
 
   // 1. Lane count must match.
-  if (sourceType.getElementCount() != resultType.getElementCount())
+  if (sourceType.getElementCount() != resultType.getElementCount()) {
     return emitOpError(
         "requires source and result logical lane counts to match");
+}
 
   Type srcElem = sourceType.getElementType();
   Type dstElem = resultType.getElementType();
@@ -4150,13 +4432,15 @@ LogicalResult VMICvtOp::verify() {
       srcFp && dstFp ? lookupVMIFpToFpContract(srcElem, dstElem)
                      : std::nullopt;
 
-  if (involvesBF16x2(srcElem, dstElem) && !fpContract)
+  if (involvesBF16x2(srcElem, dstElem) && !fpContract) {
     return emitOpError(
         "unsupported conversion involving bf16x2 element type");
+}
   if (srcFp && dstFp &&
-      involvesVMIPackedFloatCarrier(srcElem, dstElem) && !fpContract)
+      involvesVMIPackedFloatCarrier(srcElem, dstElem) && !fpContract) {
     return emitOpError(
         "unsupported packed fp-to-fp conversion element type pair");
+}
 
   // 2. Classify the conversion direction.
   CvtDirection dir;
@@ -4170,10 +4454,11 @@ LogicalResult VMICvtOp::verify() {
     else {
       // Same-width fp→fp (e.g. bf16 → f16): only allowed for VMI fp-to-fp
       // contract pairs, routed through FpNarrow (1:1 TruncF).
-      if (!fpContract)
+      if (!fpContract) {
         return emitOpError(
             "same-width fp-to-fp conversion is not supported for this type "
             "pair; see lookupVMIFpToFpContract");
+}
       dir = CvtDirection::FpNarrow;
     }
   } else if (srcFp && dstInt) {
@@ -4197,9 +4482,10 @@ LogicalResult VMICvtOp::verify() {
     else if (dstBits < srcBits) {
       dir = CvtDirection::IntNarrow;
     }
-    else
+    else {
       return emitOpError(
           "int-to-int conversion must change element bit-width");
+}
   } else {
     return emitOpError(
         "unsupported element type combination for vcvt");
@@ -4247,17 +4533,19 @@ LogicalResult VMICvtOp::verify() {
       return emitOpError("unsupported fp-to-si conversion element type pair");
     }
     if (contract->requiresSat) {
-      if (!satAttr)
+      if (!satAttr) {
         return emitOpError("'saturate' attribute is required for this "
                            "fp-to-si conversion; write 'SAT' or 'NOSAT'");
+      }
       StringRef satVal = satAttr.getValue();
       if (satVal != "SAT" && satVal != "NOSAT") {
         return emitOpError("saturate must be 'SAT' or 'NOSAT'");
       }
     } else {
-      if (satAttr)
+      if (satAttr) {
         return emitOpError("'saturate' attribute is not valid for this "
                            "fp-to-si conversion (no overflow possible)");
+      }
     }
   } else if (dir == CvtDirection::FpToUi) {
     auto contract = lookupVMIFpToUIContract(srcElem, dstElem);
@@ -4265,17 +4553,19 @@ LogicalResult VMICvtOp::verify() {
       return emitOpError("unsupported fp-to-ui conversion element type pair");
     }
     if (contract->requiresSat) {
-      if (!satAttr)
+      if (!satAttr) {
         return emitOpError("'saturate' attribute is required for this "
                            "fp-to-ui conversion; write 'SAT' or 'NOSAT'");
+}
       StringRef satVal = satAttr.getValue();
       if (satVal != "SAT" && satVal != "NOSAT") {
         return emitOpError("saturate must be 'SAT' or 'NOSAT'");
       }
     } else {
-      if (satAttr)
+      if (satAttr) {
         return emitOpError("'saturate' attribute is not valid for this "
                            "fp-to-ui conversion (no overflow possible)");
+}
     }
   } else {
     bool needSat = (dir == CvtDirection::IntNarrow);
@@ -4286,10 +4576,11 @@ LogicalResult VMICvtOp::verify() {
       needSat = !fpContract || fpContract->requiresSat;
     }
     if (needSat) {
-      if (!satAttr)
+      if (!satAttr) {
         return emitOpError("'saturate' attribute is required for fp-narrow / "
                            "int-narrow conversions; write 'SAT' or "
                            "'NOSAT'");
+}
       StringRef satVal = satAttr.getValue();
       if (satVal != "SAT" && satVal != "NOSAT") {
         return emitOpError("saturate must be 'SAT' or 'NOSAT'");
@@ -4303,10 +4594,11 @@ LogicalResult VMICvtOp::verify() {
           isa<IntegerType>(srcElem) &&
           cast<IntegerType>(srcElem).isSigned() &&
           isa<IntegerType>(dstElem) &&
-          cast<IntegerType>(dstElem).isSigned())
+          cast<IntegerType>(dstElem).isSigned()) {
         return emitOpError("si32 -> si8 int-narrow does not support "
                            "saturate=\"SAT\" (no native hardware form; "
                            "only saturate=\"NOSAT\" is allowed)");
+}
     } else if (satAttr && dir == CvtDirection::FpNarrow) {
       return emitOpError("'saturate' attribute is not valid for this fp-to-fp "
                          "narrow conversion (no saturation)");
@@ -4334,19 +4626,22 @@ LogicalResult VMIVinterpretCastOp::verify() {
       pto::getPTOStorageElemBitWidth(sourceType.getElementType());
   unsigned resultBits =
       pto::getPTOStorageElemBitWidth(resultType.getElementType());
-  if (sourceBits == 0 || resultBits == 0)
+  if (sourceBits == 0 || resultBits == 0) {
     return emitOpError(
         "requires integer or floating-point source and result element types");
+}
   if (sourceType.getElementCount() * static_cast<int64_t>(sourceBits) !=
-      resultType.getElementCount() * static_cast<int64_t>(resultBits))
+      resultType.getElementCount() * static_cast<int64_t>(resultBits)) {
     return emitOpError(
         "requires source and result to carry the same total number of bits");
+}
 
   if (isLayoutAssigned(sourceType) || isLayoutAssigned(resultType)) {
-    if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType))
+    if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType)) {
       return emitOpError(
           "requires either both source and result to carry layout or neither "
           "to carry layout");
+}
     if (sourceType.getLayout() != resultType.getLayout()) {
       return emitOpError("requires source and result layouts to match");
     }
@@ -4356,10 +4651,10 @@ LogicalResult VMIVinterpretCastOp::verify() {
 }
 
 ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
-  SmallVector<OpAsmParser::UnresolvedOperand, 4> preBracketOperands;
+  SmallVector<OpAsmParser::UnresolvedOperand, mlir::pto::kValue4> preBracketOperands;
   OpAsmParser::UnresolvedOperand operand;
   OpAsmParser::UnresolvedOperand offsetOperand;
-  SmallVector<OpAsmParser::UnresolvedOperand, 3> postBracketOps;
+  SmallVector<OpAsmParser::UnresolvedOperand, mlir::pto::kValue3> postBracketOps;
 
   if (parser.parseOperand(operand)) {
     return failure();
@@ -4391,9 +4686,10 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
     preBracketOperands.push_back(operand);
   }
 
-  if (preBracketOperands.empty())
+  if (preBracketOperands.empty()) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expected at least one value and one destination");
+  }
 
   // Optional post-bracket operands: stride, block_stride/repeat_stride, mask.
   // Up to 3, disambiguated after parsing attrs.
@@ -4403,7 +4699,7 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
       return failure();
     }
     postBracketOps.push_back(postOp);
-    if (postBracketOps.size() >= 3) {
+    if (postBracketOps.size() >= mlir::pto::kValue3) {
       break;
     }
   }
@@ -4412,7 +4708,7 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
   }
 
-  SmallVector<Type, 6> types;
+  SmallVector<Type, mlir::pto::kValue6> types;
   if (parser.parseColon() || parser.parseTypeList(types)) {
     return failure();
   }
@@ -4433,19 +4729,19 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
       hasStride = true;
       strideIdx = 0;
     }
-    if (postBracketOps.size() >= 2) {
+    if (postBracketOps.size() >= mlir::pto::kValue2) {
       hasMask = true;
       maskIdx = 1;
     }
-  } else if (postBracketOps.size() >= 2) {
+  } else if (postBracketOps.size() >= mlir::pto::kValue2) {
     // Block-stride mode: post-bracket ops are block_stride, repeat_stride[, mask]
     hasBlock = true;
     hasRepeat = true;
     blockIdx = 0;
     repeatIdx = 1;
-    if (postBracketOps.size() >= 3) {
+    if (postBracketOps.size() >= mlir::pto::kValue3) {
       hasMask = true;
-      maskIdx = 2;
+      maskIdx = mlir::pto::kValue2;
     }
   } else if (postBracketOps.size() == 1) {
     // Single post-bracket operand without group: mask
@@ -4457,11 +4753,12 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
   size_t nTypes = types.size();
   size_t expectedTypes = nValues + 1 + (hasMask ? 1 : 0);
 
-  if (nTypes != expectedTypes)
+  if (nTypes != expectedTypes) {
     return parser.emitError(parser.getCurrentLocation())
            << "expected " << expectedTypes << " types (" << nValues
            << " value(s), 1 destination" << (hasMask ? ", 1 mask" : "")
            << "), got " << nTypes;
+  }
 
   for (size_t i = 0; i < nValues; ++i) {
     if (parser.resolveOperand(preBracketOperands[i], types[i], result.operands)) {
@@ -4471,35 +4768,41 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
 
   Type destType = types[nValues];
   if (parser.resolveOperand(preBracketOperands[nValues], destType,
-                            result.operands))
+                            result.operands)) {
     return failure();
+  }
 
   if (parser.resolveOperand(offsetOperand, parser.getBuilder().getIndexType(),
-                            result.operands))
+                            result.operands)) {
     return failure();
+  }
 
   if (hasStride &&
       parser.resolveOperand(postBracketOps[strideIdx],
                             parser.getBuilder().getIndexType(),
-                            result.operands))
+                            result.operands)) {
     return failure();
+  }
 
   if (hasBlock &&
       parser.resolveOperand(postBracketOps[blockIdx],
-                            parser.getBuilder().getIntegerType(16),
-                            result.operands))
+                            parser.getBuilder().getIntegerType(mlir::pto::kValue16),
+                            result.operands)) {
     return failure();
+  }
   if (hasRepeat &&
       parser.resolveOperand(postBracketOps[repeatIdx],
-                            parser.getBuilder().getIntegerType(16),
-                            result.operands))
+                            parser.getBuilder().getIntegerType(mlir::pto::kValue16),
+                            result.operands)) {
     return failure();
+  }
 
   if (hasMask) {
     Type maskType = types.back();
     if (parser.resolveOperand(postBracketOps[maskIdx], maskType,
-                              result.operands))
+                              result.operands)) {
       return failure();
+    }
   }
 
   result.addAttribute("operandSegmentSizes",
@@ -4575,13 +4878,15 @@ LogicalResult VMIvStoreOp::verify() {
   // dist_mode and group
   bool hasBlock = static_cast<bool>(getBlockStride());
   bool hasRepeat = static_cast<bool>(getRepeatStride());
-  if (hasBlock != hasRepeat)
+  if (hasBlock != hasRepeat) {
     return emitOpError(
         "block_stride and repeat_stride must both be present or absent");
+  }
   if (hasBlock) {
-    if (getDistMode())
+    if (getDistMode()) {
       return emitOpError(
           "block_stride and dist_mode are mutually exclusive");
+    }
     if (getValues().size() != 1) {
       return emitOpError("block-stride mode requires exactly 1 value");
     }
@@ -4593,12 +4898,13 @@ LogicalResult VMIvStoreOp::verify() {
   if (nValues < 1) {
     return emitOpError("requires at least 1 value");
   }
-  if (isDintlv && nValues != 2) {
+  if (isDintlv && nValues != mlir::pto::kValue2) {
     return emitOpError("dist-mode \"dintlv\" requires exactly 2 values");
   }
-  if (!isDintlv && nValues != 1)
+  if (!isDintlv && nValues != 1) {
     return emitOpError("requires exactly 1 value for dist-mode \"")
            << (distMode ? *distMode : "continuous") << "\"";
+  }
 
   bool hasMask = !getMask().empty();
   if (getMask().size() > 1) {
@@ -4608,19 +4914,21 @@ LogicalResult VMIvStoreOp::verify() {
   if (distMode && !validDistModes().count(*distMode)) {
     return emitOpError("invalid dist-mode: \"") << *distMode << "\"";
   }
-  if (distMode && (*distMode == "unpack" || *distMode == "brc"))
+  if (distMode && (*distMode == "unpack" || *distMode == "brc")) {
     return emitOpError("dist-mode \"")
            << *distMode << "\" is not valid for vstore";
+  }
 
   auto pmode = getPmode();
   if (pmode && !validPModes().count(*pmode)) {
     return emitOpError("invalid pmode: \"") << *pmode << "\"";
   }
-  if (pmode && *pmode != "zero")
+  if (pmode && *pmode != "zero") {
     return emitOpError("pmode \"merge\" is not supported for stores: the "
                        "legacy store lowering is mask-governed only and "
                        "cannot retain prior destination contents on inactive "
                        "lanes; omit pmode (defaults to \"zero\")");
+  }
 
   auto valueType = cast<VMIVRegType>(getValues()[0].getType());
   bool isPackedGroupStore =
@@ -4629,21 +4937,24 @@ LogicalResult VMIvStoreOp::verify() {
   if (!isPackedGroupStore &&
       failed(verifyMemoryElementMatches(getOperation(),
                                         getDestination().getType(), valueType,
-                                        "destination")))
+                                        "destination"))) {
     return failure();
+  }
 
-  if (nValues == 2) {
+  if (nValues == mlir::pto::kValue2) {
     auto loType = cast<VMIVRegType>(getValues()[0].getType());
     auto hiType = cast<VMIVRegType>(getValues()[1].getType());
     if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                                {loType, hiType},
-                                               /*requireSameElement=*/true)))
+                                               /*requireSameElement=*/true))) {
       return failure();
+    }
     if (failed(verifyContiguousIfLayoutAssigned(getOperation(), loType,
                                                 "low input")) ||
         failed(verifyContiguousIfLayoutAssigned(getOperation(), hiType,
-                                                "high input")))
+                                                "high input"))) {
       return failure();
+    }
   }
 
   if (hasMask) {
@@ -4669,16 +4980,18 @@ LogicalResult VMIVsstbOp::verify() {
                                         getDestination().getType(), valueType,
                                         "destination")) ||
       failed(verifyUBBackedMemory(getOperation(), getDestination().getType(),
-                                  "destination")))
+                                  "destination"))) {
     return failure();
+  }
   if (auto pmode = getPmode(); pmode && !validPModes().count(*pmode)) {
     return emitOpError("invalid pmode: \"") << *pmode << "\"";
   }
-  if (auto pmode = getPmode(); pmode && *pmode != "zero")
+  if (auto pmode = getPmode(); pmode && *pmode != "zero") {
     return emitOpError("pmode \"merge\" is not supported for stores: the "
                        "legacy store lowering is mask-governed only and "
                        "cannot retain prior destination contents on inactive "
                        "blocks; omit pmode (defaults to \"zero\")");
+  }
   return verifyMaskMatchesData(getOperation(), maskType, valueType);
 }
 
@@ -4692,14 +5005,15 @@ LogicalResult VMIVselrOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto indexType = cast<VMIVRegType>(getIndex().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-
-  if (sourceType.getElementType() != resultType.getElementType())
+  if (sourceType.getElementType() != resultType.getElementType()) {
     return emitOpError(
         "requires result element type to match source element type");
+  }
 
-  if (indexType.getElementCount() != resultType.getElementCount())
+  if (indexType.getElementCount() != resultType.getElementCount()) {
     return emitOpError(
         "requires index lane count to match result lane count");
+  }
 
   if (!isa<IntegerType>(indexType.getElementType())) {
     return emitOpError("requires index element type to be integer");
@@ -4709,22 +5023,26 @@ LogicalResult VMIVselrOp::verify() {
       pto::getPTOStorageElemBitWidth(sourceType.getElementType());
   unsigned indexBits =
       pto::getPTOStorageElemBitWidth(indexType.getElementType());
-  if (sourceBits != 8 && sourceBits != 16 && sourceBits != 32)
+  if (sourceBits != mlir::pto::kValue8 && sourceBits != 16 && sourceBits != 32) {
     return emitOpError(
         "requires source/result element storage width to be 8, 16, or 32 bits");
-  if (indexBits != sourceBits)
+  }
+  if (indexBits != sourceBits) {
     return emitOpError(
         "requires index element storage width to match source element storage width");
+  }
 
   bool sourceHasLayout = isLayoutAssigned(sourceType);
   bool indexHasLayout = isLayoutAssigned(indexType);
   bool resultHasLayout = isLayoutAssigned(resultType);
-  if (sourceHasLayout != resultHasLayout)
+  if (sourceHasLayout != resultHasLayout) {
     return emitOpError("requires source and result to both carry layout or "
                        "neither carry layout");
-  if (indexHasLayout && !sourceHasLayout)
+  }
+  if (indexHasLayout && !sourceHasLayout) {
     return emitOpError(
         "requires index to carry layout only when source does");
+  }
 
   return success();
 }
@@ -4736,12 +5054,14 @@ LogicalResult VMIVintlvOp::verify() {
   auto highType = cast<VMIVRegType>(getHigh().getType());
   if (failed(verifyAllSameVRegShapeAndLayoutPresence(
           getOperation(), {lhsType, rhsType, lowType, highType},
-          /*requireSameElement=*/true)))
+          /*requireSameElement=*/true))) {
     return failure();
+  }
   if (failed(verifyVMIPmodeMask(getOperation(),
                                 cast<VMIMaskType>(getMask().getType()),
-                                lhsType, getPmode())))
+                                lhsType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -4752,12 +5072,14 @@ LogicalResult VMIVdintlvOp::verify() {
   auto highType = cast<VMIVRegType>(getHigh().getType());
   if (failed(verifyAllSameVRegShapeAndLayoutPresence(
           getOperation(), {lhsType, rhsType, lowType, highType},
-          /*requireSameElement=*/true)))
+          /*requireSameElement=*/true))) {
     return failure();
+  }
   if (failed(verifyVMIPmodeMask(getOperation(),
                                 cast<VMIMaskType>(getMask().getType()),
-                                lhsType, getPmode())))
+                                lhsType, getPmode()))) {
     return failure();
+  }
   return success();
 }
 
@@ -4772,8 +5094,9 @@ LogicalResult VMIVcmpOp::verify() {
   auto resultType = cast<VMIMaskType>(getResult().getType());
 
   Type eltTy = lhsType.getElementType();
-  if (failed(verifyBF16x2ComputeElementType(getOperation(), eltTy)))
+  if (failed(verifyBF16x2ComputeElementType(getOperation(), eltTy))) {
     return failure();
+  }
   if (!isVMII8I16I32OrF16BF16F32Type(eltTy)) {
     return emitOpError(
         "requires i8, i16, i32, f16, bf16, or f32 VMI element type");
@@ -4814,9 +5137,10 @@ LogicalResult VMIVcmpOp::verify() {
   }
 
   // Result mask must match seed mask.
-  if (seedType.getElementCount() != resultType.getElementCount())
+  if (seedType.getElementCount() != resultType.getElementCount()) {
     return emitOpError(
         "requires result mask lane count to match seed mask lane count");
+  }
 
   return success();
 }
@@ -4827,8 +5151,9 @@ LogicalResult VMIVcmpsOp::verify() {
   auto resultType = cast<VMIMaskType>(getResult().getType());
 
   Type eltTy = srcType.getElementType();
-  if (failed(verifyBF16x2ComputeElementType(getOperation(), eltTy)))
+  if (failed(verifyBF16x2ComputeElementType(getOperation(), eltTy))) {
     return failure();
+  }
   if (!isVMII8I16I32OrF16BF16F32Type(eltTy)) {
     return emitOpError(
         "requires i8, i16, i32, f16, bf16, or f32 VMI element type");
@@ -4872,9 +5197,10 @@ LogicalResult VMIVcmpsOp::verify() {
   }
 
   // Result mask must match seed mask.
-  if (seedType.getElementCount() != resultType.getElementCount())
+  if (seedType.getElementCount() != resultType.getElementCount()) {
     return emitOpError(
         "requires result mask lane count to match seed mask lane count");
+  }
 
   return success();
 }
@@ -4892,8 +5218,9 @@ ParseResult VMIvLoadOp::parse(OpAsmParser &parser, OperationState &result) {
 
   // Parse: %source[%offset]
   if (parser.parseOperand(sourceOperand) || parser.parseLSquare() ||
-      parser.parseOperand(offsetOperand) || parser.parseRSquare())
+      parser.parseOperand(offsetOperand) || parser.parseRSquare()) {
     return failure();
+  }
 
   // Optional comma-separated post-bracket operands.
   // 1 operand  + group attr   → stride (group mode)
@@ -4909,7 +5236,7 @@ ParseResult VMIvLoadOp::parse(OpAsmParser &parser, OperationState &result) {
       if (parser.parseOperand(postOp2)) {
         return failure();
       }
-      numPostBracket = 2;
+      numPostBracket = mlir::pto::kValue2;
     }
   }
 
@@ -4926,7 +5253,7 @@ ParseResult VMIvLoadOp::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
   }
 
-  SmallVector<Type, 2> resultTypes;
+  SmallVector<Type, mlir::pto::kValue2> resultTypes;
   if (parser.parseTypeList(resultTypes)) {
     return failure();
   }
@@ -4936,7 +5263,7 @@ ParseResult VMIvLoadOp::parse(OpAsmParser &parser, OperationState &result) {
   bool hasBlock = false;
   bool hasRepeat = false;
 
-  if (numPostBracket == 2) {
+  if (numPostBracket == mlir::pto::kValue2) {
     // block_stride + repeat_stride pair
     hasBlock = true;
     hasRepeat = true;
@@ -4954,22 +5281,26 @@ ParseResult VMIvLoadOp::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
   }
   if (parser.resolveOperand(offsetOperand, parser.getBuilder().getIndexType(),
-                            result.operands))
+                            result.operands)) {
     return failure();
+  }
   if (hasStride &&
       parser.resolveOperand(strideOperand, parser.getBuilder().getIndexType(),
-                            result.operands))
+                            result.operands)) {
     return failure();
+  }
   if (hasBlock &&
       parser.resolveOperand(blockStrideOperand,
-                            parser.getBuilder().getIntegerType(16),
-                            result.operands))
+                            parser.getBuilder().getIntegerType(mlir::pto::kValue16),
+                            result.operands)) {
     return failure();
+  }
   if (hasRepeat &&
       parser.resolveOperand(repeatStrideOperand,
-                            parser.getBuilder().getIntegerType(16),
-                            result.operands))
+                            parser.getBuilder().getIntegerType(mlir::pto::kValue16),
+                            result.operands)) {
     return failure();
+  }
 
   result.addAttribute("operandSegmentSizes",
                       parser.getBuilder().getDenseI32ArrayAttr(
@@ -5029,13 +5360,15 @@ LogicalResult VMIvLoadOp::verify() {
   // with dist_mode and group
   bool hasBlock = static_cast<bool>(getBlockStride());
   bool hasRepeat = static_cast<bool>(getRepeatStride());
-  if (hasBlock != hasRepeat)
+  if (hasBlock != hasRepeat) {
     return emitOpError(
         "block_stride and repeat_stride must both be present or absent");
+  }
   if (hasBlock) {
-    if (getDistMode())
+    if (getDistMode()) {
       return emitOpError(
           "block_stride and dist_mode are mutually exclusive");
+    }
     if (getResults().size() != 1) {
       return emitOpError("block-stride mode requires exactly 1 result");
     }
@@ -5045,12 +5378,13 @@ LogicalResult VMIvLoadOp::verify() {
   auto distMode = getDistMode();
   bool isDintlv = distMode && *distMode == "dintlv";
   size_t nResults = getResults().size();
-  if (isDintlv && nResults != 2) {
+  if (isDintlv && nResults != mlir::pto::kValue2) {
     return emitOpError("dist-mode \"dintlv\" requires exactly 2 results");
   }
-  if (!isDintlv && nResults != 1)
+  if (!isDintlv && nResults != 1) {
     return emitOpError("requires exactly 1 result for dist-mode \"")
            << (distMode ? *distMode : "continuous") << "\"";
+  }
 
   if (distMode && !validDistModes().count(*distMode)) {
     return emitOpError("invalid dist-mode: \"") << *distMode << "\"";
@@ -5067,12 +5401,14 @@ LogicalResult VMIvLoadOp::verify() {
     if (!isUnpack &&
         failed(verifyMemoryElementMatches(getOperation(),
                                           getSource().getType(), resType,
-                                          "source")))
+                                          "source"))) {
       return failure();
+    }
     if (isDintlv &&
         failed(verifyContiguousIfLayoutAssigned(getOperation(), resType,
-                                                "result")))
+                                                "result"))) {
       return failure();
+    }
   }
 
   return success();
@@ -5109,13 +5445,13 @@ FailureOr<int64_t> mlir::pto::getDataLanesPerPart(Type elementType) {
 
 FailureOr<int64_t> mlir::pto::getMaskLanesPerPart(StringRef granularity) {
   if (granularity == "b8") {
-    return 256;
+    return mlir::pto::kValue256;
   }
   if (granularity == "b16") {
-    return 128;
+    return mlir::pto::kValue128;
   }
   if (granularity == "b32") {
-    return 64;
+    return mlir::pto::kValue64;
   }
   return failure();
 }
@@ -5132,8 +5468,9 @@ FailureOr<int64_t> mlir::pto::getVMILayoutBlockElems(Type type) {
   FailureOr<int64_t> lanesPerPart = getPhysicalLanesPerPart(type);
   constexpr int64_t kVCGBlocksPerPart = 8;
   if (failed(lanesPerPart) || *lanesPerPart <= 0 ||
-      *lanesPerPart % kVCGBlocksPerPart != 0)
+      *lanesPerPart % kVCGBlocksPerPart != 0) {
     return failure();
+  }
   return *lanesPerPart / kVCGBlocksPerPart;
 }
 
@@ -5145,9 +5482,10 @@ FailureOr<int64_t> mlir::pto::getVMIPhysicalArity(Type type) {
     return failure();
   }
 
-  if ((*layout).isGroupSlots() && (*layout).getSlots() > 0)
+  if ((*layout).isGroupSlots() && (*layout).getSlots() > 0) {
     return divideCeilNonNegative((*layout).getNumGroups(),
                                  (*layout).getSlots());
+  }
 
   int64_t factor = (*layout).isDenseSplit() ? (*layout).getFactor() : 1;
   FailureOr<int64_t> blockElems = getVMILayoutBlockElems(type);
@@ -5177,8 +5515,9 @@ mlir::pto::mapLogicalLaneToPhysical(Type type, int64_t logicalLane) {
   FailureOr<int64_t> laneStride = getDenseLaneStride(type);
   FailureOr<int64_t> lanesPerPart = getPhysicalLanesPerPart(type);
   if (failed(elementCount) || failed(factor) || failed(blockElems) ||
-      failed(laneStride) || failed(lanesPerPart))
+      failed(laneStride) || failed(lanesPerPart)) {
     return failure();
+  }
   if (logicalLane < 0 || logicalLane >= *elementCount) {
     return failure();
   }
@@ -5214,11 +5553,13 @@ FailureOr<int64_t> mlir::pto::mapPhysicalLaneToLogical(Type type, int64_t part,
   FailureOr<int64_t> laneStride = getDenseLaneStride(type);
   FailureOr<int64_t> lanesPerPart = getPhysicalLanesPerPart(type);
   if (failed(elementCount) || failed(factor) || failed(blockElems) ||
-      failed(laneStride) || failed(lanesPerPart))
+      failed(laneStride) || failed(lanesPerPart)) {
     return failure();
+  }
   if (part < 0 || part >= *factor || chunk < 0 || lane < 0 ||
-      lane >= *lanesPerPart)
+      lane >= *lanesPerPart) {
     return failure();
+  }
 
   FailureOr<VMILayoutAttr> layout = getAssignedVMILayout(type);
   if (succeeded(layout) && (*layout).isGroupSlots() &&
@@ -5255,11 +5596,13 @@ FailureOr<bool> mlir::pto::isPaddingLane(Type type, int64_t part, int64_t chunk,
   FailureOr<int64_t> laneStride = getDenseLaneStride(type);
   FailureOr<int64_t> lanesPerPart = getPhysicalLanesPerPart(type);
   if (failed(elementCount) || failed(factor) || failed(blockElems) ||
-      failed(laneStride) || failed(lanesPerPart))
+      failed(laneStride) || failed(lanesPerPart)) {
     return failure();
+  }
   if (part < 0 || part >= *factor || chunk < 0 || lane < 0 ||
-      lane >= *lanesPerPart)
+      lane >= *lanesPerPart) {
     return failure();
+  }
 
   FailureOr<VMILayoutAttr> layout = getAssignedVMILayout(type);
   if (succeeded(layout) && (*layout).isGroupSlots() &&

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -14,6 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 
@@ -87,12 +88,13 @@ static LogicalResult verifyNonLowPrecisionVRegElementTypeLike(
   if (!vecType) {
     return success();
   }
-  if (pto::isPTOLowPrecisionType(vecType.getElementType()))
+  if (pto::isPTOLowPrecisionType(vecType.getElementType())) {
     return op->emitOpError()
            << roleDescription
            << " must not use low-precision vector element type; "
               "low-precision vreg elements are currently only supported on "
               "explicit memory/conversion ops such as vlds/vsts/vcvt/vmulscvt/vpack";
+  }
   return success();
 }
 
@@ -144,17 +146,18 @@ static bool isMaskGranularityAdjacentNarrowing(StringRef inputGranularity,
 
 static bool isSupportedShuffleValueType(Type type) {
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    return intType.getWidth() == 32 || intType.getWidth() == 64;
+    return intType.getWidth() == mlir::pto::kValue32 || intType.getWidth() == 64;
   }
-  if (auto vecType = dyn_cast<VectorType>(type))
-    return vecType.getRank() == 1 && vecType.getDimSize(0) == 2 &&
+  if (auto vecType = dyn_cast<VectorType>(type)) {
+    return vecType.getRank() == 1 && vecType.getDimSize(0) == mlir::pto::kValue2 &&
            vecType.getElementType().isF16();
+  }
   return type.isF16() || type.isF32();
 }
 
 static bool isSupportedReduxValueType(Type type) {
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    return intType.getWidth() == 32;
+    return intType.getWidth() == mlir::pto::kValue32;
   }
   return type.isF16() || type.isF32();
 }
@@ -171,9 +174,10 @@ LogicalResult SimtLaunchOp::verify() {
 
   func::FuncOp callee =
       SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(*this, getCalleeAttr());
-  if (!callee)
+  if (!callee) {
     return emitOpError() << "'" << getCalleeAttr().getValue()
                          << "' does not reference a valid function";
+  }
 
   if (!callee->hasAttr(pto::kPTOSimtEntryAttrName)) {
     return emitOpError() << "callee '" << getCalleeAttr().getValue()
@@ -205,15 +209,17 @@ static LogicalResult verifyShuffleSemanticControl(Operation *op,
                                                   Type controlType,
                                                   IntegerAttr widthAttr,
                                                   StringRef ctrlName) {
-  if (!isSupportedShuffleValueType(op->getResultTypes().front()))
+  if (!isSupportedShuffleValueType(op->getResultTypes().front())) {
     return op->emitOpError()
            << "requires i32, i64, f16, f32 or vector<2xf16> value/result type";
-  if (!controlType.isInteger(32))
+  }
+  if (!controlType.isInteger(32)) {
     return op->emitOpError() << "requires " << ctrlName
                              << " operand to be i32";
+  }
 
   int64_t width = widthAttr.getInt();
-  if (width != 16 && width != 32) {
+  if (width != mlir::pto::kValue16 && width != 32) {
     return op->emitOpError() << "requires width to be 16 or 32";
   }
   return success();
@@ -222,21 +228,24 @@ static LogicalResult verifyShuffleSemanticControl(Operation *op,
 static LogicalResult verifyReduxSemanticType(Operation *op, Type valueType,
                                              Attribute signednessAttr,
                                              bool requireSignedness) {
-  if (!isSupportedReduxValueType(valueType))
+  if (!isSupportedReduxValueType(valueType)) {
     return op->emitOpError()
            << "requires i32, f16 or f32 value/result type";
+  }
 
   auto intType = dyn_cast<IntegerType>(valueType);
   if (!intType) {
-    if (signednessAttr)
+    if (signednessAttr) {
       return op->emitOpError()
              << "does not accept signedness for floating-point redux";
+    }
     return success();
   }
 
-  if (!signednessAttr && requireSignedness)
+  if (!signednessAttr && requireSignedness) {
     return op->emitOpError()
            << "requires explicit signedness for integer redux";
+  }
 
   if (!signednessAttr) {
     return success();
@@ -249,7 +258,7 @@ static LogicalResult verifyReduxSemanticType(Operation *op, Type valueType,
 
 static bool isStandardScalarConvertType(Type type) {
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    return intType.getWidth() == 32 || intType.getWidth() == 64;
+    return intType.getWidth() == mlir::pto::kValue32 || intType.getWidth() == 64;
   }
   return type.isF16() || type.isBF16() || type.isF32();
 }
@@ -260,7 +269,7 @@ static bool isIntegerLikeConvertType(Type type) {
 
 static bool isVector2Of(Type type, llvm::function_ref<bool(Type)> elementPred) {
   auto vecType = dyn_cast<VectorType>(type);
-  return vecType && vecType.getRank() == 1 && vecType.getDimSize(0) == 2 &&
+  return vecType && vecType.getRank() == 1 && vecType.getDimSize(0) == mlir::pto::kValue2 &&
          elementPred(vecType.getElementType());
 }
 
@@ -321,47 +330,54 @@ static LogicalResult verifyPackedConvertControls(Operation *op, Type srcType,
   };
 
   if (isV2F32(srcType) && isV2F16(dstType)) {
-    if (rounding == pto::Rounding::H)
+    if (rounding == pto::Rounding::H) {
       return op->emitOpError()
              << "f32x2-to-f16x2 conversion supports rounding r/a/f/c/z/o";
+    }
     return success();
   }
   if (isV2F32(srcType) && isV2BF16(dstType)) {
-    if (rounding == pto::Rounding::O || rounding == pto::Rounding::H)
+    if (rounding == pto::Rounding::O || rounding == pto::Rounding::H) {
       return op->emitOpError()
              << "f32x2-to-bf16x2 conversion supports rounding r/a/f/c/z";
+    }
     return success();
   }
   if ((isV2F16(srcType) || isV2BF16(srcType)) && isV2F32(dstType)) {
-    if (rounding == pto::Rounding::O || rounding == pto::Rounding::H)
+    if (rounding == pto::Rounding::O || rounding == pto::Rounding::H) {
       return op->emitOpError()
              << "packed-to-f32x2 conversion supports rounding r/a/f/c/z";
+    }
     return success();
   }
   if (isV2F32(srcType) && isV2F8(dstType)) {
-    if (rounding != pto::Rounding::R)
+    if (rounding != pto::Rounding::R) {
       return op->emitOpError()
              << "f32x2-to-f8x2 conversion supports rounding r";
+    }
     return success();
   }
   if ((isV2F32(srcType) || isV2F16(srcType)) && isV2HiF8(dstType)) {
-    if (rounding != pto::Rounding::A && rounding != pto::Rounding::H)
+    if (rounding != pto::Rounding::A && rounding != pto::Rounding::H) {
       return op->emitOpError()
              << "f32x2/f16x2-to-hif8x2 conversion supports rounding a/h";
+    }
     return success();
   }
   if ((isV2F8(srcType) || isV2HiF8(srcType)) &&
       (isV2F32(dstType) || isV2F16(dstType))) {
-    if (!isRoundRAFZC(rounding))
+    if (!isRoundRAFZC(rounding)) {
       return op->emitOpError()
              << "f8x2/hif8x2-to-f32x2/f16x2 conversion supports rounding r/a/f/c/z";
+    }
     return success();
   }
   if ((isV2BF16(srcType) && isF4(dstType)) ||
       (isF4(srcType) && isV2BF16(dstType))) {
-    if (!isRoundRAFZC(rounding))
+    if (!isRoundRAFZC(rounding)) {
       return op->emitOpError()
              << "bf16x2-to-f4 and f4-to-bf16x2 conversion supports rounding r/a/f/c/z";
+    }
     return success();
   }
 
@@ -377,10 +393,11 @@ static LogicalResult verifyConvertControls(Operation *op, Type srcType,
                                            pto::Rounding rounding,
                                            pto::Saturation saturation,
                                            Attribute signednessAttr) {
-  if (!isSupportedConvertType(srcType) || !isSupportedConvertType(dstType))
+  if (!isSupportedConvertType(srcType) || !isSupportedConvertType(dstType)) {
     return op->emitOpError()
            << "requires i32, i64, f16, bf16, f32 or supported vector<2xT> "
               "conversion types";
+  }
 
   bool srcInt = isIntegerLikeConvertType(srcType);
   bool dstInt = isIntegerLikeConvertType(dstType);
@@ -389,62 +406,75 @@ static LogicalResult verifyConvertControls(Operation *op, Type srcType,
   bool srcLowPrecision = isSupportedLowPrecisionConvertType(srcType);
   bool dstLowPrecision = isSupportedLowPrecisionConvertType(dstType);
   if (srcPacked || dstPacked || srcLowPrecision || dstLowPrecision) {
-    if (srcInt || dstInt)
+    if (srcInt || dstInt) {
       return op->emitOpError()
              << "does not support mixed integer and packed conversion";
-    if (signednessAttr)
+    }
+    if (signednessAttr) {
       return op->emitOpError()
              << "does not accept signedness for packed floating conversion";
-    if (!((srcPacked || srcLowPrecision) && (dstPacked || dstLowPrecision)))
+    }
+    if (!((srcPacked || srcLowPrecision) && (dstPacked || dstLowPrecision))) {
       return op->emitOpError()
              << "does not support mixed scalar and packed conversion";
+    }
     return verifyPackedConvertControls(op, srcType, dstType, rounding);
   }
 
-  if (srcInt && dstInt)
+  if (srcInt && dstInt) {
     return op->emitOpError()
            << "does not support integer-to-integer conversion";
+  }
 
-  if ((srcInt || dstInt) && !signednessAttr)
+  if ((srcInt || dstInt) && !signednessAttr) {
     return op->emitOpError()
            << "requires signedness when converting to or from integer type";
-  if (!srcInt && !dstInt && signednessAttr)
+  }
+  if (!srcInt && !dstInt && signednessAttr) {
     return op->emitOpError()
            << "does not accept signedness for floating-to-floating conversion";
+  }
 
   if (srcInt) {
-    if (srcType.isInteger(64) && !dstType.isF32())
+    if (srcType.isInteger(mlir::pto::kValue64) && !dstType.isF32()) {
       return op->emitOpError()
              << "supports i64 conversion only to f32 in the confirmed slice";
-    if (srcType.isInteger(32) &&
-        !(dstType.isF32() || dstType.isF16() || dstType.isBF16()))
+    }
+    if (srcType.isInteger(mlir::pto::kValue32) &&
+        !(dstType.isF32() || dstType.isF16() || dstType.isBF16())) {
       return op->emitOpError()
              << "unsupported integer-to-floating conversion type pair";
-    if (rounding == pto::Rounding::O || rounding == pto::Rounding::H)
+    }
+    if (rounding == pto::Rounding::O || rounding == pto::Rounding::H) {
       return op->emitOpError()
              << "integer-to-floating conversion supports rounding r/a/f/c/z";
+    }
     (void)saturation;
     return success();
   }
 
-  if (dstType.isInteger(64) && !srcType.isF32())
+  if (dstType.isInteger(mlir::pto::kValue64) && !srcType.isF32()) {
     return op->emitOpError()
            << "supports conversion to i64 only from f32 in the confirmed slice";
+  }
   if (srcType.isF32()) {
-    if (dstType.isInteger(32) || dstType.isInteger(64)) {
-      if (saturation != pto::Saturation::Enable)
+    if (dstType.isInteger(mlir::pto::kValue32) || dstType.isInteger(64)) {
+      if (saturation != pto::Saturation::Enable) {
         return op->emitOpError()
                << "fp32-to-integer conversion requires saturation enable";
-      if (rounding == pto::Rounding::O || rounding == pto::Rounding::H)
+      }
+      if (rounding == pto::Rounding::O || rounding == pto::Rounding::H) {
         return op->emitOpError()
                << "fp32-to-integer conversion supports rounding r/a/f/c/z";
+      }
       return success();
     }
     if (dstType.isF16() || dstType.isBF16() || dstType.isF32()) {
       if (dstType.isF16()) {
-        if (rounding == pto::Rounding::H)
+        if (rounding == pto::Rounding::H) {
           return op->emitOpError()
                  << "fp32-to-fp16 conversion supports rounding r/a/f/c/z/o";
+        }
       } else if (rounding == pto::Rounding::O ||
                  rounding == pto::Rounding::H) {
         return op->emitOpError()
@@ -455,19 +485,22 @@ static LogicalResult verifyConvertControls(Operation *op, Type srcType,
   }
 
   if (srcType.isF16() || srcType.isBF16()) {
-    if (dstType.isInteger(32)) {
-      if (saturation != pto::Saturation::Enable)
+    if (dstType.isInteger(mlir::pto::kValue32)) {
+      if (saturation != pto::Saturation::Enable) {
         return op->emitOpError()
                << "fp16/bf16-to-integer conversion requires saturation enable";
-      if (rounding == pto::Rounding::O || rounding == pto::Rounding::H)
+      }
+      if (rounding == pto::Rounding::O || rounding == pto::Rounding::H) {
         return op->emitOpError()
                << "fp16/bf16-to-integer conversion supports rounding r/a/f/c/z";
+      }
       return success();
     }
     if (dstType.isF32() || dstType.isF16() || dstType.isBF16()) {
-      if (rounding == pto::Rounding::O || rounding == pto::Rounding::H)
+      if (rounding == pto::Rounding::O || rounding == pto::Rounding::H) {
         return op->emitOpError()
                << "fp16/bf16-to-floating conversion supports rounding r/a/f/c/z";
+      }
       return success();
     }
   }
@@ -477,7 +510,7 @@ static LogicalResult verifyConvertControls(Operation *op, Type srcType,
 
 static bool isSupportedAtomicScalarType(Type type) {
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    return intType.getWidth() == 32 || intType.getWidth() == 64;
+    return intType.getWidth() == mlir::pto::kValue32 || intType.getWidth() == 64;
   }
   return type.isF16() || type.isBF16() || type.isF32() ||
          isVector2F16OrBF16Type(type);
@@ -486,27 +519,30 @@ static bool isSupportedAtomicScalarType(Type type) {
 static LogicalResult verifyAtomicCommon(Operation *op, Value ptr, Type valueType,
                                         Type resultType, bool bitwise,
                                         Attribute signednessAttr) {
-  if (!isSupportedAtomicScalarType(valueType))
+  if (!isSupportedAtomicScalarType(valueType)) {
     return op->emitOpError()
            << "requires i32, i64, f16, bf16, f32, vector<2xf16> or "
               "vector<2xbf16> atomic value type";
-  if (resultType != valueType)
+  }
+  if (resultType != valueType) {
     return op->emitOpError()
            << "requires atomic result type to match value type";
+  }
 
   auto ptrTy = dyn_cast<PtrType>(ptr.getType());
   if (!ptrTy) {
     return op->emitOpError() << "requires !pto.ptr pointer operand";
   }
-  if (ptrTy.getElementType() != valueType)
+  if (ptrTy.getElementType() != valueType) {
     return op->emitOpError()
            << "requires atomic value type to match pointer element type";
+  }
 
   AddressSpace addressSpace = ptrTy.getMemorySpace().getAddressSpace();
   if (addressSpace != AddressSpace::GM && addressSpace != AddressSpace::VEC) {
     return op->emitOpError() << "requires GM or UB pointer";
   }
-  if (addressSpace == AddressSpace::VEC && valueType.isInteger(64)) {
+  if (addressSpace == AddressSpace::VEC && valueType.isInteger(mlir::pto::kValue64)) {
     return op->emitOpError() << "does not support i64 UB-space atomics";
   }
 
@@ -515,23 +551,26 @@ static LogicalResult verifyAtomicCommon(Operation *op, Value ptr, Type valueType
     if (!intType) {
       return op->emitOpError() << "requires integer type for bitwise atomics";
     }
-    if (addressSpace == AddressSpace::VEC && intType.getWidth() == 64) {
+    if (addressSpace == AddressSpace::VEC && intType.getWidth() == mlir::pto::kValue64) {
       return op->emitOpError() << "does not support i64 UB-space bitwise atomics";
     }
   }
 
-  if (signednessAttr && !intType)
+  if (signednessAttr && !intType) {
     return op->emitOpError()
            << "does not accept signedness for floating-point atomics";
+  }
   if (isVector2F16OrBF16Type(valueType)) {
-    if (!isInsideSimtExecutionScope(op))
+    if (!isInsideSimtExecutionScope(op)) {
       return op->emitOpError()
              << "requires packed atomics to be inside a pto.simt_entry "
                 "function or pto.section.simt on beta.1";
-    if (!op->getResult(0).use_empty())
+    }
+    if (!op->getResult(0).use_empty()) {
       return op->emitOpError()
              << "does not support using the old value result for packed "
                 "atomics on beta.1; leave the result unused";
+    }
   }
   return success();
 }
@@ -548,13 +587,14 @@ static LogicalResult verifyLdgStgAccess(Operation *op, Type ptrType,
 
   if (auto intType = dyn_cast<IntegerType>(valueType)) {
     unsigned width = intType.getWidth();
-    if (width == 8 || width == 16 || width == 32 || width == 64) {
+    if (width == mlir::pto::kValue8 || width == 16 || width == 32 || width == 64) {
       return success();
     }
   }
   if (valueType.isF16() || valueType.isBF16() || valueType.isF32() ||
-      valueType.isF64())
+      valueType.isF64()) {
     return success();
+  }
   if (pto::isPTOFloat8Type(valueType) || pto::isPTOHiFloat8Type(valueType)) {
     return success();
   }
@@ -571,9 +611,10 @@ static LogicalResult verifyLdgStgAccess(Operation *op, Type ptrType,
 
 static LogicalResult verifyLdStDevAccess(Operation *op, Type ptrType,
                                          Type valueType) {
-  if (op->hasAttr("l1cache") || op->hasAttr("l2cache"))
+  if (op->hasAttr("l1cache") || op->hasAttr("l2cache")) {
     return op->emitOpError()
            << "does not accept l1cache or l2cache policy attributes";
+  }
 
   auto ptrTy = dyn_cast<PtrType>(ptrType);
   if (!ptrTy) {
@@ -584,72 +625,85 @@ static LogicalResult verifyLdStDevAccess(Operation *op, Type ptrType,
   }
 
   auto intType = dyn_cast<IntegerType>(valueType);
-  if (!intType || (intType.getWidth() != 8 && intType.getWidth() != 16 &&
-                   intType.getWidth() != 32 && intType.getWidth() != 64))
+  if (!intType || (intType.getWidth() != mlir::pto::kValue8 && intType.getWidth() != 16 &&
+                   intType.getWidth() != mlir::pto::kValue32 && intType.getWidth() != 64)) {
     return op->emitOpError() << "supports only i8, i16, i32 or i64 values";
+  }
 
-  if (isInsideSimtExecutionScope(op))
+  if (isInsideSimtExecutionScope(op)) {
     return op->emitOpError()
            << "must be outside pto.simt_entry functions and pto.section.simt";
+  }
   auto funcOp = op->getParentOfType<func::FuncOp>();
-  if (!funcOp || !pto::isPTOEntryFunction(funcOp))
+  if (!funcOp || !pto::isPTOEntryFunction(funcOp)) {
     return op->emitOpError()
            << "requires an enclosing ordinary AICore entry function";
+  }
   return success();
 }
 
 LogicalResult PTOLoadOp::verify() {
   if (failed(verifyVPTOScalarAccessTypes(getOperation(), getPtr().getType(),
-                                         getValue().getType(), "load")))
+                                         getValue().getType(), "load"))) {
     return failure();
+  }
   return success();
 }
 
 LogicalResult PTOStoreOp::verify() {
   if (failed(verifyVPTOScalarAccessTypes(getOperation(), getPtr().getType(),
-                                         getValue().getType(), "store")))
+                                         getValue().getType(), "store"))) {
     return failure();
+  }
   return success();
 }
 
 LogicalResult PTOLdgOp::verify() {
   if (failed(verifyVPTOScalarAccessTypes(getOperation(), getPtr().getType(),
-                                         getValue().getType(), "ldg")))
+                                         getValue().getType(), "ldg"))) {
     return failure();
+  }
   if (failed(verifyLdgStgAccess(getOperation(), getPtr().getType(),
-                                getValue().getType())))
+                                getValue().getType()))) {
     return failure();
-  if (!isInsideSimtExecutionScope(getOperation()))
+  }
+  if (!isInsideSimtExecutionScope(getOperation())) {
     return emitOpError()
            << "must be inside a pto.simt_entry function or pto.section.simt";
+  }
   return success();
 }
 
 LogicalResult PTOStgOp::verify() {
   if (failed(verifyVPTOScalarAccessTypes(getOperation(), getPtr().getType(),
-                                         getValue().getType(), "stg")))
+                                         getValue().getType(), "stg"))) {
     return failure();
+  }
   if (failed(verifyLdgStgAccess(getOperation(), getPtr().getType(),
-                                getValue().getType())))
+                                getValue().getType()))) {
     return failure();
-  if (!isInsideSimtExecutionScope(getOperation()))
+  }
+  if (!isInsideSimtExecutionScope(getOperation())) {
     return emitOpError()
            << "must be inside a pto.simt_entry function or pto.section.simt";
+  }
   return success();
 }
 
 LogicalResult PTOLdDevOp::verify() {
   if (failed(verifyVPTOScalarAccessTypes(getOperation(), getPtr().getType(),
-                                         getValue().getType(), "ld_dev")))
+                                         getValue().getType(), "ld_dev"))) {
     return failure();
+  }
   return verifyLdStDevAccess(getOperation(), getPtr().getType(),
                              getValue().getType());
 }
 
 LogicalResult PTOStDevOp::verify() {
   if (failed(verifyVPTOScalarAccessTypes(getOperation(), getPtr().getType(),
-                                         getValue().getType(), "st_dev")))
+                                         getValue().getType(), "st_dev"))) {
     return failure();
+  }
   return verifyLdStDevAccess(getOperation(), getPtr().getType(),
                              getValue().getType());
 }
@@ -690,9 +744,10 @@ LogicalResult ReduxMinOp::verify() {
 }
 
 LogicalResult MulhiOp::verify() {
-  if (!getResult().getType().isInteger(32) &&
-      !getResult().getType().isInteger(64))
+  if (!getResult().getType().isInteger(mlir::pto::kValue32) &&
+      !getResult().getType().isInteger(mlir::pto::kValue64)) {
     return emitOpError() << "requires i32 or i64 result type";
+  }
   return success();
 }
 
@@ -886,10 +941,11 @@ static bool isSupportedVdupPosition(std::optional<StringRef> position) {
 }
 
 static bool isSupportedMovPadScalarType(Type type) {
-  if (auto intType = dyn_cast<IntegerType>(type))
+  if (auto intType = dyn_cast<IntegerType>(type)) {
     return intType.isSignless() &&
-           (intType.getWidth() == 8 || intType.getWidth() == 16 ||
-            intType.getWidth() == 32);
+           (intType.getWidth() == mlir::pto::kValue8 || intType.getWidth() == 16 ||
+            intType.getWidth() == mlir::pto::kValue32);
+  }
   if (auto floatType = dyn_cast<FloatType>(type)) {
     return floatType.isF16() || floatType.isBF16() || floatType.isF32();
   }
@@ -904,11 +960,11 @@ static bool isMxElementType(Type type) {
 static std::optional<StringRef> getVdupMaskGranularity(Type elementType) {
   if (auto intType = dyn_cast<IntegerType>(elementType)) {
     switch (intType.getWidth()) {
-    case 8:
+    case mlir::pto::kValue8:
       return StringRef("b8");
-    case 16:
+    case mlir::pto::kValue16:
       return StringRef("b16");
-    case 32:
+    case mlir::pto::kValue32:
       return StringRef("b32");
     default:
       return std::nullopt;
@@ -968,7 +1024,7 @@ static FailureOr<Value> resolveStoreAlignRoot(Value value, Operation *user);
 static FailureOr<Value> resolveLoadAlignRoot(Value value, Operation *user);
 
 static FailureOr<Value> resolveStoreAlignRootImpl(
-    Value current, llvm::SmallPtrSet<void *, 8> visited) {
+    Value current, llvm::SmallPtrSet<void *, mlir::pto::kValue8> visited) {
   while (true) {
     if (!visited.insert(current.getAsOpaquePointer()).second) {
       return failure();
@@ -1086,7 +1142,7 @@ static FailureOr<Value> resolveSingleAlignIfResult(scf::IfOp ifOp) {
 }
 
 static LogicalResult verifyStoreAlignLinearUses(Value value, Operation *user) {
-  llvm::SmallPtrSet<void *, 16> visited;
+  llvm::SmallPtrSet<void *, mlir::pto::kValue16> visited;
   Value current = value;
 
   while (visited.insert(current.getAsOpaquePointer()).second) {
@@ -1118,25 +1174,29 @@ static LogicalResult verifyStoreAlignLinearUses(Value value, Operation *user) {
       }
       if (auto forOp = dyn_cast<scf::ForOp>(owner)) {
         unsigned firstInitArg = forOp.getNumControlOperands();
-        if (use.getOperandNumber() < firstInitArg)
+        if (use.getOperandNumber() < firstInitArg) {
           return user->emitOpError()
                  << "found unexpected scf.for control operand use for !pto.align";
+        }
         unsigned iterIdx = use.getOperandNumber() - firstInitArg;
-        if (iterIdx >= forOp.getRegionIterArgs().size())
+        if (iterIdx >= forOp.getRegionIterArgs().size()) {
           return user->emitOpError()
                  << "found invalid scf.for iter_args use for !pto.align";
+        }
         nextValues.push_back(forOp.getRegionIterArgs()[iterIdx]);
         continue;
       }
       if (auto yieldOp = dyn_cast<scf::YieldOp>(owner)) {
         auto forOp = dyn_cast<scf::ForOp>(yieldOp->getParentOp());
-        if (!forOp)
+        if (!forOp) {
           return user->emitOpError()
                  << "found !pto.align yielded from non-scf.for loop";
+        }
         unsigned resultIdx = use.getOperandNumber();
-        if (resultIdx >= forOp.getNumResults())
+        if (resultIdx >= forOp.getNumResults()) {
           return user->emitOpError()
                  << "found invalid scf.yield result mapping for !pto.align";
+        }
         nextValues.push_back(forOp.getResult(resultIdx));
         continue;
       }
@@ -1220,7 +1280,7 @@ static LogicalResult verifyStoreAlignChain(Value align, Operation *user,
 }
 
 static FailureOr<Value> resolveLoadAlignRootImpl(
-    Value current, llvm::SmallPtrSet<void *, 8> visited) {
+    Value current, llvm::SmallPtrSet<void *, mlir::pto::kValue8> visited) {
   while (true) {
     if (!visited.insert(current.getAsOpaquePointer()).second) {
       return failure();
@@ -1317,7 +1377,7 @@ static LogicalResult verifyLoadAlignLoopThreading(Value align, Operation *user,
 }
 
 static LogicalResult verifyLoadAlignLinearUses(Value value, Operation *user) {
-  llvm::SmallPtrSet<void *, 16> visited;
+  llvm::SmallPtrSet<void *, mlir::pto::kValue16> visited;
   Value current = value;
 
   while (visited.insert(current.getAsOpaquePointer()).second) {
@@ -1590,13 +1650,13 @@ static VcvtElemKind classifyVcvtElemType(Type type) {
   }
   if (auto intType = dyn_cast<IntegerType>(type)) {
     switch (intType.getWidth()) {
-    case 8:
+    case mlir::pto::kValue8:
       return intType.isUnsigned() ? VcvtElemKind::U8 : VcvtElemKind::S8;
-    case 16:
+    case mlir::pto::kValue16:
       return intType.isUnsigned() ? VcvtElemKind::U16 : VcvtElemKind::S16;
-    case 32:
+    case mlir::pto::kValue32:
       return intType.isUnsigned() ? VcvtElemKind::U32 : VcvtElemKind::S32;
-    case 64:
+    case mlir::pto::kValue64:
       return intType.isUnsigned() ? VcvtElemKind::Invalid : VcvtElemKind::S64;
     default:
       return VcvtElemKind::Invalid;
@@ -1611,11 +1671,11 @@ static std::optional<unsigned> getVcvtElemBitWidth(VcvtElemKind kind) {
   case VcvtElemKind::BF16:
   case VcvtElemKind::S16:
   case VcvtElemKind::U16:
-    return 16;
+    return mlir::pto::kValue16;
   case VcvtElemKind::F32:
   case VcvtElemKind::S32:
   case VcvtElemKind::U32:
-    return 32;
+    return mlir::pto::kValue32;
   case VcvtElemKind::F8E4M3:
   case VcvtElemKind::F8E5M2:
   case VcvtElemKind::HiF8:
@@ -1623,9 +1683,9 @@ static std::optional<unsigned> getVcvtElemBitWidth(VcvtElemKind kind) {
   case VcvtElemKind::F4E2M1x2:
   case VcvtElemKind::S8:
   case VcvtElemKind::U8:
-    return 8;
+    return mlir::pto::kValue8;
   case VcvtElemKind::S64:
-    return 64;
+    return mlir::pto::kValue64;
   case VcvtElemKind::Invalid:
     return std::nullopt;
   }
@@ -1636,10 +1696,10 @@ static std::optional<VcvtPartFamily> classifyVcvtPartFamily(unsigned srcBits,
                                                             unsigned dstBits) {
   unsigned largerBits = std::max(srcBits, dstBits);
   unsigned smallerBits = std::min(srcBits, dstBits);
-  if (largerBits == smallerBits * 2) {
+  if (largerBits == smallerBits * mlir::pto::kValue2) {
     return VcvtPartFamily::EvenOdd;
   }
-  if (largerBits == smallerBits * 4) {
+  if (largerBits == smallerBits * mlir::pto::kValue4) {
     return VcvtPartFamily::Packed4;
   }
   return std::nullopt;
@@ -1853,13 +1913,13 @@ static std::optional<unsigned> getDistElementWidth(Type type) {
     return intType.getWidth();
   }
   if (type.isF16() || type.isBF16()) {
-    return 16;
+    return mlir::pto::kValue16;
   }
   if (type.isF32()) {
-    return 32;
+    return mlir::pto::kValue32;
   }
   if (type.isF64()) {
-    return 64;
+    return mlir::pto::kValue64;
   }
   return std::nullopt;
 }
@@ -1934,10 +1994,11 @@ static unsigned getIntOrFloatBitWidth(Type type) {
     return floatType.getWidth();
   }
   if (pto::isPTOFloat8Type(type) || pto::isPTOHiFloat8Type(type) ||
-      pto::isPTOFloat4PackedType(type))
-    return 8;
+      pto::isPTOFloat4PackedType(type)) {
+    return mlir::pto::kValue8;
+  }
   if (pto::isPTOHiFloat8x2Type(type)) {
-    return 16;
+    return mlir::pto::kValue16;
   }
   return 0;
 }
@@ -1964,9 +2025,10 @@ static LogicalResult verifyIntegerVRegTypeLike(Operation *op, Type type,
     return failure();
   }
   auto vecType = cast<VRegType>(type);
-  if (!isa<IntegerType>(vecType.getElementType()))
+  if (!isa<IntegerType>(vecType.getElementType())) {
     return op->emitOpError()
            << roleDescription << " must use integer vector element type";
+  }
   return success();
 }
 
@@ -2059,8 +2121,9 @@ static std::optional<AddressSpace> getBufferAddressSpace(Type type) {
   }
   if (auto memrefType = dyn_cast<BaseMemRefType>(type)) {
     if (auto space =
-            dyn_cast_or_null<pto::AddressSpaceAttr>(memrefType.getMemorySpace()))
+            dyn_cast_or_null<pto::AddressSpaceAttr>(memrefType.getMemorySpace())) {
       return space.getAddressSpace();
+    }
     if (auto intSpace = dyn_cast_or_null<IntegerAttr>(memrefType.getMemorySpace())) {
       return static_cast<AddressSpace>(intSpace.getInt());
     }
@@ -2073,8 +2136,9 @@ static LogicalResult verifyCubeBridgeLoadLikeOp(BridgeLoadOp op,
                                                 AddressSpace expectedDstSpace,
                                                 StringRef dstName) {
   if (!isBufferLike(op.getSource().getType()) ||
-      !isBufferLike(op.getDestination().getType()))
+      !isBufferLike(op.getDestination().getType())) {
     return op.emitOpError("requires buffer-like source and destination");
+  }
 
   if (getBufferAddressSpace(op.getSource().getType()) != AddressSpace::MAT) {
     return op.emitOpError("requires MAT source");
@@ -2114,13 +2178,13 @@ static ParseResult parseDmaTripleGroup(
   if (parser.parseKeyword(keyword) || parser.parseLParen()) {
     return failure();
   }
-  for (int i = 0; i < 3; ++i) {
+  for (int i = 0; i < mlir::pto::kValue3; ++i) {
     OpAsmParser::UnresolvedOperand operand;
     if (parser.parseOperand(operand)) {
       return failure();
     }
     operands.push_back(operand);
-    if (i != 2 && parser.parseComma()) {
+    if (i != mlir::pto::kValue2 && parser.parseComma()) {
       return failure();
     }
   }
@@ -2140,13 +2204,13 @@ static ParseResult parseOptionalDmaTripleGroupAlias(
     if (parser.parseLParen()) {
       return failure();
     }
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < mlir::pto::kValue3; ++i) {
       OpAsmParser::UnresolvedOperand operand;
       if (parser.parseOperand(operand)) {
         return failure();
       }
       operands.push_back(operand);
-      if (i != 2 && parser.parseComma()) {
+      if (i != mlir::pto::kValue2 && parser.parseComma()) {
         return failure();
       }
     }
@@ -2170,13 +2234,13 @@ static bool isDmaLoopKeyword(StringRef keyword) {
 
 static ParseResult parseDmaTripleTypes(OpAsmParser &parser,
                                        SmallVectorImpl<Type> &types) {
-  for (int i = 0; i < 3; ++i) {
+  for (int i = 0; i < mlir::pto::kValue3; ++i) {
     Type type;
     if (parser.parseType(type)) {
       return failure();
     }
     types.push_back(type);
-    if (i != 2 && parser.parseComma()) {
+    if (i != mlir::pto::kValue2 && parser.parseComma()) {
       return failure();
     }
   }
@@ -2194,8 +2258,9 @@ static ParseResult parseDmaPadTypes(OpAsmParser &parser,
     Type leftType;
     Type rightType;
     if (parser.parseType(leftType) || parser.parseComma() ||
-        parser.parseType(rightType))
+        parser.parseType(rightType)) {
       return failure();
+    }
     types.push_back(leftType);
     types.push_back(rightType);
   }
@@ -2350,9 +2415,10 @@ static FailureOr<AccStoreMode> parseAccStoreModeKeyword(StringRef keyword) {
   if (parser.parseKeyword(&modeKeyword)) {
     return failure();
   }
-  if (failed(parseAccStoreModeKeyword(modeKeyword)))
+  if (failed(parseAccStoreModeKeyword(modeKeyword))) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expected one of 'nz2nd', 'nz2dn', or 'nz2nz'");
+  }
   auto parseModeOperandWithParens = [&]() -> ParseResult {
     OpAsmParser::UnresolvedOperand operand;
     if (parser.parseLParen() || parser.parseOperand(operand) || parser.parseRParen()) {
@@ -2493,14 +2559,15 @@ parseAccStoreModeTypes(OpAsmParser &parser, StringRef modeKeyword,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &loop3SrcStrideOperands,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &loop3DstStrideOperands) {
   StringRef parsedKeyword;
-  SmallVector<OpAsmParser::UnresolvedOperand, 3> loop3Operands;
+  SmallVector<OpAsmParser::UnresolvedOperand, mlir::pto::kValue3> loop3Operands;
   if (parseOptionalDmaTripleGroupAlias(parser, {"loop3"}, parsedKeyword,
-                                       loop3Operands))
+                                       loop3Operands)) {
     return failure();
+  }
   if (!parsedKeyword.empty()) {
     loop3CountOperands.push_back(loop3Operands[0]);
     loop3SrcStrideOperands.push_back(loop3Operands[1]);
-    loop3DstStrideOperands.push_back(loop3Operands[2]);
+    loop3DstStrideOperands.push_back(loop3Operands[mlir::pto::kValue2]);
   }
   return success();
 }
@@ -2554,12 +2621,13 @@ printMteL0cL1OptionalFpcType(OpAsmPrinter &printer, Type fpcType) {
     }
     loop3CountTypes.push_back(loop3GroupTypes[0]);
     loop3SrcStrideTypes.push_back(loop3GroupTypes[1]);
-    loop3DstStrideTypes.push_back(loop3GroupTypes[2]);
-    if (succeeded(parser.parseOptionalComma()))
+    loop3DstStrideTypes.push_back(loop3GroupTypes[mlir::pto::kValue2]);
+    if (succeeded(parser.parseOptionalComma())) {
       return parser.emitError(parser.getCurrentLocation(),
                               (Twine(opName) +
                                " accepts at most one loop3 group")
                                   .str());
+    }
   }
   return success();
 }
@@ -2683,8 +2751,9 @@ static bool isStructuredAccStoreScalingPayload(Value value) {
 static Type getStructuredAccStoreScalingElementType(Value value) {
   auto ptrType = dyn_cast_or_null<PtrType>(value.getType());
   if (!ptrType ||
-      ptrType.getMemorySpace().getAddressSpace() != AddressSpace::SCALING)
+      ptrType.getMemorySpace().getAddressSpace() != AddressSpace::SCALING) {
     return {};
+  }
   return ptrType.getElementType();
 }
 
@@ -2694,7 +2763,7 @@ static Type getStructuredAccStoreScalingElementType(Value value) {
 
 static bool isStructuredAccStoreClipPayloadForUInt8(Type type) {
   auto intType = dyn_cast<IntegerType>(type);
-  if (!intType || intType.getWidth() != 16) {
+  if (!intType || intType.getWidth() != mlir::pto::kValue16) {
     return false;
   }
   return intType.isUnsigned() || intType.isSignless();
@@ -2706,7 +2775,7 @@ static bool isStructuredAccStoreClipPayloadForSignedInt(Type type) {
     return false;
   }
   unsigned width = intType.getWidth();
-  if (width != 4 && width != 8 && width != 16) {
+  if (width != mlir::pto::kValue4 && width != 8 && width != 16) {
     return false;
   }
   return intType.isSigned() || intType.isSignless();
@@ -2732,15 +2801,17 @@ static bool isStructuredAccStoreClipSupportedElementType(Type type) {
   if (!intType) {
     return false;
   }
-  if (intType.isUnsignedInteger(8)) {
+  if (intType.isUnsignedInteger(mlir::pto::kValue8)) {
     return true;
   }
-  if (intType.isSignlessInteger(4) || intType.isSignlessInteger(8) ||
-      intType.isSignlessInteger(16))
+  if (intType.isSignlessInteger(mlir::pto::kValue4) || intType.isSignlessInteger(8) ||
+      intType.isSignlessInteger(mlir::pto::kValue16)) {
     return true;
-  if (intType.isSignedInteger(4) || intType.isSignedInteger(8) ||
-      intType.isSignedInteger(16))
+  }
+  if (intType.isSignedInteger(mlir::pto::kValue4) || intType.isSignedInteger(8) ||
+      intType.isSignedInteger(16)) {
     return true;
+  }
   return false;
 }
 
@@ -2760,21 +2831,25 @@ static LogicalResult verifyStructuredAccStoreClipPayload(Operation *op,
   }
 
   auto intType = dyn_cast<IntegerType>(destinationElementType);
-  if (!intType)
+  if (!intType) {
     return op->emitOpError()
            << "clip requires destination element type to be f16, ui8, or signed 4/8/16-bit integer, got "
            << destinationElementType;
+  }
 
-  if (intType.isUnsignedInteger(8)) {
+  if (intType.isUnsignedInteger(mlir::pto::kValue8)) {
     if (!isStructuredAccStoreClipPayloadForUInt8(clipType)) {
       return op->emitOpError("clip for ui8 destination requires ui16/signless i16 payload");
     }
     return success();
   }
 
-  if (intType.isSignlessInteger(4) || intType.isSignlessInteger(8) ||
-      intType.isSignlessInteger(16) || intType.isSignedInteger(4) ||
-      intType.isSignedInteger(8) || intType.isSignedInteger(16)) {
+  if (intType.isSignlessInteger(mlir::pto::kValue4) ||
+      intType.isSignlessInteger(mlir::pto::kValue8) ||
+      intType.isSignlessInteger(mlir::pto::kValue16) ||
+      intType.isSignedInteger(mlir::pto::kValue4) ||
+      intType.isSignedInteger(mlir::pto::kValue8) ||
+      intType.isSignedInteger(mlir::pto::kValue16)) {
     if (!isStructuredAccStoreClipPayloadForSignedInt(clipType)) {
       return op->emitOpError("clip for signed 4/8/16-bit destination requires signed/signless i4/i8/i16 payload");
     }
@@ -2914,22 +2989,22 @@ static bool isStructuredAccStoreDestinationFamily(
     return type.isBF16();
   case StructuredAccStoreDestinationFamily::I32:
     if (auto intType = dyn_cast<IntegerType>(type)) {
-      return intType.getWidth() == 32;
+      return intType.getWidth() == mlir::pto::kValue32;
     }
     return false;
   case StructuredAccStoreDestinationFamily::I16:
     if (auto intType = dyn_cast<IntegerType>(type)) {
-      return intType.getWidth() == 16 && !intType.isUnsigned();
+      return intType.getWidth() == mlir::pto::kValue16 && !intType.isUnsigned();
     }
     return false;
   case StructuredAccStoreDestinationFamily::I8:
     if (auto intType = dyn_cast<IntegerType>(type)) {
-      return intType.getWidth() == 8;
+      return intType.getWidth() == mlir::pto::kValue8;
     }
     return false;
   case StructuredAccStoreDestinationFamily::I4:
     if (auto intType = dyn_cast<IntegerType>(type)) {
-      return intType.getWidth() == 4 && !intType.isUnsigned();
+      return intType.getWidth() == mlir::pto::kValue4 && !intType.isUnsigned();
     }
     return false;
   case StructuredAccStoreDestinationFamily::FP8:
@@ -2954,9 +3029,10 @@ static ParseResult parseStructuredAccStoreUnitFlag(OpAsmParser &parser,
   else if (keyword == "check_and_clear") {
     state.unitFlag = AccStoreUnitFlagCtrl::CheckAndClear;
   }
-  else
+  else {
     return parser.emitError(parser.getCurrentLocation(),
                             "expected 'check_only' or 'check_and_clear'");
+}
   return success();
 }
 
@@ -2969,8 +3045,9 @@ static ParseResult parseStructuredAccStorePreQuant(
   StringRef modeKeyword;
   if (parser.parseLParen() || parser.parseOperand(payload) || parser.parseComma() ||
       parser.parseKeyword("mode") || parser.parseEqual() ||
-      parser.parseKeyword(&modeKeyword) || parser.parseRParen())
+      parser.parseKeyword(&modeKeyword) || parser.parseRParen()) {
     return failure();
+  }
   auto mode = symbolizeAccStoreQuantPreMode(modeKeyword);
   if (!mode) {
     return parser.emitError(parser.getCurrentLocation(), "invalid pre_quant mode");
@@ -2994,8 +3071,9 @@ static ParseResult parseStructuredAccStorePreRelu(
   if (failed(parser.parseOptionalKeyword("mode"))) {
     hasPayload = true;
     if (parser.parseOperand(payload) || parser.parseComma() ||
-        parser.parseKeyword("mode"))
+        parser.parseKeyword("mode")) {
       return failure();
+    }
   }
   if (parser.parseEqual() || parser.parseKeyword(&modeKeyword)) {
     return failure();
@@ -3008,9 +3086,10 @@ static ParseResult parseStructuredAccStorePreRelu(
     if (parser.parseKeyword("clip") || parser.parseEqual()) {
       return failure();
     }
-    if (!state.clipValueOperands.empty())
+    if (!state.clipValueOperands.empty()) {
       return parser.emitError(parser.getCurrentLocation(),
                               "duplicate clip payload in pre_relu clause");
+    }
     OpAsmParser::UnresolvedOperand clipValue;
     if (parser.parseOperand(clipValue)) {
       return failure();
@@ -3031,9 +3110,10 @@ static ParseResult parseStructuredAccStorePreRelu(
 static ParseResult parseStructuredAccStoreLayout(
     OpAsmParser &parser, StructuredAccStoreAsmState &state, StringRef keyword) {
   auto mode = parseAccStoreModeKeyword(keyword);
-  if (failed(mode))
+  if (failed(mode)) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expected one of 'nz2nd', 'nz2dn', or 'nz2nz'");
+  }
   if (state.mode) {
     return parser.emitError(parser.getCurrentLocation(), "duplicate layout clause");
   }
@@ -3068,8 +3148,9 @@ static ParseResult parseStructuredAccStoreLoop3(
   OpAsmParser::UnresolvedOperand dstStride;
   if (parser.parseLParen() || parser.parseOperand(count) || parser.parseComma() ||
       parser.parseOperand(srcStride) || parser.parseComma() ||
-      parser.parseOperand(dstStride) || parser.parseRParen())
+      parser.parseOperand(dstStride) || parser.parseRParen()) {
     return failure();
+  }
   state.loop3CountOperands.push_back(count);
   state.loop3SrcStrideOperands.push_back(srcStride);
   state.loop3DstStrideOperands.push_back(dstStride);
@@ -3086,8 +3167,9 @@ static ParseResult parseStructuredAccStoreAtomic(
   if (parser.parseLParen() || parser.parseKeyword("type") || parser.parseEqual() ||
       parser.parseKeyword(&typeKeyword) || parser.parseComma() ||
       parser.parseKeyword("op") || parser.parseEqual() ||
-      parser.parseKeyword(&opKeyword) || parser.parseRParen())
+      parser.parseKeyword(&opKeyword) || parser.parseRParen()) {
     return failure();
+  }
   auto type = symbolizeAccStoreAtomicType(typeKeyword);
   auto op = symbolizeAccStoreAtomicOp(opKeyword);
   if (!type) {
@@ -3143,8 +3225,9 @@ static ParseResult parseStructuredAccStoreClauses(
     else if (keyword == "atomic") {
       kind = StructuredAccStoreClauseKind::Atomic;
     }
-    else
+    else {
       return parser.emitError(parser.getCurrentLocation(), "unknown mte_l0c clause");
+}
 
     if (static_cast<int>(kind) < lastClause) {
       return parser.emitError(parser.getCurrentLocation(),
@@ -3179,9 +3262,10 @@ static ParseResult parseStructuredAccStoreClauses(
       }
       if (succeeded(parser.parseOptionalLParen())) {
         StringRef satOption;
-        if (parser.parseKeyword(&satOption) || satOption != "preserve_nan")
+        if (parser.parseKeyword(&satOption) || satOption != "preserve_nan") {
           return parser.emitError(parser.getCurrentLocation(),
                                   "expected preserve_nan");
+        }
         if (parser.parseRParen()) {
           return failure();
         }
@@ -3245,9 +3329,10 @@ static LogicalResult verifyStructuredAccStoreLike(
         return op->emitOpError("vector pre_quant mode requires scaling pointer payload");
       }
       if (!isStructuredAccStoreFloatScalarPayloadType(
-              getStructuredAccStoreScalingElementType(preQuant)))
+              getStructuredAccStoreScalingElementType(preQuant))) {
         return op->emitOpError(
             "vector pre_quant mode requires scaling pointer element type to be f16, bf16, or f32");
+      }
     } else if (!isStructuredAccStoreFloatScalarPayload(preQuant)) {
       return op->emitOpError(
           "scalar pre_quant mode requires f16/bf16/f32 payload");
@@ -3265,7 +3350,7 @@ static LogicalResult verifyStructuredAccStoreLike(
         if (!isStructuredAccStoreFloatPreQuantMode(*preQuantMode)) {
           return emitIncompatibleQuantModeError();
         }
-      } else if (sourceElementType.isSignlessInteger(32)) {
+      } else if (sourceElementType.isSignlessInteger(mlir::pto::kValue32)) {
         if (!isStructuredAccStoreInt32PreQuantMode(*preQuantMode)) {
           return emitIncompatibleQuantModeError();
         }
@@ -3278,18 +3363,21 @@ static LogicalResult verifyStructuredAccStoreLike(
       StructuredAccStoreDestinationFamily destinationFamily =
           getStructuredAccStorePreQuantDestinationFamily(*preQuantMode);
       if (!isStructuredAccStoreDestinationFamily(destinationElementType,
-                                                destinationFamily))
+                                                 destinationFamily)) {
         return emitIncompatibleQuantModeError();
+      }
     }
   }
 
-  if (clipValue && !isStructuredAccStoreClipSupportedElementType(destinationElementType))
+  if (clipValue && !isStructuredAccStoreClipSupportedElementType(destinationElementType)) {
     return op->emitOpError()
            << "clip requires destination element type to be f16, ui8, or signed 4/8/16-bit integer, got "
            << destinationElementType;
+  }
   if (failed(verifyStructuredAccStoreClipPayload(op, destinationElementType,
-                                                 clipValue)))
+                                                 clipValue))) {
     return failure();
+  }
 
   if (!preReluMode) {
     if (preRelu) {
@@ -3326,9 +3414,10 @@ static LogicalResult verifyStructuredAccStoreLike(
         return op->emitOpError("vector_relu requires scaling pointer payload");
       }
       if (!isStructuredAccStoreFloatScalarPayloadType(
-              getStructuredAccStoreScalingElementType(preRelu)))
+              getStructuredAccStoreScalingElementType(preRelu))) {
         return op->emitOpError(
             "vector_relu requires scaling pointer element type to be f16, bf16, or f32");
+      }
       break;
     case ReluPreMode::Pwl:
       return op->emitOpError("pwl is not supported for target_profile mte_l0c_l1");
@@ -3385,8 +3474,9 @@ static LogicalResult verifyStructuredAccStoreLike(
         return op->emitOpError("loop3 requires nz2nd or nz2dn");
       }
       if (!isa<FloatType>(destinationElementType) ||
-          !cast<FloatType>(destinationElementType).isF32())
+          !cast<FloatType>(destinationElementType).isF32()) {
         return op->emitOpError("nz2nz requires destination element type to be f32");
+      }
       break;
     }
   }
@@ -3493,41 +3583,48 @@ static void printStructuredAccStoreOptionalTypes(
   if (loop0SrcStride) {
     printer << ", " << loop0SrcStride.getType();
   }
-  if (loop3Count)
+  if (loop3Count) {
     printer << ", " << loop3Count.getType() << ", " << loop3SrcStride.getType()
             << ", " << loop3DstStride.getType();
+  }
 }
 
 static ParseResult parseStructuredAccStoreTailTypes(
     OpAsmParser &parser, StructuredAccStoreAsmState &state) {
   if (!state.preQuantOperands.empty() &&
       (parser.parseComma() ||
-       parseStructuredOptionalType(parser, state.preQuantTypes)))
+       parseStructuredOptionalType(parser, state.preQuantTypes))) {
     return failure();
+  }
   if (!state.preReluOperands.empty() &&
       (parser.parseComma() ||
-       parseStructuredOptionalType(parser, state.preReluTypes)))
+       parseStructuredOptionalType(parser, state.preReluTypes))) {
     return failure();
+  }
   if (!state.clipValueOperands.empty() &&
       (parser.parseComma() ||
-       parseStructuredOptionalType(parser, state.clipValueTypes)))
+       parseStructuredOptionalType(parser, state.clipValueTypes))) {
     return failure();
+  }
   if (!state.splitOperands.empty() &&
       (parser.parseComma() ||
-       parseStructuredOptionalType(parser, state.splitTypes)))
+       parseStructuredOptionalType(parser, state.splitTypes))) {
     return failure();
+  }
   if (!state.loop0SrcStrideOperands.empty() &&
       (parser.parseComma() ||
-       parseStructuredOptionalType(parser, state.loop0SrcStrideTypes)))
+       parseStructuredOptionalType(parser, state.loop0SrcStrideTypes))) {
     return failure();
+  }
   if (!state.loop3CountOperands.empty() &&
       (parser.parseComma() ||
        parseStructuredOptionalType(parser, state.loop3CountTypes) ||
        parser.parseComma() ||
        parseStructuredOptionalType(parser, state.loop3SrcStrideTypes) ||
        parser.parseComma() ||
-       parseStructuredOptionalType(parser, state.loop3DstStrideTypes)))
+       parseStructuredOptionalType(parser, state.loop3DstStrideTypes))) {
     return failure();
+  }
   return success();
 }
 
@@ -3543,33 +3640,40 @@ template <typename OpTy>
 static void addStructuredAccStoreAttrs(OperationState &result,
                                        Builder &builder,
                                        const StructuredAccStoreAsmState &state) {
-  if (state.mode)
+  if (state.mode) {
     result.addAttribute("mode", AccStoreModeAttr::get(builder.getContext(),
                                                       *state.mode));
-  if (state.unitFlag)
+  }
+  if (state.unitFlag) {
     result.addAttribute("unit_flag",
                         AccStoreUnitFlagCtrlAttr::get(builder.getContext(),
                                                       *state.unitFlag));
-  if (state.preQuantMode)
+  }
+  if (state.preQuantMode) {
     result.addAttribute("pre_quant_mode",
                         AccStoreQuantPreModeAttr::get(builder.getContext(),
                                                       *state.preQuantMode));
-  if (state.preReluMode)
+  }
+  if (state.preReluMode) {
     result.addAttribute("pre_relu_mode",
                         ReluPreModeAttr::get(builder.getContext(),
                                              *state.preReluMode));
-  if (state.atomicType)
+  }
+  if (state.atomicType) {
     result.addAttribute("atomic_type",
                         AccStoreAtomicTypeAttr::get(builder.getContext(),
                                                     *state.atomicType));
-  if (state.atomicOp)
+  }
+  if (state.atomicOp) {
     result.addAttribute("atomic_op",
                         AccStoreAtomicOpAttr::get(builder.getContext(),
                                                   *state.atomicOp));
-  if (state.satMode)
+  }
+  if (state.satMode) {
     result.addAttribute("sat_mode",
                         AccStoreSatModeAttr::get(builder.getContext(),
                                                  *state.satMode));
+  }
 }
 
 [[maybe_unused]] static ParseResult resolveStructuredMteL0cL1OptionalOperands(
@@ -3594,13 +3698,15 @@ static void addStructuredAccStoreAttrs(OperationState &result,
                              result.operands) ||
       parser.resolveOperands(state.loop3DstStrideOperands,
                              state.loop3DstStrideTypes, location,
-                             result.operands))
+                             result.operands)) {
     return failure();
+  }
 
   auto extractResolved = [&](SmallVectorImpl<OpAsmParser::UnresolvedOperand> &ops,
                              SmallVectorImpl<Type> &types) -> Value {
-    if (ops.empty())
+    if (ops.empty()) {
       return {};
+    }
     return result.operands[resolvedOperands.size()];
   };
   resolvedOperands.push_back(extractResolved(state.preQuantOperands,
@@ -3625,9 +3731,10 @@ static void addStructuredAccStoreAttrs(OperationState &result,
 template <typename CopyOp>
 static LogicalResult verifyCopyGmToUbufOp(CopyOp op, bool expectSourceGM) {
   if (!isBufferLike(op.getSource().getType()) ||
-      !isBufferLike(op.getDestination().getType()))
+      !isBufferLike(op.getDestination().getType())) {
     return op.emitOpError(
         "requires typed !pto.ptr or memref source and destination");
+  }
 
   MemoryRole sourceRole = classifyMemoryRole(op.getSource().getType());
   MemoryRole destinationRole = classifyMemoryRole(op.getDestination().getType());
@@ -3669,9 +3776,10 @@ static LogicalResult verifyOptionalDmaLoopGroup(DmaOp op, Value count,
                 static_cast<bool>(dstStride);
   bool hasAll = static_cast<bool>(count) && static_cast<bool>(srcStride) &&
                 static_cast<bool>(dstStride);
-  if (hasAny && !hasAll)
+  if (hasAny && !hasAll) {
     return op.emitOpError() << "requires " << name
                             << " group to provide count, src stride, and dst stride together";
+  }
   return success();
 }
 
@@ -3680,18 +3788,20 @@ static LogicalResult verifyDmaLoadStoreLoopGroups(Operation *op,
                                                   ValueRange loopSrcStrides,
                                                   ValueRange loopDstStrides) {
   if (loopCounts.size() != loopSrcStrides.size() ||
-      loopCounts.size() != loopDstStrides.size())
+      loopCounts.size() != loopDstStrides.size()) {
     return op->emitOpError()
            << "requires each loop group to provide count, src stride, and dst stride together";
+  }
   return success();
 }
 
 template <typename CopyOp>
 static LogicalResult verifyCopyUbufToGmOp(CopyOp op, bool expectSourceGM) {
   if (!isBufferLike(op.getSource().getType()) ||
-      !isBufferLike(op.getDestination().getType()))
+      !isBufferLike(op.getDestination().getType())) {
     return op.emitOpError(
         "requires typed !pto.ptr or memref source and destination");
+  }
 
   MemoryRole sourceRole = classifyMemoryRole(op.getSource().getType());
   MemoryRole destinationRole = classifyMemoryRole(op.getDestination().getType());
@@ -3727,13 +3837,15 @@ static LogicalResult verifyCopyUbufToGmOp(CopyOp op, bool expectSourceGM) {
 template <typename CopyOp>
 static LogicalResult verifyCopyCbufToUbufLikeOp(CopyOp op) {
   if (!isBufferLike(op.getSource().getType()) ||
-      !isBufferLike(op.getDestination().getType()))
+      !isBufferLike(op.getDestination().getType())) {
     return op.emitOpError(
         "requires typed !pto.ptr or memref source and destination");
+  }
 
   if (classifyMemoryRole(op.getSource().getType()) != MemoryRole::Other ||
-      classifyMemoryRole(op.getDestination().getType()) != MemoryRole::UB)
+      classifyMemoryRole(op.getDestination().getType()) != MemoryRole::UB) {
     return op.emitOpError("requires CBUF source and UB destination");
+  }
 
   int64_t sourceElemBytes = getBufferElementByteSize(op.getSource().getType());
   int64_t destinationElemBytes =
@@ -3757,8 +3869,9 @@ Type VRegType::parse(AsmParser &parser) {
       failed(parser.parseDimensionList(shape, /*allowDynamic=*/false,
                                        /*withTrailingX=*/true)) ||
       shape.size() != 1 || failed(parser.parseType(elementType)) ||
-      failed(parser.parseGreater()))
+      failed(parser.parseGreater())) {
     return {};
+  }
 
   return parser.getChecked<VRegType>(loc, parser.getContext(), shape.front(),
                                     elementType);
@@ -3772,9 +3885,10 @@ void VRegType::print(AsmPrinter &printer) const {
 
 LogicalResult VRegType::verify(function_ref<InFlightDiagnostic()> emitError,
                               int64_t elementCount, Type elementType) {
-  if (elementCount <= 0)
+  if (elementCount <= 0) {
     return emitError() << "'" << formatVRegType(elementCount, elementType)
                        << "' expected a positive element count";
+  }
 
   auto intOrFloat = mlir::dyn_cast<IntegerType>(elementType);
   unsigned elementBitWidth = 0;
@@ -3790,9 +3904,10 @@ LogicalResult VRegType::verify(function_ref<InFlightDiagnostic()> emitError,
                           "low-precision element type";
   }
 
-  if (elementCount * static_cast<int64_t>(elementBitWidth) != 2048)
+  if (elementCount * static_cast<int64_t>(elementBitWidth) != mlir::pto::kValue2048) {
     return emitError() << "'" << formatVRegType(elementCount, elementType)
                        << "' expected exactly 256 bytes";
+  }
 
   return success();
 }
@@ -3822,9 +3937,10 @@ LogicalResult VecScopeOp::verify() {
   }
 
   Block &body = bodyRegion.front();
-  if (body.getNumArguments() != 0)
+  if (body.getNumArguments() != 0) {
     return emitOpError() << "expects body block to have no arguments, got "
                          << body.getNumArguments();
+  }
 
   Operation *boundaryOp = nullptr;
   bodyRegion.walk([&](Operation *op) {
@@ -3848,20 +3964,22 @@ LogicalResult StrictVecScopeOp::verify() {
   }
 
   Block &body = bodyRegion.front();
-  if (body.getNumArguments() != getCaptures().size())
+  if (body.getNumArguments() != getCaptures().size()) {
     return emitOpError() << "expects body block to have "
                          << getCaptures().size()
                          << " arguments to match explicit captures, got "
                          << body.getNumArguments();
+  }
 
   for (auto [idx, pair] :
        llvm::enumerate(llvm::zip(body.getArguments(), getCaptures()))) {
     BlockArgument blockArg = std::get<0>(pair);
     Value capture = std::get<1>(pair);
-    if (blockArg.getType() != capture.getType())
+    if (blockArg.getType() != capture.getType()) {
       return emitOpError() << "expects body block argument #" << idx
                            << " to have type " << capture.getType()
                            << ", got " << blockArg.getType();
+    }
   }
 
   Operation *boundaryOp = nullptr;
@@ -3887,8 +4005,9 @@ Type MaskType::parse(AsmParser &parser) {
   auto loc = parser.getCurrentLocation();
   StringRef granularity;
   if (failed(parser.parseLess()) || failed(parser.parseKeyword(&granularity)) ||
-      failed(parser.parseGreater()))
+      failed(parser.parseGreater())) {
     return {};
+  }
 
   return parser.getChecked<MaskType>(loc, parser.getContext(), granularity);
 }
@@ -3900,9 +4019,10 @@ void MaskType::print(AsmPrinter &printer) const {
 LogicalResult
 MaskType::verify(function_ref<InFlightDiagnostic()> emitError,
                  StringRef granularity) {
-  if (!isSupportedGranularity(granularity))
+  if (!isSupportedGranularity(granularity)) {
     return emitError() << "'" << formatMaskType(granularity)
                        << "' expected granularity to be one of b8, b16, b32";
+  }
   return success();
 }
 
@@ -3939,8 +4059,9 @@ void MteGmUbOp::build(OpBuilder &builder, OperationState &state, Value source,
          "mte_gm_ub pad config must provide both left and right counts, or omit both");
   if (pad) {
     state.addOperands(pad->value);
-    if (hasPadCounts)
+    if (hasPadCounts) {
       state.addOperands({pad->leftCount, pad->rightCount});
+    }
   }
 
   state.addAttribute(
@@ -3981,8 +4102,9 @@ ParseResult MteGmUbOp::parse(OpAsmParser &parser, OperationState &result) {
       parseRequiredOperandWithComma(parser, destination) ||
       parseRequiredOperandWithComma(parser, l2CacheCtl) ||
       parser.parseOperand(lenBurst) ||
-      parseDmaTripleGroup(parser, "nburst", nburstOperands))
+      parseDmaTripleGroup(parser, "nburst", nburstOperands)) {
     return failure();
+  }
   while (true) {
     if (succeeded(parser.parseOptionalKeyword("pad"))) {
       if (parser.parseLParen()) {
@@ -3997,8 +4119,9 @@ ParseResult MteGmUbOp::parse(OpAsmParser &parser, OperationState &result) {
         OpAsmParser::UnresolvedOperand left;
         OpAsmParser::UnresolvedOperand right;
         if (parser.parseOperand(left) || parser.parseComma() ||
-            parser.parseOperand(right))
+            parser.parseOperand(right)) {
           return failure();
+        }
         padOperands.push_back(left);
         padOperands.push_back(right);
       }
@@ -4009,16 +4132,17 @@ ParseResult MteGmUbOp::parse(OpAsmParser &parser, OperationState &result) {
     }
 
     StringRef parsedKeyword;
-    SmallVector<OpAsmParser::UnresolvedOperand, 3> loopGroupOperands;
+    SmallVector<OpAsmParser::UnresolvedOperand, mlir::pto::kValue3> loopGroupOperands;
     if (parseOptionalDmaTripleGroupAlias(parser, {"loop", "loop1", "loop2"},
-                                         parsedKeyword, loopGroupOperands))
+                                         parsedKeyword, loopGroupOperands)) {
       return failure();
+    }
     if (parsedKeyword.empty()) {
       break;
     }
     loopCountOperands.push_back(loopGroupOperands[0]);
     loopSrcStrideOperands.push_back(loopGroupOperands[1]);
-    loopDstStrideOperands.push_back(loopGroupOperands[2]);
+    loopDstStrideOperands.push_back(loopGroupOperands[mlir::pto::kValue2]);
   }
 
   if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
@@ -4032,8 +4156,9 @@ ParseResult MteGmUbOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.parseType(destinationType) || parser.parseComma() ||
       parser.parseType(l2CacheCtlType) || parser.parseComma() ||
       parser.parseType(lenBurstType) || parser.parseComma() ||
-      parseDmaTripleTypes(parser, nburstTypes))
+      parseDmaTripleTypes(parser, nburstTypes)) {
     return failure();
+  }
   while (succeeded(parser.parseOptionalComma())) {
     StringRef keyword;
     if (parser.parseKeyword(&keyword)) {
@@ -4046,7 +4171,7 @@ ParseResult MteGmUbOp::parse(OpAsmParser &parser, OperationState &result) {
       }
       loopCountTypes.push_back(loopGroupTypes[0]);
       loopSrcStrideTypes.push_back(loopGroupTypes[1]);
-      loopDstStrideTypes.push_back(loopGroupTypes[2]);
+      loopDstStrideTypes.push_back(loopGroupTypes[mlir::pto::kValue2]);
       continue;
     }
     if (keyword == "pad") {
@@ -4063,12 +4188,14 @@ ParseResult MteGmUbOp::parse(OpAsmParser &parser, OperationState &result) {
   if (loopCountOperands.size() != loopSrcStrideOperands.size() ||
       loopCountOperands.size() != loopDstStrideOperands.size() ||
       loopCountTypes.size() != loopSrcStrideTypes.size() ||
-      loopCountTypes.size() != loopDstStrideTypes.size())
+      loopCountTypes.size() != loopDstStrideTypes.size()) {
     return parser.emitError(parser.getCurrentLocation(),
                             "requires each loop group to provide count, src stride, and dst stride");
-  if (loopCountOperands.size() != loopCountTypes.size())
+  }
+  if (loopCountOperands.size() != loopCountTypes.size()) {
     return parser.emitError(parser.getCurrentLocation(),
                             "requires loop operand and type groups to match");
+  }
 
   auto &segments =
       result.getOrAddProperties<MteGmUbOp::Properties>().operandSegmentSizes;
@@ -4093,8 +4220,9 @@ ParseResult MteGmUbOp::parse(OpAsmParser &parser, OperationState &result) {
                              parser.getCurrentLocation(),
                              result.operands) ||
       parser.resolveOperands(padOperands, padTypes, parser.getCurrentLocation(),
-                             result.operands))
+                             result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -4104,11 +4232,13 @@ void MteGmUbOp::print(OpAsmPrinter &printer) {
   printDmaTripleGroup(printer, "nburst", getNBurst(), getNburstSrcStride(),
                       getNburstDstStride());
   for (auto [count, srcStride, dstStride] :
-       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides()))
+       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides())) {
     printDmaTripleGroup(printer, "loop", count, srcStride, dstStride);
-  if (getPadValue())
+  }
+  if (getPadValue()) {
     printDmaPadGroup(printer, getPadValue(), getLeftPaddingCount(),
                      getRightPaddingCount());
+  }
   printer.printOptionalAttrDict((*this)->getAttrs());
   printer << " : " << getSource().getType() << ", " << getDestination().getType()
           << ", " << getL2CacheCtl().getType() << ", " << getLenBurst().getType()
@@ -4116,13 +4246,15 @@ void MteGmUbOp::print(OpAsmPrinter &printer) {
           << ", "
           << getNburstDstStride().getType();
   for (auto [count, srcStride, dstStride] :
-       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides()))
+       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides())) {
     printDmaTripleTypes(printer, "loop", count.getType(), srcStride.getType(),
                         dstStride.getType());
-  if (getPadValue())
+  }
+  if (getPadValue()) {
     printDmaPadTypes(printer, getPadValue().getType(),
                      getLeftPaddingCount() ? getLeftPaddingCount().getType() : Type{},
                      getRightPaddingCount() ? getRightPaddingCount().getType() : Type{});
+  }
 }
 
 void MteGmUbOp::getEffects(
@@ -4138,21 +4270,24 @@ LogicalResult MteGmUbOp::verify() {
   }
   if (failed(verifyDmaLoadStoreLoopGroups(
           getOperation(), getLoopCounts(), getLoopSrcStrides(),
-          getLoopDstStrides())))
+          getLoopDstStrides()))) {
     return failure();
+  }
   if (!getPadValue() && (getLeftPaddingCount() || getRightPaddingCount())) {
     return emitOpError() << "requires pad group to provide a pad value";
   }
   if (getPadValue() && static_cast<bool>(getLeftPaddingCount()) !=
-                         static_cast<bool>(getRightPaddingCount()))
+                           static_cast<bool>(getRightPaddingCount())) {
     return emitOpError()
            << "requires pad group to provide both left and right counts, or omit both";
+  }
   if (Value padValue = getPadValue()) {
     Type valueType = padValue.getType();
-    if (!isSupportedMovPadScalarType(valueType))
+    if (!isSupportedMovPadScalarType(valueType)) {
       return emitOpError()
              << "expects pad value to be i8/i16/i32 or f16/bf16/f32 scalar, but got "
              << valueType;
+    }
   }
   return success();
 }
@@ -4405,20 +4540,23 @@ static ParseResult parseMadSemanticOpCommon(OpAsmParser &parser,
       (hasBias && parseRequiredOperandWithComma(parser, bias)) ||
       parseRequiredOperandWithComma(parser, m) ||
       parseRequiredOperandWithComma(parser, n) ||
-      parser.parseOperand(k))
+      parser.parseOperand(k)) {
     return failure();
+  }
 
   auto parseUnitFlagClause = [&]() -> ParseResult {
     if (failed(parser.parseOptionalKeyword("unit_flag"))) {
       return success();
     }
     if (parser.parseLParen() || parser.parseKeyword(&unitFlagKeyword) ||
-        parser.parseRParen())
+        parser.parseRParen()) {
       return failure();
+    }
     auto mode = parseMadUnitFlagModeToken(unitFlagKeyword);
-    if (!mode)
+    if (!mode) {
       return parser.emitError(parser.getCurrentLocation())
              << "expected unit_flag(check_only|check_and_set)";
+    }
     attrs.set("unit_flag_mode",
               pto::MadUnitFlagModeAttr::get(parser.getContext(), *mode));
     return success();
@@ -4451,12 +4589,14 @@ static ParseResult parseMadSemanticOpCommon(OpAsmParser &parser,
       return success();
     }
     if (parser.parseLParen() || parser.parseKeyword(&tf32Keyword) ||
-        parser.parseRParen())
+        parser.parseRParen()) {
       return failure();
+    }
     auto mode = parseTf32ModeToken(tf32Keyword);
-    if (!mode)
+    if (!mode) {
       return parser.emitError(parser.getCurrentLocation())
              << "expected tf32_mode(round_even|round_away)";
+    }
     attrs.set("tf32_mode", pto::Tf32ModeAttr::get(parser.getContext(), *mode));
     return success();
   };
@@ -4466,11 +4606,11 @@ static ParseResult parseMadSemanticOpCommon(OpAsmParser &parser,
     }
     return success();
   };
-
   if (failed(parseUnitFlagClause()) || failed(parseDisableGemvClause()) ||
       failed(parseSatClause()) || failed(parseTf32Clause()) ||
-      failed(parseNDirClause()))
+      failed(parseNDirClause())) {
     return failure();
+  }
 
   if (parser.parseOptionalAttrDict(attrs) || parser.parseColon()) {
     return failure();
@@ -4479,16 +4619,18 @@ static ParseResult parseMadSemanticOpCommon(OpAsmParser &parser,
   Type lhsType, rhsType, dstType, mType, nType, kType, biasType;
   if (parser.parseType(lhsType) || parser.parseComma() ||
       parser.parseType(rhsType) || parser.parseComma() ||
-      parser.parseType(dstType) || parser.parseComma())
+      parser.parseType(dstType) || parser.parseComma()) {
     return failure();
+  }
   if (hasBias) {
     if (parser.parseType(biasType) || parser.parseComma()) {
       return failure();
     }
   }
   if (parser.parseType(mType) || parser.parseComma() || parser.parseType(nType) ||
-      parser.parseComma() || parser.parseType(kType))
+      parser.parseComma() || parser.parseType(kType)) {
     return failure();
+  }
 
   result.addAttributes(attrs);
   if (hasBias) {
@@ -4498,16 +4640,18 @@ static ParseResult parseMadSemanticOpCommon(OpAsmParser &parser,
         parser.resolveOperand(bias, biasType, result.operands) ||
         parser.resolveOperand(m, mType, result.operands) ||
         parser.resolveOperand(n, nType, result.operands) ||
-        parser.resolveOperand(k, kType, result.operands))
+        parser.resolveOperand(k, kType, result.operands)) {
       return failure();
+    }
   } else {
     if (parser.resolveOperand(lhs, lhsType, result.operands) ||
         parser.resolveOperand(rhs, rhsType, result.operands) ||
         parser.resolveOperand(dst, dstType, result.operands) ||
         parser.resolveOperand(m, mType, result.operands) ||
         parser.resolveOperand(n, nType, result.operands) ||
-        parser.resolveOperand(k, kType, result.operands))
+        parser.resolveOperand(k, kType, result.operands)) {
       return failure();
+    }
   }
   return success();
 }
@@ -4577,8 +4721,9 @@ static void printMadSemanticOpWithBias(OpAsmPrinter &printer, OpT op,
 LogicalResult MadOp::verify() {
   std::optional<pto::Tf32Mode> tf32Mode;
   if (auto tf32ModeAttr =
-          (*this)->getAttrOfType<pto::Tf32ModeAttr>("tf32_mode"))
+          (*this)->getAttrOfType<pto::Tf32ModeAttr>("tf32_mode")) {
     tf32Mode = tf32ModeAttr.getValue();
+  }
   return verifyMadSemanticClauses(*this, getLhs().getType(), getRhs().getType(),
                                   getDst().getType(), std::nullopt, tf32Mode,
                                   getSatMode(),
@@ -4603,8 +4748,9 @@ Value MadOp::getBiasOrNull() { return {}; }
 LogicalResult MadAccOp::verify() {
   std::optional<pto::Tf32Mode> tf32Mode;
   if (auto tf32ModeAttr =
-          (*this)->getAttrOfType<pto::Tf32ModeAttr>("tf32_mode"))
+          (*this)->getAttrOfType<pto::Tf32ModeAttr>("tf32_mode")) {
     tf32Mode = tf32ModeAttr.getValue();
+  }
   return verifyMadSemanticClauses(*this, getLhs().getType(), getRhs().getType(),
                                   getDst().getType(), std::nullopt, tf32Mode,
                                   getSatMode(),
@@ -4629,8 +4775,9 @@ Value MadAccOp::getBiasOrNull() { return {}; }
 LogicalResult MadBiasOp::verify() {
   std::optional<pto::Tf32Mode> tf32Mode;
   if (auto tf32ModeAttr =
-          (*this)->getAttrOfType<pto::Tf32ModeAttr>("tf32_mode"))
+          (*this)->getAttrOfType<pto::Tf32ModeAttr>("tf32_mode")) {
     tf32Mode = tf32ModeAttr.getValue();
+  }
   return verifyMadSemanticClauses(*this, getLhs().getType(), getRhs().getType(),
                                   getDst().getType(), getBias().getType(),
                                   tf32Mode, getSatMode(),
@@ -4654,8 +4801,9 @@ Value MadBiasOp::getBiasOrNull() { return getBias(); }
 
 LogicalResult MadMxOp::verify() {
   if (failed(verifyMadMxCommon(*this, getLhs().getType(), getRhs().getType(),
-                               getDst().getType())))
+                               getDst().getType()))) {
     return failure();
+  }
   return verifyMadSemanticClauses(*this, getLhs().getType(), getRhs().getType(),
                                   getDst().getType(), std::nullopt, std::nullopt,
                                   getSatMode(),
@@ -4680,8 +4828,9 @@ Attribute MadMxOp::getTf32ModeAttr() { return {}; }
 
 LogicalResult MadMxAccOp::verify() {
   if (failed(verifyMadMxCommon(*this, getLhs().getType(), getRhs().getType(),
-                               getDst().getType())))
+                               getDst().getType()))) {
     return failure();
+  }
   return verifyMadSemanticClauses(*this, getLhs().getType(), getRhs().getType(),
                                   getDst().getType(), std::nullopt, std::nullopt,
                                   getSatMode(),
@@ -4706,8 +4855,9 @@ Attribute MadMxAccOp::getTf32ModeAttr() { return {}; }
 
 LogicalResult MadMxBiasOp::verify() {
   if (failed(verifyMadMxCommon(*this, getLhs().getType(), getRhs().getType(),
-                               getDst().getType(), getBias().getType())))
+                               getDst().getType(), getBias().getType()))) {
     return failure();
+  }
   return verifyMadSemanticClauses(*this, getLhs().getType(), getRhs().getType(),
                                   getDst().getType(), getBias().getType(),
                                   std::nullopt, getSatMode(),
@@ -4842,8 +4992,9 @@ template <typename ReductionOp>
 static LogicalResult verifyWideningReductionVecOp(ReductionOp op,
                                                   StringRef opName) {
   if (failed(verifyVRegTypeLike(op, op.getInput().getType(), "input")) ||
-      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result")))
+      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result"))) {
     return failure();
+  }
 
   auto inputType = dyn_cast<VRegType>(op.getInput().getType());
   auto resultType = dyn_cast<VRegType>(op.getResult().getType());
@@ -4855,26 +5006,28 @@ static LogicalResult verifyWideningReductionVecOp(ReductionOp op,
   Type expectedResultElemType = inputElemType;
   int64_t expectedResultLanes = inputType.getElementCount();
   if (auto inputInt = dyn_cast<IntegerType>(inputElemType)) {
-    if (inputInt.getWidth() < 8 || inputInt.getWidth() > 32)
+    if (inputInt.getWidth() < mlir::pto::kValue8 || inputInt.getWidth() > 32) {
       return op.emitOpError(
           "requires 8-bit, 16-bit, or 32-bit integer vector element type");
-    if (inputInt.getWidth() == 8) {
-      expectedResultElemType =
-          IntegerType::get(op.getContext(), 16, inputInt.getSignedness());
-      expectedResultLanes = inputType.getElementCount() / 2;
     }
-    if (inputInt.getWidth() == 16) {
+    if (inputInt.getWidth() == mlir::pto::kValue8) {
       expectedResultElemType =
-          IntegerType::get(op.getContext(), 32, inputInt.getSignedness());
-      expectedResultLanes = inputType.getElementCount() / 2;
+          IntegerType::get(op.getContext(), mlir::pto::kValue16, inputInt.getSignedness());
+      expectedResultLanes = inputType.getElementCount() / mlir::pto::kValue2;
+    }
+    if (inputInt.getWidth() == mlir::pto::kValue16) {
+      expectedResultElemType =
+          IntegerType::get(op.getContext(), mlir::pto::kValue32, inputInt.getSignedness());
+      expectedResultLanes = inputType.getElementCount() / mlir::pto::kValue2;
     }
   } else if (!inputElemType.isF16() && !inputElemType.isF32()) {
     return op.emitOpError("requires i16/i32/f16/f32 vector element type");
   }
 
   if (resultType.getElementCount() == expectedResultLanes &&
-      resultType.getElementType() == expectedResultElemType)
+      resultType.getElementType() == expectedResultElemType) {
     return success();
+  }
 
   return op.emitOpError() << opName << " expects result type !pto.vreg<"
                           << expectedResultLanes << "x"
@@ -4888,8 +5041,9 @@ LogicalResult VcaddOp::verify() {
 
 LogicalResult VcmaxOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getInput().getType(), "input")) ||
-      failed(verifyVRegTypeLike(*this, getResult().getType(), "result")))
+      failed(verifyVRegTypeLike(*this, getResult().getType(), "result"))) {
     return failure();
+  }
   if (getInput().getType() != getResult().getType()) {
     return emitOpError("input and result must have the same vector type");
   }
@@ -4898,8 +5052,9 @@ LogicalResult VcmaxOp::verify() {
 
 LogicalResult VcminOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getInput().getType(), "input")) ||
-      failed(verifyVRegTypeLike(*this, getResult().getType(), "result")))
+      failed(verifyVRegTypeLike(*this, getResult().getType(), "result"))) {
     return failure();
+  }
   if (getInput().getType() != getResult().getType()) {
     return emitOpError("input and result must have the same vector type");
   }
@@ -4913,9 +5068,10 @@ LogicalResult VciOp::verify() {
   }
   Type resultElemType = resultType.getElementType();
   bool supportedInteger = false;
-  if (auto intType = dyn_cast<IntegerType>(resultElemType))
-    supportedInteger = intType.getWidth() == 8 || intType.getWidth() == 16 ||
-                       intType.getWidth() == 32;
+  if (auto intType = dyn_cast<IntegerType>(resultElemType)) {
+    supportedInteger = intType.getWidth() == mlir::pto::kValue8 || intType.getWidth() == 16 ||
+                       intType.getWidth() == mlir::pto::kValue32;
+  }
   bool supportedFloat = resultElemType.isF16() || resultElemType.isF32();
   if (!supportedInteger && !supportedFloat) {
     return emitOpError("result element type must be integer or f16/f32");
@@ -4940,8 +5096,9 @@ static bool isUnsignedOrSignlessIntegerOfWidth(Type type, unsigned width) {
 static bool isSameVgather2IntegerSemantics(IntegerType sourceType,
                                            IntegerType resultType) {
   if (!sourceType || !resultType ||
-      sourceType.getWidth() != resultType.getWidth())
+      sourceType.getWidth() != resultType.getWidth()) {
     return false;
+  }
   if (sourceType.isUnsigned()) {
     return resultType.isUnsigned();
   }
@@ -4950,9 +5107,10 @@ static bool isSameVgather2IntegerSemantics(IntegerType sourceType,
 
 static bool isVgather2B8ResultType(IntegerType sourceType,
                                    IntegerType resultType) {
-  if (!sourceType || !resultType || sourceType.getWidth() != 8 ||
-      resultType.getWidth() != 16)
+  if (!sourceType || !resultType || sourceType.getWidth() != mlir::pto::kValue8 ||
+      resultType.getWidth() != mlir::pto::kValue16) {
     return false;
+  }
   if (sourceType.isUnsigned()) {
     return resultType.isUnsigned();
   }
@@ -4990,59 +5148,65 @@ LogicalResult Vgather2Op::verify() {
   StringRef expectedMaskGranularity;
   int64_t expectedLanes = 0;
 
-  if (sourceElemWidth == 8 && isa<IntegerType>(sourceElemType)) {
+  if (sourceElemWidth == mlir::pto::kValue8 && isa<IntegerType>(sourceElemType)) {
     if (!isVgather2B8ResultType(cast<IntegerType>(sourceElemType),
-                                dyn_cast<IntegerType>(resultElemType)))
+                                dyn_cast<IntegerType>(resultElemType))) {
       return emitOpError(
           "8-bit gather requires i8/ui8 source and matching i16/ui16 result");
-    expectedOffsetWidth = 16;
+    }
+    expectedOffsetWidth = mlir::pto::kValue16;
     expectedMaskGranularity = "b16";
-    expectedLanes = 128;
-  } else if (sourceElemWidth == 16) {
+    expectedLanes = mlir::pto::kValue128;
+  } else if (sourceElemWidth == mlir::pto::kValue16) {
     if (auto sourceInt = dyn_cast<IntegerType>(sourceElemType)) {
       if (!isSameVgather2IntegerSemantics(
-              sourceInt, dyn_cast<IntegerType>(resultElemType)))
+              sourceInt, dyn_cast<IntegerType>(resultElemType))) {
         return emitOpError(
             "16-bit integer gather requires matching i16/ui16 result");
+      }
     } else if (!(sourceElemType.isF16() || sourceElemType.isBF16()) ||
                sourceElemType != resultElemType) {
       return emitOpError(
           "16-bit gather requires i16/ui16/f16/bf16 source and matching result");
     }
-    expectedOffsetWidth = 16;
+    expectedOffsetWidth = mlir::pto::kValue16;
     expectedMaskGranularity = "b16";
-    expectedLanes = 128;
-  } else if (sourceElemWidth == 32) {
+    expectedLanes = mlir::pto::kValue128;
+  } else if (sourceElemWidth == mlir::pto::kValue32) {
     if (auto sourceInt = dyn_cast<IntegerType>(sourceElemType)) {
       if (!isSameVgather2IntegerSemantics(
-              sourceInt, dyn_cast<IntegerType>(resultElemType)))
+              sourceInt, dyn_cast<IntegerType>(resultElemType))) {
         return emitOpError(
             "32-bit integer gather requires matching i32/ui32 result");
+      }
     } else if (!sourceElemType.isF32() || sourceElemType != resultElemType) {
       return emitOpError(
           "32-bit gather requires i32/ui32/f32 source and matching result");
     }
-    expectedOffsetWidth = 32;
+    expectedOffsetWidth = mlir::pto::kValue32;
     expectedMaskGranularity = "b32";
-    expectedLanes = 64;
+    expectedLanes = mlir::pto::kValue64;
   } else {
     return emitOpError(
         "requires source element type i8/ui8/i16/ui16/i32/ui32/f16/bf16/f32");
   }
 
-  if (resultElemWidth != 16 && resultElemWidth != 32) {
+  if (resultElemWidth != mlir::pto::kValue16 && resultElemWidth != 32) {
     return emitOpError("result element type must be 16-bit or 32-bit");
   }
-  if (resultType.getElementCount() != expectedLanes)
+  if (resultType.getElementCount() != expectedLanes) {
     return emitOpError() << "expects result type "
                          << formatVRegType(expectedLanes, resultElemType);
-  if (!isUnsignedOrSignlessIntegerOfWidth(offsetsElemType, expectedOffsetWidth))
+  }
+  if (!isUnsignedOrSignlessIntegerOfWidth(offsetsElemType, expectedOffsetWidth)) {
     return emitOpError() << "requires ui" << expectedOffsetWidth << "/i"
                          << expectedOffsetWidth << " offset vector elements";
+  }
   if (failed(verifyMaskTypeWithGranularityLike(
           getOperation(), getMask().getType(), "mask type",
-          expectedMaskGranularity)))
+          expectedMaskGranularity))) {
     return failure();
+  }
   return success();
 }
 
@@ -5051,8 +5215,9 @@ LogicalResult CopyUbufToUbufOp::verify() {
     return emitOpError("requires pointer-like source and destination");
   }
   if (classifyMemoryRole(getSource().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getDestination().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getDestination().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed source and destination");
+  }
   return success();
 }
 
@@ -5079,8 +5244,9 @@ LogicalResult CopyUbufToCbufOp::verify() {
     return emitOpError("requires pointer-like source and destination");
   }
   if (classifyMemoryRole(getSource().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getDestination().getType()) != MemoryRole::Other)
+      classifyMemoryRole(getDestination().getType()) != MemoryRole::Other) {
     return emitOpError("requires UB-backed source and CBUF-backed destination");
+  }
   return success();
 }
 
@@ -5096,8 +5262,9 @@ LogicalResult MteUbUbOp::verify() {
     return emitOpError("requires pointer-like source and destination");
   }
   if (classifyMemoryRole(getSource().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getDestination().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getDestination().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed source and destination");
+  }
   return success();
 }
 
@@ -5113,8 +5280,9 @@ LogicalResult MteUbL1Op::verify() {
     return emitOpError("requires pointer-like source and destination");
   }
   if (classifyMemoryRole(getSource().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getDestination().getType()) != MemoryRole::Other)
+      classifyMemoryRole(getDestination().getType()) != MemoryRole::Other) {
     return emitOpError("requires UB-backed source and CBUF-backed destination");
+  }
   return success();
 }
 
@@ -5134,8 +5302,9 @@ LogicalResult VgatherbOp::verify() {
   }
 
   if (failed(verifyMaskTypeWithGranularityLike(getOperation(), getMask().getType(),
-                                               "mask type", "b32")))
+                                               "mask type", "b32"))) {
     return failure();
+  }
 
   auto offsetsType = dyn_cast<VRegType>(getOffsets().getType());
   auto resultType = dyn_cast<VRegType>(getResult().getType());
@@ -5146,7 +5315,7 @@ LogicalResult VgatherbOp::verify() {
   if (!offsetsElemType) {
     return emitOpError("offset vector must use integer element type");
   }
-  if (offsetsElemType.getWidth() != 32) {
+  if (offsetsElemType.getWidth() != mlir::pto::kValue32) {
     return emitOpError("currently requires 32-bit offset vector elements");
   }
   // vgatherb is a 32-byte block gather: each offset addresses one 32-byte block.
@@ -5185,7 +5354,7 @@ LogicalResult Vgather2BcOp::verify() {
   if (!offsetsElemType) {
     return emitOpError("offset vector must use integer element type");
   }
-  if (offsetsElemType.getWidth() != 32) {
+  if (offsetsElemType.getWidth() != mlir::pto::kValue32) {
     return emitOpError("currently requires 32-bit offset vector elements");
   }
   if (offsetsType.getElementCount() != resultType.getElementCount()) {
@@ -5196,12 +5365,14 @@ LogicalResult Vgather2BcOp::verify() {
 
 LogicalResult VbitsortOp::verify() {
   if (!isBufferLike(getDestination().getType()) || !isBufferLike(getSource().getType()) ||
-      !isBufferLike(getIndices().getType()))
+      !isBufferLike(getIndices().getType())) {
     return emitOpError("requires pointer-like destination/source/indices");
+  }
   if (classifyMemoryRole(getDestination().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSource().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getIndices().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getIndices().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed destination/source/indices");
+  }
   if (!getRepeatTimes().getType().isIndex()) {
     return emitOpError("repeat_times must be index");
   }
@@ -5222,30 +5393,34 @@ void VbitsortOp::getEffects(
 LogicalResult Vmrgsort4Op::verify() {
   if (!isBufferLike(getDestination().getType()) || !isBufferLike(getSource0().getType()) ||
       !isBufferLike(getSource1().getType()) || !isBufferLike(getSource2().getType()) ||
-      !isBufferLike(getSource3().getType()))
+      !isBufferLike(getSource3().getType())) {
     return emitOpError("requires pointer-like destination and sources");
+  }
   if (classifyMemoryRole(getDestination().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSource0().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSource1().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSource2().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSource3().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSource3().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed destination and sources");
+  }
   auto dstPtrType = dyn_cast<pto::PtrType>(getDestination().getType());
   auto src0PtrType = dyn_cast<pto::PtrType>(getSource0().getType());
   auto src1PtrType = dyn_cast<pto::PtrType>(getSource1().getType());
   auto src2PtrType = dyn_cast<pto::PtrType>(getSource2().getType());
   auto src3PtrType = dyn_cast<pto::PtrType>(getSource3().getType());
   if (!dstPtrType || !src0PtrType || !src1PtrType || !src2PtrType ||
-      !src3PtrType)
+      !src3PtrType) {
     return emitOpError("requires ptr-backed destination and sources");
+  }
 
   Type elemType = dstPtrType.getElementType();
   if (src0PtrType.getElementType() != elemType ||
       src1PtrType.getElementType() != elemType ||
       src2PtrType.getElementType() != elemType ||
-      src3PtrType.getElementType() != elemType)
+      src3PtrType.getElementType() != elemType) {
     return emitOpError(
         "requires destination and all sources to have the same element type");
+  }
   if (!elemType.isF16() && !elemType.isF32()) {
     return emitOpError("requires f16 or f32 element type");
   }
@@ -5258,22 +5433,26 @@ LogicalResult Vmrgsort4Op::verify() {
 LogicalResult VmaxOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getLhs().getType(), "lhs")) ||
       failed(verifyVRegTypeLike(*this, getRhs().getType(), "rhs")) ||
-      failed(verifyVRegTypeLike(*this, getResult().getType(), "result")))
+      failed(verifyVRegTypeLike(*this, getResult().getType(), "result"))) {
     return failure();
+  }
   if (getLhs().getType() != getRhs().getType() ||
-      getLhs().getType() != getResult().getType())
+      getLhs().getType() != getResult().getType()) {
     return emitOpError("lhs, rhs, and result must have the same vector type");
+  }
   return success();
 }
 
 LogicalResult VminOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getLhs().getType(), "lhs")) ||
       failed(verifyVRegTypeLike(*this, getRhs().getType(), "rhs")) ||
-      failed(verifyVRegTypeLike(*this, getResult().getType(), "result")))
+      failed(verifyVRegTypeLike(*this, getResult().getType(), "result"))) {
     return failure();
+  }
   if (getLhs().getType() != getRhs().getType() ||
-      getLhs().getType() != getResult().getType())
+      getLhs().getType() != getResult().getType()) {
     return emitOpError("lhs, rhs, and result must have the same vector type");
+  }
   return success();
 }
 
@@ -5300,11 +5479,12 @@ static LogicalResult verifyVldsCommon(LoadOp op) {
 
   if (op.getDistAttr()) {
     StringRef dist = *op.getDist();
-    if (!isSupportedVldsDistToken(dist))
+    if (!isSupportedVldsDistToken(dist)) {
       return op.emitOpError(
           "supports only NORM, BRC_B8/B16/B32, US_B8/B16, DS_B8/B16, "
           "UNPK_B8/B16/B32, BRC_BLK, E2B_B16/B32, UNPK4, SPLT4CHN, and "
           "SPLT2CHN_B8/B16 load distributions");
+    }
   }
 
   return success();
@@ -5372,10 +5552,10 @@ static LogicalResult verifySprStoreCommon(Operation *op, StringRef opName,
     return op->emitOpError("requires a UB-backed destination");
   }
   auto intType = dyn_cast<IntegerType>(ptrType.getElementType());
-  if (!intType || intType.getWidth() != 32 || intType.isSigned()) {
+  if (!intType || intType.getWidth() != mlir::pto::kValue32 || intType.isSigned()) {
     return op->emitOpError("requires ui32/i32 UB destination element type");
   }
-  if (!offset.getType().isInteger(32)) {
+  if (!offset.getType().isInteger(mlir::pto::kValue32)) {
     return op->emitOpError("requires i32 offset");
   }
   if (requireImmediateOffset) {
@@ -5384,7 +5564,7 @@ static LogicalResult verifySprStoreCommon(Operation *op, StringRef opName,
       return op->emitOpError("requires constant immediate offset");
     }
     int64_t signedOffset = offsetValue.getSExtValue();
-    if (signedOffset < -128 || signedOffset > 127) {
+    if (signedOffset < -mlir::pto::kValue128 || signedOffset > 127) {
       return op->emitOpError("requires signed 8-bit immediate offset");
     }
   }
@@ -5400,11 +5580,13 @@ void SprstiOp::getEffects(
 LogicalResult SprstiOp::verify() {
   if (failed(verifySprStoreCommon(getOperation(), "pto.sprsti", getSpr(),
                                   getDestination(), getOffset(),
-                                  /*requireImmediateOffset=*/true)))
+                                  /*requireImmediateOffset=*/true))) {
     return failure();
+  }
   if (getUpdatedBase() &&
-      getUpdatedBase().getType() != getDestination().getType())
+      getUpdatedBase().getType() != getDestination().getType()) {
     return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
 
@@ -5417,11 +5599,13 @@ void SprstsOp::getEffects(
 LogicalResult SprstsOp::verify() {
   if (failed(verifySprStoreCommon(getOperation(), "pto.sprsts", getSpr(),
                                   getDestination(), getOffset(),
-                                  /*requireImmediateOffset=*/false)))
+                                  /*requireImmediateOffset=*/false))) {
     return failure();
+  }
   if (getUpdatedBase() &&
-      getUpdatedBase().getType() != getDestination().getType())
+      getUpdatedBase().getType() != getDestination().getType()) {
     return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
 
@@ -5435,17 +5619,19 @@ LogicalResult VldusOp::verify() {
   if (failed(verifyLoadAlignChain(getAlign(), *this, "align type")) ||
       failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")) ||
       failed(verifyAlignTypeLike(*this, getUpdatedAlign().getType(),
-                                 "updated align type")))
+                                 "updated align type"))) {
     return failure();
+  }
   if (!isBufferLike(getSource().getType())) {
     return emitOpError("requires a pointer-like source");
   }
   if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed source");
   }
-  if (static_cast<bool>(getIncrement()) != static_cast<bool>(getUpdatedBase()))
+  if (static_cast<bool>(getIncrement()) != static_cast<bool>(getUpdatedBase())) {
     return emitOpError(
         "requires increment and updated base result to appear together");
+  }
   if (getUpdatedBase() && getUpdatedBase().getType() != getSource().getType()) {
     return emitOpError("requires updated base result to match source type");
   }
@@ -5476,9 +5662,10 @@ LogicalResult UvldOp::verify() {
 
   Type sourceElementType = sourceMemRef.getElementType();
   Type vectorElementType = cast<VRegType>(getResult().getType()).getElementType();
-  if (sourceElementType != vectorElementType)
+  if (sourceElementType != vectorElementType) {
     return emitOpError(
         "requires source element type to match vector element type");
+  }
   return success();
 }
 
@@ -5494,8 +5681,9 @@ LogicalResult VdupOp::verify() {
     return emitOpError("result element type must use b8, b16, or b32 mask granularity");
   }
   if (failed(verifyMaskTypeWithGranularityLike(
-          getOperation(), getMask().getType(), "mask type", *granularity)))
+          getOperation(), getMask().getType(), "mask type", *granularity))) {
     return failure();
+  }
 
   if (!isSupportedVdupPosition(getPosition())) {
     return emitOpError("position must be LOWEST or HIGHEST");
@@ -5549,9 +5737,10 @@ LogicalResult TensorViewAddrOp::verify() {
   }
 
   if (auto dstMemRefType = dyn_cast<BaseMemRefType>(dstType)) {
-    if (dstMemRefType.getElementType() != elementType)
+    if (dstMemRefType.getElementType() != elementType) {
       return emitOpError(
           "memref result element type must match source element type");
+    }
     if (dstMemRefType.getRank() != expectedRank) {
       return emitOpError("memref result rank must match source rank");
     }
@@ -5567,9 +5756,10 @@ LogicalResult TensorViewAddrOp::verify() {
   if (!dstPtrType) {
     return emitOpError("result must be a memref or !pto.ptr<...>");
   }
-  if (dstPtrType.getElementType() != elementType)
+  if (dstPtrType.getElementType() != elementType) {
     return emitOpError(
         "pointer result element type must match source element type");
+  }
   if (dstPtrType.getMemorySpace() != gmSpace) {
     return emitOpError("pointer result must stay in gm memory space");
   }
@@ -5597,9 +5787,10 @@ LogicalResult TileBufAddrOp::verify() {
   auto srcSpace = dyn_cast_or_null<pto::AddressSpaceAttr>(srcMemorySpace);
 
   if (auto dstMemRefType = dyn_cast<BaseMemRefType>(dstType)) {
-    if (dstMemRefType.getElementType() != elementType)
+    if (dstMemRefType.getElementType() != elementType) {
       return emitOpError(
           "memref result element type must match tile element type");
+    }
     if (dstMemRefType.getRank() != srcRank) {
       return emitOpError("memref result rank must match tile rank");
     }
@@ -5615,9 +5806,10 @@ LogicalResult TileBufAddrOp::verify() {
   if (!dstPtrType) {
     return emitOpError("result must be a memref or !pto.ptr<...>");
   }
-  if (dstPtrType.getElementType() != elementType)
+  if (dstPtrType.getElementType() != elementType) {
     return emitOpError(
         "pointer result element type must match tile element type");
+  }
   if (srcSpace && dstPtrType.getMemorySpace() != srcSpace) {
     return emitOpError("pointer result must stay within the tile memory space");
   }
@@ -5626,8 +5818,9 @@ LogicalResult TileBufAddrOp::verify() {
 
 LogicalResult PsetB8Op::verify() {
   if (failed(verifyMaskTypeWithGranularityLike(*this, getResult().getType(),
-                                               "result type", "b8")))
+                                               "result type", "b8"))) {
     return failure();
+  }
 
   if (!isSupportedPredicatePattern(getPattern())) {
     return emitOpError("requires a supported PAT_* predicate pattern");
@@ -5637,8 +5830,9 @@ LogicalResult PsetB8Op::verify() {
 
 LogicalResult PsetB16Op::verify() {
   if (failed(verifyMaskTypeWithGranularityLike(*this, getResult().getType(),
-                                               "result type", "b16")))
+                                               "result type", "b16"))) {
     return failure();
+  }
 
   if (!isSupportedPredicatePattern(getPattern())) {
     return emitOpError("requires a supported PAT_* predicate pattern");
@@ -5648,8 +5842,9 @@ LogicalResult PsetB16Op::verify() {
 
 LogicalResult PsetB32Op::verify() {
   if (failed(verifyMaskTypeWithGranularityLike(*this, getResult().getType(),
-                                               "result type", "b32")))
+                                               "result type", "b32"))) {
     return failure();
+  }
   if (!isSupportedPredicatePattern(getPattern())) {
     return emitOpError("requires a supported PAT_* predicate pattern");
   }
@@ -5658,8 +5853,9 @@ LogicalResult PsetB32Op::verify() {
 
 LogicalResult PgeB8Op::verify() {
   if (failed(verifyMaskTypeWithGranularityLike(*this, getResult().getType(),
-                                               "result type", "b8")))
+                                               "result type", "b8"))) {
     return failure();
+  }
   if (!isSupportedPredicatePattern(getPattern())) {
     return emitOpError("requires a supported PAT_* predicate pattern");
   }
@@ -5668,8 +5864,9 @@ LogicalResult PgeB8Op::verify() {
 
 LogicalResult PgeB16Op::verify() {
   if (failed(verifyMaskTypeWithGranularityLike(*this, getResult().getType(),
-                                               "result type", "b16")))
+                                               "result type", "b16"))) {
     return failure();
+  }
   if (!isSupportedPredicatePattern(getPattern())) {
     return emitOpError("requires a supported PAT_* predicate pattern");
   }
@@ -5678,8 +5875,9 @@ LogicalResult PgeB16Op::verify() {
 
 LogicalResult PgeB32Op::verify() {
   if (failed(verifyMaskTypeWithGranularityLike(*this, getResult().getType(),
-                                               "result type", "b32")))
+                                               "result type", "b32"))) {
     return failure();
+  }
   if (!isSupportedPredicatePattern(getPattern())) {
     return emitOpError("requires a supported PAT_* predicate pattern");
   }
@@ -5690,11 +5888,12 @@ template <typename PltOp>
 static LogicalResult verifyPredicateLaneCountOp(PltOp op,
                                                 StringRef granularity) {
   if (failed(verifyMaskTypeWithGranularityLike(op, op.getMask().getType(),
-                                               "mask type", granularity)))
+                                               "mask type", granularity))) {
     return failure();
+  }
   Type scalarType = op.getScalar().getType();
   auto scalarIntType = dyn_cast<IntegerType>(scalarType);
-  if (!scalarIntType || scalarIntType.getWidth() != 32) {
+  if (!scalarIntType || scalarIntType.getWidth() != mlir::pto::kValue32) {
     return op.emitOpError("requires scalar to be i32");
   }
   if (op.getScalarOut().getType() != scalarType) {
@@ -5715,12 +5914,13 @@ template <typename PltmOp>
 static LogicalResult verifyPredicateLoopBoundOp(PltmOp op,
                                                 StringRef granularity) {
   if (failed(verifyMaskTypeWithGranularityLike(op, op.getMask().getType(),
-                                               "mask type", granularity)))
+                                               "mask type", granularity))) {
     return failure();
-  if (!op.getLoop().getType().isInteger(16)) {
+  }
+  if (!op.getLoop().getType().isInteger(mlir::pto::kValue16)) {
     return op.emitOpError("requires loop operand to be i16");
   }
-  if (!op.getBound().getType().isInteger(32)) {
+  if (!op.getBound().getType().isInteger(mlir::pto::kValue32)) {
     return op.emitOpError("requires bound operand to be i32");
   }
   return success();
@@ -5738,8 +5938,9 @@ LogicalResult PltmB32Op::verify() {
 
 LogicalResult PpackOp::verify() {
   if (failed(verifyMaskTypeLike(*this, getInput().getType(), "input type")) ||
-      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
   if (!isSupportedPartToken(getPart())) {
     return emitOpError("requires part to be LOWER or HIGHER");
   }
@@ -5757,8 +5958,9 @@ LogicalResult PpackOp::verify() {
 
 LogicalResult PunpackOp::verify() {
   if (failed(verifyMaskTypeLike(*this, getInput().getType(), "input type")) ||
-      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
   if (!isSupportedPartToken(getPart())) {
     return emitOpError("requires part to be LOWER or HIGHER");
   }
@@ -5776,16 +5978,18 @@ LogicalResult PunpackOp::verify() {
 
 LogicalResult PbitcastOp::verify() {
   if (failed(verifyMaskTypeLike(*this, getInput().getType(), "input type")) ||
-      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
   return success();
 }
 
 LogicalResult PnotOp::verify() {
   if (failed(verifyMaskTypeLike(*this, getInput().getType(), "input type")) ||
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
-      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
   return success();
 }
 
@@ -5793,8 +5997,9 @@ LogicalResult PselOp::verify() {
   if (failed(verifyMaskTypeLike(*this, getSrc0().getType(), "src0 type")) ||
       failed(verifyMaskTypeLike(*this, getSrc1().getType(), "src1 type")) ||
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
-      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
   return success();
 }
 
@@ -5803,8 +6008,9 @@ static LogicalResult verifyBinaryMaskOp(BinaryMaskOp op) {
   if (failed(verifyMaskTypeLike(op, op.getSrc0().getType(), "src0 type")) ||
       failed(verifyMaskTypeLike(op, op.getSrc1().getType(), "src1 type")) ||
       failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type")) ||
-      failed(verifyMaskTypeLike(op, op.getResult().getType(), "result type")))
+      failed(verifyMaskTypeLike(op, op.getResult().getType(), "result type"))) {
     return failure();
+  }
   return success();
 }
 
@@ -5836,8 +6042,9 @@ LogicalResult PldsOp::verify() {
     return emitOpError("requires predicate load dist to be NORM, US, or DS");
   }
   if (getUpdatedBase() &&
-      getUpdatedBase().getType() != getSource().getType())
+      getUpdatedBase().getType() != getSource().getType()) {
     return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
 
@@ -5864,8 +6071,9 @@ LogicalResult PldiOp::verify() {
     return emitOpError("requires predicate load dist to be NORM, US, or DS");
   }
   if (getUpdatedBase() &&
-      getUpdatedBase().getType() != getSource().getType())
+      getUpdatedBase().getType() != getSource().getType()) {
     return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
 
@@ -5896,8 +6104,9 @@ static LogicalResult verifyElementwiseVecScalarOpLike(OpTy op) {
     return success();
   }
   if (elemInt.isUnsigned() &&
-      (scalarInt.isUnsigned() || scalarInt.isSignless()))
+      (scalarInt.isUnsigned() || scalarInt.isSignless())) {
     return success();
+  }
   if (elemInt.isSignless() && scalarInt.isSignless()) {
     return success();
   }
@@ -5923,8 +6132,9 @@ static LogicalResult verifyVecScalarMaskedOpLike(OpTy op) {
     return failure();
   }
   if (failed(verifyNonLowPrecisionVRegElementTypeLike(
-          op.getOperation(), op.getInput().getType(), "input type")))
+          op.getOperation(), op.getInput().getType(), "input type"))) {
     return failure();
+  }
   return success();
 }
 
@@ -5934,9 +6144,10 @@ static LogicalResult verifyCarryVecOp(CarryOp op) {
       failed(verifyIntegerVRegTypeLike(op, op.getRhs().getType(), "rhs type")) ||
       failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type")) ||
       failed(verifyIntegerVRegTypeLike(op, op.getResult().getType(),
-                                      "result type")) ||
-      failed(verifyMaskTypeLike(op, op.getCarry().getType(), "carry type")))
+                                       "result type")) ||
+      failed(verifyMaskTypeLike(op, op.getCarry().getType(), "carry type"))) {
     return failure();
+  }
 
   auto lhsType = cast<VRegType>(op.getLhs().getType());
   auto rhsType = cast<VRegType>(op.getRhs().getType());
@@ -5945,7 +6156,7 @@ static LogicalResult verifyCarryVecOp(CarryOp op) {
   if (lhsType != rhsType || lhsType != resultType) {
     return op.emitOpError("requires lhs, rhs, and result to have matching vector types");
   }
-  if (lhsElemType.getWidth() != 32) {
+  if (lhsElemType.getWidth() != mlir::pto::kValue32) {
     return op.emitOpError("currently requires 32-bit integer vector elements");
   }
   return success();
@@ -5955,8 +6166,9 @@ template <typename CarryWithInputOp>
 static LogicalResult verifyCarryVecOpWithInput(CarryWithInputOp op) {
   if (failed(verifyCarryVecOp(op)) ||
       failed(verifyMaskTypeLike(op, op.getCarryIn().getType(),
-                                "carry_in type")))
+                                "carry_in type"))) {
     return failure();
+  }
   return success();
 }
 
@@ -5981,7 +6193,7 @@ LogicalResult VshlsOp::verify() {
     return emitOpError("requires integer vector and integer scalar");
   }
   auto scalarType = dyn_cast<IntegerType>(getScalar().getType());
-  if (!scalarType || !scalarType.isSignlessInteger(16)) {
+  if (!scalarType || !scalarType.isSignlessInteger(mlir::pto::kValue16)) {
     return emitOpError("requires signless i16 scalar");
   }
   return success();
@@ -6002,7 +6214,7 @@ LogicalResult VshrsOp::verify() {
     return emitOpError("requires integer vector and integer scalar");
   }
   auto scalarType = dyn_cast<IntegerType>(getScalar().getType());
-  if (!scalarType || !scalarType.isSignlessInteger(16)) {
+  if (!scalarType || !scalarType.isSignlessInteger(mlir::pto::kValue16)) {
     return emitOpError("requires signless i16 scalar");
   }
   return success();
@@ -6036,8 +6248,9 @@ static LogicalResult verifyUnaryVecOp(UnaryOp op) {
     return failure();
   }
   if (failed(verifyNonLowPrecisionVRegElementTypeLike(
-          op.getOperation(), op.getInput().getType(), "operand type")))
+          op.getOperation(), op.getInput().getType(), "operand type"))) {
     return failure();
+  }
   if (op.getInput().getType() != op.getResult().getType()) {
     return op.emitOpError("requires matching register vector shape");
   }
@@ -6055,7 +6268,7 @@ LogicalResult VreluOp::verify() {
   auto inputType = cast<VRegType>(getInput().getType());
   Type elemType = inputType.getElementType();
   if (auto intType = dyn_cast<IntegerType>(elemType)) {
-    if (intType.getWidth() != 32 || intType.isUnsigned()) {
+    if (intType.getWidth() != mlir::pto::kValue32 || intType.isUnsigned()) {
       return emitOpError("requires si32/i32/f16/f32 vector element type");
     }
     return success();
@@ -6084,18 +6297,21 @@ static LogicalResult verifyBinaryVecOp(BinaryOp op,
   }
   if (!allowLowPrecision &&
       failed(verifyNonLowPrecisionVRegElementTypeLike(
-          op.getOperation(), op.getLhs().getType(), "lhs type")))
+          op.getOperation(), op.getLhs().getType(), "lhs type"))) {
     return failure();
+}
   if (allowLowPrecision) {
     auto lhsType = cast<VRegType>(op.getLhs().getType());
-    if (pto::isPTOBF16x2Type(lhsType.getElementType()))
+    if (pto::isPTOBF16x2Type(lhsType.getElementType())) {
       return op.emitOpError(
           "does not support bf16x2 vector elements; low-precision bitwise "
           "operations require an 8-bit payload type");
+}
   }
   if (op.getLhs().getType() != op.getRhs().getType() ||
-      op.getLhs().getType() != op.getResult().getType())
+      op.getLhs().getType() != op.getResult().getType()) {
     return op.emitOpError("requires matching register vector shapes");
+}
   return success();
 }
 
@@ -6119,8 +6335,9 @@ static LogicalResult verifyTernaryVecOp(TernaryOp op) {
       failed(verifyVRegTypeLike(op, op.getLhs().getType(), "lhs type")) ||
       failed(verifyVRegTypeLike(op, op.getRhs().getType(), "rhs type")) ||
       failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type")) ||
-      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type"))) {
     return failure();
+  }
   if (op.getAcc().getType() != op.getLhs().getType() ||
       op.getAcc().getType() != op.getRhs().getType() ||
       op.getAcc().getType() != op.getResult().getType()) {
@@ -6178,10 +6395,11 @@ static LogicalResult verifyGroupReductionVecOp(ReductionOp op) {
   auto inputType = cast<VRegType>(op.getInput().getType());
   Type elemType = inputType.getElementType();
   if (auto intType = dyn_cast<IntegerType>(elemType)) {
-    if (intType.getWidth() != 8 && intType.getWidth() != 16 &&
-        intType.getWidth() != 32)
+    if (intType.getWidth() != mlir::pto::kValue8 && intType.getWidth() != 16 &&
+        intType.getWidth() != mlir::pto::kValue32) {
       return op.emitOpError(
           "requires 8-bit, 16-bit, or 32-bit integer vector element type");
+    }
     return success();
   }
   if (!elemType.isF16() && !elemType.isF32()) {
@@ -6211,23 +6429,26 @@ static LogicalResult verifyHistogramOp(HistOp op) {
       failed(verifyVRegTypeLike(op, op.getSource().getType(), "source type")) ||
       failed(verifyMaskTypeWithGranularityLike(op, op.getMask().getType(),
                                                "mask type", "b8")) ||
-      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type"))) {
     return failure();
+  }
   auto accType = cast<VRegType>(op.getAcc().getType());
   auto sourceType = cast<VRegType>(op.getSource().getType());
   auto resultType = cast<VRegType>(op.getResult().getType());
   auto accElemType = dyn_cast<IntegerType>(accType.getElementType());
   auto sourceElemType = dyn_cast<IntegerType>(sourceType.getElementType());
-  if (!accElemType || accElemType.getWidth() != 16 ||
-      accType.getElementCount() != 128)
+  if (!accElemType || accElemType.getWidth() != mlir::pto::kValue16 ||
+      accType.getElementCount() != mlir::pto::kValue128) {
     return op.emitOpError("requires acc type to be !pto.vreg<128xi16>");
-  if (!sourceElemType || sourceElemType.getWidth() != 8 ||
-      sourceType.getElementCount() != 256)
+  }
+  if (!sourceElemType || sourceElemType.getWidth() != mlir::pto::kValue8 ||
+      sourceType.getElementCount() != mlir::pto::kValue256) {
     return op.emitOpError("requires source type to be !pto.vreg<256xi8>");
+  }
   if (resultType != accType) {
     return op.emitOpError("requires result type to match acc type");
   }
-  if (!op.getBin().getType().isInteger(32)) {
+  if (!op.getBin().getType().isInteger(mlir::pto::kValue32)) {
     return op.emitOpError("requires bin operand to be i32");
   }
   return success();
@@ -6242,23 +6463,27 @@ static LogicalResult verifyExtremaPredicateOp(ExtremaOp op) {
       failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type")) ||
       failed(verifyVRegTypeLike(op, op.getValue().getType(), "value type")) ||
       failed(verifyMaskTypeLike(op, op.getPredicate().getType(),
-                                "predicate type")))
+                                "predicate type"))) {
     return failure();
-  if (op.getInput().getType() != op.getValue().getType())
+  }
+  if (op.getInput().getType() != op.getValue().getType()) {
     return op.emitOpError(
         "requires input and value result to share one vector type");
-  if (op.getMask().getType() != op.getPredicate().getType())
+  }
+  if (op.getMask().getType() != op.getPredicate().getType()) {
     return op.emitOpError(
         "requires mask and predicate result to share one mask type");
+  }
 
   Type elemType = cast<VRegType>(op.getInput().getType()).getElementType();
   if (elemType.isF16() || elemType.isF32()) {
     return success();
   }
   auto intType = dyn_cast<IntegerType>(elemType);
-  if (!intType || (intType.getWidth() != 8 && intType.getWidth() != 16 &&
-                   intType.getWidth() != 32))
+  if (!intType || (intType.getWidth() != mlir::pto::kValue8 && intType.getWidth() != 16 &&
+                   intType.getWidth() != mlir::pto::kValue32)) {
     return op.emitOpError("requires i8/i16/i32/f16/f32 vector element type");
+  }
   return success();
 }
 
@@ -6269,8 +6494,9 @@ template <typename SelectOp>
 static LogicalResult verifyLaneSelectOp(SelectOp op) {
   if (failed(verifyVRegTypeLike(op, op.getSrc0().getType(), "src0 type")) ||
       failed(verifyVRegTypeLike(op, op.getSrc1().getType(), "src1 type")) ||
-      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type"))) {
     return failure();
+  }
 
   auto src0Type = cast<VRegType>(op.getSrc0().getType());
   auto src1Type = cast<VRegType>(op.getSrc1().getType());
@@ -6296,12 +6522,14 @@ static LogicalResult verifyPairVecResults(PairOp op) {
   if (failed(verifyVRegTypeLike(op, op.getLhs().getType(), "lhs type")) ||
       failed(verifyVRegTypeLike(op, op.getRhs().getType(), "rhs type")) ||
       failed(verifyVRegTypeLike(op, op.getLow().getType(), "low result type")) ||
-      failed(verifyVRegTypeLike(op, op.getHigh().getType(), "high result type")))
+      failed(verifyVRegTypeLike(op, op.getHigh().getType(), "high result type"))) {
     return failure();
+  }
   if (op.getLhs().getType() != op.getRhs().getType() ||
       op.getLhs().getType() != op.getLow().getType() ||
-      op.getLhs().getType() != op.getHigh().getType())
+      op.getLhs().getType() != op.getHigh().getType()) {
     return op.emitOpError("requires operands and results to share one vector type");
+  }
   return success();
 }
 
@@ -6309,11 +6537,13 @@ template <typename PartOp>
 static LogicalResult verifyPartVecOp(PartOp op) {
   if (failed(verifyVRegTypeLike(op, op.getLhs().getType(), "lhs type")) ||
       failed(verifyVRegTypeLike(op, op.getRhs().getType(), "rhs type")) ||
-      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type"))) {
     return failure();
+  }
   if (op.getLhs().getType() != op.getRhs().getType() ||
-      op.getLhs().getType() != op.getResult().getType())
+      op.getLhs().getType() != op.getResult().getType()) {
     return op.emitOpError("requires operands and result to share one vector type");
+  }
   if (!isSupportedPartToken(op.getPart())) {
     return op.emitOpError("requires part to be LOWER or HIGHER");
   }
@@ -6324,14 +6554,17 @@ LogicalResult VselOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getSrc0().getType(), "src0 type")) ||
       failed(verifyVRegTypeLike(*this, getSrc1().getType(), "src1 type")) ||
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
-      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
   if (failed(verifyNonLowPrecisionVRegElementTypeLike(
-          getOperation(), getSrc0().getType(), "src0 type")))
+          getOperation(), getSrc0().getType(), "src0 type"))) {
     return failure();
+  }
   if (getSrc0().getType() != getSrc1().getType() ||
-      getSrc0().getType() != getResult().getType())
+      getSrc0().getType() != getResult().getType()) {
     return emitOpError("requires src0, src1, and result to have identical vector types");
+  }
   return success();
 }
 
@@ -6343,8 +6576,9 @@ LogicalResult VsqzOp::verify() { return verifyUnaryVecOp(*this); }
 LogicalResult VusqzOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getSrc().getType(), "src type")) ||
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
-      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
   if (getSrc().getType() != getResult().getType()) {
     return emitOpError("requires src and result to share one vector type");
   }
@@ -6357,7 +6591,7 @@ LogicalResult VusqzOp::verify() {
     return emitOpError("requires signed integer vector element type");
   }
   unsigned width = elemType.getWidth();
-  if (width != 8 && width != 16 && width != 32) {
+  if (width != mlir::pto::kValue8 && width != 16 && width != mlir::pto::kValue32) {
     return emitOpError("requires s8/s16/s32 vector element type");
   }
   return success();
@@ -6365,8 +6599,9 @@ LogicalResult VusqzOp::verify() {
 
 LogicalResult VpackOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getSrc().getType(), "src type")) ||
-      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
   if (!isSupportedPartToken(getPart())) {
     return emitOpError("requires part to be LOWER or HIGHER");
   }
@@ -6377,46 +6612,55 @@ LogicalResult VpackOp::verify() {
   if (!isa<IntegerType>(srcElemType) || !isa<IntegerType>(resultElemType)) {
     return emitOpError("currently requires integer source and result element types");
   }
-  if (resultType.getElementCount() != srcType.getElementCount() * 2)
+  if (resultType.getElementCount() != srcType.getElementCount() * mlir::pto::kValue2) {
     return emitOpError(
         "requires result element count to be twice the source element count");
+  }
   unsigned srcWidth = getIntOrFloatBitWidth(srcElemType);
   unsigned resultWidth = getIntOrFloatBitWidth(resultElemType);
-  if (!srcWidth || resultWidth * 2 != srcWidth)
+  if (!srcWidth || resultWidth * mlir::pto::kValue2 != srcWidth) {
     return emitOpError(
         "requires result element width to be half the source element width");
+  }
   auto srcIntType = cast<IntegerType>(srcElemType);
   auto resultIntType = cast<IntegerType>(resultElemType);
   if (!resultIntType.isUnsigned()) {
     return emitOpError("requires unsigned result element type");
   }
-  if (!((srcIntType.getWidth() == 32 && resultIntType.getWidth() == 16) ||
-        (srcIntType.getWidth() == 16 && resultIntType.getWidth() == 8)))
+  if (!((srcIntType.getWidth() == mlir::pto::kValue32 &&
+         resultIntType.getWidth() == mlir::pto::kValue16) ||
+        (srcIntType.getWidth() == mlir::pto::kValue16 &&
+         resultIntType.getWidth() == mlir::pto::kValue8))) {
     return emitOpError(
         "currently supports only s32/u32 -> u16 and s16/u16 -> u8");
+  }
   return success();
 }
 
 template <typename UnpackOp>
 static LogicalResult verifyUnpackVecOp(UnpackOp op) {
   if (failed(verifyVRegTypeLike(op, op.getSrc().getType(), "src type")) ||
-      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type"))) {
     return failure();
+  }
   auto srcType = cast<VRegType>(op.getSrc().getType());
   auto resultType = cast<VRegType>(op.getResult().getType());
   Type srcElemType = srcType.getElementType();
   Type resultElemType = resultType.getElementType();
-  if (!isa<IntegerType>(srcElemType) || !isa<IntegerType>(resultElemType))
+  if (!isa<IntegerType>(srcElemType) || !isa<IntegerType>(resultElemType)) {
     return op.emitOpError(
         "currently requires integer source and result element types");
-  if (srcType.getElementCount() != resultType.getElementCount() * 2)
+  }
+  if (srcType.getElementCount() != resultType.getElementCount() * 2) {
     return op.emitOpError(
         "requires source element count to be twice the result element count");
+  }
   unsigned srcWidth = getIntOrFloatBitWidth(srcElemType);
   unsigned resultWidth = getIntOrFloatBitWidth(resultElemType);
-  if (!srcWidth || srcWidth * 2 != resultWidth)
+  if (!srcWidth || srcWidth * mlir::pto::kValue2 != resultWidth) {
     return op.emitOpError(
         "requires result element width to be twice the source element width");
+  }
   return success();
 }
 
@@ -6432,8 +6676,9 @@ LogicalResult VcmpOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getSrc0().getType(), "src0 type")) ||
       failed(verifyVRegTypeLike(*this, getSrc1().getType(), "src1 type")) ||
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
-      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
   if (getSrc0().getType() != getSrc1().getType()) {
     return emitOpError("requires src0 and src1 to have identical vector types");
   }
@@ -6446,8 +6691,9 @@ LogicalResult VcmpOp::verify() {
 LogicalResult VcmpsOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getSrc().getType(), "src type")) ||
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
-      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyMaskTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
   auto srcType = cast<VRegType>(getSrc().getType());
   Type srcElementType = srcType.getElementType();
   Type scalarType = getScalar().getType();
@@ -6473,20 +6719,23 @@ ParseResult VtrcOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.parseOptionalAttrDict(attrs) ||
       parser.parseColonType(inputType) || parser.parseComma() ||
       parser.parseType(maskType) || parser.parseArrow() ||
-      parser.parseType(resultType))
+      parser.parseType(resultType)) {
     return failure();
+  }
 
   auto normalized = normalizeRoundModeToken(roundModeToken);
-  if (!normalized || !isSupportedVtrcRoundMode(*normalized))
+  if (!normalized || !isSupportedVtrcRoundMode(*normalized)) {
     return parser.emitError(parser.getCurrentLocation())
            << "round mode must be one of R/A/F/C/Z or "
               "ROUND_R/ROUND_A/ROUND_F/ROUND_C/ROUND_Z";
+  }
 
   attrs.set("round_mode", parser.getBuilder().getStringAttr(*normalized));
   result.addAttributes(attrs);
   if (parser.resolveOperand(input, inputType, result.operands) ||
-      parser.resolveOperand(mask, maskType, result.operands))
+      parser.resolveOperand(mask, maskType, result.operands)) {
     return failure();
+  }
   result.addTypes(resultType);
   return success();
 }
@@ -6524,8 +6773,9 @@ LogicalResult VtrcOp::verify() {
   }
   if (failed(verifyMaskTypeWithGranularityLike(*this, getMask().getType(),
                                                "mask type",
-                                               *expectedGranularity)))
+                                               *expectedGranularity))) {
     return failure();
+  }
   auto normalized = normalizeRoundModeToken(getRoundMode());
   if (!normalized || !isSupportedVtrcRoundMode(*normalized)) {
     return emitOpError("round mode must be one of R/A/F/C/Z");
@@ -6536,8 +6786,9 @@ LogicalResult VtrcOp::verify() {
 LogicalResult VmulscvtOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getInput().getType(), "input type")) ||
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
-      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
 
   auto inputType = cast<VRegType>(getInput().getType());
   auto resultType = cast<VRegType>(getResult().getType());
@@ -6554,14 +6805,16 @@ LogicalResult VmulscvtOp::verify() {
   }
 
   if (failed(verifyMaskTypeWithGranularityLike(*this, getMask().getType(),
-                                               "mask type", "b32")))
+                                               "mask type", "b32"))) {
     return failure();
+  }
 
   auto inputBits = getVRegStorageBitWidth(inputType);
   auto resultBits = getVRegStorageBitWidth(resultType);
-  if (!inputBits || !resultBits || *inputBits != *resultBits)
+  if (!inputBits || !resultBits || *inputBits != *resultBits) {
     return emitOpError(
         "requires source and result to preserve total vector storage width");
+  }
 
   auto normalizedRnd = normalizeRoundModeToken(getRnd());
   if (!normalizedRnd) {
@@ -6588,14 +6841,16 @@ ParseResult VcvtOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.parseOperand(mask) || parser.parseOptionalAttrDict(attrs) ||
       parser.parseColonType(inputType) || parser.parseComma() ||
       parser.parseType(maskType) || parser.parseArrow() ||
-      parser.parseType(resultType))
+      parser.parseType(resultType)) {
     return failure();
+  }
 
   Attribute legacyRndAttr = attrs.get("round_mode");
   Attribute rndAttr = attrs.get("rnd");
-  if (legacyRndAttr && rndAttr)
+  if (legacyRndAttr && rndAttr) {
     return parser.emitError(parser.getCurrentLocation())
            << "rnd and round_mode cannot be specified together";
+  }
 
   auto normalizeNamedStringAttr =
       [&](StringRef sourceName, StringRef canonicalName,
@@ -6605,30 +6860,33 @@ ParseResult VcvtOp::parse(OpAsmParser &parser, OperationState &result) {
       return success();
     }
     auto strAttr = dyn_cast<StringAttr>(rawAttr);
-    if (!strAttr)
+    if (!strAttr) {
       return parser.emitError(parser.getCurrentLocation())
              << sourceName << " must be a string literal";
+    }
     auto normalized = normalizeFn(strAttr.getValue());
-    if (!normalized)
+    if (!normalized) {
       return parser.emitError(parser.getCurrentLocation())
              << sourceName << " has unsupported value '" << strAttr.getValue()
              << "'";
+    }
     attrs.erase(sourceName);
     attrs.set(canonicalName, parser.getBuilder().getStringAttr(*normalized));
     return success();
   };
-
   if (failed(normalizeNamedStringAttr("round_mode", "rnd",
                                       normalizeRoundModeToken)) ||
       failed(normalizeNamedStringAttr("rnd", "rnd", normalizeRoundModeToken)) ||
       failed(normalizeNamedStringAttr("sat", "sat", normalizeSaturationToken)) ||
-      failed(normalizeNamedStringAttr("part", "part", normalizeVcvtPartToken)))
+      failed(normalizeNamedStringAttr("part", "part", normalizeVcvtPartToken))) {
     return failure();
+  }
 
   result.addAttributes(attrs);
   if (parser.resolveOperand(input, inputType, result.operands) ||
-      parser.resolveOperand(mask, maskType, result.operands))
+      parser.resolveOperand(mask, maskType, result.operands)) {
     return failure();
+  }
   result.addTypes(resultType);
   return success();
 }
@@ -6671,8 +6929,9 @@ LogicalResult VcvtOp::verify() {
     return emitOpError("could not determine vcvt mask granularity");
   }
   if (failed(verifyMaskTypeWithGranularityLike(
-          *this, getMask().getType(), "mask type", expectedMaskGranularity)))
+          *this, getMask().getType(), "mask type", expectedMaskGranularity))) {
     return failure();
+  }
   if (inputType.getElementCount() * static_cast<int64_t>(*inputElemBits) !=
       resultType.getElementCount() * static_cast<int64_t>(*resultElemBits)) {
     return emitOpError("requires source and result vectors to carry the same "
@@ -6748,14 +7007,16 @@ LogicalResult VbitcastOp::verify() {
     if (auto intType = dyn_cast<IntegerType>(elementType)) {
       return type.getElementCount() * static_cast<int64_t>(intType.getWidth());
     }
-    if (auto floatType = dyn_cast<FloatType>(elementType))
+    if (auto floatType = dyn_cast<FloatType>(elementType)) {
       return type.getElementCount() *
              static_cast<int64_t>(floatType.getWidth());
+}
     // Packed PTO element types (f8/hif8/f4x2/bf16x2/...) have a known storage
     // width even though they are not IntegerType/FloatType.
     unsigned packedBits = pto::getPTOStorageElemBitWidth(elementType);
-    if (packedBits != 0)
+    if (packedBits != 0) {
       return type.getElementCount() * static_cast<int64_t>(packedBits);
+}
     return std::nullopt;
   };
 
@@ -6780,8 +7041,9 @@ LogicalResult PdintlvB8Op::verify() {
       failed(verifyMaskTypeWithGranularityLike(*this, getLow().getType(),
                                                "low type", "b8")) ||
       failed(verifyMaskTypeWithGranularityLike(*this, getHigh().getType(),
-                                               "high type", "b8")))
+                                               "high type", "b8"))) {
     return failure();
+  }
   return success();
 }
 
@@ -6793,8 +7055,9 @@ LogicalResult PdintlvB16Op::verify() {
       failed(verifyMaskTypeWithGranularityLike(*this, getLow().getType(),
                                                "low type", "b16")) ||
       failed(verifyMaskTypeWithGranularityLike(*this, getHigh().getType(),
-                                               "high type", "b16")))
+                                               "high type", "b16"))) {
     return failure();
+  }
   return success();
 }
 
@@ -6806,8 +7069,9 @@ LogicalResult PdintlvB32Op::verify() {
       failed(verifyMaskTypeWithGranularityLike(*this, getLow().getType(),
                                                "low type", "b32")) ||
       failed(verifyMaskTypeWithGranularityLike(*this, getHigh().getType(),
-                                               "high type", "b32")))
+                                               "high type", "b32"))) {
     return failure();
+  }
   return success();
 }
 
@@ -6819,8 +7083,9 @@ LogicalResult PintlvB8Op::verify() {
       failed(verifyMaskTypeWithGranularityLike(*this, getLow().getType(),
                                                "low type", "b8")) ||
       failed(verifyMaskTypeWithGranularityLike(*this, getHigh().getType(),
-                                               "high type", "b8")))
+                                               "high type", "b8"))) {
     return failure();
+  }
   return success();
 }
 
@@ -6832,8 +7097,9 @@ LogicalResult PintlvB16Op::verify() {
       failed(verifyMaskTypeWithGranularityLike(*this, getLow().getType(),
                                                "low type", "b16")) ||
       failed(verifyMaskTypeWithGranularityLike(*this, getHigh().getType(),
-                                               "high type", "b16")))
+                                               "high type", "b16"))) {
     return failure();
+  }
   return success();
 }
 
@@ -6845,8 +7111,9 @@ LogicalResult PintlvB32Op::verify() {
       failed(verifyMaskTypeWithGranularityLike(*this, getLow().getType(),
                                                "low type", "b32")) ||
       failed(verifyMaskTypeWithGranularityLike(*this, getHigh().getType(),
-                                               "high type", "b32")))
+                                               "high type", "b32"))) {
     return failure();
+  }
   return success();
 }
 
@@ -6857,14 +7124,15 @@ LogicalResult Vdintlvv2Op::verify() { return verifyPartVecOp(*this); }
 
 LogicalResult VmullOp::verify() {
   if (failed(verifyPairVecResults(*this)) ||
-      failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
+      failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type"))) {
     return failure();
+  }
   auto lhsType = cast<VRegType>(getLhs().getType());
   auto lhsElemType = dyn_cast<IntegerType>(lhsType.getElementType());
   if (!lhsElemType) {
     return emitOpError("requires integer vector element type");
   }
-  if (lhsElemType.getWidth() != 32) {
+  if (lhsElemType.getWidth() != mlir::pto::kValue32) {
     return emitOpError("currently requires 32-bit integer vector elements");
   }
   return success();
@@ -6875,12 +7143,14 @@ LogicalResult VmulaOp::verify() {
       failed(verifyVRegTypeLike(*this, getLhs().getType(), "lhs type")) ||
       failed(verifyVRegTypeLike(*this, getRhs().getType(), "rhs type")) ||
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
-      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
   if (getAcc().getType() != getLhs().getType() ||
       getAcc().getType() != getRhs().getType() ||
-      getAcc().getType() != getResult().getType())
+      getAcc().getType() != getResult().getType()) {
     return emitOpError("requires acc, lhs, rhs, and result to share one vector type");
+  }
   return success();
 }
 
@@ -6888,11 +7158,13 @@ template <typename BinaryVecNoMaskOp>
 static LogicalResult verifyBinaryVecNoMaskOp(BinaryVecNoMaskOp op) {
   if (failed(verifyVRegTypeLike(op, op.getLhs().getType(), "lhs type")) ||
       failed(verifyVRegTypeLike(op, op.getRhs().getType(), "rhs type")) ||
-      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type"))) {
     return failure();
+  }
   if (op.getLhs().getType() != op.getRhs().getType() ||
-      op.getLhs().getType() != op.getResult().getType())
+      op.getLhs().getType() != op.getResult().getType()) {
     return op.emitOpError("requires lhs, rhs, and result to share one vector type");
+  }
   return success();
 }
 
@@ -6914,11 +7186,13 @@ static LogicalResult verifyFloatBinaryVecMaskOp(BinaryVecMaskOp op) {
   if (failed(verifyVRegTypeLike(op, op.getLhs().getType(), "lhs type")) ||
       failed(verifyVRegTypeLike(op, op.getRhs().getType(), "rhs type")) ||
       failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type")) ||
-      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type"))) {
     return failure();
+  }
   if (op.getLhs().getType() != op.getRhs().getType() ||
-      op.getLhs().getType() != op.getResult().getType())
+      op.getLhs().getType() != op.getResult().getType()) {
     return op.emitOpError("requires lhs, rhs, and result to share one vector type");
+  }
   auto lhsType = cast<VRegType>(op.getLhs().getType());
   Type elemType = lhsType.getElementType();
   if (!elemType.isF16() && !elemType.isF32()) {
@@ -6932,8 +7206,9 @@ LogicalResult VexpdifOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getInput().getType(), "input type")) ||
       failed(verifyVRegTypeLike(*this, getMax().getType(), "max type")) ||
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
-      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
 
   auto inputType = cast<VRegType>(getInput().getType());
   auto maxType = cast<VRegType>(getMax().getType());
@@ -6952,17 +7227,19 @@ LogicalResult VexpdifOp::verify() {
   }
   if (failed(verifyMaskTypeWithGranularityLike(*this, getMask().getType(),
                                                "mask type",
-                                               *expectedGranularity)))
+                                               *expectedGranularity))) {
     return failure();
+  }
   if (!resultType.getElementType().isF32()) {
     return emitOpError("requires f32 result vector element type");
   }
 
   auto inputBits = getVRegStorageBitWidth(inputType);
   auto resultBits = getVRegStorageBitWidth(resultType);
-  if (!inputBits || !resultBits || *inputBits != *resultBits)
+  if (!inputBits || !resultBits || *inputBits != *resultBits) {
     return emitOpError(
         "requires source and result to preserve total vector storage width");
+  }
 
   StringRef part = getPart();
   if (part != "EVEN" && part != "ODD") {
@@ -6975,8 +7252,9 @@ LogicalResult VaxpyOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getSrc0().getType(), "src0 type")) ||
       failed(verifyVRegTypeLike(*this, getSrc1().getType(), "src1 type")) ||
       failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")) ||
-      failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
+      failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type"))) {
     return failure();
+  }
   auto src0Type = cast<VRegType>(getSrc0().getType());
   auto src1Type = cast<VRegType>(getSrc1().getType());
   auto resultType = cast<VRegType>(getResult().getType());
@@ -6993,8 +7271,9 @@ LogicalResult VaxpyOp::verify() {
   }
   if (failed(verifyMaskTypeWithGranularityLike(*this, getMask().getType(),
                                                "mask type",
-                                               *expectedGranularity)))
+                                               *expectedGranularity))) {
     return failure();
+  }
   if (getAlpha().getType() != elemType) {
     return emitOpError("requires alpha type to match vector element type");
   }
@@ -7005,8 +7284,9 @@ template <typename ConvOp>
 static LogicalResult verifyFusedConvVecOp(ConvOp op) {
   if (failed(verifyVRegTypeLike(op, op.getLhs().getType(), "lhs type")) ||
       failed(verifyVRegTypeLike(op, op.getRhs().getType(), "rhs type")) ||
-      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type"))) {
     return failure();
+  }
   auto lhsType = cast<VRegType>(op.getLhs().getType());
   auto rhsType = cast<VRegType>(op.getRhs().getType());
   auto resultType = cast<VRegType>(op.getResult().getType());
@@ -7014,14 +7294,16 @@ static LogicalResult verifyFusedConvVecOp(ConvOp op) {
     return op.emitOpError("requires lhs and rhs to share one vector type");
   }
   if (!isIntegerOrFloatLike(lhsType.getElementType()) ||
-      !isIntegerOrFloatLike(resultType.getElementType()))
+      !isIntegerOrFloatLike(resultType.getElementType())) {
     return op.emitOpError(
         "requires integer or floating-point vector element types");
+  }
   auto lhsBits = getVRegStorageBitWidth(lhsType);
   auto resultBits = getVRegStorageBitWidth(resultType);
-  if (!lhsBits || !resultBits || *lhsBits != *resultBits)
+  if (!lhsBits || !resultBits || *lhsBits != *resultBits) {
     return op.emitOpError(
         "requires source and result to preserve total vector storage width");
+  }
   return success();
 }
 
@@ -7047,8 +7329,9 @@ LogicalResult Vldsx2Op::verify() {
     return emitOpError("requires index offset");
   }
   if (failed(verifyVRegTypeLike(*this, getLow().getType(), "low result type")) ||
-      failed(verifyVRegTypeLike(*this, getHigh().getType(), "high result type")))
+      failed(verifyVRegTypeLike(*this, getHigh().getType(), "high result type"))) {
     return failure();
+  }
   if (getLow().getType() != getHigh().getType()) {
     return emitOpError("requires low/high results to share one vector type");
   }
@@ -7056,8 +7339,9 @@ LogicalResult Vldsx2Op::verify() {
     return emitOpError("requires a supported x2 load distribution token");
   }
   if (getUpdatedBase() &&
-      getUpdatedBase().getType() != getSource().getType())
+      getUpdatedBase().getType() != getSource().getType()) {
     return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
 
@@ -7091,8 +7375,9 @@ static LogicalResult verifyVstsCommon(StoreOp op) {
     if (std::optional<StringRef> granularity = getVstsMaskGranularityOverride(
             *dist, cast<VRegType>(op.getValue().getType()).getElementType())) {
       if (failed(verifyMaskTypeWithGranularityLike(op, op.getMask().getType(),
-                                                   "mask type", *granularity)))
+                                                   "mask type", *granularity))) {
         return failure();
+      }
     } else if (failed(verifyMaskTypeLike(op, op.getMask().getType(),
                                          "mask type"))) {
       return failure();
@@ -7110,8 +7395,9 @@ LogicalResult VstsOp::verify() {
     return failure();
   }
   if (getUpdatedBase() &&
-      getUpdatedBase().getType() != getDestination().getType())
+      getUpdatedBase().getType() != getDestination().getType()) {
     return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
 void Vstsx2Op::getEffects(
@@ -7125,8 +7411,9 @@ void Vstsx2Op::getEffects(
 LogicalResult Vstsx2Op::verify() {
   if (failed(verifyVRegTypeLike(*this, getLow().getType(), "low value type")) ||
       failed(verifyVRegTypeLike(*this, getHigh().getType(), "high value type")) ||
-      failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
+      failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type"))) {
     return failure();
+  }
   if (getLow().getType() != getHigh().getType()) {
     return emitOpError("requires low/high values to share one vector type");
   }
@@ -7169,32 +7456,36 @@ LogicalResult VscatterOp::verify() {
     return emitOpError("offset vector must use integer element type");
   }
   unsigned valueElemWidth = getPTOStorageElemBitWidth(valueType.getElementType());
-  if (valueElemWidth != 8 && valueElemWidth != 16 && valueElemWidth != 32) {
+  if (valueElemWidth != mlir::pto::kValue8 && valueElemWidth != 16 && valueElemWidth != 32) {
     return emitOpError("requires 8-, 16-, or 32-bit value elements");
   }
 
   unsigned expectedOffsetWidth = valueElemWidth == 32 ? 32 : 16;
-  if (offsetsElemType.getWidth() != expectedOffsetWidth)
+  if (offsetsElemType.getWidth() != expectedOffsetWidth) {
     return emitOpError() << "requires " << expectedOffsetWidth
                          << "-bit offset vector elements for "
                          << valueElemWidth << "-bit values";
+  }
 
   int64_t expectedOffsetCount = valueElemWidth == 8
                                     ? valueType.getElementCount() / 2
                                     : valueType.getElementCount();
-  if (offsetsType.getElementCount() != expectedOffsetCount)
+  if (offsetsType.getElementCount() != expectedOffsetCount) {
     return emitOpError() << "requires " << expectedOffsetCount
                          << " offsets for " << valueType.getElementCount()
                          << "x" << valueElemWidth << "-bit values";
+  }
 
   if (failed(verifyMaskTypeWithGranularityLike(
           *this, getMask().getType(), "mask type",
-          valueElemWidth == 32 ? "b32" : "b16")))
+          valueElemWidth == mlir::pto::kValue32 ? "b32" : "b16"))) {
     return failure();
+  }
   auto destinationType = cast<PtrType>(getDestination().getType());
-  if (destinationType.getElementType() != valueType.getElementType())
+  if (destinationType.getElementType() != valueType.getElementType()) {
     return emitOpError(
         "requires destination element type to match value element type");
+  }
   MemoryRole destinationRole = classifyMemoryRole(getDestination().getType());
   if (destinationRole == MemoryRole::GM) {
     return emitOpError("requires a UB-backed destination");
@@ -7216,17 +7507,19 @@ LogicalResult VsldbOp::verify() {
     return emitOpError("requires a UB-backed source");
   }
   if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
-      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
+      failed(verifyVRegTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
-  if (!getBlockStride().getType().isSignlessInteger(16)) {
+  }
+  if (!getBlockStride().getType().isSignlessInteger(mlir::pto::kValue16)) {
     return emitOpError("requires block_stride to be i16");
   }
-  if (!getRepeatStride().getType().isSignlessInteger(16)) {
+  if (!getRepeatStride().getType().isSignlessInteger(mlir::pto::kValue16)) {
     return emitOpError("requires repeat_stride to be i16");
   }
   if (getUpdatedBase() &&
-      getUpdatedBase().getType() != getSource().getType())
+      getUpdatedBase().getType() != getSource().getType()) {
     return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
 
@@ -7261,8 +7554,9 @@ LogicalResult PstiOp::verify() {
     return emitOpError("requires predicate store dist to be NORM or PK");
   }
   if (getUpdatedBase() &&
-      getUpdatedBase().getType() != getDestination().getType())
+      getUpdatedBase().getType() != getDestination().getType()) {
     return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
 
@@ -7284,8 +7578,9 @@ LogicalResult PstsOp::verify() {
     return emitOpError("requires predicate store dist to be NORM or PK");
   }
   if (getUpdatedBase() &&
-      getUpdatedBase().getType() != getDestination().getType())
+      getUpdatedBase().getType() != getDestination().getType()) {
     return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
 
@@ -7298,23 +7593,25 @@ void VsstbOp::getEffects(
 
 LogicalResult VsstbOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getValue().getType(), "value type")) ||
-      failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
+      failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type"))) {
     return failure();
+  }
   if (!isBufferLike(getDestination().getType())) {
     return emitOpError("requires a pointer-like destination");
   }
   if (classifyMemoryRole(getDestination().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed destination");
   }
-  if (!getBlockStride().getType().isSignlessInteger(16)) {
+  if (!getBlockStride().getType().isSignlessInteger(mlir::pto::kValue16)) {
     return emitOpError("requires block_stride to be i16");
   }
-  if (!getRepeatStride().getType().isSignlessInteger(16)) {
+  if (!getRepeatStride().getType().isSignlessInteger(mlir::pto::kValue16)) {
     return emitOpError("requires repeat_stride to be i16");
   }
   if (getUpdatedBase() &&
-      getUpdatedBase().getType() != getDestination().getType())
+      getUpdatedBase().getType() != getDestination().getType()) {
     return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
 
@@ -7336,8 +7633,9 @@ LogicalResult VstasOp::verify() {
     return emitOpError("requires a UB-backed destination");
   }
   if (getUpdatedBase() &&
-      getUpdatedBase().getType() != getDestination().getType())
+      getUpdatedBase().getType() != getDestination().getType()) {
     return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
 
@@ -7372,8 +7670,9 @@ void PstuOp::getEffects(
 LogicalResult PstuOp::verify() {
   if (failed(verifyStoreAlignChain(getAlignIn(), *this, "align_in type")) ||
       failed(verifyMaskTypeLike(*this, getValue().getType(), "value type")) ||
-      failed(verifyAlignTypeLike(*this, getAlignOut().getType(), "align_out type")))
+      failed(verifyAlignTypeLike(*this, getAlignOut().getType(), "align_out type"))) {
     return failure();
+  }
   if (!isBufferLike(getBase().getType()) || !isBufferLike(getBaseOut().getType())) {
     return emitOpError("requires pointer-like base and base_out");
   }
@@ -7386,13 +7685,13 @@ LogicalResult PstuOp::verify() {
   auto baseType = cast<pto::PtrType>(getBase().getType());
   auto maskType = cast<pto::MaskType>(getValue().getType());
   auto elemType = dyn_cast<IntegerType>(baseType.getElementType());
-  if (!elemType || elemType.isSigned() || (elemType.getWidth() != 16 && elemType.getWidth() != 32)) {
+  if (!elemType || elemType.isSigned() || (elemType.getWidth() != mlir::pto::kValue16 && elemType.getWidth() != 32)) {
     return emitOpError("requires ui16/ui32 UB base type");
   }
-  if (maskType.isB16() && elemType.getWidth() != 16) {
+  if (maskType.isB16() && elemType.getWidth() != mlir::pto::kValue16) {
     return emitOpError("requires !pto.mask<b16> to pair with !pto.ptr<ui16, ub>");
   }
-  if (maskType.isB32() && elemType.getWidth() != 32) {
+  if (maskType.isB32() && elemType.getWidth() != mlir::pto::kValue32) {
     return emitOpError("requires !pto.mask<b32> to pair with !pto.ptr<ui32, ub>");
   }
   return success();
@@ -7409,8 +7708,9 @@ void VstusOp::getEffects(
 LogicalResult VstusOp::verify() {
   if (failed(verifyStoreAlignChain(getAlignIn(), *this, "align_in type")) ||
       failed(verifyVRegTypeLike(*this, getValue().getType(), "value type")) ||
-      failed(verifyAlignTypeLike(*this, getAlignOut().getType(), "align_out type")))
+      failed(verifyAlignTypeLike(*this, getAlignOut().getType(), "align_out type"))) {
     return failure();
+  }
   if (!isBufferLike(getBase().getType())) {
     return emitOpError("requires a pointer-like base");
   }
@@ -7434,8 +7734,9 @@ void VsturOp::getEffects(
 LogicalResult VsturOp::verify() {
   if (failed(verifyStoreAlignChain(getAlignIn(), *this, "align_in type")) ||
       failed(verifyVRegTypeLike(*this, getValue().getType(), "value type")) ||
-      failed(verifyAlignTypeLike(*this, getAlignOut().getType(), "align_out type")))
+      failed(verifyAlignTypeLike(*this, getAlignOut().getType(), "align_out type"))) {
     return failure();
+  }
   if (!isBufferLike(getBase().getType())) {
     return emitOpError("requires a pointer-like base");
   }
@@ -7513,26 +7814,29 @@ ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
   if (parseRequiredOperandWithComma(parser, source) ||
       parseRequiredOperandWithComma(parser, destination) ||
       parser.parseOperand(lenBurst) ||
-      parseDmaTripleGroup(parser, "nburst", nburstOperands))
+      parseDmaTripleGroup(parser, "nburst", nburstOperands)) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalKeyword("l2_cache_ctl"))) {
     hasL2CacheCtl = true;
     if (parser.parseLParen() || parser.parseOperand(l2CacheCtl) ||
-        parser.parseRParen())
+        parser.parseRParen()) {
       return failure();
+    }
   }
   while (true) {
     StringRef parsedKeyword;
-    SmallVector<OpAsmParser::UnresolvedOperand, 3> loopGroupOperands;
+    SmallVector<OpAsmParser::UnresolvedOperand, mlir::pto::kValue3> loopGroupOperands;
     if (parseOptionalDmaTripleGroupAlias(parser, {"loop", "loop1", "loop2"},
-                                         parsedKeyword, loopGroupOperands))
+                                         parsedKeyword, loopGroupOperands)) {
       return failure();
+    }
     if (parsedKeyword.empty()) {
       break;
     }
     loopCountOperands.push_back(loopGroupOperands[0]);
     loopSrcStrideOperands.push_back(loopGroupOperands[1]);
-    loopDstStrideOperands.push_back(loopGroupOperands[2]);
+    loopDstStrideOperands.push_back(loopGroupOperands[mlir::pto::kValue2]);
   }
 
   if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
@@ -7545,8 +7849,9 @@ ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
   if (parser.parseType(sourceType) || parser.parseComma() ||
       parser.parseType(destinationType) || parser.parseComma() ||
       parser.parseType(lenBurstType) || parser.parseComma() ||
-      parseDmaTripleTypes(parser, nburstTypes))
+      parseDmaTripleTypes(parser, nburstTypes)) {
     return failure();
+  }
   if (hasL2CacheCtl) {
     if (parser.parseComma() || parser.parseType(l2CacheCtlType)) {
       return failure();
@@ -7564,7 +7869,7 @@ ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
       }
       loopCountTypes.push_back(loopGroupTypes[0]);
       loopSrcStrideTypes.push_back(loopGroupTypes[1]);
-      loopDstStrideTypes.push_back(loopGroupTypes[2]);
+      loopDstStrideTypes.push_back(loopGroupTypes[mlir::pto::kValue2]);
       continue;
     }
     return parser.emitError(parser.getCurrentLocation(),
@@ -7575,12 +7880,14 @@ ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
   if (loopCountOperands.size() != loopSrcStrideOperands.size() ||
       loopCountOperands.size() != loopDstStrideOperands.size() ||
       loopCountTypes.size() != loopSrcStrideTypes.size() ||
-      loopCountTypes.size() != loopDstStrideTypes.size())
+      loopCountTypes.size() != loopDstStrideTypes.size()) {
     return parser.emitError(parser.getCurrentLocation(),
                             "requires each loop group to provide count, src stride, and dst stride");
-  if (loopCountOperands.size() != loopCountTypes.size())
+  }
+  if (loopCountOperands.size() != loopCountTypes.size()) {
     return parser.emitError(parser.getCurrentLocation(),
                             "requires loop operand and type groups to match");
+  }
 
   auto &segments =
       result.getOrAddProperties<MteUbGmOp::Properties>().operandSegmentSizes;
@@ -7593,19 +7900,22 @@ ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.resolveOperand(destination, destinationType, result.operands) ||
       parser.resolveOperand(lenBurst, lenBurstType, result.operands) ||
       parser.resolveOperands(nburstOperands, nburstTypes, parser.getCurrentLocation(),
-                             result.operands))
+                             result.operands)) {
     return failure();
+  }
   if (hasL2CacheCtl &&
-      parser.resolveOperand(l2CacheCtl, l2CacheCtlType, result.operands))
+      parser.resolveOperand(l2CacheCtl, l2CacheCtlType, result.operands)) {
     return failure();
+  }
   if (parser.resolveOperands(loopCountOperands, loopCountTypes,
                              parser.getCurrentLocation(), result.operands) ||
       parser.resolveOperands(loopSrcStrideOperands, loopSrcStrideTypes,
                              parser.getCurrentLocation(), result.operands) ||
       parser.resolveOperands(loopDstStrideOperands, loopDstStrideTypes,
                              parser.getCurrentLocation(),
-                             result.operands))
+                             result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -7618,8 +7928,9 @@ void MteUbGmOp::print(OpAsmPrinter &printer) {
     printer << " l2_cache_ctl(" << l2CacheCtl << ")";
   }
   for (auto [count, srcStride, dstStride] :
-       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides()))
+       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides())) {
     printDmaTripleGroup(printer, "loop", count, srcStride, dstStride);
+  }
   printer.printOptionalAttrDict((*this)->getAttrs());
   printer << " : " << getSource().getType() << ", " << getDestination().getType()
           << ", " << getLenBurst().getType() << ", " << getNBurst().getType()
@@ -7630,9 +7941,10 @@ void MteUbGmOp::print(OpAsmPrinter &printer) {
     printer << ", " << l2CacheCtl.getType();
   }
   for (auto [count, srcStride, dstStride] :
-       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides()))
+       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides())) {
     printDmaTripleTypes(printer, "loop", count.getType(), srcStride.getType(),
                         dstStride.getType());
+  }
 }
 
 void MteUbGmOp::getEffects(
@@ -7644,27 +7956,32 @@ void MteUbGmOp::getEffects(
 
 LogicalResult MteUbGmOp::verify() {
   if (!isBufferLike(getSource().getType()) ||
-      !isBufferLike(getDestination().getType()))
+      !isBufferLike(getDestination().getType())) {
     return emitOpError(
         "requires typed !pto.ptr or memref source and destination");
+  }
   if (classifyMemoryRole(getSource().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getDestination().getType()) != MemoryRole::GM)
+      classifyMemoryRole(getDestination().getType()) != MemoryRole::GM) {
     return emitOpError("requires UB source and GM destination");
+  }
   int64_t sourceElemBytes = getBufferElementByteSize(getSource().getType());
   int64_t destinationElemBytes =
       getBufferElementByteSize(getDestination().getType());
-  if (sourceElemBytes <= 0 || destinationElemBytes <= 0)
+  if (sourceElemBytes <= 0 || destinationElemBytes <= 0) {
     return emitOpError(
         "requires copy source and destination element types with known byte width");
-  if (sourceElemBytes != destinationElemBytes)
+  }
+  if (sourceElemBytes != destinationElemBytes) {
     return emitOpError(
         "requires source and destination element byte widths to match");
+  }
   if (Value l2CacheCtlValue = getL2CacheCtl()) {
     APInt l2CacheCtl;
     if (matchPattern(l2CacheCtlValue, m_ConstantInt(&l2CacheCtl)) &&
-        (l2CacheCtl.isNegative() || l2CacheCtl.ugt(15)))
+        (l2CacheCtl.isNegative() || l2CacheCtl.ugt(mlir::pto::kValue15))) {
       return emitOpError(
           "requires constant l2_cache_ctl to fit in range [0, 15]");
+    }
   }
   return verifyDmaLoadStoreLoopGroups(
       getOperation(), getLoopCounts(), getLoopSrcStrides(),
@@ -7783,20 +8100,22 @@ ParseResult MteGmL1Op::parse(OpAsmParser &parser, OperationState &result) {
   if (parseRequiredOperandWithComma(parser, source) ||
       parseRequiredOperandWithComma(parser, destination) ||
       parser.parseOperand(lenBurst) ||
-      parseDmaTripleGroup(parser, "nburst", nburstOperands))
+      parseDmaTripleGroup(parser, "nburst", nburstOperands)) {
     return failure();
+  }
   while (true) {
     StringRef parsedKeyword;
-    SmallVector<OpAsmParser::UnresolvedOperand, 3> loopGroupOperands;
+    SmallVector<OpAsmParser::UnresolvedOperand, mlir::pto::kValue3> loopGroupOperands;
     if (parseOptionalDmaTripleGroupAlias(parser, {"loop", "loop1", "loop2"},
-                                         parsedKeyword, loopGroupOperands))
+                                         parsedKeyword, loopGroupOperands)) {
       return failure();
+    }
     if (parsedKeyword.empty()) {
       break;
     }
     loopCountOperands.push_back(loopGroupOperands[0]);
     loopSrcStrideOperands.push_back(loopGroupOperands[1]);
-    loopDstStrideOperands.push_back(loopGroupOperands[2]);
+    loopDstStrideOperands.push_back(loopGroupOperands[mlir::pto::kValue2]);
   }
 
   if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
@@ -7809,8 +8128,9 @@ ParseResult MteGmL1Op::parse(OpAsmParser &parser, OperationState &result) {
   if (parser.parseType(sourceType) || parser.parseComma() ||
       parser.parseType(destinationType) || parser.parseComma() ||
       parser.parseType(lenBurstType) || parser.parseComma() ||
-      parseDmaTripleTypes(parser, nburstTypes))
+      parseDmaTripleTypes(parser, nburstTypes)) {
     return failure();
+  }
   while (succeeded(parser.parseOptionalComma())) {
     StringRef keyword;
     if (parser.parseKeyword(&keyword)) {
@@ -7825,19 +8145,21 @@ ParseResult MteGmL1Op::parse(OpAsmParser &parser, OperationState &result) {
     }
     loopCountTypes.push_back(loopGroupTypes[0]);
     loopSrcStrideTypes.push_back(loopGroupTypes[1]);
-    loopDstStrideTypes.push_back(loopGroupTypes[2]);
+    loopDstStrideTypes.push_back(loopGroupTypes[mlir::pto::kValue2]);
   }
 
   int32_t loopGroupCount = static_cast<int32_t>(loopCountOperands.size());
   if (loopCountOperands.size() != loopSrcStrideOperands.size() ||
       loopCountOperands.size() != loopDstStrideOperands.size() ||
       loopCountTypes.size() != loopSrcStrideTypes.size() ||
-      loopCountTypes.size() != loopDstStrideTypes.size())
+      loopCountTypes.size() != loopDstStrideTypes.size()) {
     return parser.emitError(parser.getCurrentLocation(),
                             "requires each loop group to provide count, src stride, and dst stride");
-  if (loopCountOperands.size() != loopCountTypes.size())
+  }
+  if (loopCountOperands.size() != loopCountTypes.size()) {
     return parser.emitError(parser.getCurrentLocation(),
                             "requires loop operand and type groups to match");
+  }
 
   auto &segments =
       result.getOrAddProperties<MteGmL1Op::Properties>().operandSegmentSizes;
@@ -7855,8 +8177,9 @@ ParseResult MteGmL1Op::parse(OpAsmParser &parser, OperationState &result) {
       parser.resolveOperands(loopSrcStrideOperands, loopSrcStrideTypes,
                              parser.getCurrentLocation(), result.operands) ||
       parser.resolveOperands(loopDstStrideOperands, loopDstStrideTypes,
-                             parser.getCurrentLocation(), result.operands))
+                             parser.getCurrentLocation(), result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -7869,20 +8192,22 @@ ParseResult MteL1UbOp::parse(OpAsmParser &parser, OperationState &result) {
   if (parseRequiredOperandWithComma(parser, source) ||
       parseRequiredOperandWithComma(parser, destination) ||
       parser.parseOperand(lenBurst) ||
-      parseDmaTripleGroup(parser, "nburst", nburstOperands))
+      parseDmaTripleGroup(parser, "nburst", nburstOperands)) {
     return failure();
+  }
   while (true) {
     StringRef parsedKeyword;
-    SmallVector<OpAsmParser::UnresolvedOperand, 3> loopGroupOperands;
+    SmallVector<OpAsmParser::UnresolvedOperand, mlir::pto::kValue3> loopGroupOperands;
     if (parseOptionalDmaTripleGroupAlias(parser, {"loop", "loop1", "loop2"},
-                                         parsedKeyword, loopGroupOperands))
+                                         parsedKeyword, loopGroupOperands)) {
       return failure();
+    }
     if (parsedKeyword.empty()) {
       break;
     }
     loopCountOperands.push_back(loopGroupOperands[0]);
     loopSrcStrideOperands.push_back(loopGroupOperands[1]);
-    loopDstStrideOperands.push_back(loopGroupOperands[2]);
+    loopDstStrideOperands.push_back(loopGroupOperands[mlir::pto::kValue2]);
   }
 
   if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
@@ -7895,8 +8220,9 @@ ParseResult MteL1UbOp::parse(OpAsmParser &parser, OperationState &result) {
   if (parser.parseType(sourceType) || parser.parseComma() ||
       parser.parseType(destinationType) || parser.parseComma() ||
       parser.parseType(lenBurstType) || parser.parseComma() ||
-      parseDmaTripleTypes(parser, nburstTypes))
+      parseDmaTripleTypes(parser, nburstTypes)) {
     return failure();
+  }
   while (succeeded(parser.parseOptionalComma())) {
     StringRef keyword;
     if (parser.parseKeyword(&keyword)) {
@@ -7911,19 +8237,21 @@ ParseResult MteL1UbOp::parse(OpAsmParser &parser, OperationState &result) {
     }
     loopCountTypes.push_back(loopGroupTypes[0]);
     loopSrcStrideTypes.push_back(loopGroupTypes[1]);
-    loopDstStrideTypes.push_back(loopGroupTypes[2]);
+    loopDstStrideTypes.push_back(loopGroupTypes[mlir::pto::kValue2]);
   }
 
   int32_t loopGroupCount = static_cast<int32_t>(loopCountOperands.size());
   if (loopCountOperands.size() != loopSrcStrideOperands.size() ||
       loopCountOperands.size() != loopDstStrideOperands.size() ||
       loopCountTypes.size() != loopSrcStrideTypes.size() ||
-      loopCountTypes.size() != loopDstStrideTypes.size())
+      loopCountTypes.size() != loopDstStrideTypes.size()) {
     return parser.emitError(parser.getCurrentLocation(),
                             "requires each loop group to provide count, src stride, and dst stride");
-  if (loopCountOperands.size() != loopCountTypes.size())
+  }
+  if (loopCountOperands.size() != loopCountTypes.size()) {
     return parser.emitError(parser.getCurrentLocation(),
                             "requires loop operand and type groups to match");
+  }
 
   auto &segments =
       result.getOrAddProperties<MteL1UbOp::Properties>().operandSegmentSizes;
@@ -7941,8 +8269,9 @@ ParseResult MteL1UbOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.resolveOperands(loopSrcStrideOperands, loopSrcStrideTypes,
                              parser.getCurrentLocation(), result.operands) ||
       parser.resolveOperands(loopDstStrideOperands, loopDstStrideTypes,
-                             parser.getCurrentLocation(), result.operands))
+                             parser.getCurrentLocation(), result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -7958,14 +8287,15 @@ ParseResult MteGmL1FracOp::parse(OpAsmParser &parser, OperationState &result) {
       parseRequiredOperandWithComma(parser, destination) ||
       parser.parseKeyword(&modeKeyword) ||
       failed(parseCubeLoadFracModeKeyword(modeKeyword)) || parser.parseComma() ||
-      parseFixedKeywordOperandGroup(parser, "shape", 2, shapeOperands) ||
+      parseFixedKeywordOperandGroup(parser, "shape", mlir::pto::kValue2, shapeOperands) ||
       parser.parseComma() ||
       parseCubeLoadFracSrcLayoutGroup(parser, srcLayoutOperands) ||
       parser.parseComma() ||
-      parseFixedKeywordOperandGroup(parser, "dst_group", 4, dstGroupOperands) ||
+      parseFixedKeywordOperandGroup(parser, "dst_group", mlir::pto::kValue4, dstGroupOperands) ||
       parser.parseComma() ||
-      parseFixedKeywordOperandGroup(parser, "ctrl", 2, ctrlOperands))
+      parseFixedKeywordOperandGroup(parser, "ctrl", mlir::pto::kValue2, ctrlOperands)) {
     return failure();
+  }
 
   if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
@@ -7980,35 +8310,42 @@ ParseResult MteGmL1FracOp::parse(OpAsmParser &parser, OperationState &result) {
   if (parser.parseType(sourceType) || parser.parseComma() ||
       parser.parseType(destinationType) || parser.parseComma() ||
       parser.parseKeyword(modeKeyword) || parser.parseComma() ||
-      parseFixedKeywordTypes(parser, "shape", 2, shapeTypes) ||
+      parseFixedKeywordTypes(parser, "shape", mlir::pto::kValue2, shapeTypes) ||
       parser.parseComma() ||
       parseCubeLoadFracSrcLayoutTypes(parser, srcLayoutTypes) ||
       parser.parseComma() ||
-      parseFixedKeywordTypes(parser, "dst_group", 4, dstGroupTypes) ||
+      parseFixedKeywordTypes(parser, "dst_group", mlir::pto::kValue4, dstGroupTypes) ||
       parser.parseComma() ||
-      parseFixedKeywordTypes(parser, "ctrl", 2, ctrlTypes))
+      parseFixedKeywordTypes(parser, "ctrl", mlir::pto::kValue2, ctrlTypes)) {
     return failure();
+  }
 
   auto modeOr = parseCubeLoadFracModeKeyword(modeKeyword);
-  if (failed(modeOr))
+  if (failed(modeOr)) {
     return parser.emitError(parser.getCurrentLocation(),
                             "expected one of 'nd2nz' or 'dn2nz'");
-  if (shapeOperands.size() != 2 || shapeTypes.size() != 2)
+  }
+  if (shapeOperands.size() != 2 || shapeTypes.size() != 2) {
     return parser.emitError(parser.getCurrentLocation(),
                             "shape requires exactly two operands and types");
-  if (srcLayoutOperands.empty() || srcLayoutOperands.size() > 2 ||
-      srcLayoutTypes.empty() || srcLayoutTypes.size() > 2)
+  }
+  if (srcLayoutOperands.empty() || srcLayoutOperands.size() > mlir::pto::kValue2 ||
+      srcLayoutTypes.empty() || srcLayoutTypes.size() > mlir::pto::kValue2) {
     return parser.emitError(parser.getCurrentLocation(),
                             "src_layout requires one or two operands and types");
-  if (dstGroupOperands.size() != 4 || dstGroupTypes.size() != 4)
+  }
+  if (dstGroupOperands.size() != 4 || dstGroupTypes.size() != 4) {
     return parser.emitError(parser.getCurrentLocation(),
                             "dst_group requires exactly four operands and types");
-  if (ctrlOperands.size() != 2 || ctrlTypes.size() != 2)
+  }
+  if (ctrlOperands.size() != 2 || ctrlTypes.size() != 2) {
     return parser.emitError(parser.getCurrentLocation(),
                             "ctrl requires exactly two operands and types");
-  if (srcLayoutOperands.size() != srcLayoutTypes.size())
+  }
+  if (srcLayoutOperands.size() != srcLayoutTypes.size()) {
     return parser.emitError(parser.getCurrentLocation(),
                             "src_layout operand and type groups must match");
+  }
 
   bool hasSrcOuterStride = srcLayoutOperands.size() == 2;
   result.addAttribute(getModeAttrName(result.name),
@@ -8030,8 +8367,9 @@ ParseResult MteGmL1FracOp::parse(OpAsmParser &parser, OperationState &result) {
   if (parser.resolveOperand(source, sourceType, result.operands) ||
       parser.resolveOperand(destination, destinationType, result.operands) ||
       parser.resolveOperands(flatOperands, flatTypes, parser.getCurrentLocation(),
-                             result.operands))
+                             result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -8041,17 +8379,19 @@ void MteGmL1Op::print(OpAsmPrinter &printer) {
   printDmaTripleGroup(printer, "nburst", getNBurst(), getNburstSrcStride(),
                       getNburstDstStride());
   for (auto [count, srcStride, dstStride] :
-       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides()))
+       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides())) {
     printDmaTripleGroup(printer, "loop", count, srcStride, dstStride);
+  }
   printer.printOptionalAttrDict((*this)->getAttrs());
   printer << " : " << getSource().getType() << ", " << getDestination().getType()
           << ", " << getLenBurst().getType() << ", " << getNBurst().getType()
           << ", " << getNburstSrcStride().getType() << ", "
           << getNburstDstStride().getType();
   for (auto [count, srcStride, dstStride] :
-       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides()))
+       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides())) {
     printDmaTripleTypes(printer, "loop", count.getType(), srcStride.getType(),
                         dstStride.getType());
+  }
 }
 
 void MteL1UbOp::print(OpAsmPrinter &printer) {
@@ -8060,17 +8400,19 @@ void MteL1UbOp::print(OpAsmPrinter &printer) {
   printDmaTripleGroup(printer, "nburst", getNBurst(), getNburstSrcStride(),
                       getNburstDstStride());
   for (auto [count, srcStride, dstStride] :
-       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides()))
+       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides())) {
     printDmaTripleGroup(printer, "loop", count, srcStride, dstStride);
+  }
   printer.printOptionalAttrDict((*this)->getAttrs());
   printer << " : " << getSource().getType() << ", " << getDestination().getType()
           << ", " << getLenBurst().getType() << ", " << getNBurst().getType()
           << ", " << getNburstSrcStride().getType() << ", "
           << getNburstDstStride().getType();
   for (auto [count, srcStride, dstStride] :
-       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides()))
+       llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides())) {
     printDmaTripleTypes(printer, "loop", count.getType(), srcStride.getType(),
                         dstStride.getType());
+  }
 }
 
 void MteL1BtOp::build(OpBuilder &builder, OperationState &state, Value source,
@@ -8094,23 +8436,26 @@ ParseResult MteL1BtOp::parse(OpAsmParser &parser, OperationState &result) {
       parseRequiredOperandWithComma(parser, destination) ||
       parser.parseOperand(lenBurst) ||
       parseDmaTripleGroup(parser, "nburst", nburstOperands) ||
-      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
+  }
 
   Type sourceType, destinationType, lenBurstType;
   SmallVector<Type> nburstTypes;
   if (parser.parseType(sourceType) || parser.parseComma() ||
       parser.parseType(destinationType) || parser.parseComma() ||
       parser.parseType(lenBurstType) || parser.parseComma() ||
-      parseDmaTripleTypes(parser, nburstTypes))
+      parseDmaTripleTypes(parser, nburstTypes)) {
     return failure();
+  }
 
   if (parser.resolveOperand(source, sourceType, result.operands) ||
       parser.resolveOperand(destination, destinationType, result.operands) ||
       parser.resolveOperand(lenBurst, lenBurstType, result.operands) ||
       parser.resolveOperands(nburstOperands, nburstTypes,
-                             parser.getCurrentLocation(), result.operands))
+                             parser.getCurrentLocation(), result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -8121,23 +8466,26 @@ ParseResult MteL1FbOp::parse(OpAsmParser &parser, OperationState &result) {
       parseRequiredOperandWithComma(parser, destination) ||
       parser.parseOperand(lenBurst) ||
       parseDmaTripleGroup(parser, "nburst", nburstOperands) ||
-      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
+  }
 
   Type sourceType, destinationType, lenBurstType;
   SmallVector<Type> nburstTypes;
   if (parser.parseType(sourceType) || parser.parseComma() ||
       parser.parseType(destinationType) || parser.parseComma() ||
       parser.parseType(lenBurstType) || parser.parseComma() ||
-      parseDmaTripleTypes(parser, nburstTypes))
+      parseDmaTripleTypes(parser, nburstTypes)) {
     return failure();
+  }
 
   if (parser.resolveOperand(source, sourceType, result.operands) ||
       parser.resolveOperand(destination, destinationType, result.operands) ||
       parser.resolveOperand(lenBurst, lenBurstType, result.operands) ||
       parser.resolveOperands(nburstOperands, nburstTypes,
-                             parser.getCurrentLocation(), result.operands))
+                             parser.getCurrentLocation(), result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -8221,8 +8569,9 @@ LogicalResult MteL1BtOp::verify() {
   };
 
   if (!isBufferLike(getSource().getType()) ||
-      !isBufferLike(getDestination().getType()))
+      !isBufferLike(getDestination().getType())) {
     return emitOpError("requires buffer-like source and destination");
+  }
   if (getBufferAddressSpace(getSource().getType()) != pto::AddressSpace::MAT) {
     return emitOpError("requires MAT source");
   }
@@ -8246,9 +8595,10 @@ LogicalResult MteL1BtOp::verify() {
 }
 
 LogicalResult MteL1FbOp::verify() {
-  if (!isBufferLike(getSource().getType()) || !isBufferLike(getDestination().getType()))
+  if (!isBufferLike(getSource().getType()) || !isBufferLike(getDestination().getType())) {
     return emitOpError(
         "requires typed !pto.ptr or memref source and destination");
+  }
 
   auto getAddressSpace = [](Type type) -> std::optional<pto::AddressSpace> {
     if (auto ptrType = dyn_cast<pto::PtrType>(type)) {
@@ -8299,20 +8649,23 @@ LogicalResult MteGmL1FracOp::verify() {
       failed(checkNonNegativeConst(getDstLoop3Stride(), "dst_loop3_stride")) ||
       failed(checkNonNegativeConst(getDstLoop4Stride(), "dst_loop4_stride")) ||
       (getSrcOuterStride() &&
-       failed(checkNonNegativeConst(getSrcOuterStride(), "src_outer_stride"))))
+       failed(checkNonNegativeConst(getSrcOuterStride(), "src_outer_stride")))) {
     return failure();
+  }
 
   APInt groupCount;
   if (matchPattern(getGroupCount(), m_ConstantInt(&groupCount)) &&
-      groupCount.isZero())
+      groupCount.isZero()) {
     return emitOpError("group_count must be greater than zero");
+  }
 
   APInt smallc0En;
   APInt dValue;
   if (matchPattern(getSmallc0En(), m_ConstantInt(&smallc0En)) &&
       smallc0En.getBoolValue() && matchPattern(getDValue(), m_ConstantInt(&dValue)) &&
-      dValue.ugt(4))
+      dValue.ugt(mlir::pto::kValue4)) {
     return emitOpError("smallc0_en requires d_value <= 4");
+  }
 
   return success();
 }
@@ -8364,8 +8717,9 @@ ParseResult MteL0cL1Op::parse(OpAsmParser &parser, OperationState &result) {
       parseRequiredOperandWithComma(parser, srcStride) ||
       parseRequiredOperandWithComma(parser, dstStride) ||
       parseStructuredAccStoreClauses(parser, state) ||
-      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
+  }
 
   Type sourceType, destinationType, mType, nType, srcStrideType, dstStrideType;
   if (parser.parseType(sourceType) || parser.parseComma() ||
@@ -8373,8 +8727,9 @@ ParseResult MteL0cL1Op::parse(OpAsmParser &parser, OperationState &result) {
       parser.parseType(mType) || parser.parseComma() || parser.parseType(nType) ||
       parser.parseComma() || parser.parseType(srcStrideType) ||
       parser.parseComma() || parser.parseType(dstStrideType) ||
-      parseStructuredAccStoreTailTypes(parser, state))
+      parseStructuredAccStoreTailTypes(parser, state)) {
     return failure();
+  }
 
   setStructuredAccStoreSegmentSizes<MteL0cL1Op>(
       result, {1, 1, 1, 1, 1, 1, !state.preQuantOperands.empty() ? 1 : 0,
@@ -8415,8 +8770,9 @@ ParseResult MteL0cL1Op::parse(OpAsmParser &parser, OperationState &result) {
                              parser.getCurrentLocation(), result.operands) ||
       parser.resolveOperands(state.loop3DstStrideOperands,
                              state.loop3DstStrideTypes,
-                             parser.getCurrentLocation(), result.operands))
+                             parser.getCurrentLocation(), result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -8459,10 +8815,10 @@ static LogicalResult verifyCubeBridgeLoadStart(Operation *op, Value firstStart,
     }
     return success();
   };
-
   if (failed(checkNonNegativeConst(firstStart, firstName)) ||
-      failed(checkNonNegativeConst(secondStart, secondName)))
+      failed(checkNonNegativeConst(secondStart, secondName))) {
     return failure();
+  }
   return success();
 }
 
@@ -8489,14 +8845,17 @@ struct CubeBridgeLoadAsmOperand {
 static std::optional<unsigned> getCubeBridgeLoadOperandIndex(
     StringRef keyword, ArrayRef<StringRef> shapeNames,
     ArrayRef<StringRef> fullNames) {
-  for (auto [index, name] : llvm::enumerate(shapeNames))
+  for (auto [index, name] : llvm::enumerate(shapeNames)) {
     if (keyword == name) {
       return index;
     }
+}
 
-  for (auto [index, name] : llvm::enumerate(fullNames))
-    if (keyword == name)
+  for (auto [index, name] : llvm::enumerate(fullNames)) {
+    if (keyword == name) {
       return shapeNames.size() + index;
+}
+}
   return std::nullopt;
 }
 
@@ -8507,8 +8866,9 @@ static ParseResult parseMteL1L0OptionalOperandsOp(
   OpAsmParser::UnresolvedOperand source;
   OpAsmParser::UnresolvedOperand destination;
   if (parser.parseOperand(source) || parser.parseComma() ||
-      parser.parseOperand(destination))
+      parser.parseOperand(destination)) {
     return failure();
+}
 
   SmallVector<OpAsmParser::UnresolvedOperand, 6> legacyOperands;
   SmallVector<CubeBridgeLoadAsmOperand, 10> namedOperands(10);
@@ -8518,17 +8878,20 @@ static ParseResult parseMteL1L0OptionalOperandsOp(
   auto parseNamedOperand = [&](StringRef keyword) -> ParseResult {
     std::optional<unsigned> index =
         getCubeBridgeLoadOperandIndex(keyword, shapeNames, fullNames);
-    if (!index)
+    if (!index) {
       return parser.emitError(parser.getCurrentLocation(),
                               "unknown cube bridge load operand '")
              << keyword << "'";
-    if (namedOperands[*index].present)
+}
+    if (namedOperands[*index].present) {
       return parser.emitError(parser.getCurrentLocation(),
                               "duplicate cube bridge load operand '")
              << keyword << "'";
+}
     if (parser.parseLParen() || parser.parseOperand(namedOperands[*index].operand) ||
-        parser.parseRParen())
+        parser.parseRParen()) {
       return failure();
+}
     namedOperands[*index].present = true;
     namedOperandOrder.push_back(*index);
     return success();
@@ -8562,11 +8925,12 @@ static ParseResult parseMteL1L0OptionalOperandsOp(
   }
 
   if (!usesNamedOperands && legacyOperands.size() != 4 &&
-      legacyOperands.size() != 6)
+      legacyOperands.size() != 6) {
     return parser.emitError(
                parser.getCurrentLocation(),
                "expects either four shape-derived or six full positional ")
            << operandDescription;
+}
 
   if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
@@ -8575,10 +8939,11 @@ static ParseResult parseMteL1L0OptionalOperandsOp(
   Type sourceType;
   Type destinationType;
   if (parser.parseType(sourceType) || parser.parseComma() ||
-      parser.parseType(destinationType))
+      parser.parseType(destinationType)) {
     return failure();
+  }
 
-  SmallVector<Type, 6> legacyTypes;
+  SmallVector<Type, mlir::pto::kValue6> legacyTypes;
   if (usesNamedOperands) {
     for (unsigned index : namedOperandOrder) {
       Type type;
@@ -8602,8 +8967,9 @@ static ParseResult parseMteL1L0OptionalOperandsOp(
   segmentSizes[1] = 1;
 
   if (parser.resolveOperand(source, sourceType, result.operands) ||
-      parser.resolveOperand(destination, destinationType, result.operands))
+      parser.resolveOperand(destination, destinationType, result.operands)) {
     return failure();
+}
 
   if (usesNamedOperands) {
     for (unsigned index = 0; index < namedOperands.size(); ++index) {
@@ -8613,16 +8979,18 @@ static ParseResult parseMteL1L0OptionalOperandsOp(
       segmentSizes[2 + index] = 1;
       if (parser.resolveOperand(namedOperands[index].operand,
                                 namedOperands[index].type,
-                                result.operands))
+                                result.operands)) {
         return failure();
+}
     }
   } else {
     const unsigned base = legacyOperands.size() <= 4 ? 0 : 4;
     for (unsigned index = 0; index < legacyOperands.size(); ++index) {
       segmentSizes[2 + base + index] = 1;
       if (parser.resolveOperand(legacyOperands[index], legacyTypes[index],
-                                result.operands))
+                                result.operands)) {
         return failure();
+}
     }
   }
   setCubeBridgeLoadOperandSegmentSizes<OpTy>(result, segmentSizes);
@@ -8646,7 +9014,7 @@ static void printMteL1L0OptionalOperandsOp(
       llvm::all_of(fullOperands, [](Value value) { return static_cast<bool>(value); });
 
   printer << " " << source << ", " << destination;
-  SmallVector<Value, 10> printedOperands;
+  SmallVector<Value, mlir::pto::kValue10> printedOperands;
   if (isShapeForm) {
     for (Value value : shapeOperands) {
       printer << ", " << value;
@@ -8701,36 +9069,43 @@ static LogicalResult verifyMxLoadOperands(Operation *op,
   const bool hasFull = llvm::any_of(fullOperands, [](Value value) {
     return static_cast<bool>(value);
   });
-  if (hasShape && hasFull)
+  if (hasShape && hasFull) {
     return op->emitOpError()
            << "cannot mix shape-derived MX operands with full MX operands";
-  if (!hasShape && !hasFull)
+  }
+  if (!hasShape && !hasFull) {
     return op->emitOpError()
            << "requires either all shape-derived MX operands or all full MX operands";
+  }
 
   if (hasShape) {
-    for (auto [value, name] : llvm::zip(shapeOperands, shapeNames))
-      if (!value)
+    for (auto [value, name] : llvm::zip(shapeOperands, shapeNames)) {
+      if (!value) {
         return op->emitOpError()
                << "shape-derived MX form requires " << name;
-    return verifyCubeBridgeLoadStart(op, shapeOperands[2], shapeNames[2],
-                                     shapeOperands[3], shapeNames[3]);
+      }
+    }
+    return verifyCubeBridgeLoadStart(op, shapeOperands[mlir::pto::kValue2], shapeNames[mlir::pto::kValue2],
+                                     shapeOperands[mlir::pto::kValue3], shapeNames[mlir::pto::kValue3]);
   }
 
   static constexpr StringRef kFullNames[] = {
       "x_start", "y_start", "x_step", "y_step", "src_stride", "dst_stride"};
-  for (auto [value, name] : llvm::zip(fullOperands, kFullNames))
+  for (auto [value, name] : llvm::zip(fullOperands, kFullNames)) {
     if (!value) {
       return op->emitOpError() << "full MX form requires " << name;
     }
+  }
   if (failed(verifyCubeBridgeLoadStart(op, fullOperands[0], "x_start",
-                                       fullOperands[1], "y_start")))
+                                       fullOperands[1], "y_start"))) {
     return failure();
-  if (failed(checkNonNegativeConst(fullOperands[2], "x_step")) ||
-      failed(checkNonNegativeConst(fullOperands[3], "y_step")) ||
-      failed(checkNonNegativeConst(fullOperands[4], "src_stride")) ||
-      failed(checkNonNegativeConst(fullOperands[5], "dst_stride")))
+  }
+  if (failed(checkNonNegativeConst(fullOperands[mlir::pto::kValue2], "x_step")) ||
+      failed(checkNonNegativeConst(fullOperands[mlir::pto::kValue3], "y_step")) ||
+      failed(checkNonNegativeConst(fullOperands[mlir::pto::kValue4], "src_stride")) ||
+      failed(checkNonNegativeConst(fullOperands[mlir::pto::kValue5], "dst_stride"))) {
     return failure();
+  }
   return success();
 }
 
@@ -8759,8 +9134,9 @@ static LogicalResult verifyMxLoadAlignment(Operation *op, Value source,
   constexpr int64_t kMxSourceAlignmentBytes = 32;
   constexpr int64_t kMxDestinationAddressUnitBytes = 16;
   if (failed(verifyMxPointerAlignment(op, source, "source",
-                                      kMxSourceAlignmentBytes)))
+                                      kMxSourceAlignmentBytes))) {
     return failure();
+  }
   return verifyMxPointerAlignment(op, destination, "destination",
                                   kMxDestinationAddressUnitBytes);
 }
@@ -8769,16 +9145,19 @@ static LogicalResult verifyStaticControlRange(Operation *op, Value value,
                                               StringRef name, int64_t min,
                                               int64_t max) {
   APInt intValue;
-  if (!matchPattern(value, m_ConstantInt(&intValue)))
+  if (!matchPattern(value, m_ConstantInt(&intValue))) {
     return success();
+}
   int64_t signedValue = intValue.getSExtValue();
-  if (signedValue < min)
+  if (signedValue < min) {
     return op->emitOpError() << name
                              << (min == 0 ? " must be non-negative"
                                           : " must be greater than zero");
-  if (signedValue > max)
+}
+  if (signedValue > max) {
     return op->emitOpError() << name << " must be <= " << max
                              << " to fit the hardware control field";
+}
   return success();
 }
 
@@ -8798,8 +9177,9 @@ static LogicalResult verifyExplicitCubeBridgeLoadControls(OpTy op) {
       failed(verifyStaticControlRange(operation, op.getSrcStride(),
                                       "src_stride", 1, kU16Max)) ||
       failed(verifyStaticControlRange(operation, op.getDstStride(),
-                                      "dst_stride", 1, kU16Max)))
+                                      "dst_stride", 1, kU16Max))) {
     return failure();
+}
   return success();
 }
 
@@ -8807,22 +9187,27 @@ template <typename OpTy>
 static LogicalResult verifyS4CubeBridgeLoad(OpTy op,
                                             AddressSpace expectedDstSpace,
                                             StringRef dstName) {
-  if (failed(verifyCubeBridgeLoadLikeOp(op, expectedDstSpace, dstName)))
+  if (failed(verifyCubeBridgeLoadLikeOp(op, expectedDstSpace, dstName))) {
     return failure();
+}
 
   Type sourceElem = getBufferElementType(op.getSource().getType());
   Type destinationElem = getBufferElementType(op.getDestination().getType());
-  if (!pto::isPTOFloat4PackedType(sourceElem))
+  if (!pto::isPTOFloat4PackedType(sourceElem)) {
     return op.emitOpError(
         "requires packed FP4 source element type f4e1m2x2 or f4e2m1x2");
-  if (!pto::isPTOFloat4PackedType(destinationElem))
+}
+  if (!pto::isPTOFloat4PackedType(destinationElem)) {
     return op.emitOpError(
         "requires packed FP4 destination element type f4e1m2x2 or f4e2m1x2");
-  if (sourceElem != destinationElem)
+}
+  if (sourceElem != destinationElem) {
     return op.emitOpError(
         "requires source and destination packed FP4 element types to match");
-  if (failed(verifyExplicitCubeBridgeLoadControls(op)))
+}
+  if (failed(verifyExplicitCubeBridgeLoadControls(op))) {
     return failure();
+}
   return verifyStaticControlRange(op.getOperation(), op.getTranspose(),
                                   "transpose", 0, 1);
 }
@@ -8831,15 +9216,18 @@ template <typename OpTy>
 static LogicalResult verifyRegularCubeBridgeLoad(OpTy op,
                                                  AddressSpace expectedDstSpace,
                                                  StringRef dstName) {
-  if (failed(verifyCubeBridgeLoadLikeOp(op, expectedDstSpace, dstName)))
+  if (failed(verifyCubeBridgeLoadLikeOp(op, expectedDstSpace, dstName))) {
     return failure();
+}
   Type sourceElem = getBufferElementType(op.getSource().getType());
   Type destinationElem = getBufferElementType(op.getDestination().getType());
-  if (pto::isPTOFloat4PackedType(sourceElem))
+  if (pto::isPTOFloat4PackedType(sourceElem)) {
     return op.emitOpError("packed FP4 source requires the S4 load operation");
-  if (pto::isPTOFloat4PackedType(destinationElem))
+}
+  if (pto::isPTOFloat4PackedType(destinationElem)) {
     return op.emitOpError(
         "packed FP4 destination requires the S4 load operation");
+}
   return verifyExplicitCubeBridgeLoadControls(op);
 }
 
@@ -8852,27 +9240,33 @@ static LogicalResult verifyMteL1L0LoadOperands(
   const bool hasFull = llvm::any_of(fullOperands, [](Value value) {
     return static_cast<bool>(value);
   });
-  if (hasShape && hasFull)
+  if (hasShape && hasFull) {
     return op->emitOpError(
         "cannot mix shape-derived operands with full control operands");
-  if (!hasShape && !hasFull)
+}
+  if (!hasShape && !hasFull) {
     return op->emitOpError(
         "requires either all shape-derived operands or all full control operands");
+}
 
   if (hasShape) {
-    for (auto [value, name] : llvm::zip(shapeOperands, shapeNames))
-      if (!value)
+    for (auto [value, name] : llvm::zip(shapeOperands, shapeNames)) {
+      if (!value) {
         return op->emitOpError()
                << "shape-derived form requires " << name;
+}
+}
     return verifyCubeBridgeLoadStart(op, shapeOperands[2], shapeNames[2],
                                      shapeOperands[3], shapeNames[3]);
   }
 
   static constexpr StringRef kFullNames[] = {
       "m_start", "k_start", "m_step", "k_step", "src_stride", "dst_stride"};
-  for (auto [value, name] : llvm::zip(fullOperands, kFullNames))
-    if (!value)
+  for (auto [value, name] : llvm::zip(fullOperands, kFullNames)) {
+    if (!value) {
       return op->emitOpError() << "full control form requires " << name;
+}
+}
 
   constexpr int64_t kU16Max = 65535;
   constexpr int64_t kU8Max = 255;
@@ -8887,15 +9281,17 @@ static LogicalResult verifyMteL1L0LoadOperands(
       failed(verifyStaticControlRange(op, fullOperands[4], "src_stride", 1,
                                       kU16Max)) ||
       failed(verifyStaticControlRange(op, fullOperands[5], "dst_stride", 1,
-                                      kU16Max)))
+                                      kU16Max))) {
     return failure();
+}
   return success();
 }
 
 LogicalResult MteL0cL1Op::verify() {
   if (!isBufferLike(getSource().getType()) ||
-      !isBufferLike(getDestination().getType()))
+      !isBufferLike(getDestination().getType())) {
     return emitOpError("requires buffer-like source and destination");
+}
   std::optional<AddressSpace> sourceSpace =
       getBufferAddressSpace(getSource().getType());
   std::optional<AddressSpace> destinationSpace =
@@ -9007,8 +9403,9 @@ LogicalResult MteL1L0aMxOp::verify() {
           getOperation(), {getM(), getK(), getStartRow(), getStartCol()},
           {"m", "k", "start_row", "start_col"},
           {getXStart(), getYStart(), getXStep(), getYStep(), getSrcStride(),
-           getDstStride()})))
+           getDstStride()}))) {
     return failure();
+  }
   return verifyMxLoadAlignment(getOperation(), getSource(), getDestination());
 }
 
@@ -9042,8 +9439,9 @@ LogicalResult MteL1L0bMxOp::verify() {
           getOperation(), {getK(), getN(), getStartRow(), getStartCol()},
           {"k", "n", "start_row", "start_col"},
           {getXStart(), getYStart(), getXStep(), getYStep(), getSrcStride(),
-           getDstStride()})))
+           getDstStride()}))) {
     return failure();
+  }
   return verifyMxLoadAlignment(getOperation(), getSource(), getDestination());
 }
 
@@ -9130,8 +9528,9 @@ ParseResult MteL0cGmOp::parse(OpAsmParser &parser, OperationState &result) {
       parseRequiredOperandWithComma(parser, sid) ||
       parseRequiredOperandWithComma(parser, l2CacheCtrl) ||
       parseStructuredAccStoreClauses(parser, state) ||
-      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
+  }
 
   Type sourceType, destinationType, mType, nType, srcStrideType, dstStrideType,
       sidType, l2CacheCtrlType;
@@ -9142,8 +9541,9 @@ ParseResult MteL0cGmOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.parseComma() || parser.parseType(dstStrideType) ||
       parser.parseComma() || parser.parseType(sidType) ||
       parser.parseComma() || parser.parseType(l2CacheCtrlType) ||
-      parseStructuredAccStoreTailTypes(parser, state))
+      parseStructuredAccStoreTailTypes(parser, state)) {
     return failure();
+  }
 
   setStructuredAccStoreSegmentSizes<MteL0cGmOp>(
       result, {1, 1, 1, 1, 1, 1, !state.preQuantOperands.empty() ? 1 : 0,
@@ -9182,8 +9582,9 @@ ParseResult MteL0cGmOp::parse(OpAsmParser &parser, OperationState &result) {
                              parser.getCurrentLocation(), result.operands) ||
       parser.resolveOperands(state.loop3DstStrideOperands,
                              state.loop3DstStrideTypes,
-                             parser.getCurrentLocation(), result.operands))
+                             parser.getCurrentLocation(), result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -9219,8 +9620,9 @@ void MteL0cGmOp::print(OpAsmPrinter &printer) {
 
 LogicalResult MteL0cGmOp::verify() {
   if (!isBufferLike(getSource().getType()) ||
-      !isBufferLike(getDestination().getType()))
+      !isBufferLike(getDestination().getType())) {
     return emitOpError("requires buffer-like source and destination");
+  }
   std::optional<AddressSpace> sourceSpace =
       getBufferAddressSpace(getSource().getType());
   std::optional<AddressSpace> destinationSpace =
@@ -9255,8 +9657,9 @@ ParseResult MteL0cUbOp::parse(OpAsmParser &parser, OperationState &result) {
       parseRequiredOperandWithComma(parser, m) ||
       parseRequiredOperandWithComma(parser, n) ||
       parseRequiredOperandWithComma(parser, srcStride) ||
-      parseRequiredOperandWithComma(parser, dstStride))
+      parseRequiredOperandWithComma(parser, dstStride)) {
     return failure();
+  }
   if (parser.parseKeyword("dst_mode") || parser.parseLParen()) {
     return failure();
   }
@@ -9287,8 +9690,9 @@ ParseResult MteL0cUbOp::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
   }
   if (succeeded(parser.parseOptionalComma()) &&
-      parseStructuredAccStoreClauses(parser, state))
+      parseStructuredAccStoreClauses(parser, state)) {
     return failure();
+  }
   if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
   }
@@ -9299,11 +9703,13 @@ ParseResult MteL0cUbOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.parseType(destinationType) || parser.parseComma() ||
       parser.parseType(mType) || parser.parseComma() || parser.parseType(nType) ||
       parser.parseComma() || parser.parseType(srcStrideType) ||
-      parser.parseComma() || parser.parseType(dstStrideType))
+      parser.parseComma() || parser.parseType(dstStrideType)) {
     return failure();
+  }
   if (hasSubBlockId &&
-      (parser.parseComma() || parser.parseType(subBlockIdType)))
+      (parser.parseComma() || parser.parseType(subBlockIdType))) {
     return failure();
+  }
   if (parseStructuredAccStoreTailTypes(parser, state)) {
     return failure();
   }
@@ -9352,8 +9758,9 @@ ParseResult MteL0cUbOp::parse(OpAsmParser &parser, OperationState &result) {
                              parser.getCurrentLocation(), result.operands) ||
       parser.resolveOperands(state.loop3DstStrideOperands,
                              state.loop3DstStrideTypes,
-                             parser.getCurrentLocation(), result.operands))
+                             parser.getCurrentLocation(), result.operands)) {
     return failure();
+  }
   return success();
 }
 
@@ -9402,8 +9809,9 @@ void MteL0cUbOp::print(OpAsmPrinter &printer) {
 
 LogicalResult MteL0cUbOp::verify() {
   if (!isBufferLike(getSource().getType()) ||
-      !isBufferLike(getDestination().getType()))
+      !isBufferLike(getDestination().getType())) {
     return emitOpError("requires buffer-like source and destination");
+  }
   std::optional<AddressSpace> sourceSpace =
       getBufferAddressSpace(getSource().getType());
   std::optional<AddressSpace> destinationSpace =
@@ -9412,12 +9820,13 @@ LogicalResult MteL0cUbOp::verify() {
     return emitOpError("requires ACC source and UB destination");
   }
   if (failed(verifyStructuredAccStoreLike(
-      *this, getSource().getType(), getDestination().getType(), getPreQuant(), getPreRelu(),
-      getClipValue(), getSplit(), getLoop0SrcStride(), getLoop3Count(),
-      getLoop3SrcStride(), getLoop3DstStride(), getUnitFlag(),
-      getPreQuantMode(), getPreReluMode(), getMode(), std::nullopt,
-      std::nullopt, /*allowAtomic=*/false)))
+          *this, getSource().getType(), getDestination().getType(), getPreQuant(), getPreRelu(),
+          getClipValue(), getSplit(), getLoop0SrcStride(), getLoop3Count(),
+          getLoop3SrcStride(), getLoop3DstStride(), getUnitFlag(),
+          getPreQuantMode(), getPreReluMode(), getMode(), std::nullopt,
+          std::nullopt, /*allowAtomic=*/false))) {
     return failure();
+  }
 
   if (getDstMode() == AccStoreUbDstMode::Single) {
     if (!getSubBlockid()) {
@@ -9425,8 +9834,9 @@ LogicalResult MteL0cUbOp::verify() {
     }
     APInt subBlockId;
     if (matchPattern(getSubBlockid(), m_ConstantInt(&subBlockId)) &&
-        subBlockId.ugt(1))
+        subBlockId.ugt(1)) {
       return emitOpError("sub_blockid must be 0 or 1");
+    }
     return success();
   }
   if (getSubBlockid()) {
@@ -9447,12 +9857,14 @@ LogicalResult MteL0cUbOp::verify() {
   APInt nValue;
   if (getDstMode() == AccStoreUbDstMode::SplitM &&
       matchPattern(getM(), m_ConstantInt(&mValue)) &&
-      mValue.getZExtValue() % 2 != 0)
+      mValue.getZExtValue() % mlir::pto::kValue2 != 0) {
     return emitOpError("split-M dual destination requires m to be even");
+  }
   if (getDstMode() == AccStoreUbDstMode::SplitN &&
       matchPattern(getN(), m_ConstantInt(&nValue)) &&
-      nValue.getZExtValue() % 32 != 0)
+      nValue.getZExtValue() % mlir::pto::kValue32 != 0) {
     return emitOpError("split-N dual destination requires n to be a multiple of 32");
+  }
   return success();
 }
 
@@ -9477,12 +9889,14 @@ void UBVaddOp::getEffects(
 
 LogicalResult UBVaddOp::verify() {
   if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc0().getType()) ||
-      !isBufferLike(getSrc1().getType()))
+      !isBufferLike(getSrc1().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
@@ -9500,12 +9914,14 @@ void UBVsubOp::getEffects(
 
 LogicalResult UBVsubOp::verify() {
   if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc0().getType()) ||
-      !isBufferLike(getSrc1().getType()))
+      !isBufferLike(getSrc1().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
@@ -9523,12 +9939,14 @@ void UBVmulOp::getEffects(
 
 LogicalResult UBVmulOp::verify() {
   if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc0().getType()) ||
-      !isBufferLike(getSrc1().getType()))
+      !isBufferLike(getSrc1().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
@@ -9546,12 +9964,14 @@ void UBVdivOp::getEffects(
 
 LogicalResult UBVdivOp::verify() {
   if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc0().getType()) ||
-      !isBufferLike(getSrc1().getType()))
+      !isBufferLike(getSrc1().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
@@ -9569,12 +9989,14 @@ void UBVmaxOp::getEffects(
 
 LogicalResult UBVmaxOp::verify() {
   if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc0().getType()) ||
-      !isBufferLike(getSrc1().getType()))
+      !isBufferLike(getSrc1().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
@@ -9592,12 +10014,14 @@ void UBVminOp::getEffects(
 
 LogicalResult UBVminOp::verify() {
   if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc0().getType()) ||
-      !isBufferLike(getSrc1().getType()))
+      !isBufferLike(getSrc1().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
@@ -9615,12 +10039,14 @@ void UBVandOp::getEffects(
 
 LogicalResult UBVandOp::verify() {
   if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc0().getType()) ||
-      !isBufferLike(getSrc1().getType()))
+      !isBufferLike(getSrc1().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
@@ -9638,33 +10064,37 @@ void UBVorOp::getEffects(
 
 LogicalResult UBVorOp::verify() {
   if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc0().getType()) ||
-      !isBufferLike(getSrc1().getType()))
+      !isBufferLike(getSrc1().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
-#define PTO_DEFINE_UB_BINARY_VERIFY_AND_EFFECTS(OpName)                       \
-  void OpName::getEffects(                                                    \
-      SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>     \
-          &effects) {                                                         \
-    effects.emplace_back(MemoryEffects::Read::get(), &getSrc0Mutable());      \
-    effects.emplace_back(MemoryEffects::Read::get(), &getSrc1Mutable());      \
-    effects.emplace_back(MemoryEffects::Write::get(), &getDstMutable());      \
-  }                                                                           \
-  LogicalResult OpName::verify() {                                            \
-    if (!isBufferLike(getDst().getType()) ||                                  \
-        !isBufferLike(getSrc0().getType()) ||                                 \
-        !isBufferLike(getSrc1().getType()))                                   \
-      return emitOpError("requires pointer-like operands");                   \
-    if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||           \
-        classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||          \
-        classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)            \
-      return emitOpError("requires UB-backed operands");                      \
-    return success();                                                         \
+#define PTO_DEFINE_UB_BINARY_VERIFY_AND_EFFECTS(OpName)                   \
+  void OpName::getEffects(                                                \
+      SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> \
+          &effects) {                                                     \
+    effects.emplace_back(MemoryEffects::Read::get(), &getSrc0Mutable());  \
+    effects.emplace_back(MemoryEffects::Read::get(), &getSrc1Mutable());  \
+    effects.emplace_back(MemoryEffects::Write::get(), &getDstMutable());  \
+  }                                                                       \
+  LogicalResult OpName::verify() {                                        \
+    if (!isBufferLike(getDst().getType()) ||                              \
+        !isBufferLike(getSrc0().getType()) ||                             \
+        !isBufferLike(getSrc1().getType())) {                             \
+      return emitOpError("requires pointer-like operands");               \
+    }                                                                     \
+    if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||       \
+        classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||      \
+        classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB) {      \
+      return emitOpError("requires UB-backed operands");                  \
+    }                                                                     \
+    return success();                                                     \
   }
 
 PTO_DEFINE_UB_BINARY_VERIFY_AND_EFFECTS(UBVaddReluOp)
@@ -9685,8 +10115,9 @@ LogicalResult UBVnotOp::verify() {
     return emitOpError("requires pointer-like operands");
   }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
@@ -9706,8 +10137,9 @@ LogicalResult UBVabsOp::verify() {
     return emitOpError("requires pointer-like operands");
   }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
@@ -9727,26 +10159,29 @@ LogicalResult UBVreluOp::verify() {
     return emitOpError("requires pointer-like operands");
   }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
-#define PTO_DEFINE_UB_UNARY_VERIFY_AND_EFFECTS(OpName)                        \
-  void OpName::getEffects(                                                    \
-      SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>     \
-          &effects) {                                                         \
-    effects.emplace_back(MemoryEffects::Read::get(), &getSrcMutable());       \
-    effects.emplace_back(MemoryEffects::Write::get(), &getDstMutable());      \
-  }                                                                           \
-  LogicalResult OpName::verify() {                                            \
-    if (!isBufferLike(getDst().getType()) ||                                  \
-        !isBufferLike(getSrc().getType()))                                    \
-      return emitOpError("requires pointer-like operands");                   \
-    if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||           \
-        classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)             \
-      return emitOpError("requires UB-backed operands");                      \
-    return success();                                                         \
+#define PTO_DEFINE_UB_UNARY_VERIFY_AND_EFFECTS(OpName)                    \
+  void OpName::getEffects(                                                \
+      SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> \
+          &effects) {                                                     \
+    effects.emplace_back(MemoryEffects::Read::get(), &getSrcMutable());   \
+    effects.emplace_back(MemoryEffects::Write::get(), &getDstMutable());  \
+  }                                                                       \
+  LogicalResult OpName::verify() {                                        \
+    if (!isBufferLike(getDst().getType()) ||                              \
+        !isBufferLike(getSrc().getType())) {                              \
+      return emitOpError("requires pointer-like operands");               \
+    }                                                                     \
+    if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||       \
+        classifyMemoryRole(getSrc().getType()) != MemoryRole::UB) {       \
+      return emitOpError("requires UB-backed operands");                  \
+    }                                                                     \
+    return success();                                                     \
   }
 
 PTO_DEFINE_UB_UNARY_VERIFY_AND_EFFECTS(UBVexpOp)
@@ -9790,8 +10225,9 @@ LogicalResult UBVshlOp::verify() {
     return emitOpError("requires pointer-like operands");
   }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
@@ -9811,8 +10247,9 @@ LogicalResult UBVshrOp::verify() {
     return emitOpError("requires pointer-like operands");
   }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }
 
@@ -9832,7 +10269,8 @@ LogicalResult UBVmulSOp::verify() {
     return emitOpError("requires pointer-like operands");
   }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
-      classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)
+      classifyMemoryRole(getSrc().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed operands");
+  }
   return success();
 }

--- a/lib/PTO/Transforms/BufidSync/BufidSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncAnalysis.cpp
@@ -6,14 +6,16 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-#include "BufidSyncAnalysis.h"
-#include "PTO/IR/PTO.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "llvm/Support/Debug.h"
 #include <algorithm>
 #include <functional>
 #include <map>
 #include <tuple>
+#include "BufidSyncAnalysis.h"
+#include "PTO/IR/PTO.h"
+#include "PTO/Support/CodeConstants.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "llvm/Support/Debug.h"
+
 
 #define DEBUG_TYPE "pto-bufid-sync"
 
@@ -23,8 +25,9 @@ using namespace mlir::pto;
 bool BufidSyncAnalysis::isGMDependency(
     const SmallVector<const BaseMemInfo *> &tiles) const {
   for (auto *tile : tiles) {
-    if (tile->scope == pto::AddressSpace::GM)
+    if (tile->scope == pto::AddressSpace::GM) {
       return true;
+    }
   }
   return false;
 }
@@ -51,8 +54,9 @@ void BufidSyncAnalysis::collectDependencies() {
       auto *src = compounds[i];
       auto *dst = compounds[j];
 
-      if (isSamePipe(src, dst))
+      if (isSamePipe(src, dst)) {
         continue;
+      }
 
       DepBaseMemInfoPairVec depBaseMemInfosVec;
       bool hasDep = memAnalyzer_.DepBetween(src->defVec, dst->useVec,
@@ -68,22 +72,26 @@ void BufidSyncAnalysis::collectDependencies() {
                                          depBaseMemInfosVec);
       }
 
-      if (!hasDep)
+      if (!hasDep) {
         continue;
+      }
 
       SmallVector<const BaseMemInfo *> depTiles;
       for (auto &pair : depBaseMemInfosVec) {
         if (pair.first->scope == pto::AddressSpace::GM ||
-            pair.second->scope == pto::AddressSpace::GM)
+            pair.second->scope == pto::AddressSpace::GM) {
           continue;
-        if (pair.first->scope != pair.second->scope)
+        }
+        if (pair.first->scope != pair.second->scope) {
           continue;
+        }
         depTiles.push_back(pair.first);
         depTiles.push_back(pair.second);
       }
 
-      if (depTiles.empty())
+      if (depTiles.empty()) {
         continue;
+      }
 
       DepPair dp;
       dp.srcElement = src;
@@ -107,8 +115,9 @@ void BufidSyncAnalysis::collectTilesFromDepPairs() {
   for (auto &dp : depPairs_) {
     for (auto *memInfo : dp.depTiles) {
       Value baseBuf = memInfo->baseBuffer;
-      if (!seenBaseBuffers.insert(baseBuf).second)
+      if (!seenBaseBuffers.insert(baseBuf).second) {
         continue;
+      }
       TileInfo ti;
       ti.memInfo = memInfo;
       ti.scope = memInfo->scope;
@@ -118,8 +127,9 @@ void BufidSyncAnalysis::collectTilesFromDepPairs() {
       ti.tileValue = baseBuf;
       Value rootBuf = memInfo->rootBuffer;
       if (rootBuf && rootBuf.getDefiningOp() &&
-          rootBuf.getDefiningOp()->hasTrait<mlir::OpTrait::ConstantLike>())
+          rootBuf.getDefiningOp()->hasTrait<mlir::OpTrait::ConstantLike>()) {
         rootBuf = baseBuf;
+      }
       ti.rootBuffer = rootBuf;
       allTiles_.push_back(ti);
     }
@@ -135,8 +145,9 @@ void BufidSyncAnalysis::collectTilesFromDepPairs() {
   SmallVector<TileInfo> deduped;
   DenseSet<unsigned> removed;
   for (auto &[key, indices] : keyToIndices) {
-    if (indices.size() <= 1)
+    if (indices.size() <= 1) {
       continue;
+    }
     DenseMap<Value, unsigned> rootToFirst;
     for (unsigned idx : indices) {
       Value root = allTiles_[idx].rootBuffer;
@@ -150,23 +161,27 @@ void BufidSyncAnalysis::collectTilesFromDepPairs() {
   }
 
   for (auto &[key, indices] : keyToIndices) {
-    if (indices.size() <= 1)
+    if (indices.size() <= 1) {
       continue;
+    }
     for (unsigned k = 1; k < indices.size(); ++k) {
-      if (removed.count(indices[k]))
+      if (removed.count(indices[k])) {
         continue;
+      }
       auto &a = allTiles_[indices[0]];
       auto &b = allTiles_[indices[k]];
       if (a.scope == b.scope && a.baseAddr == b.baseAddr && a.size == b.size &&
-          memAnalyzer_.MemAlias(a.memInfo, b.memInfo))
+          memAnalyzer_.MemAlias(a.memInfo, b.memInfo)) {
         removed.insert(indices[k]);
+      }
     }
   }
 
   if (!removed.empty()) {
     for (unsigned i = 0; i < allTiles_.size(); ++i) {
-      if (!removed.count(i))
+      if (!removed.count(i)) {
         deduped.push_back(std::move(allTiles_[i]));
+      }
     }
     if (debugEnabled_) {
       llvm::outs() << "[bufid_sync] allTiles dedup: " << allTiles_.size()
@@ -181,8 +196,9 @@ void BufidSyncAnalysis::collectTilesFromDepPairs() {
 }
 
 void BufidSyncAnalysis::classifyTiles() {
-  if (allTiles_.empty())
+  if (allTiles_.empty()) {
     return;
+  }
 
   DenseMap<pto::AddressSpace, SmallVector<unsigned>> spaceGroups;
   for (unsigned i = 0; i < allTiles_.size(); ++i) {
@@ -192,8 +208,9 @@ void BufidSyncAnalysis::classifyTiles() {
   for (auto &[space, indices] : spaceGroups) {
     unsigned n = indices.size();
     SmallVector<unsigned> parent(n);
-    for (unsigned i = 0; i < n; ++i)
+    for (unsigned i = 0; i < n; ++i) {
       parent[i] = i;
+    }
 
     auto find = [&](unsigned x) -> unsigned {
       while (parent[x] != x) {
@@ -206,8 +223,9 @@ void BufidSyncAnalysis::classifyTiles() {
     auto unite = [&](unsigned a, unsigned b) {
       a = find(a);
       b = find(b);
-      if (a != b)
+      if (a != b) {
         parent[a] = b;
+      }
     };
 
     for (unsigned i = 0; i < n; ++i) {
@@ -240,12 +258,13 @@ void BufidSyncAnalysis::bronKerbosch(
     const SmallVector<SmallVector<bool>> &adjMatrix,
     SmallVector<SmallVector<unsigned>> &maximalCliques) {
   if (P.empty() && X.empty()) {
-    if (!R.empty())
+    if (!R.empty()) {
       maximalCliques.push_back(R);
+    }
     return;
   }
 
-  if (maximalCliques.size() > 100000) {
+  if (maximalCliques.size() > mlir::pto::kValue100000) {
     llvm::errs() << "[bufid_sync] bronKerbosch WARNING: too many cliques ("
                  << maximalCliques.size() << "), aborting!\n";
     return;
@@ -254,8 +273,9 @@ void BufidSyncAnalysis::bronKerbosch(
   unsigned pivot = P.empty() ? X[0] : P[0];
   SmallVector<unsigned> candidates;
   for (unsigned v : P) {
-    if (!adjMatrix[pivot][v])
+    if (!adjMatrix[pivot][v]) {
       candidates.push_back(v);
+    }
   }
 
   for (unsigned v : candidates) {
@@ -264,19 +284,22 @@ void BufidSyncAnalysis::bronKerbosch(
 
     SmallVector<unsigned> newP, newX;
     for (unsigned u : P) {
-      if (adjMatrix[v][u])
+      if (adjMatrix[v][u]) {
         newP.push_back(u);
+      }
     }
     for (unsigned u : X) {
-      if (adjMatrix[v][u])
+      if (adjMatrix[v][u]) {
         newX.push_back(u);
+      }
     }
 
     bronKerbosch(newR, newP, newX, adjMatrix, maximalCliques);
 
     auto it = std::find(P.begin(), P.end(), v);
-    if (it != P.end())
+    if (it != P.end()) {
       P.erase(it);
+    }
     X.push_back(v);
   }
 }
@@ -287,8 +310,9 @@ void BufidSyncAnalysis::allocateVirtualBufIds() {
   for (unsigned gi = 0; gi < tileGroups_.size(); ++gi) {
     auto &group = tileGroups_[gi];
     unsigned n = group.size();
-    if (n == 0)
+    if (n == 0) {
       continue;
+    }
 
     SmallVector<SmallVector<bool>> adjMatrix(
         n, SmallVector<bool>(n, false));
@@ -303,8 +327,9 @@ void BufidSyncAnalysis::allocateVirtualBufIds() {
     }
 
     SmallVector<unsigned> P;
-    for (unsigned i = 0; i < n; ++i)
+    for (unsigned i = 0; i < n; ++i) {
       P.push_back(i);
+    }
 
     SmallVector<SmallVector<unsigned>> maximalCliques;
     bronKerbosch({}, P, {}, adjMatrix, maximalCliques);
@@ -332,17 +357,20 @@ void BufidSyncAnalysis::allocateVirtualBufIds() {
 
 bool BufidSyncAnalysis::virtualBufIdContainsTile(const VirtualBufId &vbid,
                                                  const BaseMemInfo *tile) const {
-  if (!tile)
+  if (!tile) {
     return false;
-  if (vbid.scope != tile->scope)
+  }
+  if (vbid.scope != tile->scope) {
     return false;
+  }
   for (auto &t : vbid.tiles) {
     bool ptrMatch = (t.memInfo == tile);
     bool valMatch = (t.tileValue == tile->baseBuffer);
     bool aliasMatch =
         (!ptrMatch && !valMatch && memAnalyzer_.MemAlias(t.memInfo, tile));
-    if (ptrMatch || valMatch || aliasMatch)
+    if (ptrMatch || valMatch || aliasMatch) {
       return true;
+    }
   }
   return false;
 }
@@ -370,12 +398,14 @@ int BufidSyncAnalysis::findBestVirtualBufId(const DepPair &depPair) const {
   for (auto &vbid : virtualBufIds_) {
     unsigned matchedTiles = 0;
     for (auto *tile : depPair.depTiles) {
-      if (virtualBufIdContainsTile(vbid, tile))
+      if (virtualBufIdContainsTile(vbid, tile)) {
         ++matchedTiles;
+      }
     }
 
-    if (matchedTiles == 0)
+    if (matchedTiles == 0) {
       continue;
+    }
 
     bool isBetter =
         matchedTiles > bestMatchedTiles ||
@@ -397,9 +427,9 @@ int BufidSyncAnalysis::findBestVirtualBufId(const DepPair &depPair) const {
 void BufidSyncAnalysis::insertSyncOperations() {
   for (auto &dp : depPairs_) {
     int bestLogicId = findBestVirtualBufId(dp);
-
-    if (bestLogicId < 0)
+    if (bestLogicId < 0) {
       continue;
+    }
 
     Operation *srcOp = dp.srcElement->elementOp;
     Operation *dstOp = dp.dstElement->elementOp;
@@ -420,8 +450,9 @@ void BufidSyncAnalysis::insertSyncOperations() {
           break;
         }
       }
-      if (!exists)
+      if (!exists) {
         pipeBefore.push_back(getOp);
+      }
     }
 
     {
@@ -440,8 +471,9 @@ void BufidSyncAnalysis::insertSyncOperations() {
           break;
         }
       }
-      if (!exists)
+      if (!exists) {
         pipeAfter.push_back(rlsOp);
+      }
     }
 
     {
@@ -460,8 +492,9 @@ void BufidSyncAnalysis::insertSyncOperations() {
           break;
         }
       }
-      if (!exists)
+      if (!exists) {
         pipeBefore.push_back(getOp);
+      }
     }
 
     {
@@ -480,8 +513,9 @@ void BufidSyncAnalysis::insertSyncOperations() {
           break;
         }
       }
-      if (!exists)
+      if (!exists) {
         pipeAfter.push_back(rlsOp);
+      }
     }
   }
 
@@ -496,13 +530,15 @@ void BufidSyncAnalysis::optimizeSamePipeMerge() {
     DenseSet<std::pair<int, int>> seen;
     for (auto &s : build.pipeBefore) {
       auto key = std::make_pair(static_cast<int>(s.pipe), s.logicId);
-      if (seen.insert(key).second)
+      if (seen.insert(key).second) {
         logicIdToPipeInts[s.logicId].insert(static_cast<int>(s.pipe));
+      }
     }
     for (auto &s : build.pipeAfter) {
       auto key = std::make_pair(static_cast<int>(s.pipe), s.logicId);
-      if (seen.insert(key).second)
+      if (seen.insert(key).second) {
         logicIdToPipeInts[s.logicId].insert(static_cast<int>(s.pipe));
+      }
     }
   }
 
@@ -513,39 +549,46 @@ void BufidSyncAnalysis::optimizeSamePipeMerge() {
     DenseSet<std::pair<int, int>> seen;
     for (auto &s : build.pipeBefore) {
       auto key = std::make_pair(static_cast<int>(s.pipe), s.logicId);
-      if (seen.insert(key).second)
+      if (seen.insert(key).second) {
         pipeIntToLogicIds[static_cast<int>(s.pipe)].push_back(s.logicId);
+      }
     }
     for (auto &s : build.pipeAfter) {
       auto key = std::make_pair(static_cast<int>(s.pipe), s.logicId);
-      if (seen.insert(key).second)
+      if (seen.insert(key).second) {
         pipeIntToLogicIds[static_cast<int>(s.pipe)].push_back(s.logicId);
+      }
     }
 
     for (auto &[pipeInt, logicIds] : pipeIntToLogicIds) {
-      if (logicIds.size() <= 1)
+      if (logicIds.size() <= 1) {
         continue;
+      }
 
       DenseMap<int, SmallVector<int>> sigPipeToIds;
       for (int lid : logicIds) {
         auto it = logicIdToPipeInts.find(lid);
-        if (it == logicIdToPipeInts.end())
+        if (it == logicIdToPipeInts.end()) {
           continue;
+        }
         SmallVector<int> otherPipes;
         for (int p : it->second) {
-          if (p != pipeInt)
+          if (p != pipeInt) {
             otherPipes.push_back(p);
+          }
         }
-        if (otherPipes.size() == 1)
+        if (otherPipes.size() == 1) {
           sigPipeToIds[otherPipes[0]].push_back(lid);
+        }
       }
 
       for (auto &[sigPipe, ids] : sigPipeToIds) {
         if (ids.size() > 1) {
           int survivor = *std::min_element(ids.begin(), ids.end());
           for (int id : ids) {
-            if (id != survivor && !mergeMap.count(id))
+            if (id != survivor && !mergeMap.count(id)) {
               mergeMap[id] = survivor;
+            }
           }
         }
       }
@@ -560,8 +603,9 @@ void BufidSyncAnalysis::optimizeSamePipeMerge() {
   }
 
   for (auto &[id, target] : mergeMap) {
-    while (mergeMap.count(target))
+    while (mergeMap.count(target)) {
       target = mergeMap[target];
+    }
   }
 
   DenseMap<Operation *, BufSyncPipeBuild> newOp2BufSync;
@@ -572,8 +616,9 @@ void BufidSyncAnalysis::optimizeSamePipeMerge() {
     for (auto &s : build.pipeBefore) {
       int newLogicId = s.logicId;
       auto it = mergeMap.find(newLogicId);
-      if (it != mergeMap.end())
+      if (it != mergeMap.end()) {
         newLogicId = it->second;
+      }
       auto key = std::make_pair(static_cast<int>(s.pipe), newLogicId);
       if (seenBefore.insert(key).second) {
         BufSyncOperation newS = s;
@@ -586,8 +631,9 @@ void BufidSyncAnalysis::optimizeSamePipeMerge() {
     for (auto &s : build.pipeAfter) {
       int newLogicId = s.logicId;
       auto it = mergeMap.find(newLogicId);
-      if (it != mergeMap.end())
+      if (it != mergeMap.end()) {
         newLogicId = it->second;
+      }
       auto key = std::make_pair(static_cast<int>(s.pipe), newLogicId);
       if (seenAfter.insert(key).second) {
         BufSyncOperation newS = s;
@@ -659,8 +705,9 @@ void BufidSyncAnalysis::mergeGetRls() {
                     keysToErase.push_back(existingKey);
                   }
                 }
-                for (auto &key : keysToErase)
+                for (auto &key : keysToErase) {
                   rlsMap.erase(key);
+                }
               }
               newPipeBefore.push_back(sync);
             }
@@ -681,8 +728,9 @@ void BufidSyncAnalysis::mergeGetRls() {
           if (auto forOp = dyn_cast<scf::ForOp>(&op)) {
             for (auto &region : forOp->getRegions()) {
               RlsMap freshMap;
-              for (auto &subBlock : region.getBlocks())
+              for (auto &subBlock : region.getBlocks()) {
                 processBlock(&subBlock, freshMap);
+              }
             }
             rlsMap.clear();
             continue;
@@ -705,8 +753,9 @@ void BufidSyncAnalysis::mergeGetRls() {
           if (auto ifOp = dyn_cast<scf::IfOp>(&op)) {
             for (auto &region : ifOp->getRegions()) {
               RlsMap freshMap;
-              for (auto &subBlock : region.getBlocks())
+              for (auto &subBlock : region.getBlocks()) {
                 processBlock(&subBlock, freshMap);
+              }
             }
             rlsMap.clear();
             continue;
@@ -715,16 +764,19 @@ void BufidSyncAnalysis::mergeGetRls() {
       };
 
   RlsMap rootMap;
-  for (auto &block : func_.getBody().getBlocks())
+  for (auto &block : func_.getBody().getBlocks()) {
     processBlock(&block, rootMap);
+  }
 
   SmallVector<Operation *> emptyOps;
   for (auto &[op, build] : op2BufSync_) {
-    if (build.pipeBefore.empty() && build.pipeAfter.empty())
+    if (build.pipeBefore.empty() && build.pipeAfter.empty()) {
       emptyOps.push_back(op);
+    }
   }
-  for (auto *op : emptyOps)
+  for (auto *op : emptyOps) {
     op2BufSync_.erase(op);
+  }
 
   if (debugEnabled_) {
     printOp2BufSync(llvm::outs(), op2BufSync_, func_,

--- a/lib/PTO/Transforms/BufidSync/BufidSyncAnalysis.h
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncAnalysis.h
@@ -9,18 +9,19 @@
 #ifndef MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCANALYSIS_H
 #define MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCANALYSIS_H
 
-#include "PTO/Transforms/InsertSync/SyncCommon.h"
+#include <algorithm>
+#include <optional>
 #include "PTO/Transforms/InsertSync/MemoryDependentAnalyzer.h"
 #include "PTO/Transforms/InsertSync/PTOIRTranslator.h"
+#include "PTO/Transforms/InsertSync/SyncCommon.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
-#include <algorithm>
-#include <optional>
+
 
 namespace mlir {
 namespace pto {
@@ -92,22 +93,30 @@ inline llvm::StringRef stringifyAddressSpace(pto::AddressSpace as) {
 }
 
 inline std::optional<pto::AddressSpace> getTileLocFromType(Value tileValue) {
-  if (!tileValue) return std::nullopt;
+  if (!tileValue) {
+    return std::nullopt;
+  }
   auto tileType = dyn_cast<pto::TileBufType>(tileValue.getType());
   if (tileType) {
     auto asAttr = dyn_cast_or_null<pto::AddressSpaceAttr>(tileType.getMemorySpace());
-    if (asAttr) return asAttr.getAddressSpace();
+    if (asAttr) {
+      return asAttr.getAddressSpace();
+    }
   }
   auto memrefType = dyn_cast<mlir::MemRefType>(tileValue.getType());
   if (memrefType) {
     auto asAttr = dyn_cast_or_null<pto::AddressSpaceAttr>(memrefType.getMemorySpace());
-    if (asAttr) return asAttr.getAddressSpace();
+    if (asAttr) {
+      return asAttr.getAddressSpace();
+    }
   }
   return std::nullopt;
 }
 
 inline void printTileLoc(llvm::raw_ostream &os, Value tileValue) {
-  if (!tileValue) return;
+  if (!tileValue) {
+    return;
+  }
   auto *defOp = tileValue.getDefiningOp();
   if (!defOp) {
     os << " BlockArg";
@@ -115,8 +124,9 @@ inline void printTileLoc(llvm::raw_ostream &os, Value tileValue) {
   }
   os << " defBy=" << defOp->getName().getStringRef();
   auto locAs = getTileLocFromType(tileValue);
-  if (locAs)
+  if (locAs) {
     os << " typeLoc=" << stringifyAddressSpace(*locAs);
+  }
 }
 
 inline void printTileInfo(llvm::raw_ostream &os, const TileInfo &t) {
@@ -124,16 +134,17 @@ inline void printTileInfo(llvm::raw_ostream &os, const TileInfo &t) {
   os << " scope=" << static_cast<int>(t.scope)
      << "(" << stringifyAddressSpace(t.scope) << ")";
   auto typeLoc = getTileLocFromType(t.tileValue);
-  if (typeLoc && *typeLoc != t.scope)
+  if (typeLoc && *typeLoc != t.scope) {
     os << " MISMATCH! typeLoc=" << stringifyAddressSpace(*typeLoc);
+  }
   os << " baseAddr=" << t.baseAddr << " size=" << t.size;
   printTileLoc(os, t.tileValue);
   os << " root=";
   printTileValue(os, t.rootBuffer);
   if (t.rootBuffer) {
-    if (auto *defOp = t.rootBuffer.getDefiningOp())
+    if (auto *defOp = t.rootBuffer.getDefiningOp()) {
       os << " rootDefBy=" << defOp->getName().getStringRef();
-    else
+    } else
       os << " rootDefBy=BlockArg";
     os << " rootPtr=" << (const void *)t.rootBuffer.getAsOpaquePointer();
   }
@@ -177,7 +188,9 @@ inline void printTileGroups(llvm::raw_ostream &os,
   for (unsigned i = 0; i < tileGroups.size(); ++i) {
     os << "  group[" << i << "] size=" << tileGroups[i].size() << " tiles=[";
     for (unsigned j = 0; j < tileGroups[i].size(); ++j) {
-      if (j > 0) os << " ; ";
+      if (j > 0) {
+        os << " ; ";
+      }
       printTileValue(os, allTiles[tileGroups[i][j]].tileValue);
     }
     os << "]\n";
@@ -192,7 +205,9 @@ inline void printVirtualBufIds(llvm::raw_ostream &os,
        << " scope=" << static_cast<int>(vbid.scope)
        << " tileCount=" << vbid.tiles.size() << " tiles=[";
     for (unsigned i = 0; i < vbid.tiles.size(); ++i) {
-      if (i > 0) os << " ; ";
+      if (i > 0) {
+        os << " ; ";
+      }
       printTileValue(os, vbid.tiles[i].tileValue);
     }
     os << "]\n";
@@ -202,13 +217,15 @@ inline void printVirtualBufIds(llvm::raw_ostream &os,
 inline void printOp2BufSync(llvm::raw_ostream &os,
                             const DenseMap<Operation *, BufSyncPipeBuild> &op2BufSync,
                             func::FuncOp func, const char *title = nullptr) {
-  if (title)
+  if (title) {
     os << "[bufid_sync] " << title << ":\n";
+  }
 
   SmallVector<Operation *> sortedOps;
   sortedOps.reserve(op2BufSync.size());
-  for (auto &[op, build] : op2BufSync)
+  for (auto &[op, build] : op2BufSync) {
     sortedOps.push_back(op);
+  }
 
   DenseMap<Operation *, unsigned> opOrder;
   unsigned orderIdx = 0;
@@ -235,7 +252,9 @@ inline void printOp2BufSync(llvm::raw_ostream &os,
     }
     os << " <- ";
     for (unsigned i = 0; i < op->getNumOperands(); ++i) {
-      if (i > 0) os << ", ";
+      if (i > 0) {
+        os << ", ";
+      }
       op->getOperand(i).printAsOperand(os, OpPrintingFlags());
     }
     os << "\n    pipeBefore:";
@@ -261,8 +280,9 @@ inline void printLifeIntervals(llvm::raw_ostream &os,
   for (auto &iv : intervals) {
     os << "  logicId=" << iv.logicId
        << " [" << iv.startPos << "," << iv.endPos << "] pipes=";
-    for (auto p : iv.pipes)
+    for (auto p : iv.pipes) {
       os << static_cast<int>(p) << ",";
+    }
     os << "\n";
   }
 }

--- a/lib/PTO/Transforms/BufidSync/BufidSyncCodegen.cpp
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncCodegen.cpp
@@ -6,13 +6,14 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include <algorithm>
+#include <tuple>
 #include "BufidSyncCodegen.h"
 #include "PTO/IR/PTO.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/IRMapping.h"
 #include "llvm/Support/Debug.h"
-#include <algorithm>
-#include <tuple>
+
 
 #define DEBUG_TYPE "pto-bufid-sync"
 
@@ -51,8 +52,9 @@ LogicalResult BufidSyncCodegen::run() {
 
   WalkResult walkResult = func_->walk<WalkOrder::PreOrder>([&](Operation *op) {
     auto it = op2BufSync_.find(op);
-    if (it == op2BufSync_.end())
+    if (it == op2BufSync_.end()) {
       return WalkResult::advance();
+    }
 
     auto &build = it->second;
     SmallVector<BufSyncOperation> pipeBefore(build.pipeBefore.begin(),

--- a/lib/PTO/Transforms/BufidSync/BufidSyncCodegen.h
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncCodegen.h
@@ -9,12 +9,13 @@
 #ifndef MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCCODEGEN_H
 #define MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCCODEGEN_H
 
+#include <optional>
 #include "BufidSyncAnalysis.h"
 #include "BufidSyncIdAlloc.h"
 #include "PTO/Transforms/InsertSync/SyncCommon.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
-#include <optional>
+
 
 namespace mlir {
 namespace pto {

--- a/lib/PTO/Transforms/BufidSync/BufidSyncIdAlloc.cpp
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncIdAlloc.cpp
@@ -6,18 +6,24 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-#include "BufidSyncIdAlloc.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "llvm/Support/Debug.h"
 #include <algorithm>
 #include <climits>
+#include <cstddef>
 #include <map>
 #include <set>
 #include <sstream>
 #include <string>
 #include <tuple>
+#include "BufidSyncIdAlloc.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "llvm/Support/Debug.h"
+
 
 #define DEBUG_TYPE "pto-bufid-sync"
+
+namespace {
+constexpr size_t kMinimumReusableIdGroupSize = 2;
+}
 
 using namespace mlir;
 using namespace mlir::pto;
@@ -27,12 +33,14 @@ void BufidSyncIdAlloc::collectPipeSignature(
   DenseSet<PipelineType> seen;
   for (auto &[op, build] : op2BufSync_) {
     for (auto &s : build.pipeBefore) {
-      if (s.logicId == logicId && seen.insert(s.pipe).second)
+      if (s.logicId == logicId && seen.insert(s.pipe).second) {
         pipes.push_back(s.pipe);
+      }
     }
     for (auto &s : build.pipeAfter) {
-      if (s.logicId == logicId && seen.insert(s.pipe).second)
+      if (s.logicId == logicId && seen.insert(s.pipe).second) {
         pipes.push_back(s.pipe);
+      }
     }
   }
 }
@@ -84,17 +92,19 @@ void BufidSyncIdAlloc::computeLifeIntervals() {
 
     for (auto &s : build.pipeBefore) {
       unsigned pos = inLoop ? loopBegin : s.syncIRIndex;
-      if (!logicIdStartPos.count(s.logicId))
+      if (!logicIdStartPos.count(s.logicId)) {
         logicIdStartPos[s.logicId] = pos;
-      else
+      } else {
         logicIdStartPos[s.logicId] = std::min(logicIdStartPos[s.logicId], pos);
+}
     }
     for (auto &s : build.pipeAfter) {
       unsigned pos = inLoop ? loopEnd : s.syncIRIndex;
-      if (!logicIdEndPos.count(s.logicId))
+      if (!logicIdEndPos.count(s.logicId)) {
         logicIdEndPos[s.logicId] = pos;
-      else
+      } else {
         logicIdEndPos[s.logicId] = std::max(logicIdEndPos[s.logicId], pos);
+}
     }
   }
 
@@ -140,8 +150,9 @@ void BufidSyncIdAlloc::linearScanAllocate() {
     for (unsigned idx : active) {
       if (intervals_[idx].endPos < interval.startPos) {
         auto it = logicToPhysical_.find(intervals_[idx].logicId);
-        if (it != logicToPhysical_.end())
+        if (it != logicToPhysical_.end()) {
           freeIds.insert(it->second);
+        }
       } else {
         newActive.push_back(idx);
       }
@@ -175,24 +186,27 @@ void BufidSyncIdAlloc::compactPhysicalIds() {
   for (auto &[op, build] : op2BufSync_) {
     for (auto &s : build.pipeBefore) {
       activeLogicIds.insert(s.logicId);
-      if (!logicIdFirstPos.count(s.logicId))
+      if (!logicIdFirstPos.count(s.logicId)) {
         logicIdFirstPos[s.logicId] = s.syncIRIndex;
-      else
+      } else {
         logicIdFirstPos[s.logicId] = std::min(logicIdFirstPos[s.logicId], s.syncIRIndex);
+}
     }
     for (auto &s : build.pipeAfter) {
       activeLogicIds.insert(s.logicId);
-      if (!logicIdFirstPos.count(s.logicId))
+      if (!logicIdFirstPos.count(s.logicId)) {
         logicIdFirstPos[s.logicId] = s.syncIRIndex;
-      else
+      } else {
         logicIdFirstPos[s.logicId] = std::min(logicIdFirstPos[s.logicId], s.syncIRIndex);
+}
     }
   }
 
   SmallVector<int> logicIdsByPos;
   for (auto &[lid, pid] : logicToPhysical_) {
-    if (activeLogicIds.count(lid))
+    if (activeLogicIds.count(lid)) {
       logicIdsByPos.push_back(lid);
+    }
   }
   std::sort(logicIdsByPos.begin(), logicIdsByPos.end(), [&](int a, int b) {
     return logicIdFirstPos[a] < logicIdFirstPos[b];
@@ -202,13 +216,15 @@ void BufidSyncIdAlloc::compactPhysicalIds() {
   for (unsigned i = 0; i < logicIdsByPos.size(); ++i) {
     int lid = logicIdsByPos[i];
     int oldPid = logicToPhysical_[lid];
-    if (!oldPidToNew.count(oldPid))
+    if (!oldPidToNew.count(oldPid)) {
       oldPidToNew[oldPid] = static_cast<int>(oldPidToNew.size());
+    }
   }
 
   for (auto &[lid, pid] : logicToPhysical_) {
-    if (oldPidToNew.count(pid))
+    if (oldPidToNew.count(pid)) {
       pid = oldPidToNew[pid];
+    }
   }
 
   maxPhysicalIdUsed_ = static_cast<int>(oldPidToNew.size()) - 1;
@@ -226,8 +242,9 @@ void BufidSyncIdAlloc::reuseIds() {
     std::sort(s.begin(), s.end());
     std::string key;
     for (auto p : s) {
-      if (!key.empty())
+      if (!key.empty()) {
         key += ",";
+      }
       key += std::to_string(static_cast<int>(p));
     }
     return key;
@@ -238,8 +255,9 @@ void BufidSyncIdAlloc::reuseIds() {
     std::string token;
     std::istringstream iss(key);
     while (std::getline(iss, token, ',')) {
-      if (!token.empty())
+      if (!token.empty()) {
         pipes.push_back(static_cast<PipelineType>(std::stoi(token)));
+      }
     }
     return pipes;
   };
@@ -256,15 +274,17 @@ void BufidSyncIdAlloc::reuseIds() {
     }
   };
 
-  auto getMinPipeScore = [&](const SmallVector<PipelineType> &pipes) -> int {
+  auto getMinPipeScore = [&getPipeScore](
+                             const SmallVector<PipelineType> &pipes) -> int {
     int minScore = 99;
-    for (auto p : pipes)
+    for (auto p : pipes) {
       minScore = std::min(minScore, getPipeScore(p));
+    }
     return minScore;
   };
 
-  auto isConsecutiveOnPipe = [&](const SmallVector<int> &ids,
-                                 PipelineType pipe) -> bool {
+  auto isConsecutiveOnPipe = [this](const SmallVector<int> &ids,
+                                    PipelineType pipe) -> bool {
     SmallVector<std::pair<unsigned, unsigned>> idRanges;
     for (int lid : ids) {
       unsigned minIdx = UINT_MAX, maxIdx = 0;
@@ -282,25 +302,29 @@ void BufidSyncIdAlloc::reuseIds() {
           }
         }
       }
-      if (minIdx != UINT_MAX)
+      if (minIdx != UINT_MAX) {
         idRanges.push_back({minIdx, maxIdx});
+      }
     }
     std::sort(idRanges.begin(), idRanges.end());
     for (unsigned i = 1; i < idRanges.size(); ++i) {
-      if (idRanges[i].first <= idRanges[i - 1].second)
+      if (idRanges[i].first <= idRanges[i - 1].second) {
         return false;
+      }
     }
     for (unsigned i = 1; i < idRanges.size(); ++i) {
       unsigned gapStart = idRanges[i - 1].second;
       unsigned gapEnd = idRanges[i].first;
       for (auto &[op, build] : op2BufSync_) {
         for (auto &s : build.pipeBefore) {
-          if (s.syncIRIndex > gapStart && s.syncIRIndex < gapEnd)
+          if (s.syncIRIndex > gapStart && s.syncIRIndex < gapEnd) {
             return false;
+          }
         }
         for (auto &s : build.pipeAfter) {
-          if (s.syncIRIndex > gapStart && s.syncIRIndex < gapEnd)
+          if (s.syncIRIndex > gapStart && s.syncIRIndex < gapEnd) {
             return false;
+          }
         }
       }
     }
@@ -316,22 +340,26 @@ void BufidSyncIdAlloc::reuseIds() {
     DenseMap<int, DenseSet<PipelineType>> logicIdSeenPipes;
     for (auto &[op, build] : op2BufSync_) {
       for (auto &s : build.pipeBefore) {
-        if (logicIdSeenPipes[s.logicId].insert(s.pipe).second)
+        if (logicIdSeenPipes[s.logicId].insert(s.pipe).second) {
           logicIdPipes[s.logicId].push_back(s.pipe);
-        if (!logicIdFirstPos.count(s.logicId))
+        }
+        if (!logicIdFirstPos.count(s.logicId)) {
           logicIdFirstPos[s.logicId] = s.syncIRIndex;
-        else
+        } else {
           logicIdFirstPos[s.logicId] =
               std::min(logicIdFirstPos[s.logicId], s.syncIRIndex);
+}
       }
       for (auto &s : build.pipeAfter) {
-        if (logicIdSeenPipes[s.logicId].insert(s.pipe).second)
+        if (logicIdSeenPipes[s.logicId].insert(s.pipe).second) {
           logicIdPipes[s.logicId].push_back(s.pipe);
-        if (!logicIdFirstPos.count(s.logicId))
+        }
+        if (!logicIdFirstPos.count(s.logicId)) {
           logicIdFirstPos[s.logicId] = s.syncIRIndex;
-        else
+        } else {
           logicIdFirstPos[s.logicId] =
               std::min(logicIdFirstPos[s.logicId], s.syncIRIndex);
+}
       }
     }
 
@@ -352,8 +380,9 @@ void BufidSyncIdAlloc::reuseIds() {
     int bestScore = -1;
     std::string bestSigKey;
     for (auto &[sigKey, ids] : sigGroups) {
-      if (ids.size() < 2)
+      if (ids.size() < kMinimumReusableIdGroupSize) {
         continue;
+      }
       SmallVector<PipelineType> sigPipes = decodeSig(sigKey);
       int pipeScore = getMinPipeScore(sigPipes);
       int idNum = static_cast<int>(ids.size());
@@ -376,8 +405,9 @@ void BufidSyncIdAlloc::reuseIds() {
     std::sort(groupIds.begin(), groupIds.end(), [&](int a, int b) {
       auto itA = logicIdFirstPos.find(a);
       auto itB = logicIdFirstPos.find(b);
-      if (itA == logicIdFirstPos.end() || itB == logicIdFirstPos.end())
+      if (itA == logicIdFirstPos.end() || itB == logicIdFirstPos.end()) {
         return a < b;
+      }
       return itA->second < itB->second;
     });
 
@@ -425,8 +455,9 @@ void BufidSyncIdAlloc::reuseIds() {
     }
 
     for (auto &[lid, donorLid] : mergeMap) {
-      while (mergeMap.count(donorLid))
+      while (mergeMap.count(donorLid)) {
         donorLid = mergeMap[donorLid];
+      }
     }
 
     DenseMap<Operation *, BufSyncPipeBuild> newOp2BufSync;
@@ -437,8 +468,9 @@ void BufidSyncIdAlloc::reuseIds() {
       for (auto &s : build.pipeBefore) {
         int newLogicId = s.logicId;
         auto it = mergeMap.find(newLogicId);
-        if (it != mergeMap.end())
+        if (it != mergeMap.end()) {
           newLogicId = it->second;
+        }
         auto key = std::make_pair(static_cast<int>(s.pipe), newLogicId);
         if (seenBefore.insert(key).second) {
           BufSyncOperation newS = s;
@@ -451,8 +483,9 @@ void BufidSyncIdAlloc::reuseIds() {
       for (auto &s : build.pipeAfter) {
         int newLogicId = s.logicId;
         auto it = mergeMap.find(newLogicId);
-        if (it != mergeMap.end())
+        if (it != mergeMap.end()) {
           newLogicId = it->second;
+        }
         auto key = std::make_pair(static_cast<int>(s.pipe), newLogicId);
         if (seenAfter.insert(key).second) {
           BufSyncOperation newS = s;
@@ -480,8 +513,9 @@ void BufidSyncIdAlloc::reuseIds() {
 
     for (auto &[lid, pid] : logicToPhysical_) {
       auto it = mergeMap.find(lid);
-      if (it != mergeMap.end())
+      if (it != mergeMap.end()) {
         pid = logicToPhysical_[it->second];
+      }
     }
 
     compactPhysicalIds();
@@ -527,9 +561,10 @@ bool BufidSyncIdAlloc::validateNoSamePhysicalIdNesting(
     for (auto &sync : build.pipeBefore) {
       auto it = logicToPhysical_.find(sync.logicId);
       if (it == logicToPhysical_.end()) {
-        if (error)
+        if (error) {
           *error = "missing physical bufid for logic id " +
                    std::to_string(sync.logicId);
+        }
         return false;
       }
       events.push_back({sync.syncIRIndex, 0, sync.type, sync.logicId,
@@ -538,9 +573,10 @@ bool BufidSyncIdAlloc::validateNoSamePhysicalIdNesting(
     for (auto &sync : build.pipeAfter) {
       auto it = logicToPhysical_.find(sync.logicId);
       if (it == logicToPhysical_.end()) {
-        if (error)
+        if (error) {
           *error = "missing physical bufid for logic id " +
                    std::to_string(sync.logicId);
+        }
         return false;
       }
       events.push_back({sync.syncIRIndex, 1, sync.type, sync.logicId,

--- a/lib/PTO/Transforms/BufidSync/BufidSyncIdAlloc.h
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncIdAlloc.h
@@ -9,8 +9,9 @@
 #ifndef MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCIDALLOC_H
 #define MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCIDALLOC_H
 
-#include "BufidSyncAnalysis.h"
 #include <string>
+#include "BufidSyncAnalysis.h"
+
 
 namespace mlir {
 namespace pto {

--- a/lib/PTO/Transforms/BufidSync/BufidSyncPass.cpp
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncPass.cpp
@@ -6,17 +6,19 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include <string>
 #include "BufidSyncAnalysis.h"
 #include "BufidSyncCodegen.h"
 #include "BufidSyncIdAlloc.h"
 #include "PTO/IR/PTO.h"
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/InsertSync/MemoryDependentAnalyzer.h"
 #include "PTO/Transforms/InsertSync/PTOIRTranslator.h"
 #include "PTO/Transforms/InsertSync/SyncCommon.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/Support/Debug.h"
-#include <string>
+
 
 #define DEBUG_TYPE "pto-bufid-sync"
 
@@ -31,7 +33,7 @@ namespace {
 struct PTOBufidSyncPass
     : public impl::PTOBufidSyncBase<PTOBufidSyncPass> {
   PTOBufidSyncPass() = default;
-  PTOBufidSyncPass(const PTOBufidSyncOptions &options) {
+  explicit PTOBufidSyncPass(const PTOBufidSyncOptions &options) {
     enableBufidSyncDebug = options.enableBufidSyncDebug;
   }
   void runOnOperation() override;
@@ -85,7 +87,7 @@ void PTOBufidSyncPass::runOnOperation() {
   }
 
   BufidSyncIdAlloc idAlloc(analysis.getVirtualBufIds(),
-                           analysis.getOp2BufSync(), syncIR, 32,
+                           analysis.getOp2BufSync(), syncIR, mlir::pto::kValue32,
                            enableBufidSyncDebug);
 
   idAlloc.computeLifeIntervals();

--- a/lib/PTO/Transforms/CppPostprocess.cpp
+++ b/lib/PTO/Transforms/CppPostprocess.cpp
@@ -8,6 +8,7 @@
 
 #include "PTO/Transforms/CppPostprocess.h"
 
+#include "PTO/Support/CodeConstants.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -21,10 +22,12 @@ namespace pto {
 
 namespace {
 
+constexpr size_t kLastUseReplacementReserve = 32;
+
 struct ParsedMarkerCall {
   size_t markerPos;
   size_t rparenPos;
-  llvm::SmallVector<llvm::StringRef, 8> args;
+  llvm::SmallVector<llvm::StringRef, mlir::pto::kValue8> args;
 };
 
 static bool parseMarkerArgs(llvm::StringRef argsRef,
@@ -90,14 +93,17 @@ static bool parseLastUseMarkerName(llvm::StringRef markerName,
     if (token.empty()) {
       return false;
     }
-    if (!llvm::all_of(token, [](char c) { return std::isdigit(c); }))
+    if (!llvm::all_of(token, [](char c) { return std::isdigit(c); })) {
       return false;
-    if (!lastUseArgs.empty())
+    }
+    if (!lastUseArgs.empty()) {
       lastUseArgs.append(", ");
+    }
     lastUseArgs.append(token.str());
-    if (next == llvm::StringRef::npos)
+    if (next == llvm::StringRef::npos) {
       break;
-    pos = next + 2;
+    }
+    pos = next + mlir::pto::kValue2;
   }
   return !lastUseArgs.empty();
 }
@@ -115,8 +121,9 @@ bool rewriteLastUseMarkersInCpp(std::string &cpp) {
     }
 
     size_t lparenPos = markerPos + kPrefix.size();
-    while (lparenPos < cpp.size() && cpp[lparenPos] != '(')
+    while (lparenPos < cpp.size() && cpp[lparenPos] != '(') {
       ++lparenPos;
+    }
     if (lparenPos >= cpp.size()) {
       searchPos = markerPos + 1;
       continue;
@@ -131,8 +138,9 @@ bool rewriteLastUseMarkersInCpp(std::string &cpp) {
         ++parenDepth;
         continue;
       }
-      if (c != ')')
+      if (c != ')') {
         continue;
+      }
       if (parenDepth == 0) {
         call.rparenPos = i;
         break;
@@ -160,7 +168,7 @@ bool rewriteLastUseMarkersInCpp(std::string &cpp) {
 
     std::string replacement;
     replacement.reserve(callee.size() + lastUseArgs.size() + argsRef.size() +
-                        32);
+                        kLastUseReplacementReserve);
     replacement.append("[[pto::last_use(");
     replacement.append(lastUseArgs);
     replacement.append(")]] ");

--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -27,6 +27,7 @@
 //      operands directly (no type bridging needed).
 //
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/Passes.h"
@@ -97,8 +98,8 @@ struct OperandTypeInfo {
   std::string dtype; // all kinds: element type string (e.g. "f32")
 
   // --- Tile-only (TileBufType) ---
-  SmallVector<int64_t, 2> tileShape;
-  SmallVector<int64_t, 2> tileValidShape;
+  SmallVector<int64_t, mlir::pto::kValue2> tileShape;
+  SmallVector<int64_t, mlir::pto::kValue2> tileValidShape;
   std::string tileMemorySpace; // e.g. "ub", "gm", "mat", "left", "right", "acc", "bias"
   int32_t blayout = 0;
   int32_t slayout = 0;
@@ -123,13 +124,14 @@ struct OperandTypeInfo {
     if (kind != rhs.kind || dtype != rhs.dtype) {
       return false;
     }
-    if (kind == OperandKind::Tile)
+    if (kind == OperandKind::Tile) {
       return tileShape == rhs.tileShape &&
              tileValidShape == rhs.tileValidShape &&
              tileMemorySpace == rhs.tileMemorySpace &&
              blayout == rhs.blayout && slayout == rhs.slayout &&
              fractal == rhs.fractal && pad == rhs.pad &&
              compact == rhs.compact;
+    }
     if (kind == OperandKind::Vector) {
       return vectorShape == rhs.vectorShape;
     }
@@ -149,8 +151,8 @@ struct OperandTypeInfo {
 struct SpecKey {
   std::string opName;
   std::string targetArch;
-  SmallVector<OperandTypeInfo, 4> operands;
-  SmallVector<std::pair<std::string, std::string>, 4> contextAttrs;
+  SmallVector<OperandTypeInfo, mlir::pto::kValue4> operands;
+  SmallVector<std::pair<std::string, std::string>, mlir::pto::kValue4> contextAttrs;
 
   bool operator==(const SpecKey &rhs) const {
     return opName == rhs.opName && targetArch == rhs.targetArch &&
@@ -243,40 +245,40 @@ static std::string getDtypeString(Type elemTy) {
   if (isa<pto::F4E2M1x2Type>(elemTy)) {
     return "f4e2m1x2";
   }
-  if (elemTy.isUnsignedInteger(64)) {
+  if (elemTy.isUnsignedInteger(mlir::pto::kValue64)) {
     return "ui64";
   }
-  if (elemTy.isUnsignedInteger(32)) {
+  if (elemTy.isUnsignedInteger(mlir::pto::kValue32)) {
     return "ui32";
   }
-  if (elemTy.isUnsignedInteger(16)) {
+  if (elemTy.isUnsignedInteger(mlir::pto::kValue16)) {
     return "ui16";
   }
-  if (elemTy.isUnsignedInteger(8)) {
+  if (elemTy.isUnsignedInteger(mlir::pto::kValue8)) {
     return "ui8";
   }
-  if (elemTy.isSignedInteger(64)) {
+  if (elemTy.isSignedInteger(mlir::pto::kValue64)) {
     return "si64";
   }
-  if (elemTy.isSignedInteger(32)) {
+  if (elemTy.isSignedInteger(mlir::pto::kValue32)) {
     return "si32";
   }
-  if (elemTy.isSignedInteger(16)) {
+  if (elemTy.isSignedInteger(mlir::pto::kValue16)) {
     return "si16";
   }
-  if (elemTy.isSignedInteger(8)) {
+  if (elemTy.isSignedInteger(mlir::pto::kValue8)) {
     return "si8";
   }
-  if (elemTy.isSignlessInteger(64)) {
+  if (elemTy.isSignlessInteger(mlir::pto::kValue64)) {
     return "i64";
   }
-  if (elemTy.isSignlessInteger(32)) {
+  if (elemTy.isSignlessInteger(mlir::pto::kValue32)) {
     return "i32";
   }
-  if (elemTy.isSignlessInteger(16)) {
+  if (elemTy.isSignlessInteger(mlir::pto::kValue16)) {
     return "i16";
   }
-  if (elemTy.isSignlessInteger(8)) {
+  if (elemTy.isSignlessInteger(mlir::pto::kValue8)) {
     return "i8";
   }
   return "";
@@ -599,11 +601,12 @@ static LogicalResult appendOpContextAttrs(
   }
   if (auto tfillpad = dyn_cast<pto::TFillPadOp>(op)) {
     auto kind = pto::inferTFillPadLoweringKindAfterMemoryPlanning(tfillpad);
-    if (failed(kind))
+    if (failed(kind)) {
       return tfillpad.emitOpError(
           "cannot infer a supported lowering; expand and in-place forms "
           "require loc=vec, statically comparable physical shapes, and "
           "resolved planned addresses");
+    }
     StringRef token;
     switch (*kind) {
     case pto::TFillPadLoweringKind::Normal:
@@ -799,8 +802,9 @@ static std::optional<OperandTypeInfo> buildOperandTypeInfo(Value value) {
     if (validShape.empty()) {
       info.tileValidShape.assign(tbTy.getShape().begin(), tbTy.getShape().end());
     }
-    else
+    else {
       info.tileValidShape.assign(validShape.begin(), validShape.end());
+}
     info.tileMemorySpace = getMemorySpaceString(tbTy);
     if (auto config = tbTy.getConfigAttr()) {
       info.blayout = static_cast<int32_t>(config.getBLayout().getValue());
@@ -1009,8 +1013,9 @@ static std::string buildOperandSpecsJson(const SpecKey &key) {
           if (ShapedType::isDynamic(op.viewStrides[dim])) {
             json += "null";
           }
-          else
+          else {
             json += std::to_string(op.viewStrides[dim]);
+}
         }
         json += "]";
       }
@@ -1216,10 +1221,11 @@ func::FuncOp ExpandState::invokeInProcessTileLib(const SpecKey &key,
                    << entrySymbol << "\n";
       return failure();
     }
-    if (!importedEntry->hasAttr("pto.tilelang.instance"))
+    if (!importedEntry->hasAttr("pto.tilelang.instance")) {
       llvm::errs() << "ExpandTileOp: warning: in-process PTODSL entry @"
                    << importedEntry.getSymName()
                    << " missing pto.tilelang.instance attribute\n";
+    }
     return success();
   });
   if (failed(materializationResult)) {
@@ -1277,7 +1283,7 @@ LogicalResult ExpandState::expandTileOpsInFunction(func::FuncOp func,
   OpBuilder builder(ctx);
 
   // Collect tile ops first (avoid modifying while iterating).
-  SmallVector<Operation *, 16> tileOps;
+  SmallVector<Operation *, mlir::pto::kValue16> tileOps;
   func.walk([&](Operation *op) {
     if (pto::isTileLibExpandableOp(op)) {
       tileOps.push_back(op);
@@ -1286,8 +1292,9 @@ LogicalResult ExpandState::expandTileOpsInFunction(func::FuncOp func,
 
   for (auto *op : tileOps) {
     auto specKey = buildSpecKey(op);
-    if (failed(specKey))
+    if (failed(specKey)) {
       return failure();
+    }
 
     // Materialize the selected PTODSL template in-process.
     func::FuncOp dslFn = invokeTileLib(*specKey, op, mod, ctx);

--- a/lib/PTO/Transforms/FoldTileBufIntrinsics.cpp
+++ b/lib/PTO/Transforms/FoldTileBufIntrinsics.cpp
@@ -32,6 +32,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 
@@ -105,17 +106,19 @@ static bool isPTOViewBridgeType(Type type) {
 }
 
 static bool eraseDeadViewBridgeCasts(func::FuncOp func) {
-  SmallVector<UnrealizedConversionCastOp, 8> deadCasts;
+  SmallVector<UnrealizedConversionCastOp, mlir::pto::kValue8> deadCasts;
   func.walk([&](UnrealizedConversionCastOp castOp) {
     if (!castOp.use_empty() || castOp.getNumOperands() != 1 ||
-        castOp.getNumResults() != 1)
+        castOp.getNumResults() != 1) {
       return;
+    }
 
     Type srcTy = castOp.getOperand(0).getType();
     Type dstTy = castOp.getResult(0).getType();
     if ((isa<MemRefType>(srcTy) && isPTOViewBridgeType(dstTy)) ||
-        (isPTOViewBridgeType(srcTy) && isa<MemRefType>(dstTy)))
+        (isPTOViewBridgeType(srcTy) && isa<MemRefType>(dstTy))) {
       deadCasts.push_back(castOp);
+    }
   });
 
   for (auto castOp : llvm::reverse(deadCasts)) {
@@ -125,12 +128,13 @@ static bool eraseDeadViewBridgeCasts(func::FuncOp func) {
 }
 
 static bool eraseDeadMemrefViewOps(func::FuncOp func) {
-  SmallVector<Operation *, 8> deadMemrefOps;
+  SmallVector<Operation *, mlir::pto::kValue8> deadMemrefOps;
   func.walk([&](Operation *op) {
     if ((isa<memref::SubViewOp>(op) ||
          isa<memref::ReinterpretCastOp>(op)) &&
-        op->use_empty())
+        op->use_empty()) {
       deadMemrefOps.push_back(op);
+    }
   });
 
   for (Operation *op : llvm::reverse(deadMemrefOps)) {
@@ -140,12 +144,13 @@ static bool eraseDeadMemrefViewOps(func::FuncOp func) {
 }
 
 static bool eraseDeadTensorViewOps(func::FuncOp func) {
-  SmallVector<Operation *, 8> deadViewOps;
+  SmallVector<Operation *, mlir::pto::kValue8> deadViewOps;
   func.walk([&](Operation *op) {
     if ((isa<pto::PartitionViewOp>(op) ||
          isa<pto::MakeTensorViewOp>(op)) &&
-        op->use_empty())
+        op->use_empty()) {
       deadViewOps.push_back(op);
+    }
   });
 
   for (Operation *op : llvm::reverse(deadViewOps)) {
@@ -419,7 +424,6 @@ static Value computeLinearOffset(OpBuilder &builder, Location loc,
                                  ArrayRef<OpFoldResult> rcStrides) {
   bool rcAllZero = isAllStaticZero(rcOffsets);
   bool svAllZero = isAllStaticZero(svOffsets);
-
   if (rcAllZero && svAllZero) {
     return Value();
   }
@@ -475,16 +479,19 @@ static Value resolvePTOViewDim(Value view, int64_t dim, OpBuilder &builder,
                                Operation *user) {
   view = unwrapPTOViewBridge(view);
   if (Value projected = projectSCFIfViewResult(
-          view, PTOViewProjectionKind::Dim, dim, {}, builder, user))
+          view, PTOViewProjectionKind::Dim, dim, {}, builder, user)) {
     return projected;
+  }
   if (auto partition = view.getDefiningOp<pto::PartitionViewOp>()) {
-    if (dim < 0 || dim >= static_cast<int64_t>(partition.getSizes().size()))
+    if (dim < 0 || dim >= static_cast<int64_t>(partition.getSizes().size())) {
       return {};
+    }
     return partition.getSizes()[dim];
   }
   if (auto makeView = view.getDefiningOp<pto::MakeTensorViewOp>()) {
-    if (dim < 0 || dim >= static_cast<int64_t>(makeView.getShape().size()))
+    if (dim < 0 || dim >= static_cast<int64_t>(makeView.getShape().size())) {
       return {};
+    }
     return makeView.getShape()[dim];
   }
   (void)builder;
@@ -496,14 +503,16 @@ static Value resolvePTOViewStride(Value view, int64_t dim, OpBuilder &builder,
                                   Operation *user) {
   view = unwrapPTOViewBridge(view);
   if (Value projected = projectSCFIfViewResult(
-          view, PTOViewProjectionKind::Stride, dim, {}, builder, user))
+          view, PTOViewProjectionKind::Stride, dim, {}, builder, user)) {
     return projected;
+  }
   if (auto partition = view.getDefiningOp<pto::PartitionViewOp>()) {
     return resolvePTOViewStride(partition.getSource(), dim, builder, user);
   }
   if (auto makeView = view.getDefiningOp<pto::MakeTensorViewOp>()) {
-    if (dim < 0 || dim >= static_cast<int64_t>(makeView.getStrides().size()))
+    if (dim < 0 || dim >= static_cast<int64_t>(makeView.getStrides().size())) {
       return {};
+    }
     return makeView.getStrides()[dim];
   }
   return {};
@@ -513,8 +522,9 @@ static Value resolvePTOViewAddress(Value view, pto::PtrType resultType,
                                    OpBuilder &builder, Operation *user) {
   view = unwrapPTOViewBridge(view);
   if (Value projected = projectSCFIfViewResult(
-          view, PTOViewProjectionKind::Address, 0, resultType, builder, user))
+          view, PTOViewProjectionKind::Address, 0, resultType, builder, user)) {
     return projected;
+  }
   if (auto makeView = view.getDefiningOp<pto::MakeTensorViewOp>()) {
     Value ptr = makeView.getPtr();
     if (ptr.getType() == resultType) {
@@ -523,15 +533,17 @@ static Value resolvePTOViewAddress(Value view, pto::PtrType resultType,
     return builder.create<pto::CastPtrOp>(user->getLoc(), resultType, ptr);
   }
   auto partition = view.getDefiningOp<pto::PartitionViewOp>();
-  if (!partition)
+  if (!partition) {
     return {};
+  }
 
   Value linearOffset;
   for (unsigned index = 0; index < partition.getOffsets().size(); ++index) {
     Value stride = resolvePTOViewStride(partition.getSource(), index, builder,
                                         user);
-    if (!stride)
+    if (!stride) {
       return {};
+    }
     Value offset = partition.getOffsets()[index];
     Value term = builder.create<arith::MulIOp>(user->getLoc(), offset, stride);
     linearOffset = linearOffset
@@ -541,8 +553,9 @@ static Value resolvePTOViewAddress(Value view, pto::PtrType resultType,
   }
   Value base =
       resolvePTOViewAddress(partition.getSource(), resultType, builder, user);
-  if (!base)
+  if (!base) {
     return {};
+  }
   if (!linearOffset) {
     return base;
   }
@@ -564,23 +577,27 @@ static Value projectSCFIfViewResult(Value view, PTOViewProjectionKind kind,
                                     OpBuilder &builder, Operation *user) {
   auto result = dyn_cast<OpResult>(view);
   auto ifOp = result ? dyn_cast<scf::IfOp>(result.getOwner()) : scf::IfOp();
-  if (!ifOp || ifOp.getNumRegions() != 2)
+  if (!ifOp || ifOp.getNumRegions() != mlir::pto::kValue2) {
     return {};
-  if (kind == PTOViewProjectionKind::Address && !resultPtrType)
+  }
+  if (kind == PTOViewProjectionKind::Address && !resultPtrType) {
     return {};
+  }
   auto thenYield = dyn_cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator());
   auto elseYield = dyn_cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator());
   unsigned resultIndex = result.getResultNumber();
   if (!thenYield || !elseYield ||
       resultIndex >= thenYield.getNumOperands() ||
-      resultIndex >= elseYield.getNumOperands())
+      resultIndex >= elseYield.getNumOperands()) {
     return {};
+  }
 
   Type projectionType = kind == PTOViewProjectionKind::Address
                             ? Type(resultPtrType)
                             : Type(builder.getIndexType());
-  if (!projectionType)
+  if (!projectionType) {
     return {};
+  }
   SmallVector<Type> resultTypes(ifOp.getResultTypes().begin(),
                                 ifOp.getResultTypes().end());
   resultTypes.push_back(projectionType);
@@ -591,7 +608,8 @@ static Value projectSCFIfViewResult(Value view, PTOViewProjectionKind kind,
       /*addThenBlock=*/true, /*addElseBlock=*/true);
   newIf->setAttrs(ifOp->getAttrs());
 
-  auto cloneBranch = [&](Block *source, Block *target, scf::YieldOp oldYield,
+  auto cloneBranch = [&ifBuilder, dim, kind, resultIndex, resultPtrType, user](
+                         Block *source, Block *target, scf::YieldOp oldYield,
                          bool &failed) {
     IRMapping mapping;
     cloneBlockWithoutTerminator(source, target, mapping, ifBuilder);
@@ -635,8 +653,9 @@ static Value projectSCFIfViewResult(Value view, PTOViewProjectionKind kind,
 
   for (auto [oldResult, newResult] :
        llvm::zip_equal(ifOp.getResults(), newIf.getResults().take_front(
-                                               ifOp.getNumResults())))
+                                              ifOp.getNumResults()))) {
     oldResult.replaceAllUsesWith(newResult);
+  }
   Value projection = newIf.getResult(newIf.getNumResults() - 1);
   ifOp.erase();
   return projection;
@@ -668,30 +687,30 @@ struct FoldTileBufIntrinsicsPass
       return;
     }
 
-    SmallVector<pto::TileBufAddrOp, 8> addrOps;
-    SmallVector<pto::TileValidRowsOp, 8> rowsOps;
-    SmallVector<pto::TileValidColsOp, 8> colsOps;
-    SmallVector<pto::TensorViewAddrOp, 8> tvAddrOps;
-    SmallVector<pto::GetTensorViewDimOp, 8> tvDimOps;
-    SmallVector<pto::GetTensorViewStrideOp, 8> tvStrideOps;
-    SmallVector<pto::GetValidShapeOp, 8> getValidShapeOps;
+    SmallVector<pto::TileBufAddrOp, mlir::pto::kValue8> addrOps;
+    SmallVector<pto::TileValidRowsOp, mlir::pto::kValue8> rowsOps;
+    SmallVector<pto::TileValidColsOp, mlir::pto::kValue8> colsOps;
+    SmallVector<pto::TensorViewAddrOp, mlir::pto::kValue8> tvAddrOps;
+    SmallVector<pto::GetTensorViewDimOp, mlir::pto::kValue8> tvDimOps;
+    SmallVector<pto::GetTensorViewStrideOp, mlir::pto::kValue8> tvStrideOps;
+    SmallVector<pto::GetValidShapeOp, mlir::pto::kValue8> getValidShapeOps;
 
     func.walk([&](Operation *op) {
       if (auto addr = dyn_cast<pto::TileBufAddrOp>(op)) {
         addrOps.push_back(addr);
-      }
-      else if (auto rows = dyn_cast<pto::TileValidRowsOp>(op))
+      } else if (auto rows = dyn_cast<pto::TileValidRowsOp>(op)) {
         rowsOps.push_back(rows);
-      else if (auto cols = dyn_cast<pto::TileValidColsOp>(op))
+      } else if (auto cols = dyn_cast<pto::TileValidColsOp>(op)) {
         colsOps.push_back(cols);
-      else if (auto tvAddr = dyn_cast<pto::TensorViewAddrOp>(op))
+      } else if (auto tvAddr = dyn_cast<pto::TensorViewAddrOp>(op)) {
         tvAddrOps.push_back(tvAddr);
-      else if (auto tvDim = dyn_cast<pto::GetTensorViewDimOp>(op))
+      } else if (auto tvDim = dyn_cast<pto::GetTensorViewDimOp>(op)) {
         tvDimOps.push_back(tvDim);
-      else if (auto tvStride = dyn_cast<pto::GetTensorViewStrideOp>(op))
+      } else if (auto tvStride = dyn_cast<pto::GetTensorViewStrideOp>(op)) {
         tvStrideOps.push_back(tvStride);
-      else if (auto gvs = dyn_cast<pto::GetValidShapeOp>(op))
+      } else if (auto gvs = dyn_cast<pto::GetValidShapeOp>(op)) {
         getValidShapeOps.push_back(gvs);
+      }
     });
 
     if (shouldFoldAddrFamily(*mode)) {
@@ -714,14 +733,16 @@ struct FoldTileBufIntrinsicsPass
         auto validShape = tileTy.getValidShape();
 
         Value rowReplacement;
-        if (!validShape.empty() && validShape[0] != ShapedType::kDynamic)
+        if (!validShape.empty() && validShape[0] != ShapedType::kDynamic) {
           rowReplacement =
               builder.create<arith::ConstantIndexOp>(gvsOp.getLoc(), validShape[0]);
+        }
 
         Value colReplacement;
-        if (validShape.size() >= 2 && validShape[1] != ShapedType::kDynamic)
+        if (validShape.size() >= mlir::pto::kValue2 && validShape[1] != ShapedType::kDynamic) {
           colReplacement =
               builder.create<arith::ConstantIndexOp>(gvsOp.getLoc(), validShape[1]);
+        }
 
         if (!rowReplacement || !colReplacement) {
           auto handleInfo = resolveTileHandle(gvsOp.getSource(), gvsOp);
@@ -864,7 +885,7 @@ struct FoldTileBufIntrinsicsPass
       for (auto colsOp : colsOps) {
         builder.setInsertionPoint(colsOp);
         auto tbTy = dyn_cast<pto::TileBufType>(colsOp.getSrc().getType());
-        if (!tbTy || tbTy.getValidShape().size() < 2) {
+        if (!tbTy || tbTy.getValidShape().size() < mlir::pto::kValue2) {
           colsOp.emitError("tile_valid_cols: invalid tile_buf type");
           return signalPassFailure();
         }
@@ -1037,25 +1058,27 @@ struct FoldTileBufIntrinsicsPass
     // Clean up dead unrealized_conversion_cast ops that bridged
     // memref -> partition_tensor_view / tile_buf and are now unused
     // after folding.
-    SmallVector<UnrealizedConversionCastOp, 8> deadCasts;
+    SmallVector<UnrealizedConversionCastOp, mlir::pto::kValue8> deadCasts;
     func.walk([&](UnrealizedConversionCastOp castOp) {
       if (castOp.use_empty() && castOp.getNumOperands() == 1 &&
           isa<MemRefType>(castOp.getOperand(0).getType()) &&
           isa<MemRefType, pto::PartitionTensorViewType, pto::TileBufType>(
-              castOp.getResult(0).getType()))
+              castOp.getResult(0).getType())) {
         deadCasts.push_back(castOp);
+      }
     });
     for (auto castOp : llvm::reverse(deadCasts)) {
       castOp.erase();
     }
 
     while (true) {
-      SmallVector<Operation *, 8> deadMemrefOps;
+      SmallVector<Operation *, mlir::pto::kValue8> deadMemrefOps;
       func.walk([&](Operation *op) {
         if ((isa<memref::SubViewOp>(op) ||
              isa<memref::ReinterpretCastOp>(op)) &&
-            op->use_empty())
+            op->use_empty()) {
           deadMemrefOps.push_back(op);
+        }
       });
       if (deadMemrefOps.empty()) {
         break;
@@ -1068,7 +1091,7 @@ struct FoldTileBufIntrinsicsPass
     // Erase metadata writes only after every reader has been folded. TileOp
     // helper ABI reads marked above must remain runtime reads, so their
     // set_validshape updates are still observable by later lowering.
-    SmallVector<pto::SetValidShapeOp, 8> setValidShapeOps;
+    SmallVector<pto::SetValidShapeOp, mlir::pto::kValue8> setValidShapeOps;
     func.walk([&](pto::SetValidShapeOp op) { setValidShapeOps.push_back(op); });
     for (auto op : llvm::reverse(setValidShapeOps)) {
       bool hasRuntimeReader = false;
@@ -1090,7 +1113,7 @@ struct FoldTileBufIntrinsicsPass
     bool tileDceChanged = true;
     while (tileDceChanged) {
       tileDceChanged = false;
-      SmallVector<Operation *, 8> deadTileOps;
+      SmallVector<Operation *, mlir::pto::kValue8> deadTileOps;
       func.walk([&](Operation *op) {
         if (!op->use_empty()) {
           return;
@@ -1100,8 +1123,9 @@ struct FoldTileBufIntrinsicsPass
         }
         else if (auto castOp = dyn_cast<UnrealizedConversionCastOp>(op)) {
           if (castOp.getNumOperands() == 1 &&
-              isa<pto::TileBufType>(castOp.getResult(0).getType()))
+              isa<pto::TileBufType>(castOp.getResult(0).getType())) {
             deadTileOps.push_back(op);
+          }
         }
       });
       for (auto *op : llvm::reverse(deadTileOps)) {

--- a/lib/PTO/Transforms/GraphSyncSolver/EventIdSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/EventIdSolver.cpp
@@ -23,6 +23,9 @@
 //===----------- EventIdSolver.cpp ---- Graph Sync Solver -----------------===//
 //===----------------------------------------------------------------------===//
 
+#include <cstdint>
+#include <numeric>
+#include <utility>
 #include "PTO/Transforms/GraphSyncSolver/EventIdSolver.h"
 #include "PTO/Transforms/GraphSyncSolver/Utility.h"
 #include "llvm/ADT/DenseSet.h"
@@ -32,9 +35,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
-#include <cstdint>
-#include <numeric>
-#include <utility>
+
 
 #define DEBUG_TYPE "PTO-gss-eventidsolver"
 
@@ -237,8 +238,9 @@ EventIdSolver::getAdjNodesUsedEventIds(EventIdNode *node) {
   }
   LLVM_DEBUG({
     llvm::dbgs() << "used-event-ids: ";
-    for (auto e : usedEventIds)
+    for (auto e : usedEventIds) {
       llvm::dbgs() << e << ' ';
+    }
     llvm::dbgs() << "\n";
   });
   llvm::SmallVector<int64_t> usedEventIdsVec(usedEventIds.begin(),
@@ -291,8 +293,9 @@ EventIdSolver::getChosenEventIds(EventIdNode *node, int64_t eventIdMax) {
   }
   LLVM_DEBUG({
     llvm::dbgs() << "chosen-event-ids: ";
-    for (auto e : chosenEventIds)
+    for (auto e : chosenEventIds) {
       llvm::dbgs() << e << ' ';
+    }
     llvm::dbgs() << '\n';
   });
   assert(node->eventIdNum == static_cast<int64_t>(chosenEventIds.size()));

--- a/lib/PTO/Transforms/GraphSyncSolver/GraphSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/GraphSolver.cpp
@@ -23,14 +23,14 @@
 //===----------- GraphSolver.cpp ---- Graph Sync Solver -------------------===//
 //===----------------------------------------------------------------------===//
 
-#include "PTO/Transforms/GraphSyncSolver/GraphSolver.h"
-
-#include "PTO/IR/PTO.h"
-#include "PTO/Transforms/GraphSyncSolver/Utility.h"
-#include "llvm/Support/Debug.h"
 #include <optional>
 #include <queue>
 #include <utility>
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/GraphSyncSolver/GraphSolver.h"
+#include "PTO/Transforms/GraphSyncSolver/Utility.h"
+#include "llvm/Support/Debug.h"
+
 
 #define DEBUG_TYPE "PTO-gss-graph-solver"
 

--- a/lib/PTO/Transforms/GraphSyncSolver/MemInfo.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/MemInfo.cpp
@@ -23,18 +23,20 @@
 //===------------- MemInfo.cpp ---- Graph Sync Solver ---------------------===//
 //===----------------------------------------------------------------------===//
 
-#include "PTO/Transforms/GraphSyncSolver/MemInfo.h"
+#include <cstdint>
+#include "../Utils.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOMultiBuffer.h"
 #include "PTO/IR/PTOTypeUtils.h"
-#include "../Utils.h"
+#include "PTO/Support/CodeConstants.h"
+#include "PTO/Transforms/GraphSyncSolver/MemInfo.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/ErrorHandling.h"
-#include <cstdint>
+
 
 using namespace mlir;
 using namespace pto::syncsolver;
@@ -43,29 +45,33 @@ namespace mlir::pto::syncsolver {
 
 static std::optional<int64_t> getTileBufferBitSize(pto::TileBufType type) {
   auto bitWidth = getPTOStorageElemBitWidth(type.getElementType());
-  if (bitWidth == 0)
+  if (bitWidth == 0) {
     return ShapedType::kDynamic;
+  }
 
   ArrayRef<int64_t> shape = type.getShape();
   if (type.getCompactModeI32() ==
       static_cast<int32_t>(pto::CompactMode::RowPlusOne)) {
-    if (shape.size() != 2 || llvm::is_contained(shape, ShapedType::kDynamic))
+    if (shape.size() != mlir::pto::kValue2 || llvm::is_contained(shape, ShapedType::kDynamic)) {
       return ShapedType::kDynamic;
+    }
 
     bool rowMajor = type.getBLayoutValueI32() ==
                     static_cast<int32_t>(pto::BLayout::RowMajor);
     int64_t major = rowMajor ? shape[0] : shape[1];
     int64_t minor = rowMajor ? shape[1] : shape[0];
-    if (major == 0 || minor == 0)
+    if (major == 0 || minor == 0) {
       return 0;
+    }
     return ((major - 1) * (minor + 1) + minor) *
            static_cast<int64_t>(bitWidth);
   }
 
   int64_t numElements = 1;
   for (int64_t dim : shape) {
-    if (dim == ShapedType::kDynamic)
+    if (dim == ShapedType::kDynamic) {
       return ShapedType::kDynamic;
+    }
     numElements *= dim;
   }
   return numElements * bitWidth;
@@ -108,16 +114,19 @@ llvm::SmallVector<int64_t> getAddresses(const llvm::SmallVector<Value> &addrs) {
 }
 
 static std::optional<pto::AddressSpace> getValueAddressSpace(Value value) {
-  if (!value)
+  if (!value) {
     return std::nullopt;
-  if (auto space = pto::getPTOAddressSpaceAttr(value.getType()))
+  }
+  if (auto space = pto::getPTOAddressSpaceAttr(value.getType())) {
     return space.getAddressSpace();
+  }
   if (auto memRefType = dyn_cast<BaseMemRefType>(value.getType());
       memRefType && !memRefType.getMemorySpace()) {
     return pto::AddressSpace::GM;
   }
-  if (isa<pto::TensorViewType, pto::PartitionTensorViewType>(value.getType()))
+  if (isa<pto::TensorViewType, pto::PartitionTensorViewType>(value.getType())) {
     return pto::AddressSpace::GM;
+  }
   return std::nullopt;
 }
 
@@ -132,8 +141,9 @@ static MemInfo getConservativeIntToPtrMemInfo(pto::IntToPtrOp intToPtr) {
 
 static std::optional<int64_t> getConstantI64(Value value) {
   IntegerAttr attr;
-  if (!value || !matchPattern(value, m_Constant(&attr)))
+  if (!value || !matchPattern(value, m_Constant(&attr))) {
     return std::nullopt;
+  }
   return attr.getValue().getSExtValue();
 }
 
@@ -142,27 +152,32 @@ static PointerLikeInfo getPointerLikeInfo(pto::AllocMultiTileOp alloc) {
   info.allocateSize = getBufferBitSize(alloc.getResult());
   auto slotType = alloc.getResult().getType().getSlotType();
   if (auto space = dyn_cast_or_null<pto::AddressSpaceAttr>(
-          slotType.getMemorySpace()))
+          slotType.getMemorySpace())) {
     info.addressSpace = space.getAddressSpace();
+  }
 
   if (auto planned = alloc->getAttrOfType<DenseI64ArrayAttr>(
           pto::kPtoMultiBufferAddrsAttrName)) {
-    for (int64_t address : planned.asArrayRef())
+    for (int64_t address : planned.asArrayRef()) {
       info.addresses.push_back(address * pto::kBitsToByte);
+    }
   } else if (auto base = getConstantI64(alloc.getAddr())) {
     int64_t slotBits = info.allocateSize.value_or(ShapedType::kDynamic);
-    for (uint32_t slot = 0; slot < alloc.getResult().getType().getCount(); ++slot)
+    for (uint32_t slot = 0; slot < alloc.getResult().getType().getCount(); ++slot) {
       info.addresses.push_back(*base * pto::kBitsToByte + slot * slotBits);
+    }
   }
-  if (auto loop = alloc->getParentOfType<LoopLikeOpInterface>())
+  if (auto loop = alloc->getParentOfType<LoopLikeOpInterface>()) {
     info.parentLoop = loop;
+  }
   return info;
 }
 
 static MemInfo getMemInfoForMultiTileGet(pto::MultiTileGetOp get) {
   auto alloc = get.getSource().getDefiningOp<pto::AllocMultiTileOp>();
-  if (!alloc)
+  if (!alloc) {
     return MemInfo(get.getResult(), isWorkSpaceFuncArgument(get.getResult()));
+  }
 
   PointerLikeInfo info = getPointerLikeInfo(alloc);
   IntegerAttr slotAttr;
@@ -174,8 +189,9 @@ static MemInfo getMemInfoForMultiTileGet(pto::MultiTileGetOp get) {
       info.addresses.assign(1, address);
     }
   }
-  if (auto loop = get->getParentOfType<LoopLikeOpInterface>())
+  if (auto loop = get->getParentOfType<LoopLikeOpInterface>()) {
     info.parentLoop = loop;
+  }
   return MemInfo(get.getResult(), info);
 }
 
@@ -184,10 +200,12 @@ MemInfo getMemInfo(Value val) {
     if (auto intToPtr = llvm::dyn_cast<pto::IntToPtrOp>(defOp)) {
       return getConservativeIntToPtrMemInfo(intToPtr);
     }
-    if (auto allocMulti = llvm::dyn_cast<pto::AllocMultiTileOp>(defOp))
+    if (auto allocMulti = llvm::dyn_cast<pto::AllocMultiTileOp>(defOp)) {
       return MemInfo(val, getPointerLikeInfo(allocMulti));
-    if (auto multiGet = llvm::dyn_cast<pto::MultiTileGetOp>(defOp))
+    }
+    if (auto multiGet = llvm::dyn_cast<pto::MultiTileGetOp>(defOp)) {
       return getMemInfoForMultiTileGet(multiGet);
+    }
   }
   return MemInfo(val, isWorkSpaceFuncArgument(val));
 }
@@ -223,9 +241,10 @@ bool PointerLikeInfo::checkConflict(const PointerLikeInfo &pointerLikeInfo1,
   auto &offsets2 = pointerLikeInfo2.addresses;
   auto sz1 = static_cast<int64_t>(offsets1.size());
   auto sz2 = static_cast<int64_t>(offsets2.size());
-  if (sz1 == 0 || sz2 == 0)
+  if (sz1 == 0 || sz2 == 0) {
     return pointerLikeInfo1.addressSpace == pto::AddressSpace::GM ||
            pointerLikeInfo2.addressSpace == pto::AddressSpace::GM;
+  }
 
   int64_t len1 = sz1;
   int64_t len2 = sz2;
@@ -295,12 +314,14 @@ bool MemInfo::checkConflict(const MemInfo &memInfo1, const MemInfo &memInfo2,
   };
 
   if (auto unknownSpace = getUnknownAddressSpace(memInfo1)) {
-    if (aliasesAddressSpace(memInfo2, *unknownSpace))
+    if (aliasesAddressSpace(memInfo2, *unknownSpace)) {
       return true;
+    }
   }
   if (auto unknownSpace = getUnknownAddressSpace(memInfo2)) {
-    if (aliasesAddressSpace(memInfo1, *unknownSpace))
+    if (aliasesAddressSpace(memInfo1, *unknownSpace)) {
       return true;
+    }
   }
 
   return memInfo1.value == memInfo2.value;

--- a/lib/PTO/Transforms/GraphSyncSolver/PTOGraphSyncSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/PTOGraphSyncSolver.cpp
@@ -63,8 +63,9 @@ struct PTOGraphSyncSolverPass
       }
       return WalkResult::advance();
     });
-    if (hasExplicitSync)
+    if (hasExplicitSync) {
       return;
+    }
 
     // Derive the arch mode from the module's --pto-arch attribute (same
     // source as LoweringSyncToPipe / PTOA5NormalizeTMov / PTOPlanMemory).

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolver.cpp
@@ -23,14 +23,21 @@
 //===--------- SyncSolver.cpp ------- Graph Sync Solver -------------------===//
 //===----------------------------------------------------------------------===//
 
-#include "PTO/Transforms/GraphSyncSolver/SyncSolver.h"
+#include <algorithm>
+#include <climits>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <numeric>
+#include <tuple>
+#include <utility>
+#include "PTO/IR/PTO.h"
 #include "PTO/Transforms/GraphSyncSolver/GraphSolver.h"
 #include "PTO/Transforms/GraphSyncSolver/MemInfo.h"
+#include "PTO/Transforms/GraphSyncSolver/SyncSolver.h"
 #include "PTO/Transforms/GraphSyncSolver/SyncSolverIR.h"
 #include "PTO/Transforms/GraphSyncSolver/Utility.h"
 #include "PTO/Transforms/SlotAffineAnalysis.h"
-
-#include "PTO/IR/PTO.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
@@ -42,14 +49,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/LogicalResult.h"
-#include <algorithm>
-#include <climits>
-#include <cstdint>
-#include <limits>
-#include <memory>
-#include <numeric>
-#include <tuple>
-#include <utility>
+
 
 #define DEBUG_TYPE "PTO-gss-solver"
 
@@ -60,12 +60,14 @@ namespace {
 mlir::pto::SlotRelation compareMemInfoSlotSSA(const MemInfo &memInfo1,
                                               const MemInfo &memInfo2) {
   size_t n = std::max<size_t>(memInfo1.getSz(), memInfo2.getSz());
-  if (n < 2 || n > std::numeric_limits<uint32_t>::max())
+  if (n < 2 || n > std::numeric_limits<uint32_t>::max()) {
     return mlir::pto::SlotRelation::kUnknown;
+  }
   Value slot1 = mlir::pto::findMultiTileSlotExpr(memInfo1.value);
   Value slot2 = mlir::pto::findMultiTileSlotExpr(memInfo2.value);
-  if (!slot1 || !slot2)
+  if (!slot1 || !slot2) {
     return mlir::pto::SlotRelation::kUnknown;
+  }
   return mlir::pto::compareSlotSSA(slot1, slot2, static_cast<uint32_t>(n));
 }
 
@@ -164,8 +166,9 @@ bool Solver::checkSkipParallelLoop(Occurrence *occ1, Occurrence *occ2) {
   auto [parOcc1, parOcc2] = Occurrence::getLCAPair(occ1, occ2);
   assert(parOcc1 != nullptr && parOcc2 != nullptr);
   auto *parentLCALoopOcc = Occurrence::getParentloop(parOcc1);
-  if (parentLCALoopOcc == nullptr)
+  if (parentLCALoopOcc == nullptr) {
     return false;
+  }
   auto *parentLCALoopOp = llvm::cast<Loop>(parentLCALoopOcc->op);
   return parentLCALoopOp->isParallel;
 }
@@ -522,12 +525,14 @@ Solver::getMultiBufferEventIdInfo(Occurrence *occ1, Occurrence *occ2,
   bool slotOp1Ambiguous = false, slotOp2Ambiguous = false;
   auto collectSlot = [](const MemInfo &mi, Value &slot, bool &ambiguous) {
     Value s = mlir::pto::findMultiTileSlotExpr(mi.value);
-    if (!s)
+    if (!s) {
       return;
-    if (!slot)
+    }
+    if (!slot) {
       slot = s;
-    else if (slot != s)
+    } else if (slot != s) {
       ambiguous = true;
+    }
   };
 
   for (auto &memInfo1 : rwOp1->readMemInfo) {

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolverCodeGen.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolverCodeGen.cpp
@@ -29,23 +29,28 @@ static EventAttr makeEvent(MLIRContext *ctx, int64_t eventId) {
 }
 
 Operation *CodeGenerator::resolveSyncAnchor(OperationBase *opBase) {
-  if (!opBase)
+  if (!opBase) {
     return nullptr;
+  }
   if (auto *ph = dyn_cast<PlaceHolder>(opBase)) {
-    if (ph->beforeOp)
+    if (ph->beforeOp) {
       return ph->beforeOp->op;
-    if (ph->afterOp)
+    }
+    if (ph->afterOp) {
       return ph->afterOp->op;
-    if (ph->block)
+    }
+    if (ph->block) {
       return ph->block->getParentOp();
+    }
     return nullptr;
   }
   return opBase->op;
 }
 
 Location CodeGenerator::resolveSyncLoc(OperationBase *opBase) {
-  if (Operation *anchor = resolveSyncAnchor(opBase))
+  if (Operation *anchor = resolveSyncAnchor(opBase)) {
     return anchor->getLoc();
+  }
   return funcOp.getLoc();
 }
 
@@ -62,10 +67,11 @@ void CodeGenerator::setInsertionPoint(IRRewriter &rewriter,
     // at the end of the block.
     if (ph->scopeEnd && ph->block) {
       if (!ph->block->empty() &&
-          ph->block->back().hasTrait<OpTrait::IsTerminator>())
+          ph->block->back().hasTrait<OpTrait::IsTerminator>()) {
         rewriter.setInsertionPoint(&ph->block->back());
-      else
+      } else {
         rewriter.setInsertionPointToEnd(ph->block);
+}
       return;
     }
     // Loop-boundary slot. The placeholder names the linked loop op via
@@ -73,10 +79,11 @@ void CodeGenerator::setInsertionPoint(IRRewriter &rewriter,
     // by the solver's convention agrees with the field that is set.
     OperationBase *linked = ph->beforeOp ? ph->beforeOp : ph->afterOp;
     if (linked && linked->op) {
-      if (insertAfter)
+      if (insertAfter) {
         rewriter.setInsertionPointAfter(linked->op);
-      else
+      } else {
         rewriter.setInsertionPoint(linked->op);
+}
       return;
     }
     // Malformed placeholder: fall back to the function entry to keep the
@@ -89,10 +96,11 @@ void CodeGenerator::setInsertionPoint(IRRewriter &rewriter,
     rewriter.setInsertionPointToStart(&funcOp.getBody().front());
     return;
   }
-  if (insertAfter)
+  if (insertAfter) {
     rewriter.setInsertionPointAfter(anchor);
-  else
+  } else {
     rewriter.setInsertionPoint(anchor);
+}
 }
 
 void CodeGenerator::emitSyncOp(IRRewriter &rewriter, SyncOp *syncOp) {
@@ -104,8 +112,9 @@ void CodeGenerator::emitSyncOp(IRRewriter &rewriter, SyncOp *syncOp) {
   }
 
   auto *setWait = dyn_cast<SetWaitOp>(syncOp);
-  if (!setWait || setWait->eventIds.empty())
+  if (!setWait || setWait->eventIds.empty()) {
     return;
+  }
 
   // The first/last-iter wrapping path (scf.if(isFirstIter/isLastIter) {
   // set/wait }) lives behind the MmadL1 decomposition optimization in the
@@ -153,10 +162,11 @@ void CodeGenerator::emitSyncOp(IRRewriter &rewriter, SyncOp *syncOp) {
       selected = rewriter.create<arith::SelectOp>(loc, isThis, idI, selected);
     }
 
-    if (isSet)
+    if (isSet) {
       rewriter.create<pto::SetFlagDynOp>(loc, srcAttr, dstAttr, selected);
-    else if (isWait)
+    } else if (isWait) {
       rewriter.create<pto::WaitFlagDynOp>(loc, srcAttr, dstAttr, selected);
+    }
     return;
   }
 
@@ -166,10 +176,11 @@ void CodeGenerator::emitSyncOp(IRRewriter &rewriter, SyncOp *syncOp) {
   // the conservative N-static fanout rather than dropping the dep).
   for (int64_t eventId : setWait->eventIds) {
     auto eventAttr = makeEvent(rewriter.getContext(), eventId);
-    if (isSet)
+    if (isSet) {
       rewriter.create<pto::SetFlagOp>(loc, srcAttr, dstAttr, eventAttr);
-    else if (isWait)
+    } else if (isWait) {
       rewriter.create<pto::WaitFlagOp>(loc, srcAttr, dstAttr, eventAttr);
+    }
   }
 }
 
@@ -177,8 +188,9 @@ void CodeGenerator::emitSyncMap(IRRewriter &rewriter, SyncMap &syncMap,
                                 bool insertAfter) {
   for (auto &[opBase, syncOps] : syncMap) {
     setInsertionPoint(rewriter, opBase, insertAfter);
-    for (auto &syncOp : syncOps)
+    for (auto &syncOp : syncOps) {
       emitSyncOp(rewriter, syncOp.get());
+    }
   }
 }
 

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolverIR.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolverIR.cpp
@@ -23,12 +23,14 @@
 //===---------- SyncSolverIR.cpp ---- Graph Sync Solver -------------------===//
 //===----------------------------------------------------------------------===//
 
-#include "PTO/Transforms/GraphSyncSolver/SyncSolverIR.h"
+#include <string>
 #include "PTO/IR/PTO.h"
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/GraphSyncSolver/MemInfo.h"
+#include "PTO/Transforms/GraphSyncSolver/SyncSolverIR.h"
 #include "PTO/Transforms/GraphSyncSolver/Utility.h"
 #include "llvm/ADT/StringExtras.h"
-#include <string>
+
 
 using namespace mlir;
 using namespace pto::syncsolver;
@@ -157,7 +159,7 @@ std::string Scope::str(int indent, bool recursive) const {
   if (recursive) {
     ret += " {\n";
     for (auto &op : body) {
-      ret += op->str(indent + 2, true) + "\n";
+      ret += op->str(indent + mlir::pto::kValue2, true) + "\n";
     }
     ret += std::string(indent, ' ') + "}";
   }
@@ -179,7 +181,7 @@ std::string Loop::str(int indent, bool recursive) const {
   if (recursive) {
     ret += " {\n";
     for (auto &op : body) {
-      ret += op->str(indent + 2, true) + "\n";
+      ret += op->str(indent + mlir::pto::kValue2, true) + "\n";
     }
     ret += std::string(indent, ' ') + "}";
   }
@@ -198,11 +200,11 @@ std::string Condition::str(int indent, bool recursive) const {
     ret += " {\n";
     for (auto &op : body) {
       if (op.get() == getTrueScope()) {
-        ret += std::string(indent + 2, ' ') + "(trueScope)\n";
+        ret += std::string(indent + mlir::pto::kValue2, ' ') + "(trueScope)\n";
       } else if (op.get() == getFalseScope()) {
-        ret += std::string(indent + 2, ' ') + "(falseScope)\n";
+        ret += std::string(indent + mlir::pto::kValue2, ' ') + "(falseScope)\n";
       }
-      ret += op->str(indent + 2, true) + "\n";
+      ret += op->str(indent + mlir::pto::kValue2, true) + "\n";
     }
     ret += std::string(indent, ' ') + "}";
   }
@@ -250,10 +252,10 @@ std::string RWOperation::str(int indent, bool recursive) const {
          " " + unitFlag + "\n";
   if (indent) {
     for (auto memInfo : this->readMemInfo) {
-      ret += std::string(indent + 2, ' ') + "read: " + memInfo.str() + "\n";
+      ret += std::string(indent + mlir::pto::kValue2, ' ') + "read: " + memInfo.str() + "\n";
     }
     for (auto memInfo : this->writeMemInfo) {
-      ret += std::string(indent + 2, ' ') + "write: " + memInfo.str() + "\n";
+      ret += std::string(indent + mlir::pto::kValue2, ' ') + "write: " + memInfo.str() + "\n";
     }
   }
   ret.pop_back();
@@ -370,10 +372,10 @@ std::string ConflictPair::str() const {
 
   ret += "\n";
   if (this->op1 != nullptr) {
-    ret += this->op1->str(2, false) + '\n';
+    ret += this->op1->str(mlir::pto::kValue2, false) + '\n';
   }
   if (this->op2 != nullptr) {
-    ret += this->op2->str(2, false) + '\n';
+    ret += this->op2->str(mlir::pto::kValue2, false) + '\n';
   }
   // ret += this->opSet->str(0, false) + '\n';
   // ret += this->opWait->str(0, false) + '\n';

--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolverIRTranslator.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolverIRTranslator.cpp
@@ -59,29 +59,36 @@ llvm::SmallVector<Value> IRTranslator::tracebackMemValsStep(Value val) {
   if (auto blockArg = dyn_cast<BlockArgument>(val)) {
     if (auto forOp =
             dyn_cast_if_present<scf::ForOp>(blockArg.getOwner()->getParentOp())) {
-      if (auto *init = forOp.getTiedLoopInit(blockArg))
+      if (auto *init = forOp.getTiedLoopInit(blockArg)) {
         out.push_back(init->get());
-      if (auto *yield = forOp.getTiedLoopYieldedValue(blockArg))
+      }
+      if (auto *yield = forOp.getTiedLoopYieldedValue(blockArg)) {
         out.push_back(yield->get());
+      }
     }
     if (auto whileOp = dyn_cast_if_present<scf::WhileOp>(
             blockArg.getOwner()->getParentOp())) {
       unsigned index = blockArg.getArgNumber();
       if (blockArg.getOwner() == &whileOp.getBefore().front()) {
-        if (index < whileOp.getInits().size())
+        if (index < whileOp.getInits().size()) {
           out.push_back(whileOp.getInits()[index]);
-        if (index < whileOp.getYieldedValues().size())
+        }
+        if (index < whileOp.getYieldedValues().size()) {
           out.push_back(whileOp.getYieldedValues()[index]);
+        }
       } else if (blockArg.getOwner() == &whileOp.getAfter().front()) {
         auto conditionArgs = whileOp.getConditionOp().getArgs();
-        if (index < conditionArgs.size())
+        if (index < conditionArgs.size()) {
           out.push_back(conditionArgs[index]);
-        if (index < whileOp.getYieldedValues().size())
+        }
+        if (index < whileOp.getYieldedValues().size()) {
           out.push_back(whileOp.getYieldedValues()[index]);
+        }
       }
     }
-    if (blockArgAliases.contains(val))
+    if (blockArgAliases.contains(val)) {
       llvm::append_range(out, blockArgAliases[val]);
+    }
     return out;
   }
 

--- a/lib/PTO/Transforms/GraphSyncSolver/Utility.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/Utility.cpp
@@ -23,16 +23,18 @@
 //===------------- Utility.cpp ---- Graph Sync Solver ---------------------===//
 //===----------------------------------------------------------------------===//
 
-#include "PTO/Transforms/GraphSyncSolver/Utility.h"
-#include "PTO/IR/PTO.h"
-#include "PTO/Transforms/GraphSyncSolver/SyncSolverIR.h"
-#include "mlir/IR/Value.h"
-#include "llvm/Support/ErrorHandling.h"
 #include <cstdint>
 #include <numeric>
 #include <tuple>
 #include <utility>
 #include <vector>
+#include "PTO/IR/PTO.h"
+#include "PTO/Support/CodeConstants.h"
+#include "PTO/Transforms/GraphSyncSolver/SyncSolverIR.h"
+#include "PTO/Transforms/GraphSyncSolver/Utility.h"
+#include "mlir/IR/Value.h"
+#include "llvm/Support/ErrorHandling.h"
+
 
 using namespace mlir;
 using namespace pto::syncsolver;
@@ -283,22 +285,22 @@ int64_t getHWAvailableEventIdNum(SyncMode syncMode, pto::PIPE setPipe,
         {{pto::PIPE::PIPE_M, pto::PIPE::PIPE_FIX}, 1},
         {{pto::PIPE::PIPE_FIX, pto::PIPE::PIPE_M}, 1},
     };
-    int64_t eventIdNum = INTRA_CORE_EVENT_ID_NUM;
-    eventIdNum -= reservedIntraCoreEventIdNum;
+    int64_t eventIdNum = kIntraCoreEventIdCount;
+    eventIdNum -= kReservedIntraCoreEventIdCount;
     auto it = reservedEventIdNum.find({setPipe, waitPipe});
     if (it != reservedEventIdNum.end()) {
       eventIdNum -= it->second;
     }
     return eventIdNum;
   } else if (syncMode == SyncMode::CROSS_CORE_SYNC) {
-    int64_t eventIdNum = CROSS_CORE_EVENT_ID_NUM;
-    eventIdNum -= reservedCrossCoreEventIdNum;
+    int64_t eventIdNum = kCrossCoreEventIdCount;
+    eventIdNum -= kReservedCrossCoreEventIdCount;
     return eventIdNum;
   } else if (syncMode == SyncMode::TEST_INTRA_CORE_MODE) {
-    int64_t eventIdNum = TEST_INTRA_CORE_EVENT_ID_NUM;
+    int64_t eventIdNum = kTestIntraCoreEventIdCount;
     return eventIdNum;
   } else if (syncMode == SyncMode::TEST_CROSS_CORE_MODE) {
-    int64_t eventIdNum = TEST_CROSS_CORE_EVENT_ID_NUM;
+    int64_t eventIdNum = kTestCrossCoreEventIdCount;
     return eventIdNum;
   }
   llvm_unreachable("getHWAvailableEventIdNum: unhandled SyncMode");
@@ -314,8 +316,8 @@ SmallVector<int64_t> getHWAvailableEventIds(SyncMode syncMode,
         {{pto::PIPE::PIPE_M, pto::PIPE::PIPE_FIX}, 1},
         {{pto::PIPE::PIPE_FIX, pto::PIPE::PIPE_M}, 1},
     };
-    int64_t eventIdNum = INTRA_CORE_EVENT_ID_NUM;
-    eventIdNum -= reservedIntraCoreEventIdNum;
+    int64_t eventIdNum = kIntraCoreEventIdCount;
+    eventIdNum -= kReservedIntraCoreEventIdCount;
     auto it = reservedEventIdNum.find({setPipe, waitPipe});
     if (it != reservedEventIdNum.end()) {
       eventIdNum -= it->second;
@@ -325,20 +327,20 @@ SmallVector<int64_t> getHWAvailableEventIds(SyncMode syncMode,
               static_cast<int64_t>(0));
     return hwAvailableEventIds;
   } else if (syncMode == SyncMode::CROSS_CORE_SYNC) {
-    int64_t eventIdNum = CROSS_CORE_EVENT_ID_NUM;
-    eventIdNum -= reservedCrossCoreEventIdNum;
+    int64_t eventIdNum = kCrossCoreEventIdCount;
+    eventIdNum -= kReservedCrossCoreEventIdCount;
     SmallVector<int64_t> hwAvailableEventIds(eventIdNum);
     std::iota(hwAvailableEventIds.begin(), hwAvailableEventIds.end(),
               static_cast<int64_t>(0));
     return hwAvailableEventIds;
   } else if (syncMode == SyncMode::TEST_INTRA_CORE_MODE) {
-    int64_t eventIdNum = TEST_INTRA_CORE_EVENT_ID_NUM;
+    int64_t eventIdNum = kTestIntraCoreEventIdCount;
     SmallVector<int64_t> availableEventIds(eventIdNum);
     std::iota(availableEventIds.begin(), availableEventIds.end(),
               static_cast<int64_t>(0));
     return availableEventIds;
   } else if (syncMode == SyncMode::TEST_CROSS_CORE_MODE) {
-    int64_t eventIdNum = TEST_CROSS_CORE_EVENT_ID_NUM;
+    int64_t eventIdNum = kTestCrossCoreEventIdCount;
     SmallVector<int64_t> availableEventIds(eventIdNum);
     std::iota(availableEventIds.begin(), availableEventIds.end(),
               static_cast<int64_t>(0));
@@ -409,12 +411,12 @@ Value getValueOrCreateCastToI64(IRRewriter &rewriter, Location loc, Value val) {
   assert(isa<OpResult>(val));
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointAfterValue(val);
-  if (!val.getType().isInteger(64)) {
+  if (!val.getType().isInteger(mlir::pto::kValue64)) {
     if (val.getType().isIndex()) {
       val = rewriter.create<arith::IndexCastOp>(
-          loc, rewriter.getIntegerType(64), val);
+          loc, rewriter.getIntegerType(mlir::pto::kValue64), val);
     } else if (val.getType().isInteger()) {
-      val = rewriter.create<arith::ExtSIOp>(loc, rewriter.getIntegerType(64),
+      val = rewriter.create<arith::ExtSIOp>(loc, rewriter.getIntegerType(mlir::pto::kValue64),
                                             val);
     } else {
       llvm_unreachable("unhandled casting type");

--- a/lib/PTO/Transforms/InferPTOLayout.cpp
+++ b/lib/PTO/Transforms/InferPTOLayout.cpp
@@ -306,13 +306,15 @@ static void verifyOrSetLayoutAttr(Operation *op,
 
 static std::optional<Layout> inferFromStaticMemRefTy(MemRefType mrTy) {
   if (!mrTy.hasStaticShape() || mrTy.getRank() == 0 ||
-      mrTy.getRank() > kPaddedLayoutRank)
+      mrTy.getRank() > kPaddedLayoutRank) {
     return std::nullopt;
+  }
   SmallVector<int64_t> strideInts;
   int64_t offset = ShapedType::kDynamic;
   if (failed(
-          mlir::pto::getPTOMemRefStridesAndOffset(mrTy, strideInts, offset)))
+          mlir::pto::getPTOMemRefStridesAndOffset(mrTy, strideInts, offset))) {
     return std::nullopt;
+  }
   if (offset == ShapedType::kDynamic ||
       llvm::any_of(strideInts,
                    [](int64_t s) { return s == ShapedType::kDynamic; })) {
@@ -384,7 +386,7 @@ struct LayoutPreference {
 
 static LayoutPreference collectPreferredLayoutFromConsumers(Value tensorView) {
   LayoutPreference result;
-  auto mergePref = [&](std::optional<Layout> candidate) {
+  auto mergePref = [&result](std::optional<Layout> candidate) {
     if (!candidate) {
       return;
     }
@@ -398,7 +400,7 @@ static LayoutPreference collectPreferredLayoutFromConsumers(Value tensorView) {
     }
   };
 
-  auto walkUses = [&](auto &&self, Value v) -> void {
+  auto walkUses = [&mergePref](auto &&self, Value v) -> void {
     for (OpOperand &use : v.getUses()) {
       Operation *owner = use.getOwner();
       unsigned operandIndex = use.getOperandNumber();
@@ -458,8 +460,9 @@ static std::optional<Layout> inferMakeTensorViewLayout(
   auto pref = collectPreferredLayoutFromConsumers(op.getResult());
   if (!pref.conflict && pref.preferred &&
       (*pref.preferred == Layout::MX_A_ZZ ||
-       *pref.preferred == Layout::MX_B_NN))
+       *pref.preferred == Layout::MX_B_NN)) {
     return pref.preferred;
+  }
   std::optional<Layout> preferredForAmbiguous = std::nullopt;
   if (!pref.conflict && isMinorColsOne(shape)) {
     preferredForAmbiguous = pref.preferred;
@@ -551,8 +554,9 @@ static ResolvedLayoutInfo resolveLayoutFromViewValue(Value v) {
       info.owner = def;
       info.layout = layoutAttr.getLayout();
       if (auto inferred =
-              def->getAttrOfType<BoolAttr>(kInferredLayoutAttrName))
+              def->getAttrOfType<BoolAttr>(kInferredLayoutAttrName)) {
         info.inferred = inferred.getValue();
+      }
       return info;
     }
     if (auto part = dyn_cast<PartitionViewOp>(def)) {

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -11,9 +11,16 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <utility>
 #include "PTO/IR/PTO.h"
-#include "PTO/Transforms/InsertSync/InsertSyncAnalysis.h"
+#include "PTO/IR/PTOMultiBuffer.h"
 #include "PTO/IR/PTOTypeUtils.h"
+#include "PTO/Support/CodeConstants.h"
+#include "PTO/Transforms/InsertSync/InsertSyncAnalysis.h"
 #include "PTO/Transforms/InsertSync/SyncCommon.h"
 #include "PTO/Transforms/SlotAffineAnalysis.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -23,11 +30,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
-#include <algorithm>
-#include <limits>
-#include <memory>
-#include <optional>
-#include <utility>
+
 
 #define DEBUG_TYPE "pto-insert-sync-analysis"
 
@@ -44,31 +47,37 @@ static constexpr unsigned kPipeVPruneMinRepeat = 16U;
 static bool hasReadWriteScratchDependency(
     Operation *op, const DepBaseMemInfoPairVec &dependencies) {
   auto effectsOp = dyn_cast_or_null<MemoryEffectOpInterface>(op);
-  if (!effectsOp)
+  if (!effectsOp) {
     return false;
+  }
 
   llvm::DenseSet<Value> reads;
   llvm::DenseSet<Value> writes;
-  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, 8> effects;
+  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, mlir::pto::kValue8> effects;
   effectsOp.getEffects(effects);
   for (const auto &effect : effects) {
     Value value = effect.getValue();
-    if (!value)
+    if (!value) {
       continue;
-    if (isa<MemoryEffects::Read>(effect.getEffect()))
+    }
+    if (isa<MemoryEffects::Read>(effect.getEffect())) {
       reads.insert(value);
-    if (isa<MemoryEffects::Write>(effect.getEffect()))
+    }
+    if (isa<MemoryEffects::Write>(effect.getEffect())) {
       writes.insert(value);
+    }
   }
 
   ValueRange dpsInits;
-  if (auto ptoDpsOp = dyn_cast<pto::PTO_DpsInitOpInterface>(op))
+  if (auto ptoDpsOp = dyn_cast<pto::PTO_DpsInitOpInterface>(op)) {
     dpsInits = ptoDpsOp.getDpsInits();
-  else if (auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op))
+  } else if (auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op)) {
     dpsInits = dpsOp.getDpsInits();
+  }
   return llvm::any_of(writes, [&](Value value) {
-    if (!reads.contains(value) || llvm::is_contained(dpsInits, value))
+    if (!reads.contains(value) || llvm::is_contained(dpsInits, value)) {
       return false;
+    }
     return llvm::any_of(dependencies, [&](const auto &dependency) {
       auto matches = [&](const BaseMemInfo *info) {
         return info &&
@@ -80,8 +89,8 @@ static bool hasReadWriteScratchDependency(
 }
 
 struct RepeatAccessShape {
-  SmallVector<int64_t, 2> fullShape;
-  SmallVector<int64_t, 2> validShape;
+  SmallVector<int64_t, mlir::pto::kValue2> fullShape;
+  SmallVector<int64_t, mlir::pto::kValue2> validShape;
   Type elementType;
 };
 
@@ -89,12 +98,16 @@ static std::optional<RepeatAccessShape> getKnownRepeatAccessShapeFromType(Type t
   if (auto tileTy = dyn_cast<TileBufType>(ty)) {
     ArrayRef<int64_t> fullShape = tileTy.getShape();
     ArrayRef<int64_t> validShape = tileTy.getValidShape();
-    if (fullShape.size() != 2 || validShape.size() != 2) return std::nullopt;
+    if (fullShape.size() != mlir::pto::kValue2 || validShape.size() != mlir::pto::kValue2) {
+      return std::nullopt;
+    }
     if (fullShape[0] < 0 || fullShape[1] < 0 || validShape[0] < 0 ||
-        validShape[1] < 0)
+        validShape[1] < 0) {
       return std::nullopt;
-    if (validShape[0] > fullShape[0] || validShape[1] > fullShape[1])
+    }
+    if (validShape[0] > fullShape[0] || validShape[1] > fullShape[1]) {
       return std::nullopt;
+    }
     return RepeatAccessShape{
         SmallVector<int64_t, 2>{fullShape[0], fullShape[1]},
         SmallVector<int64_t, 2>{validShape[0], validShape[1]},
@@ -105,9 +118,13 @@ static std::optional<RepeatAccessShape> getKnownRepeatAccessShapeFromType(Type t
 }
 
 static std::optional<RepeatAccessShape> getKnownRepeatAccessShape(Value access) {
-  if (!access) return std::nullopt;
+  if (!access) {
+    return std::nullopt;
+  }
   auto shape = getKnownRepeatAccessShapeFromType(access.getType());
-  if (!shape) return std::nullopt;
+  if (!shape) {
+    return std::nullopt;
+  }
 
   return shape;
 }
@@ -115,10 +132,12 @@ static std::optional<RepeatAccessShape> getKnownRepeatAccessShape(Value access) 
 static std::optional<BLayout> getKnownBLayout(Type ty) {
   if (auto tileTy = dyn_cast<TileBufType>(ty)) {
     int32_t layout = tileTy.getBLayoutValueI32();
-    if (layout == static_cast<int32_t>(BLayout::RowMajor))
+    if (layout == static_cast<int32_t>(BLayout::RowMajor)) {
       return BLayout::RowMajor;
-    if (layout == static_cast<int32_t>(BLayout::ColMajor))
+    }
+    if (layout == static_cast<int32_t>(BLayout::ColMajor)) {
       return BLayout::ColMajor;
+    }
   }
 
   return std::nullopt;
@@ -127,35 +146,49 @@ static std::optional<BLayout> getKnownBLayout(Type ty) {
 static bool isProvenContiguousAccess(Value access,
                                      const RepeatAccessShape &shape) {
   auto layout = getKnownBLayout(access.getType());
-  if (!layout) return false;
+  if (!layout) {
+    return false;
+  }
 
   int64_t fullRow = shape.fullShape[0];
   int64_t fullCol = shape.fullShape[1];
   int64_t validRow = shape.validShape[0];
   int64_t validCol = shape.validShape[1];
 
-  if (*layout == BLayout::RowMajor)
+  if (*layout == BLayout::RowMajor) {
     return validCol == fullCol || validRow == 1;
-  if (*layout == BLayout::ColMajor)
+  }
+  if (*layout == BLayout::ColMajor) {
     return validRow == fullRow || validCol == 1;
+  }
   return false;
 }
 
 static std::optional<unsigned> getRepeatCountForAccess(Value access) {
-  if (!access) return std::nullopt;
+  if (!access) {
+    return std::nullopt;
+  }
   auto shape = getKnownRepeatAccessShape(access);
-  if (!shape || !isProvenContiguousAccess(access, *shape)) return std::nullopt;
+  if (!shape || !isProvenContiguousAccess(access, *shape)) {
+    return std::nullopt;
+  }
 
   unsigned elemBytes = pto::getPTOStorageElemByteSize(shape->elementType);
-  if (elemBytes == 0) return std::nullopt;
+  if (elemBytes == 0) {
+    return std::nullopt;
+  }
 
   uint64_t validElems = static_cast<uint64_t>(shape->validShape[0]) *
                         static_cast<uint64_t>(shape->validShape[1]);
   uint64_t elemsPerRepeat = kVectorRegisterSizeInBytes / elemBytes;
-  if (elemsPerRepeat == 0) return std::nullopt;
+  if (elemsPerRepeat == 0) {
+    return std::nullopt;
+  }
 
   uint64_t repeat = (validElems + elemsPerRepeat - 1U) / elemsPerRepeat;
-  if (repeat > std::numeric_limits<unsigned>::max()) return std::nullopt;
+  if (repeat > std::numeric_limits<unsigned>::max()) {
+    return std::nullopt;
+  }
   return static_cast<unsigned>(repeat);
 }
 
@@ -361,9 +394,10 @@ unsigned InsertSyncAnalysis::InsertLoopSync(
     // paths by not promoting alreadySync from the loop-body traversal into the
     // outer state. We only carry syncFinder updates, matching no-else branch
     // behavior in InsertBranchSync.
-    for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++)
+    for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
       syncRecordList[bufferIdx].syncFinder =
           syncRecordForList[bufferIdx].syncFinder;
+    }
     return (loopElement->endId - loopElement->beginId);
   }
   return 0;
@@ -396,8 +430,9 @@ unsigned InsertSyncAnalysis::InsertBranchSync(
     } else {
       // No else-branch: do not promote `alreadySync`, but keep syncFinder
       // updates from the then-branch.
-      for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++)
+      for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
         syncRecordList[bufferIdx].syncFinder = syncRecordIfList[bufferIdx].syncFinder;
+      }
     }
     return (branchElement->endId - branchElement->beginId);
   } else if (branchElement->getBranchKind() == KindOfBranch::ELSE_BEGIN &&
@@ -443,17 +478,20 @@ void InsertSyncAnalysis::InsertSync(
 // the dep is kept and the existing conservative path runs.
 static bool isForwardDepDroppableBySlotAffine(const BaseMemInfo *a,
                                               const BaseMemInfo *b) {
-  if (!a || !b)
+  if (!a || !b) {
     return false;
+  }
   size_t aN = a->baseAddresses.size();
   size_t bN = b->baseAddresses.size();
   size_t n = std::max(aN, bN);
-  if (n < 2)
+  if (n < kPtoMultiBufferMinNum) {
     return false;
+  }
   Value slotA = findMultiTileSlotExpr(a->baseBuffer);
   Value slotB = findMultiTileSlotExpr(b->baseBuffer);
-  if (!slotA || !slotB)
+  if (!slotA || !slotB) {
     return false;
+  }
   return compareSlotSSA(slotA, slotB, static_cast<uint32_t>(n)) ==
          SlotRelation::kDisjoint;
 }
@@ -482,8 +520,9 @@ void InsertSyncAnalysis::MemAnalyze(
     };
     depVec.erase(std::remove_if(depVec.begin(), depVec.end(), isDroppable),
                  depVec.end());
-    if (depVec.empty())
+    if (depVec.empty()) {
       return;
+    }
   }
 
   if (CanPrunePipeVBarrier(nowCompound, frontCompound, depVec, forEndIndex)) {
@@ -527,8 +566,12 @@ bool InsertSyncAnalysis::IsMemInfoHasDependency(
     if (memAnalyzer_.DepBetween(nowCompound->useVec, frontCompound->useVec,
                                rrDepVec)) {
       for (auto &pair : rrDepVec) {
-        if (!pair.first) continue;
-        if (pair.first->scope != pto::AddressSpace::ACC) continue;
+        if (!pair.first) {
+          continue;
+        }
+        if (pair.first->scope != pto::AddressSpace::ACC) {
+          continue;
+        }
         depBaseMemInfosVec.push_back(pair);
         hasDependency = true;
       }
@@ -543,8 +586,12 @@ bool InsertSyncAnalysis::CanPrunePipeVBarrier(
     const CompoundInstanceElement *frontCompound,
     const DepBaseMemInfoPairVec &depBaseMemInfosVec,
     const std::optional<unsigned> &forEndIndex) const {
-  if (forEndIndex.has_value()) return false;
-  if (!nowCompound || !frontCompound) return false;
+  if (forEndIndex.has_value()) {
+    return false;
+  }
+  if (!nowCompound || !frontCompound) {
+    return false;
+  }
   if (nowCompound->kPipeValue != PipelineType::PIPE_V ||
       frontCompound->kPipeValue != PipelineType::PIPE_V) {
     return false;
@@ -567,24 +614,31 @@ bool InsertSyncAnalysis::CanPrunePipeVBarrier(
   // the exact same access.
   SmallVector<const BaseMemInfo *, 2> producerAccesses;
   for (const auto &pair : depBaseMemInfosVec) {
-    if (!isSameExactAccess(pair.first, pair.second)) return false;
+    if (!isSameExactAccess(pair.first, pair.second)) {
+      return false;
+    }
 
     if (containsExactAccess(nowCompound->useVec, pair.first) &&
         containsExactAccess(frontCompound->defVec, pair.second)) {
-      if (!llvm::is_contained(producerAccesses, pair.second))
+      if (!llvm::is_contained(producerAccesses, pair.second)) {
         producerAccesses.push_back(pair.second);
+      }
     } else {
       return false;
     }
   }
-  if (producerAccesses.empty()) return false;
+  if (producerAccesses.empty()) {
+    return false;
+  }
 
   // The caller is analyzing this specific front->now dependency. Do not look
   // for a later text-order writer here; it may belong to a different branch
   // path or a zero-trip loop body.
   for (const BaseMemInfo *producerAccess : producerAccesses) {
     auto repeat = getRepeatCountForAccess(producerAccess->baseBuffer);
-    if (!repeat || *repeat < kPipeVPruneMinRepeat) return false;
+    if (!repeat || *repeat < kPipeVPruneMinRepeat) {
+      return false;
+    }
   }
 
   return true;
@@ -696,8 +750,12 @@ bool InsertSyncAnalysis::isAlreadySync(
     SyncRecordList &syncRecordList, unsigned recordListIndex) {
   (void)nowCompound;
   const PipelineType frontPipe = frontCompound->kPipeValue;
-  if (recordListIndex >= syncRecordList.size()) return false;
-  if (!isValidPipeIndex(frontPipe)) return false;
+  if (recordListIndex >= syncRecordList.size()) {
+    return false;
+  }
+  if (!isValidPipeIndex(frontPipe)) {
+    return false;
+  }
   return syncRecordList[recordListIndex]
       .alreadySync[static_cast<unsigned>(frontPipe)];
 }
@@ -708,7 +766,9 @@ void InsertSyncAnalysis::UpdateAlreadySync(const SyncOps &syncVector,
   for (auto *sync : syncVector) {
     // A slot-keyed event orders only the selected physical slot. It must not
     // make later accesses through another slot look globally synchronized.
-    if (isSlotKeyedSync(sync)) continue;
+    if (isSlotKeyedSync(sync)) {
+      continue;
+    }
     for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
       UpdateSyncRecord(sync, syncRecordList[bufferIdx], nowPipeValue);
     }
@@ -746,7 +806,9 @@ void InsertSyncAnalysis::UpdateSyncRecord(const SyncOperation *sync,
   bool canTransitivelyEliminate =
       recordAlready[static_cast<unsigned>(waitPipeValue)] ||
       (nowPipeValue == waitPipeValue);
-  if (!canTransitivelyEliminate) return;
+  if (!canTransitivelyEliminate) {
+    return;
+  }
 
   if (recordFinder[sync->GetSyncIndex()] &&
       (sync->GetType() == SyncOperation::TYPE::SET_EVENT ||
@@ -770,9 +832,13 @@ void InsertSyncAnalysis::UpdateSyncRecordInfo(
   auto *newSync = syncPair[0].get();
   // Dynamic event IDs cover one runtime-selected slot, not the complete pipe
   // dependency represented by this record.
-  if (isSlotKeyedSync(newSync)) return;
+  if (isSlotKeyedSync(newSync)) {
+    return;
+  }
   for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
-    if (!isValidPipeIndex(newSync->GetSrcPipe())) continue;
+    if (!isValidPipeIndex(newSync->GetSrcPipe())) {
+      continue;
+    }
     syncRecordList[bufferIdx]
         .alreadySync[static_cast<unsigned>(newSync->GetSrcPipe())] = true;
   }
@@ -785,7 +851,9 @@ void InsertSyncAnalysis::UpdateSyncRecordInfo(
 void InsertSyncAnalysis::InsertLastPipeAll() {
   for (auto it = syncIR_.rbegin(); it != syncIR_.rend(); ++it) {
     auto *element = it->get();
-    if (isa<PlaceHolderInstanceElement>(element)) continue;
+    if (isa<PlaceHolderInstanceElement>(element)) {
+      continue;
+    }
 
     auto barrierOp = std::make_unique<SyncOperation>(
         SyncOperation::TYPE::PIPE_BARRIER, PipelineType::PIPE_ALL,
@@ -812,13 +880,16 @@ SmallVector<Value> InsertSyncAnalysis::GetMemInfoBuffers(
   llvm::DenseSet<Value> touchedBuffer;
   SmallVector<Value> result;
   for (auto &pair : depBaseMemInfosVec) {
-    if (pair.first && pair.first->rootBuffer)
+    if (pair.first && pair.first->rootBuffer) {
       touchedBuffer.insert(pair.first->rootBuffer);
-    if (pair.second && pair.second->rootBuffer)
+    }
+    if (pair.second && pair.second->rootBuffer) {
       touchedBuffer.insert(pair.second->rootBuffer);
+    }
   }
-  for (auto v : touchedBuffer)
+  for (auto v : touchedBuffer) {
     result.push_back(v);
+  }
   llvm::sort(result, [](Value lhs, Value rhs) {
     return lhs.getAsOpaquePointer() < rhs.getAsOpaquePointer();
   });
@@ -844,13 +915,15 @@ int InsertSyncAnalysis::GetEventIdNum(
     bool isLocalB =
         pair.second && (pair.second->scope == pto::AddressSpace::MAT ||
                         pair.second->scope == pto::AddressSpace::VEC);
-    if (!isLocalA && !isLocalB)
+    if (!isLocalA && !isLocalB) {
       continue;
+    }
     size_t aN = pair.first ? pair.first->baseAddresses.size() : 1;
     size_t bN = pair.second ? pair.second->baseAddresses.size() : 1;
     int pairN = static_cast<int>(std::max(aN, bN));
-    if (pairN <= 1)
+    if (pairN <= 1) {
       continue;
+    }
     if (eventIdNum == 1) {
       eventIdNum = pairN;
     } else if (eventIdNum != pairN) {
@@ -868,7 +941,9 @@ bool InsertSyncAnalysis::IsGMHazard(
     const CompoundInstanceElement *frontCompound) const {
   auto hasGM = [](const SmallVector<const BaseMemInfo *> &vec) {
     for (const auto *info : vec) {
-      if (info->scope == pto::AddressSpace::GM) return true;
+      if (info->scope == pto::AddressSpace::GM) {
+        return true;
+      }
     }
     return false;
   };
@@ -878,10 +953,15 @@ bool InsertSyncAnalysis::IsGMHazard(
 
   bool nowWritesGM = hasGM(nowCompound->defVec);
   bool nowReadsGM = hasGM(nowCompound->useVec);
-
-  if (frontWritesGM && nowReadsGM) return true;  // RAW
-  if (frontReadsGM && nowWritesGM) return true;  // WAR
-  if (frontWritesGM && nowWritesGM) return true; // WAW
+  if (frontWritesGM && nowReadsGM) {
+    return true; // RAW
+  }
+  if (frontReadsGM && nowWritesGM) {
+    return true; // WAR
+  }
+  if (frontWritesGM && nowWritesGM) {
+    return true; // WAW
+  }
 
   // RAR is considered safe for GM in this simplified model.
   return false;

--- a/lib/PTO/Transforms/InsertSync/InsertSyncDebug.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncDebug.cpp
@@ -123,34 +123,41 @@ static void dumpEventIds(llvm::raw_ostream &os,
   os << "[";
   for (size_t i = 0; i < eventIds.size(); ++i) {
     os << eventIds[i];
-    if (i + 1 != eventIds.size())
+    if (i + 1 != eventIds.size()) {
       os << ",";
+    }
   }
   os << "]";
 }
 
 static void dumpSyncOp(llvm::raw_ostream &os, const SyncOperation *op,
                        bool showUselessSync) {
-  if (!op)
+  if (!op) {
     return;
-  if (op->uselessSync && !showUselessSync)
+  }
+  if (op->uselessSync && !showUselessSync) {
     return;
+  }
 
   os << SyncOperation::TypeName(op->GetType());
   os << " <" << getPipelineName(op->GetSrcPipe()) << " -> "
      << getPipelineName(op->GetDstPipe()) << ">";
   os << " idx=" << op->GetSyncIndex();
 
-  if (op->GetForEndIndex().has_value())
+  if (op->GetForEndIndex().has_value()) {
     os << " forEnd=" << op->GetForEndIndex().value();
+  }
 
-  if (op->eventIdNum != 1)
+  if (op->eventIdNum != 1) {
     os << " eventIdNum=" << op->eventIdNum;
+  }
 
-  if (op->isCompensation)
+  if (op->isCompensation) {
     os << " compensation";
-  if (op->uselessSync)
+  }
+  if (op->uselessSync) {
     os << " useless";
+  }
 
   if (!op->eventIds.empty()) {
     os << " eventIds=";
@@ -176,8 +183,9 @@ static void dumpMemInfoList(llvm::raw_ostream &os, llvm::StringRef tag,
     } else {
       os << "<null-root>";
     }
-    if (i + 1 != list.size())
+    if (i + 1 != list.size()) {
       os << ", ";
+    }
   }
   os << "]";
 }
@@ -186,26 +194,30 @@ static void dumpSyncIR(llvm::raw_ostream &os, const SyncIRs &syncIR,
                        Operation *opForPrinting, InsertSyncDumpOptions options,
                        bool showMemInfo) {
   std::optional<mlir::AsmState> state;
-  if (showMemInfo && opForPrinting)
+  if (showMemInfo && opForPrinting) {
     state.emplace(opForPrinting);
+  }
 
   int indent = 0;
-  auto indentBy = [&](int extra = 0) {
+  auto indentBy = [&indent](int extra = 0) {
     return static_cast<unsigned>(std::max(0, indent) * 2 + extra);
   };
 
   for (const auto &e : syncIR) {
-    if (!e)
+    if (!e) {
       continue;
+    }
 
     if (auto *loop = dyn_cast<LoopInstanceElement>(e.get())) {
-      if (loop->getLoopKind() == KindOfLoop::LOOP_END)
+      if (loop->getLoopKind() == KindOfLoop::LOOP_END) {
         indent = std::max(0, indent - 1);
+      }
     }
     if (auto *branch = dyn_cast<BranchInstanceElement>(e.get())) {
       if (branch->getBranchKind() == KindOfBranch::IF_END ||
-          branch->getBranchKind() == KindOfBranch::ELSE_BEGIN)
+          branch->getBranchKind() == KindOfBranch::ELSE_BEGIN) {
         indent = std::max(0, indent - 1);
+      }
     }
 
     os.indent(indentBy());
@@ -243,8 +255,9 @@ static void dumpSyncIR(llvm::raw_ostream &os, const SyncIRs &syncIR,
     case InstanceElement::KindTy::PLACE_HOLDER: {
       auto *ph = cast<PlaceHolderInstanceElement>(e.get());
       os << "PLACE_HOLDER (parentScopeId=" << ph->parentScopeId;
-      if (ph->isVirtualElse)
+      if (ph->isVirtualElse) {
         os << ", virtualElse";
+      }
       os << ")\n";
       break;
     }
@@ -252,10 +265,12 @@ static void dumpSyncIR(llvm::raw_ostream &os, const SyncIRs &syncIR,
 
     auto dumpOps = [&](llvm::StringRef prefix, const SyncOps &ops) {
       for (const auto *op : ops) {
-        if (!op)
+        if (!op) {
           continue;
-        if (op->uselessSync && !options.showUselessSync)
+        }
+        if (op->uselessSync && !options.showUselessSync) {
           continue;
+        }
         os.indent(indentBy(kDebugDumpIndentSpaces));
         os << prefix << ": ";
         dumpSyncOp(os, op, options.showUselessSync);
@@ -267,13 +282,15 @@ static void dumpSyncIR(llvm::raw_ostream &os, const SyncIRs &syncIR,
     dumpOps("POST", e->pipeAfter);
 
     if (auto *loop = dyn_cast<LoopInstanceElement>(e.get())) {
-      if (loop->getLoopKind() == KindOfLoop::LOOP_BEGIN)
+      if (loop->getLoopKind() == KindOfLoop::LOOP_BEGIN) {
         indent += 1;
+      }
     }
     if (auto *branch = dyn_cast<BranchInstanceElement>(e.get())) {
       if (branch->getBranchKind() == KindOfBranch::IF_BEGIN ||
-          branch->getBranchKind() == KindOfBranch::ELSE_BEGIN)
+          branch->getBranchKind() == KindOfBranch::ELSE_BEGIN) {
         indent += 1;
+      }
     }
   }
 }
@@ -283,18 +300,21 @@ void mlir::pto::dumpInsertSyncPhase(llvm::StringRef phase, const SyncIRs &syncIR
                                    Operation *opForPrinting,
                                    llvm::raw_ostream &os) {
   const unsigned level = getInsertSyncDebugLevel();
-  if (level < static_cast<unsigned>(InsertSyncDebugLevel::Phase))
+  if (level < static_cast<unsigned>(InsertSyncDebugLevel::Phase)) {
     return;
+  }
 
   unsigned activeOps = 0;
   unsigned setCnt = 0, waitCnt = 0, barrierCnt = 0;
   unsigned blockSetCnt = 0, blockWaitCnt = 0, blockAllCnt = 0;
   for (const auto &group : syncOperations) {
     for (const auto &op : group) {
-      if (!op)
+      if (!op) {
         continue;
-      if (op->uselessSync)
+      }
+      if (op->uselessSync) {
         continue;
+      }
       activeOps++;
       switch (op->GetType()) {
       case SyncOperation::TYPE::SET_EVENT:

--- a/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
+++ b/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
@@ -27,8 +27,9 @@ static bool isTraceEnabled() {
  
 // [Debug] 打印 Value 详细信息
 static void printValueDebug(const char* tag, Value v) {
-  if (!isTraceEnabled())
+  if (!isTraceEnabled()) {
     return;
+  }
   llvm::errs() << tag << ": ";
   if (!v) {
     llvm::errs() << "NULL\n";
@@ -57,8 +58,9 @@ static Value GetRealRoot(Value v) {
   while (v && depth++ < maxDepth) {
     Operation *defOp = v.getDefiningOp();
     if (!defOp) {
-        if (trace)
-          llvm::errs() << "    -> Reached BlockArgument. Stop.\n";
+      if (trace) {
+        llvm::errs() << "    -> Reached BlockArgument. Stop.\n";
+      }
         break; 
     }
  
@@ -75,41 +77,47 @@ static Value GetRealRoot(Value v) {
 // constant. Tile roots otherwise carry their planned addresses in
 // `BaseMemInfo::baseAddresses`.
 static uint64_t getRootBaseAddress(Value rootBuffer) {
-  if (!rootBuffer)
+  if (!rootBuffer) {
     return 0;
+  }
   if (auto cst = rootBuffer.getDefiningOp<arith::ConstantOp>()) {
-    if (auto attr = dyn_cast<IntegerAttr>(cst.getValue()))
+    if (auto attr = dyn_cast<IntegerAttr>(cst.getValue())) {
       return attr.getValue().getZExtValue();
+    }
   }
   return 0;
 }
 
 static bool isIntegerConstant(Value value) {
-  if (!value)
+  if (!value) {
     return false;
+  }
   auto cst = value.getDefiningOp<arith::ConstantOp>();
   return cst && isa<IntegerAttr>(cst.getValue());
 }
 
 static bool hasKnownLocalAbsoluteAddress(const BaseMemInfo *info) {
-  if (!info || info->baseAddresses.empty() || info->allocateSize == 0)
+  if (!info || info->baseAddresses.empty() || info->allocateSize == 0) {
     return false;
+  }
 
   Value root = info->rootBuffer;
-  if (!root)
+  if (!root) {
     return false;
+  }
 
-  if (auto alloc = root.getDefiningOp<pto::AllocTileOp>())
+  if (auto alloc = root.getDefiningOp<pto::AllocTileOp>()) {
     return isIntegerConstant(alloc.getAddr());
+  }
 
-  if (isIntegerConstant(root))
+  if (isIntegerConstant(root)) {
     return true;
+  }
 
   return false;
 }
 
 // Cross-root byte-range overlap check for local memory (UB/L1).
-//
 // `MemAlias` historically only checked byte-range overlap when the two
 // `rootBuffer` SSA values were identical (same `alloc_tile`).
 // When PlanMemory reuses the same physical UB region for two *different*
@@ -117,7 +125,6 @@ static bool hasKnownLocalAbsoluteAddress(const BaseMemInfo *info) {
 // overlap — so `MemAlias` returned false and InsertSync silently dropped the
 // cross-pipe hazard (issue #934: MTE3 tstore racing a V-pipe write into an
 // overlapping-but-different-root buffer).
-//
 // This helper re-derives the absolute address as `getRootBaseAddress(root) +
 // baseAddresses[i]` and performs the same `maxStart < minEnd` overlap test
 // across every address pair, regardless of root identity.
@@ -126,8 +133,9 @@ static bool isLocalBufferOverlapCrossRoot(const BaseMemInfo *a,
   // Cross-root checks are only meaningful after physical addresses have been
   // materialized. For unknown-address roots keep the historical behavior:
   // different roots are treated as independent.
-  if (!hasKnownLocalAbsoluteAddress(a) || !hasKnownLocalAbsoluteAddress(b))
+  if (!hasKnownLocalAbsoluteAddress(a) || !hasKnownLocalAbsoluteAddress(b)) {
     return false;
+  }
 
   uint64_t rootBaseA = getRootBaseAddress(a->rootBuffer);
   uint64_t rootBaseB = getRootBaseAddress(b->rootBuffer);
@@ -140,8 +148,9 @@ static bool isLocalBufferOverlapCrossRoot(const BaseMemInfo *a,
       uint64_t bEnd = bStart + b->allocateSize;
       uint64_t maxStart = std::max(aStart, bStart);
       uint64_t minEnd = std::min(aEnd, bEnd);
-      if (maxStart < minEnd)
+      if (maxStart < minEnd) {
         return true;
+      }
     }
   }
   return false;
@@ -185,14 +194,16 @@ bool MemoryDependentAnalyzer::MemAlias(const BaseMemInfo *a,
   }
  
   if (as != bs) {
-    if (isTraceEnabled())
+    if (isTraceEnabled()) {
       llvm::errs() << "    -> Scope Mismatch. False.\n";
+    }
     return false;
   }
 
   if (a->aliasesUnknownRange || b->aliasesUnknownRange) {
-    if (isTraceEnabled())
+    if (isTraceEnabled()) {
       llvm::errs() << "    -> Unknown range in same scope. True.\n";
+    }
     return true;
   }
  
@@ -207,18 +218,25 @@ bool MemoryDependentAnalyzer::MemAlias(const BaseMemInfo *a,
   // the same physical range with a different alloc_tile root. Compare those
   // ranges directly when both sides carry known physical local addresses.
   if (a->hasKnownPhysicalAddresses && b->hasKnownPhysicalAddresses) {
-    if (isTraceEnabled())
+    if (isTraceEnabled()) {
       llvm::errs() << "    -> Comparing known physical local ranges.\n";
-    if (a->baseAddresses.empty() || b->baseAddresses.empty())
+    }
+    if (a->baseAddresses.empty() || b->baseAddresses.empty()) {
       return true;
-    if (a->allocateSize == 0 || b->allocateSize == 0)
+    }
+    if (a->allocateSize == 0 || b->allocateSize == 0) {
       return true;
+    }
     return isBufferAddressRangeOverlap(a, b);
   }
 
   if (a->rootBuffer == b->rootBuffer) {
-    if (a->baseAddresses.empty() || b->baseAddresses.empty()) return true;
-    if (a->allocateSize == 0 || b->allocateSize == 0) return true;
+    if (a->baseAddresses.empty() || b->baseAddresses.empty()) {
+      return true;
+    }
+    if (a->allocateSize == 0 || b->allocateSize == 0) {
+      return true;
+    }
     return isBufferAddressRangeOverlap(a, b);
   }
  
@@ -233,16 +251,20 @@ bool MemoryDependentAnalyzer::MemAlias(const BaseMemInfo *a,
   }
  
   if (realRootA == realRootB && realRootA != nullptr) {
-      if (isTraceEnabled())
-        llvm::errs() << "      -> MATCH! Real roots are the same.\n";
-      if (a->baseAddresses.empty() || b->baseAddresses.empty())
-        return true;
-      if (a->allocateSize == 0 || b->allocateSize == 0)
-        return true;
+    if (isTraceEnabled()) {
+      llvm::errs() << "      -> MATCH! Real roots are the same.\n";
+    }
+    if (a->baseAddresses.empty() || b->baseAddresses.empty()) {
+      return true;
+    }
+    if (a->allocateSize == 0 || b->allocateSize == 0) {
+      return true;
+    }
       return isBufferAddressRangeOverlap(a, b);
   } else {
-      if (isTraceEnabled())
-        llvm::errs() << "      -> Mismatch. Real roots differ.\n";
+    if (isTraceEnabled()) {
+      llvm::errs() << "      -> Mismatch. Real roots differ.\n";
+    }
   }
 
   // 2.3 Cross-root absolute-address overlap check.
@@ -254,28 +276,34 @@ bool MemoryDependentAnalyzer::MemAlias(const BaseMemInfo *a,
   // a cross-pipe hazard (e.g. MTE3 tstore vs a V-pipe write into an
   // overlapping region) is not silently dropped (issue #934).
   bool crossRootOverlap = isLocalBufferOverlapCrossRoot(a, b);
-  if (isTraceEnabled())
+  if (isTraceEnabled()) {
     llvm::errs() << "      -> Cross-root overlap check: "
                  << (crossRootOverlap ? "true" : "false") << "\n";
+  }
   return crossRootOverlap;
 }
  
 bool MemoryDependentAnalyzer::isGMBufferOverlap(const BaseMemInfo *a,
                                                 const BaseMemInfo *b) {
-  if (a->baseAddresses.empty() || b->baseAddresses.empty())
+  if (a->baseAddresses.empty() || b->baseAddresses.empty()) {
     return true;
+  }
   if (a->rootBuffer != b->rootBuffer) {
     Value realRootA = GetRealRoot(a->rootBuffer);
     Value realRootB = GetRealRoot(b->rootBuffer);
     if (realRootA != realRootB) {
         return false;
     }
-    if (a->allocateSize == 0 || b->allocateSize == 0) return true;
+    if (a->allocateSize == 0 || b->allocateSize == 0) {
+      return true;
+    }
     return isBufferAddressRangeOverlap(a, b);
   }
- 
-  if (a->allocateSize == 0 || b->allocateSize == 0) return true;
- 
+
+  if (a->allocateSize == 0 || b->allocateSize == 0) {
+    return true;
+  }
+
   return isBufferAddressRangeOverlap(a, b);
 }
  

--- a/lib/PTO/Transforms/InsertSync/MoveSyncState.cpp
+++ b/lib/PTO/Transforms/InsertSync/MoveSyncState.cpp
@@ -158,9 +158,10 @@ void MoveSyncState::MoveForSync() {
           continue;
         }
         // 遍历循环体内的所有指令
-        for (unsigned i = forCompound->beginId + 1; i < forCompound->endId; i++)
+        for (unsigned i = forCompound->beginId + 1; i < forCompound->endId; i++) {
           MoveOutSync(syncIR_[i].get(),
                       {forCompound->beginId, forCompound->endId});
+        }
       }
     }
   }

--- a/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
@@ -44,11 +44,13 @@ using MemoryEffectVector =
 static uint64_t getStaticBufferSizeInBytes(ArrayRef<int64_t> shape,
                                            Type elementType) {
   uint64_t size = pto::getPTOStorageElemByteSize(elementType);
-  if (size == 0)
+  if (size == 0) {
     return 0;
+  }
   for (int64_t dim : shape) {
-    if (dim == ShapedType::kDynamic)
+    if (dim == ShapedType::kDynamic) {
       return 0;
+    }
     size *= static_cast<uint64_t>(dim);
   }
   return size;
@@ -57,40 +59,47 @@ static uint64_t getStaticBufferSizeInBytes(ArrayRef<int64_t> shape,
 static uint64_t getTileBufferFootprintBytes(pto::TileBufType type) {
   ArrayRef<int64_t> shape = type.getShape();
   uint64_t elemBytes = pto::getPTOStorageElemByteSize(type.getElementType());
-  if (elemBytes == 0)
+  if (elemBytes == 0) {
     return 0;
+  }
   if (type.getCompactModeI32() !=
-      static_cast<int32_t>(pto::CompactMode::RowPlusOne))
+      static_cast<int32_t>(pto::CompactMode::RowPlusOne)) {
     return getStaticBufferSizeInBytes(shape, type.getElementType());
+  }
   if (shape.size() != kTileRank2D ||
-      llvm::is_contained(shape, ShapedType::kDynamic))
+      llvm::is_contained(shape, ShapedType::kDynamic)) {
     return 0;
+  }
 
   bool rowMajor =
       type.getBLayoutValueI32() == static_cast<int32_t>(pto::BLayout::RowMajor);
   uint64_t major = static_cast<uint64_t>(rowMajor ? shape[0] : shape[1]);
   uint64_t minor = static_cast<uint64_t>(rowMajor ? shape[1] : shape[0]);
-  if (major == 0 || minor == 0)
+  if (major == 0 || minor == 0) {
     return 0;
+  }
   return ((major - 1) * (minor + 1) + minor) * elemBytes;
 }
 
 static pto::AddressSpace getTileAddressSpace(pto::TileBufType type) {
   if (auto attr =
-          dyn_cast_or_null<pto::AddressSpaceAttr>(type.getMemorySpace()))
+          dyn_cast_or_null<pto::AddressSpaceAttr>(type.getMemorySpace())) {
     return attr.getAddressSpace();
+  }
   return pto::AddressSpace::MAT;
 }
 
 static void
 appendUniqueMemInfo(SmallVectorImpl<std::unique_ptr<BaseMemInfo>> &infos,
                     std::unique_ptr<BaseMemInfo> candidate) {
-  if (!candidate)
+  if (!candidate) {
     return;
+  }
   if (llvm::any_of(infos, [&](const std::unique_ptr<BaseMemInfo> &info) {
         return info && *info == *candidate;
-      }))
+      })) {
     return;
+  }
   infos.emplace_back(std::move(candidate));
 }
 
@@ -127,15 +136,18 @@ static bool getConstIndexValue(Value value, int64_t &out) {
   auto constOp = value.getDefiningOp<arith::ConstantOp>();
   auto intAttr =
       constOp ? dyn_cast<IntegerAttr>(constOp.getValue()) : IntegerAttr();
-  if (!intAttr) return false;
+  if (!intAttr) {
+    return false;
+  }
   out = intAttr.getInt();
   return true;
 }
 
 static std::optional<uint64_t> getKnownPhysicalAddress(Value value) {
   int64_t address = 0;
-  if (!getConstIndexValue(value, address) || address < 0)
+  if (!getConstIndexValue(value, address) || address < 0) {
     return std::nullopt;
+  }
   return static_cast<uint64_t>(address);
 }
 
@@ -145,8 +157,9 @@ static bool isLocalAddressSpace(pto::AddressSpace space) {
 }
 
 static pto::AddressSpace getPointerLikeAddressSpace(Type type) {
-  if (auto space = pto::getPTOAddressSpaceAttr(type))
+  if (auto space = pto::getPTOAddressSpaceAttr(type)) {
     return space.getAddressSpace();
+  }
   return pto::AddressSpace::GM;
 }
 
@@ -164,32 +177,45 @@ static int64_t getTileMajorStride(pto::TileBufType type) {
   bool rowMajor =
       type.getBLayoutValueI32() == static_cast<int32_t>(pto::BLayout::RowMajor);
   int64_t stride = rowMajor ? cols : rows;
-  if (type.getCompactModeI32() == static_cast<int32_t>(pto::CompactMode::RowPlusOne))
+  if (type.getCompactModeI32() == static_cast<int32_t>(pto::CompactMode::RowPlusOne)) {
     ++stride;
+  }
   return stride;
 }
 
 static std::optional<SmallVector<uint64_t>>
 getPtoSubViewBaseAddresses(pto::SubViewOp op, pto::TileBufType sourceType,
                            int64_t elemBytes) {
-  if (!isStaticRank2Shape(sourceType.getShape())) return std::nullopt;
-  if (sourceType.getSLayoutValueI32() !=
-      static_cast<int32_t>(pto::SLayout::NoneBox))
+  if (!isStaticRank2Shape(sourceType.getShape())) {
     return std::nullopt;
-  if (op.getOffsets().size() != kTileRank2D) return std::nullopt;
+  }
+  if (sourceType.getSLayoutValueI32() !=
+      static_cast<int32_t>(pto::SLayout::NoneBox)) {
+    return std::nullopt;
+  }
+  if (op.getOffsets().size() != kTileRank2D) {
+    return std::nullopt;
+  }
 
   int64_t rowOffset = 0;
   int64_t colOffset = 0;
   if (!getConstIndexValue(op.getOffsets()[0], rowOffset) ||
-      !getConstIndexValue(op.getOffsets()[1], colOffset))
+      !getConstIndexValue(op.getOffsets()[1], colOffset)) {
     return std::nullopt;
-  if (rowOffset < 0 || colOffset < 0) return std::nullopt;
+  }
+  if (rowOffset < 0 || colOffset < 0) {
+    return std::nullopt;
+  }
 
   auto sizesAttr = op.getSizes();
-  if (!sizesAttr || sizesAttr.size() != kTileRank2D) return std::nullopt;
+  if (!sizesAttr || sizesAttr.size() != kTileRank2D) {
+    return std::nullopt;
+  }
   int64_t rowSize = cast<IntegerAttr>(sizesAttr[0]).getInt();
   int64_t colSize = cast<IntegerAttr>(sizesAttr[1]).getInt();
-  if (rowSize <= 0 || colSize <= 0) return std::nullopt;
+  if (rowSize <= 0 || colSize <= 0) {
+    return std::nullopt;
+  }
 
   bool rowMajor =
       sourceType.getBLayoutValueI32() == static_cast<int32_t>(pto::BLayout::RowMajor);
@@ -217,14 +243,17 @@ namespace {
 
 static func::FuncOp lookupSyncHelper(func::CallOp callOp) {
   auto module = callOp->getParentOfType<ModuleOp>();
-  if (!module || callOp.getCallee().empty())
+  if (!module || callOp.getCallee().empty()) {
     return {};
+  }
   auto callee = module.lookupSymbol<func::FuncOp>(callOp.getCallee());
-  if (!callee)
+  if (!callee) {
     return {};
+  }
   if (!callee->hasAttr("pto.tileop.helper") &&
-      !callee->hasAttr("pto.ptodsl.subkernel_helper"))
+      !callee->hasAttr("pto.ptodsl.subkernel_helper")) {
     return {};
+  }
   return callee;
 }
 
@@ -239,8 +268,9 @@ static std::optional<pto::PipelineType> getSyncHelperPipe(func::FuncOp callee) {
   }
 
   auto kindAttr = callee->getAttrOfType<mlir::StringAttr>("pto.tileop.kind");
-  if (!kindAttr)
+  if (!kindAttr) {
     return std::nullopt;
+  }
   return llvm::StringSwitch<std::optional<pto::PipelineType>>(
              kindAttr.getValue())
       .Case("cube", pto::PipelineType::PIPE_M)
@@ -289,8 +319,9 @@ void PTOIRTranslator::UpdateKernelArgMemInfo() {
       space = getTileAddressSpace(slotType);
       sizeInBytes = getTileBufferFootprintBytes(slotType);
       baseAddresses.clear();
-      for (uint32_t slot = 0; slot < multiType.getCount(); ++slot)
+      for (uint32_t slot = 0; slot < multiType.getCount(); ++slot) {
         baseAddresses.push_back(sizeInBytes == 0 ? 0 : slot * sizeInBytes);
+      }
     } else if (auto viewType = dyn_cast<pto::TensorViewType>(argType)) {
       space = pto::AddressSpace::GM;
       sizeInBytes = getStaticBufferSizeInBytes(viewType.getShape(),
@@ -314,7 +345,6 @@ void PTOIRTranslator::UpdateKernelArgMemInfo() {
 // ============================================================================
 void PTOIRTranslator::RecursionIR(Region *region) {
   auto result = region->walk<WalkOrder::PreOrder>([&](Operation *op) {
-
     // --- Case A: 内存分配 (AllocTile) ---
     if (auto allocOp = dyn_cast<pto::AllocTileOp>(op)) {
       if (failed(UpdateAllocTileOpMemInfo(allocOp))) {
@@ -327,8 +357,9 @@ void PTOIRTranslator::RecursionIR(Region *region) {
       }
     }
     else if (auto declareOp = dyn_cast<pto::DeclareTileOp>(op)) {
-      if (failed(UpdateDeclareTileOpMemInfo(declareOp)))
+      if (failed(UpdateDeclareTileOpMemInfo(declareOp))) {
         return WalkResult::interrupt();
+      }
     }
     else if (auto declareGlobalOp = dyn_cast<pto::DeclareGlobalOp>(op)) {
       if (failed(UpdateDeclareGlobalOpMemInfo(declareGlobalOp))) {
@@ -349,8 +380,9 @@ void PTOIRTranslator::RecursionIR(Region *region) {
       UpdateAliasBufferInfo(ptrToIntOp.getResult(), ptrToIntOp.getPtr());
     }
     else if (auto intToPtrOp = dyn_cast<pto::IntToPtrOp>(op)) {
-      if (failed(UpdateIntToPtrOpMemInfo(intToPtrOp)))
+      if (failed(UpdateIntToPtrOpMemInfo(intToPtrOp))) {
         return WalkResult::interrupt();
+      }
     }
     else if (auto castPtrOp = dyn_cast<pto::CastPtrOp>(op)) {
       if (isa<pto::PtrType>(castPtrOp.getInput().getType()) &&
@@ -421,15 +453,17 @@ LogicalResult PTOIRTranslator::UpdateAllocTileOpMemInfo(pto::AllocTileOp op) {
   // If alloc_tile carries an explicit address, record it when it's a constant.
   if (Value addr = op.getAddr()) {
     knownPhysicalAddress = getKnownPhysicalAddress(addr);
-    if (knownPhysicalAddress)
+    if (knownPhysicalAddress) {
       baseAddr = *knownPhysicalAddress;
+    }
   }
 
   // 1. 计算大小
   if (tileType) {
     sizeInBytes = getTileBufferFootprintBytes(tileType);
-    if (sizeInBytes == 0)
+    if (sizeInBytes == 0) {
       return failure();
+    }
   }
 
   // 2. 解析地址空间
@@ -461,27 +495,32 @@ PTOIRTranslator::UpdateAllocMultiTileOpMemInfo(pto::AllocMultiTileOp op) {
   pto::TileBufType slotType = multiType.getSlotType();
 
   uint64_t slotBytes = getTileBufferFootprintBytes(slotType);
-  if (slotBytes == 0)
+  if (slotBytes == 0) {
     return failure();
+  }
 
   pto::AddressSpace space = pto::AddressSpace::MAT;
   if (auto attr = dyn_cast_or_null<pto::AddressSpaceAttr>(
-          slotType.getMemorySpace()))
+          slotType.getMemorySpace())) {
     space = attr.getAddressSpace();
+  }
 
   SmallVector<uint64_t> addresses;
   bool hasKnownAddresses = false;
   if (auto planned = op->getAttrOfType<DenseI64ArrayAttr>(
           pto::kPtoMultiBufferAddrsAttrName)) {
-    if (planned.size() != multiType.getCount())
+    if (planned.size() != multiType.getCount()) {
       return op.emitError("planned address count does not match slot count");
-    for (int64_t address : planned.asArrayRef())
+    }
+    for (int64_t address : planned.asArrayRef()) {
       addresses.push_back(static_cast<uint64_t>(address));
+    }
     hasKnownAddresses = true;
   } else if (Value base = op.getAddr()) {
     if (std::optional<uint64_t> knownBase = getKnownPhysicalAddress(base)) {
-      for (uint32_t slot = 0; slot < multiType.getCount(); ++slot)
+      for (uint32_t slot = 0; slot < multiType.getCount(); ++slot) {
         addresses.push_back(*knownBase + slot * slotBytes);
+      }
       hasKnownAddresses = true;
     }
   }
@@ -502,17 +541,20 @@ LogicalResult
 PTOIRTranslator::UpdateDeclareTileOpMemInfo(pto::DeclareTileOp op) {
   Value result = op.getTile();
   auto tileType = dyn_cast<pto::TileBufType>(result.getType());
-  if (!tileType)
+  if (!tileType) {
     return op.emitError("requires a tile_buf result for sync analysis");
+  }
 
   uint64_t sizeInBytes = getTileBufferFootprintBytes(tileType);
-  if (sizeInBytes == 0)
+  if (sizeInBytes == 0) {
     return failure();
+  }
 
   pto::AddressSpace space = pto::AddressSpace::MAT;
   if (auto attr = dyn_cast_or_null<pto::AddressSpaceAttr>(
-          tileType.getMemorySpace()))
+          tileType.getMemorySpace())) {
     space = attr.getAddressSpace();
+  }
 
   auto info = std::make_unique<BaseMemInfo>(
       result, result, space, SmallVector<uint64_t>{0}, sizeInBytes);
@@ -524,8 +566,9 @@ LogicalResult
 PTOIRTranslator::UpdateDeclareGlobalOpMemInfo(pto::DeclareGlobalOp op) {
   Value res = op.getEntry();
   auto tensorViewType = dyn_cast<pto::TensorViewType>(res.getType());
-  if (!tensorViewType)
+  if (!tensorViewType) {
     return failure();
+  }
 
   uint64_t sizeInBytes = 0;
   ArrayRef<int64_t> shape = tensorViewType.getShape();
@@ -535,11 +578,13 @@ PTOIRTranslator::UpdateDeclareGlobalOpMemInfo(pto::DeclareGlobalOp op) {
   if (isStatic) {
     int64_t elemSize = static_cast<int64_t>(
         pto::getPTOStorageElemByteSize(tensorViewType.getElementType()));
-    if (elemSize == 0)
+    if (elemSize == 0) {
       return failure();
+    }
     int64_t numElements = 1;
-    for (int64_t dim : shape)
+    for (int64_t dim : shape) {
       numElements *= dim;
+    }
     sizeInBytes = static_cast<uint64_t>(numElements * elemSize);
   }
 
@@ -570,7 +615,9 @@ void PTOIRTranslator::UpdatePTOOpInfoWithPipeline(Operation *op,
                                                   pto::PipelineType pipe,
                                                   bool skipIfNoMemInfo) {
   // 如果 Op 不属于任何关心的流水线，直接跳过，不建立 Sync 节点
-  if (pipe == pto::PipelineType::PIPE_UNASSIGNED) return;
+  if (pipe == pto::PipelineType::PIPE_UNASSIGNED) {
+    return;
+  }
 
   SmallVector<const BaseMemInfo *> defVec;
   SmallVector<const BaseMemInfo *> useVec;
@@ -580,7 +627,9 @@ void PTOIRTranslator::UpdatePTOOpInfoWithPipeline(Operation *op,
     memEffect.getEffects(effects);
     for (auto &effect : effects) {
       Value val = effect.getValue();
-      if (!val) continue;
+      if (!val) {
+        continue;
+      }
 
        // 只有当 Value 在我们的 BufferMap 中有记录时，才视为有效依赖
        // (过滤掉比如 Loop Iterator 或其他标量)
@@ -597,8 +646,9 @@ void PTOIRTranslator::UpdatePTOOpInfoWithPipeline(Operation *op,
                             << " has Pipe but no MemoryEffects interface.\n");
   }
 
-  if (skipIfNoMemInfo && defVec.empty() && useVec.empty())
+  if (skipIfNoMemInfo && defVec.empty() && useVec.empty()) {
     return;
+  }
 
   // 3. 构建 Compound Node
   auto compoundElement = std::make_unique<CompoundInstanceElement>(
@@ -640,8 +690,9 @@ void PTOIRTranslator::MakeMacroCompound(Operation *op, PipelineType pipe,
 
 void PTOIRTranslator::UpdateMacroOpInfo(Operation *op) {
   auto model = getSyncMacroModel(op);
-  if (!model)
+  if (!model) {
     return;
+  }
   for (const auto &phase : model->phases) {
     MakeMacroCompound(op, phase.pipe, ValueRange(phase.defValues),
                       ValueRange(phase.useValues), phase.phaseId);
@@ -650,34 +701,41 @@ void PTOIRTranslator::UpdateMacroOpInfo(Operation *op) {
 
 void PTOIRTranslator::UpdateHelperCallInfo(func::CallOp callOp) {
   func::FuncOp callee = lookupSyncHelper(callOp);
-  if (!callee)
+  if (!callee) {
     return;
+  }
 
   std::optional<pto::PipelineType> pipe = getSyncHelperPipe(callee);
-  if (!pipe || *pipe == pto::PipelineType::PIPE_UNASSIGNED)
+  if (!pipe || *pipe == pto::PipelineType::PIPE_UNASSIGNED) {
     return;
+  }
 
   SmallVector<const BaseMemInfo *> defVec;
   SmallVector<const BaseMemInfo *> useVec;
   auto effects = callee->getAttrOfType<ArrayAttr>(kTileOpEffectsAttr);
   bool hasPreciseEffects = effects && effects.size() == callOp.getNumOperands();
   for (auto [operandIndex, operand] : llvm::enumerate(callOp.getOperands())) {
-    if (!isSyncHelperMemoryOperand(operand.getType()))
+    if (!isSyncHelperMemoryOperand(operand.getType())) {
       continue;
+    }
 
     StringRef effect = "readwrite";
     if (hasPreciseEffects) {
-      if (auto effectAttr = dyn_cast<StringAttr>(effects[operandIndex]))
+      if (auto effectAttr = dyn_cast<StringAttr>(effects[operandIndex])) {
         effect = effectAttr.getValue();
+      }
     }
-    if (effect == "read" || effect == "readwrite")
+    if (effect == "read" || effect == "readwrite") {
       UpdateDefUseVec({operand}, useVec);
-    if (effect == "write" || effect == "readwrite")
+    }
+    if (effect == "write" || effect == "readwrite") {
       UpdateDefUseVec({operand}, defVec);
+    }
   }
 
-  if (defVec.empty() && useVec.empty())
+  if (defVec.empty() && useVec.empty()) {
     return;
+  }
 
   auto compoundElement = std::make_unique<CompoundInstanceElement>(
       index, defVec, useVec, *pipe, callOp->getName());
@@ -824,7 +882,9 @@ void PTOIRTranslator::UpdateIfOpInfo(scf::IfOp ifOp) {
 
 void PTOIRTranslator::UpdateYieldOpInfo(scf::YieldOp yieldOp) {
   auto *parentOp = yieldOp->getParentOp();
-  if (!parentOp || isa<scf::WhileOp>(parentOp)) return;
+  if (!parentOp || isa<scf::WhileOp>(parentOp)) {
+    return;
+  }
 
   assert(parentOp->getResults().size() == yieldOp->getOpOperands().size());
   for (auto [yieldVal, resultVal] : llvm::zip(yieldOp->getOpOperands(), parentOp->getResults())) {
@@ -836,12 +896,17 @@ void PTOIRTranslator::UpdateYieldOpInfo(scf::YieldOp yieldOp) {
 // 8. 辅助函数
 // ============================================================================
 void PTOIRTranslator::UpdateAliasBufferInfo(Value result, Value source) {
-  if (!result || !source) return;
-  if (!buffer2MemInfoMap_.contains(source)) return;
+  if (!result || !source) {
+    return;
+  }
+  if (!buffer2MemInfoMap_.contains(source)) {
+    return;
+  }
 
   auto &resultMemInfoVec = buffer2MemInfoMap_[result];
-  for (auto &parentInfo : buffer2MemInfoMap_[source])
+  for (auto &parentInfo : buffer2MemInfoMap_[source]) {
     appendUniqueMemInfo(resultMemInfoVec, parentInfo->clone(result));
+  }
 }
 
 void PTOIRTranslator::UpdateConservativeAliasBufferInfo(Value result,
@@ -851,8 +916,9 @@ void PTOIRTranslator::UpdateConservativeAliasBufferInfo(Value result,
 
 LogicalResult PTOIRTranslator::UpdateIntToPtrOpMemInfo(pto::IntToPtrOp op) {
   Value result = op.getResult();
-  if (!result)
+  if (!result) {
     return failure();
+  }
 
   // Preserve provenance across the explicit byte-address round trip:
   //   %addr = pto.ptrtoint %ptr
@@ -862,8 +928,9 @@ LogicalResult PTOIRTranslator::UpdateIntToPtrOpMemInfo(pto::IntToPtrOp op) {
   // chain as tile stores/loads through the original pointer.
   if (auto ptrToInt = op.getAddr().getDefiningOp<pto::PtrToIntOp>()) {
     UpdateConservativeAliasBufferInfo(result, ptrToInt.getPtr());
-    if (buffer2MemInfoMap_.contains(result))
+    if (buffer2MemInfoMap_.contains(result)) {
       return success();
+    }
   }
 
   // A raw integer address may still point at any object in its address space.
@@ -887,10 +954,12 @@ void PTOIRTranslator::UpdateMultiTileGetAliasBufferInfo(
 void PTOIRTranslator::UpdateSlotSelectedAliasBufferInfo(Value result,
                                                         Value source,
                                                         Value slot) {
-  if (!result || !source)
+  if (!result || !source) {
     return;
-  if (!buffer2MemInfoMap_.contains(source))
+  }
+  if (!buffer2MemInfoMap_.contains(source)) {
     return;
+  }
 
   IntegerAttr constAttr;
   bool isConstSlot = matchPattern(slot, m_Constant(&constAttr));
@@ -920,8 +989,12 @@ void PTOIRTranslator::UpdateSlotSelectedAliasBufferInfo(Value result,
 void PTOIRTranslator::UpdateTileSubViewAliasBufferInfo(pto::SubViewOp op) {
   Value result = op.getResult();
   Value source = op.getSource();
-  if (!result || !source) return;
-  if (!buffer2MemInfoMap_.contains(source)) return;
+  if (!result || !source) {
+    return;
+  }
+  if (!buffer2MemInfoMap_.contains(source)) {
+    return;
+  }
 
   auto sourceType = dyn_cast<pto::TileBufType>(source.getType());
   if (!sourceType) {
@@ -962,8 +1035,9 @@ void PTOIRTranslator::UpdateTileSubViewAliasBufferInfo(pto::SubViewOp op) {
     SmallVector<uint64_t> addresses;
     addresses.reserve(subViewAddresses->size());
     uint64_t parentBase = parentInfo->baseAddresses[0];
-    for (uint64_t offset : *subViewAddresses)
+    for (uint64_t offset : *subViewAddresses) {
       addresses.push_back(parentBase + offset);
+    }
     newInfo->baseAddresses = std::move(addresses);
     newInfo->allocateSize = segmentSize;
     resultMemInfoVec.emplace_back(std::move(newInfo));
@@ -1003,13 +1077,20 @@ void PTOIRTranslator::printMemInfoList(llvm::raw_ostream &os,
   os << "[";
   bool first = true;
   for (const auto *info : list) {
-    if (!first) os << ", ";
+    if (!first) {
+      os << ", ";
+    }
     info->rootBuffer.printAsOperand(os, state);
     // [Fix] 打印 MAT 或 VEC 或 GM
-    if (info->scope == pto::AddressSpace::GM) os << "(GM)";
-    else if (info->scope == pto::AddressSpace::MAT) os << "(MAT)";
-    else if (info->scope == pto::AddressSpace::VEC) os << "(VEC)";
-    else os << "(Other)"; // 处理 LEFT/RIGHT/ACC 等其他情况
+    if (info->scope == pto::AddressSpace::GM) {
+      os << "(GM)";
+    } else if (info->scope == pto::AddressSpace::MAT) {
+      os << "(MAT)";
+    } else if (info->scope == pto::AddressSpace::VEC) {
+      os << "(VEC)";
+    } else {
+      os << "(Other)"; // 处理 LEFT/RIGHT/ACC 等其他情况
+    }
     first = false;
   }
   os << "]";

--- a/lib/PTO/Transforms/InsertSync/PTOInsertSync.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOInsertSync.cpp
@@ -62,13 +62,13 @@ static bool hasGatherScatterLikeOps(func::FuncOp func) {
 struct PTOInsertSyncPass : public mlir::pto::impl::PTOInsertSyncBase<PTOInsertSyncPass> {
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-
     // Backend-partitioned PTODSL containers carry private func declarations
     // in the outer child module to model cross-child calls. Those declaration
     // funcs have a function type but no entry block arguments, so the
     // translator's argument walk must not run on them.
-    if (func.isDeclaration())
+    if (func.isDeclaration()) {
       return;
+    }
 
     // If the function already contains explicit synchronization ops (either
     // low-level pipe flags or the higher-level record/wait events), do not run
@@ -100,7 +100,9 @@ struct PTOInsertSyncPass : public mlir::pto::impl::PTOInsertSyncBase<PTOInsertSy
     translator.Build();
 
     // 如果 IR 太简单，直接跳过
-    if (syncIR.size() <= 1) return;
+    if (syncIR.size() <= 1) {
+      return;
+    }
 
     dumpInsertSyncPhase("After Translator", syncIR, syncOpsStorage,
                         func.getOperation());

--- a/lib/PTO/Transforms/InsertSync/RemoveRedundantSync.cpp
+++ b/lib/PTO/Transforms/InsertSync/RemoveRedundantSync.cpp
@@ -11,10 +11,11 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-#include "PTO/Transforms/InsertSync/RemoveRedundantSync.h"
-#include "llvm/ADT/STLExtras.h"
 #include <algorithm>
 #include <vector>
+#include "PTO/Transforms/InsertSync/RemoveRedundantSync.h"
+#include "llvm/ADT/STLExtras.h"
+
 
 #define DEBUG_TYPE "pto-inject-sync"
 
@@ -49,7 +50,6 @@ void RemoveRedundantSync::Run() {
          auto *syncOp2 = syncPair2.first;
          bool hasLoop1 = syncOp1->GetForEndIndex().has_value();
          bool hasLoop2 = syncOp2->GetForEndIndex().has_value();
-
          if (hasLoop1 && hasLoop2) {
            if (syncOp1->GetForEndIndex().value() != syncOp2->GetForEndIndex().value()) {
              return syncOp1->GetForEndIndex().value() > syncOp2->GetForEndIndex().value();
@@ -187,7 +187,9 @@ bool RemoveRedundantSync::CheckBranchBetween(
   bool endIsInsideThenBranch =
       (!hasElseBranch && endId < branchElement->endId) ||
       (hasElseBranch && endId < branchElement->branchId);
-  if (endIsInsideThenBranch) return false;
+  if (endIsInsideThenBranch) {
+    return false;
+  }
 
   bool endIsInsideElseBranch = hasElseBranch &&
                                endId >= branchElement->branchId &&
@@ -201,7 +203,6 @@ bool RemoveRedundantSync::CheckBranchBetween(
   if (hasElseBranch) {
     bool coveredInThen = CheckRepeatSync(branchElement->beginId, branchElement->branchId, syncFinder, setFlag);
     bool coveredInElse = CheckRepeatSync(branchElement->branchId, branchElement->endId, syncFinder, setFlag);
-
     if (coveredInThen && coveredInElse) {
       return true;
     }
@@ -236,7 +237,9 @@ bool RemoveRedundantSync::CanMatchedSync(SmallVector<bool> &syncFinder,
   // whole-pipe pair -- which is strictly stronger -- but it may never PROVIDE
   // coverage for another pair. Letting it do so drops the guard on every access
   // that resolves to a different slot (issue #1118).
-  if (isSlotKeyedSync(relatedSync)) return false;
+  if (isSlotKeyedSync(relatedSync)) {
+    return false;
+  }
 
   bool isWait = (relatedSync->GetType() == SyncOperation::TYPE::WAIT_EVENT);
   bool isSet = (relatedSync->GetType() == SyncOperation::TYPE::SET_EVENT);
@@ -247,14 +250,26 @@ bool RemoveRedundantSync::CanMatchedSync(SmallVector<bool> &syncFinder,
       isSet |= (relatedSync->GetType() == SyncOperation::TYPE::SYNC_BLOCK_SET);
   }
 
-  if (!isWait && !isSet) return false;
-  if (relatedSync->GetSyncIndex() == setFlag->GetSyncIndex()) return false;
-  if (relatedSync->eventIdNum > setFlag->eventIdNum) return false;
-  if (relatedSync->isCompensation || setFlag->isCompensation) return false;
+  if (!isWait && !isSet) {
+    return false;
+  }
+  if (relatedSync->GetSyncIndex() == setFlag->GetSyncIndex()) {
+    return false;
+  }
+  if (relatedSync->eventIdNum > setFlag->eventIdNum) {
+    return false;
+  }
+  if (relatedSync->isCompensation || setFlag->isCompensation) {
+    return false;
+  }
 
   // Pipe 检查：内部同步必须也是解决同样的 Src -> Dst 依赖
-  if (relatedSync->GetSrcPipe() != setFlag->GetSrcPipe()) return false;
-  if (relatedSync->GetDstPipe() != setFlag->GetDstPipe()) return false;
+  if (relatedSync->GetSrcPipe() != setFlag->GetSrcPipe()) {
+    return false;
+  }
+  if (relatedSync->GetDstPipe() != setFlag->GetDstPipe()) {
+    return false;
+  }
 
   // 2. 状态机逻辑
   // 如果遇到了 Set，记录下来

--- a/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
@@ -13,6 +13,7 @@
 
 #include "PTO/Transforms/InsertSync/SyncCodegen.h"
 #include "PTO/IR/PTO.h"
+#include "PTO/IR/PTOMultiBuffer.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -45,16 +46,21 @@ static pto::EventAttr getEventAttr(Builder &builder, int id) {
 
 static bool IsSameSyncSignature(const SyncOperation *existing,
                                 const SyncOperation *candidate) {
-  if (existing->GetType() != candidate->GetType())
+  if (existing->GetType() != candidate->GetType()) {
     return false;
-  if (existing->GetActualSrcPipe() != candidate->GetActualSrcPipe())
+  }
+  if (existing->GetActualSrcPipe() != candidate->GetActualSrcPipe()) {
     return false;
-  if (existing->GetActualDstPipe() != candidate->GetActualDstPipe())
+  }
+  if (existing->GetActualDstPipe() != candidate->GetActualDstPipe()) {
     return false;
-  if (existing->IsAutoSyncTailBarrier() != candidate->IsAutoSyncTailBarrier())
+  }
+  if (existing->IsAutoSyncTailBarrier() != candidate->IsAutoSyncTailBarrier()) {
     return false;
-  if (candidate->isSyncSetType() || candidate->isSyncWaitType())
+  }
+  if (candidate->isSyncSetType() || candidate->isSyncWaitType()) {
     return existing->eventIds == candidate->eventIds;
+  }
   return true;
 }
 
@@ -62,16 +68,20 @@ static bool IsSyncExist(const SyncOps &list, SyncOperation *newSync) {
   // Tombstone entries are soft-deleted and should never participate in
   // deduplication; otherwise they can shadow a later live sync with
   // the same signature.
-  if (newSync->uselessSync)
+  if (newSync->uselessSync) {
     return true;
+  }
 
   for (auto *existing : list) {
-    if (existing == newSync)
+    if (existing == newSync) {
       return true;
-    if (existing->uselessSync)
+    }
+    if (existing->uselessSync) {
       continue;
-    if (!IsSameSyncSignature(existing, newSync))
+    }
+    if (!IsSameSyncSignature(existing, newSync)) {
       continue;
+    }
     return true;
   }
   return false;
@@ -79,8 +89,9 @@ static bool IsSyncExist(const SyncOps &list, SyncOperation *newSync) {
 
 static void MergeSyncList(SyncOps &dstList, const SyncOps &srcList) {
   for (auto *sync : srcList) {
-    if (sync->uselessSync)
+    if (sync->uselessSync) {
       continue;
+    }
     if (!IsSyncExist(dstList, sync)) {
       dstList.push_back(sync);
     }
@@ -88,8 +99,9 @@ static void MergeSyncList(SyncOps &dstList, const SyncOps &srcList) {
 }
 
 static Operation *resolveSyncInsertAnchor(Operation *op, SyncOperation *sync) {
-  if (!sync->isCompensation)
+  if (!sync->isCompensation) {
     return op;
+  }
 
   if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
     if (!ifOp.elseBlock()) {
@@ -102,8 +114,9 @@ static Operation *resolveSyncInsertAnchor(Operation *op, SyncOperation *sync) {
     return ifOp.getElseRegion().front().getTerminator();
   }
 
-  if (op->hasTrait<OpTrait::IsTerminator>())
+  if (op->hasTrait<OpTrait::IsTerminator>()) {
     return op;
+  }
   return op->getBlock()->getTerminator();
 }
 
@@ -125,14 +138,16 @@ static void setSyncInsertionPoint(IRRewriter &rewriter, Operation *op,
 static bool hasNeighborBarrier(Block *block, Block::iterator ip,
                                pto::PipeAttr pipeAttr, bool insertBefore) {
   if (insertBefore) {
-    if (ip == block->begin())
+    if (ip == block->begin()) {
       return false;
+    }
     auto prevBarrier = dyn_cast<pto::BarrierOp>(&*std::prev(ip));
     return prevBarrier && prevBarrier.getPipe() == pipeAttr;
   }
 
-  if (ip == block->end())
+  if (ip == block->end()) {
     return false;
+  }
   auto nextBarrier = dyn_cast<pto::BarrierOp>(&*ip);
   return nextBarrier && nextBarrier.getPipe() == pipeAttr;
 }
@@ -221,7 +236,9 @@ void SyncCodegen::updatePlaceHolderOpInsertSync(PlaceHolderInstanceElement *plac
   // 1. 处理 Virtual Else
   if (placeHolder->isVirtualElse) {
       auto ifOp = dyn_cast<scf::IfOp>(placeHolder->parentIfOp);
-      if (!ifOp) return;
+      if (!ifOp) {
+        return;
+      }
 
       // 如果还没有 else block，创建一个
       if (!ifOp.elseBlock()) {
@@ -256,7 +273,9 @@ void SyncCodegen::updatePlaceHolderOpInsertSync(PlaceHolderInstanceElement *plac
   }
 
   // 执行常规的 Sync 插入
-  if (!placeHolder->elementOp) return;
+  if (!placeHolder->elementOp) {
+    return;
+  }
   auto &pipeBuild = op2InsertSync[placeHolder->elementOp];
   MergeSyncList(pipeBuild.pipeBefore, placeHolder->pipeBefore);
   MergeSyncList(pipeBuild.pipeAfter, placeHolder->pipeAfter);
@@ -264,8 +283,9 @@ void SyncCodegen::updatePlaceHolderOpInsertSync(PlaceHolderInstanceElement *plac
 
 void SyncCodegen::SyncInsert(IRRewriter &rewriter, Operation *op,
                              SyncOperation *sync, bool beforeInsert) {
-  if (sync->uselessSync)
+  if (sync->uselessSync) {
     return;
+  }
 
   Operation *insertAnchorOp = resolveSyncInsertAnchor(op, sync);
   bool forceBefore = shouldInsertBefore(insertAnchorOp, beforeInsert, sync);
@@ -303,8 +323,9 @@ void SyncCodegen::CreateBarrierOp(IRRewriter &rewriter, Operation *op,
   Block *block = rewriter.getInsertionBlock();
   Block::iterator ip = rewriter.getInsertionPoint();
   auto currentPipeAttr = getPipeAttr(rewriter, sync->GetActualSrcPipe());
-  if (hasNeighborBarrier(block, ip, currentPipeAttr, insertAtPos))
+  if (hasNeighborBarrier(block, ip, currentPipeAttr, insertAtPos)) {
     return;
+  }
 
   auto barrier = rewriter.create<pto::BarrierOp>(op->getLoc(), currentPipeAttr);
 
@@ -312,13 +333,15 @@ void SyncCodegen::CreateBarrierOp(IRRewriter &rewriter, Operation *op,
 }
 
 void SyncCodegen::AppendAutoSyncTailBarrierIfNeeded(IRRewriter &rewriter) {
-  if (!pendingAutoSyncTailBarrier_)
+  if (!pendingAutoSyncTailBarrier_) {
     return;
+  }
 
   SmallVector<func::ReturnOp, kReturnOpInlineCapacity> returns;
   func_.walk([&](func::ReturnOp ret) { returns.push_back(ret); });
-  if (returns.empty())
+  if (returns.empty()) {
     return;
+  }
 
   auto pipeAllAttr = getPipeAttr(rewriter, PipelineType::PIPE_ALL);
   for (auto ret : returns) {
@@ -371,7 +394,8 @@ void SyncCodegen::CreateSetWaitOpForMultiBuffer(IRRewriter &rewriter,
   // allocated event ids so the hardware sees event id `eventIds[slot % N]`.
   // For the common N == 2 case this collapses to a single arith.select.
   uint32_t n = sync->slotCount;
-  assert(n >= 2 && "multi-buffer codegen requires slotCount >= 2");
+  assert(n >= mlir::pto::kPtoMultiBufferMinNum &&
+         "multi-buffer codegen requires slotCount >= 2");
   assert(sync->eventIds.size() == n &&
          "multi-buffer codegen expects N event ids");
 
@@ -411,7 +435,9 @@ Value SyncCodegen::GetBufferSelected(IRRewriter &rewriter, Operation *op,
   }
 
   auto parentLoop = op->getParentOfType<scf::ForOp>();
-  if (!parentLoop) return nullptr;
+  if (!parentLoop) {
+    return nullptr;
+  }
 
   Value counter;
   if (loop2BufferCounter.count(parentLoop)) {

--- a/lib/PTO/Transforms/InsertSync/SyncCommon.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCommon.cpp
@@ -11,17 +11,18 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-#include "PTO/Transforms/InsertSync/SyncCommon.h"
+#include <map>
+#include <memory>
+#include <utility>
 #include "PTO/IR/PTO.h"
+#include "PTO/Transforms/InsertSync/SyncCommon.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
-#include <memory>
-#include <utility>
-#include <map>
+
 
 #define DEBUG_TYPE "pto-inject-sync"
 
@@ -40,8 +41,9 @@ mlir::pto::canonicalizeSyncDepRoots(const SmallVector<Value> &roots) {
   SmallVector<const void *> result;
   result.reserve(roots.size());
   for (Value value : roots) {
-    if (!value)
+    if (!value) {
       continue;
+    }
     result.push_back(value.getAsOpaquePointer());
   }
   llvm::sort(result);
@@ -51,10 +53,12 @@ mlir::pto::canonicalizeSyncDepRoots(const SmallVector<Value> &roots) {
 
 bool mlir::pto::hasSameSyncDepRoots(const SyncOperation *lhs,
                                     const SyncOperation *rhs) {
-  if (!lhs || !rhs)
+  if (!lhs || !rhs) {
     return false;
-  if (lhs->depRootBuffers.empty() || rhs->depRootBuffers.empty())
+  }
+  if (lhs->depRootBuffers.empty() || rhs->depRootBuffers.empty()) {
     return false;
+  }
   return canonicalizeSyncDepRoots(lhs->depRootBuffers) ==
          canonicalizeSyncDepRoots(rhs->depRootBuffers);
 }

--- a/lib/PTO/Transforms/InsertSync/SyncEventIdAllocation.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncEventIdAllocation.cpp
@@ -11,10 +11,11 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-#include "PTO/Transforms/InsertSync/SyncEventIdAllocation.h"
-#include "PTO/Transforms/InsertSync/SyncCommon.h"
-#include "PTO/Transforms/InsertSync/SyncMacroModel.h"
 #include <algorithm>
+#include "PTO/Transforms/InsertSync/SyncCommon.h"
+#include "PTO/Transforms/InsertSync/SyncEventIdAllocation.h"
+#include "PTO/Transforms/InsertSync/SyncMacroModel.h"
+
 
 #define DEBUG_TYPE "pto-inject-sync"
 
@@ -90,7 +91,9 @@ void SyncEventIdAllocation::reserveBlockAllEventIds() {
       }
     }
     // ... check pipeAfter ...
-    if (blockSyncAllExists) break;
+    if (blockSyncAllExists) {
+      break;
+    }
   }
   if (blockSyncAllExists) {
     reservedBlockSyncEventIdNum = kReservedBlockSyncEventIdNum;
@@ -109,9 +112,15 @@ void SyncEventIdAllocation::SetBlockSyncAllEventID(SyncOperation *sync) {
 
 void SyncEventIdAllocation::AllocateEventId(InstanceElement *e) {
   for (auto &sync : e->pipeBefore) {
-    if (sync->uselessSync) continue;
-    if (!sync->eventIds.empty()) continue; // Already allocated
-    if (sync->isBarrierType()) continue;   // Barrier needs no ID
+    if (sync->uselessSync) {
+      continue;
+    }
+    if (!sync->eventIds.empty()) {
+      continue; // Already allocated
+    }
+    if (sync->isBarrierType()) {
+      continue; // Barrier needs no ID
+    }
 
     if (sync->GetType() == SyncOperation::TYPE::SYNC_BLOCK_ALL) {
       SetBlockSyncAllEventID(sync);
@@ -147,8 +156,9 @@ void SyncEventIdAllocation::SetEventId(SyncOperation *sync) {
   // unavailable. Historically this pass treated reserved IDs as being at the
   // end of the [0..kTotalEventIdNum) range.
   if (availableEventIdNum < poolSize) {
-    for (size_t id = availableEventIdNum; id < poolSize; ++id)
+    for (size_t id = availableEventIdNum; id < poolSize; ++id) {
       eventIdLifetimeAvailableStatus[id] = false;
+    }
   }
 
   size_t idSize = static_cast<size_t>(sync->eventIdNum);
@@ -175,7 +185,9 @@ SmallVector<int> SyncEventIdAllocation::UpdateBlockAvailableEventId(
   SmallVector<int> canAllocaEventId;
   size_t idSize = static_cast<size_t>(sync->eventIdNum);
   for (unsigned id = 0; id < eventIdNum; id++) {
-    if (canAllocaEventId.size() == idSize) break;
+    if (canAllocaEventId.size() == idSize) {
+      break;
+    }
     if (!canAllocaEventId.empty() && !eventIdLifetimeAvailableStatus[id]) {
       canAllocaEventId.clear();
       continue;
@@ -199,7 +211,9 @@ SmallVector<int> SyncEventIdAllocation::GetAvailableEventId(
 
   // Strategy 1: Prioritize idle IDs
   for (unsigned id = 0; id < eventIdNum; id++) {
-    if (canAllocaEventId.size() == idSize) break;
+    if (canAllocaEventId.size() == idSize) {
+      break;
+    }
     if (eventIdLifetimeAvailableStatus[id] && eventIdIdleStatus[id]) {
       eventIdLifetimeAvailableStatus[id] = false;
       canAllocaEventId.push_back(id);
@@ -208,7 +222,9 @@ SmallVector<int> SyncEventIdAllocation::GetAvailableEventId(
 
   // Strategy 2: Use any available
   for (unsigned id = 0; id < eventIdNum; id++) {
-    if (canAllocaEventId.size() == idSize) break;
+    if (canAllocaEventId.size() == idSize) {
+      break;
+    }
     if (eventIdLifetimeAvailableStatus[id]) {
       eventIdLifetimeAvailableStatus[id] = false;
       canAllocaEventId.push_back(id);
@@ -286,12 +302,15 @@ void SyncEventIdAllocation::FindUseEventID(unsigned int begin, unsigned int end,
   eventCyclePool.try_emplace(scopePair, EventCyclePool(eventIdSize));
   EventCyclePool &seqPool = eventCyclePool[scopePair];
   // The pool is keyed by scopePair and should have a stable size.
-  if (seqPool.slot.size() < eventIdSize)
+  if (seqPool.slot.size() < eventIdSize) {
     seqPool.slot.resize(eventIdSize);
+  }
 
   for (size_t i = 0; i < eventIdSize; i++) {
     auto &syncLifeCycle = seqPool.slot[i];
-    if (syncLifeCycle.empty()) continue;
+    if (syncLifeCycle.empty()) {
+      continue;
+    }
 
     if (CheckSyncLifeCycleConflict(syncLifeCycle, begin, end, eventId, i)) {
       continue;
@@ -438,8 +457,9 @@ void SyncEventIdAllocation::SetUseEventID(unsigned int begin, unsigned int end,
   eventCyclePool.try_emplace(scopePair, EventCyclePool(poolSize));
 
   EventCyclePool &seqPool = eventCyclePool[scopePair];
-  if (seqPool.slot.size() < poolSize)
+  if (seqPool.slot.size() < poolSize) {
     seqPool.slot.resize(poolSize);
+  }
   auto &syncLifeCycle = seqPool.slot[eventId];
   bool isInsert = false;
 
@@ -460,7 +480,9 @@ void SyncEventIdAllocation::SetUseEventID(unsigned int begin, unsigned int end,
       return;
     }
   }
-  if (!isInsert) llvm_unreachable("Can't insert this sync cycle!");
+  if (!isInsert) {
+    llvm_unreachable("Can't insert this sync cycle!");
+  }
 }
 
 void SyncEventIdAllocation::SeedHiddenMacroEventIds(
@@ -472,16 +494,21 @@ void SyncEventIdAllocation::SeedHiddenMacroEventIds(
   // for every kernel.
   for (size_t i = 0; i < syncIR_.size(); ++i) {
     auto *firstPhase = dyn_cast<CompoundInstanceElement>(syncIR_[i].get());
-    if (!firstPhase || firstPhase->macroOpInstanceId != 0) continue;
+    if (!firstPhase || firstPhase->macroOpInstanceId != 0) {
+      continue;
+    }
     Operation *op = firstPhase->elementOp;
     auto model = getSyncMacroModel(op);
-    if (!model || model->hiddenEvents.empty())
+    if (!model || model->hiddenEvents.empty()) {
       continue;
+    }
 
     unsigned end = firstPhase->GetIndex() + 1;
     for (size_t j = i + 1; j < syncIR_.size(); ++j) {
       auto *otherPhase = dyn_cast<CompoundInstanceElement>(syncIR_[j].get());
-      if (!otherPhase || otherPhase->elementOp != op) continue;
+      if (!otherPhase || otherPhase->elementOp != op) {
+        continue;
+      }
       end = otherPhase->GetIndex();
     }
     unsigned begin = firstPhase->GetIndex();
@@ -491,12 +518,15 @@ void SyncEventIdAllocation::SeedHiddenMacroEventIds(
     if (end + 1 < syncIR_.size()) {
       ++end;
     }
-    if (begin >= end) continue;
+    if (begin >= end) {
+      continue;
+    }
 
     for (const auto &hiddenEvent : model->hiddenEvents) {
       int scopePair = ScopePair(hiddenEvent.srcPipe, hiddenEvent.dstPipe);
-      if (scopeFilter && !scopeFilter->contains(scopePair))
+      if (scopeFilter && !scopeFilter->contains(scopePair)) {
         continue;
+      }
       for (unsigned eventId : hiddenEvent.eventIds) {
         SetUseEventID(begin, end, scopePair, eventId, kTotalEventIdNum);
       }
@@ -564,8 +594,12 @@ void SyncEventIdAllocation::clearAllocatedEventId() {
   }
   // Clear IDs
   for (auto &e : syncIR_) {
-    for (auto &sync : e->pipeBefore) ClearEventId(sync);
-    for (auto &sync : e->pipeAfter) ClearEventId(sync);
+    for (auto& sync : e->pipeBefore) {
+      ClearEventId(sync);
+    }
+    for (auto& sync : e->pipeAfter) {
+      ClearEventId(sync);
+    }
   }
 }
 
@@ -586,7 +620,9 @@ void SyncEventIdAllocation::ReallocatedEventId() {
 }
 
 void SyncEventIdAllocation::ClearEventId(const SyncOperation *sync) {
-  if (sync->isBarrierType()) return;
+  if (sync->isBarrierType()) {
+    return;
+  }
   auto &syncPair = syncOperations_[sync->GetSyncIndex()];
   SyncOperation *setSync = syncPair[0].get();
   SyncOperation *waitSync = syncPair[1].get();
@@ -644,8 +680,12 @@ void SyncEventIdAllocation::MoveOutBackwardMatchSync(
 
   // Conflict detection logic (simplified for PTO port)
   for (unsigned int i = 0; i <= syncIR_.size() - 1; i++) {
-    if (isConflictEventId) break;
-    if ((i > setSync->GetSyncIRIndex()) && (i < waitSync->GetSyncIRIndex())) continue;
+    if (isConflictEventId) {
+      break;
+    }
+    if ((i > setSync->GetSyncIRIndex()) && (i < waitSync->GetSyncIRIndex())) {
+      continue;
+    }
 
     for (auto &sync : syncIR_[i]->pipeBefore) {
       if (!sync->uselessSync &&
@@ -675,7 +715,9 @@ void SyncEventIdAllocation::IgnoreBackHeadAndTailSync() {
     }
     bool isPipeMTE1ToPipeMSync = sync->GetSrcPipe() == PipelineType::PIPE_M &&
                                  sync->GetDstPipe() == PipelineType::PIPE_MTE1;
-    if (!isPipeMTE1ToPipeMSync) continue;
+    if (!isPipeMTE1ToPipeMSync) {
+      continue;
+    }
 
     auto &syncPair = syncOperations_[sync->GetSyncIndex()];
     if (sync->eventIds.empty()) {
@@ -692,7 +734,9 @@ bool SyncEventIdAllocation::TryWidenByOtherSync(const SyncOperation *sync) {
   SyncOperation *waitSync = syncPair[1].get();
 
   SyncOperation *widenSync = FindWidenSync(setSync, waitSync);
-  if (widenSync == nullptr) return false;
+  if (widenSync == nullptr) {
+    return false;
+  }
 
   setSync->uselessSync = true;
   waitSync->uselessSync = true;
@@ -716,7 +760,9 @@ bool SyncEventIdAllocation::TryWidenByOtherSync(const SyncOperation *sync) {
       }
     }
     widenSetSyncIR->pipeAfter = newPipeAfter;
-    if (!removeSync) llvm_unreachable("in widen fun, remove sync failed");
+    if (!removeSync) {
+      llvm_unreachable("in widen fun, remove sync failed");
+    }
   }
   return true;
 }
@@ -737,8 +783,12 @@ SyncEventIdAllocation::FindWidenSync(const SyncOperation *setSync,
 
     // Stop at control flow boundaries logic...
     if (auto *loopInst = dyn_cast<LoopInstanceElement>(tmpIr)) {
-       if (loopInst->getLoopKind() == KindOfLoop::LOOP_BEGIN) break;
-       if (loopInst->getLoopKind() == KindOfLoop::LOOP_END) loopId = static_cast<int>(loopInst->beginId);
+      if (loopInst->getLoopKind() == KindOfLoop::LOOP_BEGIN) {
+        break;
+      }
+      if (loopInst->getLoopKind() == KindOfLoop::LOOP_END) {
+        loopId = static_cast<int>(loopInst->beginId);
+      }
     }
     // ... Branch checks ...
 
@@ -767,9 +817,7 @@ SyncEventIdAllocation::FindWidenSync(const SyncOperation *setSync,
         bool canForwardReuse =
             (setSync->GetSyncIRIndex() > setSame->GetSyncIRIndex() &&
              setSync->GetSyncIRIndex() <= waitSame->GetSyncIRIndex());
-
         // ... Backward reuse logic ...
-
         if (canForwardReuse /* || canBackwardReuse */) {
             return setSame; // Simplification: return first valid match
         }

--- a/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
@@ -7,6 +7,7 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 #include "PTO/Transforms/InsertSync/SyncMacroModel.h"
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "mlir/IR/Matchers.h"
 
@@ -15,11 +16,14 @@ using namespace mlir::pto;
 
 namespace {
 
+constexpr size_t kTensorRank = 2;
+
 SmallVector<unsigned> getSequentialEventIds(unsigned count) {
   SmallVector<unsigned> eventIds;
   eventIds.reserve(count);
-  for (unsigned eventId = 0; eventId < count; ++eventId)
+  for (unsigned eventId = 0; eventId < count; ++eventId) {
     eventIds.push_back(eventId);
+  }
   return eventIds;
 }
 
@@ -49,8 +53,9 @@ void addBidirectionalHiddenEvent(SyncMacroModel &model, PipelineType firstPipe,
 SmallVector<Value> getPingPongValues(Value ping, Value pong = {}) {
   SmallVector<Value> values;
   values.push_back(ping);
-  if (pong)
+  if (pong) {
     values.push_back(pong);
+  }
   return values;
 }
 
@@ -156,8 +161,9 @@ std::optional<SyncMacroModel> getCollectiveCommSyncMacroModel(Operation *op) {
 }
 
 std::optional<SyncMacroModel> getTScatterSyncMacroModel(pto::TScatterOp op) {
-  if (!op.hasIndexForm() || getTargetArch(op.getOperation()) == PTOArch::A5)
+  if (!op.hasIndexForm() || getTargetArch(op.getOperation()) == PTOArch::A5) {
     return std::nullopt;
+  }
 
   SyncMacroModel model;
   // A2/A3 indexed TSCATTER first initializes dst with vector_dup, then runs a
@@ -171,13 +177,15 @@ std::optional<SyncMacroModel> getTScatterSyncMacroModel(pto::TScatterOp op) {
 }
 
 std::optional<SyncMacroModel> getTGatherSyncMacroModel(pto::TGatherOp op) {
-  if (!op.hasCompareForm() || getTargetArch(op.getOperation()) == PTOArch::A5)
+  if (!op.hasCompareForm() || getTargetArch(op.getOperation()) == PTOArch::A5) {
     return std::nullopt;
+  }
 
   Value tmp = op.getTmp();
   Value cdst = op.getCdst();
-  if (!tmp || !cdst)
+  if (!tmp || !cdst) {
     return std::nullopt;
+  }
 
   SyncMacroModel model;
   // A2/A3 compare TGATHER lowers to TCMPS on PIPE_V, an index generation loop
@@ -199,8 +207,9 @@ static std::optional<pto::AddressSpace>
 getMGatherOperandAddressSpace(::mlir::Type ty) {
   if (auto tb = ::mlir::dyn_cast<::mlir::pto::TileBufType>(ty)) {
     if (auto as = ::mlir::dyn_cast_or_null<::mlir::pto::AddressSpaceAttr>(
-            tb.getMemorySpace()))
+            tb.getMemorySpace())) {
       return as.getAddressSpace();
+    }
     return std::nullopt;
   }
   return std::nullopt;
@@ -217,25 +226,29 @@ getMGatherOperandShapeFromType(::mlir::Type ty, bool useValidShape = true) {
 }
 
 static std::optional<int64_t> getConstantIndex(Value value) {
-  if (!value)
+  if (!value) {
     return std::nullopt;
+  }
 
   APInt intValue;
-  if (!matchPattern(value, m_ConstantInt(&intValue)))
+  if (!matchPattern(value, m_ConstantInt(&intValue))) {
     return std::nullopt;
+  }
   return intValue.getSExtValue();
 }
 
-static std::optional<SmallVector<Value, 2>> lookupMGatherValidDims(Value value) {
+static std::optional<SmallVector<Value, mlir::pto::kValue2>> lookupMGatherValidDims(Value value) {
   if (auto regionResult = dyn_cast<OpResult>(value)) {
     if (auto fusionRegion = dyn_cast<pto::FusionRegionOp>(regionResult.getOwner())) {
       auto yieldOp =
           dyn_cast<pto::YieldOp>(fusionRegion.getBody().front().getTerminator());
-      if (!yieldOp)
+      if (!yieldOp) {
         return std::nullopt;
+      }
       unsigned resultIndex = regionResult.getResultNumber();
-      if (resultIndex >= yieldOp.getNumOperands())
+      if (resultIndex >= yieldOp.getNumOperands()) {
         return std::nullopt;
+      }
       return lookupMGatherValidDims(yieldOp.getOperand(resultIndex));
     }
   }
@@ -246,24 +259,28 @@ static std::optional<SmallVector<Value, 2>> lookupMGatherValidDims(Value value) 
 static std::optional<SmallVector<int64_t>>
 getMGatherOperandShape(Value value, bool useValidShape = true) {
   auto shape = getMGatherOperandShapeFromType(value.getType(), useValidShape);
-  if (!shape || !useValidShape)
+  if (!shape || !useValidShape) {
     return shape;
+  }
 
   auto validDims = lookupMGatherValidDims(value);
-  if (!validDims || validDims->size() != 2)
+  if (!validDims || validDims->size() != kTensorRank) {
     return shape;
+  }
 
   if (shape->size() >= 1) {
-    if (auto validRow = getConstantIndex((*validDims)[0]))
+    if (auto validRow = getConstantIndex((*validDims)[0])) {
       (*shape)[0] = *validRow;
-    else if ((*validDims)[0])
+    } else if ((*validDims)[0]) {
       (*shape)[0] = ShapedType::kDynamic;
+    }
   }
-  if (shape->size() >= 2) {
-    if (auto validCol = getConstantIndex((*validDims)[1]))
+  if (shape->size() >= mlir::pto::kValue2) {
+    if (auto validCol = getConstantIndex((*validDims)[1])) {
       (*shape)[1] = *validCol;
-    else if ((*validDims)[1])
+    } else if ((*validDims)[1]) {
       (*shape)[1] = ShapedType::kDynamic;
+    }
   }
   return shape;
 }
@@ -273,7 +290,6 @@ getMGatherOperandShape(Value value, bool useValidShape = true) {
 // reachable lowering path as SyncMacroPhases so InsertSyncAnalysis can derive the
 // real cross-pipe sync (notably the MTE2->S wait for the scalar index read that
 // MGatherOp::getPipe() hides by reporting a single pipe).
-//
 // Also reserve pto-isa's fixed internal event ids through hiddenEvents so
 // compiler-generated sync around the macro does not reuse EVENT_ID0 on pipe
 // pairs already consumed inside the library implementation.
@@ -286,8 +302,9 @@ std::optional<SyncMacroModel> getMGatherSyncMacroModel(pto::MGatherOp op) {
   const bool isGm2L1 = dstSpace && *dstSpace == pto::AddressSpace::MAT;
 
   auto coalesceAttr = op.getCoalesceAttr();
-  if (!coalesceAttr)
+  if (!coalesceAttr) {
     return std::nullopt;
+  }
 
   const PTOArch arch = getTargetArch(op.getOperation());
   const pto::Coalesce coalesce = coalesceAttr.getValue();
@@ -299,8 +316,9 @@ std::optional<SyncMacroModel> getMGatherSyncMacroModel(pto::MGatherOp op) {
     // Elem additionally writes the GM scratch (owned by S in the template) before
     // the MTE2 bulk copy reads it, so model scratch as a S def / MTE2 use.
     SmallVector<Value> sDefs;
-    if (coalesce == pto::Coalesce::Elem && op.getScratch())
+    if (coalesce == pto::Coalesce::Elem && op.getScratch()) {
       sDefs.push_back(op.getScratch());
+    }
     addPhase(model, PipelineType::PIPE_S, ValueRange(sDefs),
              ValueRange{op.getIdx()});
     if (coalesce == pto::Coalesce::Elem && op.getScratch()) {
@@ -389,15 +407,20 @@ std::optional<SyncMacroModel> getMGatherSyncMacroModel(pto::MGatherOp op) {
 } // namespace
 
 std::optional<SyncMacroModel> mlir::pto::getSyncMacroModel(Operation *op) {
-  if (auto model = getP2PCommSyncMacroModel(op))
+  if (auto model = getP2PCommSyncMacroModel(op)) {
     return model;
-  if (auto model = getCollectiveCommSyncMacroModel(op))
+  }
+  if (auto model = getCollectiveCommSyncMacroModel(op)) {
     return model;
-  if (auto tscatter = dyn_cast<pto::TScatterOp>(op))
+  }
+  if (auto tscatter = dyn_cast<pto::TScatterOp>(op)) {
     return getTScatterSyncMacroModel(tscatter);
-  if (auto tgather = dyn_cast<pto::TGatherOp>(op))
+  }
+  if (auto tgather = dyn_cast<pto::TGatherOp>(op)) {
     return getTGatherSyncMacroModel(tgather);
-  if (auto mgather = dyn_cast<pto::MGatherOp>(op))
+  }
+  if (auto mgather = dyn_cast<pto::MGatherOp>(op)) {
     return getMGatherSyncMacroModel(mgather);
+  }
   return std::nullopt;
 }

--- a/lib/PTO/Transforms/InsertTemplateAttributes.cpp
+++ b/lib/PTO/Transforms/InsertTemplateAttributes.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/Passes.h"
@@ -85,40 +86,40 @@ static std::string getDtypeString(Type elementType) {
   if (isa<pto::F4E2M1x2Type>(elementType)) {
     return "f4e2m1x2";
   }
-  if (elementType.isUnsignedInteger(64)) {
+  if (elementType.isUnsignedInteger(mlir::pto::kValue64)) {
     return "ui64";
   }
-  if (elementType.isUnsignedInteger(32)) {
+  if (elementType.isUnsignedInteger(mlir::pto::kValue32)) {
     return "ui32";
   }
-  if (elementType.isUnsignedInteger(16)) {
+  if (elementType.isUnsignedInteger(mlir::pto::kValue16)) {
     return "ui16";
   }
-  if (elementType.isUnsignedInteger(8)) {
+  if (elementType.isUnsignedInteger(mlir::pto::kValue8)) {
     return "ui8";
   }
-  if (elementType.isSignedInteger(64)) {
+  if (elementType.isSignedInteger(mlir::pto::kValue64)) {
     return "si64";
   }
-  if (elementType.isSignedInteger(32)) {
+  if (elementType.isSignedInteger(mlir::pto::kValue32)) {
     return "si32";
   }
-  if (elementType.isSignedInteger(16)) {
+  if (elementType.isSignedInteger(mlir::pto::kValue16)) {
     return "si16";
   }
-  if (elementType.isSignedInteger(8)) {
+  if (elementType.isSignedInteger(mlir::pto::kValue8)) {
     return "si8";
   }
-  if (elementType.isSignlessInteger(64)) {
+  if (elementType.isSignlessInteger(mlir::pto::kValue64)) {
     return "i64";
   }
-  if (elementType.isSignlessInteger(32)) {
+  if (elementType.isSignlessInteger(mlir::pto::kValue32)) {
     return "i32";
   }
-  if (elementType.isSignlessInteger(16)) {
+  if (elementType.isSignlessInteger(mlir::pto::kValue16)) {
     return "i16";
   }
-  if (elementType.isSignlessInteger(8)) {
+  if (elementType.isSignlessInteger(mlir::pto::kValue8)) {
     return "i8";
   }
   return "";
@@ -535,14 +536,16 @@ static void appendOpContextAttrs(
     attrs.emplace_back("rounds", std::to_string(trandom.getRounds()));
   }
   if (auto tcmp = dyn_cast<pto::TCmpOp>(op)) {
-    if (auto cmpModeAttr = tcmp.getCmpModeAttr())
+    if (auto cmpModeAttr = tcmp.getCmpModeAttr()) {
       attrs.emplace_back("cmp_mode",
                          stringifyCmpMode(cmpModeAttr.getValue()).str());
+    }
   }
   if (auto tcmps = dyn_cast<pto::TCmpSOp>(op)) {
-    if (auto cmpModeAttr = tcmps.getCmpModeAttr())
+    if (auto cmpModeAttr = tcmps.getCmpModeAttr()) {
       attrs.emplace_back("cmp_mode",
                          stringifyCmpMode(cmpModeAttr.getValue()).str());
+    }
   }
   if (auto tinsert = dyn_cast<pto::TInsertOp>(op)) {
     if (auto modeAttr = tinsert.getAccToVecModeAttr()) {
@@ -552,9 +555,10 @@ static void appendOpContextAttrs(
     attrs.emplace_back("relu_pre_mode",
                        stringifyReluPreMode(tinsert.getReluPreMode()).str());
   }
-  if (auto tmrgsort = dyn_cast<pto::TMrgSortOp>(op))
+  if (auto tmrgsort = dyn_cast<pto::TMrgSortOp>(op)) {
     attrs.emplace_back("exhausted",
                        tmrgsort.getExhausted() ? "1" : "0");
+  }
   if (auto tgather = dyn_cast<pto::TGatherOp>(op)) {
     if (auto maskPatternAttr = tgather.getMaskPatternAttr()) {
       attrs.emplace_back(
@@ -597,7 +601,7 @@ static void appendOpContextAttrs(
 }
 
 static std::string buildContextAttrsJson(Operation *operation) {
-  SmallVector<std::pair<std::string, std::string>, 4> attrs;
+  SmallVector<std::pair<std::string, std::string>, mlir::pto::kValue4> attrs;
   appendOpContextAttrs(operation, attrs);
 
   std::string json = "{";

--- a/lib/PTO/Transforms/LowerPTOToUBufOps.cpp
+++ b/lib/PTO/Transforms/LowerPTOToUBufOps.cpp
@@ -14,6 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/Passes.h"
@@ -47,6 +48,7 @@ static constexpr int64_t kRepeatStrideMax = 255;
 static constexpr int64_t kSmallRptBinOp = 4;
 static constexpr int64_t kDefaultRepeatStride = 8;
 static constexpr unsigned kMaskLen = 64;
+static constexpr unsigned kHalfElementSizeBytes = 2;
 
 //===----------------------------------------------------------------------===//
 // Utilities
@@ -54,15 +56,15 @@ static constexpr unsigned kMaskLen = 64;
 
 static unsigned getElementSize(Type elemTy) {
   if (elemTy.isF16() || elemTy.isBF16()) {
-    return 2;
+    return kHalfElementSizeBytes;
   }
   if (elemTy.isF32()) {
-    return 4;
+    return mlir::pto::kValue4;
   }
   if (auto intTy = dyn_cast<IntegerType>(elemTy)) {
     unsigned width = intTy.getWidth();
-    if (width == 16 || width == 32) {
-      return width / 8;
+    if (width == mlir::pto::kValue16 || width == 32) {
+      return width / mlir::pto::kValue8;
     }
   }
   return 0;
@@ -146,8 +148,8 @@ struct TileShapeInfo {
 };
 
 struct TileShapeMetadata {
-  SmallVector<int64_t, 2> shape;
-  SmallVector<int64_t, 2> validShape;
+  SmallVector<int64_t, mlir::pto::kValue2> shape;
+  SmallVector<int64_t, mlir::pto::kValue2> validShape;
 };
 
 using TileShapeMap = DenseMap<Value, TileShapeMetadata>;
@@ -188,7 +190,7 @@ static std::optional<TileShapeInfo> extractTileShapeInfoFromValue(
     return std::nullopt;
   }
 
-  if (shape.size() < 2) {
+  if (shape.size() < mlir::pto::kValue2) {
     return std::nullopt;
   }
 
@@ -211,14 +213,14 @@ static std::optional<TileShapeInfo> extractTileShapeInfoFromValue(
   info.cols = cols;
   info.rows = rows;
   info.elemSize = elemSize;
-  info.elementsPerRepeat = 256 / elemSize;
-  info.blockSizeElem = 32 / elemSize;
+  info.elementsPerRepeat = mlir::pto::kValue256 / elemSize;
+  info.blockSizeElem = mlir::pto::kValue32 / elemSize;
   return info;
 }
 
 static std::optional<TileShapeInfo> extractTileShapeInfo(
     Operation *op, const TileShapeMap &tileShapes) {
-  return extractTileShapeInfoFromValue(op->getOperand(2), tileShapes);
+  return extractTileShapeInfoFromValue(op->getOperand(mlir::pto::kValue2), tileShapes);
 }
 
 static bool canLower(Operation *op, const TileShapeMap &tileShapes) {
@@ -1005,7 +1007,7 @@ private:
       Value asInt = builder.create<arith::BitcastOp>(loc, intTy, scalar);
       return builder.create<arith::ExtSIOp>(loc, builder.getI64Type(), asInt);
     }
-    if (scalar.getType().isInteger(64)) {
+    if (scalar.getType().isInteger(mlir::pto::kValue64)) {
       return scalar;
     }
     return builder.create<arith::ExtSIOp>(loc, builder.getI64Type(), scalar);
@@ -1056,7 +1058,7 @@ private:
     int64_t headRepeats = totalV / epr;
     int64_t tailElements = totalV % epr;
 
-    auto emitShift = [&](Value d, Value s) {
+    auto emitShift = [this, loc, &b, scalar](Value d, Value s) {
       Value scalarI64 = scalar;
       if (scalarI64.getType() != b.getI64Type()) {
         scalarI64 = b.create<arith::ExtSIOp>(
@@ -1119,7 +1121,7 @@ private:
       b.setInsertionPointAfter(forOp);
       return;
     }
-    auto emit = [&](Value rd, Value rs) {
+    auto emit = [this, loc, &b](Value rd, Value rs) {
       b.create<UBop>(loc, rd, rs,
                      i64c1(loc, b), i64c1(loc, b), i64c1(loc, b),
                      i64c8(loc, b), i64c8(loc, b));
@@ -1180,7 +1182,7 @@ private:
       b.setInsertionPointAfter(forOp);
       return;
     }
-    auto emit = [&](Value rd) {
+    auto emit = [this, loc, &b, scalar](Value rd) {
       Value scalarI64 = scalar;
       if (scalarI64.getType() != b.getI64Type()) {
         scalarI64 = b.create<arith::ExtSIOp>(loc, b.getI64Type(), scalar);
@@ -1390,7 +1392,7 @@ private:
       return failure();
     }
     ArrayRef<int64_t> shape = memTy.getShape();
-    if (shape.size() < 2) {
+    if (shape.size() < mlir::pto::kValue2) {
       return failure();
     }
     if (!hasUnitInnermostStride(view)) {
@@ -1485,13 +1487,13 @@ private:
   LogicalResult emitMteGmUb(Location loc, OpBuilder &b, Value gmPtr,
                              Value ubPtr, const DmaViewInfo &viewInfo,
                              Type elemTy, ArrayRef<int64_t> tileShape) {
-    if (tileShape.size() < 2) {
+    if (tileShape.size() < mlir::pto::kValue2) {
       return failure();
     }
     int64_t ubCols = tileShape[1];
     unsigned elemSize = getElementSize(elemTy);
     unsigned nd = viewInfo.sizes.size();
-    if (nd < 2) {
+    if (nd < mlir::pto::kValue2) {
       return failure();
     }
 
@@ -1535,13 +1537,13 @@ private:
   LogicalResult emitMteUbGm(Location loc, OpBuilder &b, Value ubPtr,
                              Value gmPtr, const DmaViewInfo &viewInfo,
                              Type elemTy, ArrayRef<int64_t> tileShape) {
-    if (tileShape.size() < 2) {
+    if (tileShape.size() < mlir::pto::kValue2) {
       return failure();
     }
     int64_t ubCols = tileShape[1];
     unsigned elemSize = getElementSize(elemTy);
     unsigned nd = viewInfo.sizes.size();
-    if (nd < 2) {
+    if (nd < mlir::pto::kValue2) {
       return failure();
     }
 

--- a/lib/PTO/Transforms/PTOA5NormalizeTMovPass.cpp
+++ b/lib/PTO/Transforms/PTOA5NormalizeTMovPass.cpp
@@ -45,24 +45,28 @@ static bool isA5RiskyVecVecColMajorTMov(pto::TMovOp op) {
     return false;
   auto srcTb = dyn_cast<pto::TileBufType>(op.getSrc().getType());
   auto dstTb = dyn_cast<pto::TileBufType>(op.getDst().getType());
-  if (!srcTb || !dstTb)
+  if (!srcTb || !dstTb) {
     return false;
-  if (!isVecTileType(srcTb) || !isVecTileType(dstTb))
+  }
+  if (!isVecTileType(srcTb) || !isVecTileType(dstTb)) {
     return false;
+  }
   return isColMajorNoneBox(srcTb) && isColMajorNoneBox(dstTb);
 }
 
 static std::optional<pto::AddressSpace> getAddressSpaceFromValueType(Type type) {
   if (auto tb = dyn_cast<pto::TileBufType>(type)) {
     if (auto as =
-            dyn_cast_or_null<pto::AddressSpaceAttr>(tb.getMemorySpace()))
+            dyn_cast_or_null<pto::AddressSpaceAttr>(tb.getMemorySpace())) {
       return as.getAddressSpace();
+    }
     return std::nullopt;
   }
   if (auto mr = dyn_cast<MemRefType>(type)) {
     if (auto ms = mr.getMemorySpace()) {
-      if (auto as = dyn_cast<pto::AddressSpaceAttr>(ms))
+      if (auto as = dyn_cast<pto::AddressSpaceAttr>(ms)) {
         return as.getAddressSpace();
+      }
     }
   }
   return std::nullopt;
@@ -80,8 +84,9 @@ static bool hasInterveningUsesOfDst(Operation *start, Operation *end,
   for (Operation *cursor = start->getNextNode(); cursor && cursor != end;
        cursor = cursor->getNextNode()) {
     for (Value operand : cursor->getOperands()) {
-      if (operand == dst)
+      if (operand == dst) {
         return true;
+      }
     }
   }
   return false;
@@ -91,10 +96,12 @@ static pto::TMovOp findMatchingScaleTileTMov(pto::TGetScaleAddrOp op) {
   Value dst = op.getDst();
   for (Operation *cursor = op->getPrevNode(); cursor; cursor = cursor->getPrevNode()) {
     auto mov = dyn_cast<pto::TMovOp>(cursor);
-    if (!mov || mov.getDst() != dst || !isA5ScaleTileTMov(mov))
+    if (!mov || mov.getDst() != dst || !isA5ScaleTileTMov(mov)) {
       continue;
-    if (hasInterveningUsesOfDst(mov, op, dst))
+    }
+    if (hasInterveningUsesOfDst(mov, op, dst)) {
       return {};
+    }
     return mov;
   }
   return {};
@@ -153,8 +160,9 @@ buildRowMajorReinterpretType(MLIRContext *ctx, pto::TileBufType srcType) {
   }
 
   auto cfg = srcType.getConfigAttr();
-  if (!cfg)
+  if (!cfg) {
     cfg = pto::TileBufConfigAttr::getDefault(ctx);
+  }
   auto newCfg = buildRowMajorConfig(ctx, cfg);
 
   return pto::TileBufType::get(ctx, swappedShape, srcType.getElementType(),
@@ -177,8 +185,9 @@ struct PTOA5NormalizeTMovPass
     : public mlir::pto::impl::PTOA5NormalizeTMovBase<PTOA5NormalizeTMovPass> {
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (!isTargetArchA5(func.getOperation()))
+    if (!isTargetArchA5(func.getOperation())) {
       return;
+    }
 
     SmallVector<pto::TGetScaleAddrOp, kRiskyOpReserveSize> scaleAddrOps;
     func.walk([&](pto::TGetScaleAddrOp op) { scaleAddrOps.push_back(op); });

--- a/lib/PTO/Transforms/PTOAnalyzeSIMTPersistentFragment.cpp
+++ b/lib/PTO/Transforms/PTOAnalyzeSIMTPersistentFragment.cpp
@@ -32,8 +32,9 @@ struct PTOAnalyzeSIMTPersistentFragmentPass
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal())
+    if (func.isExternal()) {
       return;
+    }
 
     const auto &analysis = getAnalysis<pto::SIMTPersistentFragmentAnalysis>();
     if (!analysis.isValid()) {

--- a/lib/PTO/Transforms/PTOCanonicalizeIR.cpp
+++ b/lib/PTO/Transforms/PTOCanonicalizeIR.cpp
@@ -69,8 +69,9 @@ static SmallVector<int64_t, kCanonicalRank5>
 rightAlignShapeToRank5(ArrayRef<int64_t> shape) {
   SmallVector<int64_t, kCanonicalRank5> result(kCanonicalRank5, kUnitExtent);
   unsigned shift = kCanonicalRank5 - shape.size();
-  for (auto [idx, dim] : llvm::enumerate(shape))
+  for (auto [idx, dim] : llvm::enumerate(shape)) {
     result[shift + idx] = dim;
+  }
   return result;
 }
 
@@ -83,8 +84,9 @@ static SmallVector<Value, kCanonicalRank5>
 rightAlignValuesToRank5(ValueRange values, Value fill) {
   SmallVector<Value, kCanonicalRank5> result(kCanonicalRank5, fill);
   unsigned shift = kCanonicalRank5 - values.size();
-  for (auto [idx, value] : llvm::enumerate(values))
+  for (auto [idx, value] : llvm::enumerate(values)) {
     result[shift + idx] = value;
+  }
   return result;
 }
 
@@ -92,26 +94,22 @@ rightAlignValuesToRank5(ValueRange values, Value fill) {
 // Stride expansion: uses the same cumulative-product rule as
 // rightAlignTo5D (InferPTOLayout.cpp) and buildGlobalTensorShapeAndStride
 // (PTOToEmitC.cpp): stride[i] = shape[i+1] * stride[i+1].
-//
 // For a rank-2 view [R, C] right-aligned into [1, 1, 1, R, C]:
 //   - ND (row-major): original strides = [C, 1]
 //     padded strides: stride[2] = shape[3]*stride[3] = R*C,
 //                    stride[1] = shape[2]*stride[2] = 1*R*C = R*C,
 //                    stride[0] = shape[1]*stride[1] = 1*R*C = R*C
 //     → [R*C, R*C, R*C, C, 1]
-//
 //   - DN (col-major): original strides = [1, R]
 //     padded strides: stride[2] = shape[3]*stride[3] = R*1 = R,
 //                    stride[1] = shape[2]*stride[2] = 1*R = R,
 //                    stride[0] = shape[1]*stride[1] = 1*R = R
 //     → [R, R, R, 1, R]
-//
 // Note: the ND branch was previously incorrectly using rowStride (=C) for
 // all three leading dims, producing [C, C, C, C, 1] instead of the correct
 // cumulative product [R*C, R*C, R*C, C, 1]. The DN branch was correct by
 // coincidence because colStride == R and the cumulative product of unit-extent
 // leading dims also collapses to R.
-//
 // For rank-1 [N], the same rule produces [N*S, N*S, N*S, N*S, S], where S is
 // the original stride.
 // ---------------------------------------------------------------------------
@@ -136,40 +134,46 @@ buildCanonicalStrides(MakeTensorViewOp op, IRRewriter &rewriter) {
 }
 
 static bool isLowRankViewLike(Type type) {
-  if (auto viewType = dyn_cast<TensorViewType>(type))
+  if (auto viewType = dyn_cast<TensorViewType>(type)) {
     return viewType.getRank() > 0 && viewType.getRank() < kCanonicalRank5;
-  if (auto viewType = dyn_cast<PartitionTensorViewType>(type))
+  }
+  if (auto viewType = dyn_cast<PartitionTensorViewType>(type)) {
     return viewType.getRank() > 0 && viewType.getRank() < kCanonicalRank5;
+  }
   return false;
 }
 
 static std::optional<unsigned> getLowRankViewRank(Type type) {
   if (auto viewType = dyn_cast<TensorViewType>(type)) {
     unsigned rank = viewType.getRank();
-    if (rank > 0 && rank < kCanonicalRank5)
+    if (rank > 0 && rank < kCanonicalRank5) {
       return rank;
+    }
   }
   if (auto viewType = dyn_cast<PartitionTensorViewType>(type)) {
     unsigned rank = viewType.getRank();
-    if (rank > 0 && rank < kCanonicalRank5)
+    if (rank > 0 && rank < kCanonicalRank5) {
       return rank;
+    }
   }
   return std::nullopt;
 }
 
 static Type canonicalViewType(Type type) {
   if (auto viewType = dyn_cast<TensorViewType>(type)) {
-    if (viewType.getRank() > 0 && viewType.getRank() < kCanonicalRank5)
+    if (viewType.getRank() > 0 && viewType.getRank() < kCanonicalRank5) {
       return TensorViewType::get(type.getContext(),
                                  rightAlignShapeToRank5(viewType.getShape()),
                                  viewType.getElementType());
+    }
     return type;
   }
   if (auto viewType = dyn_cast<PartitionTensorViewType>(type)) {
-    if (viewType.getRank() > 0 && viewType.getRank() < kCanonicalRank5)
+    if (viewType.getRank() > 0 && viewType.getRank() < kCanonicalRank5) {
       return PartitionTensorViewType::get(
           type.getContext(), rightAlignShapeToRank5(viewType.getShape()),
           viewType.getElementType());
+    }
     return type;
   }
   return type;
@@ -189,13 +193,15 @@ static LogicalResult rewriteMakeTensorView(MakeTensorViewOp op,
                                            IRRewriter &rewriter) {
   auto oldType = dyn_cast<TensorViewType>(op.getResult().getType());
   if (!oldType || oldType.getRank() == 0 ||
-      oldType.getRank() >= kCanonicalRank5)
+      oldType.getRank() >= kCanonicalRank5) {
     return success();
+  }
 
   unsigned rank = oldType.getRank();
-  if (op.getShape().size() != rank || op.getStrides().size() != rank)
+  if (op.getShape().size() != rank || op.getStrides().size() != rank) {
     return op.emitOpError(
         "low-rank tensor_view must have matching shape and stride operands");
+  }
 
   rewriter.setInsertionPoint(op);
   Value one = getOrCreateIndexConstant(rewriter, op.getLoc(), kUnitExtent);
@@ -216,18 +222,21 @@ static LogicalResult rewritePartitionView(PartitionViewOp op,
                                           IRRewriter &rewriter) {
   auto sourceType = dyn_cast<TensorViewType>(op.getSource().getType());
   auto resultType = dyn_cast<PartitionTensorViewType>(op.getResult().getType());
-  if (!sourceType || !resultType)
+  if (!sourceType || !resultType) {
     return success();
+  }
 
   unsigned operandRank = op.getOffsets().size();
   if (operandRank == 0 || operandRank >= kCanonicalRank5 ||
-      op.getSizes().size() != operandRank)
+      op.getSizes().size() != operandRank) {
     return success();
+  }
 
-  if (sourceType.getRank() != kCanonicalRank5)
+  if (sourceType.getRank() != kCanonicalRank5) {
     return op.emitOpError(
         "low-rank partition_tensor_view normalization expects canonical rank-5 "
         "source tensor_view");
+  }
 
   rewriter.setInsertionPoint(op);
   Value zero = getOrCreateIndexConstant(rewriter, op.getLoc(), 0);
@@ -290,13 +299,15 @@ static void canonicalizeValueTypes(func::FuncOp func) {
   func->walk([](Operation *op) {
     for (Region &region : op->getRegions()) {
       for (Block &block : region) {
-        for (BlockArgument arg : block.getArguments())
+        for (BlockArgument arg : block.getArguments()) {
           canonicalizeValueType(arg);
+        }
       }
     }
 
-    for (OpResult result : op->getResults())
+    for (OpResult result : op->getResults()) {
       canonicalizeValueType(result);
+    }
   });
 }
 
@@ -339,23 +350,27 @@ struct PTOCanonicalizeIRPass
     SmallVector<std::tuple<Operation *, Value, unsigned>> dimIndexOps;
 
     func.walk([&](MakeTensorViewOp op) {
-      if (isLowRankViewLike(op.getResult().getType()))
+      if (isLowRankViewLike(op.getResult().getType())) {
         makeViews.push_back(op);
+      }
     });
     func.walk([&](PartitionViewOp op) {
       unsigned rank = op.getOffsets().size();
-      if (rank > 0 && rank < kCanonicalRank5 && op.getSizes().size() == rank)
+      if (rank > 0 && rank < kCanonicalRank5 && op.getSizes().size() == rank) {
         partitionViews.push_back(op);
+      }
     });
     func.walk([&](GetTensorViewDimOp op) {
       if (std::optional<unsigned> rank =
-              getLowRankViewRank(op.getTensorView().getType()))
+              getLowRankViewRank(op.getTensorView().getType())) {
         dimIndexOps.emplace_back(op.getOperation(), op.getDimIndex(), *rank);
+      }
     });
     func.walk([&](GetTensorViewStrideOp op) {
       if (std::optional<unsigned> rank =
-              getLowRankViewRank(op.getTensorView().getType()))
+              getLowRankViewRank(op.getTensorView().getType())) {
         dimIndexOps.emplace_back(op.getOperation(), op.getDimIndex(), *rank);
+      }
     });
 
     IRRewriter rewriter(func.getContext());

--- a/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
+++ b/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
@@ -14,6 +14,8 @@
 
 #include "PTO/Transforms/Passes.h"
 
+#include "PTO/Support/CodeConstants.h"
+
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/IRMapping.h"
@@ -56,8 +58,8 @@ struct EscapingMovedValue {
 };
 
 struct ResultlessScopePlan {
-  SmallVector<Operation *, 16> hoistOps;
-  SmallVector<Operation *, 16> moveOps;
+  SmallVector<Operation *, mlir::pto::kValue16> hoistOps;
+  SmallVector<Operation *, mlir::pto::kValue16> moveOps;
 };
 
 struct LogicalScopePlan {
@@ -258,9 +260,9 @@ static bool anyUserIsMoved(Value result,
   return false;
 }
 
-static llvm::SmallPtrSet<Operation *, 16>
+static llvm::SmallPtrSet<Operation *, mlir::pto::kValue16>
 computeMovedOpsForResultlessScope(ArrayRef<Operation *> ops) {
-  llvm::SmallPtrSet<Operation *, 16> movedOps;
+  llvm::SmallPtrSet<Operation *, mlir::pto::kValue16> movedOps;
   for (Operation *op : ops) {
     if (classifyOperationForInference(op) == VPTOInferenceOpClass::Vector) {
       movedOps.insert(op);
@@ -273,8 +275,9 @@ computeMovedOpsForResultlessScope(ArrayRef<Operation *> ops) {
     for (Operation *op : llvm::reverse(ops)) {
       if (movedOps.contains(op) ||
           classifyOperationForInference(op) !=
-              VPTOInferenceOpClass::SafeScalar)
+              VPTOInferenceOpClass::SafeScalar) {
         continue;
+      }
 
       bool hasMovedUser = false;
       bool allUsersMoved = true;
@@ -402,7 +405,7 @@ static void collectGreedyLogicalScopePlans(
 static void assignLogicalScopeAnchorsForCluster(
     ArrayRef<Operation *> ops,
     llvm::DenseMap<Operation *, Operation *> &logicalScopeAnchors) {
-  SmallVector<LogicalScopePlan, 8> plans;
+  SmallVector<LogicalScopePlan, mlir::pto::kValue8> plans;
   collectGreedyLogicalScopePlans(ops, plans);
 
   llvm::DenseMap<Operation *, Operation *> scopeAnchorByMovedOp;
@@ -435,9 +438,9 @@ static void assignLogicalScopeAnchorsForCluster(
 static llvm::DenseMap<Operation *, Operation *>
 computeLogicalScopeAnchors(Block &block) {
   llvm::DenseMap<Operation *, Operation *> logicalScopeAnchors;
-  SmallVector<Operation *, 32> pending;
+  SmallVector<Operation *, mlir::pto::kValue32> pending;
 
-  auto flush = [&]() {
+  auto flush = [&logicalScopeAnchors, &pending]() {
     if (pending.empty()) {
       return;
     }
@@ -470,7 +473,7 @@ static LogicalResult rematerializeEscapingValueForUserSegments(
 
   llvm::DenseMap<Operation *, Operation *> logicalScopeAnchors =
       computeLogicalScopeAnchors(block);
-  llvm::DenseMap<Operation *, SmallVector<OpOperand *, 4>> usesBySegment;
+  llvm::DenseMap<Operation *, SmallVector<OpOperand *, mlir::pto::kValue4>> usesBySegment;
 
   for (OpOperand &use : result.getUses()) {
     Operation *user = use.getOwner();
@@ -585,7 +588,7 @@ buildResultlessScopePlan(ArrayRef<Operation *> ops, ResultlessScopePlan &plan,
     return failure();
   }
 
-  llvm::SmallPtrSet<Operation *, 16> movedOps =
+  llvm::SmallPtrSet<Operation *, mlir::pto::kValue16> movedOps =
       computeMovedOpsForResultlessScope(ops);
   if (movedOps.empty()) {
     return failure();
@@ -595,11 +598,12 @@ buildResultlessScopePlan(ArrayRef<Operation *> ops, ResultlessScopePlan &plan,
     return failure();
   }
 
-  llvm::SmallPtrSet<Operation *, 16> hoistedOps;
+  llvm::SmallPtrSet<Operation *, mlir::pto::kValue16> hoistedOps;
   for (Operation *op : ops) {
     if (movedOps.contains(op) ||
-        classifyOperationForInference(op) != VPTOInferenceOpClass::SafeScalar)
+        classifyOperationForInference(op) != VPTOInferenceOpClass::SafeScalar) {
       continue;
+    }
 
     for (Value result : op->getResults()) {
       if (anyUserIsMoved(result, movedOps)) {
@@ -615,8 +619,9 @@ buildResultlessScopePlan(ArrayRef<Operation *> ops, ResultlessScopePlan &plan,
     for (Operation *op : llvm::reverse(ops)) {
       if (movedOps.contains(op) || hoistedOps.contains(op) ||
           classifyOperationForInference(op) !=
-              VPTOInferenceOpClass::SafeScalar)
+              VPTOInferenceOpClass::SafeScalar) {
         continue;
+      }
 
       bool feedsHoistedOp = false;
       for (Value result : op->getResults()) {
@@ -712,8 +717,9 @@ static LogicalResult wrapGreedySubclusters(ArrayRef<Operation *> ops,
     if (bestEnd == begin) {
       if (classifyOperationForInference(ops[begin]) ==
               VPTOInferenceOpClass::Vector &&
-          sawEscapingMovedResult && escapingValue.requiresDiagnostic)
+          sawEscapingMovedResult && escapingValue.requiresDiagnostic) {
         return emitEscapingVectorScopeValueError(escapingValue);
+      }
       ++begin;
       continue;
     }
@@ -763,7 +769,7 @@ static FailureOr<bool> fixOneEscapingSubcluster(ArrayRef<Operation *> ops,
         ArrayRef<Operation *> escapingCandidate =
             ops.slice(escapingCandidateBegin,
                       escapingCandidateEnd - escapingCandidateBegin);
-        llvm::SmallPtrSet<Operation *, 16> movedOps =
+        llvm::SmallPtrSet<Operation *, mlir::pto::kValue16> movedOps =
             computeMovedOpsForResultlessScope(escapingCandidate);
         Block *block = ops.front()->getBlock();
         if (!block) {
@@ -771,8 +777,9 @@ static FailureOr<bool> fixOneEscapingSubcluster(ArrayRef<Operation *> ops,
         }
 
         if (succeeded(rematerializeEscapingValueForUserSegments(
-                escapingValue.value, movedOps, *block, cache, context)))
+                escapingValue.value, movedOps, *block, cache, context))) {
           return true;
+        }
         return false;
       }
       ++begin;
@@ -791,8 +798,8 @@ static LogicalResult repairEscapingSubclusters(Block &block,
   SegmentRematCache cache;
   for (unsigned iteration = 0; iteration < kMaxRepairIterations; ++iteration) {
     bool changedInIteration = false;
-    SmallVector<Operation *, 32> pending;
-    SmallVector<Operation *, 32> ops;
+    SmallVector<Operation *, mlir::pto::kValue32> pending;
+    SmallVector<Operation *, mlir::pto::kValue32> ops;
     for (Operation &op : block) {
       ops.push_back(&op);
     }
@@ -845,7 +852,7 @@ static LogicalResult inferVecScopesInBlock(Block &block, MLIRContext *context) {
     return failure();
   }
 
-  SmallVector<Operation *, 16> pending;
+  SmallVector<Operation *, mlir::pto::kValue16> pending;
 
   auto flush = [&]() -> LogicalResult {
     if (failed(wrapGreedySubclusters(pending, context))) {
@@ -855,7 +862,7 @@ static LogicalResult inferVecScopesInBlock(Block &block, MLIRContext *context) {
     return success();
   };
 
-  SmallVector<Operation *, 32> ops;
+  SmallVector<Operation *, mlir::pto::kValue32> ops;
   for (Operation &op : block) {
     ops.push_back(&op);
   }
@@ -877,7 +884,7 @@ static LogicalResult inferVecScopesInBlock(Block &block, MLIRContext *context) {
     return failure();
   }
 
-  SmallVector<Operation *, 32> remainingOps;
+  SmallVector<Operation *, mlir::pto::kValue32> remainingOps;
   for (Operation &op : block) {
     remainingOps.push_back(&op);
   }

--- a/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
+++ b/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
@@ -249,7 +249,7 @@ struct PTOInferValidatePipeInitPass
     llvm::DenseMap<Operation *, SmallVector<Operation *>> adjacency;
     std::map<PipePeerKey, SmallVector<Operation *>> keyedInits;
 
-    auto collectInit = [&](auto initOp) {
+    auto collectInit = [&adjacency, &initInfos, &keyedInits](auto initOp) {
       PipeInitInfo &info = initInfos.emplace_back();
       info.op = initOp.getOperation();
       info.funcOp = initOp->template getParentOfType<func::FuncOp>();
@@ -258,7 +258,8 @@ struct PTOInferValidatePipeInitPass
       info.explicitNoSplit = getNoSplitAttr(initOp);
       adjacency[info.op];
 
-      auto recordAddr = [&](Value addr, int8_t effectiveDirMask) {
+      auto recordAddr = [&info, &keyedInits](Value addr,
+                                              int8_t effectiveDirMask) {
         if (!addr) {
           return;
         }
@@ -270,7 +271,8 @@ struct PTOInferValidatePipeInitPass
         keyedInits[*key].push_back(info.op);
       };
 
-      auto recordGlobalTensor = [&](int8_t effectiveDirMask) {
+      auto recordGlobalTensor = [&info, &keyedInits](
+                                   int8_t effectiveDirMask) {
         keyedInits[getGlobalTensorPipeKey(info.op, effectiveDirMask)].push_back(
             info.op);
       };

--- a/lib/PTO/Transforms/PTOInjectBarrierAllSync.cpp
+++ b/lib/PTO/Transforms/PTOInjectBarrierAllSync.cpp
@@ -45,19 +45,22 @@ static bool isPipeAllBarrier(Operation *op) {
 
 static bool hasPreviousPipeAllBarrier(Operation *op) {
   Block *block = op->getBlock();
-  if (!block)
+  if (!block) {
     return false;
+  }
   auto it = op->getIterator();
-  if (it == block->begin())
+  if (it == block->begin()) {
     return false;
+  }
   return isPipeAllBarrier(&*std::prev(it));
 }
 
 static bool shouldInjectBarrierAllBefore(Operation *op) {
   Dialect *dialect = op->getDialect();
   if (!dialect ||
-      dialect->getNamespace() != pto::PTODialect::getDialectNamespace())
+      dialect->getNamespace() != pto::PTODialect::getDialectNamespace()) {
     return false;
+  }
 
   return isa<pto::OpPipeInterface>(op) && hasReadOrWriteMemoryEffect(op);
 }
@@ -74,8 +77,9 @@ struct PTOInjectBarrierAllSyncPass
     func.walk<WalkOrder::PreOrder>([&](Operation *op) {
       if (shouldInjectBarrierAllBefore(op)) {
         sawMemoryEffectingPipeOp = true;
-        if (hasPreviousPipeAllBarrier(op))
+        if (hasPreviousPipeAllBarrier(op)) {
           return WalkResult::advance();
+        }
         insertionPoints.push_back(op);
       }
       return WalkResult::advance();
@@ -83,8 +87,9 @@ struct PTOInjectBarrierAllSyncPass
 
     if (sawMemoryEffectingPipeOp) {
       func.walk([&](func::ReturnOp ret) {
-        if (!hasPreviousPipeAllBarrier(ret))
+        if (!hasPreviousPipeAllBarrier(ret)) {
           tailInsertionPoints.push_back(ret);
+        }
       });
     }
 

--- a/lib/PTO/Transforms/PTOInstantiateAndInlineOpLib.cpp
+++ b/lib/PTO/Transforms/PTOInstantiateAndInlineOpLib.cpp
@@ -69,8 +69,9 @@ static bool isInlineableLibFunc(func::FuncOp fn) {
   // Keep OP-Lib behavior unchanged while TileLang private template helpers are
   // still handled on the VPTO tile-op expansion path, together with
   // TileLang inline_proc helpers that only become meaningful after ExpandTileOp.
-  if (isInstanceFunc(fn) || isTilelangInlineProcFunc(fn) || isSoftLibFunc(fn))
+  if (isInstanceFunc(fn) || isTilelangInlineProcFunc(fn) || isSoftLibFunc(fn)) {
     return true;
+  }
   return isTilelangTemplateFunc(fn);
 }
 

--- a/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
+++ b/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
@@ -6,16 +6,17 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include <optional>
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Dominance.h"
-#include "mlir/Pass/Pass.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
 #include "llvm/ADT/DenseMap.h"
-#include <optional>
+
 
 namespace mlir {
 namespace pto {
@@ -56,8 +57,9 @@ using FrontendPipeHandleMap = llvm::DenseMap<int32_t, FrontendPipeHandles>;
 
 template <typename InitOpT>
 static LogicalResult requireFrontendGmSlotBuffer(InitOpT initOp) {
-  if (initOp.getGmSlotBuffer())
+  if (initOp.getGmSlotBuffer()) {
     return success();
+  }
   return initOp.emitOpError("requires 'gm_slot_buffer' when lowering to a2/a3");
 }
 
@@ -84,8 +86,8 @@ static void propagateFixpipePeerKeyAttrs(InitOpT initOp, Operation *pipeOp,
     return;
   }
 
-  auto setPeerKeyAttrs = [&](FlatSymbolRefAttr ownerFuncAttr,
-                             StringRef reserveName) {
+  auto setPeerKeyAttrs = [&rewriter, pipeOp](FlatSymbolRefAttr ownerFuncAttr,
+                                              StringRef reserveName) {
     pipeOp->setAttr(kPipePeerOwnerFuncAttrName, ownerFuncAttr);
     pipeOp->setAttr(kPipePeerReserveNameAttrName,
                     rewriter.getStringAttr(reserveName));
@@ -103,8 +105,9 @@ static void propagateFixpipePeerKeyAttrs(InitOpT initOp, Operation *pipeOp,
                           .template getDefiningOp<ImportReservedBufferOp>()) {
     auto peerFunc = lookupPeerFuncAcrossContainer(importOp.getOperation(),
                                                   importOp.getPeerFuncAttr());
-    if (!peerFunc)
+    if (!peerFunc) {
       return;
+    }
     setPeerKeyAttrs(FlatSymbolRefAttr::get(peerFunc), importOp.getName());
   }
 }
@@ -120,11 +123,13 @@ static int32_t getFrontendSlotNum(InitOpT initOp) {
 }
 
 static std::optional<int64_t> getStaticIndexLikeValue(Value value) {
-  if (auto cst = value.getDefiningOp<arith::ConstantIndexOp>())
+  if (auto cst = value.getDefiningOp<arith::ConstantIndexOp>()) {
     return cst.value();
+  }
   if (auto cst = value.getDefiningOp<arith::ConstantOp>()) {
-    if (auto intAttr = dyn_cast<IntegerAttr>(cst.getValue()))
+    if (auto intAttr = dyn_cast<IntegerAttr>(cst.getValue())) {
       return intAttr.getInt();
+    }
   }
   return std::nullopt;
 }
@@ -142,8 +147,9 @@ static SmallVector<int64_t> getStaticTensorViewStrides(Value tensor) {
 
   auto tvTy = dyn_cast<TensorViewType>(makeView.getResult().getType());
   if (!tvTy ||
-      makeView.getStrides().size() != static_cast<size_t>(tvTy.getRank()))
+      makeView.getStrides().size() != static_cast<size_t>(tvTy.getRank())) {
     return {};
+  }
 
   strides.reserve(makeView.getStrides().size());
   for (Value stride : makeView.getStrides()) {
@@ -213,9 +219,10 @@ static FailureOr<Value> createFrontendLocalPipe(InitOpT initOp,
   auto accPushEpilogueAttr = initOp.getAccPushEpilogueAttr();
 
   if (arch == PTOArch::A5) {
-    if (!localAddr)
+    if (!localAddr) {
       return initOp.emitOpError(
           "requires local consumer buffer operands when lowering to a5");
+    }
     auto pipe = rewriter.create<InitializeL2LPipeOp>(
         loc, pipeTy, dirAttr, slotSizeAttr, slotNumAttr, IntegerAttr{},
         noSplitAttr, accPushEpilogueAttr, localAddr, peerLocalAddr);
@@ -224,8 +231,9 @@ static FailureOr<Value> createFrontendLocalPipe(InitOpT initOp,
     return pipe.getPipe();
   }
 
-  if (failed(requireFrontendGmSlotBuffer(initOp)))
+  if (failed(requireFrontendGmSlotBuffer(initOp))) {
     return failure();
+  }
   if (!localAddr) {
     return initOp.emitOpError(
         "requires local consumer buffer operands for local FIFO pipe lowering");
@@ -256,8 +264,9 @@ lowerSingleDirectionFrontendInit(InitOpT initOp, IRRewriter &rewriter,
                                                      localAddr)
                     : createFrontendLocalPipe(initOp, rewriter, arch, pipeTy,
                                               dirMask, slotNum, localAddr);
-  if (failed(pipeOr))
+  if (failed(pipeOr)) {
     return failure();
+  }
 
   FrontendPipeHandles handles;
   SmallVector<int64_t> slotStrides =
@@ -287,8 +296,9 @@ lowerBidirectionalFrontendInit(InitOpT initOp, IRRewriter &rewriter,
                                               kBidirectionalDirMask, slotNum,
                                               initOp.getC2vConsumerBuf(),
                                               initOp.getV2cConsumerBuf());
-  if (failed(pipeOr))
+  if (failed(pipeOr)) {
     return failure();
+  }
 
   FrontendPipeHandles handles;
   handles.c2vPipe = *pipeOr;
@@ -354,8 +364,9 @@ static FailureOr<FrontendPipeHandles> lowerAndEraseFrontendInit(InitOpT initOp,
                                                                 IRRewriter &rewriter) {
   rewriter.setInsertionPoint(initOp);
   auto loweredOr = lowerFrontendInitOp(initOp, rewriter);
-  if (failed(loweredOr))
+  if (failed(loweredOr)) {
     return failure();
+  }
   propagateFrontendNoSplitAttr(initOp, *loweredOr);
   rewriter.eraseOp(initOp);
   return *loweredOr;
@@ -412,8 +423,9 @@ static FailureOr<FrontendPipeHandleMap> lowerInitIfPresent(func::FuncOp funcOp,
     if (auto init = dyn_cast<AicInitializePipeOp>(op)) {
       int32_t id = init.getId();
       auto loweredOr = lowerAndEraseFrontendInit(init, rewriter);
-      if (failed(loweredOr))
+      if (failed(loweredOr)) {
         return failure();
+      }
       handlesById.try_emplace(id, *loweredOr);
       continue;
     }
@@ -421,8 +433,9 @@ static FailureOr<FrontendPipeHandleMap> lowerInitIfPresent(func::FuncOp funcOp,
     auto init = cast<AivInitializePipeOp>(op);
     int32_t id = init.getId();
     auto loweredOr = lowerAndEraseFrontendInit(init, rewriter);
-    if (failed(loweredOr))
+    if (failed(loweredOr)) {
       return failure();
+    }
     handlesById.try_emplace(id, *loweredOr);
   }
 
@@ -450,8 +463,9 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
   SmallVector<Operation *> frontendOps;
   funcOp.walk([&](Operation *op) {
     if (isa<TAllocToAivOp, TAllocToAicOp, TPushToAivOp, TPushToAicOp,
-            TPopFromAicOp, TPopFromAivOp, TFreeFromAicOp, TFreeFromAivOp>(op))
+            TPopFromAicOp, TPopFromAivOp, TFreeFromAicOp, TFreeFromAivOp>(op)) {
       frontendOps.push_back(op);
+    }
   });
 
   auto lookupHandles = [&](Operation *op, int32_t id)
@@ -477,8 +491,9 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
 
     if (auto alloc = dyn_cast<TAllocToAivOp>(op)) {
       auto handlesOr = lookupHandles(op, alloc.getId());
-      if (failed(handlesOr))
+      if (failed(handlesOr)) {
         return failure();
+      }
       const FrontendPipeHandles &handles = **handlesOr;
       if (!handles.c2vPipe) {
         op->emitOpError() << "requires initialize_pipe(id = " << alloc.getId()
@@ -496,8 +511,9 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
 
     if (auto alloc = dyn_cast<TAllocToAicOp>(op)) {
       auto handlesOr = lookupHandles(op, alloc.getId());
-      if (failed(handlesOr))
+      if (failed(handlesOr)) {
         return failure();
+      }
       const FrontendPipeHandles &handles = **handlesOr;
       if (!handles.v2cPipe) {
         op->emitOpError() << "requires initialize_pipe(id = " << alloc.getId()
@@ -515,8 +531,9 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
 
     if (auto push = dyn_cast<TPushToAivOp>(op)) {
       auto handlesOr = lookupHandles(op, push.getId());
-      if (failed(handlesOr))
+      if (failed(handlesOr)) {
         return failure();
+      }
       const FrontendPipeHandles &handles = **handlesOr;
       if (!handles.c2vPipe) {
         op->emitOpError() << "requires initialize_pipe(id = " << push.getId()
@@ -530,8 +547,9 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
 
     if (auto push = dyn_cast<TPushToAicOp>(op)) {
       auto handlesOr = lookupHandles(op, push.getId());
-      if (failed(handlesOr))
+      if (failed(handlesOr)) {
         return failure();
+      }
       const FrontendPipeHandles &handles = **handlesOr;
       if (!handles.v2cPipe) {
         op->emitOpError() << "requires initialize_pipe(id = " << push.getId()
@@ -546,8 +564,9 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
 
     if (auto pop = dyn_cast<TPopFromAicOp>(op)) {
       auto handlesOr = lookupHandles(op, pop.getId());
-      if (failed(handlesOr))
+      if (failed(handlesOr)) {
         return failure();
+      }
       const FrontendPipeHandles &handles = **handlesOr;
       if (!handles.c2vPipe) {
         op->emitOpError() << "requires initialize_pipe(id = " << pop.getId()
@@ -577,8 +596,9 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
 
     if (auto pop = dyn_cast<TPopFromAivOp>(op)) {
       auto handlesOr = lookupHandles(op, pop.getId());
-      if (failed(handlesOr))
+      if (failed(handlesOr)) {
         return failure();
+      }
       const FrontendPipeHandles &handles = **handlesOr;
       if (!handles.v2cPipe) {
         op->emitOpError() << "requires initialize_pipe(id = " << pop.getId()
@@ -608,8 +628,9 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
 
     if (auto free = dyn_cast<TFreeFromAicOp>(op)) {
       auto handlesOr = lookupHandles(op, free.getId());
-      if (failed(handlesOr))
+      if (failed(handlesOr)) {
         return failure();
+      }
       const FrontendPipeHandles &handles = **handlesOr;
       if (!handles.c2vPipe) {
         op->emitOpError() << "requires initialize_pipe(id = " << free.getId()
@@ -624,8 +645,9 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
 
     auto free = cast<TFreeFromAivOp>(op);
     auto handlesOr = lookupHandles(op, free.getId());
-    if (failed(handlesOr))
+    if (failed(handlesOr)) {
       return failure();
+    }
     const FrontendPipeHandles &handles = **handlesOr;
     if (!handles.v2cPipe) {
       op->emitOpError() << "requires initialize_pipe(id = " << free.getId()
@@ -645,8 +667,9 @@ struct PTOLowerFrontendPipeOpsPass
           PTOLowerFrontendPipeOpsPass> {
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
-    if (!hasFrontendPipeOps(funcOp))
+    if (!hasFrontendPipeOps(funcOp)) {
       return;
+    }
 
     IRRewriter rewriter(funcOp.getContext());
     auto loweredOr = lowerInitIfPresent(funcOp, rewriter);
@@ -655,8 +678,9 @@ struct PTOLowerFrontendPipeOpsPass
       return;
     }
 
-    if (failed(lowerFrontendDataOps(funcOp, *loweredOr, rewriter)))
+    if (failed(lowerFrontendDataOps(funcOp, *loweredOr, rewriter))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/PTOMaterializeImplicitTmp.cpp
+++ b/lib/PTO/Transforms/PTOMaterializeImplicitTmp.cpp
@@ -8,6 +8,7 @@
 
 //===- PTOMaterializeImplicitTmp.cpp --------------------------------------===//
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/Passes.h"
 
 #include "PTO/IR/PTO.h"
@@ -25,23 +26,27 @@ using namespace mlir;
 
 namespace {
 
+constexpr int64_t kRowMajorNoneBoxSFractalSize = 512;
+
 static pto::TileBufConfigAttr makeRowMajorNoneBoxConfig(MLIRContext *ctx) {
   OpBuilder builder(ctx);
   return pto::TileBufConfigAttr::get(
       ctx, pto::BLayoutAttr::get(ctx, pto::BLayout::RowMajor),
       pto::SLayoutAttr::get(ctx, pto::SLayout::NoneBox),
-      builder.getI32IntegerAttr(512),
+      builder.getI32IntegerAttr(kRowMajorNoneBoxSFractalSize),
       pto::PadValueAttr::get(ctx, pto::PadValue::Null),
       pto::CompactModeAttr::get(ctx, pto::CompactMode::Null));
 }
 
 static unsigned getTCIDstBitWidth(pto::TCIOp op) {
   auto tileTy = dyn_cast<pto::TileBufType>(op.getDst().getType());
-  if (!tileTy)
+  if (!tileTy) {
     return 0;
+  }
   auto elemTy = dyn_cast<IntegerType>(tileTy.getElementType());
-  if (!elemTy)
+  if (!elemTy) {
     return 0;
+  }
   return elemTy.getWidth();
 }
 
@@ -57,22 +62,25 @@ static pto::TileBufType makeTCITmpType(MLIRContext *ctx, unsigned dstBitWidth) {
 
 static std::optional<int64_t> getElemBytes(Type elemTy) {
   unsigned bits = pto::getPTOStorageElemBitWidth(elemTy);
-  if (bits == 0 || bits % 8 != 0)
+  if (bits == 0 || bits % mlir::pto::kValue8 != 0) {
     return std::nullopt;
-  return bits / 8;
+  }
+  return bits / mlir::pto::kValue8;
 }
 
-static SmallVector<int64_t, 4> getValidShapeVec(Type ty) {
-  if (auto tileTy = dyn_cast<pto::TileBufType>(ty))
-    return SmallVector<int64_t, 4>(tileTy.getValidShape().begin(),
-                                  tileTy.getValidShape().end());
+static SmallVector<int64_t, mlir::pto::kValue4> getValidShapeVec(Type ty) {
+  if (auto tileTy = dyn_cast<pto::TileBufType>(ty)) {
+    return SmallVector<int64_t, mlir::pto::kValue4>(tileTy.getValidShape().begin(),
+                                   tileTy.getValidShape().end());
+  }
   return {};
 }
 
-static SmallVector<int64_t, 4> getShapeVec(Type ty) {
-  if (auto tileTy = dyn_cast<pto::TileBufType>(ty))
-    return SmallVector<int64_t, 4>(tileTy.getShape().begin(),
-                                  tileTy.getShape().end());
+static SmallVector<int64_t, mlir::pto::kValue4> getShapeVec(Type ty) {
+  if (auto tileTy = dyn_cast<pto::TileBufType>(ty)) {
+    return SmallVector<int64_t, mlir::pto::kValue4>(tileTy.getShape().begin(),
+                                   tileTy.getShape().end());
+  }
   return {};
 }
 
@@ -100,15 +108,18 @@ static FailureOr<pto::TileBufType> makeSameShapeTmpType(MLIRContext *ctx,
                                                         Value like,
                                                         Type elementType = {}) {
   auto likeTy = dyn_cast<pto::TileBufType>(like.getType());
-  if (!likeTy)
+  if (!likeTy) {
     return failure();
-  if (!elementType)
+  }
+  if (!elementType) {
     elementType = likeTy.getElementType();
+  }
   auto shape = getShapeVec(like.getType());
   auto validShape = getValidShapeVec(like.getType());
   if (shape.empty() || validShape.empty() || hasDynamicDim(shape) ||
-      hasDynamicDim(validShape))
+      hasDynamicDim(validShape)) {
     return failure();
+  }
   return makeVecTmpType(ctx, shape, elementType, validShape);
 }
 
@@ -121,8 +132,9 @@ static FailureOr<Value> createAllocTmp(OpBuilder &builder, Location loc,
 
 static void copyAttrsExceptOperandSegments(Operation *from, OperationState &to) {
   for (NamedAttribute attr : from->getAttrs()) {
-    if (attr.getName() == "operandSegmentSizes")
+    if (attr.getName() == "operandSegmentSizes") {
       continue;
+    }
     to.addAttribute(attr.getName(), attr.getValue());
   }
 }
@@ -144,11 +156,13 @@ static void rebuildWithOperands(Operation *op, ArrayRef<Value> operands,
 
 static bool validShapesCompatible(ArrayRef<int64_t> lhs,
                                   ArrayRef<int64_t> rhs) {
-  if (lhs.size() != rhs.size())
+  if (lhs.size() != rhs.size()) {
     return false;
+  }
   for (auto [l, r] : llvm::zip(lhs, rhs)) {
-    if (l != ShapedType::kDynamic && r != ShapedType::kDynamic && l != r)
+    if (l != ShapedType::kDynamic && r != ShapedType::kDynamic && l != r) {
       return false;
+    }
   }
   return true;
 }
@@ -176,8 +190,9 @@ static RowExpandMode classifyTRowExpandBinaryMode(Value src0, Value src1,
   auto dstValid = getValidShapeVec(dst.getType());
   auto src0Valid = getValidShapeVec(src0.getType());
   auto src1Valid = getValidShapeVec(src1.getType());
-  if (dstValid.size() != 2 || src0Valid.size() != 2 || src1Valid.size() != 2)
+  if (dstValid.size() != mlir::pto::kValue2 || src0Valid.size() != mlir::pto::kValue2 || src1Valid.size() != mlir::pto::kValue2) {
     return RowExpandMode::Unknown;
+  }
 
   Value expanded;
   ArrayRef<int64_t> expandedValid;
@@ -193,20 +208,24 @@ static RowExpandMode classifyTRowExpandBinaryMode(Value src0, Value src1,
 
   int64_t expandedCols = expandedValid[1];
   if (isColMajorTile(expanded) &&
-      (expandedCols == ShapedType::kDynamic || expandedCols == 1))
+      (expandedCols == ShapedType::kDynamic || expandedCols == 1)) {
     return RowExpandMode::Mode1ColMajorScalar;
+  }
 
   auto dstTileTy = dyn_cast<pto::TileBufType>(dst.getType());
-  if (!dstTileTy)
+  if (!dstTileTy) {
     return RowExpandMode::Unknown;
+  }
   auto elemBytes = getElemBytes(dstTileTy.getElementType());
-  if (!elemBytes || *elemBytes == 0)
+  if (!elemBytes || *elemBytes == 0) {
     return RowExpandMode::Unknown;
+  }
   int64_t expectedMode2Cols = 32 / *elemBytes;
   if (isRowMajorTile(expanded) &&
       (expandedCols == ShapedType::kDynamic ||
-       expandedCols == expectedMode2Cols))
+       expandedCols == expectedMode2Cols)) {
     return RowExpandMode::Mode2RowMajorBlock;
+  }
 
   return RowExpandMode::Unknown;
 }
@@ -225,13 +244,16 @@ static pto::TileBufType makeTRowExpandTmpType(MLIRContext *ctx,
 static FailureOr<pto::TileBufType> makeA5PlaceholderTmpType(
     MLIRContext *ctx, Value like, Type elementType = {}) {
   auto likeTy = dyn_cast<pto::TileBufType>(like.getType());
-  if (!likeTy)
+  if (!likeTy) {
     return failure();
-  if (!elementType)
+  }
+  if (!elementType) {
     elementType = likeTy.getElementType();
+  }
   auto elemBytes = getElemBytes(elementType);
-  if (!elemBytes || *elemBytes <= 0)
+  if (!elemBytes || *elemBytes <= 0) {
     return failure();
+  }
   int64_t cols = std::max<int64_t>(1, 32 / *elemBytes);
   return makeVecTmpType(ctx, {1, cols}, elementType, {1, cols});
 }
@@ -244,15 +266,18 @@ static void replaceTRowExpandBinaryOpWithTmp(Operation *op, Value src0,
 template <typename OpTy>
 static LogicalResult materializeTRowExpandTmp(OpTy op, bool requireExplicitTmp,
                                               MLIRContext *ctx) {
-  if (op.getTmp())
+  if (op.getTmp()) {
     return success();
-  if (pto::getTargetArch(op.getOperation()) == pto::PTOArch::A5)
+  }
+  if (pto::getTargetArch(op.getOperation()) == pto::PTOArch::A5) {
     return success();
+  }
 
   RowExpandMode mode =
       classifyTRowExpandBinaryMode(op.getSrc0(), op.getSrc1(), op.getDst());
-  if (mode != RowExpandMode::Mode1ColMajorScalar)
+  if (mode != RowExpandMode::Mode1ColMajorScalar) {
     return success();
+  }
 
   if (requireExplicitTmp) {
     // Row-expand is the one A2/A3 tmp-aware family whose no-tmp overload is
@@ -264,8 +289,9 @@ static LogicalResult materializeTRowExpandTmp(OpTy op, bool requireExplicitTmp,
   }
 
   auto dstTy = dyn_cast<pto::TileBufType>(op.getDst().getType());
-  if (!dstTy)
+  if (!dstTy) {
     return op.emitOpError("expects tile_buf dst when materializing implicit tmp");
+  }
 
   OpBuilder builder(op);
   Value tmp =
@@ -282,26 +308,31 @@ static LogicalResult materializeTRowExpandTmp(OpTy op, bool requireExplicitTmp,
 static LogicalResult replaceTColSumWithTmp(pto::TColSumOp op,
                                            bool requireExplicitTmp,
                                            MLIRContext *ctx) {
-  if (op.getTmp() || !op.getIsBinary())
+  if (op.getTmp() || !op.getIsBinary()) {
     return success();
-  if (requireExplicitTmp)
+  }
+  if (requireExplicitTmp) {
     return op.emitOpError(
         "requires explicit tmp for binary tcolsum when PlanMemory is skipped");
+  }
 
   auto srcTy = dyn_cast<pto::TileBufType>(op.getSrc().getType());
-  if (!srcTy)
+  if (!srcTy) {
     return op.emitOpError("expects tile_buf src when materializing implicit tmp");
+  }
   auto valid = getValidShapeVec(op.getSrc().getType());
-  if (valid.size() != 2 || hasDynamicDim(valid))
+  if (valid.size() != mlir::pto::kValue2 || hasDynamicDim(valid)) {
     return op.emitOpError(
         "requires static src valid_shape to materialize binary tcolsum tmp");
+  }
 
-  SmallVector<int64_t, 2> tmpShape{ceilDiv(valid[0], 2), valid[1]};
+  SmallVector<int64_t, mlir::pto::kValue2> tmpShape{ceilDiv(valid[0], mlir::pto::kValue2), valid[1]};
   auto tmpType = makeVecTmpType(ctx, tmpShape, srcTy.getElementType(), tmpShape);
   OpBuilder builder(op);
   FailureOr<Value> tmp = createAllocTmp(builder, op.getLoc(), tmpType);
-  if (failed(tmp))
+  if (failed(tmp)) {
     return failure();
+  }
 
   rebuildWithOperands(op.getOperation(), {op.getSrc(), *tmp, op.getDst()},
                       ArrayRef<int32_t>{1, 1, 1});
@@ -311,24 +342,29 @@ static LogicalResult replaceTColSumWithTmp(pto::TColSumOp op,
 static LogicalResult replaceTQuantWithTmp(pto::TQuantOp op,
                                           bool requireExplicitTmp,
                                           MLIRContext *ctx) {
-  if (op.getTmp() || pto::getTargetArch(op.getOperation()) == pto::PTOArch::A5)
+  if (op.getTmp() || pto::getTargetArch(op.getOperation()) == pto::PTOArch::A5) {
     return success();
-  if (requireExplicitTmp)
+  }
+  if (requireExplicitTmp) {
     return op.emitOpError("requires explicit tmp when PlanMemory is skipped");
+  }
 
   FailureOr<pto::TileBufType> tmpType = makeSameShapeTmpType(
       ctx, op.getSrc(), Float32Type::get(ctx));
-  if (failed(tmpType))
+  if (failed(tmpType)) {
     return op.emitOpError(
         "requires static tile_buf src to materialize implicit tquant tmp");
+  }
   OpBuilder builder(op);
   FailureOr<Value> tmp = createAllocTmp(builder, op.getLoc(), *tmpType);
-  if (failed(tmp))
+  if (failed(tmp)) {
     return failure();
+  }
 
   SmallVector<Value> operands{op.getSrc(), op.getFp()};
-  if (op.getOffset())
+  if (op.getOffset()) {
     operands.push_back(op.getOffset());
+  }
   operands.push_back(*tmp);
   operands.push_back(op.getDst());
   rebuildWithOperands(op.getOperation(), operands,
@@ -344,19 +380,23 @@ static bool isFloatingPointTile(Value value) {
 static LogicalResult replaceTPowWithTmp(pto::TPowOp op,
                                         bool requireExplicitTmp,
                                         MLIRContext *ctx) {
-  if (op.getTmp() || !isFloatingPointTile(op.getDst()))
+  if (op.getTmp() || !isFloatingPointTile(op.getDst())) {
     return success();
-  if (requireExplicitTmp)
+  }
+  if (requireExplicitTmp) {
     return op.emitOpError("requires explicit tmp when PlanMemory is skipped");
+  }
 
   FailureOr<pto::TileBufType> tmpType = makeSameShapeTmpType(ctx, op.getDst());
-  if (failed(tmpType))
+  if (failed(tmpType)) {
     return op.emitOpError(
         "requires static tile_buf dst to materialize implicit tpow tmp");
+  }
   OpBuilder builder(op);
   FailureOr<Value> tmp = createAllocTmp(builder, op.getLoc(), *tmpType);
-  if (failed(tmp))
+  if (failed(tmp)) {
     return failure();
+  }
 
   rebuildWithOperands(op.getOperation(),
                       {op.getBase(), op.getExp(), op.getDst(), *tmp},
@@ -367,19 +407,23 @@ static LogicalResult replaceTPowWithTmp(pto::TPowOp op,
 static LogicalResult replaceTPowSWithTmp(pto::TPowSOp op,
                                          bool requireExplicitTmp,
                                          MLIRContext *ctx) {
-  if (op.getTmp() || !isFloatingPointTile(op.getDst()))
+  if (op.getTmp() || !isFloatingPointTile(op.getDst())) {
     return success();
-  if (requireExplicitTmp)
+  }
+  if (requireExplicitTmp) {
     return op.emitOpError("requires explicit tmp when PlanMemory is skipped");
+  }
 
   FailureOr<pto::TileBufType> tmpType = makeSameShapeTmpType(ctx, op.getDst());
-  if (failed(tmpType))
+  if (failed(tmpType)) {
     return op.emitOpError(
         "requires static tile_buf dst to materialize implicit tpows tmp");
+  }
   OpBuilder builder(op);
   FailureOr<Value> tmp = createAllocTmp(builder, op.getLoc(), *tmpType);
-  if (failed(tmp))
+  if (failed(tmp)) {
     return failure();
+  }
 
   rebuildWithOperands(op.getOperation(),
                       {op.getSrc(), op.getScalar(), op.getDst(), *tmp},
@@ -390,21 +434,25 @@ static LogicalResult replaceTPowSWithTmp(pto::TPowSOp op,
 static LogicalResult replaceTSort32WithTmp(pto::TSort32Op op,
                                            bool requireExplicitTmp,
                                            MLIRContext *ctx) {
-  if (op.getTmp())
+  if (op.getTmp()) {
     return success();
+  }
   auto valid = getValidShapeVec(op.getSrc().getType());
-  if (valid.size() != 2)
+  if (valid.size() != mlir::pto::kValue2) {
     return success();
+  }
   // Only a statically-known 32-aligned width provably skips the tail path and
   // needs no tmp. A dynamic width may be non-aligned at runtime, so it must be
   // treated conservatively rather than assumed aligned.
   bool dynamicWidth = valid[1] == ShapedType::kDynamic;
-  if (!dynamicWidth && valid[1] % 32 == 0)
+  if (!dynamicWidth && valid[1] % mlir::pto::kValue32 == 0) {
     return success();
-  if (requireExplicitTmp)
+  }
+  if (requireExplicitTmp) {
     return op.emitOpError(
         "requires explicit tmp for tsort32 with dynamic or non-32-aligned width "
         "when PlanMemory is skipped");
+  }
 
   FailureOr<pto::TileBufType> tmpType = failure();
   if (dynamicWidth) {
@@ -412,18 +460,21 @@ static LogicalResult replaceTSort32WithTmp(pto::TSort32Op op,
     // the full physical width to guarantee room for the tail path.
     auto srcTy = dyn_cast<pto::TileBufType>(op.getSrc().getType());
     auto shape = getShapeVec(op.getSrc().getType());
-    if (srcTy && shape.size() == 2 && !hasDynamicDim(shape))
+    if (srcTy && shape.size() == mlir::pto::kValue2 && !hasDynamicDim(shape)) {
       tmpType = makeVecTmpType(ctx, shape, srcTy.getElementType(), shape);
+    }
   } else {
     tmpType = makeSameShapeTmpType(ctx, op.getSrc());
   }
-  if (failed(tmpType))
+  if (failed(tmpType)) {
     return op.emitOpError(
         "requires static tile_buf src to materialize implicit tsort32 tmp");
+  }
   OpBuilder builder(op);
   FailureOr<Value> tmp = createAllocTmp(builder, op.getLoc(), *tmpType);
-  if (failed(tmp))
+  if (failed(tmp)) {
     return failure();
+  }
 
   rebuildWithOperands(op.getOperation(), {op.getSrc(), op.getIdx(), *tmp, op.getDst()},
                       ArrayRef<int32_t>{1, 1, 1, 1});
@@ -434,23 +485,27 @@ template <typename OpTy>
 static LogicalResult replaceRowReductionWithTmp(OpTy op,
                                                  bool requireExplicitTmp,
                                                  MLIRContext *ctx) {
-  if (op.getTmp())
+  if (op.getTmp()) {
     return success();
+  }
 
   bool isA5 = pto::getTargetArch(op.getOperation()) == pto::PTOArch::A5;
-  if (requireExplicitTmp && !isA5)
+  if (requireExplicitTmp && !isA5) {
     return op.emitOpError("requires explicit tmp when PlanMemory is skipped");
+  }
 
   FailureOr<pto::TileBufType> tmpType =
       isA5 ? makeA5PlaceholderTmpType(ctx, op.getSrc())
            : makeSameShapeTmpType(ctx, op.getSrc());
-  if (failed(tmpType))
+  if (failed(tmpType)) {
     return op.emitOpError(
         "requires static tile_buf src to materialize implicit row-reduction tmp");
+  }
   OpBuilder builder(op);
   FailureOr<Value> tmp = createAllocTmp(builder, op.getLoc(), *tmpType);
-  if (failed(tmp))
+  if (failed(tmp)) {
     return failure();
+  }
 
   rebuildWithOperands(op.getOperation(), {op.getSrc(), *tmp, op.getDst()},
                       ArrayRef<int32_t>{1, 1, 1});
@@ -460,21 +515,25 @@ static LogicalResult replaceRowReductionWithTmp(OpTy op,
 static LogicalResult replaceTXorWithTmp(pto::TXorOp op,
                                         bool requireExplicitTmp,
                                         MLIRContext *ctx) {
-  if (op.getTmp())
+  if (op.getTmp()) {
     return success();
+  }
   bool isA5 = pto::getTargetArch(op.getOperation()) == pto::PTOArch::A5;
-  if (requireExplicitTmp && !isA5)
+  if (requireExplicitTmp && !isA5) {
     return op.emitOpError("requires explicit tmp when PlanMemory is skipped");
+  }
   FailureOr<pto::TileBufType> tmpType =
       isA5 ? makeA5PlaceholderTmpType(ctx, op.getDst())
            : makeSameShapeTmpType(ctx, op.getDst());
-  if (failed(tmpType))
+  if (failed(tmpType)) {
     return op.emitOpError(
         "requires static tile_buf dst to materialize implicit txor tmp");
+  }
   OpBuilder builder(op);
   FailureOr<Value> tmp = createAllocTmp(builder, op.getLoc(), *tmpType);
-  if (failed(tmp))
+  if (failed(tmp)) {
     return failure();
+  }
   rebuildWithOperands(op.getOperation(),
                       {op.getSrc0(), op.getSrc1(), *tmp, op.getDst()},
                       ArrayRef<int32_t>{1, 1, 1, 1});
@@ -484,21 +543,25 @@ static LogicalResult replaceTXorWithTmp(pto::TXorOp op,
 static LogicalResult replaceTXorSWithTmp(pto::TXorSOp op,
                                          bool requireExplicitTmp,
                                          MLIRContext *ctx) {
-  if (op.getTmp())
+  if (op.getTmp()) {
     return success();
+  }
   bool isA5 = pto::getTargetArch(op.getOperation()) == pto::PTOArch::A5;
-  if (requireExplicitTmp && !isA5)
+  if (requireExplicitTmp && !isA5) {
     return op.emitOpError("requires explicit tmp when PlanMemory is skipped");
+  }
   FailureOr<pto::TileBufType> tmpType =
       isA5 ? makeA5PlaceholderTmpType(ctx, op.getDst())
            : makeSameShapeTmpType(ctx, op.getDst());
-  if (failed(tmpType))
+  if (failed(tmpType)) {
     return op.emitOpError(
         "requires static tile_buf dst to materialize implicit txors tmp");
+  }
   OpBuilder builder(op);
   FailureOr<Value> tmp = createAllocTmp(builder, op.getLoc(), *tmpType);
-  if (failed(tmp))
+  if (failed(tmp)) {
     return failure();
+  }
   rebuildWithOperands(op.getOperation(),
                       {op.getSrc(), op.getScalar(), *tmp, op.getDst()},
                       ArrayRef<int32_t>{1, 1, 1, 1});
@@ -509,20 +572,23 @@ static LogicalResult replaceFixedDpsOpWithTmp(
     Operation *op, ArrayRef<Value> operands, pto::TileBufType tmpType,
     ArrayRef<int32_t> operandSegments, bool requireExplicitTmp,
     StringRef opName) {
-  if (requireExplicitTmp)
+  if (requireExplicitTmp) {
     return op->emitOpError(
         "requires explicit tmp when PlanMemory is skipped");
+  }
   OpBuilder builder(op);
   FailureOr<Value> tmp = createAllocTmp(builder, op->getLoc(), tmpType);
-  if (failed(tmp))
+  if (failed(tmp)) {
     return failure();
+  }
   SmallVector<Value> finalOperands;
   finalOperands.reserve(operands.size() + 1);
   for (Value operand : operands) {
-    if (operand)
+    if (operand) {
       finalOperands.push_back(operand);
-    else
+    } else {
       finalOperands.push_back(*tmp);
+}
   }
   rebuildWithOperands(op, finalOperands, operandSegments);
   (void)opName;
@@ -534,12 +600,13 @@ static FailureOr<pto::TileBufType> makeTPReluTmpType(MLIRContext *ctx,
   auto dstTy = dyn_cast<pto::TileBufType>(dst.getType());
   auto shape = getShapeVec(dst.getType());
   auto valid = getValidShapeVec(dst.getType());
-  if (!dstTy || shape.size() != 2 || valid.size() != 2 ||
-      hasDynamicDim(shape) || hasDynamicDim(valid))
+  if (!dstTy || shape.size() != mlir::pto::kValue2 || valid.size() != mlir::pto::kValue2 ||
+      hasDynamicDim(shape) || hasDynamicDim(valid)) {
     return failure();
+  }
   int64_t validCols = ceilDiv(valid[1], 8);
   int64_t cols = std::max<int64_t>(32, ceilDiv(validCols, 32) * 32);
-  return makeVecTmpType(ctx, {valid[0] + 1, cols}, IntegerType::get(ctx, 8),
+  return makeVecTmpType(ctx, {valid[0] + 1, cols}, IntegerType::get(ctx, mlir::pto::kValue8),
                         {valid[0], validCols});
 }
 
@@ -548,9 +615,10 @@ static FailureOr<pto::TileBufType> makeRowsTmpType(MLIRContext *ctx,
   auto dstTy = dyn_cast<pto::TileBufType>(dst.getType());
   auto shape = getShapeVec(dst.getType());
   auto valid = getValidShapeVec(dst.getType());
-  if (!dstTy || shape.size() != 2 || valid.size() != 2 ||
-      hasDynamicDim(shape) || hasDynamicDim(valid))
+  if (!dstTy || shape.size() != mlir::pto::kValue2 || valid.size() != mlir::pto::kValue2 ||
+      hasDynamicDim(shape) || hasDynamicDim(valid)) {
     return failure();
+  }
   return makeVecTmpType(ctx, {rows, shape[1]}, dstTy.getElementType(),
                         {rows, valid[1]});
 }
@@ -560,17 +628,19 @@ static LogicalResult materializeFixedMandatoryTmp(Operation *op,
                                                    MLIRContext *ctx) {
   return llvm::TypeSwitch<Operation *, LogicalResult>(op)
       .Case<pto::TPReluOp>([&](auto typedOp) -> LogicalResult {
-        if (typedOp.getTmp())
+        if (typedOp.getTmp()) {
           return success();
+        }
         bool isA5 =
             pto::getTargetArch(op) == pto::PTOArch::A5;
         auto type = isA5 ? makeA5PlaceholderTmpType(
                                ctx, typedOp.getDst(),
                                IntegerType::get(ctx, 8))
                          : makeTPReluTmpType(ctx, typedOp.getDst());
-        if (failed(type))
+        if (failed(type)) {
           return typedOp.emitOpError(
               "requires static tile_buf dst to materialize implicit tprelu tmp");
+        }
         return replaceFixedDpsOpWithTmp(
             op, {typedOp.getSrc0(), typedOp.getSrc1(), Value(),
                  typedOp.getDst()},
@@ -578,38 +648,43 @@ static LogicalResult materializeFixedMandatoryTmp(Operation *op,
             "tprelu");
       })
       .Case<pto::TRemOp>([&](auto typedOp) -> LogicalResult {
-        if (typedOp.getTmp())
+        if (typedOp.getTmp()) {
           return success();
+        }
         bool isA5 =
             pto::getTargetArch(op) == pto::PTOArch::A5;
         auto type = isA5 ? makeA5PlaceholderTmpType(ctx, typedOp.getDst())
                          : makeRowsTmpType(ctx, typedOp.getDst(), 2);
-        if (failed(type))
+        if (failed(type)) {
           return typedOp.emitOpError(
               "requires static tile_buf dst to materialize implicit trem tmp");
+        }
         return replaceFixedDpsOpWithTmp(
             op, {typedOp.getSrc0(), typedOp.getSrc1(), Value(),
                  typedOp.getDst()},
             *type, {1, 1, 1, 1}, isA5 ? false : requireExplicitTmp, "trem");
       })
       .Case<pto::TRemSOp>([&](auto typedOp) -> LogicalResult {
-        if (typedOp.getTmp())
+        if (typedOp.getTmp()) {
           return success();
+        }
         bool isA5 =
             pto::getTargetArch(op) == pto::PTOArch::A5;
         auto type = isA5 ? makeA5PlaceholderTmpType(ctx, typedOp.getDst())
                          : makeRowsTmpType(ctx, typedOp.getDst(), 1);
-        if (failed(type))
+        if (failed(type)) {
           return typedOp.emitOpError(
               "requires static tile_buf dst to materialize implicit trems tmp");
+        }
         return replaceFixedDpsOpWithTmp(
             op, {typedOp.getSrc(), typedOp.getScalar(), Value(),
                  typedOp.getDst()},
             *type, {1, 1, 1, 1}, isA5 ? false : requireExplicitTmp, "trems");
       })
       .Case<pto::TSelOp>([&](auto typedOp) -> LogicalResult {
-        if (typedOp.getTmp())
+        if (typedOp.getTmp()) {
           return success();
+        }
         bool isA5 =
             pto::getTargetArch(op) == pto::PTOArch::A5;
         auto type = isA5 ? makeA5PlaceholderTmpType(
@@ -617,45 +692,51 @@ static LogicalResult materializeFixedMandatoryTmp(Operation *op,
                                IntegerType::get(ctx, 32))
                          : makeVecTmpType(ctx, {1, 16},
                                           IntegerType::get(ctx, 32), {1, 16});
-        if (failed(type))
+        if (failed(type)) {
           return typedOp.emitOpError(
               "requires static tile_buf dst to materialize implicit tsel tmp");
+        }
         return replaceFixedDpsOpWithTmp(
             op, {typedOp.getMask(), typedOp.getSrc0(), typedOp.getSrc1(),
                  Value(), typedOp.getDst()},
             *type, {1, 1, 1, 1, 1}, isA5 ? false : requireExplicitTmp, "tsel");
       })
       .Case<pto::TSelSOp>([&](auto typedOp) -> LogicalResult {
-        if (typedOp.getTmp())
+        if (typedOp.getTmp()) {
           return success();
+        }
         bool isA5 =
             pto::getTargetArch(op) == pto::PTOArch::A5;
         auto type = isA5 ? makeA5PlaceholderTmpType(ctx, typedOp.getSrc())
                          : makeRowsTmpType(ctx, typedOp.getSrc(), 1);
-        if (failed(type))
+        if (failed(type)) {
           return typedOp.emitOpError(
               "requires static tile_buf src to materialize implicit tsels tmp");
+        }
         return replaceFixedDpsOpWithTmp(
             op, {typedOp.getMask(), typedOp.getSrc(), Value(),
                  typedOp.getScalar(), typedOp.getDst()},
             *type, {1, 1, 1, 1, 1}, isA5 ? false : requireExplicitTmp, "tsels");
       })
       .Case<pto::TTransOp>([&](auto typedOp) -> LogicalResult {
-        if (typedOp.getTmp())
+        if (typedOp.getTmp()) {
           return success();
+        }
         bool isA5 =
             pto::getTargetArch(op) == pto::PTOArch::A5;
         auto srcTy = dyn_cast<pto::TileBufType>(typedOp.getSrc().getType());
         auto dstTy = dyn_cast<pto::TileBufType>(typedOp.getDst().getType());
         auto srcShape = getShapeVec(typedOp.getSrc().getType());
         auto dstShape = getShapeVec(typedOp.getDst().getType());
-        if (!srcTy || !dstTy || srcShape.size() != 2 || dstShape.size() != 2 ||
-            hasDynamicDim(srcShape) || hasDynamicDim(dstShape))
+        if (!srcTy || !dstTy || srcShape.size() != mlir::pto::kValue2 || dstShape.size() != mlir::pto::kValue2 ||
+            hasDynamicDim(srcShape) || hasDynamicDim(dstShape)) {
           return typedOp.emitOpError(
               "requires static tile_buf src to materialize implicit ttrans tmp");
+        }
         auto elemBytes = getElemBytes(srcTy.getElementType());
-        if (!elemBytes)
+        if (!elemBytes) {
           return typedOp.emitOpError("failed to infer ttrans element size");
+        }
         int64_t rowStride = *elemBytes == 1 ? 32 : 16;
         int64_t elemPerBlock = 32 / *elemBytes;
         bool usesTmp = dstShape[1] % rowStride == 0 &&
@@ -664,11 +745,13 @@ static LogicalResult materializeFixedMandatoryTmp(Operation *op,
         FailureOr<pto::TileBufType> type =
             isA5 ? makeA5PlaceholderTmpType(ctx, typedOp.getSrc())
                  : makeSameShapeTmpType(ctx, typedOp.getSrc());
-        if (!isA5 && !usesTmp)
+        if (!isA5 && !usesTmp) {
           type = makeVecTmpType(ctx, {1, elemPerBlock},
                                 srcTy.getElementType(), {1, elemPerBlock});
-        if (failed(type))
+        }
+        if (failed(type)) {
           return typedOp.emitOpError("failed to build implicit ttrans tmp");
+        }
         return replaceFixedDpsOpWithTmp(
             op, {typedOp.getSrc(), Value(), typedOp.getDst()}, *type,
             {1, 1, 1}, isA5 ? false : requireExplicitTmp, "ttrans");
@@ -678,17 +761,19 @@ static LogicalResult materializeFixedMandatoryTmp(Operation *op,
 
 static bool tcvtNeedsTmp(pto::TCvtOp op) {
   if (pto::getTargetArch(op.getOperation()) == pto::PTOArch::A5 ||
-      op.getSatMode() != pto::SaturationMode::OFF)
+      op.getSatMode() != pto::SaturationMode::OFF) {
     return false;
+  }
   auto srcTy = dyn_cast<pto::TileBufType>(op.getSrc().getType());
   auto dstTy = dyn_cast<pto::TileBufType>(op.getDst().getType());
-  if (!srcTy || !dstTy)
+  if (!srcTy || !dstTy) {
     return false;
+  }
   Type srcElem = srcTy.getElementType();
   Type dstElem = dstTy.getElementType();
-  return (srcElem.isF32() && dstElem.isInteger(16)) ||
+  return (srcElem.isF32() && dstElem.isInteger(mlir::pto::kValue16)) ||
          (srcElem.isF16() &&
-          (dstElem.isInteger(16) || dstElem.isInteger(8)));
+          (dstElem.isInteger(mlir::pto::kValue16) || dstElem.isInteger(8)));
 }
 
 static FailureOr<pto::TileBufType> makeTCvtTmpType(MLIRContext *ctx,
@@ -697,9 +782,10 @@ static FailureOr<pto::TileBufType> makeTCvtTmpType(MLIRContext *ctx,
   auto dstValid = getValidShapeVec(op.getDst().getType());
   auto srcTy = dyn_cast<pto::TileBufType>(op.getSrc().getType());
   auto dstTy = dyn_cast<pto::TileBufType>(op.getDst().getType());
-  if (!srcTy || !dstTy || srcShape.size() != 2 || dstValid.size() != 2 ||
-      hasDynamicDim(srcShape) || hasDynamicDim(dstValid))
+  if (!srcTy || !dstTy || srcShape.size() != mlir::pto::kValue2 || dstValid.size() != mlir::pto::kValue2 ||
+      hasDynamicDim(srcShape) || hasDynamicDim(dstValid)) {
     return failure();
+  }
   int64_t rows = dstValid[0], cols = dstValid[1];
   int64_t bytes = 0;
   if (rows > 0 && cols > 0 && srcTy.getElementType().isF32()) {
@@ -715,25 +801,28 @@ static FailureOr<pto::TileBufType> makeTCvtTmpType(MLIRContext *ctx,
     int64_t width = std::min<int64_t>(cols, 64);
     int64_t halfToI16 = 32 * ceilDiv(width, 8);
     int64_t halfToI8 = std::max(halfToI16, 128 + 32 * ceilDiv(width, 16));
-    bytes = dstTy.getElementType().isInteger(8) ? halfToI8 : halfToI16;
+    bytes = dstTy.getElementType().isInteger(mlir::pto::kValue8) ? halfToI8 : halfToI16;
   }
   int64_t allocatedBytes = std::max<int64_t>(32, ceilDiv(bytes, 32) * 32);
-  return makeVecTmpType(ctx, {1, allocatedBytes}, IntegerType::get(ctx, 8),
+  return makeVecTmpType(ctx, {1, allocatedBytes}, IntegerType::get(ctx, mlir::pto::kValue8),
                         {1, allocatedBytes});
 }
 
 static LogicalResult materializeTCvtTmp(pto::TCvtOp op,
                                         bool requireExplicitTmp,
                                         MLIRContext *ctx) {
-  if (op.getTmp() || !tcvtNeedsTmp(op))
+  if (op.getTmp() || !tcvtNeedsTmp(op)) {
     return success();
-  if (requireExplicitTmp)
+  }
+  if (requireExplicitTmp) {
     return op.emitOpError(
         "requires explicit tmp for non-saturating narrowing tcvt when PlanMemory is skipped");
+  }
   auto type = makeTCvtTmpType(ctx, op);
-  if (failed(type))
+  if (failed(type)) {
     return op.emitOpError(
         "requires static tile_buf shapes to materialize implicit tcvt tmp");
+  }
   return replaceFixedDpsOpWithTmp(op.getOperation(),
                                   {op.getSrc(), Value(), op.getDst()}, *type,
                                   {1, 1, 1}, requireExplicitTmp, "tcvt");
@@ -742,42 +831,49 @@ static LogicalResult materializeTCvtTmp(pto::TCvtOp op,
 static LogicalResult materializeTMrgSortTmp(pto::TMrgSortOp op,
                                             bool requireExplicitTmp,
                                             MLIRContext *ctx) {
-  if (!op.isFormat2WithoutTmp())
+  if (!op.isFormat2WithoutTmp()) {
     return success();
-  if (requireExplicitTmp)
+  }
+  if (requireExplicitTmp) {
     return op.emitOpError(
         "requires explicit tmp for tmrgsort format2 when PlanMemory is skipped");
+  }
   int64_t totalCols = 0;
   Type elementType;
   SmallVector<Value> operands;
   for (Value src : op.getSrcs()) {
     auto srcTy = dyn_cast<pto::TileBufType>(src.getType());
     auto shape = getShapeVec(src.getType());
-    if (!srcTy || shape.size() != 2 || hasDynamicDim(shape))
+    if (!srcTy || shape.size() != mlir::pto::kValue2 || hasDynamicDim(shape)) {
       return op.emitOpError(
           "requires static rank-2 tile_buf srcs to materialize tmrgsort tmp");
-    if (!elementType)
+    }
+    if (!elementType) {
       elementType = srcTy.getElementType();
+    }
     totalCols += shape[1];
     operands.push_back(src);
   }
-  if (!elementType || totalCols <= 0)
+  if (!elementType || totalCols <= 0) {
     return op.emitOpError("failed to infer tmrgsort format2 tmp type");
+  }
   // The verifier requires tmp.cols >= dst.cols as well as tmp.cols >=
   // sum(src.cols), so size the scratch by the wider of the two.
   int64_t dstCols = 0;
   for (Value dst : op.getDsts()) {
     auto dstShape = getShapeVec(dst.getType());
-    if (dstShape.size() == 2 && dstShape[1] != ShapedType::kDynamic)
+    if (dstShape.size() == mlir::pto::kValue2 && dstShape[1] != ShapedType::kDynamic) {
       dstCols = std::max(dstCols, dstShape[1]);
+    }
   }
   int64_t tmpCols = std::max(totalCols, dstCols);
   pto::TileBufType tmpType =
       makeVecTmpType(ctx, {1, tmpCols}, elementType, {1, tmpCols});
   OpBuilder builder(op);
   FailureOr<Value> tmp = createAllocTmp(builder, op.getLoc(), tmpType);
-  if (failed(tmp))
+  if (failed(tmp)) {
     return failure();
+  }
   SmallVector<Value> finalOperands;
   finalOperands.append(operands.begin(), operands.end());
   finalOperands.append(op.getDsts().begin(), op.getDsts().end());
@@ -810,13 +906,15 @@ struct PTOMaterializeImplicitTmpPass
 
     SmallVector<pto::TCIOp> tciOps;
     func.walk([&](pto::TCIOp op) {
-      if (!op.getTmp())
+      if (!op.getTmp()) {
         tciOps.push_back(op);
+      }
     });
 
     for (pto::TCIOp op : tciOps) {
-      if (pto::getTargetArch(op.getOperation()) == pto::PTOArch::A5)
+      if (pto::getTargetArch(op.getOperation()) == pto::PTOArch::A5) {
         continue;
+      }
 
       if (requireExplicitTmp) {
         op.emitOpError("requires explicit tmp when PlanMemory is skipped");
@@ -836,8 +934,9 @@ struct PTOMaterializeImplicitTmpPass
           loc, TypeRange{}, op.getS(), tmp, op.getDst(),
           op.getDescendingAttr());
       for (NamedAttribute attr : op->getAttrs()) {
-        if (attr.getName() == "operandSegmentSizes")
+        if (attr.getName() == "operandSegmentSizes") {
           continue;
+        }
         newOp->setAttr(attr.getName(), attr.getValue());
       }
       op.erase();
@@ -847,8 +946,9 @@ struct PTOMaterializeImplicitTmpPass
     func.walk([&](Operation *op) {
       if (isa<pto::TRowExpandAddOp, pto::TRowExpandSubOp,
               pto::TRowExpandMulOp, pto::TRowExpandDivOp,
-              pto::TRowExpandMaxOp, pto::TRowExpandMinOp>(op))
+              pto::TRowExpandMaxOp, pto::TRowExpandMinOp>(op)) {
         rowExpandOps.push_back(op);
+      }
     });
 
     for (Operation *op : rowExpandOps) {
@@ -862,16 +962,18 @@ struct PTOMaterializeImplicitTmpPass
                                                     ctx);
                   })
               .Default([](Operation *) { return success(); });
-      if (mlir::failed(result))
+      if (mlir::failed(result)) {
         failed = true;
+      }
     }
 
     SmallVector<Operation *> optionalTmpOps;
     func.walk([&](Operation *op) {
       if (isa<pto::TColSumOp, pto::TQuantOp, pto::TPowOp,
               pto::TPowSOp, pto::TSort32Op, pto::TXorOp,
-              pto::TXorSOp, pto::TCvtOp, pto::TMrgSortOp>(op))
+              pto::TXorSOp, pto::TCvtOp, pto::TMrgSortOp>(op)) {
         optionalTmpOps.push_back(op);
+      }
     });
 
     for (Operation *op : optionalTmpOps) {
@@ -905,16 +1007,18 @@ struct PTOMaterializeImplicitTmpPass
                 return materializeTMrgSortTmp(typedOp, requireExplicitTmp, ctx);
               })
               .Default([](Operation *) { return success(); });
-      if (mlir::failed(result))
+      if (mlir::failed(result)) {
         failed = true;
+      }
     }
 
     SmallVector<Operation *> rowReductionOps;
     func.walk([&](Operation *op) {
       if (isa<pto::TRowMaxOp, pto::TRowMinOp, pto::TRowSumOp,
               pto::TRowProdOp, pto::TColArgMaxOp, pto::TColArgMinOp,
-              pto::TRowArgMaxOp, pto::TRowArgMinOp>(op))
+              pto::TRowArgMaxOp, pto::TRowArgMinOp>(op)) {
         rowReductionOps.push_back(op);
+      }
     });
 
     for (Operation *op : rowReductionOps) {
@@ -927,24 +1031,28 @@ struct PTOMaterializeImplicitTmpPass
                                                   ctx);
               })
               .Default([](Operation *) { return success(); });
-      if (mlir::failed(result))
+      if (mlir::failed(result)) {
         failed = true;
+      }
     }
 
     SmallVector<Operation *> mandatoryTmpOps;
     func.walk([&](Operation *op) {
       if (isa<pto::TPReluOp, pto::TRemOp, pto::TRemSOp, pto::TSelOp,
-              pto::TSelSOp, pto::TTransOp>(op))
+              pto::TSelSOp, pto::TTransOp>(op)) {
         mandatoryTmpOps.push_back(op);
+      }
     });
     for (Operation *op : mandatoryTmpOps) {
       if (mlir::failed(
-              materializeFixedMandatoryTmp(op, requireExplicitTmp, ctx)))
+              materializeFixedMandatoryTmp(op, requireExplicitTmp, ctx))) {
         failed = true;
+      }
     }
 
-    if (failed)
+    if (failed) {
       signalPassFailure();
+    }
   }
 
 private:

--- a/lib/PTO/Transforms/PTOMaterializeSIMTPersistentFragment.cpp
+++ b/lib/PTO/Transforms/PTOMaterializeSIMTPersistentFragment.cpp
@@ -16,6 +16,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 #include "SIMTPersistentFragmentAnalysis.h"
@@ -105,10 +106,12 @@ static LogicalResult rewireScalarAccess(Operation *access,
 
 // Return the scalar or vector value type carried by an LLVM memory access.
 static FailureOr<Type> getPersistentAccessType(Operation *access) {
-  if (auto load = dyn_cast<LLVM::LoadOp>(access))
+  if (auto load = dyn_cast<LLVM::LoadOp>(access)) {
     return load.getRes().getType();
-  if (auto store = dyn_cast<LLVM::StoreOp>(access))
+  }
+  if (auto store = dyn_cast<LLVM::StoreOp>(access)) {
     return store.getValue().getType();
+  }
   access->emitOpError(
       "expected an llvm.load or llvm.store persistent fragment access");
   return failure();
@@ -120,8 +123,9 @@ static LogicalResult validateAccessRewritePlan(
         &laneRewritesByAccess) {
   for (auto &[access, laneRewrites] : laneRewritesByAccess) {
     FailureOr<Type> accessType = getPersistentAccessType(access);
-    if (failed(accessType))
+    if (failed(accessType)) {
       return failure();
+    }
 
     llvm::sort(laneRewrites, [](const PersistentLaneRewrite &lhs,
                                 const PersistentLaneRewrite &rhs) {
@@ -129,8 +133,9 @@ static LogicalResult validateAccessRewritePlan(
     });
 
     unsigned expectedLaneCount = 1;
-    if (auto vectorType = dyn_cast<VectorType>(*accessType))
+    if (auto vectorType = dyn_cast<VectorType>(*accessType)) {
       expectedLaneCount = static_cast<unsigned>(vectorType.getNumElements());
+    }
 
     if (laneRewrites.size() != expectedLaneCount) {
       return access->emitOpError()
@@ -153,8 +158,9 @@ static LogicalResult validateAccessRewritePlan(
 static bool
 isFragmentActiveInSection(const PersistentFragmentAnalysis &fragment,
                           pto::SectionSimtOp section) {
-  if (fragment.initSection == section)
+  if (fragment.initSection == section) {
     return true;
+  }
   return llvm::any_of(fragment.carrySections, [&](pto::SectionSimtOp carry) {
     return carry == section;
   });
@@ -179,8 +185,9 @@ validateSectionWorklist(const PersistentMaterializationPlan &plan,
 
   unsigned expectedElementIndex = 0;
   for (const PersistentFragmentAnalysis &fragment : plan.fragments) {
-    if (!isFragmentActiveInSection(fragment, section))
+    if (!isFragmentActiveInSection(fragment, section)) {
       continue;
+    }
 
     for (const ResidentElementPlan &expectedElement :
          fragment.residentElements) {
@@ -262,13 +269,15 @@ buildPersistentTransformWorklist(const PersistentMaterializationPlan &plan,
                                  PersistentTransformWorklist &worklist) {
   worklist.sections.clear();
   worklist.sections.reserve(plan.sections.size());
-  for (pto::SectionSimtOp section : plan.sections)
+  for (pto::SectionSimtOp section : plan.sections) {
     worklist.sections.emplace_back(section);
+  }
 
   llvm::DenseMap<Operation *, PersistentSectionWorklist *> worklistBySection;
   for (PersistentSectionWorklist &sectionWorklist : worklist.sections) {
-    if (!sectionWorklist.section)
+    if (!sectionWorklist.section) {
       return failure();
+    }
     auto [it, inserted] = worklistBySection.try_emplace(
         sectionWorklist.section.getOperation(), &sectionWorklist);
     (void)it;
@@ -318,20 +327,22 @@ if (accessSection == section) {
       }
       return success();
     };
-
-    if (failed(addToSection(fragment.initSection)))
+    if (failed(addToSection(fragment.initSection))) {
       return failure();
+    }
     for (pto::SectionSimtOp section : fragment.carrySections) {
-      if (failed(addToSection(section)))
+      if (failed(addToSection(section))) {
         return failure();
+      }
     }
   }
 
   llvm::DenseMap<Operation *, llvm::DenseSet<unsigned>> assignedAccessLanes;
   for (PersistentSectionWorklist &sectionWorklist : worklist.sections) {
     if (failed(validateSectionWorklist(plan, sectionWorklist,
-                                       assignedAccessLanes)))
+                                       assignedAccessLanes))) {
       return failure();
+    }
   }
 
   for (const PersistentFragmentAnalysis &fragment : plan.fragments) {
@@ -362,8 +373,9 @@ static LogicalResult rewritePersistentAccess(
     Operation *access, ArrayRef<PersistentLaneRewrite> laneRewrites,
     MutableArrayRef<PersistentElementRewrite> elementRewrites) {
   FailureOr<Type> accessType = getPersistentAccessType(access);
-  if (failed(accessType))
+  if (failed(accessType)) {
     return failure();
+  }
 
   if (!isa<VectorType>(*accessType)) {
     assert(laneRewrites.size() == 1 && laneRewrites.front().laneIndex == 0 &&
@@ -432,7 +444,7 @@ materializeSection(const PersistentSectionWorklist &sectionWorklist,
   Value proxyArraySize;
   if (hasLocalAccess) {
     proxyArraySize = entryBuilder.create<arith::ConstantIntOp>(section.getLoc(),
-                                                               1, /*width=*/32);
+                                                               1, /*width=*/mlir::pto::kValue32);
   }
 
   // Emit the complete resume prologue before proxy setup so the group remains
@@ -484,8 +496,9 @@ materializeSection(const PersistentSectionWorklist &sectionWorklist,
     if (accessIt == laneRewritesByAccess.end()) {
       continue;
     }
-    if (failed(rewritePersistentAccess(&op, accessIt->second, rewrites)))
+    if (failed(rewritePersistentAccess(&op, accessIt->second, rewrites))) {
       return failure();
+    }
     ++rewrittenAccessCount;
   }
   if (rewrittenAccessCount != laneRewritesByAccess.size()) {
@@ -561,8 +574,9 @@ static LogicalResult eraseDeadPersistentGEPs(Value pointer) {
   }
 
   for (LLVM::GEPOp gep : derivedPointers) {
-    if (failed(eraseDeadPersistentGEPs(gep.getRes())))
+    if (failed(eraseDeadPersistentGEPs(gep.getRes()))) {
       return failure();
+    }
     if (!gep.getRes().use_empty()) {
       return gep.emitOpError(
           "persistent fragment derived pointer still has live uses after "
@@ -580,14 +594,16 @@ materializePersistentFragments(func::FuncOp func, DominanceInfo &dominance,
                                const PersistentTransformWorklist &worklist) {
   DataLayout dataLayout = DataLayout::closest(func);
   for (const PersistentSectionWorklist &sectionWorklist : worklist.sections) {
-    if (failed(materializeSection(sectionWorklist, dataLayout, dominance)))
+    if (failed(materializeSection(sectionWorklist, dataLayout, dominance))) {
       return failure();
+    }
   }
 
   for (const PersistentFragmentAnalysis &fragment : plan.fragments) {
     LLVM::AllocaOp allocaOp = fragment.allocaOp;
-    if (failed(eraseDeadPersistentGEPs(allocaOp.getRes())))
+    if (failed(eraseDeadPersistentGEPs(allocaOp.getRes()))) {
       return failure();
+    }
     if (!allocaOp.getRes().use_empty()) {
       return allocaOp.emitOpError(
           "persistent fragment still has live uses after materialization");
@@ -613,8 +629,9 @@ struct PTOMaterializeSIMTPersistentFragmentPass
     }
 
     const PersistentMaterializationPlan &plan = analysis.getPlan();
-    if (plan.fragments.empty())
+    if (plan.fragments.empty()) {
       return;
+    }
 
     // Convert the fragment/element-oriented analysis plan into a validated,
     // section/operation-oriented worklist before any IR mutation.

--- a/lib/PTO/Transforms/PTONormalizeUncoveredTileSections.cpp
+++ b/lib/PTO/Transforms/PTONormalizeUncoveredTileSections.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 #include "Utils.h"
@@ -30,6 +31,9 @@ namespace {
 
 using InferredSectionKind = PhysicalSectionKind;
 
+constexpr int8_t kC2VDirMask = 1;
+constexpr int8_t kV2CDirMask = 2;
+
 struct UncoveredTopLevelSegment {
   Operation *firstOp = nullptr;
   Operation *lastOp = nullptr;
@@ -38,7 +42,7 @@ struct UncoveredTopLevelSegment {
   bool containsNestedExplicitSection = false;
   unsigned vectorTileOpCount = 0;
   unsigned cubeTileOpCount = 0;
-  SmallVector<Operation *, 4> ambiguousTileOps;
+  SmallVector<Operation *, mlir::pto::kValue4> ambiguousTileOps;
 };
 
 static void mergeSegmentSummary(UncoveredTopLevelSegment &dst,
@@ -155,8 +159,9 @@ classifyMteOpByAddressSpace(MteOpInterface mteOp) {
 
 static std::optional<InferredSectionKind>
 classifyRawSectionCarrierOp(Operation *op) {
-  if (!isRawSectionCarrierOp(op))
+  if (!isRawSectionCarrierOp(op)) {
     return std::nullopt;
+  }
   if (isa<VectorMicroOpInterface>(op)) {
     return InferredSectionKind::Vector;
   }
@@ -164,8 +169,9 @@ classifyRawSectionCarrierOp(Operation *op) {
     return InferredSectionKind::Cube;
   }
   if (auto mteOp = dyn_cast<MteOpInterface>(op)) {
-    if (auto kind = classifyMteOpByAddressSpace(mteOp))
+    if (auto kind = classifyMteOpByAddressSpace(mteOp)) {
       return kind;
+    }
     return classifyTileOpByPipe(op);
   }
   if (auto setFlag = dyn_cast<SetFlagOp>(op)) {
@@ -187,10 +193,12 @@ classifyRawSectionCarrierOp(Operation *op) {
     }
     return classifySyncPipe(waitFlag.getDstPipe().getPipe());
   }
-  if (auto syncSet = dyn_cast<SyncSetOp>(op))
+  if (auto syncSet = dyn_cast<SyncSetOp>(op)) {
     return classifySyncPipe(syncSet.getPipe().getPipe());
-  if (auto syncWait = dyn_cast<SyncWaitOp>(op))
+  }
+  if (auto syncWait = dyn_cast<SyncWaitOp>(op)) {
     return classifySyncPipe(syncWait.getPipe().getPipe());
+  }
   return std::nullopt;
 }
 
@@ -237,8 +245,9 @@ static bool hasExplicitFunctionKernelKind(func::FuncOp funcOp) {
 }
 
 static bool isInsideKernelKindModule(func::FuncOp funcOp) {
-  if (!funcOp)
+  if (!funcOp) {
     return false;
+  }
   ModuleOp owner = funcOp->getParentOfType<ModuleOp>();
   return owner && owner->hasAttr(FunctionKernelKindAttr::name);
 }
@@ -249,18 +258,21 @@ static bool hasKnownKernelKindContext(func::FuncOp funcOp) {
 }
 
 static std::optional<AddressSpace> getBufferAddressSpace(Type type) {
-  if (auto ptrType = dyn_cast<PtrType>(type))
+  if (auto ptrType = dyn_cast<PtrType>(type)) {
     return ptrType.getMemorySpace().getAddressSpace();
+  }
   if (auto tileType = dyn_cast<TileBufType>(type)) {
     if (auto attr =
-            dyn_cast_or_null<AddressSpaceAttr>(tileType.getMemorySpace()))
+            dyn_cast_or_null<AddressSpaceAttr>(tileType.getMemorySpace())) {
       return attr.getAddressSpace();
+    }
     return std::nullopt;
   }
   if (auto memrefType = dyn_cast<MemRefType>(type)) {
     if (auto attr =
-            dyn_cast_or_null<AddressSpaceAttr>(memrefType.getMemorySpace()))
+            dyn_cast_or_null<AddressSpaceAttr>(memrefType.getMemorySpace())) {
       return attr.getAddressSpace();
+    }
     return std::nullopt;
   }
   return std::nullopt;
@@ -277,17 +289,20 @@ static std::optional<int8_t> getPipeHandleDirMask(Value pipeHandle) {
   if (!pipeHandle) {
     return std::nullopt;
   }
-  if (auto init = pipeHandle.getDefiningOp<InitializeL2LPipeOp>())
+  if (auto init = pipeHandle.getDefiningOp<InitializeL2LPipeOp>()) {
     return init.getDirMask();
-  if (auto init = pipeHandle.getDefiningOp<InitializeL2G2LPipeOp>())
+  }
+  if (auto init = pipeHandle.getDefiningOp<InitializeL2G2LPipeOp>()) {
     return init.getDirMask();
+  }
   return std::nullopt;
 }
 
 static std::optional<InferredSectionKind>
 classifyTileSectionByAddressSpace(std::optional<AddressSpace> space) {
-  if (!space)
+  if (!space) {
     return std::nullopt;
+  }
 
   switch (*space) {
   case AddressSpace::VEC:
@@ -311,10 +326,10 @@ classifyInternalPipeTileOp(Operation *op) {
     if (!dirMask) {
       return std::nullopt;
     }
-    if (*dirMask == 1) {
+    if (*dirMask == kC2VDirMask) {
       return InferredSectionKind::Cube;
     }
-    if (*dirMask == 2) {
+    if (*dirMask == kV2CDirMask) {
       return InferredSectionKind::Vector;
     }
     return classifyTileSectionByAddressSpace(
@@ -326,10 +341,10 @@ classifyInternalPipeTileOp(Operation *op) {
     if (!dirMask) {
       return std::nullopt;
     }
-    if (*dirMask == 1) {
+    if (*dirMask == kC2VDirMask) {
       return InferredSectionKind::Vector;
     }
-    if (*dirMask == 2) {
+    if (*dirMask == kV2CDirMask) {
       return InferredSectionKind::Cube;
     }
     return classifyTileSectionByAddressSpace(
@@ -341,10 +356,10 @@ classifyInternalPipeTileOp(Operation *op) {
     if (!dirMask) {
       return std::nullopt;
     }
-    if (*dirMask == 1) {
+    if (*dirMask == kC2VDirMask) {
       return InferredSectionKind::Vector;
     }
-    if (*dirMask == 2) {
+    if (*dirMask == kV2CDirMask) {
       return InferredSectionKind::Cube;
     }
     if (!free.getEntry()) {
@@ -359,10 +374,10 @@ classifyInternalPipeTileOp(Operation *op) {
     if (!dirMask) {
       return std::nullopt;
     }
-    if (*dirMask == 1) {
+    if (*dirMask == kC2VDirMask) {
       return InferredSectionKind::Cube;
     }
-    if (*dirMask == 2) {
+    if (*dirMask == kV2CDirMask) {
       return InferredSectionKind::Vector;
     }
     return std::nullopt;
@@ -373,16 +388,20 @@ classifyInternalPipeTileOp(Operation *op) {
 
 static std::optional<InferredSectionKind> classifyTileOpByName(Operation *op) {
   StringRef name = op->getName().getStringRef();
-  if (name.starts_with("pto.tmatmul") || name.starts_with("pto.tgemv"))
+  if (name.starts_with("pto.tmatmul") || name.starts_with("pto.tgemv")) {
     return InferredSectionKind::Cube;
+  }
   if (name == "pto.talloc_to_aiv" || name == "pto.tpush_to_aic" ||
-      name == "pto.tpop_from_aic" || name == "pto.tfree_from_aic")
+      name == "pto.tpop_from_aic" || name == "pto.tfree_from_aic") {
     return InferredSectionKind::Vector;
+  }
   if (name == "pto.talloc_to_aic" || name == "pto.tpush_to_aiv" ||
-      name == "pto.tpop_from_aiv" || name == "pto.tfree_from_aiv")
+      name == "pto.tpop_from_aiv" || name == "pto.tfree_from_aiv") {
     return InferredSectionKind::Cube;
-  if (name.ends_with("_to_aiv") || name.ends_with("_from_aiv"))
+  }
+  if (name.ends_with("_to_aiv") || name.ends_with("_from_aiv")) {
     return InferredSectionKind::Vector;
+  }
   return std::nullopt;
 }
 
@@ -392,11 +411,13 @@ static std::optional<InferredSectionKind> classifyTileOpByPipe(Operation *op) {
 
 static std::optional<InferredSectionKind>
 classifyTileOpByAddressSpace(Operation *op) {
-  SmallVector<AddressSpace, 8> spaces;
-  for (Value operand : op->getOperands())
+  SmallVector<AddressSpace, mlir::pto::kValue8> spaces;
+  for (Value operand : op->getOperands()) {
     collectTileAddressSpaces(operand.getType(), spaces);
-  for (Value result : op->getResults())
+  }
+  for (Value result : op->getResults()) {
     collectTileAddressSpaces(result.getType(), spaces);
+  }
 
   bool sawVec = false;
   bool sawMat = false;
@@ -514,7 +535,7 @@ static std::optional<InferredSectionKind> classifyTileOp(Operation *op) {
 struct ModuleKindSummary {
   unsigned vectorCount = 0;
   unsigned cubeCount = 0;
-  SmallVector<Operation *, 4> ambiguousOps;
+  SmallVector<Operation *, mlir::pto::kValue4> ambiguousOps;
 };
 
 enum class FunctionKindCacheState : uint8_t {
@@ -539,19 +560,21 @@ static void inspectModuleKindOperation(Operation *op,
   if (isRawSectionCarrierOp(op)) {
     if (std::optional<InferredSectionKind> kind =
             classifyRawSectionCarrierOp(op)) {
-      if (*kind == InferredSectionKind::Vector)
+      if (*kind == InferredSectionKind::Vector) {
         ++summary.vectorCount;
-      else
+      } else {
         ++summary.cubeCount;
+}
     } else {
       summary.ambiguousOps.push_back(op);
     }
   } else if (isPipeLikeOp(op)) {
     if (std::optional<InferredSectionKind> kind = classifyTileOp(op)) {
-      if (*kind == InferredSectionKind::Vector)
+      if (*kind == InferredSectionKind::Vector) {
         ++summary.vectorCount;
-      else
+      } else {
         ++summary.cubeCount;
+}
     } else if (isTileLikeOp(op)) {
       summary.ambiguousOps.push_back(op);
     }
@@ -561,16 +584,18 @@ static void inspectModuleKindOperation(Operation *op,
 
   for (Region &region : op->getRegions()) {
     for (Block &block : region.getBlocks()) {
-      for (Operation &nested : block.getOperations())
+      for (Operation &nested : block.getOperations()) {
         inspectModuleKindOperation(&nested, summary);
+      }
     }
   }
 }
 
 static FunctionKindCacheState
 encodeFunctionKind(std::optional<InferredSectionKind> kind) {
-  if (!kind)
+  if (!kind) {
     return FunctionKindCacheState::Unknown;
+  }
   return *kind == InferredSectionKind::Vector ? FunctionKindCacheState::Vector
                                               : FunctionKindCacheState::Cube;
 }
@@ -658,8 +683,9 @@ static std::optional<InferredSectionKind> inferWholeFunctionKind(
     if (func::CallOp callOp = getTransparentWrapperCall(funcOp)) {
       auto callee = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
           funcOp, callOp.getCalleeAttr());
-      if (callee && callee != funcOp)
+      if (callee && callee != funcOp) {
         inferredKind = inferWholeFunctionKind(callee, cache);
+      }
     }
   }
 
@@ -758,10 +784,11 @@ static void inspectSegmentOperation(Operation *op,
     std::optional<InferredSectionKind> kind =
         isTileLikeOp(op) ? classifyTileOp(op) : classifyRawSectionCarrierOp(op);
     if (kind) {
-      if (*kind == InferredSectionKind::Vector)
+      if (*kind == InferredSectionKind::Vector) {
         ++segment.vectorTileOpCount;
-      else
+      } else {
         ++segment.cubeTileOpCount;
+}
     } else {
       segment.ambiguousTileOps.push_back(op);
     }
@@ -799,8 +826,9 @@ inferSegmentKind(const UncoveredTopLevelSegment &segment) {
 
 static UncoveredTopLevelSegment summarizeTopLevelOperation(Operation *op) {
   UncoveredTopLevelSegment summary;
-  if (!op || isa<func::ReturnOp>(op) || isExplicitSection(op))
+  if (!op || isa<func::ReturnOp>(op) || isExplicitSection(op)) {
     return summary;
+  }
 
   summary.firstOp = op;
   summary.lastOp = op;
@@ -813,8 +841,9 @@ static UncoveredTopLevelSegment summarizeTopLevelOperation(Operation *op) {
 
 static void collectUncoveredTopLevelSegments(
     func::FuncOp funcOp, SmallVectorImpl<UncoveredTopLevelSegment> &segments) {
-  if (!funcOp || funcOp.isDeclaration() || !funcOp.getBody().hasOneBlock())
+  if (!funcOp || funcOp.isDeclaration() || !funcOp.getBody().hasOneBlock()) {
     return;
+  }
 
   Block &entryBlock = funcOp.getBody().front();
   UncoveredTopLevelSegment current;
@@ -898,10 +927,11 @@ emitSegmentInferenceError(func::FuncOp funcOp,
     diag << "; saw both vector-like and cube-like ops in the same segment";
   } else if (!segment.ambiguousTileOps.empty()) {
     diag << "; ambiguous op(s): ";
-    for (size_t i = 0, e = segment.ambiguousTileOps.size(); i < e && i < 3;
+    for (size_t i = 0, e = segment.ambiguousTileOps.size(); i < e && i < mlir::pto::kValue3;
          ++i) {
-      if (i)
+      if (i) {
         diag << ", ";
+      }
       diag << '\'' << segment.ambiguousTileOps[i]->getName().getStringRef()
            << '\'';
     }
@@ -935,7 +965,7 @@ static LogicalResult normalizeFunction(func::FuncOp funcOp) {
     return success();
   }
 
-  SmallVector<UncoveredTopLevelSegment, 4> segments;
+  SmallVector<UncoveredTopLevelSegment, mlir::pto::kValue4> segments;
   collectUncoveredTopLevelSegments(funcOp, segments);
   for (const UncoveredTopLevelSegment &segment : llvm::reverse(segments)) {
     if (!segment.containsTileOp || segment.containsNestedExplicitSection) {
@@ -965,7 +995,7 @@ verifyFunctionHasNoResidualUncoveredTileSegments(func::FuncOp funcOp) {
     return success();
   }
 
-  SmallVector<UncoveredTopLevelSegment, 4> segments;
+  SmallVector<UncoveredTopLevelSegment, mlir::pto::kValue4> segments;
   collectUncoveredTopLevelSegments(funcOp, segments);
   for (const UncoveredTopLevelSegment &segment : segments) {
     if (!segment.containsTileOp) {
@@ -979,23 +1009,28 @@ verifyFunctionHasNoResidualUncoveredTileSegments(func::FuncOp funcOp) {
 static LogicalResult scanModuleForUncoveredTileSegments(ModuleOp module) {
   LogicalResult status = success();
   module.walk([&](ModuleOp nestedModule) {
-    if (failed(status))
+    if (failed(status)) {
       return WalkResult::interrupt();
+    }
     status = tryAssignWholeModuleKernelKind(nestedModule);
     return failed(status) ? WalkResult::interrupt() : WalkResult::advance();
   });
-  if (failed(status))
+  if (failed(status)) {
     return status;
+  }
 
   module.walk([&](func::FuncOp funcOp) {
-    if (failed(status))
+    if (failed(status)) {
       return WalkResult::interrupt();
+    }
     status = tryAssignWholeFunctionKernelKind(funcOp);
-    if (failed(status))
+    if (failed(status)) {
       return WalkResult::interrupt();
+    }
     status = normalizeFunction(funcOp);
-    if (succeeded(status))
+    if (succeeded(status)) {
       status = verifyFunctionHasNoResidualUncoveredTileSegments(funcOp);
+    }
     return failed(status) ? WalkResult::interrupt() : WalkResult::advance();
   });
   return status;
@@ -1005,8 +1040,9 @@ struct PTONormalizeUncoveredTileSectionsPass
     : public mlir::pto::impl::PTONormalizeUncoveredTileSectionsBase<
           PTONormalizeUncoveredTileSectionsPass> {
   void runOnOperation() override {
-    if (failed(scanModuleForUncoveredTileSegments(getOperation())))
+    if (failed(scanModuleForUncoveredTileSegments(getOperation()))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/PTOOutlineSIMTSections.cpp
+++ b/lib/PTO/Transforms/PTOOutlineSIMTSections.cpp
@@ -218,8 +218,9 @@ static func::FuncOp createOutlinedHelper(ModuleOp module,
 
   Block *entry = helper.addEntryBlock();
   IRMapping mapping;
-  for (auto [capture, arg] : llvm::zip(captures, entry->getArguments()))
+  for (auto [capture, arg] : llvm::zip(captures, entry->getArguments())) {
     mapping.map(capture, arg);
+  }
 
   OpBuilder bodyBuilder = OpBuilder::atBlockEnd(entry);
   cloneExternalConstants(sectionOp, bodyBuilder, mapping);

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -9,6 +9,7 @@
 //===- PlanMemory.cpp ----Plan Buffer Memory Address ----------------------===//
 //===----------------------------------------------------------------------===//
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTOPlanMemory.h"
 
 #include "PTO/IR/PTOMultiBuffer.h"
@@ -78,7 +79,7 @@ static std::optional<int64_t> getTileBufferFootprintBytes(TileBufType type) {
     return totalStaticSize.value() * static_cast<int64_t>(elemBytes);
   }
 
-  if (shape.size() != 2 || llvm::is_contained(shape, ShapedType::kDynamic)) {
+  if (shape.size() != mlir::pto::kValue2 || llvm::is_contained(shape, ShapedType::kDynamic)) {
     return std::nullopt;
   }
 
@@ -146,26 +147,28 @@ static bool isIgnoredA5TmpOperandUse(OpOperand &use) {
   }
 
   if (isNameIn(name, {"pto.trowargmax", "pto.trowargmin", "pto.trowmax",
-                     "pto.trowmin", "pto.trowsum", "pto.trowprod"}))
+                      "pto.trowmin", "pto.trowsum", "pto.trowprod"})) {
     return operandNo == 1;
+  }
 
   if (name == "pto.txors") {
-    return operandNo == 2;
+    return operandNo == mlir::pto::kValue2;
   }
 
   if (isNameIn(name, {"pto.tprelu", "pto.txor", "pto.tsels",
-                     "pto.trowexpand", "pto.tcolexpand",
-                     "pto.trowexpandadd", "pto.trowexpanddiv",
-                     "pto.trowexpandexpdif", "pto.trowexpandmax",
-                     "pto.trowexpandmin", "pto.trowexpandmul",
-                     "pto.trowexpandsub", "pto.tcolexpandadd",
-                     "pto.tcolexpanddiv", "pto.tcolexpandexpdif",
-                     "pto.tcolexpandmax", "pto.tcolexpandmin",
-                     "pto.tcolexpandmul", "pto.tcolexpandsub"}))
-    return operandNo == 2;
+                      "pto.trowexpand", "pto.tcolexpand",
+                      "pto.trowexpandadd", "pto.trowexpanddiv",
+                      "pto.trowexpandexpdif", "pto.trowexpandmax",
+                      "pto.trowexpandmin", "pto.trowexpandmul",
+                      "pto.trowexpandsub", "pto.tcolexpandadd",
+                      "pto.tcolexpanddiv", "pto.tcolexpandexpdif",
+                      "pto.tcolexpandmax", "pto.tcolexpandmin",
+                      "pto.tcolexpandmul", "pto.tcolexpandsub"})) {
+    return operandNo == mlir::pto::kValue2;
+  }
 
   if (name == "pto.tsel") {
-    return operandNo == 3;
+    return operandNo == mlir::pto::kValue3;
   }
 
   return false;
@@ -193,7 +196,7 @@ static void collectStableValueOrder(Region &region,
                                     AsmState &asmState,
                                     DenseMap<Value, std::string> &stableValueKeys,
                                     SmallVectorImpl<Value> &seenValues) {
-  auto recordValue = [&](Value value) {
+  auto recordValue = [&asmState, &seenValues, &stableValueKeys](Value value) {
     if (stableValueKeys.find(value) != stableValueKeys.end()) {
       return;
     }
@@ -1071,7 +1074,7 @@ void MemLivenessAnalysis::RecordSemanticConflict(Value lhs, Value rhs) {
   SetVector<Value> rhsAliases = GetAliasBuffers(rhs);
   rhsAliases.insert(rhs);
 
-  auto appendUniquePair = [&](Value a, Value b) {
+  auto appendUniquePair = [this](Value a, Value b) {
     if (!a || !b || a == b) {
       return;
     }
@@ -1279,7 +1282,7 @@ bool MemPlan::HasSemanticConflict(const StorageEntry *entry,
     return false;
   }
 
-  auto containsPair = [&](Value lhs, Value rhs) {
+  auto containsPair = [this](Value lhs, Value rhs) {
     ValuePair pair = isLessValue(lhs, rhs) ? ValuePair(lhs, rhs)
                                            : ValuePair(rhs, lhs);
     return llvm::is_contained(semanticConflictPairs, pair);
@@ -2738,8 +2741,9 @@ private:
 static FailureOr<MemPlanMode> parseLegacyMemPlanMode(func::FuncOp func,
                                                      llvm::StringRef memMode) {
   if (memMode.equals_insensitive("local") ||
-      memMode.equals_insensitive("local-mem-plan"))
+      memMode.equals_insensitive("local-mem-plan")) {
     return MemPlanMode::LOCAL_MEM_PLAN;
+  }
   if (memMode.equals_insensitive("global-work-space-plan")) {
     return MemPlanMode::GLOBAL_WORKSPACE_PLAN;
   }

--- a/lib/PTO/Transforms/PTOPlanMemory.h
+++ b/lib/PTO/Transforms/PTOPlanMemory.h
@@ -11,14 +11,15 @@
 #ifndef PTO_PLAN_MEMORY_H
 #define PTO_PLAN_MEMORY_H
 
-#include "PTO/IR/PTO.h"
+#include <list>
 #include "OptMemPlanForPipeline.h"
+#include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Analysis/Liveness.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "llvm/ADT/SmallSet.h"
-#include <list>
+
 
 namespace mlir {
 namespace pto {

--- a/lib/PTO/Transforms/PTOPlanMemoryModern.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemoryModern.cpp
@@ -8,8 +8,11 @@
 
 //===- PTOPlanMemoryModern.cpp - modern static local memory planner -------===//
 
+#include <limits>
+#include <tuple>
 #include "PTO/IR/PTOMultiBuffer.h"
 #include "PTO/IR/PTOTypeUtils.h"
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/Passes.h"
 #include "Utils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -20,16 +23,10 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
-#include <limits>
-#include <tuple>
+
 
 using namespace mlir;
 using namespace mlir::pto;
-
-namespace mlir::pto {
-LogicalResult runModernPlanMemory(func::FuncOp func, llvm::StringRef memMode,
-                                  bool orderBySize);
-} // namespace mlir::pto
 
 namespace {
 
@@ -59,7 +56,7 @@ struct RootInfo {
   SmallVector<uint64_t> offsets;
 };
 
-using RootList = SmallVector<Value, 4>;
+using RootList = SmallVector<Value, mlir::pto::kValue4>;
 
 struct OpAccess {
   Operation *op = nullptr;
@@ -151,22 +148,23 @@ static bool isIgnoredA5TmpOperandUse(OpOperand &use) {
   }
 
   if (name == "pto.txors") {
-    return operandNo == 2;
+    return operandNo == mlir::pto::kValue2;
   }
 
   if (isNameIn(name, {"pto.tprelu", "pto.txor", "pto.tsels",
-                     "pto.trowexpand", "pto.tcolexpand",
-                     "pto.trowexpandadd", "pto.trowexpanddiv",
-                     "pto.trowexpandexpdif", "pto.trowexpandmax",
-                     "pto.trowexpandmin", "pto.trowexpandmul",
-                     "pto.trowexpandsub", "pto.tcolexpandadd",
-                     "pto.tcolexpanddiv", "pto.tcolexpandexpdif",
-                     "pto.tcolexpandmax", "pto.tcolexpandmin",
-                     "pto.tcolexpandmul", "pto.tcolexpandsub"}))
-    return operandNo == 2;
+                      "pto.trowexpand", "pto.tcolexpand",
+                      "pto.trowexpandadd", "pto.trowexpanddiv",
+                      "pto.trowexpandexpdif", "pto.trowexpandmax",
+                      "pto.trowexpandmin", "pto.trowexpandmul",
+                      "pto.trowexpandsub", "pto.tcolexpandadd",
+                      "pto.tcolexpanddiv", "pto.tcolexpandexpdif",
+                      "pto.tcolexpandmax", "pto.tcolexpandmin",
+                      "pto.tcolexpandmul", "pto.tcolexpandsub"})) {
+    return operandNo == mlir::pto::kValue2;
+  }
 
   if (name == "pto.tsel") {
-    return operandNo == 3;
+    return operandNo == mlir::pto::kValue3;
   }
 
   return false;
@@ -297,7 +295,7 @@ static InplacePolicy getInplacePolicy(Operation *op) {
 
   if (name == "pto.tsel") {
     policy.forbidOutputAliasOperands.push_back(0); // mask
-    policy.forbidOutputAliasOperands.push_back(3); // tmp
+    policy.forbidOutputAliasOperands.push_back(mlir::pto::kValue3); // tmp
   }
 
   if (isOneOf(name, {
@@ -337,7 +335,7 @@ static SmallVector<Value> getWrittenNonDpsOperands(Operation *op,
     return scratchOperands;
   }
 
-  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, 8> effects;
+  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, mlir::pto::kValue8> effects;
   memEffect.getEffects(effects);
   for (const auto &effect : effects) {
     if (!isa<MemoryEffects::Write>(effect.getEffect())) {
@@ -366,7 +364,7 @@ static bool hasReadEffectOnValue(Operation *op, Value value) {
     return false;
   }
 
-  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, 8> effects;
+  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, mlir::pto::kValue8> effects;
   memEffect.getEffects(effects);
   for (const auto &effect : effects) {
     if (!isa<MemoryEffects::Read>(effect.getEffect())) {
@@ -453,10 +451,10 @@ struct PlannerAnalysis {
     uint64_t slotCount = 1;
     if (auto multiType = dyn_cast<MultiTileBufType>(value.getType())) {
       slotCount = multiType.getCount();
-    }
-    else if (auto attr =
-                 defOp->getAttrOfType<IntegerAttr>(pto::kPtoMultiBufferAttrName))
+    } else if (auto attr =
+                   defOp->getAttrOfType<IntegerAttr>(pto::kPtoMultiBufferAttrName)) {
       slotCount = attr.getValue().getZExtValue();
+    }
     MemSpec spec = getMemSpec(getTargetArch(func), *space);
     uint64_t slotBytes = alignUp(*bytesOr, spec.alignmentBytes);
 
@@ -803,7 +801,7 @@ struct PlannerAnalysis {
     access.opIndex = facts.opAccesses.size();
     access.inLoop = isInsideLoop(op);
 
-    SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, 8> effects;
+    SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, mlir::pto::kValue8> effects;
     memEffect.getEffects(effects);
     for (const auto &effect : effects) {
       Value value = effect.getValue();
@@ -1217,12 +1215,12 @@ static bool accessesRoot(const OpAccess &access, Value root) {
 static bool accessPairHasMemoryDependency(const OpAccess &lhs,
                                           const OpAccess &rhs, Value lhsRoot,
                                           Value rhsRoot) {
-  auto depends = [&](Value writtenRoot, Value otherRoot) {
+  auto depends = [&lhs, &rhs](Value writtenRoot, Value otherRoot) {
     return containsRoot(lhs.writes, writtenRoot) &&
            (containsRoot(rhs.reads, otherRoot) ||
             containsRoot(rhs.writes, otherRoot));
   };
-  auto reverseDepends = [&](Value readRoot, Value writtenRoot) {
+  auto reverseDepends = [&lhs, &rhs](Value readRoot, Value writtenRoot) {
     return containsRoot(lhs.reads, readRoot) &&
            containsRoot(rhs.writes, writtenRoot);
   };
@@ -1306,7 +1304,7 @@ static uint64_t getGroupReuseCost(const RootInfo &info,
 
 static bool isHotRoot(const RootInfo &info) {
   if (info.loopAccessCount > 0 &&
-      (info.accessCount >= 2 || info.pipeVAccessCount > 0 ||
+      (info.accessCount >= mlir::pto::kValue2 || info.pipeVAccessCount > 0 ||
        info.mteAccessCount > 0)) {
     return true;
   }
@@ -1314,16 +1312,16 @@ static bool isHotRoot(const RootInfo &info) {
   // Some PTODSL kernels express repeated work through task/block parallelism
   // rather than an explicit scf.for in PTO IR. Repeated local accesses on
   // PIPE_V/MTE are still hot enough that over-clustering can hurt scheduling.
-  return info.accessCount >= 2 &&
+  return info.accessCount >= mlir::pto::kValue2 &&
          (info.pipeVAccessCount > 0 || info.mteAccessCount > 0);
 }
 
 static uint64_t getRootHotness(const RootInfo &info) {
   uint64_t hotness = info.accessCount;
-  hotness += static_cast<uint64_t>(info.loopAccessCount) * 2;
+  hotness += static_cast<uint64_t>(info.loopAccessCount) * mlir::pto::kValue2;
   hotness += static_cast<uint64_t>(info.writeAccessCount);
-  hotness += static_cast<uint64_t>(info.pipeVAccessCount) * 2;
-  hotness += static_cast<uint64_t>(info.mteAccessCount) * 2;
+  hotness += static_cast<uint64_t>(info.pipeVAccessCount) * mlir::pto::kValue2;
+  hotness += static_cast<uint64_t>(info.mteAccessCount) * mlir::pto::kValue2;
   return hotness;
 }
 
@@ -1449,7 +1447,6 @@ static ReuseGroup *chooseReuseGroupByCost(
     return std::tie(lhsCost, lhsBytes, lhsOrder) <
            std::tie(rhsCost, rhsBytes, rhsOrder);
   };
-
   if (isBetter(freshFits, freshCost, freshProjectedBytes, freshOrder, bestFits,
                bestCost, bestProjectedBytes, bestOrder)) {
     return nullptr;
@@ -1661,9 +1658,9 @@ static LogicalResult materializePlannedOffsets(
 
 } // namespace
 
-LogicalResult mlir::pto::runModernPlanMemory(func::FuncOp func,
-                                             llvm::StringRef memMode,
-                                             bool orderBySize) {
+static LogicalResult runModernPlanMemory(func::FuncOp func,
+                                         llvm::StringRef memMode,
+                                         bool orderBySize) {
   if (!memMode.equals_insensitive("local")) {
     func.emitError("unsupported mem-mode '")
         << memMode << "'; only 'local' is currently implemented";
@@ -1737,8 +1734,8 @@ LogicalResult mlir::pto::runModernPlanMemory(func::FuncOp func,
 
     if (scopeRequiredBytes > spec.capacityBytes) {
       func.emitError() << stringifyEnum(space) << " overflow, requires "
-                       << (scopeRequiredBytes * 8) << " bits while "
-                       << (spec.capacityBytes * 8) << " bits available";
+                       << (scopeRequiredBytes * mlir::pto::kValue8) << " bits while "
+                       << (spec.capacityBytes * mlir::pto::kValue8) << " bits available";
       return failure();
     }
 
@@ -1776,7 +1773,7 @@ LogicalResult mlir::pto::runModernPlanMemory(func::FuncOp func,
       return WalkResult::interrupt();
     }
 
-    reserveOp->setAttr("base", IntegerAttr::get(IntegerType::get(ctx, 32),
+    reserveOp->setAttr("base", IntegerAttr::get(IntegerType::get(ctx, mlir::pto::kValue32),
                                                 static_cast<int32_t>(*baseOr)));
     return WalkResult::advance();
   });
@@ -1844,7 +1841,7 @@ struct PlanMemoryModernPass
 
     for (func::FuncOp funcOp : funcs) {
       if (failed(
-              mlir::pto::runModernPlanMemory(funcOp, memMode, orderBySize))) {
+              runModernPlanMemory(funcOp, memMode, orderBySize))) {
         signalPassFailure();
         return;
       }

--- a/lib/PTO/Transforms/PTORematerializeFixpipeVectorQuant.cpp
+++ b/lib/PTO/Transforms/PTORematerializeFixpipeVectorQuant.cpp
@@ -77,8 +77,9 @@ struct PTORematerializeFixpipeVectorQuantPass
 
         for (Region &region : op->getRegions()) {
           for (Block &nestedBlock : region) {
-            if (failed(self(self, nestedBlock)))
+            if (failed(self(self, nestedBlock))) {
               return failure();
+            }
           }
         }
       }

--- a/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
+++ b/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
@@ -9,6 +9,7 @@
 //===- PTORemoveIdentityTMov.cpp -----------------------------------------===//
 //===----------------------------------------------------------------------===//
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/InsertSync/MemoryDependentAnalyzer.h"
@@ -37,10 +38,12 @@ using namespace mlir::pto;
 namespace {
 
 static std::optional<unsigned> getIntegerLikeBitWidth(Type type) {
-  if (auto intTy = dyn_cast<IntegerType>(type))
+  if (auto intTy = dyn_cast<IntegerType>(type)) {
     return intTy.getWidth();
-  if (isa<IndexType>(type))
-    return 64;
+  }
+  if (isa<IndexType>(type)) {
+    return mlir::pto::kValue64;
+  }
   return std::nullopt;
 }
 
@@ -92,23 +95,28 @@ static std::optional<APInt> tryEvalIntegerLikeConstant(Value value) {
     return std::nullopt;
   }
 
-  if (auto castOp = dyn_cast<arith::IndexCastOp>(defOp))
+  if (auto castOp = dyn_cast<arith::IndexCastOp>(defOp)) {
     return evalSignedCast(castOp.getIn(), castOp.getType());
-  if (auto castOp = dyn_cast<arith::IndexCastUIOp>(defOp))
+  }
+  if (auto castOp = dyn_cast<arith::IndexCastUIOp>(defOp)) {
     return evalUnsignedCast(castOp.getIn(), castOp.getType());
-  if (auto castOp = dyn_cast<arith::ExtSIOp>(defOp))
+  }
+  if (auto castOp = dyn_cast<arith::ExtSIOp>(defOp)) {
     return evalSignedCast(castOp.getIn(), castOp.getType());
-  if (auto castOp = dyn_cast<arith::ExtUIOp>(defOp))
+  }
+  if (auto castOp = dyn_cast<arith::ExtUIOp>(defOp)) {
     return evalUnsignedCast(castOp.getIn(), castOp.getType());
-  if (auto castOp = dyn_cast<arith::TruncIOp>(defOp))
+  }
+  if (auto castOp = dyn_cast<arith::TruncIOp>(defOp)) {
     return evalTruncCast(castOp.getIn(), castOp.getType());
+  }
 
   return std::nullopt;
 }
 
 static std::optional<int64_t> tryEvalI64Constant(Value value) {
   std::optional<APInt> apInt = tryEvalIntegerLikeConstant(value);
-  if (!apInt || apInt->getBitWidth() > 64) {
+  if (!apInt || apInt->getBitWidth() > mlir::pto::kValue64) {
     return std::nullopt;
   }
   return apInt->getSExtValue();
@@ -153,8 +161,9 @@ tryGetConcreteRootAddress(const BaseMemInfo *info) {
     return std::nullopt;
   }
 
-  if (auto alloc = dyn_cast<pto::AllocTileOp>(defOp))
+  if (auto alloc = dyn_cast<pto::AllocTileOp>(defOp)) {
     return tryEvalI64Constant(alloc.getAddr());
+  }
 
   return std::nullopt;
 }
@@ -312,21 +321,26 @@ static bool hasCompatibleIdentityTypes(TMovOp op) {
 }
 
 static bool hasLowPrecisionElement(Value value) {
-  if (auto tileTy = dyn_cast<TileBufType>(value.getType()))
+  if (auto tileTy = dyn_cast<TileBufType>(value.getType())) {
     return isPTOLowPrecisionType(tileTy.getElementType());
-  if (auto memrefTy = dyn_cast<MemRefType>(value.getType()))
+  }
+  if (auto memrefTy = dyn_cast<MemRefType>(value.getType())) {
     return isPTOLowPrecisionType(memrefTy.getElementType());
+  }
   return false;
 }
 
 static bool touchesLowPrecisionElement(TMovOp op) {
-  if (hasLowPrecisionElement(op.getSrc()) || hasLowPrecisionElement(op.getDst()))
+  if (hasLowPrecisionElement(op.getSrc()) || hasLowPrecisionElement(op.getDst())) {
     return true;
+  }
   return llvm::any_of(op->getResults(), [](OpResult result) {
-    if (auto tileTy = dyn_cast<TileBufType>(result.getType()))
+    if (auto tileTy = dyn_cast<TileBufType>(result.getType())) {
       return isPTOLowPrecisionType(tileTy.getElementType());
-    if (auto memrefTy = dyn_cast<MemRefType>(result.getType()))
+    }
+    if (auto memrefTy = dyn_cast<MemRefType>(result.getType())) {
       return isPTOLowPrecisionType(memrefTy.getElementType());
+    }
     return false;
   });
 }
@@ -335,7 +349,6 @@ static bool
 isIdentityTMovByMemInfo(TMovOp op, const Buffer2MemInfoMap &buffer2MemInfoMap) {
   Value src = op.getSrc();
   Value dst = op.getDst();
-
   if (!isStaticallyAddressableValue(src) || !isStaticallyAddressableValue(dst)) {
     return false;
   }
@@ -355,8 +368,8 @@ struct PTORemoveIdentityTMovPass
           PTORemoveIdentityTMovPass> {
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    SmallVector<TMovOp, 16> identityMoves;
-    SmallVector<TMovOp, 16> memInfoCandidates;
+    SmallVector<TMovOp, mlir::pto::kValue16> identityMoves;
+    SmallVector<TMovOp, mlir::pto::kValue16> memInfoCandidates;
 
     func.walk([&](TMovOp op) {
       if (!hasPlainTMovSemantics(op) || !hasCompatibleIdentityTypes(op) ||

--- a/lib/PTO/Transforms/PTORemoveRedundantBarrier.cpp
+++ b/lib/PTO/Transforms/PTORemoveRedundantBarrier.cpp
@@ -6,15 +6,16 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include <memory>
 #include "PTO/IR/PTO.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Pass/Pass.h"
-#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include <memory>
+
 
 using namespace mlir;
 using namespace mlir::pto;
@@ -190,7 +191,6 @@ struct PTORemoveRedundantBarrierPass : public PassWrapper<PTORemoveRedundantBarr
       for (auto it = block->begin(); it != block->end(); ++it) {
         Operation *op = &*it;
         Attribute pipe = getOpPipe(op);
-
         // === 1. 状态更新 ===
         if (pipe) {
             intraPipeDirtySet.insert(pipe);
@@ -200,7 +200,6 @@ struct PTORemoveRedundantBarrierPass : public PassWrapper<PTORemoveRedundantBarr
         // === 2. Barrier 消除 ===
         if (auto barrierOp = dyn_cast<pto::BarrierOp>(op)) {
             Attribute bPipe = barrierOp.getPipe();
-            
             // 规则 A: Dead Pipeline
             // 后面没活干了 -> 删除 (保护空气没有意义)
             if (!isPipelineActiveFuture(block, std::next(it), bPipe)) {
@@ -245,8 +244,7 @@ struct PTORemoveRedundantBarrierPass : public PassWrapper<PTORemoveRedundantBarr
         Attribute setSrc;
         Attribute setDst;
         if (getSetSyncPipes(op, setSrc, setDst)) {
-
-            // 规则 A: Dead Receiver (死信)
+          // 规则 A: Dead Receiver (死信)
             // 如果 dst 后面没有 Resource Op，发信号也没人用。
             // 注意：因为 isPipelineActiveFuture 忽略了 WaitOp，
             // 所以如果后面只有 Wait <Src, Dst> 而没有 Dst 的实质操作，这里也会判定为 Dead，

--- a/lib/PTO/Transforms/PTOResolveBufferSelect.cpp
+++ b/lib/PTO/Transforms/PTOResolveBufferSelect.cpp
@@ -17,6 +17,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOMultiBuffer.h"
 #include "PTO/IR/PTOTypeUtils.h"
@@ -41,6 +42,15 @@ using namespace mlir;
 
 namespace {
 
+constexpr int64_t kSFractal1024 = 1024;
+constexpr int64_t kSFractal512 = 512;
+constexpr int64_t kSFractal32 = 32;
+constexpr int64_t kFractalInnerDimension = 16;
+constexpr int64_t kSFractal32InnerColumnCount = 2;
+constexpr uint64_t kCubeTileAddressAlignmentBytes = 512;
+constexpr uint64_t kVectorTileAddressAlignmentBytes = 32;
+constexpr unsigned kI64BitWidth = 64;
+
 static uint64_t alignUp(uint64_t value, uint64_t align) {
   if (align == 0) {
     return value;
@@ -52,7 +62,7 @@ static Value ensureI64(Value value, IRRewriter &rewriter, Location loc) {
   if (!value) {
     return {};
   }
-  if (value.getType().isInteger(64)) {
+  if (value.getType().isInteger(kI64BitWidth)) {
     return value;
   }
   if (value.getType().isIndex()) {
@@ -67,8 +77,9 @@ static Value ensureI64(Value value, IRRewriter &rewriter, Location loc) {
 static bool getTilePointerStrides(pto::TileBufType type, int64_t &rowStride,
                                   int64_t &colStride) {
   auto shape = type.getShape();
-  if (shape.size() != 2 || llvm::is_contained(shape, ShapedType::kDynamic))
+  if (shape.size() != mlir::pto::kValue2 || llvm::is_contained(shape, ShapedType::kDynamic)) {
     return false;
+  }
 
   auto config = type.getConfigAttr();
   int32_t bl = static_cast<int32_t>(config.getBLayout().getValue());
@@ -89,18 +100,18 @@ static bool getTilePointerStrides(pto::TileBufType type, int64_t &rowStride,
   int64_t innerRows = 1;
   int64_t innerCols = 1;
   int32_t fractal = config.getSFractalSize().getInt();
-  if (fractal == 1024) {
-    innerRows = 16;
-    innerCols = 16;
-  } else if (fractal == 32) {
-    innerRows = 16;
-    innerCols = 2;
-  } else if (fractal == 512 && sl == 1) {
-    innerRows = 16;
-    innerCols = 32 / elemBytes;
-  } else if (fractal == 512 && sl == 2) {
-    innerRows = 32 / elemBytes;
-    innerCols = 16;
+  if (fractal == kSFractal1024) {
+    innerRows = kFractalInnerDimension;
+    innerCols = kFractalInnerDimension;
+  } else if (fractal == kSFractal32) {
+    innerRows = kFractalInnerDimension;
+    innerCols = kSFractal32InnerColumnCount;
+  } else if (fractal == kSFractal512 && sl == 1) {
+    innerRows = kFractalInnerDimension;
+    innerCols = kSFractal32 / elemBytes;
+  } else if (fractal == kSFractal512 && sl == 2) {
+    innerRows = kSFractal32 / elemBytes;
+    innerCols = kFractalInnerDimension;
   } else {
     return false;
   }
@@ -131,19 +142,20 @@ static bool getTilePointerStrides(pto::TileBufType type, int64_t &rowStride,
 static uint64_t getTileAddressAlignmentBytes(pto::TileBufType type) {
   auto addrSpace =
       dyn_cast_or_null<pto::AddressSpaceAttr>(type.getMemorySpace());
-  if (!addrSpace)
+  if (!addrSpace) {
     return 1;
+  }
 
   switch (addrSpace.getAddressSpace()) {
   case pto::AddressSpace::LEFT:
   case pto::AddressSpace::RIGHT:
   case pto::AddressSpace::ACC:
-    return 512;
+    return kCubeTileAddressAlignmentBytes;
   case pto::AddressSpace::VEC:
   case pto::AddressSpace::MAT:
   case pto::AddressSpace::BIAS:
   case pto::AddressSpace::SCALING:
-    return 32;
+    return kVectorTileAddressAlignmentBytes;
   case pto::AddressSpace::GM:
   case pto::AddressSpace::Zero:
     return 1;
@@ -153,20 +165,23 @@ static uint64_t getTileAddressAlignmentBytes(pto::TileBufType type) {
 
 static Value computeTileAddress(Value value, IRRewriter &rewriter,
                                 Location loc) {
-  if (auto alloc = value.getDefiningOp<pto::AllocTileOp>())
+  if (auto alloc = value.getDefiningOp<pto::AllocTileOp>()) {
     return ensureI64(alloc.getAddr(), rewriter, loc);
+  }
   if (auto subview = value.getDefiningOp<pto::SubViewOp>()) {
     Value base = computeTileAddress(subview.getSource(), rewriter, loc);
     auto sourceType = subview.getSource().getType();
     int64_t rowStride = 0;
     int64_t colStride = 0;
     if (!base || !getTilePointerStrides(sourceType, rowStride, colStride) ||
-        subview.getOffsets().size() != 2)
+        subview.getOffsets().size() != mlir::pto::kValue2) {
       return {};
+    }
     Value row = ensureI64(subview.getOffsets()[0], rewriter, loc);
     Value col = ensureI64(subview.getOffsets()[1], rewriter, loc);
-    if (!row || !col)
+    if (!row || !col) {
       return {};
+    }
     Value rowScale = rewriter.create<arith::ConstantIntOp>(loc, rowStride, 64);
     Value colScale = rewriter.create<arith::ConstantIntOp>(loc, colStride, 64);
     row = rewriter.create<arith::MulIOp>(loc, row, rowScale);
@@ -204,8 +219,9 @@ static pto::TileBufType getSubviewPhysicalType(pto::SubViewOp op) {
                             inheritedColStride) &&
       getTilePointerStrides(compactChildType, childRowStride, childColStride) &&
       inheritedRowStride == childRowStride &&
-      inheritedColStride == childColStride)
+      inheritedColStride == childColStride) {
     physicalShape = resultType.getShape();
+  }
 
   return pto::TileBufType::get(
       op.getContext(), physicalShape, resultType.getElementType(),
@@ -218,19 +234,22 @@ static Value getSubviewValidOperand(pto::SubViewOp op,
                                     unsigned dim, IRRewriter &rewriter) {
   Value operand = dim == 0 ? op.getValidRow() : op.getValidCol();
   ArrayRef<int64_t> validShape = physicalType.getValidShape();
-  if (validShape.size() <= dim || validShape[dim] >= 0)
+  if (validShape.size() <= dim || validShape[dim] >= 0) {
     return {};
-  if (operand)
+  }
+  if (operand) {
     return operand;
+  }
   ArrayRef<int64_t> shape = physicalType.getShape();
-  if (shape.size() > dim && shape[dim] != ShapedType::kDynamic)
+  if (shape.size() > dim && shape[dim] != ShapedType::kDynamic) {
     return rewriter.create<arith::ConstantIndexOp>(op.getLoc(), shape[dim]);
+  }
   return {};
 }
 
 static LogicalResult resolveTileNativeSubviews(ModuleOp module,
                                                MLIRContext *ctx) {
-  SmallVector<pto::SubViewOp, 16> subviews;
+  SmallVector<pto::SubViewOp, mlir::pto::kValue16> subviews;
   module.walk([&](pto::SubViewOp op) { subviews.push_back(op); });
   for (pto::SubViewOp op : subviews) {
     IRRewriter rewriter(ctx);
@@ -277,9 +296,10 @@ static LogicalResult getMultiTileAddresses(pto::AllocMultiTileOp alloc,
     if (planned.size() != count) {
       return alloc.emitError("planned address count does not match slot count");
     }
-    for (int64_t address : planned.asArrayRef())
+    for (int64_t address : planned.asArrayRef()) {
       addrs.push_back(rewriter.create<arith::ConstantIntOp>(
-          alloc.getLoc(), address, 64));
+          alloc.getLoc(), address, kI64BitWidth));
+    }
     return success();
   }
 
@@ -311,18 +331,19 @@ static LogicalResult getMultiTileAddresses(pto::AllocMultiTileOp alloc,
 
 static LogicalResult resolveTileNativeMultiGets(ModuleOp module,
                                                 MLIRContext *ctx) {
-  SmallVector<pto::MultiTileGetOp, 8> gets;
+  SmallVector<pto::MultiTileGetOp, mlir::pto::kValue8> gets;
   module.walk([&](pto::MultiTileGetOp op) { gets.push_back(op); });
 
   for (pto::MultiTileGetOp op : gets) {
     auto alloc = op.getSource().getDefiningOp<pto::AllocMultiTileOp>();
-    if (!alloc)
+    if (!alloc) {
       return op.emitError(
           "currently requires a direct pto.alloc_multi_tile source");
+    }
 
     IRRewriter rewriter(ctx);
     rewriter.setInsertionPoint(op);
-    SmallVector<Value, 8> addrs;
+    SmallVector<Value, mlir::pto::kValue8> addrs;
     if (failed(getMultiTileAddresses(alloc, rewriter, addrs))) {
       return failure();
     }
@@ -331,8 +352,9 @@ static LogicalResult resolveTileNativeMultiGets(ModuleOp module,
     IntegerAttr constSlotAttr;
     if (matchPattern(op.getSlot(), m_Constant(&constSlotAttr))) {
       int64_t slot = constSlotAttr.getValue().getSExtValue();
-      if (slot < 0 || slot >= static_cast<int64_t>(addrs.size()))
+      if (slot < 0 || slot >= static_cast<int64_t>(addrs.size())) {
         return op.emitError("constant slot is outside planned address range");
+      }
       selectedAddr = addrs[static_cast<size_t>(slot)];
     } else {
       selectedAddr = addrs.front();
@@ -352,7 +374,7 @@ static LogicalResult resolveTileNativeMultiGets(ModuleOp module,
     rewriter.replaceOp(op, slotHandle.getResult());
   }
 
-  SmallVector<pto::AllocMultiTileOp, 8> allocs;
+  SmallVector<pto::AllocMultiTileOp, mlir::pto::kValue8> allocs;
   module.walk([&](pto::AllocMultiTileOp op) { allocs.push_back(op); });
   for (pto::AllocMultiTileOp alloc : allocs) {
     if (!alloc.getResult().use_empty()) {

--- a/lib/PTO/Transforms/PTOResolveReservedBuffersPass.cpp
+++ b/lib/PTO/Transforms/PTOResolveReservedBuffersPass.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
 #include <map>
@@ -149,8 +150,9 @@ static PipeInitInfo buildPipeInitInfo(InitOpT initOp) {
   info.slotSize = initOp.getSlotSize();
   info.slotNum = initOp.getSlotNum();
   if constexpr (std::is_same_v<InitOpT, InitializeL2G2LPipeOp>) {
-    if (auto attr = initOp.getLocalSlotNumAttr())
+    if (auto attr = initOp.getLocalSlotNumAttr()) {
       info.localSlotNum = attr.getInt();
+    }
     info.globalOnly = !initOp.getLocalAddr();
   }
   return info;
@@ -159,10 +161,13 @@ static PipeInitInfo buildPipeInitInfo(InitOpT initOp) {
 static PipePeerKey getGlobalTensorPipeKey(const PipeInitInfo &info) {
   std::string id = "unknown";
   if (auto idAttr =
-          info.op->getAttrOfType<IntegerAttr>(kFrontendPipeIdAttrName))
+          info.op->getAttrOfType<IntegerAttr>(kFrontendPipeIdAttrName)) {
     id = std::to_string(idAttr.getInt());
-  else
-    id = std::to_string(reinterpret_cast<uintptr_t>(info.op));
+  } else {
+    llvm::raw_string_ostream stream(id);
+    stream << info.op;
+    stream.flush();
+  }
   return PipePeerKey{"__pto_globaltensor_pipe", "id_" + id, info.dirMask};
 }
 
@@ -177,7 +182,8 @@ static LogicalResult collectPeerAwareInit(InitOpT initOp,
     return success();
   }
 
-  auto recordAddr = [&](Value addr, int8_t effectiveDirMask) {
+  auto recordAddr = [&info, &keyedInits](Value addr,
+                                         int8_t effectiveDirMask) {
     if (!addr) {
       return false;
     }
@@ -212,25 +218,29 @@ static LogicalResult collectPeerAwareInit(InitOpT initOp,
 }
 
 static IntegerAttr getFlagBaseAttr(Operation *op) {
-  if (auto initOp = dyn_cast<InitializeL2LPipeOp>(op))
+  if (auto initOp = dyn_cast<InitializeL2LPipeOp>(op)) {
     return initOp.getFlagBaseAttr();
+  }
   return cast<InitializeL2G2LPipeOp>(op).getFlagBaseAttr();
 }
 
 static void setFlagBaseAttr(Operation *op, IntegerAttr attr) {
   if (auto initOp = dyn_cast<InitializeL2LPipeOp>(op)) {
-    if (!initOp.getFlagBaseAttr())
+    if (!initOp.getFlagBaseAttr()) {
       setFlagBaseAttr(initOp, attr);
+    }
     return;
   }
   auto initOp = cast<InitializeL2G2LPipeOp>(op);
-  if (!initOp.getFlagBaseAttr())
+  if (!initOp.getFlagBaseAttr()) {
     setFlagBaseAttr(initOp, attr);
+  }
 }
 
 static std::optional<int32_t> getFrontendPipeId(Operation *op) {
-  if (auto attr = op->getAttrOfType<IntegerAttr>(kFrontendPipeIdAttrName))
+  if (auto attr = op->getAttrOfType<IntegerAttr>(kFrontendPipeIdAttrName)) {
     return attr.getInt();
+  }
   return std::nullopt;
 }
 
@@ -350,9 +360,10 @@ buildPeerAwareComponents(const SmallVectorImpl<PipeInitInfo> &initInfos,
   llvm::stable_sort(components, [](const PipeComponent &lhs,
                                    const PipeComponent &rhs) {
     auto sortKey = [](const PipeComponent &component) {
-      if (component.frontendId)
+      if (component.frontendId) {
         return std::tuple(0, *component.frontendId, component.dirMask,
                           component.creationOrder);
+      }
       return std::tuple(1, 0, int8_t{0}, component.creationOrder);
     };
     return sortKey(lhs) < sortKey(rhs);
@@ -380,15 +391,17 @@ static LogicalResult reserveComponentFlagBase(const PipeComponent &component,
   }
   for (const std::string &funcName : component.participants) {
     for (const FlagInterval &used : usedByFunc[funcName]) {
-      if (!overlaps(interval, used))
+      if (!overlaps(interval, used)) {
         continue;
+      }
       return component.ops.front()->emitOpError(
           "conflicting flag_base across peer pipe init components in the same function");
     }
   }
 
-  for (const std::string &funcName : component.participants)
+  for (const std::string &funcName : component.participants) {
     usedByFunc[funcName].push_back(interval);
+  }
   return success();
 }
 
@@ -412,8 +425,9 @@ static FailureOr<int32_t> chooseFlagBaseForComponent(const PipeComponent &compon
     int32_t nextCandidate = candidateBase + 2;
     for (const std::string &funcName : component.participants) {
       for (const FlagInterval &used : usedByFunc[funcName]) {
-        if (!overlaps(candidate, used))
+        if (!overlaps(candidate, used)) {
           continue;
+        }
         conflict = true;
         nextCandidate = std::max(nextCandidate, alignToEven(used.end));
       }
@@ -424,8 +438,9 @@ static FailureOr<int32_t> chooseFlagBaseForComponent(const PipeComponent &compon
     candidateBase = nextCandidate;
   }
 
-  if (failed(reserveComponentFlagBase(component, candidateBase, usedByFunc)))
+  if (failed(reserveComponentFlagBase(component, candidateBase, usedByFunc))) {
     return failure();
+  }
   return candidateBase;
 }
 
@@ -440,27 +455,31 @@ struct PTOResolveReservedBuffersPass
     PipeInitGroups keyedInits;
     LogicalResult status = success();
 
-    auto collectInit = [&](auto initOp) {
-      if (failed(status))
+    auto collectInit = [&initInfos, &keyedInits, &status](auto initOp) {
+      if (failed(status)) {
         return;
+      }
       status = collectPeerAwareInit(initOp, initInfos, keyedInits);
     };
 
     moduleOp.walk([&](InitializeL2LPipeOp initOp) { collectInit(initOp); });
     moduleOp.walk([&](InitializeL2G2LPipeOp initOp) { collectInit(initOp); });
-    if (failed(status))
+    if (failed(status)) {
       return failure();
+    }
 
     auto componentsOr = buildPeerAwareComponents(initInfos, keyedInits);
-    if (failed(componentsOr))
+    if (failed(componentsOr)) {
       return failure();
+    }
 
     OpBuilder builder(moduleOp.getContext());
     PipeFlagUsage usedByFunc;
     for (const PipeComponent &component : *componentsOr) {
       auto chosenBaseOr = chooseFlagBaseForComponent(component, usedByFunc);
-      if (failed(chosenBaseOr))
+      if (failed(chosenBaseOr)) {
         return failure();
+      }
       auto flagBaseAttr = builder.getI32IntegerAttr(*chosenBaseOr);
       for (Operation *op : component.ops) {
         setFlagBaseAttr(op, flagBaseAttr);
@@ -514,9 +533,10 @@ struct PTOResolveReservedBuffersPass
 
         auto peerReserve =
             findReserveBufferByName(peerFunc, importOp.getName());
-        if (!peerReserve)
+        if (!peerReserve) {
           return importOp.emitOpError(
               "expects matching peer reserve_buffer to exist");
+        }
 
         auto baseAttr = peerReserve.getBaseAttr();
         if (!baseAttr) {

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -13169,10 +13169,12 @@ struct SCFWhileToCF : public OpRewritePattern<scf::WhileOp> {
                                     Location loc, Block *afterWhileBlock) {
     SmallVector<Value> exitArgs;
     exitArgs.reserve(op.getNumResults());
-    for (Type type : op.getResultTypes())
+    for (Type type : op.getResultTypes()) {
       exitArgs.push_back(afterWhileBlock->addArgument(type, loc));
-    for (auto result : llvm::enumerate(op.getResults()))
+    }
+    for (auto result : llvm::enumerate(op.getResults())) {
       result.value().replaceAllUsesWith(exitArgs[result.index()]);
+    }
   }
 
   LogicalResult matchAndRewrite(scf::WhileOp op,
@@ -13888,8 +13890,9 @@ static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
             [](Operation *) { return true; });
 
         for (func::FuncOp func : functions) {
-          if (!needsWholeFunctionSCFToCF(func))
+          if (!needsWholeFunctionSCFToCF(func)) {
             continue;
+          }
           if (failed(applyPartialConversion(func, scfToCfTarget,
                                             frozenSCFToCF))) {
             func.emitError()

--- a/lib/PTO/Transforms/PTOVPTOPtrBoundary.cpp
+++ b/lib/PTO/Transforms/PTOVPTOPtrBoundary.cpp
@@ -68,8 +68,9 @@ static LogicalResult eraseDeadVPTOMemRefScaffold(ModuleOp module) {
         return;
       }
       if (isa<memref::ReinterpretCastOp, memref::SubViewOp,
-              memref::MemorySpaceCastOp>(op))
+              memref::MemorySpaceCastOp>(op)) {
         deadOps.push_back(op);
+      }
     });
 
     for (pto::CastPtrOp castOp : trivialCasts) {
@@ -290,10 +291,11 @@ LogicalResult mlir::pto::convertVPTOEmissionBoundaryToPtr(
 
       Type newType = convertVPTOBoundaryMemRefType(inputType);
       if (!newType) {
-        if (diagOS)
+        if (diagOS) {
           *diagOS << "VPTO emission-boundary ptr rewrite failed: unsupported "
                      "memref argument type in "
                   << func.getName() << ": " << inputType << "\n";
+        }
         sawFailure = true;
         continue;
       }
@@ -342,10 +344,11 @@ LogicalResult mlir::pto::convertVPTOEmissionBoundaryToPtr(
       if (!isa<BaseMemRefType>(resultType)) {
         continue;
       }
-      if (diagOS)
+      if (diagOS) {
         *diagOS << "VPTO emission-boundary ptr rewrite failed: memref result "
                    "is unsupported for "
                 << func.getName() << ": " << resultType << "\n";
+      }
       sawFailure = true;
     }
 

--- a/lib/PTO/Transforms/PTOValidateIntToPtrUses.cpp
+++ b/lib/PTO/Transforms/PTOValidateIntToPtrUses.cpp
@@ -37,8 +37,9 @@ LogicalResult mlir::pto::validateIntToPtrUses(func::FuncOp func) {
   WalkResult walkResult = func.walk([&](IntToPtrOp op) -> WalkResult {
     Value ptr = op.getResult();
     for (OpOperand &use : ptr.getUses()) {
-      if (isAllowedIntToPtrUse(ptr, use))
+      if (isAllowedIntToPtrUse(ptr, use)) {
         continue;
+      }
 
       Operation *user = use.getOwner();
       InFlightDiagnostic diag =
@@ -62,8 +63,9 @@ struct PTOValidateIntToPtrUsesPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PTOValidateIntToPtrUsesPass)
 
   void runOnOperation() override {
-    if (failed(validateIntToPtrUses(getOperation())))
+    if (failed(validateIntToPtrUses(getOperation()))) {
       signalPassFailure();
+    }
   }
 };
 } // namespace

--- a/lib/PTO/Transforms/PTOValidateVMIIR.cpp
+++ b/lib/PTO/Transforms/PTOValidateVMIIR.cpp
@@ -141,8 +141,9 @@ bool isStructuralOp(Operation *op) {
 
 bool hasVMIType(Operation *op) {
   if (llvm::any_of(op->getOperandTypes(), isVMIType) ||
-      llvm::any_of(op->getResultTypes(), isVMIType))
+      llvm::any_of(op->getResultTypes(), isVMIType)) {
     return true;
+  }
   for (Region &region : op->getRegions()) {
     for (Block &block : region) {
       if (llvm::any_of(block.getArgumentTypes(), isVMIType)) {
@@ -185,7 +186,8 @@ LogicalResult emitLayoutSupportContract(Operation *op,
   os << message << ": " << reason;
 
   bool printedAny = false;
-  auto printValueType = [&](StringRef kind, int64_t index, Type type) {
+  auto printValueType = [&os, &printedAny](StringRef kind, int64_t index,
+                                            Type type) {
     if (!isVMIType(type)) {
       return;
     }
@@ -211,7 +213,7 @@ LogicalResult
 emitHelperMaterializationContract(Operation *helper, Type sourceType,
                                   Type resultType, StringRef helperName,
                                   StringRef reason, llvm::raw_ostream *diagOS) {
-  auto emitFallback = [&]() {
+  auto emitFallback = [diagOS, helper, helperName, reason]() {
     return emitLayoutContract(
         helper, diagOS,
         Twine(helperName) +
@@ -242,11 +244,12 @@ emitHelperMaterializationContract(Operation *helper, Type sourceType,
 
 LogicalResult verifyBoundaryType(Operation *owner, Type type,
                                  llvm::raw_ostream *diagOS) {
-  if (isVMIType(type) && !isSurfaceVMIType(type))
+  if (isVMIType(type) && !isSurfaceVMIType(type)) {
     return emitInvariant(
         owner, diagOS,
         "VMI producer boundary requires surface !pto.vmi.vreg or "
         "!pto.vmi.mask<Nxpred> type");
+  }
 
   return success();
 }
@@ -279,11 +282,12 @@ LogicalResult verifyBoundaryTypeTree(Operation *owner, Type type,
 
 LogicalResult verifyLayoutAssignedType(Operation *owner, Type type,
                                        llvm::raw_ostream *diagOS) {
-  if (isVMIType(type) && !isLayoutAssignedVMIType(type))
+  if (isVMIType(type) && !isLayoutAssignedVMIType(type)) {
     return emitInvariant(
         owner, diagOS,
         "layout-assigned VMI IR requires !pto.vmi.vreg with layout and "
         "!pto.vmi.mask with b8/b16/b32 granularity plus layout");
+  }
 
   return success();
 }
@@ -569,11 +573,12 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
     }
 
     std::string reason;
-    if (failed(supports.getStoreLayoutFact(valueType, &reason)))
+    if (failed(supports.getStoreLayoutFact(valueType, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS,
           "pto.vmi.store has no registered contiguous-memory layout support",
           reason);
+    }
     return success();
   }
 
@@ -585,10 +590,11 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
     }
 
     std::string reason;
-    if (failed(supports.getGroupLoadLayoutFact(load, &reason)))
+    if (failed(supports.getGroupLoadLayoutFact(load, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS,
           "pto.vmi.group_load has no registered layout support", reason);
+    }
     return success();
   }
 
@@ -596,20 +602,22 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
     auto resultType = cast<VMIVRegType>(load.getResult().getType());
     std::string reason;
     if (failed(supports.getGroupSlotLoadLayoutFact(
-            resultType, load.getNumGroupsAttr().getInt(), &reason)))
+            resultType, load.getNumGroupsAttr().getInt(), &reason))) {
       return emitLayoutSupportContract(
           op, diagOS,
           "pto.vmi.group_slot_load has no registered layout support", reason);
+    }
     return success();
   }
 
   if (auto load = dyn_cast<VMIGroupBroadcastLoadOp>(op)) {
     std::string reason;
-    if (failed(supports.getGroupBroadcastLoadSupport(load, &reason)))
+    if (failed(supports.getGroupBroadcastLoadSupport(load, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS,
           "pto.vmi.group_broadcast_load has no registered layout support",
           reason);
+    }
     return success();
   }
 
@@ -622,11 +630,12 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
 
     std::string reason;
     if (failed(supports.getGroupStoreLayoutFact(
-            valueType, store.getNumGroupsAttr().getInt(), &reason)))
+            valueType, store.getNumGroupsAttr().getInt(), &reason))) {
       return emitLayoutSupportContract(
           op, diagOS,
           "pto.vmi.group_store has no registered group_slots layout support",
           reason);
+    }
     return success();
   }
 
@@ -638,12 +647,13 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
     }
 
     std::string reason;
-    if (failed(supports.getGroupReduceAddFSupport(reduce, &reason)))
+    if (failed(supports.getGroupReduceAddFSupport(reduce, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS,
           "pto.vmi.group_reduce_addf has no registered group_slots layout "
           "support",
           reason);
+    }
     return success();
   }
 
@@ -655,12 +665,13 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
     }
 
     std::string reason;
-    if (failed(supports.getGroupReduceMaxFSupport(reduce, &reason)))
+    if (failed(supports.getGroupReduceMaxFSupport(reduce, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS,
           "pto.vmi.group_reduce_maxf has no registered group_slots layout "
           "support",
           reason);
+    }
     return success();
   }
 
@@ -672,12 +683,13 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
     }
 
     std::string reason;
-    if (failed(supports.getGroupReduceMinFSupport(reduce, &reason)))
+    if (failed(supports.getGroupReduceMinFSupport(reduce, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS,
           "pto.vmi.group_reduce_minf has no registered group_slots layout "
           "support",
           reason);
+    }
     return success();
   }
 
@@ -689,12 +701,13 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
     }
 
     std::string reason;
-    if (failed(supports.getGroupReduceAddISupport(reduce, &reason)))
+    if (failed(supports.getGroupReduceAddISupport(reduce, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS,
           "pto.vmi.group_reduce_addi has no registered group_slots layout "
           "support",
           reason);
+    }
     return success();
   }
 
@@ -706,12 +719,13 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
     }
 
     std::string reason;
-    if (failed(supports.getGroupReduceMaxISupport(reduce, &reason)))
+    if (failed(supports.getGroupReduceMaxISupport(reduce, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS,
           "pto.vmi.group_reduce_maxi has no registered group_slots layout "
           "support",
           reason);
+    }
     return success();
   }
 
@@ -723,12 +737,13 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
     }
 
     std::string reason;
-    if (failed(supports.getGroupReduceMinISupport(reduce, &reason)))
+    if (failed(supports.getGroupReduceMinISupport(reduce, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS,
           "pto.vmi.group_reduce_mini has no registered group_slots layout "
           "support",
           reason);
+    }
     return success();
   }
 
@@ -740,54 +755,60 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
     }
 
     std::string reason;
-    if (failed(supports.getGroupBroadcastSupport(broadcast, &reason)))
+    if (failed(supports.getGroupBroadcastSupport(broadcast, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS,
           "pto.vmi.group_broadcast has no registered layout support", reason);
+    }
     return success();
   }
 
   if (auto hist = dyn_cast<VMIVdhistOp>(op)) {
     std::string reason;
-    if (failed(supports.getVdhistSupport(hist, &reason)))
+    if (failed(supports.getVdhistSupport(hist, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS, "pto.vmi.vdhist has no registered histogram support",
           reason);
+    }
     return success();
   }
 
   if (auto hist = dyn_cast<VMIVchistOp>(op)) {
     std::string reason;
-    if (failed(supports.getVchistSupport(hist, &reason)))
+    if (failed(supports.getVchistSupport(hist, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS, "pto.vmi.vchist has no registered histogram support",
           reason);
+    }
     return success();
   }
 
   if (auto truncf = dyn_cast<VMITruncFOp>(op)) {
     std::string reason;
-    if (failed(supports.getTruncFSupport(truncf, &reason)))
+    if (failed(supports.getTruncFSupport(truncf, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS, "pto.vmi.truncf has no registered layout support",
           reason);
+    }
     return success();
   }
 
   if (auto extf = dyn_cast<VMIExtFOp>(op)) {
     std::string reason;
-    if (failed(supports.getExtFSupport(extf, &reason)))
+    if (failed(supports.getExtFSupport(extf, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS, "pto.vmi.extf has no registered layout support", reason);
+    }
     return success();
   }
 
   if (auto bitcast = dyn_cast<VMIBitcastOp>(op)) {
     std::string reason;
-    if (failed(supports.getBitcastSupport(bitcast, &reason)))
+    if (failed(supports.getBitcastSupport(bitcast, &reason))) {
       return emitLayoutSupportContract(
           op, diagOS, "pto.vmi.bitcast has no registered layout support",
           reason);
+    }
     return success();
   }
 

--- a/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
+++ b/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
@@ -20,6 +20,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 
@@ -75,14 +76,15 @@ static bool isOpInRange(Operation *op, Operation *first, Operation *last) {
 }
 
 static constexpr int64_t kSimtKeepResumeSlotLimit = 123;
+static constexpr unsigned kWideValueRegisterCount = 2;
 
 static std::optional<unsigned> getSimtKeepResumeRegisterCount(Type type) {
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.getWidth() <= 32) {
+    if (intType.getWidth() <= mlir::pto::kValue32) {
       return 1;
     }
-    if (intType.getWidth() == 64) {
-      return 2;
+    if (intType.getWidth() == mlir::pto::kValue64) {
+      return kWideValueRegisterCount;
     }
     return std::nullopt;
   }
@@ -113,19 +115,22 @@ static LogicalResult verifySimtKeepResumeSlotRange(OpT op) {
     return success();
   }
   int64_t slot = op.getSlot();
-  if (slot < 0 || slot >= kSimtKeepResumeSlotLimit)
+  if (slot < 0 || slot >= kSimtKeepResumeSlotLimit) {
     return op.emitOpError()
            << "requires slot in range [0, "
            << (kSimtKeepResumeSlotLimit - 1) << "]";
-  if (*registerCount == 2) {
-    if ((slot % 2) != 0)
+  }
+  if (*registerCount == mlir::pto::kValue2) {
+    if ((slot % kWideValueRegisterCount) != 0) {
       return op.emitOpError()
              << "requires an even slot for 64-bit keep/resume values";
-    if (slot + 1 >= kSimtKeepResumeSlotLimit)
+    }
+    if (slot + 1 >= kSimtKeepResumeSlotLimit) {
       return op.emitOpError()
              << "requires slot in range [0, "
-             << (kSimtKeepResumeSlotLimit - 2)
+             << (kSimtKeepResumeSlotLimit - mlir::pto::kValue2)
              << "] for 64-bit keep/resume values";
+    }
   }
   return success();
 }
@@ -152,17 +157,18 @@ static bool overlapsEarlierSimtKeepResumeSlotUse(OpT op,
 
 static LogicalResult verifyUniqueResumeGroupSlots(ResumeOp current,
                                                   Operation *first) {
-  SmallVector<int64_t, 4> slots;
+  SmallVector<int64_t, mlir::pto::kValue4> slots;
   for (Operation *cur = first; cur; cur = cur->getNextNode()) {
     auto resume = dyn_cast<ResumeOp>(cur);
     if (!resume) {
       break;
     }
     if (overlapsEarlierSimtKeepResumeSlotUse(resume, slots) &&
-        resume.getOperation() == current.getOperation())
+        resume.getOperation() == current.getOperation()) {
       return current.emitOpError()
              << "duplicates an earlier slot " << resume.getSlot()
              << " in the SIMT resume prologue group";
+    }
   }
   return success();
 }
@@ -170,17 +176,18 @@ static LogicalResult verifyUniqueResumeGroupSlots(ResumeOp current,
 static LogicalResult verifyUniqueKeepGroupSlots(KeepOp current,
                                                 Operation *first,
                                                 Operation *last) {
-  SmallVector<int64_t, 4> slots;
+  SmallVector<int64_t, mlir::pto::kValue4> slots;
   for (Operation *cur = first; cur; cur = cur->getNextNode()) {
     auto keep = dyn_cast<KeepOp>(cur);
     if (!keep) {
       break;
     }
     if (overlapsEarlierSimtKeepResumeSlotUse(keep, slots) &&
-        keep.getOperation() == current.getOperation())
+        keep.getOperation() == current.getOperation()) {
       return current.emitOpError()
              << "duplicates an earlier slot " << keep.getSlot()
              << " in the SIMT keep epilogue group";
+    }
     if (cur == last) {
       break;
     }
@@ -317,11 +324,11 @@ public:
     }
 
     switch (intType.getWidth()) {
-    case 8:
+    case mlir::pto::kValue8:
       return VPTOMaskGranularity::B8;
-    case 16:
+    case mlir::pto::kValue16:
       return VPTOMaskGranularity::B16;
-    case 32:
+    case mlir::pto::kValue32:
       return VPTOMaskGranularity::B32;
     default:
       return std::nullopt;
@@ -353,19 +360,22 @@ public:
     }
 
     if (isa<CopyGmToUbufOp, CopyUbufToUbufOp, CopyUbufToGmOp,
-            CopyCbufToUbufOp, CopyUbufToCbufOp>(op))
+            CopyCbufToUbufOp, CopyUbufToCbufOp>(op)) {
       return VPTOBufferAddressFamily::Copy;
+    }
 
     if (isa<VldasOp, VldusOp, PstuOp, VstusOp, VsturOp, MadOp, MadMxOp,
             CopyGmToCbufOp, LoadCbufToCaOp,
-            LoadCbufToCbOp, CopyMatrixCcToGmOp>(op))
+            LoadCbufToCbOp, CopyMatrixCcToGmOp>(op)) {
       return VPTOBufferAddressFamily::PtrOnly;
+    }
 
     if (isa<VldsOp, UvldOp, PldsOp, PldiOp, VstsOp, PstiOp, PstsOp,
             VbitsortOp, Vmrgsort4Op, Vgather2Op,
             VgatherbOp, Vgather2BcOp, VscatterOp, Vldsx2Op, Vstsx2Op, VsldbOp,
-            VsstbOp, VstasOp, VstarOp>(op))
+            VsstbOp, VstasOp, VstarOp>(op)) {
       return VPTOBufferAddressFamily::BufferLike;
+    }
 
     return VPTOBufferAddressFamily::None;
   }
@@ -431,8 +441,9 @@ public:
     }
 
     if (stage == VPTOLegalityStage::Emission &&
-        failed(validateEmissionRules()))
+        failed(validateEmissionRules())) {
       return failure();
+    }
 
     return success();
   }
@@ -508,53 +519,53 @@ private:
     if (auto elementIntType = dyn_cast<IntegerType>(elementType)) {
       width = elementIntType.getWidth();
     } else if (elementType.isF16() || elementType.isBF16()) {
-      width = 16;
+      width = mlir::pto::kValue16;
     } else if (elementType.isF32()) {
-      width = 32;
+      width = mlir::pto::kValue32;
     } else if (elementType.isF64()) {
-      width = 64;
+      width = mlir::pto::kValue64;
     } else {
       return std::nullopt;
     }
 
     if (dist == "PK_B16") {
-      if (width == 8) {
+      if (width == mlir::pto::kValue8) {
         return VPTOMaskGranularity::B16;
       }
       return std::nullopt;
     }
     if (dist == "PK_B32") {
-      if (width == 16) {
+      if (width == mlir::pto::kValue16) {
         return VPTOMaskGranularity::B32;
       }
       return std::nullopt;
     }
     if (dist == "PK_B64") {
-      if (width == 32) {
+      if (width == mlir::pto::kValue32) {
         return VPTOMaskGranularity::B32;
       }
       return std::nullopt;
     }
     if (dist == "PK4_B32") {
-      if (width == 8) {
+      if (width == mlir::pto::kValue8) {
         return VPTOMaskGranularity::B32;
       }
       return std::nullopt;
     }
     if (dist == "MRG4CHN_B8") {
-      if (width == 8) {
+      if (width == mlir::pto::kValue8) {
         return VPTOMaskGranularity::B32;
       }
       return std::nullopt;
     }
     if (dist == "MRG2CHN_B8") {
-      if (width == 8) {
+      if (width == mlir::pto::kValue8) {
         return VPTOMaskGranularity::B16;
       }
       return std::nullopt;
     }
     if (dist == "MRG2CHN_B16") {
-      if (width == 16) {
+      if (width == mlir::pto::kValue16) {
         return VPTOMaskGranularity::B32;
       }
     }
@@ -595,8 +606,9 @@ private:
     auto input = VPTOLegalityHelper::getMaskGranularity(op.getInput().getType());
     auto result = VPTOLegalityHelper::getMaskGranularity(op.getResult().getType());
     if (!input || !result || *input == *result ||
-        isAdjacentMaskGranularityNarrowing(*input, *result))
+        isAdjacentMaskGranularityNarrowing(*input, *result)) {
       return success();
+    }
 
     return op.emitOpError()
            << "input mask type " << op.getInput().getType()
@@ -608,8 +620,9 @@ private:
     auto input = VPTOLegalityHelper::getMaskGranularity(op.getInput().getType());
     auto result = VPTOLegalityHelper::getMaskGranularity(op.getResult().getType());
     if (!input || !result || *input == *result ||
-        isAdjacentMaskGranularityWidening(*input, *result))
+        isAdjacentMaskGranularityWidening(*input, *result)) {
       return success();
+    }
 
     return op.emitOpError()
            << "input mask type " << op.getInput().getType()
@@ -655,7 +668,7 @@ private:
   }
 
   void emitHardwareSupportWarnings(Operation *op) const {
-    auto emitForStore = [&](auto storeOp) {
+    auto emitForStore = [this](auto storeOp) {
       Operation *store = storeOp.getOperation();
       auto distAttr = store->getAttrOfType<StringAttr>("dist");
       if (!distAttr) {
@@ -663,11 +676,12 @@ private:
       }
 
       StringRef dist = distAttr.getValue();
-      if (dist == "MRG4CHN_B8" || dist == "MRG2CHN_B8" || dist == "MRG2CHN_B16")
+      if (dist == "MRG4CHN_B8" || dist == "MRG2CHN_B8" || dist == "MRG2CHN_B16") {
         writeDiagnostic((Twine("warning: ") + store->getName().getStringRef() +
                          " dist " + dist +
                          " is not supported on the current hardware\n")
                             .str());
+      }
     };
 
     if (auto vsts = dyn_cast<VstsOp>(op)) {
@@ -693,8 +707,9 @@ private:
         failed(validateSameMaskGranularity(op, op.getMask().getType(),
                                            "mask type",
                                            op.getCarry().getType(),
-                                           "carry type")))
+                                           "carry type"))) {
       return failure();
+    }
 
     if constexpr (std::is_same_v<CarryOp, VaddcsOp> ||
                   std::is_same_v<CarryOp, VsubcsOp>) {
@@ -705,8 +720,9 @@ private:
           failed(validateSameMaskGranularity(op, op.getCarryIn().getType(),
                                              "carry_in type",
                                              op.getCarry().getType(),
-                                             "carry type")))
+                                             "carry type"))) {
         return failure();
+      }
     }
 
     return success();
@@ -723,8 +739,9 @@ private:
         failed(validateSameMaskGranularity(op, op.getMask().getType(),
                                            "seed mask type",
                                            op.getResult().getType(),
-                                           "result mask type")))
+                                           "result mask type"))) {
       return failure();
+    }
     return success();
   }
 
@@ -744,8 +761,9 @@ private:
         failed(validateSameMaskGranularity(op, op.getInput().getType(),
                                            "input mask type",
                                            op.getResult().getType(),
-                                           "result mask type")))
+                                           "result mask type"))) {
       return failure();
+    }
     return success();
   }
 
@@ -761,8 +779,9 @@ private:
         failed(validateSameMaskGranularity(op, op.getSrc0().getType(),
                                            "src0 mask type",
                                            op.getResult().getType(),
-                                           "result mask type")))
+                                           "result mask type"))) {
       return failure();
+    }
     return success();
   }
 
@@ -839,7 +858,7 @@ private:
 
           Type elemType = vecType.getElementType();
           if (auto intType = dyn_cast<IntegerType>(elemType)) {
-            if (intType.getWidth() == 32 && !intType.isUnsigned()) {
+            if (intType.getWidth() == mlir::pto::kValue32 && !intType.isUnsigned()) {
               return success();
             }
           } else if (elemType.isF16() || elemType.isF32()) {
@@ -929,33 +948,36 @@ private:
         }
 
         auto intAttr = dyn_cast<IntegerAttr>(attr);
-        if (!intAttr || !intAttr.getType().isSignlessInteger(32))
+        if (!intAttr || !intAttr.getType().isSignlessInteger(32)) {
           return func.emitError()
                  << "'" << attrName
                  << "' must be a signless i32 integer attribute";
+        }
 
-        if (intAttr.getInt() <= 0)
+        if (intAttr.getInt() <= 0) {
           return func.emitError()
                  << "'" << attrName << "' must be a positive integer, got "
                  << intAttr.getInt();
+        }
 
-        if (intAttr.getInt() > upperBound)
+        if (intAttr.getInt() > upperBound) {
           return func.emitError()
                  << "'" << attrName << "' must be in range [1, "
                  << upperBound << "] for " << description;
+        }
 
-        if (!func->hasAttr(pto::kPTOSimtEntryAttrName))
+        if (!func->hasAttr(pto::kPTOSimtEntryAttrName)) {
           return func.emitError()
                  << "'" << attrName << "' is only allowed on functions marked '"
                  << pto::kPTOSimtEntryAttrName << "'";
+        }
 
         return success();
       };
-
       if (failed(validatePositiveI32FuncAttr(pto::kPTOSimtMaxThreadsAttrName,
-                                             2048, "SIMT max threads")) ||
+                                             mlir::pto::kValue2048, "SIMT max threads")) ||
           failed(validatePositiveI32FuncAttr(pto::kPTOSimtMaxRegistersAttrName,
-                                             128, "SIMT max registers"))) {
+                                             mlir::pto::kValue128, "SIMT max registers"))) {
         return failure();
       }
 
@@ -1198,7 +1220,6 @@ private:
 
       VPTOBufferAddressFamily family =
           VPTOLegalityHelper::classifyBufferAddressFamily(op);
-
       if (family == VPTOBufferAddressFamily::BufferLike) {
         for (OpOperand *operand : VPTOLegalityHelper::collectBufferOperands(op)) {
           Type operandType = operand->get().getType();

--- a/lib/PTO/Transforms/PTOVerifyTFreePass.cpp
+++ b/lib/PTO/Transforms/PTOVerifyTFreePass.cpp
@@ -116,8 +116,9 @@ static LogicalResult verifyNoTileUsesAfterTFree(TPopOp tpopOp,
 
 static bool isInsideSectionOrAttributedKernel(TPopOp tpopOp, func::FuncOp funcOp) {
   if (tpopOp->getParentOfType<SectionCubeOp>() ||
-      tpopOp->getParentOfType<SectionVectorOp>())
+      tpopOp->getParentOfType<SectionVectorOp>()) {
     return true;
+  }
   return funcOp &&
          funcOp->hasAttr(FunctionKernelKindAttr::name);
 }

--- a/lib/PTO/Transforms/PTOWrapFunctionsInSectionsPass.cpp
+++ b/lib/PTO/Transforms/PTOWrapFunctionsInSectionsPass.cpp
@@ -61,12 +61,14 @@ static LogicalResult rewriteFunction(func::FuncOp funcOp) {
   auto kernelKindAttr =
       funcOp->getAttrOfType<FunctionKernelKindAttr>(
           FunctionKernelKindAttr::name);
-  if (!kernelKindAttr)
+  if (!kernelKindAttr) {
     return success();
+  }
 
-  if (!funcOp.getBody().hasOneBlock())
+  if (!funcOp.getBody().hasOneBlock()) {
     return funcOp.emitOpError(
         "requires a single-block body for kernel_kind wrapping");
+  }
 
   if (hasExistingSection(funcOp)) {
     return funcOp.emitOpError(
@@ -90,8 +92,9 @@ struct PTOWrapFunctionsInSectionsPass
           PTOWrapFunctionsInSectionsPass> {
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
-    if (failed(rewriteFunction(funcOp)))
+    if (failed(rewriteFunction(funcOp))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/SIMTPersistentFragmentAnalysis.cpp
+++ b/lib/PTO/Transforms/SIMTPersistentFragmentAnalysis.cpp
@@ -17,6 +17,7 @@
 
 #include "SIMTPersistentFragmentAnalysis.h"
 
+#include "PTO/Support/CodeConstants.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Dominance.h"
@@ -39,6 +40,7 @@ namespace {
 
 constexpr llvm::StringLiteral kPersistentAttrName = "pto.persistent";
 constexpr int64_t kPersistentSlotLimit = 123;
+constexpr int64_t kWideValueSlotWidth = 2;
 
 struct PointerWorkItem {
   Value pointer;
@@ -69,14 +71,15 @@ struct PersistentAccessDiscovery {
 };
 
 static bool isSupportedPersistentScalarType(Type type) {
-  if (auto intType = dyn_cast<IntegerType>(type))
-    return intType.getWidth() <= 64;
+  if (auto intType = dyn_cast<IntegerType>(type)) {
+    return intType.getWidth() <= mlir::pto::kValue64;
+  }
   return type.isF16() || type.isBF16() || type.isF32();
 }
 
 static FailureOr<int64_t> getSignedInt64(const APInt &value, Operation *anchor,
                                          StringRef description) {
-  if (!value.isSignedIntN(64)) {
+  if (!value.isSignedIntN(mlir::pto::kValue64)) {
     anchor->emitOpError() << description << " does not fit in signed i64";
     return failure();
   }
@@ -121,8 +124,9 @@ static FailureOr<FragmentShape> getFragmentShape(LLVM::AllocaOp allocaOp,
 
   FailureOr<int64_t> elementCount = getConstantInt64(
       allocaOp.getArraySize(), allocaOp, "persistent fragment element count");
-  if (failed(elementCount))
+  if (failed(elementCount)) {
     return failure();
+  }
   if (*elementCount <= 0) {
     return allocaOp.emitOpError(
         "persistent SIMT fragment element count must be positive");
@@ -130,8 +134,9 @@ static FailureOr<FragmentShape> getFragmentShape(LLVM::AllocaOp allocaOp,
 
   FailureOr<int64_t> elementByteSize = getFixedTypeByteSize(
       elementType, allocaOp, "persistent fragment element type", dataLayout);
-  if (failed(elementByteSize))
+  if (failed(elementByteSize)) {
     return failure();
+  }
 
   int64_t totalByteSize;
   if (llvm::MulOverflow(*elementCount, *elementByteSize, totalByteSize)) {
@@ -152,8 +157,9 @@ static FailureOr<int64_t> getStaticGEPIndex(LLVM::GEPOp gep) {
   }
 
   auto index = indices[0];
-  if (auto constant = llvm::dyn_cast_if_present<IntegerAttr>(index))
+  if (auto constant = llvm::dyn_cast_if_present<IntegerAttr>(index)) {
     return getSignedInt64(constant.getValue(), gep, "GEP index");
+  }
 
   Value dynamicIndex = llvm::dyn_cast_if_present<Value>(index);
   if (!dynamicIndex) {
@@ -166,13 +172,15 @@ static FailureOr<int64_t> getStaticGEPIndex(LLVM::GEPOp gep) {
 static FailureOr<int64_t> getStaticGEPByteOffset(LLVM::GEPOp gep,
                                                  const DataLayout &dataLayout) {
   FailureOr<int64_t> index = getStaticGEPIndex(gep);
-  if (failed(index))
+  if (failed(index)) {
     return failure();
+  }
 
   FailureOr<int64_t> elementByteSize = getFixedTypeByteSize(
       gep.getElemType(), gep, "GEP element type", dataLayout);
-  if (failed(elementByteSize))
+  if (failed(elementByteSize)) {
     return failure();
+  }
 
   int64_t byteOffset;
   if (llvm::MulOverflow(*index, *elementByteSize, byteOffset)) {
@@ -216,7 +224,7 @@ getPersistentAccessLaneCount(Operation *access, Type accessType,
       return failure();
     }
     int64_t vectorLaneCount = vectorType.getDimSize(0);
-    if (vectorLaneCount != 2 && vectorLaneCount != 4) {
+    if (vectorLaneCount != mlir::pto::kValue2 && vectorLaneCount != 4) {
       access->emitOpError()
           << "persistent SIMT fragment currently supports only 2- or 4-lane "
              "vector accesses, got "
@@ -225,8 +233,9 @@ getPersistentAccessLaneCount(Operation *access, Type accessType,
     }
     scalarType = vectorType.getElementType();
     laneCount = static_cast<unsigned>(vectorLaneCount);
-    if (failed(validateScalarizableVectorAccess(access)))
+    if (failed(validateScalarizableVectorAccess(access))) {
       return failure();
+    }
   }
 
   if (!isSupportedPersistentScalarType(scalarType)) {
@@ -268,8 +277,9 @@ static LogicalResult recordAccess(Operation *access, Type accessType,
   Type elementType = allocaOp.getElemType();
   FailureOr<unsigned> laneCount =
       getPersistentAccessLaneCount(access, accessType, elementType);
-  if (failed(laneCount))
+  if (failed(laneCount)) {
     return failure();
+  }
   if (byteOffset < 0 || byteOffset % shape.elementByteSize != 0) {
     return access->emitOpError()
            << "persistent SIMT fragment byte offset " << byteOffset
@@ -347,8 +357,9 @@ findInitSection(DominanceInfo &dominance,
   // storing a long-lived operation-to-index map in the analysis result.
   SmallVector<pto::SectionSimtOp> accessedSections;
   for (pto::SectionSimtOp section : plan.sections) {
-    if (accessedSectionSet.contains(section.getOperation()))
+    if (accessedSectionSet.contains(section.getOperation())) {
       accessedSections.push_back(section);
+    }
   }
   if (accessedSections.size() != accessedSectionSet.size()) {
     return fragment.allocaOp.emitOpError(
@@ -360,13 +371,15 @@ findInitSection(DominanceInfo &dominance,
   for (pto::SectionSimtOp candidate : accessedSections) {
     bool dominatesAllAccessSections =
         llvm::all_of(accessedSections, [&](pto::SectionSimtOp section) {
-          if (section == candidate)
+          if (section == candidate) {
             return true;
+          }
           return dominance.dominates(candidate.getOperation(),
                                      section.getOperation());
         });
-    if (!dominatesAllAccessSections)
+    if (!dominatesAllAccessSections) {
       continue;
+    }
 
     if (initSection) {
       fragment.allocaOp.emitOpError(
@@ -453,12 +466,14 @@ validateCarrySectionDimensions(pto::SectionSimtOp initSection,
                                PersistentFragmentAnalysis &fragment) {
   fragment.carrySections.clear();
   for (pto::SectionSimtOp section : plan.sections) {
-    if (section == initSection)
+    if (section == initSection) {
       continue;
+    }
     // Only sections dominated by init can carry initialized fragment state.
     if (!dominance.dominates(initSection.getOperation(),
-                             section.getOperation()))
+                             section.getOperation())) {
       continue;
+    }
     if (!haveSameLaunchDimensions(initSection, section)) {
       return section.emitOpError()
              << "persistent SIMT fragment carry section launch dimensions ("
@@ -481,16 +496,19 @@ analyzeResidentElements(DominanceInfo &dominance,
                         const PersistentAccessDiscovery &discovery) {
   FailureOr<pto::SectionSimtOp> initSection =
       findInitSection(dominance, plan, discovery, fragment);
-  if (failed(initSection))
+  if (failed(initSection)) {
     return failure();
+  }
   fragment.initSection = *initSection;
 
   llvm::DenseSet<int64_t> residentElementSet;
   if (failed(collectResidentElements(*initSection, discovery, fragment,
-                                     residentElementSet)))
+                                     residentElementSet))) {
     return failure();
-  if (failed(validateResidentAccesses(residentElementSet, discovery)))
+  }
+  if (failed(validateResidentAccesses(residentElementSet, discovery))) {
     return failure();
+  }
 
   return validateCarrySectionDimensions(*initSection, dominance, plan,
                                         fragment);
@@ -498,10 +516,12 @@ analyzeResidentElements(DominanceInfo &dominance,
 
 static FailureOr<int64_t> getPersistentSlotWidth(Type type, Operation *anchor) {
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.getWidth() <= 32)
+    if (intType.getWidth() <= mlir::pto::kValue32) {
       return 1;
-    if (intType.getWidth() <= 64)
-      return 2;
+    }
+    if (intType.getWidth() <= 64) {
+      return kWideValueSlotWidth;
+    }
   } else if (type.isF16() || type.isBF16() || type.isF32()) {
     return 1;
   }
@@ -519,14 +539,16 @@ allocatePersistentSlots(func::FuncOp func,
     Type elementType = fragment.allocaOp.getElemType();
     FailureOr<int64_t> slotWidth =
         getPersistentSlotWidth(elementType, fragment.allocaOp);
-    if (failed(slotWidth))
+    if (failed(slotWidth)) {
       return failure();
+    }
 
     for (ResidentElementPlan &residentElement : fragment.residentElements) {
       int64_t elementOffset = residentElement.elementOffset;
       int64_t slot = nextSlot;
-      if (*slotWidth == 2 && slot % 2 != 0)
+      if (*slotWidth == mlir::pto::kValue2 && slot % mlir::pto::kValue2 != 0) {
         ++slot;
+      }
 
       if (slot > kPersistentSlotLimit - *slotWidth) {
         return fragment.allocaOp.emitOpError()
@@ -605,8 +627,9 @@ analyzePersistentFragment(LLVM::AllocaOp allocaOp, DominanceInfo &dominance,
                           PersistentFragmentAnalysis &fragment,
                           PersistentAccessDiscovery &discovery) {
   func::FuncOp parentFunc = allocaOp->getParentOfType<func::FuncOp>();
-  if (!parentFunc)
+  if (!parentFunc) {
     return allocaOp.emitOpError("must be nested in a func.func");
+  }
 
   if (!isa<UnitAttr>(allocaOp->getAttr(kPersistentAttrName))) {
     return allocaOp.emitOpError()
@@ -623,8 +646,9 @@ analyzePersistentFragment(LLVM::AllocaOp allocaOp, DominanceInfo &dominance,
 
   DataLayout dataLayout = DataLayout::closest(allocaOp);
   FailureOr<FragmentShape> shape = getFragmentShape(allocaOp, dataLayout);
-  if (failed(shape))
+  if (failed(shape)) {
     return failure();
+  }
 
   SmallVector<PointerWorkItem> pointerWorklist{{allocaOp.getRes(), 0}};
   llvm::DenseMap<Value, int64_t> pointerOffsets;
@@ -662,8 +686,9 @@ analyzePersistentFragment(LLVM::AllocaOp allocaOp, DominanceInfo &dominance,
 
         FailureOr<int64_t> gepByteOffset =
             getStaticGEPByteOffset(gep, dataLayout);
-        if (failed(gepByteOffset))
+        if (failed(gepByteOffset)) {
           return failure();
+        }
         int64_t derivedByteOffset;
         if (llvm::AddOverflow(item.byteOffset, *gepByteOffset,
                               derivedByteOffset)) {
@@ -677,8 +702,9 @@ analyzePersistentFragment(LLVM::AllocaOp allocaOp, DominanceInfo &dominance,
 
       if (auto load = dyn_cast<LLVM::LoadOp>(user)) {
         if (failed(recordAccess(load, load.getRes().getType(), item.byteOffset,
-                                parentFunc, allocaOp, *shape, discovery)))
+                                parentFunc, allocaOp, *shape, discovery))) {
           return failure();
+        }
         continue;
       }
 
@@ -690,8 +716,9 @@ analyzePersistentFragment(LLVM::AllocaOp allocaOp, DominanceInfo &dominance,
         }
         if (failed(recordAccess(store, store.getValue().getType(),
                                 item.byteOffset, parentFunc, allocaOp, *shape,
-                                discovery)))
+                                discovery))) {
           return failure();
+        }
         continue;
       }
 
@@ -748,19 +775,22 @@ SIMTPersistentFragmentAnalysis::SIMTPersistentFragmentAnalysis(
     accessDiscoveries.emplace_back();
     if (failed(analyzePersistentFragment(allocaOp, dominance, candidate,
                                          candidate.fragments.back(),
-                                         accessDiscoveries.back())))
+                                         accessDiscoveries.back()))) {
       return;
+    }
   }
 
-  if (failed(allocatePersistentSlots(func, candidate)))
+  if (failed(allocatePersistentSlots(func, candidate))) {
     return;
+  }
   for (unsigned fragmentIndex = 0;
        fragmentIndex < static_cast<unsigned>(candidate.fragments.size());
        ++fragmentIndex) {
     if (failed(materializeResidentAccessLanes(
             candidate, candidate.fragments[fragmentIndex],
-            accessDiscoveries[fragmentIndex])))
+            accessDiscoveries[fragmentIndex]))) {
       return;
+    }
   }
   // Publish only a fully checked plan. No analysis result is visible to the
   // materialization pass after an intermediate failure.

--- a/lib/PTO/Transforms/SIMTPersistentFragmentAnalysis.h
+++ b/lib/PTO/Transforms/SIMTPersistentFragmentAnalysis.h
@@ -53,8 +53,9 @@ struct PersistentFragmentAnalysis {
 
   ResidentElementPlan *findResidentElement(int64_t elementOffset) {
     for (ResidentElementPlan &element : residentElements) {
-      if (element.elementOffset == elementOffset)
+      if (element.elementOffset == elementOffset) {
         return &element;
+      }
     }
     return nullptr;
   }

--- a/lib/PTO/Transforms/SlotAffineAnalysis.cpp
+++ b/lib/PTO/Transforms/SlotAffineAnalysis.cpp
@@ -10,6 +10,7 @@
 
 #include "PTO/Transforms/SlotAffineAnalysis.h"
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -24,12 +25,14 @@ namespace pto {
 
 Value findMultiTileSlotExpr(Value v) {
   int hops = 0;
-  while (v && hops++ < 32) {
+  while (v && hops++ < mlir::pto::kValue32) {
     Operation *op = v.getDefiningOp();
-    if (!op)
+    if (!op) {
       return {};
-    if (auto get = dyn_cast<pto::MultiTileGetOp>(op))
+    }
+    if (auto get = dyn_cast<pto::MultiTileGetOp>(op)) {
       return get.getSlot();
+    }
     if (auto subview = dyn_cast<pto::SubViewOp>(op)) {
       v = subview.getSource();
       continue;
@@ -48,6 +51,8 @@ Value findMultiTileSlotExpr(Value v) {
 }
 
 namespace {
+
+constexpr int kMaxAddSubPeelCount = 4;
 
 // Canonical form `(innerSym + innerOffset) mod N`. `innerSym` may be null
 // when the input is a pure constant -- then the canonical form is just
@@ -130,10 +135,11 @@ static bool extractSlotForm(Value slot, uint32_t expectN, SlotForm &out) {
     // Peel at most one add/sub of a constant.
     Value rem = inner;
     int peeled = 0;
-    while (peeled++ < 4) {
+    while (peeled++ < kMaxAddSubPeelCount) {
       Value next;
-      if (!peelAddSubConst(rem, next, offset))
+      if (!peelAddSubConst(rem, next, offset)) {
         break;
+      }
       rem = next;
     }
     int64_t cst;
@@ -174,16 +180,19 @@ static int64_t pyMod(int64_t a, int64_t n) {
 } // namespace
 
 SlotRelation compareSlotSSA(Value a, Value b, uint32_t N) {
-  if (!a || !b || N == 0)
+  if (!a || !b || N == 0) {
     return SlotRelation::kUnknown;
+  }
 
   // Shortcut: same SSA value -> always equal regardless of N.
-  if (a == b)
+  if (a == b) {
     return SlotRelation::kEqual;
+  }
 
   SlotForm fa, fb;
-  if (!extractSlotForm(a, N, fa) || !extractSlotForm(b, N, fb))
+  if (!extractSlotForm(a, N, fa) || !extractSlotForm(b, N, fb)) {
     return SlotRelation::kUnknown;
+  }
 
   // Only compare slot forms that share the canonical `mod N` window the
   // caller asked about. The shared utility leaves slots that were not

--- a/lib/PTO/Transforms/TileFusion/FusionAnalysis.cpp
+++ b/lib/PTO/Transforms/TileFusion/FusionAnalysis.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/TileFusion/FusionAnalysis.h"
 
 #include "PTO/IR/PTO.h"
@@ -35,13 +36,13 @@ static int64_t getConstantIndexOrDynamic(Value value) {
   return ShapedType::kDynamic;
 }
 
-static SmallVector<int64_t, 4> getValidShapeVec(Type type) {
+static SmallVector<int64_t, mlir::pto::kValue4> getValidShapeVec(Type type) {
   if (auto tileType = dyn_cast<pto::TileBufType>(type)) {
-    return SmallVector<int64_t, 4>(tileType.getValidShape().begin(),
+    return SmallVector<int64_t, mlir::pto::kValue4>(tileType.getValidShape().begin(),
                                    tileType.getValidShape().end());
   }
   if (auto shapedType = dyn_cast<ShapedType>(type)) {
-    return SmallVector<int64_t, 4>(shapedType.getShape().begin(),
+    return SmallVector<int64_t, mlir::pto::kValue4>(shapedType.getShape().begin(),
                                    shapedType.getShape().end());
   }
   return {};
@@ -90,7 +91,7 @@ class StructuralSignatureMap {
 public:
   struct Key {
     void *opNamePtr; // OperationName::getAsOpaquePointer()
-    SmallVector<Value, 4> operands;
+    SmallVector<Value, mlir::pto::kValue4> operands;
     Attribute attrs;
 
     bool operator==(const Key &rhs) const {
@@ -100,9 +101,11 @@ public:
       if (operands.size() != rhs.operands.size()) {
         return false;
       }
-      for (auto [l, r] : llvm::zip(operands, rhs.operands))
-        if (l != r)
+      for (auto [l, r] : llvm::zip(operands, rhs.operands)) {
+        if (l != r) {
           return false;
+        }
+      }
       return attrs == rhs.attrs;
     }
   };
@@ -116,8 +119,9 @@ public:
     }
     static unsigned getHashValue(const Key &key) {
       unsigned h = DenseMapInfo<void *>::getHashValue(key.opNamePtr);
-      for (Value v : key.operands)
+      for (Value v : key.operands) {
         h = llvm::hash_combine(h, DenseMapInfo<Value>::getHashValue(v));
+      }
       h = llvm::hash_combine(h, DenseMapInfo<Attribute>::getHashValue(key.attrs));
       return h;
     }
@@ -176,11 +180,12 @@ static Value canonicalizeValue(Value value,
   }
 
   // Recursively canonicalize all operands.
-  SmallVector<Value, 4> canonicalOperands;
+  SmallVector<Value, mlir::pto::kValue4> canonicalOperands;
   canonicalOperands.reserve(op->getNumOperands());
-  for (Value operand : op->getOperands())
+  for (Value operand : op->getOperands()) {
     canonicalOperands.push_back(
         canonicalizeValue(operand, canonicalByValue, signatureMap));
+  }
 
   // Build structural key and look up / create representative.
   StructuralSignatureMap::Key key;
@@ -245,10 +250,11 @@ public:
 
     conflicts[lhsRoot] = conflicts[lhsRoot] || conflicts[rhsRoot];
     if (constants[lhsRoot] && constants[rhsRoot] &&
-        *constants[lhsRoot] != *constants[rhsRoot])
+        *constants[lhsRoot] != *constants[rhsRoot]) {
       conflicts[lhsRoot] = true;
-    else if (!constants[lhsRoot])
+    } else if (!constants[lhsRoot]) {
       constants[lhsRoot] = constants[rhsRoot];
+    }
   }
 
   void bindConstant(unsigned dim, int64_t value) {
@@ -289,10 +295,10 @@ public:
   }
 
 private:
-  SmallVector<unsigned, 32> parent;
-  SmallVector<unsigned, 32> rank;
-  SmallVector<std::optional<int64_t>, 32> constants;
-  SmallVector<bool, 32> conflicts;
+  SmallVector<unsigned, mlir::pto::kValue32> parent;
+  SmallVector<unsigned, mlir::pto::kValue32> rank;
+  SmallVector<std::optional<int64_t>, mlir::pto::kValue32> constants;
+  SmallVector<bool, mlir::pto::kValue32> conflicts;
 };
 
 static void bindDimToValue(ShapeConstraintSolver &solver,
@@ -369,8 +375,8 @@ static ShapeValueDims getValueDims(
   }
 
   ShapeValueDims dims;
-  SmallVector<int64_t, 4> validShape = getValidShapeVec(value.getType());
-  if (validShape.size() >= 2) {
+  SmallVector<int64_t, mlir::pto::kValue4> validShape = getValidShapeVec(value.getType());
+  if (validShape.size() >= mlir::pto::kValue2) {
     dims.rows = solver.createDim();
     dims.cols = solver.createDim();
     if (!ShapedType::isDynamic(validShape[0])) {
@@ -414,10 +420,11 @@ static void mergeAllShapes(
   ShapeValueDims anchor = getValueDims(solver, dimsByValue, symbolDimByValue,
                                         canonicalByValue, signatureMap,
                                         values.front());
-  for (Value value : values.drop_front())
+  for (Value value : values.drop_front()) {
     mergeShapes(solver, anchor,
                 getValueDims(solver, dimsByValue, symbolDimByValue,
                              canonicalByValue, signatureMap, value));
+  }
 }
 
 static void applyShapeConstraintsForNode(
@@ -429,7 +436,7 @@ static void applyShapeConstraintsForNode(
   const FusionOpSemantics &semantics = node.semantics;
   switch (semantics.computeFamily) {
   case FusionComputeFamily::Elementwise: {
-    SmallVector<Value, 6> values;
+    SmallVector<Value, mlir::pto::kValue6> values;
     values.append(semantics.tileInputs.begin(), semantics.tileInputs.end());
     values.append(semantics.tileOutputs.begin(), semantics.tileOutputs.end());
     mergeAllShapes(solver, dimsByValue, symbolDimByValue, canonicalByValue,
@@ -447,23 +454,25 @@ static void applyShapeConstraintsForNode(
     ShapeValueDims output = getValueDims(
         solver, dimsByValue, symbolDimByValue, canonicalByValue, signatureMap,
         semantics.tileOutputs.front());
-    if (!semantics.tileInputs.empty())
+    if (!semantics.tileInputs.empty()) {
       mergeShapes(solver,
                   getValueDims(solver, dimsByValue, symbolDimByValue,
                                canonicalByValue, signatureMap,
                                semantics.tileInputs[0]),
                   output);
-    if (semantics.tileInputs.size() >= 2) {
+    }
+    if (semantics.tileInputs.size() >= mlir::pto::kValue2) {
       ShapeValueDims rowInput = getValueDims(
           solver, dimsByValue, symbolDimByValue, canonicalByValue, signatureMap,
           semantics.tileInputs[1]);
       mergeRows(solver, rowInput, output);
       solver.bindConstant(rowInput.cols, 1);
     }
-    for (Value extraOutput : ArrayRef<Value>(semantics.tileOutputs).drop_front())
+    for (Value extraOutput : ArrayRef<Value>(semantics.tileOutputs).drop_front()) {
       mergeShapes(solver, output,
                   getValueDims(solver, dimsByValue, symbolDimByValue,
                                canonicalByValue, signatureMap, extraOutput));
+    }
     return;
   }
   case FusionComputeFamily::ReduceRow:
@@ -486,10 +495,11 @@ static void applyShapeConstraintsForNode(
       solver.bindConstant(output.rows, 1);
       mergeCols(solver, input, output);
     }
-    for (Value extraOutput : ArrayRef<Value>(semantics.tileOutputs).drop_front())
+    for (Value extraOutput : ArrayRef<Value>(semantics.tileOutputs).drop_front()) {
       mergeShapes(solver, output,
                   getValueDims(solver, dimsByValue, symbolDimByValue,
                                canonicalByValue, signatureMap, extraOutput));
+    }
     return;
   }
   case FusionComputeFamily::Unknown:
@@ -508,21 +518,24 @@ static ShapeValueDims getIterationDomainDimsForNode(
   case FusionComputeFamily::Elementwise:
   case FusionComputeFamily::ScalarExpand:
   case FusionComputeFamily::RowBroadcastBinary:
-    if (!semantics.tileOutputs.empty())
+    if (!semantics.tileOutputs.empty()) {
       return getValueDims(solver, dimsByValue, symbolDimByValue,
                           canonicalByValue, signatureMap,
                           semantics.tileOutputs.front());
-    if (!semantics.tileInputs.empty())
+    }
+    if (!semantics.tileInputs.empty()) {
       return getValueDims(solver, dimsByValue, symbolDimByValue,
                           canonicalByValue, signatureMap,
                           semantics.tileInputs.front());
+    }
     break;
   case FusionComputeFamily::ReduceRow:
   case FusionComputeFamily::ReduceCol:
-    if (!semantics.tileInputs.empty())
+    if (!semantics.tileInputs.empty()) {
       return getValueDims(solver, dimsByValue, symbolDimByValue,
                           canonicalByValue, signatureMap,
                           semantics.tileInputs.front());
+    }
     break;
   case FusionComputeFamily::Unknown:
     break;
@@ -603,8 +616,8 @@ struct Rank2IterationSpace {
 };
 
 static std::optional<Rank2IterationSpace> getRank2IterationSpace(Value value) {
-  SmallVector<int64_t, 4> validShape = getValidShapeVec(value.getType());
-  if (validShape.size() < 2) {
+  SmallVector<int64_t, mlir::pto::kValue4> validShape = getValidShapeVec(value.getType());
+  if (validShape.size() < mlir::pto::kValue2) {
     return std::nullopt;
   }
   return Rank2IterationSpace{validShape[0], validShape[1]};
@@ -676,7 +689,7 @@ static IterationDomainInfo
 inferIterationDomainInfo(const FusionOpSemantics &semantics) {
   switch (semantics.computeFamily) {
   case FusionComputeFamily::Elementwise: {
-    SmallVector<Value, 6> anchors;
+    SmallVector<Value, mlir::pto::kValue6> anchors;
     anchors.append(semantics.tileInputs.begin(), semantics.tileInputs.end());
     anchors.append(semantics.tileOutputs.begin(), semantics.tileOutputs.end());
     return inferConsensusIterationDomain(anchors);
@@ -746,17 +759,20 @@ static LogicalResult inferDynamicIterationDomain(FusionBlockAnalysis &analysis) 
   StructuralSignatureMap signatureMap;
 
   for (const FusionComputeNode &node : analysis.computeNodes) {
-    for (Value input : node.semantics.tileInputs)
+    for (Value input : node.semantics.tileInputs) {
       (void)getValueDims(solver, dimsByValue, symbolDimByValue,
-                          canonicalByValue, signatureMap, input);
-    for (Value output : node.semantics.tileOutputs)
+                         canonicalByValue, signatureMap, input);
+    }
+    for (Value output : node.semantics.tileOutputs) {
       (void)getValueDims(solver, dimsByValue, symbolDimByValue,
-                          canonicalByValue, signatureMap, output);
+                         canonicalByValue, signatureMap, output);
+    }
   }
 
-  for (const FusionComputeNode &node : analysis.computeNodes)
+  for (const FusionComputeNode &node : analysis.computeNodes) {
     applyShapeConstraintsForNode(solver, dimsByValue, symbolDimByValue,
                                  canonicalByValue, signatureMap, node);
+  }
 
   // pto.set_validshape mutates runtime valid-row/valid-col metadata in-place
   // on a tile_buf.  If a set_validshape modifies a tile that participates in
@@ -809,8 +825,9 @@ static FusionWriteInstanceEscapeClass classifyEscapeClass(
       live.hasLocalHardBoundaryUsers) {
     return FusionWriteInstanceEscapeClass::HardExternal;
   }
-  if (live.hasLocalBoundaryUsers)
+  if (live.hasLocalBoundaryUsers) {
     return FusionWriteInstanceEscapeClass::LocalBoundaryExternal;
+  }
   return FusionWriteInstanceEscapeClass::Internal;
 }
 
@@ -914,8 +931,9 @@ static std::optional<unsigned> findReachingWriteInstance(
 
   for (unsigned writeInstanceId : llvm::reverse(writeInstanceIds)) {
     if (mutableWriteInstances[writeInstanceId].producerBlockOrder <
-        *userBlockOrder)
+        *userBlockOrder) {
       return writeInstanceId;
+    }
   }
   return std::nullopt;
 }
@@ -926,9 +944,11 @@ static bool isDpsInitOperandUse(OpOperand &use) {
     return false;
   }
 
-  for (OpOperand &dpsInit : dpsIface.getDpsInitsMutable())
-    if (&dpsInit == &use)
+  for (OpOperand &dpsInit : dpsIface.getDpsInitsMutable()) {
+    if (&dpsInit == &use) {
       return true;
+    }
+  }
   return false;
 }
 
@@ -1004,8 +1024,9 @@ static void finalizeWriteInstances(
     }
   }
 
-  for (MutableWriteInstance &state : mutableWriteInstances)
+  for (MutableWriteInstance &state : mutableWriteInstances) {
     state.live.escapeClass = classifyEscapeClass(state.live);
+  }
 }
 
 /// Build the shared dataflow graph (compute nodes, DFG edges, value liveness,
@@ -1019,8 +1040,8 @@ static FailureOr<FusionBlockAnalysis> analyzeBlockDFG(Block &block) {
 
   DenseMap<Value, unsigned> producerByValue;
   DenseMap<Value, unsigned> livenessSlotByValue;
-  SmallVector<MutableLiveness, 8> mutableLiveness;
-  SmallVector<MutableWriteInstance, 8> mutableWriteInstances;
+  SmallVector<MutableLiveness, mlir::pto::kValue8> mutableLiveness;
+  SmallVector<MutableWriteInstance, mlir::pto::kValue8> mutableWriteInstances;
   DenseMap<Operation *, FusionOpKind> kindByOp;
   DenseMap<Operation *, unsigned> computeNodeByOp;
   DenseMap<Operation *, unsigned> blockOrderByOp;
@@ -1129,10 +1150,13 @@ static LogicalResult analyzeRegionDFG(Region &region,
       return failure();
     }
     blocks.push_back(std::move(*blockAnalysis));
-    for (Operation &op : block)
-      for (Region &nested : op.getRegions())
-        if (failed(analyzeRegionDFG(nested, blocks)))
+    for (Operation &op : block) {
+      for (Region &nested : op.getRegions()) {
+        if (failed(analyzeRegionDFG(nested, blocks))) {
           return failure();
+        }
+      }
+    }
   }
   return success();
 }

--- a/lib/PTO/Transforms/TileFusion/FusionOpSemantics.cpp
+++ b/lib/PTO/Transforms/TileFusion/FusionOpSemantics.cpp
@@ -8,6 +8,7 @@
 
 #include "PTO/Transforms/TileFusion/FusionOpSemantics.h"
 
+#include "PTO/Support/CodeConstants.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"
 
@@ -37,8 +38,8 @@ static bool isTileFusionTileValue(Value value) {
   return isa<pto::TileBufType>(value.getType());
 }
 
-static SmallVector<Value, 2> collectNormalizedTileOutputs(Operation *op) {
-  SmallVector<Value, 2> outputs;
+static SmallVector<Value, mlir::pto::kValue2> collectNormalizedTileOutputs(Operation *op) {
+  SmallVector<Value, mlir::pto::kValue2> outputs;
 
   if (auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(op)) {
     for (Value init : dpsIface.getDpsInits()) {
@@ -46,13 +47,15 @@ static SmallVector<Value, 2> collectNormalizedTileOutputs(Operation *op) {
         outputs.push_back(init);
       }
     }
-    if (!outputs.empty())
+    if (!outputs.empty()) {
       return outputs;
+    }
   }
 
   for (Value result : op->getResults()) {
-    if (isTileFusionTileValue(result))
+    if (isTileFusionTileValue(result)) {
       outputs.push_back(result);
+    }
   }
   return outputs;
 }
@@ -90,18 +93,21 @@ FailureOr<FusionOpSemantics> getFusionOpSemantics(Operation *op) {
 
   semantics.kind = FusionOpKind::Compute;
   semantics.tileOutputs = collectNormalizedTileOutputs(op);
-  if (semantics.tileOutputs.empty())
+  if (semantics.tileOutputs.empty()) {
     return failure();
+  }
 
-  SmallVector<unsigned, 4> dpsInitOperandNumbers;
+  SmallVector<unsigned, mlir::pto::kValue4> dpsInitOperandNumbers;
   if (dpsIface) {
-    for (OpOperand &dpsInit : dpsIface.getDpsInitsMutable())
+    for (OpOperand &dpsInit : dpsIface.getDpsInitsMutable()) {
       dpsInitOperandNumbers.push_back(dpsInit.getOperandNumber());
+    }
   }
 
   for (OpOperand &operand : op->getOpOperands()) {
-    if (llvm::is_contained(dpsInitOperandNumbers, operand.getOperandNumber()))
+    if (llvm::is_contained(dpsInitOperandNumbers, operand.getOperandNumber())) {
       continue;
+    }
 
     Value value = operand.get();
     if (isTileFusionTileValue(value)) {
@@ -113,8 +119,9 @@ FailureOr<FusionOpSemantics> getFusionOpSemantics(Operation *op) {
 
   if (semantics.tileInputs.empty()) {
     for (Value output : semantics.tileOutputs) {
-      if (!isa<pto::TileBufType>(output.getType()))
+      if (!isa<pto::TileBufType>(output.getType())) {
         return failure();
+      }
     }
   }
 

--- a/lib/PTO/Transforms/TileFusion/PTOFlattenFusionRegion.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFlattenFusionRegion.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 
@@ -32,21 +33,24 @@ static LogicalResult flattenFusionRegion(pto::FusionRegionOp fusionRegion) {
     return fusionRegion.emitOpError("expects body to terminate with pto.yield");
   }
 
-  SmallVector<Value, 8> yieldedValues(yieldOp.getValues().begin(),
+  SmallVector<Value, mlir::pto::kValue8> yieldedValues(yieldOp.getValues().begin(),
                                       yieldOp.getValues().end());
 
   Operation *anchor = fusionRegion.getOperation();
-  SmallVector<Operation *, 16> opsToMove;
+  SmallVector<Operation *, mlir::pto::kValue16> opsToMove;
   opsToMove.reserve(body.getOperations().size());
-  for (Operation &op : body.without_terminator())
+  for (Operation &op : body.without_terminator()) {
     opsToMove.push_back(&op);
+  }
 
-  for (Operation *op : opsToMove)
+  for (Operation *op : opsToMove) {
     op->moveBefore(anchor);
+  }
 
   for (auto [result, replacement] :
-       llvm::zip(anchor->getResults(), yieldedValues))
+       llvm::zip(anchor->getResults(), yieldedValues)) {
     result.replaceAllUsesWith(replacement);
+  }
 
   yieldOp.erase();
   anchor->erase();
@@ -65,7 +69,7 @@ struct PTOFlattenFusionRegionPass
       return;
     }
 
-    SmallVector<pto::FusionRegionOp, 8> fusionRegions;
+    SmallVector<pto::FusionRegionOp, mlir::pto::kValue8> fusionRegions;
     func.walk<WalkOrder::PostOrder>([&](pto::FusionRegionOp fusionRegion) {
       fusionRegions.push_back(fusionRegion);
     });

--- a/lib/PTO/Transforms/TileFusion/PTOFusionLoadStoreElision.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionLoadStoreElision.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 
@@ -34,7 +35,7 @@ namespace {
 struct TrackedStore {
   Operation *op = nullptr;
   Value base;
-  SmallVector<Value, 2> indices;
+  SmallVector<Value, mlir::pto::kValue2> indices;
   Value mask;
   Value value;
 };
@@ -212,9 +213,11 @@ static Value getCanonicalTrackedValue(Value value) {
 }
 
 static Operation *getTopLevelAncestorInBlock(Operation *op, Block *block) {
-  for (Operation *cur = op; cur; cur = cur->getParentOp())
-    if (cur->getBlock() == block)
+  for (Operation *cur = op; cur; cur = cur->getParentOp()) {
+    if (cur->getBlock() == block) {
       return cur;
+    }
+  }
   return nullptr;
 }
 
@@ -290,7 +293,7 @@ static Block *getLeafLoopBody(scf::ForOp carrierLoop) {
 
   scf::ForOp currentLoop = carrierLoop;
   while (currentLoop) {
-    SmallVector<Operation *, 8> bodyOps;
+    SmallVector<Operation *, mlir::pto::kValue8> bodyOps;
     scf::ForOp innerLoop;
     for (Operation &op : currentLoop.getBody()->without_terminator()) {
       bodyOps.push_back(&op);
@@ -307,9 +310,11 @@ static Block *getLeafLoopBody(scf::ForOp carrierLoop) {
       if (!leafBody) {
         return nullptr;
       }
-      for (Operation &op : leafBody->without_terminator())
-        if (!isSupportedLeafOp(&op))
+      for (Operation &op : leafBody->without_terminator()) {
+        if (!isSupportedLeafOp(&op)) {
           return nullptr;
+        }
+      }
       return leafBody;
     }
 
@@ -331,9 +336,11 @@ static Block *getLeafLoopBody(scf::ForOp carrierLoop) {
 }
 
 static bool isSupportedStraightLineBlock(Block &body) {
-  for (Operation &op : body.without_terminator())
-    if (!isSupportedLeafOp(&op))
+  for (Operation &op : body.without_terminator()) {
+    if (!isSupportedLeafOp(&op)) {
       return false;
+    }
+  }
   return true;
 }
 
@@ -465,14 +472,15 @@ static bool shouldElideTailStore(
 
 static bool elideLoadStoreRoundTripsInLeafBody(
     Block &body, const FusionRegionStoreContext *context, Operation *scopeOp) {
-  SmallVector<Operation *, 8> eraseOrder;
-  llvm::SmallPtrSet<Operation *, 8> scheduledForErase;
-  SmallVector<TrackedStore, 8> trackedStores;
+  SmallVector<Operation *, mlir::pto::kValue8> eraseOrder;
+  llvm::SmallPtrSet<Operation *, mlir::pto::kValue8> scheduledForErase;
+  SmallVector<TrackedStore, mlir::pto::kValue8> trackedStores;
   bool changed = false;
 
-  auto scheduleErase = [&](Operation *op) {
-    if (scheduledForErase.insert(op).second)
+  auto scheduleErase = [&eraseOrder, &scheduledForErase](Operation *op) {
+    if (scheduledForErase.insert(op).second) {
       eraseOrder.push_back(op);
+    }
   };
 
   for (Operation &op : body.without_terminator()) {
@@ -488,7 +496,7 @@ static bool elideLoadStoreRoundTripsInLeafBody(
 
       Value base = load.getSource();
       Value offset = load.getOffset();
-      SmallVector<Value, 4> loadIndices{offset};
+      SmallVector<Value, mlir::pto::kValue4> loadIndices{offset};
       int matchIndex =
           findTrackedStoreIndex(trackedStores, base, loadIndices, inferredMask);
       if (matchIndex >= 0) {
@@ -505,7 +513,7 @@ static bool elideLoadStoreRoundTripsInLeafBody(
       Value base = store.getDestination();
       Value offset = store.getOffset();
       Value mask = store.getMask();
-      SmallVector<Value, 4> storeIndices{offset};
+      SmallVector<Value, mlir::pto::kValue4> storeIndices{offset};
       int matchIndex =
           findTrackedStoreIndex(trackedStores, base, storeIndices, mask);
       if (matchIndex >= 0) {
@@ -584,8 +592,9 @@ struct PTOFusionLoadStoreElisionPass
       changed |= elideLoadStoreRoundTripsInLeafBody(body, &it->second, nullptr);
     });
 
-    auto runElisionForLeafBody = [&](Block *leafBody, Operation *scopeOp,
-                                     pto::FusionRegionOp fusionRegion) {
+    auto runElisionForLeafBody = [&changed, &regionContexts](
+                                        Block *leafBody, Operation *scopeOp,
+                                        pto::FusionRegionOp fusionRegion) {
       if (!leafBody || !fusionRegion) {
         return;
       }

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/TileFusion/FusionAnalysis.h"
 #include "PTO/Transforms/TileFusion/FusionOpSemantics.h"
 
@@ -108,8 +109,9 @@ static bool hasHardBoundaryBetween(const pto::FusionComputeNode &a,
   Operation *cursor = earlier.op->getNextNode();
   while (cursor && cursor != later.op) {
     if (cursor->hasTrait<OpTrait::IsTerminator>() ||
-        !cursor->getRegions().empty() || isa<CallOpInterface>(cursor))
+        !cursor->getRegions().empty() || isa<CallOpInterface>(cursor)) {
       return true;
+    }
     cursor = cursor->getNextNode();
   }
   return false;
@@ -118,9 +120,11 @@ static bool hasHardBoundaryBetween(const pto::FusionComputeNode &a,
 static bool hasHardBoundaryToGroup(
     ArrayRef<const pto::FusionComputeNode *> group,
     const pto::FusionComputeNode &candidate) {
-  for (const pto::FusionComputeNode *member : group)
-    if (hasHardBoundaryBetween(*member, candidate))
+  for (const pto::FusionComputeNode *member : group) {
+    if (hasHardBoundaryBetween(*member, candidate)) {
       return true;
+    }
+  }
   return false;
 }
 
@@ -137,9 +141,11 @@ static bool dependsOnPreviousNode(
     }
   }
 
-  for (Value output : previous.semantics.tileOutputs)
-    if (llvm::is_contained(current.semantics.tileInputs, output))
+  for (Value output : previous.semantics.tileOutputs) {
+    if (llvm::is_contained(current.semantics.tileInputs, output)) {
       return true;
+    }
+  }
 
   return false;
 }
@@ -183,10 +189,10 @@ static void assignStableGroupMetadata(ArrayRef<PlannedFusionGroup> groups,
         buildStableInGroupOrder(group->members);
     for (auto [order, node] : llvm::enumerate(stableOrder)) {
       node->op->setAttr(kFusionGroupIdAttr,
-                        IntegerAttr::get(IntegerType::get(ctx, 64), groupId));
+                        IntegerAttr::get(IntegerType::get(ctx, mlir::pto::kValue64), groupId));
       node->op->setAttr(
           kFusionOrderAttr,
-          IntegerAttr::get(IntegerType::get(ctx, 64),
+          IntegerAttr::get(IntegerType::get(ctx, mlir::pto::kValue64),
                            static_cast<int64_t>(order)));
     }
   }
@@ -202,8 +208,9 @@ countEdgesFromGroup(const pto::FusionBlockAnalysis &blockAnalysis,
                     ArrayRef<const pto::FusionComputeNode *> group,
                     const pto::FusionComputeNode &candidate) {
   DenseSet<unsigned> producerIds;
-  for (const pto::FusionComputeNode *member : group)
+  for (const pto::FusionComputeNode *member : group) {
     producerIds.insert(member->id);
+  }
 
   unsigned count = 0;
   for (unsigned edgeId : candidate.incomingEdges) {
@@ -243,13 +250,17 @@ static bool nodesHaveDirectDataFlowConnection(
     }
   }
 
-  for (Value output : lhs.semantics.tileOutputs)
-    if (llvm::is_contained(rhs.semantics.tileInputs, output))
+  for (Value output : lhs.semantics.tileOutputs) {
+    if (llvm::is_contained(rhs.semantics.tileInputs, output)) {
       return true;
+    }
+  }
 
-  for (Value output : rhs.semantics.tileOutputs)
-    if (llvm::is_contained(lhs.semantics.tileInputs, output))
+  for (Value output : rhs.semantics.tileOutputs) {
+    if (llvm::is_contained(lhs.semantics.tileInputs, output)) {
       return true;
+    }
+  }
 
   return false;
 }
@@ -259,9 +270,11 @@ countConnectionsToGroup(const pto::FusionBlockAnalysis &blockAnalysis,
                         ArrayRef<const pto::FusionComputeNode *> group,
                         const pto::FusionComputeNode &candidate) {
   unsigned connections = 0;
-  for (const pto::FusionComputeNode *member : group)
-    if (nodesHaveDirectDataFlowConnection(blockAnalysis, *member, candidate))
+  for (const pto::FusionComputeNode *member : group) {
+    if (nodesHaveDirectDataFlowConnection(blockAnalysis, *member, candidate)) {
       ++connections;
+    }
+  }
   return connections;
 }
 
@@ -358,13 +371,13 @@ public:
     GroupFootprint footprint = computeGroupFootprint(proposedGroup);
 
     decision.cost.dependencyBenefit =
-        4 * static_cast<int64_t>(
+        mlir::pto::kValue4 * static_cast<int64_t>(
                 countEdgesFromGroup(ctx.blockAnalysis, currentGroup, candidate));
-    decision.cost.loopMergeBenefit = 2;
+    decision.cost.loopMergeBenefit = mlir::pto::kValue2;
     decision.cost.liveTilePenalty =
-        std::max<int64_t>(0, static_cast<int64_t>(footprint.liveTileCount) - 4);
+        std::max<int64_t>(0, static_cast<int64_t>(footprint.liveTileCount) - mlir::pto::kValue4);
     decision.cost.vfParameterPenalty = std::max<int64_t>(
-        0, static_cast<int64_t>(footprint.vfParameterCount) - 6);
+        0, static_cast<int64_t>(footprint.vfParameterCount) - mlir::pto::kValue6);
     decision.accept = decision.cost.total() > 0;
     return decision;
   }
@@ -405,8 +418,9 @@ public:
     }
 
     if (currentGroup.front()->iterationDomainClass !=
-        candidate.iterationDomainClass)
+        candidate.iterationDomainClass) {
       return decision;
+    }
 
     if (hasHardBoundaryToGroup(currentGroup, candidate)) {
       return decision;
@@ -418,17 +432,17 @@ public:
       return decision;
     }
 
-    SmallVector<const pto::FusionComputeNode *, 8> proposedGroup(
+    SmallVector<const pto::FusionComputeNode *, mlir::pto::kValue8> proposedGroup(
         currentGroup.begin(), currentGroup.end());
     proposedGroup.push_back(&candidate);
     GroupFootprint footprint = computeGroupFootprint(proposedGroup);
 
-    decision.cost.dependencyBenefit = 4 * static_cast<int64_t>(connectionCount);
-    decision.cost.loopMergeBenefit = 4;
+    decision.cost.dependencyBenefit = mlir::pto::kValue4 * static_cast<int64_t>(connectionCount);
+    decision.cost.loopMergeBenefit = mlir::pto::kValue4;
     decision.cost.liveTilePenalty = std::max<int64_t>(
-        0, static_cast<int64_t>(footprint.liveTileCount) - 10);
+        0, static_cast<int64_t>(footprint.liveTileCount) - mlir::pto::kValue10);
     decision.cost.vfParameterPenalty = std::max<int64_t>(
-        0, static_cast<int64_t>(footprint.vfParameterCount) - 12);
+        0, static_cast<int64_t>(footprint.vfParameterCount) - mlir::pto::kValue12);
     decision.accept = decision.cost.total() > 0;
     return decision;
   }
@@ -438,19 +452,19 @@ class StrategyEngine {
 public:
   virtual ~StrategyEngine() = default;
 
-  virtual SmallVector<PlannedFusionGroup, 8>
+  virtual SmallVector<PlannedFusionGroup, mlir::pto::kValue8>
   planBlock(const PlanningContext &ctx, const CostModel &costModel) const = 0;
 };
 
 class ConservativeGreedyStrategyEngine final : public StrategyEngine {
 public:
-  SmallVector<PlannedFusionGroup, 8>
+  SmallVector<PlannedFusionGroup, mlir::pto::kValue8>
   planBlock(const PlanningContext &ctx,
             const CostModel &costModel) const override {
-    SmallVector<PlannedFusionGroup, 8> groups;
+    SmallVector<PlannedFusionGroup, mlir::pto::kValue8> groups;
     SmallVector<const pto::FusionComputeNode *, 8> chain;
 
-    auto flushChain = [&]() {
+    auto flushChain = [&chain, &groups]() {
       if (chain.size() < 2) {
         chain.clear();
         return;
@@ -492,10 +506,10 @@ public:
 
 class ConservativeDAGGreedyStrategyEngine final : public StrategyEngine {
 public:
-  SmallVector<PlannedFusionGroup, 8>
+  SmallVector<PlannedFusionGroup, mlir::pto::kValue8>
   planBlock(const PlanningContext &ctx,
             const CostModel &costModel) const override {
-    SmallVector<PlannedFusionGroup, 8> groups;
+    SmallVector<PlannedFusionGroup, mlir::pto::kValue8> groups;
     DenseSet<unsigned> assignedNodes;
 
     for (const pto::FusionComputeNode &seed : ctx.blockAnalysis.computeNodes) {
@@ -519,8 +533,9 @@ public:
         for (const pto::FusionComputeNode &candidate :
              ctx.blockAnalysis.computeNodes) {
           if (assignedNodes.contains(candidate.id) ||
-              groupNodeIds.contains(candidate.id))
+              groupNodeIds.contains(candidate.id)) {
             continue;
+          }
 
           PlanningDecision appendDecision =
               costModel.evaluateAppend(ctx, groupMembers, candidate);
@@ -534,7 +549,7 @@ public:
         }
       }
 
-      if (groupMembers.size() < 2) {
+      if (groupMembers.size() < mlir::pto::kValue2) {
         continue;
       }
 
@@ -611,7 +626,7 @@ struct FusionPlanPass : public pto::impl::FusionPlanBase<FusionPlanPass> {
 
     for (const pto::FusionBlockAnalysis &blockAnalysis : analysis.blocks) {
       PlanningContext planningCtx{blockAnalysis};
-      SmallVector<PlannedFusionGroup, 8> groups =
+      SmallVector<PlannedFusionGroup, mlir::pto::kValue8> groups =
           strategyEngine.planBlock(planningCtx, costModel);
       assignStableGroupMetadata(groups, ctx, nextGroupId);
     }

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPredicateElision.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPredicateElision.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 
@@ -37,12 +38,12 @@ struct PltCandidate {
   Value mask;
   Value scalarOut;
   unsigned bitWidth = 0;
-  SmallVector<unsigned, 4> dominatingCandidates;
+  SmallVector<unsigned, mlir::pto::kValue4> dominatingCandidates;
 };
 
 struct FusionRegionPredicateContext {
   pto::FusionRegionOp fusionRegion;
-  SmallVector<PltCandidate, 8> pltCandidates;
+  SmallVector<PltCandidate, mlir::pto::kValue8> pltCandidates;
 };
 
 enum class EquivalenceState : uint8_t {
@@ -54,7 +55,7 @@ enum class EquivalenceState : uint8_t {
 struct ValueEquivalenceContext {
   // Cache pairwise equivalence inside one fusion-region rewrite walk. This
   // keeps recursive loop-carried checks bounded and deterministic.
-  llvm::DenseMap<Value, llvm::SmallDenseMap<Value, EquivalenceState, 4>>
+  llvm::DenseMap<Value, llvm::SmallDenseMap<Value, EquivalenceState, mlir::pto::kValue4>>
       states;
 };
 
@@ -90,11 +91,13 @@ static std::optional<EquivalenceState>
 lookupEquivalenceState(ValueEquivalenceContext &context, Value lhs, Value rhs) {
   normalizeValuePair(lhs, rhs);
   auto outerIt = context.states.find(lhs);
-  if (outerIt == context.states.end())
+  if (outerIt == context.states.end()) {
     return std::nullopt;
+  }
   auto innerIt = outerIt->second.find(rhs);
-  if (innerIt == outerIt->second.end())
+  if (innerIt == outerIt->second.end()) {
     return std::nullopt;
+  }
   return innerIt->second;
 }
 
@@ -152,12 +155,15 @@ static std::optional<PltScalarOutInfo> getPltScalarOutInfo(Value value) {
     return std::nullopt;
   }
 
-  if (auto plt = dyn_cast<pto::PltB8Op>(result.getOwner()))
+  if (auto plt = dyn_cast<pto::PltB8Op>(result.getOwner())) {
     return PltScalarOutInfo{plt.getScalar(), 8};
-  if (auto plt = dyn_cast<pto::PltB16Op>(result.getOwner()))
+  }
+  if (auto plt = dyn_cast<pto::PltB16Op>(result.getOwner())) {
     return PltScalarOutInfo{plt.getScalar(), 16};
-  if (auto plt = dyn_cast<pto::PltB32Op>(result.getOwner()))
+  }
+  if (auto plt = dyn_cast<pto::PltB32Op>(result.getOwner())) {
     return PltScalarOutInfo{plt.getScalar(), 32};
+  }
   return std::nullopt;
 }
 
@@ -173,16 +179,19 @@ static bool areEquivalentLoopCarriedValues(Value lhs, Value rhs,
   }
 
   if (lhsInfo->forOp.getRegionIterArgs().size() !=
-      lhsInfo->forOp.getInitArgs().size())
+      lhsInfo->forOp.getInitArgs().size()) {
     return false;
+  }
   if (lhsInfo->forOp.getRegionIterArgs().size() !=
-      lhsInfo->forOp.getYieldedValues().size())
+      lhsInfo->forOp.getYieldedValues().size()) {
     return false;
+  }
 
   ValueRange initArgs = lhsInfo->forOp.getInitArgs();
   if (!areEquivalentValues(initArgs[lhsInfo->iterArgIndex],
-                           initArgs[rhsInfo->iterArgIndex], context))
+                           initArgs[rhsInfo->iterArgIndex], context)) {
     return false;
+  }
 
   ValueRange yieldedValues = lhsInfo->forOp.getYieldedValues();
   std::optional<PltScalarOutInfo> lhsYieldInfo =
@@ -322,8 +331,9 @@ buildFusionRegionPredicateContext(pto::FusionRegionOp fusionRegion,
       return WalkResult::skip();
     }
 
-    if (std::optional<PltCandidate> candidate = buildPltCandidate(op))
+    if (std::optional<PltCandidate> candidate = buildPltCandidate(op)) {
       context.pltCandidates.push_back(std::move(*candidate));
+    }
     return WalkResult::advance();
   });
 
@@ -350,8 +360,9 @@ findEquivalentDominatingCandidate(FusionRegionPredicateContext &context,
     // Equivalence is checked on the scalar input; when it holds, both plt
     // results are reused as a pair.
     if (areEquivalentValues(getCurrentScalarOperand(previous), currentScalar,
-                            valueContext))
+                            valueContext)) {
       return previousIndex;
+    }
   }
   return std::nullopt;
 }
@@ -360,7 +371,7 @@ static bool
 elideEquivalentPltCandidates(FusionRegionPredicateContext &context) {
   bool changed = false;
   llvm::DenseSet<unsigned> erased;
-  SmallVector<Operation *, 8> opsToErase;
+  SmallVector<Operation *, mlir::pto::kValue8> opsToErase;
   ValueEquivalenceContext valueContext;
 
   for (unsigned currentIndex = 0; currentIndex < context.pltCandidates.size();
@@ -405,7 +416,7 @@ struct PTOFusionPredicateElisionPass
     }
 
     DominanceInfo &dominanceInfo = getAnalysis<DominanceInfo>();
-    SmallVector<FusionRegionPredicateContext, 4> fusionContexts;
+    SmallVector<FusionRegionPredicateContext, mlir::pto::kValue4> fusionContexts;
     func.walk([&](pto::FusionRegionOp fusionRegion) {
       FusionRegionPredicateContext context =
           buildFusionRegionPredicateContext(fusionRegion, dominanceInfo);

--- a/lib/PTO/Transforms/TileFusion/PTOFusionRegionGen.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionRegionGen.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 #include "PTO/Transforms/TileFusion/FusionAnalysis.h"
@@ -49,12 +50,12 @@ struct GroupSpanMember {
 struct GroupSpan {
   Block *block = nullptr;
   int64_t groupId = -1;
-  SmallVector<GroupSpanMember, 8> members;
+  SmallVector<GroupSpanMember, mlir::pto::kValue8> members;
 };
 
 struct GroupSpanInterface {
-  SmallVector<Value, 8> externallyVisibleValues;
-  SmallVector<Operation *, 8> localDefs;
+  SmallVector<Value, mlir::pto::kValue8> externallyVisibleValues;
+  SmallVector<Operation *, mlir::pto::kValue8> localDefs;
 };
 
 struct FusionBlockAnalysisIndex {
@@ -155,16 +156,20 @@ collectGroupSpansInBlock(Block &block, SmallVectorImpl<GroupSpan> &spans) {
 }
 
 static bool isNestedInOp(Operation *op, Operation *ancestor) {
-  for (Operation *cur = op; cur; cur = cur->getParentOp())
-    if (cur == ancestor)
+  for (Operation *cur = op; cur; cur = cur->getParentOp()) {
+    if (cur == ancestor) {
       return true;
+    }
+  }
   return false;
 }
 
 static bool isNestedInSpan(Operation *op, const DenseSet<Operation *> &spanOps) {
-  for (Operation *cur = op; cur; cur = cur->getParentOp())
-    if (spanOps.contains(cur))
+  for (Operation *cur = op; cur; cur = cur->getParentOp()) {
+    if (spanOps.contains(cur)) {
       return true;
+    }
+  }
   return false;
 }
 
@@ -176,9 +181,11 @@ static void appendUniqueValue(SmallVectorImpl<Value> &values,
 }
 
 static Operation *getTopLevelAncestorInBlock(Operation *op, Block *block) {
-  for (Operation *cur = op; cur; cur = cur->getParentOp())
-    if (cur->getBlock() == block)
+  for (Operation *cur = op; cur; cur = cur->getParentOp()) {
+    if (cur->getBlock() == block) {
       return cur;
+    }
+  }
   return nullptr;
 }
 
@@ -207,9 +214,11 @@ static bool hasReplaceableUseOutsideSpan(Value value,
 
 static bool hasAnyUseOutsideSpan(Value value,
                                  const DenseSet<Operation *> &spanOps) {
-  for (OpOperand &use : value.getUses())
-    if (!isNestedInSpan(use.getOwner(), spanOps))
+  for (OpOperand &use : value.getUses()) {
+    if (!isNestedInSpan(use.getOwner(), spanOps)) {
       return true;
+    }
+  }
   return false;
 }
 
@@ -253,12 +262,15 @@ writeInstanceEscapesSpan(const pto::FusionWriteInstanceLiveness &writeInstance,
                          const DenseSet<unsigned> &spanNodeIds) {
   if (writeInstance.hasExternalUsers || writeInstance.escapesBlock ||
       writeInstance.hasLocalBoundaryUsers ||
-      writeInstance.hasLocalHardBoundaryUsers)
+      writeInstance.hasLocalHardBoundaryUsers) {
     return true;
+  }
 
-  for (unsigned consumerNode : writeInstance.consumerNodes)
-    if (!spanNodeIds.contains(consumerNode))
+  for (unsigned consumerNode : writeInstance.consumerNodes) {
+    if (!spanNodeIds.contains(consumerNode)) {
       return true;
+    }
+  }
   return false;
 }
 
@@ -309,9 +321,11 @@ buildGroupSpanInterface(const GroupSpan &span,
   }
 
   for (const GroupSpanMember &member : span.members) {
-    for (Value result : member.op->getResults())
-      if (hasReplaceableUseOutsideSpan(result, spanOps, boundary))
+    for (Value result : member.op->getResults()) {
+      if (hasReplaceableUseOutsideSpan(result, spanOps, boundary)) {
         appendUniqueValue(iface.externallyVisibleValues, seenOutputs, result);
+      }
+    }
 
     if (auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(member.op)) {
       unsigned tileOutputIndex = 0;
@@ -438,7 +452,7 @@ encapsulateGroupSpan(const GroupSpan &span,
     return failure();
   }
 
-  SmallVector<Type, 8> outputTypes;
+  SmallVector<Type, mlir::pto::kValue8> outputTypes;
   outputTypes.reserve(iface.externallyVisibleValues.size());
   for (Value output : iface.externallyVisibleValues) {
     outputTypes.push_back(output.getType());
@@ -472,7 +486,7 @@ encapsulateGroupSpan(const GroupSpan &span,
 
   clearSpanFusionMetadata(span);
 
-  SmallVector<Value, 8> yieldValues;
+  SmallVector<Value, mlir::pto::kValue8> yieldValues;
   yieldValues.reserve(iface.externallyVisibleValues.size());
   for (Value output : iface.externallyVisibleValues) {
     yieldValues.push_back(output);
@@ -492,23 +506,29 @@ encapsulateGroupSpan(const GroupSpan &span,
 static LogicalResult processRegion(Region &region,
                                    const PreFusionAnalysisIndex *analysisIndex) {
   for (Block &block : region.getBlocks()) {
-    SmallVector<Region *, 4> nestedRegions;
-    for (Operation &op : block)
-      for (Region &nestedRegion : op.getRegions())
+    SmallVector<Region *, mlir::pto::kValue4> nestedRegions;
+    for (Operation &op : block) {
+      for (Region &nestedRegion : op.getRegions()) {
         nestedRegions.push_back(&nestedRegion);
+      }
+    }
 
-    for (Region *nestedRegion : nestedRegions)
-      if (failed(processRegion(*nestedRegion, analysisIndex)))
+    for (Region *nestedRegion : nestedRegions) {
+      if (failed(processRegion(*nestedRegion, analysisIndex))) {
         return failure();
+      }
+    }
 
-    SmallVector<GroupSpan, 8> spans;
+    SmallVector<GroupSpan, mlir::pto::kValue8> spans;
     if (failed(collectGroupSpansInBlock(block, spans))) {
       return failure();
     }
 
-    for (const GroupSpan &span : spans)
-      if (failed(encapsulateGroupSpan(span, analysisIndex)))
+    for (const GroupSpan &span : spans) {
+      if (failed(encapsulateGroupSpan(span, analysisIndex))) {
         return failure();
+      }
+    }
   }
   return success();
 }

--- a/lib/PTO/Transforms/TileFusion/PTOLowLevelLoopFusion.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOLowLevelLoopFusion.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 
@@ -37,14 +38,14 @@ namespace {
 
 struct LoopLevelInfo {
   scf::ForOp loop;
-  SmallVector<Operation *, 4> preludeOps;
-  SmallVector<Operation *, 4> epilogueOps;
+  SmallVector<Operation *, mlir::pto::kValue4> preludeOps;
+  SmallVector<Operation *, mlir::pto::kValue4> epilogueOps;
 };
 
 struct StageInfo {
-  SmallVector<Operation *, 4> setupOps;
-  SmallVector<LoopLevelInfo, 4> levels;
-  SmallVector<Operation *, 8> leafOps;
+  SmallVector<Operation *, mlir::pto::kValue4> setupOps;
+  SmallVector<LoopLevelInfo, mlir::pto::kValue4> levels;
+  SmallVector<Operation *, mlir::pto::kValue8> leafOps;
 
   scf::ForOp getOuterLoop() const { return levels.front().loop; }
   unsigned getDepth() const { return levels.size(); }
@@ -78,8 +79,9 @@ static bool isSupportedPreludeOp(Operation *op) {
 static bool isSupportedLeafOp(Operation *op) { return op->getNumRegions() == 0; }
 
 static bool isInterstageSetupOp(Operation *op) {
-  if (isPureNoRegionOp(op))
+  if (isPureNoRegionOp(op)) {
     return true;
+  }
 
   return false;
 }
@@ -148,8 +150,9 @@ static Value traceAliasRootOneStep(Value value) {
     auto *parentOp = arg.getOwner()->getParentOp();
     if (auto forOp = dyn_cast_or_null<scf::ForOp>(parentOp)) {
       if (arg.getArgNumber() > 0 &&
-          forOp.getInitArgs().size() >= arg.getArgNumber())
+          forOp.getInitArgs().size() >= arg.getArgNumber()) {
         return forOp.getInitArgs()[arg.getArgNumber() - 1];
+      }
     }
   }
 
@@ -158,22 +161,30 @@ static Value traceAliasRootOneStep(Value value) {
     return {};
   }
 
-  if (auto subview = dyn_cast<memref::SubViewOp>(def))
+  if (auto subview = dyn_cast<memref::SubViewOp>(def)) {
     return subview.getSource();
-  if (auto cast = dyn_cast<memref::CastOp>(def))
+  }
+  if (auto cast = dyn_cast<memref::CastOp>(def)) {
     return cast.getSource();
-  if (auto cast = dyn_cast<memref::ReinterpretCastOp>(def))
+  }
+  if (auto cast = dyn_cast<memref::ReinterpretCastOp>(def)) {
     return cast.getSource();
-  if (auto cast = dyn_cast<memref::MemorySpaceCastOp>(def))
+  }
+  if (auto cast = dyn_cast<memref::MemorySpaceCastOp>(def)) {
     return cast.getSource();
-  if (auto transpose = dyn_cast<memref::TransposeOp>(def))
+  }
+  if (auto transpose = dyn_cast<memref::TransposeOp>(def)) {
     return transpose.getIn();
-  if (auto subview = dyn_cast<pto::SubViewOp>(def))
+  }
+  if (auto subview = dyn_cast<pto::SubViewOp>(def)) {
     return subview.getSource();
-  if (auto bitcast = dyn_cast<pto::BitcastOp>(def))
+  }
+  if (auto bitcast = dyn_cast<pto::BitcastOp>(def)) {
     return bitcast.getSrc();
-  if (auto reshape = dyn_cast<pto::TReshapeOp>(def))
+  }
+  if (auto reshape = dyn_cast<pto::TReshapeOp>(def)) {
     return reshape.getSrc();
+  }
   if (auto cast = dyn_cast<UnrealizedConversionCastOp>(def)) {
     if (cast.getInputs().empty()) {
       return {};
@@ -227,7 +238,7 @@ static LogicalResult collectAliasRelevantRoots(
     return failure();
   }
 
-  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, 4> effects;
+  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, mlir::pto::kValue4> effects;
   effectsOp.getEffects(effects);
   for (const auto &effect : effects) {
     Value effectValue = effect.getValue();
@@ -264,31 +275,34 @@ static bool containsEquivalentRoot(ArrayRef<Value> roots, Value candidate) {
 static bool canMoveAcrossStages(Operation *movableOp,
                                 ArrayRef<StageInfo> crossStages,
                                 llvm::raw_ostream *debugOS) {
-  SmallVector<Value, 4> movableRoots;
+  SmallVector<Value, mlir::pto::kValue4> movableRoots;
   if (failed(collectAliasRelevantRoots(movableOp, movableRoots))) {
-    if (debugOS)
+    if (debugOS) {
       *debugOS << "[op-fusion] reject movable op " << movableOp->getName()
                << " at " << movableOp->getLoc()
                << ": touched roots are not alias-analyzable\n";
+    }
     return false;
   }
   for (const StageInfo &crossStage : crossStages) {
     for (Operation *op : crossStage.leafOps) {
-      SmallVector<Value, 4> opRoots;
+      SmallVector<Value, mlir::pto::kValue4> opRoots;
       if (failed(collectAliasRelevantRoots(op, opRoots))) {
-        if (debugOS)
+        if (debugOS) {
           *debugOS << "[op-fusion] reject movable op " << movableOp->getName()
                    << " at " << movableOp->getLoc()
                    << ": crossed effects of " << op->getName()
                    << " are not alias-analyzable\n";
+        }
         return false;
       }
       for (Value movableRoot : movableRoots) {
         if (containsEquivalentRoot(opRoots, movableRoot)) {
-          if (debugOS)
+          if (debugOS) {
             *debugOS << "[op-fusion] reject movable op "
                      << movableOp->getName() << " at " << movableOp->getLoc()
                      << ": touched root may alias a crossed stage memory op\n";
+          }
           return false;
         }
       }
@@ -299,21 +313,23 @@ static bool canMoveAcrossStages(Operation *movableOp,
     // against epilogueOps at every nesting depth.
     for (const LoopLevelInfo &level : crossStage.levels) {
       for (Operation *op : level.epilogueOps) {
-        SmallVector<Value, 4> opRoots;
+        SmallVector<Value, mlir::pto::kValue4> opRoots;
         if (failed(collectAliasRelevantRoots(op, opRoots))) {
-          if (debugOS)
+          if (debugOS) {
             *debugOS << "[op-fusion] reject movable op " << movableOp->getName()
                      << " at " << movableOp->getLoc()
                      << ": crossed effects of " << op->getName()
                      << " are not alias-analyzable\n";
+          }
           return false;
         }
         for (Value movableRoot : movableRoots) {
           if (containsEquivalentRoot(opRoots, movableRoot)) {
-            if (debugOS)
+            if (debugOS) {
               *debugOS << "[op-fusion] reject movable op "
                        << movableOp->getName() << " at " << movableOp->getLoc()
                        << ": touched root may alias a crossed stage epilogue op\n";
+            }
             return false;
           }
         }
@@ -333,8 +349,9 @@ static bool arePreludeReordersLegal(ArrayRef<StageInfo> stages,
     // leaf and epilogue ops in the fused loop.  Check they don't alias.
     for (const LoopLevelInfo &level : stages[stageIndex].levels) {
       for (Operation *op : level.preludeOps) {
-        if (!canMoveAcrossStages(op, priorStages, debugOS))
+        if (!canMoveAcrossStages(op, priorStages, debugOS)) {
           return false;
+        }
       }
     }
 
@@ -346,8 +363,9 @@ static bool arePreludeReordersLegal(ArrayRef<StageInfo> stages,
         for (Operation *epilogueOp : priorLevel.epilogueOps) {
           if (!canMoveAcrossStages(epilogueOp,
                                    ArrayRef<StageInfo>(&stages[stageIndex], 1),
-                                   debugOS))
+                                   debugOS)) {
             return false;
+          }
         }
       }
     }
@@ -361,7 +379,7 @@ static LogicalResult analyzeStage(scf::ForOp outerLoop, StageInfo &stage) {
     stage.levels.push_back(LoopLevelInfo{currentLoop, {}, {}});
     LoopLevelInfo &currentLevel = stage.levels.back();
 
-    SmallVector<Operation *, 8> bodyOps;
+    SmallVector<Operation *, mlir::pto::kValue8> bodyOps;
     scf::ForOp childLoop;
     for (Operation &op : currentLoop.getBody()->without_terminator()) {
       bodyOps.push_back(&op);
@@ -413,9 +431,9 @@ static LogicalResult analyzeStage(scf::ForOp outerLoop, StageInfo &stage) {
   return failure();
 }
 
-static SmallVector<StageInfo, 8> collectStageRunFrom(scf::ForOp firstLoop,
+static SmallVector<StageInfo, mlir::pto::kValue8> collectStageRunFrom(scf::ForOp firstLoop,
                                                      llvm::raw_ostream *debugOS) {
-  SmallVector<StageInfo, 8> stages;
+  SmallVector<StageInfo, mlir::pto::kValue8> stages;
 
   StageInfo firstStage;
   if (failed(analyzeStage(firstLoop, firstStage))) {
@@ -427,7 +445,7 @@ static SmallVector<StageInfo, 8> collectStageRunFrom(scf::ForOp firstLoop,
   }
   stages.push_back(std::move(firstStage));
 
-  SmallVector<Operation *, 4> pendingSetup;
+  SmallVector<Operation *, mlir::pto::kValue4> pendingSetup;
   for (Operation *op = firstLoop->getNextNode(); op; op = op->getNextNode()) {
     if (auto nextLoop = dyn_cast<scf::ForOp>(op)) {
       StageInfo nextStage;
@@ -470,8 +488,9 @@ static void cloneOpAndMapResults(OpBuilder &builder, Operation *op,
                                  IRMapping &mapping) {
   Operation *cloned = builder.clone(*op, mapping);
   for (auto [oldRes, newRes] :
-       llvm::zip(op->getResults(), cloned->getResults()))
+       llvm::zip(op->getResults(), cloned->getResults())) {
     mapping.map(oldRes, newRes);
+  }
 }
 
 static void appendMappedValues(ValueRange values, IRMapping &mapping,
@@ -487,10 +506,11 @@ static scf::ForOp buildFusedLoopNestAtLevel(OpBuilder &builder,
                                             unsigned levelIndex) {
   scf::ForOp firstLoop = stages.front().levels[levelIndex].loop;
 
-  SmallVector<Value, 8> fusedInitArgs;
-  for (auto [stageIndex, stage] : llvm::enumerate(stages))
+  SmallVector<Value, mlir::pto::kValue8> fusedInitArgs;
+  for (auto [stageIndex, stage] : llvm::enumerate(stages)) {
     appendMappedValues(ValueRange(stage.levels[levelIndex].loop.getInitArgs()),
                        mappings[stageIndex], fusedInitArgs);
+  }
 
   auto fusedLoop = builder.create<scf::ForOp>(
       firstLoop.getLoc(),
@@ -505,34 +525,41 @@ static scf::ForOp buildFusedLoopNestAtLevel(OpBuilder &builder,
     mappings[stageIndex].map(originalLoop.getInductionVar(),
                              fusedLoop.getInductionVar());
     for (auto [argIndex, originalArg] :
-         llvm::enumerate(originalLoop.getRegionIterArgs()))
+         llvm::enumerate(originalLoop.getRegionIterArgs())) {
       mappings[stageIndex].map(
           originalArg, fusedLoop.getRegionIterArgs()[iterArgOffset + argIndex]);
+    }
     iterArgOffset += originalLoop.getRegionIterArgs().size();
   }
 
   OpBuilder bodyBuilder = OpBuilder::atBlockBegin(fusedLoop.getBody());
-  for (auto [stageIndex, stage] : llvm::enumerate(stages))
-    for (Operation *op : stage.levels[levelIndex].preludeOps)
+  for (auto [stageIndex, stage] : llvm::enumerate(stages)) {
+    for (Operation *op : stage.levels[levelIndex].preludeOps) {
       cloneOpAndMapResults(bodyBuilder, op, mappings[stageIndex]);
+    }
+  }
 
   if (levelIndex + 1 < stages.front().getDepth()) {
     (void)buildFusedLoopNestAtLevel(bodyBuilder, stages, mappings,
                                     levelIndex + 1);
   } else {
-    for (auto [stageIndex, stage] : llvm::enumerate(stages))
-      for (Operation *op : stage.leafOps)
+    for (auto [stageIndex, stage] : llvm::enumerate(stages)) {
+      for (Operation *op : stage.leafOps) {
         cloneOpAndMapResults(bodyBuilder, op, mappings[stageIndex]);
+      }
+    }
   }
 
   // Clone epilogue ops after the inner loop / leaf ops for each stage.
   // Epilogue ops appear after the child loop in the original stage and
   // must come after all inner-level body ops in the fused loop too.
-  for (auto [stageIndex, stage] : llvm::enumerate(stages))
-    for (Operation *op : stage.levels[levelIndex].epilogueOps)
+  for (auto [stageIndex, stage] : llvm::enumerate(stages)) {
+    for (Operation *op : stage.levels[levelIndex].epilogueOps) {
       cloneOpAndMapResults(bodyBuilder, op, mappings[stageIndex]);
+    }
+  }
 
-  SmallVector<Value, 8> fusedYieldOperands;
+  SmallVector<Value, mlir::pto::kValue8> fusedYieldOperands;
   for (auto [stageIndex, stage] : llvm::enumerate(stages)) {
     auto originalYield = cast<scf::YieldOp>(
         stage.levels[levelIndex].loop.getBody()->getTerminator());
@@ -543,8 +570,9 @@ static scf::ForOp buildFusedLoopNestAtLevel(OpBuilder &builder,
   Block *fusedBody = fusedLoop.getBody();
   Operation *fusedTerminator = nullptr;
   if (!fusedBody->empty() &&
-      fusedBody->back().hasTrait<OpTrait::IsTerminator>())
+      fusedBody->back().hasTrait<OpTrait::IsTerminator>()) {
     fusedTerminator = &fusedBody->back();
+  }
 
   if (auto fusedYield = dyn_cast_or_null<scf::YieldOp>(fusedTerminator)) {
     fusedYield->setOperands(fusedYieldOperands);
@@ -556,9 +584,10 @@ static scf::ForOp buildFusedLoopNestAtLevel(OpBuilder &builder,
   unsigned resultOffset = 0;
   for (auto [stageIndex, stage] : llvm::enumerate(stages)) {
     scf::ForOp originalLoop = stage.levels[levelIndex].loop;
-    for (Value originalResult : originalLoop.getResults())
+    for (Value originalResult : originalLoop.getResults()) {
       mappings[stageIndex].map(originalResult,
                                fusedLoop.getResults()[resultOffset++]);
+    }
   }
 
   return fusedLoop;
@@ -566,7 +595,7 @@ static scf::ForOp buildFusedLoopNestAtLevel(OpBuilder &builder,
 
 static bool fuseStageRun(SmallVectorImpl<StageInfo> &stages,
                          llvm::raw_ostream *debugOS) {
-  if (stages.size() < 2) {
+  if (stages.size() < mlir::pto::kValue2) {
     if (debugOS) {
       *debugOS << "[op-fusion] reject loop run: need at least 2 stages, got "
                << stages.size() << "\n";
@@ -588,13 +617,15 @@ static bool fuseStageRun(SmallVectorImpl<StageInfo> &stages,
   }
 
   OpBuilder blockBuilder(first.getOuterLoop());
-  SmallVector<IRMapping, 8> stageMappings(stages.size());
+  SmallVector<IRMapping, mlir::pto::kValue8> stageMappings(stages.size());
   auto fusedOuterLoop =
       buildFusedLoopNestAtLevel(blockBuilder, stages, stageMappings, 0);
 
-  for (StageInfo &stage : llvm::drop_begin(stages))
-    for (Operation *setupOp : stage.setupOps)
+  for (StageInfo &stage : llvm::drop_begin(stages)) {
+    for (Operation *setupOp : stage.setupOps) {
       setupOp->moveBefore(fusedOuterLoop);
+    }
+  }
 
   for (StageInfo &stage : llvm::reverse(stages)) {
     stage.getOuterLoop().erase();
@@ -615,7 +646,7 @@ static bool fuseStageRunsInBlock(Block &block, llvm::raw_ostream *debugOS) {
         continue;
       }
 
-      SmallVector<StageInfo, 8> stages =
+      SmallVector<StageInfo, mlir::pto::kValue8> stages =
           collectStageRunFrom(firstLoop, debugOS);
       if (!fuseStageRun(stages, debugOS)) {
         continue;

--- a/lib/PTO/Transforms/TileFusion/PTOMarkLastUse.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOMarkLastUse.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 
@@ -47,7 +48,7 @@ struct GroupSpanMember {
 struct GroupSpan {
   Block *block = nullptr;
   int64_t groupId = -1;
-  SmallVector<GroupSpanMember, 8> members;
+  SmallVector<GroupSpanMember, mlir::pto::kValue8> members;
 };
 
 static bool isTileType(Type type) {
@@ -58,8 +59,9 @@ static bool isDpsInitOperand(OpOperand &operand) {
   Operation *owner = operand.getOwner();
   if (auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(owner)) {
     for (OpOperand &init : dpsIface.getDpsInitsMutable()) {
-      if (&init == &operand)
+      if (&init == &operand) {
         return true;
+      }
     }
   }
   return false;
@@ -76,8 +78,8 @@ static bool isTileInputOperand(OpOperand &operand) {
 // The last-use mask is indexed by tile operand slots only, in source operand
 // order after filtering out scalar operands. DPS init/output tile slots are
 // preserved and always materialize as 0.
-static SmallVector<OpOperand *, 4> collectTileOperands(Operation *op) {
-  SmallVector<OpOperand *, 4> tileOperands;
+static SmallVector<OpOperand *, mlir::pto::kValue4> collectTileOperands(Operation *op) {
+  SmallVector<OpOperand *, mlir::pto::kValue4> tileOperands;
   for (OpOperand &operand : op->getOpOperands()) {
     if (isTileOperand(operand)) {
       tileOperands.push_back(&operand);
@@ -107,8 +109,9 @@ collectGroupSpansInBlock(Block &block, SmallVectorImpl<GroupSpan> &spans) {
   GroupSpan current;
 
   auto flush = [&]() -> LogicalResult {
-    if (current.members.empty())
+    if (current.members.empty()) {
       return success();
+    }
 
     current.block = &block;
     auto [it, inserted] =
@@ -159,8 +162,9 @@ collectGroupSpansInBlock(Block &block, SmallVectorImpl<GroupSpan> &spans) {
     }
 
     if (current.groupId != *groupId) {
-      if (failed(flush()))
+      if (failed(flush())) {
         return failure();
+      }
       current.groupId = *groupId;
     }
 
@@ -221,7 +225,7 @@ static bool isHardSpanBarrier(Operation *op) {
 }
 
 static bool hasHardBarrierInSpan(const GroupSpan &span) {
-  if (span.members.size() < 2) {
+  if (span.members.size() < mlir::pto::kValue2) {
     return false;
   }
   for (size_t i = 0; i + 1 < span.members.size(); ++i) {
@@ -250,13 +254,13 @@ static void markGroupSpanLastUse(const GroupSpan &span) {
   Operation *spanEnd = span.members.back().op;
   for (const GroupSpanMember &member : span.members) {
     Operation &op = *member.op;
-    SmallVector<OpOperand *, 4> tileOperands = collectTileOperands(&op);
+    SmallVector<OpOperand *, mlir::pto::kValue4> tileOperands = collectTileOperands(&op);
     if (tileOperands.empty()) {
       op.removeAttr(kLastUseAttrName);
       continue;
     }
 
-    SmallVector<int64_t, 8> lastUseMask;
+    SmallVector<int64_t, mlir::pto::kValue8> lastUseMask;
     lastUseMask.reserve(tileOperands.size());
     for (OpOperand *operand : tileOperands) {
       if (!isTileInputOperand(*operand)) {
@@ -279,7 +283,7 @@ static void markGroupSpanLastUse(const GroupSpan &span) {
 
 static LogicalResult markRegionLastUse(Region &region) {
   for (Block &block : region.getBlocks()) {
-    SmallVector<GroupSpan, 8> spans;
+    SmallVector<GroupSpan, mlir::pto::kValue8> spans;
     if (failed(collectGroupSpansInBlock(block, spans))) {
       return failure();
     }
@@ -287,11 +291,13 @@ static LogicalResult markRegionLastUse(Region &region) {
       markGroupSpanLastUse(span);
     }
 
-    for (Operation &op : block)
-      for (Region &nestedRegion : op.getRegions())
+    for (Operation &op : block) {
+      for (Region &nestedRegion : op.getRegions()) {
         if (failed(markRegionLastUse(nestedRegion))) {
           return failure();
         }
+      }
+    }
   }
   return success();
 }

--- a/lib/PTO/Transforms/TileFusion/PTOOpScheduling.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOOpScheduling.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/TileFusion/FusionAnalysis.h"
 #include "PTO/Transforms/TileFusion/FusionOpSemantics.h"
 
@@ -54,7 +55,7 @@ struct GroupMember {
 struct ScheduledGroup {
   int64_t groupId = 0;
   unsigned firstOriginalIndex = 0;
-  SmallVector<GroupMember, 8> members;
+  SmallVector<GroupMember, mlir::pto::kValue8> members;
 };
 
 static std::optional<int64_t> getRequiredI64Attr(Operation *op,
@@ -72,19 +73,24 @@ static bool hasIncompleteFusionMetadata(Operation *op) {
 }
 
 static bool sharesAnyValue(ArrayRef<Value> lhs, ArrayRef<Value> rhs) {
-  for (Value value : lhs)
-    if (llvm::is_contained(rhs, value))
+  for (Value value : lhs) {
+    if (llvm::is_contained(rhs, value)) {
       return true;
+    }
+  }
   return false;
 }
 
 static SchedulingBarrierKind classifySchedulingBarrier(Operation *op) {
-  if (op->hasTrait<OpTrait::IsTerminator>() || !op->getRegions().empty())
+  if (op->hasTrait<OpTrait::IsTerminator>() || !op->getRegions().empty()) {
     return SchedulingBarrierKind::HardBoundary;
-  if (isa<CallOpInterface>(op))
+  }
+  if (isa<CallOpInterface>(op)) {
     return SchedulingBarrierKind::HardBoundary;
-  if (isa<pto::AllocTileOp>(op))
+  }
+  if (isa<pto::AllocTileOp>(op)) {
     return SchedulingBarrierKind::Movable;
+  }
 
   FailureOr<pto::FusionOpSemantics> semanticsOr = pto::getFusionOpSemantics(op);
   if (succeeded(semanticsOr)) {
@@ -106,8 +112,9 @@ static SchedulingBarrierKind classifySchedulingBarrier(Operation *op) {
 static bool hasTileDependency(Operation *opA, Operation *opB) {
   // alloc_tile is a pure buffer allocation with no tile-level data dependency
   // on any compute op — it does not consume or produce tile data.
-  if (isa<pto::AllocTileOp>(opA) || isa<pto::AllocTileOp>(opB))
+  if (isa<pto::AllocTileOp>(opA) || isa<pto::AllocTileOp>(opB)) {
     return false;
+  }
 
   FailureOr<pto::FusionOpSemantics> aSemOr = pto::getFusionOpSemantics(opA);
   FailureOr<pto::FusionOpSemantics> bSemOr = pto::getFusionOpSemantics(opB);
@@ -284,7 +291,7 @@ static void movePrefixPastBarrier(ArrayRef<GroupMember> members,
 }
 
 static void scheduleGroup(ScheduledGroup &group) {
-  if (group.members.size() < 2) {
+  if (group.members.size() < mlir::pto::kValue2) {
     return;
   }
 
@@ -299,8 +306,9 @@ static void scheduleGroup(ScheduledGroup &group) {
 
       Operation *blockingOp = placement->getNextNode();
       if (!blockingOp || blockingOp == op ||
-          !canMoveLaterAcross(placement, blockingOp))
+          !canMoveLaterAcross(placement, blockingOp)) {
         break;
+      }
 
       if (!canPrefixMoveLaterAcross(group.members, placement, blockingOp)) {
         break;
@@ -314,17 +322,21 @@ static void scheduleGroup(ScheduledGroup &group) {
 
 static LogicalResult scheduleRegion(Region &region) {
   for (Block &block : region.getBlocks()) {
-    SmallVector<ScheduledGroup, 8> groups;
-    if (failed(collectScheduledGroups(block, groups)))
+    SmallVector<ScheduledGroup, mlir::pto::kValue8> groups;
+    if (failed(collectScheduledGroups(block, groups))) {
       return failure();
+    }
     for (ScheduledGroup &group : groups) {
       scheduleGroup(group);
     }
 
-    for (Operation &op : block)
-      for (Region &nestedRegion : op.getRegions())
-        if (failed(scheduleRegion(nestedRegion)))
+    for (Operation &op : block) {
+      for (Region &nestedRegion : op.getRegions()) {
+        if (failed(scheduleRegion(nestedRegion))) {
           return failure();
+        }
+      }
+    }
   }
   return success();
 }
@@ -350,7 +362,7 @@ static LogicalResult scheduleRegion(Region &region) {
 
 struct FusionSpan {
   int64_t originalGroupId = 0;
-  SmallVector<Operation *, 8> members;
+  SmallVector<Operation *, mlir::pto::kValue8> members;
 };
 
 // Collect the physically contiguous spans of fusion metadata in `block`, in
@@ -367,7 +379,7 @@ collectPhysicalFusionSpans(Block &block,
   FusionSpan current;
   bool hasCurrent = false;
 
-  auto flush = [&]() {
+  auto flush = [&current, &hasCurrent, &spans]() {
     if (!hasCurrent) {
       return;
     }
@@ -411,7 +423,7 @@ collectPhysicalFusionSpans(Block &block,
 static LogicalResult
 normalizeBlockFusionMetadata(Block &block, MLIRContext *context,
                             int64_t &nextGroupId) {
-  SmallVector<FusionSpan, 8> spans;
+  SmallVector<FusionSpan, mlir::pto::kValue8> spans;
   if (failed(collectPhysicalFusionSpans(block, spans))) {
     return failure();
   }
@@ -426,7 +438,7 @@ normalizeBlockFusionMetadata(Block &block, MLIRContext *context,
 
   const IntegerType i64 = IntegerType::get(context, 64);
   for (FusionSpan &span : spans) {
-    if (span.members.size() < 2) {
+    if (span.members.size() < mlir::pto::kValue2) {
       continue;
     }
 
@@ -451,11 +463,14 @@ normalizeScheduledFusionMetadata(Region &region, MLIRContext *context,
 
     // Recurse into nested regions in the same pre-order walk used by
     // scheduleRegion, so the function-wide id counter stays deterministic.
-    for (Operation &op : block)
-      for (Region &nestedRegion : op.getRegions())
+    for (Operation &op : block) {
+      for (Region &nestedRegion : op.getRegions()) {
         if (failed(normalizeScheduledFusionMetadata(nestedRegion, context,
-                                                    nextGroupId)))
+                                                    nextGroupId))) {
           return failure();
+        }
+      }
+    }
   }
   return success();
 }

--- a/lib/PTO/Transforms/TileFusion/PTOPrintPreFusionAnalysis.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOPrintPreFusionAnalysis.cpp
@@ -136,12 +136,13 @@ buildValueLabels(Block &block, const pto::FusionBlockAnalysis &analysis) {
   unsigned boundaryOrdinal = 0;
 
   for (const pto::FusionComputeNode &node : analysis.computeNodes) {
-    for (auto [idx, output] : llvm::enumerate(node.semantics.tileOutputs))
+    for (auto [idx, output] : llvm::enumerate(node.semantics.tileOutputs)) {
       labels.try_emplace(
           output,
           (llvm::Twine("node") + llvm::Twine(node.id) + ".out" +
            llvm::Twine(idx))
               .str());
+    }
   }
 
   for (Operation &op : block) {
@@ -152,18 +153,24 @@ buildValueLabels(Block &block, const pto::FusionBlockAnalysis &analysis) {
     }
 
     if (semanticsOr->kind == pto::FusionOpKind::LocalBoundary) {
-      for (Value input : semanticsOr->tileInputs)
-        if (!labels.count(input))
+      for (Value input : semanticsOr->tileInputs) {
+        if (!labels.count(input)) {
           labels.try_emplace(input, makeExternalValueLabel(externalOrdinal++));
-      for (Value output : semanticsOr->tileOutputs)
-        if (!labels.count(output))
+        }
+      }
+      for (Value output : semanticsOr->tileOutputs) {
+        if (!labels.count(output)) {
           labels.try_emplace(output, makeBoundaryValueLabel(boundaryOrdinal++));
+        }
+      }
       continue;
     }
 
-    for (Value input : semanticsOr->tileInputs)
-      if (!labels.count(input))
+    for (Value input : semanticsOr->tileInputs) {
+      if (!labels.count(input)) {
         labels.try_emplace(input, makeExternalValueLabel(externalOrdinal++));
+      }
+    }
   }
 
   return labels;
@@ -176,20 +183,23 @@ static void printLocalBoundaries(llvm::raw_ostream &os, Block &block,
     FailureOr<pto::FusionOpSemantics> semanticsOr =
         pto::getFusionOpSemantics(&op);
     if (failed(semanticsOr) ||
-        semanticsOr->kind != pto::FusionOpKind::LocalBoundary)
+        semanticsOr->kind != pto::FusionOpKind::LocalBoundary) {
       continue;
+    }
 
     os << "    local_boundary[" << boundaryId++ << "] op="
        << semanticsOr->opName << " inputs=[";
     for (auto [idx, input] : llvm::enumerate(semanticsOr->tileInputs)) {
-      if (idx)
+      if (idx) {
         os << ", ";
+      }
       os << valueLabels.lookup(input);
     }
     os << "] outputs=[";
     for (auto [idx, output] : llvm::enumerate(semanticsOr->tileOutputs)) {
-      if (idx)
+      if (idx) {
         os << ", ";
+      }
       os << valueLabels.lookup(output);
     }
     os << "]\n";
@@ -242,14 +252,16 @@ struct PrintPreFusionAnalysisPass
            << stringifyComputeFamily(node.semantics.computeFamily)
            << " domain_class=" << node.iterationDomainClass << " inputs=[";
         for (auto [idx, input] : llvm::enumerate(node.semantics.tileInputs)) {
-          if (idx)
+          if (idx) {
             os << ", ";
+          }
           os << valueLabels.lookup(input);
         }
         os << "] outputs=[";
         for (auto [idx, output] : llvm::enumerate(node.semantics.tileOutputs)) {
-          if (idx)
+          if (idx) {
             os << ", ";
+          }
           os << valueLabels.lookup(output);
         }
         os << "] incoming=";

--- a/lib/PTO/Transforms/TileFusion/PTOUnrollAfterLoopFusion.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOUnrollAfterLoopFusion.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/Passes.h"
 
 #include "PTO/IR/PTO.h" // FusionRegionOp
@@ -179,7 +180,7 @@ struct PTOUnrollAfterLoopFusion
     // Gather all scf.for in post-order (innermost first). The walk callback
     // only collects; every mutation happens in the loop below, after the walk
     // completes, so we never walk IR being rewritten under us.
-    SmallVector<scf::ForOp, 4> candidates;
+    SmallVector<scf::ForOp, mlir::pto::kValue4> candidates;
     func.walk([&](scf::ForOp forOp) { candidates.push_back(forOp); });
 
     for (scf::ForOp forOp : candidates) {

--- a/lib/PTO/Transforms/TileLibService.cpp
+++ b/lib/PTO/Transforms/TileLibService.cpp
@@ -32,8 +32,9 @@ void mlir::pto::TileLibRuntime::install(
 
 void mlir::pto::TileLibRuntime::uninstall(TileLibService *service) {
   std::lock_guard<std::mutex> lock(getRuntimeMutex());
-  if (getRuntimeService().get() == service)
+  if (getRuntimeService().get() == service) {
     getRuntimeService().reset();
+  }
 }
 
 std::shared_ptr<mlir::pto::TileLibService>

--- a/lib/PTO/Transforms/Utils.cpp
+++ b/lib/PTO/Transforms/Utils.cpp
@@ -35,17 +35,20 @@ static constexpr llvm::StringLiteral kFrontendPipeIdAttrName =
 FailureOr<bool> hasTFillPadExpandedPhysicalShape(TFillPadOp op) {
   auto srcType = dyn_cast<TileBufType>(op.getSrc().getType());
   auto dstType = dyn_cast<TileBufType>(op.getDst().getType());
-  if (!srcType || !dstType || srcType.getRank() != dstType.getRank())
+  if (!srcType || !dstType || srcType.getRank() != dstType.getRank()) {
     return failure();
+  }
 
   bool expanded = false;
   for (auto [srcDim, dstDim] :
        llvm::zip_equal(srcType.getShape(), dstType.getShape())) {
-    if (srcDim == dstDim)
+    if (srcDim == dstDim) {
       continue;
+    }
     if (ShapedType::isDynamic(srcDim) || ShapedType::isDynamic(dstDim) ||
-        dstDim < srcDim)
+        dstDim < srcDim) {
       return failure();
+    }
     expanded = true;
   }
   return expanded;
@@ -55,11 +58,13 @@ static Value peelTFillPadStorageAlias(Value value) {
   constexpr unsigned kMaxDepth = 32;
   for (unsigned depth = 0; value && depth < kMaxDepth; ++depth) {
     Operation *def = value.getDefiningOp();
-    if (!def)
+    if (!def) {
       break;
+    }
     if (auto cast = dyn_cast<UnrealizedConversionCastOp>(def)) {
-      if (cast.getNumOperands() != 1 || cast.getNumResults() != 1)
+      if (cast.getNumOperands() != 1 || cast.getNumResults() != 1) {
         break;
+      }
       value = cast.getOperand(0);
       continue;
     }
@@ -79,18 +84,21 @@ static Value peelTFillPadStorageAlias(Value value) {
 static bool haveSameKnownTFillPadStartAddress(Value src, Value dst) {
   src = peelTFillPadStorageAlias(src);
   dst = peelTFillPadStorageAlias(dst);
-  if (src == dst)
+  if (src == dst) {
     return true;
+  }
 
   auto srcAlloc = src.getDefiningOp<AllocTileOp>();
   auto dstAlloc = dst.getDefiningOp<AllocTileOp>();
-  if (!srcAlloc || !dstAlloc || !srcAlloc.getAddr() || !dstAlloc.getAddr())
+  if (!srcAlloc || !dstAlloc || !srcAlloc.getAddr() || !dstAlloc.getAddr()) {
     return false;
+  }
 
   Value srcAddr = srcAlloc.getAddr();
   Value dstAddr = dstAlloc.getAddr();
-  if (srcAddr == dstAddr)
+  if (srcAddr == dstAddr) {
     return true;
+  }
 
   IntegerAttr srcConst;
   IntegerAttr dstConst;
@@ -102,8 +110,9 @@ static bool haveSameKnownTFillPadStartAddress(Value src, Value dst) {
 FailureOr<TFillPadLoweringKind>
 inferTFillPadLoweringKindAfterMemoryPlanning(TFillPadOp op) {
   FailureOr<bool> expanded = hasTFillPadExpandedPhysicalShape(op);
-  if (failed(expanded))
+  if (failed(expanded)) {
     return failure();
+  }
 
   auto srcSpace = GetBufferSpaceAttr(op.getSrc());
   auto dstSpace = GetBufferSpaceAttr(op.getDst());
@@ -112,13 +121,15 @@ inferTFillPadLoweringKindAfterMemoryPlanning(TFillPadOp op) {
                dstSpace->getAddressSpace() == AddressSpace::VEC;
 
   if (*expanded) {
-    if (!isVec)
+    if (!isVec) {
       return failure();
+    }
     return TFillPadLoweringKind::Expand;
   }
   if (isVec &&
-      haveSameKnownTFillPadStartAddress(op.getSrc(), op.getDst()))
+      haveSameKnownTFillPadStartAddress(op.getSrc(), op.getDst())) {
     return TFillPadLoweringKind::InPlace;
+  }
   return TFillPadLoweringKind::Normal;
 }
 
@@ -156,8 +167,9 @@ func::ReturnOp getAssumedUniqueReturnOp(func::FuncOp funcOp) {
 }
 
 Value peelUnrealized(Value value) {
-  if (auto castOp = value.getDefiningOp<UnrealizedConversionCastOp>())
+  if (auto castOp = value.getDefiningOp<UnrealizedConversionCastOp>()) {
     return castOp.getOperand(0);
+  }
   return value;
 }
 
@@ -195,18 +207,22 @@ Operation *getPipeInitDef(Value pipeHandle) {
 }
 
 AccPushEpilogueAttr getPipeInitAccPushEpilogue(Operation *initOp) {
-  if (auto init = dyn_cast_or_null<InitializeL2LPipeOp>(initOp))
+  if (auto init = dyn_cast_or_null<InitializeL2LPipeOp>(initOp)) {
     return init.getAccPushEpilogueAttr();
-  if (auto init = dyn_cast_or_null<InitializeL2G2LPipeOp>(initOp))
+  }
+  if (auto init = dyn_cast_or_null<InitializeL2G2LPipeOp>(initOp)) {
     return init.getAccPushEpilogueAttr();
+  }
   return {};
 }
 
 std::optional<int32_t> getFrontendPipeIdFromInit(Operation *initOp) {
-  if (!initOp)
+  if (!initOp) {
     return std::nullopt;
-  if (auto attr = initOp->getAttrOfType<IntegerAttr>(kFrontendPipeIdAttrName))
+  }
+  if (auto attr = initOp->getAttrOfType<IntegerAttr>(kFrontendPipeIdAttrName)) {
     return static_cast<int32_t>(attr.getInt());
+  }
   return std::nullopt;
 }
 
@@ -251,14 +267,16 @@ void setBaseMemRefTypeScope(Value val, AddressSpaceAttr targetMemScope) {
 std::optional<AddressSpaceAttr> GetBufferSpaceAttr(Value operand) {
   if (auto tileTy = dyn_cast<pto::TileBufType>(operand.getType())) {
     if (auto memorySpaceAttr =
-            dyn_cast_or_null<AddressSpaceAttr>(tileTy.getMemorySpace()))
+            dyn_cast_or_null<AddressSpaceAttr>(tileTy.getMemorySpace())) {
       return memorySpaceAttr;
+    }
     return std::nullopt;
   }
   if (auto multiTy = dyn_cast<pto::MultiTileBufType>(operand.getType())) {
     if (auto memorySpaceAttr = dyn_cast_or_null<AddressSpaceAttr>(
-            multiTy.getSlotType().getMemorySpace()))
+            multiTy.getSlotType().getMemorySpace())) {
       return memorySpaceAttr;
+    }
     return std::nullopt;
   }
 
@@ -267,8 +285,9 @@ std::optional<AddressSpaceAttr> GetBufferSpaceAttr(Value operand) {
   }
   auto memRefType = cast<MemRefType>(operand.getType());
   auto memorySpace = memRefType.getMemorySpace();
-  if (!memorySpace)
+  if (!memorySpace) {
     return std::nullopt;
+  }
   auto memorySpaceAttr = dyn_cast<AddressSpaceAttr>(memorySpace);
   if (!memorySpaceAttr) {
     return std::nullopt;
@@ -317,8 +336,9 @@ std::optional<std::pair<Value, Value>> getOperationAliasInfo(Operation *op) {
   } else if (auto castOp = dyn_cast<memref::CastOp>(op)) {
     return std::make_pair(castOp.getResult(), castOp.getViewSource());
   } else if (auto castOp = dyn_cast<UnrealizedConversionCastOp>(op)) {
-    if (castOp.getNumOperands() == 1 && castOp.getNumResults() == 1)
+    if (castOp.getNumOperands() == 1 && castOp.getNumResults() == 1) {
       return std::make_pair(castOp.getResult(0), castOp.getOperand(0));
+    }
   } else if (auto extractStridedMetadataOp =
                  dyn_cast<memref::ExtractStridedMetadataOp>(op)) {
     return std::make_pair(extractStridedMetadataOp.getBaseBuffer(),

--- a/lib/PTO/Transforms/VMIControlFlowSupport.cpp
+++ b/lib/PTO/Transforms/VMIControlFlowSupport.cpp
@@ -19,35 +19,41 @@ using namespace mlir::pto;
 LogicalResult VMIControlFlowSupport::addForConstraints(
     scf::ForOp forOp, EquivalenceCallback addEquivalent) {
   scf::YieldOp yieldOp = nullptr;
-  if (Block *body = forOp.getBody())
+  if (Block *body = forOp.getBody()) {
     yieldOp = dyn_cast<scf::YieldOp>(body->getTerminator());
+  }
 
   for (auto [index, initArg] : llvm::enumerate(forOp.getInitArgs())) {
     Value anchor = initArg;
     if (index < forOp.getRegionIterArgs().size() &&
-        failed(addEquivalent(anchor, forOp.getRegionIterArgs()[index], forOp)))
+        failed(addEquivalent(anchor, forOp.getRegionIterArgs()[index], forOp))) {
       return failure();
+    }
     if (yieldOp && index < yieldOp.getNumOperands() &&
-        failed(addEquivalent(anchor, yieldOp.getOperand(index), forOp)))
+        failed(addEquivalent(anchor, yieldOp.getOperand(index), forOp))) {
       return failure();
+    }
     if (index < forOp.getNumResults() &&
-        failed(addEquivalent(anchor, forOp.getResult(index), forOp)))
+        failed(addEquivalent(anchor, forOp.getResult(index), forOp))) {
       return failure();
+    }
   }
   return success();
 }
 
 LogicalResult VMIControlFlowSupport::addWhileConstraints(
     scf::WhileOp whileOp, EquivalenceCallback addEquivalent) {
-  if (whileOp.getBefore().empty() || whileOp.getAfter().empty())
+  if (whileOp.getBefore().empty() || whileOp.getAfter().empty()) {
     return success();
+  }
 
   Block &beforeBlock = whileOp.getBefore().front();
   Block &afterBlock = whileOp.getAfter().front();
   auto conditionOp = dyn_cast<scf::ConditionOp>(beforeBlock.getTerminator());
   auto yieldOp = dyn_cast<scf::YieldOp>(afterBlock.getTerminator());
-  if (!conditionOp || !yieldOp)
+  if (!conditionOp || !yieldOp) {
     return success();
+  }
 
   // The before region carries the initial operands back through the after
   // region's yield.  The condition's forwarded values are a separate carry
@@ -56,21 +62,25 @@ LogicalResult VMIControlFlowSupport::addWhileConstraints(
   for (auto [index, init] : llvm::enumerate(whileOp.getInits())) {
     if (index < whileOp.getBeforeArguments().size() &&
         failed(addEquivalent(init, whileOp.getBeforeArguments()[index],
-                             whileOp)))
+                             whileOp))) {
       return failure();
+    }
     if (index < yieldOp.getNumOperands() &&
-        failed(addEquivalent(init, yieldOp.getOperand(index), whileOp)))
+        failed(addEquivalent(init, yieldOp.getOperand(index), whileOp))) {
       return failure();
+    }
   }
 
   for (auto [index, forwarded] : llvm::enumerate(conditionOp.getArgs())) {
     if (index < afterBlock.getNumArguments() &&
         failed(addEquivalent(forwarded, afterBlock.getArgument(index),
-                             whileOp)))
+                             whileOp))) {
       return failure();
+    }
     if (index < whileOp.getNumResults() &&
-        failed(addEquivalent(forwarded, whileOp.getResult(index), whileOp)))
+        failed(addEquivalent(forwarded, whileOp.getResult(index), whileOp))) {
       return failure();
+    }
   }
   return success();
 }

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -12,6 +12,7 @@
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/IR/VMIUtils.h"
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/Passes.h"
 #include "PTO/Transforms/VMIControlFlowSupport.h"
 #include "PTO/Transforms/VMILayoutPropagation.h"
@@ -93,11 +94,14 @@ struct MaskUseRequest {
 };
 
 static std::optional<int64_t> getConstantIndexValue(Value value) {
-  if (auto constant = value.getDefiningOp<arith::ConstantIndexOp>())
+  if (auto constant = value.getDefiningOp<arith::ConstantIndexOp>()) {
     return constant.value();
-  if (auto constant = value.getDefiningOp<arith::ConstantOp>())
-    if (auto integerAttr = dyn_cast<IntegerAttr>(constant.getValue()))
+  }
+  if (auto constant = value.getDefiningOp<arith::ConstantOp>()) {
+    if (auto integerAttr = dyn_cast<IntegerAttr>(constant.getValue())) {
       return integerAttr.getInt();
+    }
+  }
   return std::nullopt;
 }
 
@@ -109,16 +113,18 @@ static bool isLane0SplatShuffle(VMIShuffleOp op) {
 }
 
 bool containsVMIType(Type type) {
-  if (isa<VMIVRegType, VMIMaskType>(type))
+  if (isa<VMIVRegType, VMIMaskType>(type)) {
     return true;
+  }
   if (auto functionType = dyn_cast<FunctionType>(type)) {
     return llvm::any_of(functionType.getInputs(),
                         [](Type input) { return containsVMIType(input); }) ||
            llvm::any_of(functionType.getResults(),
                         [](Type result) { return containsVMIType(result); });
   }
-  if (auto shapedType = dyn_cast<ShapedType>(type))
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
     return containsVMIType(shapedType.getElementType());
+  }
   return false;
 }
 
@@ -128,40 +134,46 @@ struct LayoutSolver {
 
   unsigned addDataValue(Value value) {
     auto type = dyn_cast<VMIVRegType>(value.getType());
-    if (!type)
+    if (!type) {
       return ~0U;
+    }
     auto [it, inserted] = dataIds.try_emplace(value, dataNodes.size());
     if (inserted) {
       dataNodes.push_back(
           DataNode{value, type, it->second, type.getLayoutAttr(), {}});
-      if (type.getLayoutAttr())
+      if (type.getLayoutAttr()) {
         dataLayoutSeeds.push_back(DataLayoutSeed{
             value, type.getLayoutAttr(), DataLayoutSeedPhase::Explicit});
+      }
     }
     return it->second;
   }
 
   unsigned addMaskValue(Value value) {
     auto type = dyn_cast<VMIMaskType>(value.getType());
-    if (!type)
+    if (!type) {
       return ~0U;
+    }
     auto [it, inserted] = maskIds.try_emplace(value, maskNodes.size());
-    if (inserted)
+    if (inserted) {
       maskNodes.push_back(
           MaskNode{value, type, it->second, type.getLayoutAttr()});
+    }
     return it->second;
   }
 
   unsigned find(unsigned id) {
-    if (dataNodes[id].parent == id)
+    if (dataNodes[id].parent == id) {
       return id;
+    }
     dataNodes[id].parent = find(dataNodes[id].parent);
     return dataNodes[id].parent;
   }
 
   unsigned findMask(unsigned id) {
-    if (maskNodes[id].parent == id)
+    if (maskNodes[id].parent == id) {
       return id;
+    }
     maskNodes[id].parent = findMask(maskNodes[id].parent);
     return maskNodes[id].parent;
   }
@@ -176,54 +188,64 @@ struct LayoutSolver {
   LogicalResult uniteDataEquivalent(Value lhs, Value rhs, Operation *op) {
     unsigned lhsId = addDataValue(lhs);
     unsigned rhsId = addDataValue(rhs);
-    if (lhsId == ~0U || rhsId == ~0U)
+    if (lhsId == ~0U || rhsId == ~0U) {
       return success();
+    }
     unsigned lhsRoot = find(lhsId);
     unsigned rhsRoot = find(rhsId);
-    if (lhsRoot == rhsRoot)
+    if (lhsRoot == rhsRoot) {
       return success();
+    }
 
     DataNode &lhsNode = dataNodes[lhsRoot];
     DataNode &rhsNode = dataNodes[rhsRoot];
     if (lhsNode.naturalLayout && rhsNode.naturalLayout &&
-        lhsNode.naturalLayout != rhsNode.naturalLayout)
+        lhsNode.naturalLayout != rhsNode.naturalLayout) {
       return op->emitError()
              << kVMIDiagLayoutContractPrefix << "conflicting natural layouts "
              << lhsNode.naturalLayout << " and " << rhsNode.naturalLayout;
+    }
     if (lhsNode.preferredLayout && rhsNode.preferredLayout &&
-        lhsNode.preferredLayout != rhsNode.preferredLayout)
+        lhsNode.preferredLayout != rhsNode.preferredLayout) {
       return op->emitError()
              << kVMIDiagLayoutContractPrefix << "conflicting preferred layouts "
              << lhsNode.preferredLayout << " and " << rhsNode.preferredLayout;
+    }
 
     rhsNode.parent = lhsRoot;
-    if (!lhsNode.naturalLayout)
+    if (!lhsNode.naturalLayout) {
       lhsNode.naturalLayout = rhsNode.naturalLayout;
-    if (!lhsNode.preferredLayout)
+    }
+    if (!lhsNode.preferredLayout) {
       lhsNode.preferredLayout = rhsNode.preferredLayout;
+    }
     return success();
   }
 
   LogicalResult uniteMask(Value lhs, Value rhs, Operation *op) {
     unsigned lhsId = addMaskValue(lhs);
     unsigned rhsId = addMaskValue(rhs);
-    if (lhsId == ~0U || rhsId == ~0U)
+    if (lhsId == ~0U || rhsId == ~0U) {
       return success();
+    }
     unsigned lhsRoot = findMask(lhsId);
     unsigned rhsRoot = findMask(rhsId);
-    if (lhsRoot == rhsRoot)
+    if (lhsRoot == rhsRoot) {
       return success();
+    }
 
     MaskNode &lhsNode = maskNodes[lhsRoot];
     MaskNode &rhsNode = maskNodes[rhsRoot];
     if (lhsNode.requestedLayout && rhsNode.requestedLayout &&
-        lhsNode.requestedLayout != rhsNode.requestedLayout)
+        lhsNode.requestedLayout != rhsNode.requestedLayout) {
       return op->emitError()
              << kVMIDiagLayoutContractPrefix << "conflicting mask layouts "
              << lhsNode.requestedLayout << " and " << rhsNode.requestedLayout;
+    }
     rhsNode.parent = lhsRoot;
-    if (!lhsNode.requestedLayout)
+    if (!lhsNode.requestedLayout) {
       lhsNode.requestedLayout = rhsNode.requestedLayout;
+    }
     return success();
   }
 
@@ -231,14 +253,16 @@ struct LayoutSolver {
   setNaturalLayout(Value value, VMILayoutAttr layout, Operation *op,
                    DataLayoutSeedPhase phase = DataLayoutSeedPhase::Other) {
     unsigned id = addDataValue(value);
-    if (id == ~0U || !layout)
+    if (id == ~0U || !layout) {
       return success();
+    }
     unsigned root = find(id);
     VMILayoutAttr existing = dataNodes[root].naturalLayout;
-    if (existing && existing != layout)
+    if (existing && existing != layout) {
       return op->emitError()
              << kVMIDiagLayoutContractPrefix << "conflicting natural layouts "
              << existing << " and " << layout;
+    }
     dataNodes[root].naturalLayout = layout;
     dataLayoutSeeds.push_back(DataLayoutSeed{value, layout, phase});
     return success();
@@ -248,14 +272,16 @@ struct LayoutSolver {
   setPreferredLayout(Value value, VMILayoutAttr layout, Operation *op,
                      DataLayoutSeedPhase phase = DataLayoutSeedPhase::Other) {
     unsigned id = addDataValue(value);
-    if (id == ~0U || !layout)
+    if (id == ~0U || !layout) {
       return success();
+    }
     unsigned root = find(id);
     VMILayoutAttr existing = dataNodes[root].preferredLayout;
-    if (existing && existing != layout)
+    if (existing && existing != layout) {
       return op->emitError()
              << kVMIDiagLayoutContractPrefix << "conflicting preferred layouts "
              << existing << " and " << layout;
+    }
     dataNodes[root].preferredLayout = layout;
     dataLayoutSeeds.push_back(DataLayoutSeed{value, layout, phase});
     return success();
@@ -266,10 +292,12 @@ struct LayoutSolver {
   }
 
   DataLayoutSeedPhase getCastSeedPhase(const VMICastLayoutFact &fact) {
-    if (fact.priority == VMICastLayoutPriority::High)
+    if (fact.priority == VMICastLayoutPriority::High) {
       return DataLayoutSeedPhase::CompactCast;
-    if (fact.priority == VMICastLayoutPriority::LaneStrideNarrowing)
+    }
+    if (fact.priority == VMICastLayoutPriority::LaneStrideNarrowing) {
       return DataLayoutSeedPhase::LaneStrideNarrowCast;
+    }
     return DataLayoutSeedPhase::Cast;
   }
 
@@ -277,15 +305,17 @@ struct LayoutSolver {
     VMILayoutSupport supports;
     FailureOr<VMIStoreLayoutFact> fact =
         supports.getPreferredStoreLayoutFact(type);
-    if (failed(fact))
+    if (failed(fact)) {
       return {};
+    }
     return fact->valueLayout;
   }
 
   bool hasDataLayoutSeed(Value value) {
     unsigned id = addDataValue(value);
-    if (id == ~0U)
+    if (id == ~0U) {
       return false;
+    }
     DataNode &node = dataNodes[find(id)];
     return static_cast<bool>(node.naturalLayout || node.preferredLayout);
   }
@@ -303,26 +333,31 @@ struct LayoutSolver {
 
   VMILayoutAttr getPreferredGroupSlotsLayout(VMIVRegType type,
                                              int64_t numGroups) {
-    if (VMILayoutAttr existing = type.getLayoutAttr())
-      if (existing.isGroupSlots() && existing.getSlots() > 0)
+    if (VMILayoutAttr existing = type.getLayoutAttr()) {
+      if (existing.isGroupSlots() && existing.getSlots() > 0) {
         return existing;
+      }
+    }
     VMILayoutSupport supports;
     FailureOr<VMIGroupReduceLayoutFact> fact =
         supports.getPreferredGroupReduceLayoutFact(type, numGroups);
-    if (succeeded(fact))
+    if (succeeded(fact)) {
       return fact->resultLayout;
+    }
     return getGroupSlotsLayout(numGroups);
   }
 
   VMILayoutAttr getPreferredGroupReduceSourceLayout(VMIVRegType type,
                                                     int64_t numGroups) {
-    if (VMILayoutAttr existing = type.getLayoutAttr())
+    if (VMILayoutAttr existing = type.getLayoutAttr()) {
       return existing;
+    }
     VMILayoutSupport supports;
     FailureOr<VMIGroupReduceLayoutFact> fact =
         supports.getPreferredGroupReduceLayoutFact(type, numGroups);
-    if (succeeded(fact))
+    if (succeeded(fact)) {
       return fact->sourceLayout;
+    }
     return getContiguousLayout();
   }
 
@@ -330,45 +365,52 @@ struct LayoutSolver {
                                                  int64_t numGroups,
                                                  VMIGroupReduceLayoutFact fact) {
     if (!fact.sourceLayout || !fact.sourceLayout.isContiguous() ||
-        fact.sourceLayout.getLaneStride() != 1)
+        fact.sourceLayout.getLaneStride() != 1) {
       return DataLayoutSeedPhase::Reduce;
+    }
 
     VMILayoutSupport supports;
-    FailureOr<SmallVector<VMIGroupReduceLayoutFact, 4>> resultFacts =
+    FailureOr<SmallVector<VMIGroupReduceLayoutFact, mlir::pto::kValue4>> resultFacts =
         supports.getGroupReduceLayoutFactsForLayout(
             sourceType, numGroups, VMIGroupReduceLayoutPort::Result,
             fact.resultLayout);
-    if (succeeded(resultFacts) && resultFacts->size() > 1)
+    if (succeeded(resultFacts) && resultFacts->size() > 1) {
       return DataLayoutSeedPhase::WeakReduce;
+    }
     return DataLayoutSeedPhase::Reduce;
   }
 
   VMILayoutAttr getPreferredGroupSlotLoadLayout(VMIGroupSlotLoadOp op) {
     auto type = cast<VMIVRegType>(op.getResult().getType());
     int64_t numGroups = op.getNumGroupsAttr().getInt();
-    if (VMILayoutAttr existing = type.getLayoutAttr())
-      if (existing.isGroupSlots() && existing.getSlots() > 0)
+    if (VMILayoutAttr existing = type.getLayoutAttr()) {
+      if (existing.isGroupSlots() && existing.getSlots() > 0) {
         return existing;
+      }
+    }
     std::optional<int64_t> sourceGroupStride =
         getConstantIndexValue(op.getSourceGroupStride());
-    if (sourceGroupStride && *sourceGroupStride == 1)
-      return VMILayoutAttr::getGroupSlots(ctx, numGroups, /*slots=*/8);
+    if (sourceGroupStride && *sourceGroupStride == 1) {
+      return VMILayoutAttr::getGroupSlots(ctx, numGroups, /*slots=*/mlir::pto::kValue8);
+    }
     return VMILayoutAttr::getGroupSlots(ctx, numGroups, /*slots=*/1);
   }
 
   VMILayoutAttr
   getPreferredGroupBroadcastLoadLayout(VMIGroupBroadcastLoadOp op) {
     auto type = cast<VMIVRegType>(op.getResult().getType());
-    if (VMILayoutAttr existing = type.getLayoutAttr())
+    if (VMILayoutAttr existing = type.getLayoutAttr()) {
       return existing;
+    }
 
     VMILayoutSupport supports;
     FailureOr<VMIGroupBroadcastLoadDirectFact> fact =
         supports.getGroupBroadcastLoadDirectFact(
             type, op.getSource().getType(), op.getSourceGroupStride(),
             op.getNumGroupsAttr().getInt());
-    if (failed(fact))
+    if (failed(fact)) {
       return {};
+    }
     return fact->layout.resultLayout;
   }
 
@@ -382,94 +424,117 @@ struct LayoutSolver {
   VMILayoutAttr getPreferredGroupBroadcastSourceLayout(Value value,
                                                        int64_t numGroups) {
     auto type = dyn_cast<VMIVRegType>(value.getType());
-    if (!type)
+    if (!type) {
       return getContiguousLayout();
-    if (VMILayoutAttr existing = type.getLayoutAttr())
-      if (existing.isGroupSlots() && existing.getSlots() > 0)
+    }
+    if (VMILayoutAttr existing = type.getLayoutAttr()) {
+      if (existing.isGroupSlots() && existing.getSlots() > 0) {
         return existing;
+      }
+    }
     VMILayoutAttr solved = getDataLayout(value);
     if (solved && solved.isGroupSlots() && solved.getNumGroups() == numGroups &&
-        solved.getSlots() > 0)
+        solved.getSlots() > 0) {
       return solved;
-    if (type.getElementCount() == numGroups)
+    }
+    if (type.getElementCount() == numGroups) {
       // Prefer the packed carrier for plastic producers, including partial
       // packets with fewer than eight groups.  This keeps the broadcast on
       // the single-source vselr path; explicit or otherwise fixed slots=1
       // values retain their layout and use the cross-source fallback.
-      return VMILayoutAttr::getGroupSlots(ctx, numGroups, /*slots=*/8);
-    if (auto load = value.getDefiningOp<VMIGroupSlotLoadOp>())
+      return VMILayoutAttr::getGroupSlots(ctx, numGroups, /*slots=*/mlir::pto::kValue8);
+    }
+    if (auto load = value.getDefiningOp<VMIGroupSlotLoadOp>()) {
       return getPreferredGroupSlotLoadLayout(load);
+    }
     return getPreferredGroupSlotsLayout(type, numGroups);
   }
 
   VMILayoutAttr
   getPreferredGroupBroadcastResultLayout(VMIGroupBroadcastOp op) {
     auto type = cast<VMIVRegType>(op.getResult().getType());
-    if (VMILayoutAttr existing = type.getLayoutAttr())
+    if (VMILayoutAttr existing = type.getLayoutAttr()) {
       return existing;
+    }
 
     FailureOr<int64_t> lanesPerPart =
         getDataLanesPerPart(type.getElementType());
     int64_t numGroups = op.getNumGroupsAttr().getInt();
     if (failed(lanesPerPart) || numGroups <= 0 ||
-        type.getElementCount() % numGroups != 0)
+        type.getElementCount() % numGroups != 0) {
       return {};
+    }
 
     int64_t groupSize = type.getElementCount() / numGroups;
     int64_t vcgBlockElems = *lanesPerPart / 8;
     if (type.getElementCount() < *lanesPerPart &&
-        groupSize == vcgBlockElems)
-      return VMILayoutAttr::getContiguous(ctx, /*laneStride=*/2);
+        groupSize == vcgBlockElems) {
+      return VMILayoutAttr::getContiguous(ctx, /*laneStride=*/mlir::pto::kValue2);
+    }
     return {};
   }
 
   VMILayoutAttr getPreferredGroupLoadResultLayout(VMIGroupLoadOp op) {
     auto type = cast<VMIVRegType>(op.getResult().getType());
-    if (VMILayoutAttr existing = type.getLayoutAttr())
+    if (VMILayoutAttr existing = type.getLayoutAttr()) {
       return existing;
+    }
 
     int64_t numGroups = op.getNumGroupsAttr().getInt();
-    if (numGroups <= 0 || type.getElementCount() % numGroups != 0)
+    if (numGroups <= 0 || type.getElementCount() % numGroups != 0) {
       return getContiguousLayout();
+    }
 
-    if (!type.getElementType().isF32())
+    if (!type.getElementType().isF32()) {
       return getContiguousLayout();
+    }
 
     int64_t groupSize = type.getElementCount() / numGroups;
     std::optional<int64_t> rowStride = getConstantIndexValue(op.getRowStride());
-    if (rowStride && *rowStride == groupSize)
+    if (rowStride && *rowStride == groupSize) {
       return getContiguousLayout();
-    if (!rowStride || *rowStride <= 0 || *rowStride % 8 != 0)
+    }
+    if (!rowStride || *rowStride <= 0 || *rowStride % 8 != 0) {
       return getContiguousLayout();
+    }
 
-    if (groupSize == 16)
-      return VMILayoutAttr::getBlockDeinterleaved(ctx, 2);
-    if (groupSize == 32)
-      return VMILayoutAttr::getBlockDeinterleaved(ctx, 4);
+    if (groupSize == mlir::pto::kValue16) {
+      return VMILayoutAttr::getBlockDeinterleaved(ctx, mlir::pto::kValue2);
+    }
+    if (groupSize == mlir::pto::kValue32) {
+      return VMILayoutAttr::getBlockDeinterleaved(ctx, mlir::pto::kValue4);
+    }
 
     return getContiguousLayout();
   }
 
   LogicalResult validateGroupLoadLayoutPlan(VMIGroupLoadOp op) {
     auto type = cast<VMIVRegType>(op.getResult().getType());
-    if (type.getLayoutAttr())
+    if (type.getLayoutAttr()) {
       return success();
+    }
 
     int64_t numGroups = op.getNumGroupsAttr().getInt();
-    if (numGroups <= 0 || type.getElementCount() % numGroups != 0)
+    if (numGroups <= 0 || type.getElementCount() % numGroups != 0) {
       return success();
-    if (!type.getElementType().isF32())
+    }
+    if (!type.getElementType().isF32()) {
       return success();
+    }
 
     int64_t groupSize = type.getElementCount() / numGroups;
-    if (groupSize != 16 && groupSize != 32)
+    if (groupSize != mlir::pto::kValue16 &&
+        groupSize != mlir::pto::kValue32) {
       return success();
+    }
 
     std::optional<int64_t> rowStride = getConstantIndexValue(op.getRowStride());
-    if (rowStride && *rowStride == groupSize)
+    if (rowStride && *rowStride == groupSize) {
       return success();
-    if (rowStride && *rowStride > 0 && *rowStride % 8 == 0)
+    }
+    if (rowStride && *rowStride > 0 && *rowStride % 8 == 0) {
       return success();
+    }
 
     return op.emitError()
            << kVMIDiagLayoutContractPrefix << "pto.vmi.group_load group_size "
@@ -481,13 +546,16 @@ struct LayoutSolver {
 
   VMILayoutAttr getDataLayout(Value value) {
     unsigned id = addDataValue(value);
-    if (id == ~0U)
+    if (id == ~0U) {
       return {};
+    }
     unsigned root = find(id);
-    if (dataNodes[root].naturalLayout)
+    if (dataNodes[root].naturalLayout) {
       return dataNodes[root].naturalLayout;
-    if (dataNodes[root].preferredLayout)
+    }
+    if (dataNodes[root].preferredLayout) {
       return dataNodes[root].preferredLayout;
+    }
     return getContiguousLayout();
   }
 
@@ -502,20 +570,23 @@ struct LayoutSolver {
 
   LogicalResult constrainElementwiseBinary(OpOperand &lhs, OpOperand &rhs,
                                            Value result, Operation *op) {
-    if (failed(unite(lhs.get(), rhs.get(), op)))
+    if (failed(unite(lhs.get(), rhs.get(), op))) {
       return failure();
+    }
     return unite(lhs.get(), result, op);
   }
 
   LogicalResult
   requestMaskUse(OpOperand &operand, VMILayoutAttr layout, Operation *op,
                  DataLayoutSeedPhase phase = DataLayoutSeedPhase::Other) {
-    if (!isa<VMIMaskType>(operand.get().getType()))
+    if (!isa<VMIMaskType>(operand.get().getType())) {
       return success();
-    if (!layout)
+    }
+    if (!layout) {
       return op->emitError()
              << kVMIDiagLayoutContractPrefix
              << "cannot infer concrete mask use layout";
+    }
     maskUseRequests.push_back(MaskUseRequest{&operand, layout, phase});
     return success();
   }
@@ -526,12 +597,14 @@ struct LayoutSolver {
         addDataValue(result);
         addMaskValue(result);
       }
-      for (Region &region : op->getRegions())
-        for (Block &block : region)
+      for (Region &region : op->getRegions()) {
+        for (Block &block : region) {
           for (BlockArgument arg : block.getArguments()) {
             addDataValue(arg);
             addMaskValue(arg);
           }
+        }
+      }
     });
     return success();
   }
@@ -540,36 +613,42 @@ struct LayoutSolver {
     WalkResult result = module.walk([&](Operation *op) -> WalkResult {
       if (auto groupIota = dyn_cast<VMIGroupIotaOp>(op)) {
         if (failed(setNaturalLayout(groupIota.getResult(),
-                                    getContiguousLayout(), op)))
+                                    getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto maskAnd = dyn_cast<VMIMaskAndOp>(op)) {
         if (failed(uniteMask(maskAnd.getLhs(), maskAnd.getRhs(), op)) ||
-            failed(uniteMask(maskAnd.getLhs(), maskAnd.getResult(), op)))
+            failed(uniteMask(maskAnd.getLhs(), maskAnd.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto maskOr = dyn_cast<VMIMaskOrOp>(op)) {
         if (failed(uniteMask(maskOr.getLhs(), maskOr.getRhs(), op)) ||
-            failed(uniteMask(maskOr.getLhs(), maskOr.getResult(), op)))
+            failed(uniteMask(maskOr.getLhs(), maskOr.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto maskXor = dyn_cast<VMIMaskXOrOp>(op)) {
         if (failed(uniteMask(maskXor.getLhs(), maskXor.getRhs(), op)) ||
-            failed(uniteMask(maskXor.getLhs(), maskXor.getResult(), op)))
+            failed(uniteMask(maskXor.getLhs(), maskXor.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto maskNot = dyn_cast<VMIMaskNotOp>(op)) {
-        if (failed(uniteMask(maskNot.getSource(), maskNot.getResult(), op)))
+        if (failed(uniteMask(maskNot.getSource(), maskNot.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto ensure = dyn_cast<VMIEnsureMaskLayoutOp>(op)) {
-        if (failed(uniteMask(ensure.getSource(), ensure.getResult(), op)))
+        if (failed(uniteMask(ensure.getSource(), ensure.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto ensure = dyn_cast<VMIEnsureMaskGranularityOp>(op)) {
@@ -578,142 +657,164 @@ struct LayoutSolver {
       if (auto addf = dyn_cast<VMIAddFOp>(op)) {
         if (failed(constrainElementwiseBinary(addf.getLhsMutable(),
                                               addf.getRhsMutable(),
-                                              addf.getResult(), op)))
+                                              addf.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto addi = dyn_cast<VMIAddIOp>(op)) {
         if (failed(constrainElementwiseBinary(addi.getLhsMutable(),
                                               addi.getRhsMutable(),
-                                              addi.getResult(), op)))
+                                              addi.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto subf = dyn_cast<VMISubFOp>(op)) {
         if (failed(constrainElementwiseBinary(subf.getLhsMutable(),
                                               subf.getRhsMutable(),
-                                              subf.getResult(), op)))
+                                              subf.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto subi = dyn_cast<VMISubIOp>(op)) {
         if (failed(constrainElementwiseBinary(subi.getLhsMutable(),
                                               subi.getRhsMutable(),
-                                              subi.getResult(), op)))
+                                              subi.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto mulf = dyn_cast<VMIMulFOp>(op)) {
         if (failed(constrainElementwiseBinary(mulf.getLhsMutable(),
                                               mulf.getRhsMutable(),
-                                              mulf.getResult(), op)))
+                                              mulf.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto muli = dyn_cast<VMIMulIOp>(op)) {
         if (failed(constrainElementwiseBinary(muli.getLhsMutable(),
                                               muli.getRhsMutable(),
-                                              muli.getResult(), op)))
+                                              muli.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vecScalar = dyn_cast<VMIAddSOp>(op)) {
-        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op)))
+        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vecScalar = dyn_cast<VMIMulSOp>(op)) {
-        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op)))
+        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vecScalar = dyn_cast<VMIMaxSOp>(op)) {
-        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op)))
+        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vecScalar = dyn_cast<VMIMinSOp>(op)) {
-        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op)))
+        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vecScalar = dyn_cast<VMIShlSOp>(op)) {
-        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op)))
+        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vecScalar = dyn_cast<VMIShrSOp>(op)) {
-        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op)))
+        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vmull = dyn_cast<VMIVmullOp>(op)) {
         if (failed(constrainElementwiseBinary(vmull.getAMutable(),
                                               vmull.getBMutable(),
                                               vmull.getLow(), op)) ||
-            failed(unite(vmull.getA(), vmull.getHigh(), op)))
+            failed(unite(vmull.getA(), vmull.getHigh(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto addc = dyn_cast<VMIVaddcOp>(op)) {
         if (failed(constrainElementwiseBinary(addc.getLhsMutable(),
                                               addc.getRhsMutable(),
-                                              addc.getResult(), op)))
+                                              addc.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto addcs = dyn_cast<VMIVaddcsOp>(op)) {
         if (failed(constrainElementwiseBinary(addcs.getLhsMutable(),
                                               addcs.getRhsMutable(),
-                                              addcs.getResult(), op)))
+                                              addcs.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto fma = dyn_cast<VMIFmaOp>(op)) {
         if (failed(unite(fma.getLhs(), fma.getRhs(), op)) ||
             failed(unite(fma.getLhs(), fma.getAcc(), op)) ||
-            failed(unite(fma.getLhs(), fma.getResult(), op)))
+            failed(unite(fma.getLhs(), fma.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto divf = dyn_cast<VMIDivFOp>(op)) {
         if (failed(constrainElementwiseBinary(divf.getLhsMutable(),
                                               divf.getRhsMutable(),
-                                              divf.getResult(), op)))
+                                              divf.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto minf = dyn_cast<VMIMinFOp>(op)) {
         if (failed(constrainElementwiseBinary(minf.getLhsMutable(),
                                               minf.getRhsMutable(),
-                                              minf.getResult(), op)))
+                                              minf.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto mini = dyn_cast<VMIMinIOp>(op)) {
         if (failed(constrainElementwiseBinary(mini.getLhsMutable(),
                                               mini.getRhsMutable(),
-                                              mini.getResult(), op)))
+                                              mini.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto maxf = dyn_cast<VMIMaxFOp>(op)) {
         if (failed(constrainElementwiseBinary(maxf.getLhsMutable(),
                                               maxf.getRhsMutable(),
-                                              maxf.getResult(), op)))
+                                              maxf.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto maxi = dyn_cast<VMIMaxIOp>(op)) {
         if (failed(constrainElementwiseBinary(maxi.getLhsMutable(),
                                               maxi.getRhsMutable(),
-                                              maxi.getResult(), op)))
+                                              maxi.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto negf = dyn_cast<VMINegFOp>(op)) {
-        if (failed(unite(negf.getSource(), negf.getResult(), op)))
+        if (failed(unite(negf.getSource(), negf.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto negi = dyn_cast<VMINegIOp>(op)) {
@@ -723,33 +824,39 @@ struct LayoutSolver {
         return WalkResult::advance();
       }
       if (auto absf = dyn_cast<VMIAbsFOp>(op)) {
-        if (failed(unite(absf.getSource(), absf.getResult(), op)))
+        if (failed(unite(absf.getSource(), absf.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto absi = dyn_cast<VMIAbsIOp>(op)) {
-        if (failed(unite(absi.getSource(), absi.getResult(), op)))
+        if (failed(unite(absi.getSource(), absi.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto sqrt = dyn_cast<VMISqrtOp>(op)) {
-        if (failed(unite(sqrt.getSource(), sqrt.getResult(), op)))
+        if (failed(unite(sqrt.getSource(), sqrt.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto exp = dyn_cast<VMIExpOp>(op)) {
-        if (failed(unite(exp.getSource(), exp.getResult(), op)))
+        if (failed(unite(exp.getSource(), exp.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto ln = dyn_cast<VMILnOp>(op)) {
-        if (failed(unite(ln.getSource(), ln.getResult(), op)))
+        if (failed(unite(ln.getSource(), ln.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto relu = dyn_cast<VMIReluOp>(op)) {
-        if (failed(unite(relu.getSource(), relu.getResult(), op)))
+        if (failed(unite(relu.getSource(), relu.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto fptosi = dyn_cast<VMIFPToSIOp>(op)) {
@@ -759,11 +866,13 @@ struct LayoutSolver {
         FailureOr<VMICastLayoutFact> fact =
             supports.getPreferredCastLayoutFact(sourceType, resultType);
         VMILayoutAttr resultLayout = getContiguousLayout();
-        if (succeeded(fact))
+        if (succeeded(fact)) {
           resultLayout = fact->resultLayout;
+        }
         if (failed(setPreferredLayout(fptosi.getResult(), resultLayout,
-                                      op, DataLayoutSeedPhase::Cast)))
+                                      op, DataLayoutSeedPhase::Cast))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto fptoui = dyn_cast<VMIFPToUIOp>(op)) {
@@ -773,11 +882,13 @@ struct LayoutSolver {
         FailureOr<VMICastLayoutFact> fact =
             supports.getPreferredCastLayoutFact(sourceType, resultType);
         VMILayoutAttr resultLayout = getContiguousLayout();
-        if (succeeded(fact))
+        if (succeeded(fact)) {
           resultLayout = fact->resultLayout;
+        }
         if (failed(setPreferredLayout(fptoui.getResult(), resultLayout,
-                                      op, DataLayoutSeedPhase::Cast)))
+                                      op, DataLayoutSeedPhase::Cast))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto sitofp = dyn_cast<VMISIToFPOp>(op)) {
@@ -787,164 +898,192 @@ struct LayoutSolver {
         FailureOr<VMICastLayoutFact> fact =
             supports.getPreferredCastLayoutFact(sourceType, resultType);
         VMILayoutAttr resultLayout = getContiguousLayout();
-        if (succeeded(fact))
+        if (succeeded(fact)) {
           resultLayout = fact->resultLayout;
+        }
         if (failed(setPreferredLayout(sitofp.getResult(), resultLayout,
-                                      op, DataLayoutSeedPhase::Cast)))
+                                      op, DataLayoutSeedPhase::Cast))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto andi = dyn_cast<VMIAndIOp>(op)) {
         if (failed(constrainElementwiseBinary(andi.getLhsMutable(),
                                               andi.getRhsMutable(),
-                                              andi.getResult(), op)))
+                                              andi.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto ori = dyn_cast<VMIOrIOp>(op)) {
         if (failed(constrainElementwiseBinary(
-                ori.getLhsMutable(), ori.getRhsMutable(), ori.getResult(), op)))
+                ori.getLhsMutable(), ori.getRhsMutable(), ori.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto xori = dyn_cast<VMIXOrIOp>(op)) {
         if (failed(constrainElementwiseBinary(xori.getLhsMutable(),
                                               xori.getRhsMutable(),
-                                              xori.getResult(), op)))
+                                              xori.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto shli = dyn_cast<VMIShLIOp>(op)) {
         if (failed(constrainElementwiseBinary(shli.getLhsMutable(),
                                               shli.getRhsMutable(),
-                                              shli.getResult(), op)))
+                                              shli.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto shrui = dyn_cast<VMIShRUIOp>(op)) {
         if (failed(constrainElementwiseBinary(shrui.getLhsMutable(),
                                               shrui.getRhsMutable(),
-                                              shrui.getResult(), op)))
+                                              shrui.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto shrsi = dyn_cast<VMIShRSIOp>(op)) {
         if (failed(constrainElementwiseBinary(shrsi.getLhsMutable(),
                                               shrsi.getRhsMutable(),
-                                              shrsi.getResult(), op)))
+                                              shrsi.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto notOp = dyn_cast<VMINotOp>(op)) {
-        if (failed(unite(notOp.getSource(), notOp.getResult(), op)))
+        if (failed(unite(notOp.getSource(), notOp.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto cmpf = dyn_cast<VMICmpFOp>(op)) {
-        if (failed(unite(cmpf.getLhs(), cmpf.getRhs(), op)))
+        if (failed(unite(cmpf.getLhs(), cmpf.getRhs(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto cmpi = dyn_cast<VMICmpIOp>(op)) {
-        if (failed(unite(cmpi.getLhs(), cmpi.getRhs(), op)))
+        if (failed(unite(cmpi.getLhs(), cmpi.getRhs(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto select = dyn_cast<VMISelectOp>(op)) {
         if (failed(unite(select.getTrueValue(), select.getFalseValue(), op)) ||
-            failed(unite(select.getTrueValue(), select.getResult(), op)))
+            failed(unite(select.getTrueValue(), select.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vselr = dyn_cast<VMIVselrOp>(op)) {
         VMILayoutSupport supports;
         FailureOr<VMIVselrLayoutFact> fact =
             supports.getPreferredVselrLayoutFact(vselr);
-        if (failed(fact))
+        if (failed(fact)) {
           return WalkResult::advance();
+        }
         requestDataUse(vselr.getSourceMutable(), fact->sourceLayout);
         requestDataUse(vselr.getIndexMutable(), fact->indexLayout);
-        if (failed(setNaturalLayout(vselr.getResult(), fact->resultLayout, op)))
+        if (failed(setNaturalLayout(vselr.getResult(), fact->resultLayout, op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto activePrefix = dyn_cast<VMIActivePrefixIndexOp>(op)) {
         if (failed(setNaturalLayout(activePrefix.getResult(),
-                                    getContiguousLayout(), op)))
+                                    getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto compress = dyn_cast<VMICompressOp>(op)) {
         requestDataUse(compress.getSourceMutable(), getContiguousLayout());
         if (failed(setNaturalLayout(compress.getResult(), getContiguousLayout(),
-                                    op)))
+                                    op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIReduceAddIOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(reduce.getMaskMutable(),
-                                  getContiguousLayout(), op)))
+                                  getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(reduce.getResult(), getContiguousLayout(),
-                                    op, DataLayoutSeedPhase::Reduce)))
+                                    op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIReduceAddFOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(reduce.getMaskMutable(),
-                                  getContiguousLayout(), op)))
+                                  getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(reduce.getResult(), getContiguousLayout(),
-                                    op, DataLayoutSeedPhase::Reduce)))
+                                    op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIReduceMaxFOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(reduce.getMaskMutable(),
-                                  getContiguousLayout(), op)))
+                                  getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(reduce.getResult(), getContiguousLayout(),
-                                    op, DataLayoutSeedPhase::Reduce)))
+                                    op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIReduceMinFOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(reduce.getMaskMutable(),
-                                  getContiguousLayout(), op)))
+                                  getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(reduce.getResult(), getContiguousLayout(),
-                                    op, DataLayoutSeedPhase::Reduce)))
+                                    op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIReduceMaxIOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(reduce.getMaskMutable(),
-                                  getContiguousLayout(), op)))
+                                  getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(reduce.getResult(), getContiguousLayout(),
-                                    op, DataLayoutSeedPhase::Reduce)))
+                                    op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIReduceMinIOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(reduce.getMaskMutable(),
-                                  getContiguousLayout(), op)))
+                                  getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(reduce.getResult(), getContiguousLayout(),
-                                    op, DataLayoutSeedPhase::Reduce)))
+                                    op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIGroupReduceAddFOp>(op)) {
@@ -963,15 +1102,17 @@ struct LayoutSolver {
         requestDataUse(reduce.getSourceMutable(), sourceLayout, /*late=*/false,
                        usePhase);
         if (failed(requestMaskUse(reduce.getMaskMutable(), sourceLayout, op,
-                                  usePhase)))
+                                  usePhase))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(
                 reduce.getResult(),
                 succeeded(fact)
                     ? fact->resultLayout
                     : getPreferredGroupSlotsLayout(resultType, numGroups),
-                op, DataLayoutSeedPhase::Reduce)))
+                op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIGroupReduceMaxFOp>(op)) {
@@ -990,15 +1131,17 @@ struct LayoutSolver {
         requestDataUse(reduce.getSourceMutable(), sourceLayout, /*late=*/false,
                        usePhase);
         if (failed(requestMaskUse(reduce.getMaskMutable(), sourceLayout, op,
-                                  usePhase)))
+                                  usePhase))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(
                 reduce.getResult(),
                 succeeded(fact)
                     ? fact->resultLayout
                     : getPreferredGroupSlotsLayout(resultType, numGroups),
-                op, DataLayoutSeedPhase::Reduce)))
+                op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIGroupReduceMinFOp>(op)) {
@@ -1017,15 +1160,17 @@ struct LayoutSolver {
         requestDataUse(reduce.getSourceMutable(), sourceLayout, /*late=*/false,
                        usePhase);
         if (failed(requestMaskUse(reduce.getMaskMutable(), sourceLayout, op,
-                                  usePhase)))
+                                  usePhase))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(
                 reduce.getResult(),
                 succeeded(fact)
                     ? fact->resultLayout
                     : getPreferredGroupSlotsLayout(resultType, numGroups),
-                op, DataLayoutSeedPhase::Reduce)))
+                op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIGroupReduceAddIOp>(op)) {
@@ -1044,15 +1189,17 @@ struct LayoutSolver {
         requestDataUse(reduce.getSourceMutable(), sourceLayout, /*late=*/false,
                        usePhase);
         if (failed(requestMaskUse(reduce.getMaskMutable(), sourceLayout, op,
-                                  usePhase)))
+                                  usePhase))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(
                 reduce.getResult(),
                 succeeded(fact)
                     ? fact->resultLayout
                     : getPreferredGroupSlotsLayout(resultType, numGroups),
-                op, DataLayoutSeedPhase::Reduce)))
+                op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIGroupReduceMaxIOp>(op)) {
@@ -1071,15 +1218,17 @@ struct LayoutSolver {
         requestDataUse(reduce.getSourceMutable(), sourceLayout, /*late=*/false,
                        usePhase);
         if (failed(requestMaskUse(reduce.getMaskMutable(), sourceLayout, op,
-                                  usePhase)))
+                                  usePhase))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(
                 reduce.getResult(),
                 succeeded(fact)
                     ? fact->resultLayout
                     : getPreferredGroupSlotsLayout(resultType, numGroups),
-                op, DataLayoutSeedPhase::Reduce)))
+                op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIGroupReduceMinIOp>(op)) {
@@ -1098,15 +1247,17 @@ struct LayoutSolver {
         requestDataUse(reduce.getSourceMutable(), sourceLayout, /*late=*/false,
                        usePhase);
         if (failed(requestMaskUse(reduce.getMaskMutable(), sourceLayout, op,
-                                  usePhase)))
+                                  usePhase))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(
                 reduce.getResult(),
                 succeeded(fact)
                     ? fact->resultLayout
                     : getPreferredGroupSlotsLayout(resultType, numGroups),
-                op, DataLayoutSeedPhase::Reduce)))
+                op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto broadcast = dyn_cast<VMIGroupBroadcastOp>(op)) {
@@ -1118,8 +1269,9 @@ struct LayoutSolver {
         if (failed(setPreferredLayout(
                 broadcast.getResult(),
                 getPreferredGroupBroadcastResultLayout(broadcast), op,
-                DataLayoutSeedPhase::GroupBroadcast)))
+                DataLayoutSeedPhase::GroupBroadcast))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto hist = dyn_cast<VMIVdhistOp>(op)) {
@@ -1128,11 +1280,13 @@ struct LayoutSolver {
         requestDataUse(hist.getSourceMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(hist.getMaskMutable(), getContiguousLayout(),
-                                  op, DataLayoutSeedPhase::Reduce)))
+                                  op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(hist.getResult(), getContiguousLayout(), op,
-                                    DataLayoutSeedPhase::Reduce)))
+                                    DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto hist = dyn_cast<VMIVchistOp>(op)) {
@@ -1141,11 +1295,13 @@ struct LayoutSolver {
         requestDataUse(hist.getSourceMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(hist.getMaskMutable(), getContiguousLayout(),
-                                  op, DataLayoutSeedPhase::Reduce)))
+                                  op, DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(hist.getResult(), getContiguousLayout(), op,
-                                    DataLayoutSeedPhase::Reduce)))
+                                    DataLayoutSeedPhase::Reduce))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vexpdif = dyn_cast<VMIVexpdifOp>(op)) {
@@ -1179,8 +1335,9 @@ struct LayoutSolver {
             supports.getPreferredCastLayoutFact(sourceType, resultType);
         if (succeeded(fact)) {
           if (failed(setPreferredLayout(extf.getResult(), fact->resultLayout,
-                                        op, getCastSeedPhase(*fact))))
+                                        op, getCastSeedPhase(*fact)))) {
             return WalkResult::interrupt();
+          }
         }
         return WalkResult::advance();
       }
@@ -1192,8 +1349,9 @@ struct LayoutSolver {
             supports.getPreferredCastLayoutFact(sourceType, resultType);
         if (succeeded(fact)) {
           if (failed(setPreferredLayout(extsi.getResult(), fact->resultLayout,
-                                        op, getCastSeedPhase(*fact))))
+                                        op, getCastSeedPhase(*fact)))) {
             return WalkResult::interrupt();
+          }
         }
         return WalkResult::advance();
       }
@@ -1205,8 +1363,9 @@ struct LayoutSolver {
             supports.getPreferredCastLayoutFact(sourceType, resultType);
         if (succeeded(fact)) {
           if (failed(setPreferredLayout(extui.getResult(), fact->resultLayout,
-                                        op, getCastSeedPhase(*fact))))
+                                        op, getCastSeedPhase(*fact)))) {
             return WalkResult::interrupt();
+          }
         }
         return WalkResult::advance();
       }
@@ -1225,8 +1384,9 @@ struct LayoutSolver {
                 ? getCastSeedPhase(*fact)
                 : DataLayoutSeedPhase::Cast;
         if (failed(setPreferredLayout(truncf.getResult(), resultLayout, op,
-                                      phase)))
+                                      phase))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto trunci = dyn_cast<VMITruncIOp>(op)) {
@@ -1244,13 +1404,15 @@ struct LayoutSolver {
                 ? getCastSeedPhase(*fact)
                 : DataLayoutSeedPhase::Cast;
         if (failed(setPreferredLayout(trunci.getResult(), resultLayout, op,
-                                      phase)))
+                                      phase))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto bitcast = dyn_cast<VMIBitcastOp>(op)) {
-        if (failed(unite(bitcast.getSource(), bitcast.getResult(), op)))
+        if (failed(unite(bitcast.getSource(), bitcast.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vintlv = dyn_cast<VMIVintlvOp>(op)) {
@@ -1258,13 +1420,15 @@ struct LayoutSolver {
         auto valueType = cast<VMIVRegType>(vintlv.getLow().getType());
         FailureOr<VMIInterleaveLayoutFact> fact =
             supports.getPreferredVintlvLayoutFact(valueType);
-        if (failed(fact))
+        if (failed(fact)) {
           return WalkResult::advance();
+        }
         requestDataUse(vintlv.getLhsMutable(), fact->lhsLayout);
         requestDataUse(vintlv.getRhsMutable(), fact->rhsLayout);
         if (failed(requestMaskUse(vintlv.getMaskMutable(), fact->maskLayout,
-                                  op)))
+                                  op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vdintlv = dyn_cast<VMIVdintlvOp>(op)) {
@@ -1272,13 +1436,15 @@ struct LayoutSolver {
         auto valueType = cast<VMIVRegType>(vdintlv.getLow().getType());
         FailureOr<VMIInterleaveLayoutFact> fact =
             supports.getPreferredVdintlvLayoutFact(valueType);
-        if (failed(fact))
+        if (failed(fact)) {
           return WalkResult::advance();
+        }
         requestDataUse(vdintlv.getLhsMutable(), fact->lhsLayout);
         requestDataUse(vdintlv.getRhsMutable(), fact->rhsLayout);
         if (failed(requestMaskUse(vdintlv.getMaskMutable(), fact->maskLayout,
-                                  op)))
+                                  op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto load = dyn_cast<VMIDeinterleaveLoadOp>(op)) {
@@ -1286,45 +1452,53 @@ struct LayoutSolver {
         FailureOr<VMIDeinterleaveLoadLayoutFact> fact =
             supports.getPreferredDeinterleaveLoadLayoutFact(
                 cast<VMIVRegType>(load.getLow().getType()));
-        if (failed(fact))
+        if (failed(fact)) {
           return WalkResult::advance();
+        }
         if (failed(setNaturalLayout(load.getLow(), fact->lowLayout, op)) ||
-            failed(setNaturalLayout(load.getHigh(), fact->highLayout, op)))
+            failed(setNaturalLayout(load.getHigh(), fact->highLayout, op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto load = dyn_cast<VMIMaskedLoadOp>(op)) {
         requestDataUse(load.getPassthruMutable(), getContiguousLayout());
         if (failed(
-                setNaturalLayout(load.getResult(), getContiguousLayout(), op)))
+                setNaturalLayout(load.getResult(), getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto gather = dyn_cast<VMIGatherOp>(op)) {
         requestDataUse(gather.getIndicesMutable(), getContiguousLayout());
         requestDataUse(gather.getPassthruMutable(), getContiguousLayout());
         if (failed(requestMaskUse(gather.getMaskMutable(),
-                                  getContiguousLayout(), op)))
+                                  getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         if (failed(setNaturalLayout(gather.getResult(), getContiguousLayout(),
-                                    op)))
+                                    op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto load = dyn_cast<VMIExpandLoadOp>(op)) {
         requestDataUse(load.getPassthruMutable(), getContiguousLayout());
         if (failed(
-                setNaturalLayout(load.getResult(), getContiguousLayout(), op)))
+                setNaturalLayout(load.getResult(), getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto load = dyn_cast<VMIGroupLoadOp>(op)) {
-        if (failed(validateGroupLoadLayoutPlan(load)))
+        if (failed(validateGroupLoadLayoutPlan(load))) {
           return WalkResult::interrupt();
+        }
         VMILayoutAttr layout = getPreferredGroupLoadResultLayout(load);
         if (layout.isContiguous() && layout.getLaneStride() == 1) {
-          if (failed(setPreferredLayout(load.getResult(), layout, op)))
+          if (failed(setPreferredLayout(load.getResult(), layout, op))) {
             return WalkResult::interrupt();
+          }
         } else if (failed(setNaturalLayout(load.getResult(), layout, op,
                                            DataLayoutSeedPhase::GroupLoad))) {
           return WalkResult::interrupt();
@@ -1334,8 +1508,9 @@ struct LayoutSolver {
       if (auto load = dyn_cast<VMIGroupSlotLoadOp>(op)) {
         if (failed(setPreferredLayout(
                 load.getResult(), getPreferredGroupSlotLoadLayout(load), op,
-                DataLayoutSeedPhase::GroupSlotLoad)))
+                DataLayoutSeedPhase::GroupSlotLoad))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto load = dyn_cast<VMIGroupBroadcastLoadOp>(op)) {
@@ -1345,25 +1520,30 @@ struct LayoutSolver {
                 : DataLayoutSeedPhase::Other;
         if (failed(setNaturalLayout(load.getResult(),
                                     getPreferredGroupBroadcastLoadLayout(load),
-                                    op, phase)))
+                                    op, phase))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto load = dyn_cast<VMIStrideLoadOp>(op)) {
         if (failed(
-                setNaturalLayout(load.getResult(), getContiguousLayout(), op)))
+                setNaturalLayout(load.getResult(), getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         if (failed(requestMaskUse(load.getMaskMutable(), getContiguousLayout(),
-                                  op)))
+                                  op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto store = dyn_cast<VMIStoreOp>(op)) {
         auto valueType = cast<VMIVRegType>(store.getValue().getType());
-        if (!hasDataLayoutSeed(store.getValue()))
-          if (VMILayoutAttr layout = getPreferredDenseStoreLayout(valueType))
+        if (!hasDataLayoutSeed(store.getValue())) {
+          if (VMILayoutAttr layout = getPreferredDenseStoreLayout(valueType)) {
             requestDataUse(store.getValueMutable(), layout, /*late=*/false,
                            DataLayoutSeedPhase::Store);
+          }
+        }
         return WalkResult::advance();
       }
       if (auto store = dyn_cast<VMIInterleaveStoreOp>(op)) {
@@ -1386,10 +1566,11 @@ struct LayoutSolver {
         FailureOr<VMIGroupStoreLayoutFact> preferredFact =
             supports.getPreferredGroupStoreLayoutFact(store, valueType);
         if (succeeded(preferredFact) &&
-            preferredFact->valueLayout != highPriorityLayout)
+            preferredFact->valueLayout != highPriorityLayout) {
           requestDataUse(store.getValueMutable(), preferredFact->valueLayout,
                          /*late=*/false,
                          DataLayoutSeedPhase::GroupStoreFallback);
+        }
         return WalkResult::advance();
       }
       if (auto store = dyn_cast<VMIMaskedStoreOp>(op)) {
@@ -1403,8 +1584,9 @@ struct LayoutSolver {
                            /*late=*/false,
                            DataLayoutSeedPhase::Store);
             if (failed(requestMaskUse(store.getMaskMutable(), fact->maskLayout,
-                                      op, DataLayoutSeedPhase::Store)))
+                                      op, DataLayoutSeedPhase::Store))) {
               return WalkResult::interrupt();
+            }
           }
         }
         return WalkResult::advance();
@@ -1412,23 +1594,26 @@ struct LayoutSolver {
       if (auto store = dyn_cast<VMIStrideStoreOp>(op)) {
         requestDataUse(store.getValueMutable(), getContiguousLayout());
         if (failed(requestMaskUse(store.getMaskMutable(), getContiguousLayout(),
-                                  op)))
+                                  op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto scatter = dyn_cast<VMIScatterOp>(op)) {
         requestDataUse(scatter.getValueMutable(), getContiguousLayout());
         requestDataUse(scatter.getIndicesMutable(), getContiguousLayout());
         if (failed(requestMaskUse(scatter.getMaskMutable(),
-                                  getContiguousLayout(), op)))
+                                  getContiguousLayout(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto store = dyn_cast<VMICompressStoreOp>(op)) {
         requestDataUse(store.getValueMutable(), getContiguousLayout());
         if (failed(requestMaskUse(store.getMaskMutable(), getContiguousLayout(),
-                                  op)))
+                                  op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto split = dyn_cast<VMIChannelSplitOp>(op)) {
@@ -1441,9 +1626,11 @@ struct LayoutSolver {
         }
         requestDataUse(split.getSourceMutable(),
                        VMILayoutAttr::getDeinterleaved(ctx, channels));
-        for (Value result : split.getResults())
-          if (failed(setNaturalLayout(result, getContiguousLayout(), op)))
+        for (Value result : split.getResults()) {
+          if (failed(setNaturalLayout(result, getContiguousLayout(), op))) {
             return WalkResult::interrupt();
+          }
+        }
         return WalkResult::advance();
       }
       if (auto merge = dyn_cast<VMIChannelMergeOp>(op)) {
@@ -1454,57 +1641,68 @@ struct LayoutSolver {
                                "channels";
           return WalkResult::interrupt();
         }
-        for (OpOperand &input : merge.getInputsMutable())
+        for (OpOperand &input : merge.getInputsMutable()) {
           requestDataUse(input, getContiguousLayout());
+        }
         if (failed(setNaturalLayout(
                 merge.getResult(),
-                VMILayoutAttr::getDeinterleaved(ctx, channels), op)))
+                VMILayoutAttr::getDeinterleaved(ctx, channels), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto shuffle = dyn_cast<VMIShuffleOp>(op)) {
         auto sourceType = cast<VMIVRegType>(shuffle.getSource().getType());
         auto resultType = cast<VMIVRegType>(shuffle.getResult().getType());
-        if (sourceType.hasLayout() || resultType.hasLayout())
+        if (sourceType.hasLayout() || resultType.hasLayout()) {
           return WalkResult::advance();
+        }
 
         requestDataUse(shuffle.getSourceMutable(), getContiguousLayout());
-        if (isLane0SplatShuffle(shuffle))
+        if (isLane0SplatShuffle(shuffle)) {
           return WalkResult::advance();
+        }
         if (failed(setNaturalLayout(shuffle.getResult(), getContiguousLayout(),
-                                    op)))
+                                    op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-        if (failed(addIfConstraints(ifOp)))
+        if (failed(addIfConstraints(ifOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto executeRegionOp = dyn_cast<scf::ExecuteRegionOp>(op)) {
-        if (failed(addExecuteRegionConstraints(executeRegionOp)))
+        if (failed(addExecuteRegionConstraints(executeRegionOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto indexSwitchOp = dyn_cast<scf::IndexSwitchOp>(op)) {
-        if (failed(addIndexSwitchConstraints(indexSwitchOp)))
+        if (failed(addIndexSwitchConstraints(indexSwitchOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
-        if (failed(addWhileConstraints(whileOp)))
+        if (failed(addWhileConstraints(whileOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto forOp = dyn_cast<scf::ForOp>(op)) {
-        if (failed(addForConstraints(forOp)))
+        if (failed(addForConstraints(forOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto branchOp = dyn_cast<cf::BranchOp>(op)) {
         if (failed(addBranchConstraints(branchOp.getDest(),
-                                        branchOp.getDestOperands(), op)))
+                                        branchOp.getDestOperands(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto condBranchOp = dyn_cast<cf::CondBranchOp>(op)) {
@@ -1513,29 +1711,34 @@ struct LayoutSolver {
                                         op)) ||
             failed(addBranchConstraints(condBranchOp.getFalseDest(),
                                         condBranchOp.getFalseDestOperands(),
-                                        op)))
+                                        op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto switchOp = dyn_cast<cf::SwitchOp>(op)) {
         if (failed(addBranchConstraints(switchOp.getDefaultDestination(),
-                                        switchOp.getDefaultOperands(), op)))
+                                        switchOp.getDefaultOperands(), op))) {
           return WalkResult::interrupt();
+        }
         for (auto [dest, operands] : llvm::zip(switchOp.getCaseDestinations(),
                                                switchOp.getCaseOperands())) {
-          if (failed(addBranchConstraints(dest, operands, op)))
+          if (failed(addBranchConstraints(dest, operands, op))) {
             return WalkResult::interrupt();
+          }
         }
         return WalkResult::advance();
       }
       if (auto returnOp = dyn_cast<func::ReturnOp>(op)) {
-        if (failed(addReturnConstraints(returnOp)))
+        if (failed(addReturnConstraints(returnOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto callOp = dyn_cast<func::CallOp>(op)) {
-        if (failed(addCallConstraints(callOp)))
+        if (failed(addCallConstraints(callOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (op->getName().getStringRef() == "func.call_indirect") {
@@ -1563,8 +1766,9 @@ struct LayoutSolver {
   }
 
   LogicalResult uniteEquivalentValues(Value lhs, Value rhs, Operation *op) {
-    if (failed(uniteDataEquivalent(lhs, rhs, op)))
+    if (failed(uniteDataEquivalent(lhs, rhs, op))) {
       return failure();
+    }
     return uniteMask(lhs, rhs, op);
   }
 
@@ -1572,14 +1776,17 @@ struct LayoutSolver {
     for (OpResult result : ifOp->getResults()) {
       unsigned resultNo = result.getResultNumber();
       for (Region *region : {&ifOp.getThenRegion(), &ifOp.getElseRegion()}) {
-        if (region->empty())
+        if (region->empty()) {
           continue;
+        }
         auto yieldOp = dyn_cast<scf::YieldOp>(region->front().getTerminator());
-        if (!yieldOp || resultNo >= yieldOp.getNumOperands())
+        if (!yieldOp || resultNo >= yieldOp.getNumOperands()) {
           continue;
+        }
         if (failed(uniteEquivalentValues(result, yieldOp.getOperand(resultNo),
-                                         ifOp)))
+                                         ifOp))) {
           return failure();
+        }
       }
     }
     return success();
@@ -1588,21 +1795,25 @@ struct LayoutSolver {
   LogicalResult addYieldConstraints(ResultRange results, scf::YieldOp yieldOp,
                                     Operation *op) {
     for (auto [index, result] : llvm::enumerate(results)) {
-      if (index >= yieldOp.getNumOperands())
+      if (index >= yieldOp.getNumOperands()) {
         break;
-      if (failed(uniteEquivalentValues(result, yieldOp.getOperand(index), op)))
+      }
+      if (failed(uniteEquivalentValues(result, yieldOp.getOperand(index), op))) {
         return failure();
+      }
     }
     return success();
   }
 
   LogicalResult addExecuteRegionConstraints(scf::ExecuteRegionOp executeOp) {
     WalkResult result = executeOp.getRegion().walk([&](scf::YieldOp yieldOp) {
-      if (yieldOp->getParentOp() != executeOp.getOperation())
+      if (yieldOp->getParentOp() != executeOp.getOperation()) {
         return WalkResult::advance();
+      }
       if (failed(
-              addYieldConstraints(executeOp->getResults(), yieldOp, executeOp)))
+              addYieldConstraints(executeOp->getResults(), yieldOp, executeOp))) {
         return WalkResult::interrupt();
+      }
       return WalkResult::advance();
     });
     return failure(result.wasInterrupted());
@@ -1611,17 +1822,20 @@ struct LayoutSolver {
   LogicalResult addIndexSwitchConstraints(scf::IndexSwitchOp indexSwitchOp) {
     auto addBlockTerminator = [&](Block &block) -> LogicalResult {
       auto yieldOp = dyn_cast<scf::YieldOp>(block.getTerminator());
-      if (!yieldOp)
+      if (!yieldOp) {
         return success();
+      }
       return addYieldConstraints(indexSwitchOp->getResults(), yieldOp,
                                  indexSwitchOp);
     };
-
-    if (failed(addBlockTerminator(indexSwitchOp.getDefaultBlock())))
+    if (failed(addBlockTerminator(indexSwitchOp.getDefaultBlock()))) {
       return failure();
-    for (unsigned idx = 0, e = indexSwitchOp.getNumCases(); idx < e; ++idx)
-      if (failed(addBlockTerminator(indexSwitchOp.getCaseBlock(idx))))
+    }
+    for (unsigned idx = 0, e = indexSwitchOp.getNumCases(); idx < e; ++idx) {
+      if (failed(addBlockTerminator(indexSwitchOp.getCaseBlock(idx)))) {
         return failure();
+      }
+    }
     return success();
   }
 
@@ -1641,21 +1855,25 @@ struct LayoutSolver {
 
   LogicalResult addBranchConstraints(Block *dest, OperandRange operands,
                                      Operation *op) {
-    if (!dest)
+    if (!dest) {
       return success();
+    }
     for (auto [index, operand] : llvm::enumerate(operands)) {
-      if (index >= dest->getNumArguments())
+      if (index >= dest->getNumArguments()) {
         break;
-      if (failed(uniteEquivalentValues(operand, dest->getArgument(index), op)))
+      }
+      if (failed(uniteEquivalentValues(operand, dest->getArgument(index), op))) {
         return failure();
+      }
     }
     return success();
   }
 
   LogicalResult addReturnConstraints(func::ReturnOp returnOp) {
     auto func = returnOp->getParentOfType<func::FuncOp>();
-    if (!func)
+    if (!func) {
       return success();
+    }
 
     auto it = firstReturnOperandsByFunc.find(func);
     if (it == firstReturnOperandsByFunc.end()) {
@@ -1666,11 +1884,13 @@ struct LayoutSolver {
 
     ArrayRef<Value> firstOperands = it->second;
     for (auto [index, operand] : llvm::enumerate(returnOp.getOperands())) {
-      if (index >= firstOperands.size())
+      if (index >= firstOperands.size()) {
         break;
+      }
       if (failed(
-              uniteEquivalentValues(firstOperands[index], operand, returnOp)))
+              uniteEquivalentValues(firstOperands[index], operand, returnOp))) {
         return failure();
+      }
     }
     return success();
   }
@@ -1687,31 +1907,36 @@ struct LayoutSolver {
   }
 
   LogicalResult addCallConstraints(func::CallOp callOp) {
-    if (!hasVMIValueTypes(callOp))
+    if (!hasVMIValueTypes(callOp)) {
       return success();
+    }
 
     auto callee = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
         callOp, callOp.getCalleeAttr());
-    if (!callee || callee.empty())
+    if (!callee || callee.empty()) {
       return callOp.emitError()
              << kVMIDiagLayoutContractPrefix
              << "VMI typed call requires a direct internal callee with a body";
+    }
 
     for (auto [operand, argument] :
          llvm::zip(callOp.getOperands(), callee.getArguments())) {
-      if (failed(uniteEquivalentValues(operand, argument, callOp)))
+      if (failed(uniteEquivalentValues(operand, argument, callOp))) {
         return failure();
+      }
     }
 
     SmallVector<func::ReturnOp> returns;
     callee.walk([&](func::ReturnOp returnOp) { returns.push_back(returnOp); });
     for (func::ReturnOp returnOp : returns) {
       for (auto [index, result] : llvm::enumerate(callOp.getResults())) {
-        if (index >= returnOp.getNumOperands())
+        if (index >= returnOp.getNumOperands()) {
           break;
+        }
         if (failed(uniteEquivalentValues(result, returnOp.getOperand(index),
-                                         callOp)))
+                                         callOp))) {
           return failure();
+        }
       }
     }
     return success();
@@ -1727,15 +1952,17 @@ struct LayoutSolver {
 
   FailureOr<Value> materializeLayoutValue(Value value, Type targetType,
                                           Location loc, OpBuilder &builder) {
-    if (value.getType() == targetType)
+    if (value.getType() == targetType) {
       return value;
+    }
 
     if (auto sourceType = dyn_cast<VMIVRegType>(value.getType())) {
       auto targetVRegType = dyn_cast<VMIVRegType>(targetType);
       if (!targetVRegType ||
           sourceType.getElementCount() != targetVRegType.getElementCount() ||
-          sourceType.getElementType() != targetVRegType.getElementType())
+          sourceType.getElementType() != targetVRegType.getElementType()) {
         return failure();
+      }
       return builder.create<VMIEnsureLayoutOp>(loc, targetVRegType, value)
           .getResult();
     }
@@ -1744,8 +1971,9 @@ struct LayoutSolver {
       auto targetMaskType = dyn_cast<VMIMaskType>(targetType);
       if (!targetMaskType ||
           sourceType.getElementCount() != targetMaskType.getElementCount() ||
-          sourceType.getGranularity() != targetMaskType.getGranularity())
+          sourceType.getGranularity() != targetMaskType.getGranularity()) {
         return failure();
+      }
       return builder
           .create<VMIEnsureMaskLayoutOp>(loc, targetMaskType, value)
           .getResult();
@@ -1758,19 +1986,23 @@ struct LayoutSolver {
     SmallVector<Type> resultTypes;
     bool found = false;
     module.walk([&](func::CallOp call) {
-      if (call.getCallee() != func.getSymName())
+      if (call.getCallee() != func.getSymName()) {
         return;
+      }
       if (!found) {
         resultTypes.assign(call.getResultTypes().begin(),
                            call.getResultTypes().end());
         found = true;
         return;
       }
-      if (resultTypes.size() != call.getNumResults())
+      if (resultTypes.size() != call.getNumResults()) {
         return;
-      for (auto [index, type] : llvm::enumerate(call.getResultTypes()))
-        if (index < resultTypes.size() && resultTypes[index] != type)
+      }
+      for (auto [index, type] : llvm::enumerate(call.getResultTypes())) {
+        if (index < resultTypes.size() && resultTypes[index] != type) {
           resultTypes[index] = {};
+        }
+      }
     });
     return found ? resultTypes : SmallVector<Type>{};
   }
@@ -1781,48 +2013,58 @@ struct LayoutSolver {
     WalkResult callResult = module.walk([&](func::CallOp call) -> WalkResult {
       auto callee = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
           call, call.getCalleeAttr());
-      if (!callee || callee.empty())
+      if (!callee || callee.empty()) {
         return WalkResult::advance();
+      }
 
       rewriter.setInsertionPoint(call);
       for (auto [index, operand] : llvm::enumerate(call.getOperands())) {
-        if (index >= callee.getNumArguments())
+        if (index >= callee.getNumArguments()) {
           break;
+        }
         Type targetType = callee.getArgument(index).getType();
-        if (!isa<VMIVRegType, VMIMaskType>(targetType))
+        if (!isa<VMIVRegType, VMIMaskType>(targetType)) {
           continue;
+        }
         FailureOr<Value> materialized =
             materializeLayoutValue(operand, targetType, call.getLoc(),
                                    rewriter);
-        if (failed(materialized))
+        if (failed(materialized)) {
           return WalkResult::interrupt();
+        }
         call->setOperand(index, *materialized);
       }
       return WalkResult::advance();
     });
-    if (callResult.wasInterrupted())
+    if (callResult.wasInterrupted()) {
       return failure();
+    }
 
     WalkResult returnResult = module.walk([&](func::FuncOp func) -> WalkResult {
       SmallVector<Type> resultTypes = getCallResultTypes(func);
-      if (resultTypes.empty())
+      if (resultTypes.empty()) {
         return WalkResult::advance();
+      }
 
       WalkResult nested = func.walk([&](func::ReturnOp ret) -> WalkResult {
         rewriter.setInsertionPoint(ret);
         for (auto [index, operand] : llvm::enumerate(ret.getOperands())) {
-          if (index >= resultTypes.size())
+          if (index >= resultTypes.size()) {
             break;
-          if (!resultTypes[index])
+          }
+          if (!resultTypes[index]) {
             continue;
+          }
           Type targetType = resultTypes[index];
-          if (!isa<VMIVRegType, VMIMaskType>(targetType))
+          if (!isa<VMIVRegType, VMIMaskType>(targetType)) {
             continue;
+          }
           FailureOr<Value> materialized =
               materializeLayoutValue(operand, targetType, ret.getLoc(),
                                      rewriter);
-          if (failed(materialized))
+          if (failed(materialized)) {
             return WalkResult::interrupt();
+          }
           ret->setOperand(index, *materialized);
         }
         return WalkResult::advance();
@@ -1838,16 +2080,19 @@ struct LayoutSolver {
     for (DataUseRequest request : dataUseRequests) {
       Value value = request.operand->get();
       auto sourceType = dyn_cast<VMIVRegType>(value.getType());
-      if (!sourceType)
+      if (!sourceType) {
         continue;
+      }
       VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
-      if (!sourceLayout)
+      if (!sourceLayout) {
         return request.operand->getOwner()->emitError()
                << kVMIDiagLayoutContractPrefix
                << "data use materialization requires layout-assigned source "
                   "type";
-      if (sourceLayout == request.layout)
+      }
+      if (sourceLayout == request.layout) {
         continue;
+      }
 
       auto resultType =
           VMIVRegType::get(ctx, sourceType.getElementCount(),
@@ -1871,69 +2116,83 @@ struct LayoutSolver {
   LogicalResult requestDataLayoutSeeds(VMILayoutPropagator &propagator,
                                        DataLayoutSeedPhase phase,
                                        bool skipAlreadyRequested) {
-    SmallVector<Value, 16> protectedValues;
+    SmallVector<Value, mlir::pto::kValue16> protectedValues;
     if (skipAlreadyRequested) {
       for (DataLayoutSeed seed : dataLayoutSeeds) {
-        if (seed.phase != phase)
+        if (seed.phase != phase) {
           continue;
+        }
         if (hasRequestedLayout(propagator, seed.value) &&
-            !llvm::is_contained(protectedValues, seed.value))
+            !llvm::is_contained(protectedValues, seed.value)) {
           protectedValues.push_back(seed.value);
+        }
       }
     }
 
     for (DataLayoutSeed seed : dataLayoutSeeds) {
-      if (seed.phase != phase)
+      if (seed.phase != phase) {
         continue;
-      if (llvm::is_contained(protectedValues, seed.value))
+      }
+      if (llvm::is_contained(protectedValues, seed.value)) {
         continue;
-      if (failed(propagator.request(seed.value, seed.layout)))
+      }
+      if (failed(propagator.request(seed.value, seed.layout))) {
         return failure();
+      }
     }
     return success();
   }
 
   LogicalResult requestDataUseSeeds(VMILayoutPropagator &propagator,
                                     DataLayoutSeedPhase phase, bool late) {
-    for (DataUseRequest request : dataUseRequests)
+    for (DataUseRequest request : dataUseRequests) {
       if (request.phase == phase && request.late == late) {
         if (hasLayoutAssignment(propagator, request.operand->get())) {
           VMILayoutAttr assigned =
               propagator.getRequestedOrCurrentLayout(request.operand->get());
-          if (propagator.canUseOperandLayout(*request.operand, assigned))
+          if (propagator.canUseOperandLayout(*request.operand, assigned)) {
             continue;
+          }
         }
-        if (failed(propagator.request(*request.operand, request.layout)))
+        if (failed(propagator.request(*request.operand, request.layout))) {
           return failure();
+        }
       }
+    }
     return success();
   }
 
   LogicalResult requestMaskUseSeeds(VMILayoutPropagator &propagator,
                                     DataLayoutSeedPhase phase) {
-    for (MaskUseRequest request : maskUseRequests)
+    for (MaskUseRequest request : maskUseRequests) {
       if (request.phase == phase) {
         if (hasLayoutAssignment(propagator, request.operand->get())) {
           VMILayoutAttr assigned =
               propagator.getRequestedOrCurrentLayout(request.operand->get());
-          if (propagator.canUseOperandLayout(*request.operand, assigned))
+          if (propagator.canUseOperandLayout(*request.operand, assigned)) {
             continue;
+          }
         }
-        if (failed(propagator.request(*request.operand, request.layout)))
+        if (failed(propagator.request(*request.operand, request.layout))) {
           return failure();
+        }
       }
+    }
     return success();
   }
 
   LogicalResult runSeedPhase(VMILayoutPropagator &propagator,
                              DataLayoutSeedPhase phase) {
     if (failed(requestDataLayoutSeeds(propagator, phase,
-                                      /*skipAlreadyRequested=*/true)))
+                                      /*skipAlreadyRequested=*/true))) {
       return failure();
-    if (failed(requestDataUseSeeds(propagator, phase, /*late=*/false)))
+    }
+    if (failed(requestDataUseSeeds(propagator, phase, /*late=*/false))) {
       return failure();
-    if (failed(requestMaskUseSeeds(propagator, phase)))
+    }
+    if (failed(requestMaskUseSeeds(propagator, phase))) {
       return failure();
+    }
     return propagator.run();
   }
 
@@ -1948,40 +2207,53 @@ struct LayoutSolver {
       propagator.addEquivalentValues(root.value, node.value);
     }
     if (failed(requestDataLayoutSeeds(propagator, DataLayoutSeedPhase::Explicit,
-                                      /*skipAlreadyRequested=*/false)))
+                                      /*skipAlreadyRequested=*/false))) {
       return failure();
+    }
     for (MaskNode &node : maskNodes) {
       MaskNode &root = maskNodes[findMask(maskIds.lookup(node.value))];
       if (root.requestedLayout &&
-          failed(propagator.request(node.value, root.requestedLayout)))
+          failed(propagator.request(node.value, root.requestedLayout))) {
         return failure();
+      }
     }
-    if (failed(propagator.run()))
+    if (failed(propagator.run())) {
       return failure();
+    }
 
     for (int64_t phase = static_cast<int64_t>(DataLayoutSeedPhase::SeedStart);
-         phase < static_cast<int64_t>(DataLayoutSeedPhase::SeedEnd); ++phase)
+         phase < static_cast<int64_t>(DataLayoutSeedPhase::SeedEnd); ++phase) {
       if (failed(runSeedPhase(propagator,
-                              static_cast<DataLayoutSeedPhase>(phase))))
+                              static_cast<DataLayoutSeedPhase>(phase)))) {
         return failure();
+      }
+    }
 
-    for (DataUseRequest request : dataUseRequests)
+    for (DataUseRequest request : dataUseRequests) {
       if (request.late &&
-          failed(propagator.request(*request.operand, request.layout)))
+          failed(propagator.request(*request.operand, request.layout))) {
         return failure();
-    if (failed(propagator.run()))
+      }
+    }
+    if (failed(propagator.run())) {
       return failure();
+    }
 
-    for (DataNode &node : dataNodes)
+    for (DataNode &node : dataNodes) {
       if (!propagator.getRequestedLayout(node.value) &&
-          failed(propagator.request(node.value, getContiguousLayout())))
+          failed(propagator.request(node.value, getContiguousLayout()))) {
         return failure();
-    for (MaskNode &node : maskNodes)
+      }
+    }
+    for (MaskNode &node : maskNodes) {
       if (!propagator.getRequestedLayout(node.value) &&
-          failed(propagator.request(node.value, getContiguousLayout())))
+          failed(propagator.request(node.value, getContiguousLayout()))) {
         return failure();
-    if (failed(propagator.run()))
+      }
+    }
+    if (failed(propagator.run())) {
       return failure();
+    }
 
     IRRewriter rewriter(ctx);
     return propagator.apply(rewriter);
@@ -1989,23 +2261,27 @@ struct LayoutSolver {
 
   void rewriteFunctionType() {
     module.walk([&](func::FuncOp func) {
-      if (func.empty())
+      if (func.empty()) {
         return;
+      }
 
       SmallVector<Type> inputs;
       inputs.reserve(func.getNumArguments());
-      for (BlockArgument arg : func.getArguments())
+      for (BlockArgument arg : func.getArguments()) {
         inputs.push_back(arg.getType());
+      }
 
       SmallVector<Type> results;
       auto it = firstReturnOperandsByFunc.find(func);
       SmallVector<Type> callResultTypes = getCallResultTypes(func);
       if (!callResultTypes.empty()) {
-        for (Type type : callResultTypes)
+        for (Type type : callResultTypes) {
           results.push_back(type);
+        }
       } else if (it != firstReturnOperandsByFunc.end()) {
-        for (Value operand : it->second)
+        for (Value operand : it->second) {
           results.push_back(operand.getType());
+        }
       } else {
         FunctionType functionType = func.getFunctionType();
         for (Type type : functionType.getResults()) {
@@ -2027,14 +2303,18 @@ struct LayoutSolver {
   }
 
   LogicalResult run() {
-    if (failed(collect()))
+    if (failed(collect())) {
       return failure();
-    if (failed(addConstraints()))
+    }
+    if (failed(addConstraints())) {
       return failure();
-    if (failed(applyLayouts()))
+    }
+    if (failed(applyLayouts())) {
       return failure();
-    if (failed(materializeCallBoundaries()))
+    }
+    if (failed(materializeCallBoundaries())) {
       return failure();
+    }
     rewriteFunctionType();
     return validateVMILayoutAssignedIR(module, /*diagOS=*/nullptr,
                                        /*verifyHelperSupport=*/false);
@@ -2057,8 +2337,9 @@ struct VMILayoutAssignmentPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(VMILayoutAssignmentPass)
 
   void runOnOperation() override {
-    if (failed(LayoutSolver(getOperation()).run()))
+    if (failed(LayoutSolver(getOperation()).run())) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/VMILayoutFold.cpp
+++ b/lib/PTO/Transforms/VMILayoutFold.cpp
@@ -12,6 +12,7 @@
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/IR/VMIUtils.h"
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/Passes.h"
 #include "PTO/Transforms/VMILayoutSupport.h"
 
@@ -46,37 +47,44 @@ static bool isUnitContiguousLayout(VMILayoutAttr layout) {
 }
 
 static bool isLoadProducerLayout(VMIVRegType type) {
-  if (!type)
+  if (!type) {
     return false;
-  VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout)
-    return false;
-  if (layout.isContiguous() && layout.getLaneStride() == 1)
-    return true;
-  if (layout.isContiguous() && layout.getLaneStride() == 2) {
-    unsigned elementBits = pto::getPTOStorageElemBitWidth(type.getElementType());
-    return elementBits == 8 || elementBits == 16 || elementBits == 32;
   }
-  if (layout.isContiguous() && layout.getLaneStride() == 4) {
+  VMILayoutAttr layout = type.getLayoutAttr();
+  if (!layout) {
+    return false;
+  }
+  if (layout.isContiguous() && layout.getLaneStride() == 1) {
+    return true;
+  }
+  if (layout.isContiguous() && layout.getLaneStride() == mlir::pto::kValue2) {
     unsigned elementBits = pto::getPTOStorageElemBitWidth(type.getElementType());
-    return elementBits == 8;
+    return elementBits == mlir::pto::kValue8 || elementBits == 16 || elementBits == 32;
+  }
+  if (layout.isContiguous() && layout.getLaneStride() == mlir::pto::kValue4) {
+    unsigned elementBits = pto::getPTOStorageElemBitWidth(type.getElementType());
+    return elementBits == mlir::pto::kValue8;
   }
   if (!layout.isDeinterleaved() || layout.getLaneStride() != 1 ||
-      (layout.getFactor() != 2 && layout.getFactor() != 4))
+      (layout.getFactor() != mlir::pto::kValue2 &&
+       layout.getFactor() != mlir::pto::kValue4)) {
     return false;
+  }
   unsigned elementBits = pto::getPTOStorageElemBitWidth(type.getElementType());
-  return elementBits == 8 || elementBits == 16 || elementBits == 32;
+  return elementBits == mlir::pto::kValue8 || elementBits == 16 || elementBits == 32;
 }
 
 static bool isFoldableLoadEnsure(VMIEnsureLayoutOp ensure) {
   auto load = ensure.getSource().getDefiningOp<VMILoadOp>();
-  if (!load)
+  if (!load) {
     return false;
+  }
 
   auto sourceType = dyn_cast<VMIVRegType>(ensure.getSource().getType());
   auto resultType = dyn_cast<VMIVRegType>(ensure.getResult().getType());
-  if (!hasSameDataShapeAndElementType(sourceType, resultType))
+  if (!hasSameDataShapeAndElementType(sourceType, resultType)) {
     return false;
+  }
 
   return isLoadProducerLayout(resultType);
 }
@@ -84,15 +92,17 @@ static bool isFoldableLoadEnsure(VMIEnsureLayoutOp ensure) {
 static void tryFoldLoadEnsures(
     VMILoadOp load, SmallVectorImpl<VMIEnsureLayoutOp> &maybeDeadEnsures) {
   auto sourceType = dyn_cast<VMIVRegType>(load.getResult().getType());
-  if (!sourceType)
+  if (!sourceType) {
     return;
+  }
 
   VMIVRegType targetType;
   SmallVector<VMIEnsureLayoutOp> ensures;
   for (OpOperand &use : load.getResult().getUses()) {
     auto ensure = dyn_cast<VMIEnsureLayoutOp>(use.getOwner());
-    if (!ensure || use.getOperandNumber() != 0 || !isFoldableLoadEnsure(ensure))
+    if (!ensure || use.getOperandNumber() != 0 || !isFoldableLoadEnsure(ensure)) {
       return;
+    }
 
     auto resultType = cast<VMIVRegType>(ensure.getResult().getType());
     if (!targetType) {
@@ -103,8 +113,9 @@ static void tryFoldLoadEnsures(
     ensures.push_back(ensure);
   }
 
-  if (ensures.empty() || targetType == sourceType)
+  if (ensures.empty() || targetType == sourceType) {
     return;
+  }
 
   load.getResult().setType(targetType);
   for (VMIEnsureLayoutOp ensure : ensures) {
@@ -117,11 +128,13 @@ static void
 tryFoldNestedEnsureLayout(VMIEnsureLayoutOp ensure,
                           SmallVectorImpl<VMIEnsureLayoutOp> &maybeDeadEnsures) {
   auto inner = ensure.getSource().getDefiningOp<VMIEnsureLayoutOp>();
-  if (!inner)
+  if (!inner) {
     return;
+  }
 
-  if (inner.getSource().getType() != ensure.getResult().getType())
+  if (inner.getSource().getType() != ensure.getResult().getType()) {
     return;
+  }
 
   ensure.getResult().replaceAllUsesWith(inner.getSource());
   maybeDeadEnsures.push_back(ensure);
@@ -131,14 +144,16 @@ tryFoldNestedEnsureLayout(VMIEnsureLayoutOp ensure,
 static bool isFoldableStoreEnsure(VMIEnsureLayoutOp ensure) {
   auto sourceType = dyn_cast<VMIVRegType>(ensure.getSource().getType());
   auto resultType = dyn_cast<VMIVRegType>(ensure.getResult().getType());
-  if (!sourceType || !resultType)
+  if (!sourceType || !resultType) {
     return false;
+  }
 
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
   if (!isUnitContiguousLayout(resultLayout) ||
-      isUnitContiguousLayout(sourceLayout))
+      isUnitContiguousLayout(sourceLayout)) {
     return false;
+  }
 
   VMILayoutSupport supports;
   return succeeded(supports.getStoreLayoutFact(sourceType));
@@ -147,8 +162,9 @@ static bool isFoldableStoreEnsure(VMIEnsureLayoutOp ensure) {
 static void tryFoldEnsureLayoutIntoOperand(
     OpOperand &operand, SmallVectorImpl<VMIEnsureLayoutOp> &maybeDeadEnsures) {
   auto ensure = operand.get().getDefiningOp<VMIEnsureLayoutOp>();
-  if (!ensure || !isFoldableStoreEnsure(ensure))
+  if (!ensure || !isFoldableStoreEnsure(ensure)) {
     return;
+  }
 
   operand.set(ensure.getSource());
   maybeDeadEnsures.push_back(ensure);
@@ -159,25 +175,30 @@ static void tryFoldEnsureLayoutIntoMaskedStore(
     SmallVectorImpl<VMIEnsureLayoutOp> &maybeDeadEnsures,
     SmallVectorImpl<VMIEnsureMaskLayoutOp> &maybeDeadMaskEnsures) {
   auto ensure = store.getValue().getDefiningOp<VMIEnsureLayoutOp>();
-  if (!ensure || !isFoldableStoreEnsure(ensure))
+  if (!ensure || !isFoldableStoreEnsure(ensure)) {
     return;
+  }
   auto maskEnsure = store.getMask().getDefiningOp<VMIEnsureMaskLayoutOp>();
-  if (!maskEnsure)
+  if (!maskEnsure) {
     return;
+  }
 
   auto sourceType = dyn_cast<VMIVRegType>(ensure.getSource().getType());
   auto maskSourceType = dyn_cast<VMIMaskType>(maskEnsure.getSource().getType());
   auto maskResultType = dyn_cast<VMIMaskType>(maskEnsure.getResult().getType());
-  if (!sourceType || !maskSourceType || !maskResultType)
+  if (!sourceType || !maskSourceType || !maskResultType) {
     return;
+  }
 
   VMILayoutAttr maskResultLayout = maskResultType.getLayoutAttr();
-  if (!isUnitContiguousLayout(maskResultLayout))
+  if (!isUnitContiguousLayout(maskResultLayout)) {
     return;
+  }
 
   VMILayoutSupport supports;
-  if (failed(supports.getMaskedStoreLayoutFact(sourceType, maskSourceType)))
+  if (failed(supports.getMaskedStoreLayoutFact(sourceType, maskSourceType))) {
     return;
+  }
 
   store.getValueMutable().set(ensure.getSource());
   store.getMaskMutable().set(maskEnsure.getSource());
@@ -203,21 +224,25 @@ struct VMILayoutFoldPass
     });
 
     module.walk([&](Operation *op) {
-      if (auto store = dyn_cast<VMIStoreOp>(op))
+      if (auto store = dyn_cast<VMIStoreOp>(op)) {
         tryFoldEnsureLayoutIntoOperand(store.getValueMutable(),
                                        maybeDeadEnsures);
-      if (auto maskedStore = dyn_cast<VMIMaskedStoreOp>(op))
+      }
+      if (auto maskedStore = dyn_cast<VMIMaskedStoreOp>(op)) {
         tryFoldEnsureLayoutIntoMaskedStore(maskedStore, maybeDeadEnsures,
                                            maybeDeadMaskEnsures);
+      }
     });
 
     for (VMIEnsureMaskLayoutOp ensure : llvm::reverse(maybeDeadMaskEnsures)) {
-      if (ensure->use_empty())
+      if (ensure->use_empty()) {
         ensure.erase();
+      }
     }
     for (VMIEnsureLayoutOp ensure : llvm::reverse(maybeDeadEnsures)) {
-      if (ensure->use_empty())
+      if (ensure->use_empty()) {
         ensure.erase();
+      }
     }
   }
 };

--- a/lib/PTO/Transforms/VMILayoutPropagation.cpp
+++ b/lib/PTO/Transforms/VMILayoutPropagation.cpp
@@ -11,6 +11,7 @@
 
 #include "PTO/Transforms/VMILayoutPropagation.h"
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/VMIUtils.h"
 #include "PTO/Transforms/VMILayoutSupport.h"
 
@@ -26,7 +27,7 @@ struct VMILayoutFact {
 };
 
 struct VMILayoutRelation {
-  SmallVector<VMILayoutFact, 4> facts;
+  SmallVector<VMILayoutFact, mlir::pto::kValue4> facts;
 };
 
 static VMILayoutFact valueFact(Value value, VMILayoutAttr layout) {
@@ -37,30 +38,32 @@ static VMILayoutFact operandFact(OpOperand &operand, VMILayoutAttr layout) {
   return VMILayoutFact{/*value=*/{}, &operand, layout};
 }
 
-static VMILayoutRelation makeRelation(SmallVector<VMILayoutFact, 4> facts) {
+static VMILayoutRelation makeRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4> facts) {
   VMILayoutRelation relation;
   relation.facts = std::move(facts);
   return relation;
 }
 
-static SmallVector<VMILayoutRelation, 4>
-makeSingleRelation(SmallVector<VMILayoutFact, 4> facts) {
-  SmallVector<VMILayoutRelation, 4> relations;
+static SmallVector<VMILayoutRelation, mlir::pto::kValue4>
+makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4> facts) {
+  SmallVector<VMILayoutRelation, mlir::pto::kValue4> relations;
   relations.push_back(makeRelation(std::move(facts)));
   return relations;
 }
 
 static bool hasAmbiguousTransferTargets(ArrayRef<VMILayoutFact> facts) {
   auto sameTarget = [](const VMILayoutFact &lhs, const VMILayoutFact &rhs) {
-    if (lhs.operand || rhs.operand)
+    if (lhs.operand || rhs.operand) {
       return lhs.operand && lhs.operand == rhs.operand;
+    }
     return lhs.value && lhs.value == rhs.value;
   };
 
   for (auto [index, fact] : llvm::enumerate(facts)) {
     for (const VMILayoutFact &other : facts.drop_front(index + 1)) {
-      if (sameTarget(fact, other) && fact.layout != other.layout)
+      if (sameTarget(fact, other) && fact.layout != other.layout) {
         return true;
+      }
     }
   }
   return false;
@@ -69,27 +72,33 @@ static bool hasAmbiguousTransferTargets(ArrayRef<VMILayoutFact> facts) {
 static bool relationContainsOperandLayout(const VMILayoutRelation &relation,
                                           OpOperand &operand,
                                           VMILayoutAttr layout) {
-  for (const VMILayoutFact &fact : relation.facts)
-    if (fact.operand == &operand)
+  for (const VMILayoutFact &fact : relation.facts) {
+    if (fact.operand == &operand) {
       return fact.layout == layout;
+    }
+  }
   return false;
 }
 
 static bool relationContainsValueLayout(const VMILayoutRelation &relation,
                                         Value value, VMILayoutAttr layout) {
-  for (const VMILayoutFact &fact : relation.facts)
-    if (!fact.operand && fact.value == value)
+  for (const VMILayoutFact &fact : relation.facts) {
+    if (!fact.operand && fact.value == value) {
       return fact.layout == layout;
+    }
+  }
   return false;
 }
 
 static Type getValueTypeWithLayout(Value value, VMILayoutAttr layout) {
-  if (auto type = dyn_cast<VMIVRegType>(value.getType()))
+  if (auto type = dyn_cast<VMIVRegType>(value.getType())) {
     return VMIVRegType::get(type.getContext(), type.getElementCount(),
                             type.getElementType(), layout);
-  if (auto type = dyn_cast<VMIMaskType>(value.getType()))
+  }
+  if (auto type = dyn_cast<VMIMaskType>(value.getType())) {
     return VMIMaskType::get(type.getContext(), type.getElementCount(),
                             type.getGranularity(), layout);
+  }
   return {};
 }
 
@@ -97,7 +106,7 @@ class VMILayoutTransfer {
 public:
   virtual ~VMILayoutTransfer() = default;
 
-  virtual FailureOr<SmallVector<VMILayoutRelation, 4>>
+  virtual FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const = 0;
@@ -106,23 +115,28 @@ public:
                           VMILayoutAttr changedLayout,
                           VMILayoutPropagator &propagator,
                           OpOperand *changedOperand) const {
-    FailureOr<SmallVector<VMILayoutRelation, 4>> relations =
+    FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>> relations =
         query(op, changedValue, changedLayout, propagator, changedOperand);
-    if (failed(relations) || relations->empty())
+    if (failed(relations) || relations->empty()) {
       return success();
-    if (relations->size() != 1)
+    }
+    if (relations->size() != 1) {
       return success();
+    }
     const VMILayoutRelation &relation = relations->front();
-    if (hasAmbiguousTransferTargets(relation.facts))
+    if (hasAmbiguousTransferTargets(relation.facts)) {
       return success();
+    }
     for (const VMILayoutFact &fact : relation.facts) {
       if (fact.operand) {
-        if (failed(propagator.request(*fact.operand, fact.layout)))
+        if (failed(propagator.request(*fact.operand, fact.layout))) {
           return failure();
+        }
         continue;
       }
-      if (failed(propagator.request(fact.value, fact.layout)))
+      if (failed(propagator.request(fact.value, fact.layout))) {
         return failure();
+      }
     }
     return success();
   }
@@ -130,28 +144,32 @@ public:
 
 class VMILayoutMaterializationTransfer final {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Value source, VMILayoutAttr sourceLayout,
         VMILayoutAttr resultLayout) const {
-    if (!source || !sourceLayout || !resultLayout)
+    if (!source || !sourceLayout || !resultLayout) {
       return failure();
-    if (sourceLayout == resultLayout)
-      return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+    }
+    if (sourceLayout == resultLayout) {
+      return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
           valueFact(source, sourceLayout)});
+    }
 
     Type sourceAssignedType = getValueTypeWithLayout(source, sourceLayout);
     Type resultAssignedType = getValueTypeWithLayout(source, resultLayout);
-    if (!sourceAssignedType || !resultAssignedType)
+    if (!sourceAssignedType || !resultAssignedType) {
       return failure();
+    }
 
     VMILayoutSupport supports;
     if (auto sourceVRegType = dyn_cast<VMIVRegType>(sourceAssignedType)) {
       auto resultVRegType = dyn_cast<VMIVRegType>(resultAssignedType);
       if (!resultVRegType ||
           failed(supports.getEnsureLayoutFact(sourceVRegType,
-                                              resultVRegType)))
+                                              resultVRegType))) {
         return failure();
-      return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+      }
+      return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
           valueFact(source, sourceLayout)});
     }
 
@@ -159,9 +177,10 @@ public:
       auto resultMaskType = dyn_cast<VMIMaskType>(resultAssignedType);
       if (!resultMaskType ||
           failed(supports.getEnsureMaskLayoutFact(sourceMaskType,
-                                                  resultMaskType)))
+                                                  resultMaskType))) {
         return failure();
-      return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+      }
+      return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
           valueFact(source, sourceLayout)});
     }
     return failure();
@@ -187,62 +206,70 @@ static bool isCastOp(Operation *op) {
 
 class VMISameLayoutTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
-    SmallVector<VMILayoutFact, 4> facts;
-    for (OpOperand &operand : op->getOpOperands())
+    SmallVector<VMILayoutFact, mlir::pto::kValue4> facts;
+    for (OpOperand &operand : op->getOpOperands()) {
       facts.push_back(operandFact(operand, changedLayout));
-    for (Value result : op->getResults())
+    }
+    for (Value result : op->getResults()) {
       facts.push_back(valueFact(result, changedLayout));
+    }
     return makeSingleRelation(std::move(facts));
   }
 };
 
 class VMICastTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
-    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1) {
       return failure();
+    }
 
     auto sourceType = dyn_cast<VMIVRegType>(op->getOperand(0).getType());
     auto resultType = dyn_cast<VMIVRegType>(op->getResult(0).getType());
-    if (!sourceType || !resultType)
+    if (!sourceType || !resultType) {
       return failure();
+    }
 
     VMILayoutSupport supports;
 
     if (changedValue == op->getOperand(0)) {
-      FailureOr<SmallVector<VMICastLayoutFact, 4>> facts =
+      FailureOr<SmallVector<VMICastLayoutFact, mlir::pto::kValue4>> facts =
           supports.getCastLayoutFactsForLayout(
               sourceType, resultType, VMICastLayoutPort::Source,
               changedLayout);
-      if (failed(facts) || facts->empty())
+      if (failed(facts) || facts->empty()) {
         return failure();
-      SmallVector<VMILayoutRelation, 4> relations;
-      for (const VMICastLayoutFact &fact : *facts)
-        relations.push_back(makeRelation(SmallVector<VMILayoutFact, 4>{
+      }
+      SmallVector<VMILayoutRelation, mlir::pto::kValue4> relations;
+      for (const VMICastLayoutFact &fact : *facts) {
+        relations.push_back(makeRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
             operandFact(op->getOpOperand(0), fact.sourceLayout),
             valueFact(op->getResult(0), fact.resultLayout)}));
+      }
       return relations;
     }
 
     if (changedValue == op->getResult(0)) {
-      FailureOr<SmallVector<VMICastLayoutFact, 4>> facts =
+      FailureOr<SmallVector<VMICastLayoutFact, mlir::pto::kValue4>> facts =
           supports.getCastLayoutFactsForLayout(
               sourceType, resultType, VMICastLayoutPort::Result,
               changedLayout);
-      if (failed(facts) || facts->empty())
+      if (failed(facts) || facts->empty()) {
         return failure();
-      SmallVector<VMILayoutRelation, 4> relations;
-      for (const VMICastLayoutFact &fact : *facts)
-        relations.push_back(makeRelation(SmallVector<VMILayoutFact, 4>{
+      }
+      SmallVector<VMILayoutRelation, mlir::pto::kValue4> relations;
+      for (const VMICastLayoutFact &fact : *facts) {
+        relations.push_back(makeRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
             operandFact(op->getOpOperand(0), fact.sourceLayout),
             valueFact(op->getResult(0), fact.resultLayout)}));
+      }
       return relations;
     }
     return failure();
@@ -315,18 +342,20 @@ public:
 
 class VMIBitcastTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto bitcast = dyn_cast<VMIBitcastOp>(op);
-    if (!bitcast)
+    if (!bitcast) {
       return failure();
+    }
 
     auto sourceType = dyn_cast<VMIVRegType>(bitcast.getSource().getType());
     auto resultType = dyn_cast<VMIVRegType>(bitcast.getResult().getType());
-    if (!sourceType || !resultType)
+    if (!sourceType || !resultType) {
       return failure();
+    }
 
     VMICastLayoutPort port;
     if (changedOperand == &bitcast.getSourceMutable() ||
@@ -339,64 +368,72 @@ public:
     }
 
     VMILayoutSupport supports;
-    FailureOr<SmallVector<VMIBitcastLayoutFact, 4>> facts =
+    FailureOr<SmallVector<VMIBitcastLayoutFact, mlir::pto::kValue4>> facts =
         supports.getBitcastLayoutFactsForLayout(sourceType, resultType, port,
                                                 changedLayout);
-    if (failed(facts) || facts->empty())
+    if (failed(facts) || facts->empty()) {
       return failure();
+    }
 
-    SmallVector<VMILayoutRelation, 4> relations;
-    for (const VMIBitcastLayoutFact &fact : *facts)
-      relations.push_back(makeRelation(SmallVector<VMILayoutFact, 4>{
+    SmallVector<VMILayoutRelation, mlir::pto::kValue4> relations;
+    for (const VMIBitcastLayoutFact &fact : *facts) {
+      relations.push_back(makeRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
           operandFact(bitcast.getSourceMutable(), fact.sourceLayout),
           valueFact(bitcast.getResult(), fact.resultLayout)}));
+    }
     return relations;
   }
 };
 
 class VMIMaskGranularityCastTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto ensure = dyn_cast<VMIEnsureMaskGranularityOp>(op);
-    if (!ensure)
+    if (!ensure) {
       return failure();
+    }
 
     auto sourceType = dyn_cast<VMIMaskType>(ensure.getSource().getType());
     auto resultType = dyn_cast<VMIMaskType>(ensure.getResult().getType());
-    if (!sourceType || !resultType)
+    if (!sourceType || !resultType) {
       return failure();
+    }
 
     VMILayoutSupport supports;
     if (changedValue == ensure.getSource()) {
-      FailureOr<SmallVector<VMIMaskGranularityCastLayoutFact, 4>> facts =
+      FailureOr<SmallVector<VMIMaskGranularityCastLayoutFact, mlir::pto::kValue4>> facts =
           supports.getMaskGranularityCastLayoutFactsForLayout(
               sourceType, resultType, VMICastLayoutPort::Source,
               changedLayout);
-      if (failed(facts) || facts->empty())
+      if (failed(facts) || facts->empty()) {
         return failure();
-      SmallVector<VMILayoutRelation, 4> relations;
-      for (const VMIMaskGranularityCastLayoutFact &fact : *facts)
-        relations.push_back(makeRelation(SmallVector<VMILayoutFact, 4>{
+      }
+      SmallVector<VMILayoutRelation, mlir::pto::kValue4> relations;
+      for (const VMIMaskGranularityCastLayoutFact &fact : *facts) {
+        relations.push_back(makeRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
             operandFact(ensure.getSourceMutable(), fact.sourceLayout),
             valueFact(ensure.getResult(), fact.resultLayout)}));
+      }
       return relations;
     }
 
     if (changedValue == ensure.getResult()) {
-      FailureOr<SmallVector<VMIMaskGranularityCastLayoutFact, 4>> facts =
+      FailureOr<SmallVector<VMIMaskGranularityCastLayoutFact, mlir::pto::kValue4>> facts =
           supports.getMaskGranularityCastLayoutFactsForLayout(
               sourceType, resultType, VMICastLayoutPort::Result,
               changedLayout);
-      if (failed(facts) || facts->empty())
+      if (failed(facts) || facts->empty()) {
         return failure();
-      SmallVector<VMILayoutRelation, 4> relations;
-      for (const VMIMaskGranularityCastLayoutFact &fact : *facts)
-        relations.push_back(makeRelation(SmallVector<VMILayoutFact, 4>{
+      }
+      SmallVector<VMILayoutRelation, mlir::pto::kValue4> relations;
+      for (const VMIMaskGranularityCastLayoutFact &fact : *facts) {
+        relations.push_back(makeRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
             operandFact(ensure.getSourceMutable(), fact.sourceLayout),
             valueFact(ensure.getResult(), fact.resultLayout)}));
+      }
       return relations;
     }
     return failure();
@@ -405,63 +442,69 @@ public:
 
 class VMIFreeResultLayoutTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
-    if (isa<OpResult>(changedValue) && changedValue.getDefiningOp() == op)
-      return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+    if (isa<OpResult>(changedValue) && changedValue.getDefiningOp() == op) {
+      return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
           valueFact(changedValue, changedLayout)});
+    }
     return failure();
   }
 };
 
 class VMIContiguousResultLayoutTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     if (!isa<OpResult>(changedValue) || changedValue.getDefiningOp() != op ||
-        !changedLayout.isContiguous())
+        !changedLayout.isContiguous()) {
       return failure();
-    return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+    }
+    return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
         valueFact(changedValue, changedLayout)});
   }
 };
 
 class VMILoadTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto load = dyn_cast<VMILoadOp>(op);
-    if (!load || changedValue != load.getResult())
+    if (!load || changedValue != load.getResult()) {
       return failure();
+    }
     auto resultType = dyn_cast<VMIVRegType>(load.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return failure();
+    }
     auto assignedType = VMIVRegType::get(
         resultType.getContext(), resultType.getElementCount(),
         resultType.getElementType(), changedLayout);
     VMILayoutSupport supports;
-    if (failed(supports.getLoadLayoutFact(assignedType)))
+    if (failed(supports.getLoadLayoutFact(assignedType))) {
       return failure();
-    return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+    }
+    return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
         valueFact(load.getResult(), changedLayout)});
   }
 };
 
 class VMIDeinterleaveLoadTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto load = dyn_cast<VMIDeinterleaveLoadOp>(op);
-    if (!load)
+    if (!load) {
       return failure();
+    }
 
     VMIDeinterleaveLoadLayoutPort port;
     if (changedValue == load.getLow()) {
@@ -473,18 +516,20 @@ public:
     }
 
     auto valueType = dyn_cast<VMIVRegType>(changedValue.getType());
-    if (!valueType)
+    if (!valueType) {
       return failure();
+    }
     VMILayoutSupport supports;
-    FailureOr<SmallVector<VMIDeinterleaveLoadLayoutFact, 4>> facts =
+    FailureOr<SmallVector<VMIDeinterleaveLoadLayoutFact, mlir::pto::kValue4>> facts =
         supports.getDeinterleaveLoadLayoutFactsForLayout(
             valueType, port, changedLayout);
-    if (failed(facts) || facts->empty())
+    if (failed(facts) || facts->empty()) {
       return failure();
+    }
 
-    SmallVector<VMILayoutRelation, 4> relations;
+    SmallVector<VMILayoutRelation, mlir::pto::kValue4> relations;
     for (const VMIDeinterleaveLoadLayoutFact &fact : *facts) {
-      relations.push_back(makeRelation(SmallVector<VMILayoutFact, 4>{
+      relations.push_back(makeRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
           valueFact(load.getLow(), fact.lowLayout),
           valueFact(load.getHigh(), fact.highLayout)}));
     }
@@ -494,59 +539,69 @@ public:
 
 class VMIGroupLoadTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto load = dyn_cast<VMIGroupLoadOp>(op);
-    if (!load || changedValue != load.getResult())
+    if (!load || changedValue != load.getResult()) {
       return failure();
+    }
     auto resultType = dyn_cast<VMIVRegType>(load.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return failure();
+    }
     auto assignedType = VMIVRegType::get(
         resultType.getContext(), resultType.getElementCount(),
         resultType.getElementType(), changedLayout);
     VMILayoutSupport supports;
     if (failed(supports.getGroupLoadLayoutFact(
             assignedType, load.getRowStride(),
-            load.getNumGroupsAttr().getInt())))
+            load.getNumGroupsAttr().getInt()))) {
       return failure();
-    return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+    }
+    return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
         valueFact(load.getResult(), changedLayout)});
   }
 };
 
 class VMIGroupReduceTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
-    if (auto reduce = dyn_cast<VMIGroupReduceAddFOp>(op))
+    if (auto reduce = dyn_cast<VMIGroupReduceAddFOp>(op)) {
       return queryReduce(reduce, changedValue, changedLayout, changedOperand);
-    if (auto reduce = dyn_cast<VMIGroupReduceMaxFOp>(op))
+    }
+    if (auto reduce = dyn_cast<VMIGroupReduceMaxFOp>(op)) {
       return queryReduce(reduce, changedValue, changedLayout, changedOperand);
-    if (auto reduce = dyn_cast<VMIGroupReduceMinFOp>(op))
+    }
+    if (auto reduce = dyn_cast<VMIGroupReduceMinFOp>(op)) {
       return queryReduce(reduce, changedValue, changedLayout, changedOperand);
-    if (auto reduce = dyn_cast<VMIGroupReduceAddIOp>(op))
+    }
+    if (auto reduce = dyn_cast<VMIGroupReduceAddIOp>(op)) {
       return queryReduce(reduce, changedValue, changedLayout, changedOperand);
-    if (auto reduce = dyn_cast<VMIGroupReduceMaxIOp>(op))
+    }
+    if (auto reduce = dyn_cast<VMIGroupReduceMaxIOp>(op)) {
       return queryReduce(reduce, changedValue, changedLayout, changedOperand);
-    if (auto reduce = dyn_cast<VMIGroupReduceMinIOp>(op))
+    }
+    if (auto reduce = dyn_cast<VMIGroupReduceMinIOp>(op)) {
       return queryReduce(reduce, changedValue, changedLayout, changedOperand);
+    }
     return failure();
   }
 
 private:
   template <typename OpTy>
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   queryReduce(OpTy reduce, Value changedValue, VMILayoutAttr changedLayout,
               OpOperand *changedOperand) const {
     auto sourceType = dyn_cast<VMIVRegType>(reduce.getSource().getType());
     auto resultType = dyn_cast<VMIVRegType>(reduce.getResult().getType());
-    if (!sourceType || !resultType)
+    if (!sourceType || !resultType) {
       return failure();
+    }
 
     VMIGroupReduceLayoutPort port;
     if (changedValue == reduce.getSource()) {
@@ -560,15 +615,16 @@ private:
     }
 
     VMILayoutSupport supports;
-    FailureOr<SmallVector<VMIGroupReduceLayoutFact, 4>> facts =
+    FailureOr<SmallVector<VMIGroupReduceLayoutFact, mlir::pto::kValue4>> facts =
         supports.getGroupReduceLayoutFactsForLayout(
             sourceType, reduce.getNumGroupsAttr().getInt(), port,
             changedLayout);
-    if (failed(facts) || facts->empty())
+    if (failed(facts) || facts->empty()) {
       return failure();
-    SmallVector<VMILayoutRelation, 4> relations;
+    }
+    SmallVector<VMILayoutRelation, mlir::pto::kValue4> relations;
     for (const VMIGroupReduceLayoutFact &fact : *facts) {
-      relations.push_back(makeRelation(SmallVector<VMILayoutFact, 4>{
+      relations.push_back(makeRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
           operandFact(reduce.getSourceMutable(), fact.sourceLayout),
           operandFact(reduce.getMaskMutable(), fact.maskLayout),
           valueFact(reduce.getResult(), fact.resultLayout)}));
@@ -579,66 +635,74 @@ private:
 
 class VMIGroupSlotLoadTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto load = dyn_cast<VMIGroupSlotLoadOp>(op);
-    if (!load || changedValue != load.getResult())
+    if (!load || changedValue != load.getResult()) {
       return failure();
+    }
     auto resultType = dyn_cast<VMIVRegType>(load.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return failure();
+    }
     auto assignedType = VMIVRegType::get(
         resultType.getContext(), resultType.getElementCount(),
         resultType.getElementType(), changedLayout);
     VMILayoutSupport supports;
     if (failed(supports.getGroupSlotLoadLayoutFact(
-            assignedType, load.getNumGroupsAttr().getInt())))
+            assignedType, load.getNumGroupsAttr().getInt()))) {
       return failure();
-    return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+    }
+    return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
         valueFact(load.getResult(), changedLayout)});
   }
 };
 
 class VMIGroupBroadcastLoadTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto load = dyn_cast<VMIGroupBroadcastLoadOp>(op);
-    if (!load || changedValue != load.getResult())
+    if (!load || changedValue != load.getResult()) {
       return failure();
+    }
     auto resultType = dyn_cast<VMIVRegType>(load.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return failure();
+    }
     auto assignedType = VMIVRegType::get(
         resultType.getContext(), resultType.getElementCount(),
         resultType.getElementType(), changedLayout);
     VMILayoutSupport supports;
     if (failed(supports.getGroupBroadcastLoadLayoutFact(
             assignedType, load.getSourceGroupStride(),
-            load.getNumGroupsAttr().getInt())))
+            load.getNumGroupsAttr().getInt()))) {
       return failure();
-    return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+    }
+    return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
         valueFact(load.getResult(), changedLayout)});
   }
 };
 
 class VMIGroupBroadcastTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto broadcast = dyn_cast<VMIGroupBroadcastOp>(op);
-    if (!broadcast)
+    if (!broadcast) {
       return failure();
+    }
     auto sourceType = dyn_cast<VMIVRegType>(broadcast.getSource().getType());
     auto resultType = dyn_cast<VMIVRegType>(broadcast.getResult().getType());
-    if (!sourceType || !resultType)
+    if (!sourceType || !resultType) {
       return failure();
+    }
 
     int64_t numGroups = broadcast.getNumGroupsAttr().getInt();
     VMIGroupBroadcastLayoutPort port;
@@ -651,14 +715,15 @@ public:
     }
 
     VMILayoutSupport supports;
-    FailureOr<SmallVector<VMIGroupBroadcastLayoutFact, 4>> facts =
+    FailureOr<SmallVector<VMIGroupBroadcastLayoutFact, mlir::pto::kValue4>> facts =
         supports.getGroupBroadcastLayoutFactsForLayout(
             sourceType, resultType, numGroups, port, changedLayout);
-    if (failed(facts) || facts->empty())
+    if (failed(facts) || facts->empty()) {
       return failure();
-    SmallVector<VMILayoutRelation, 4> relations;
+    }
+    SmallVector<VMILayoutRelation, mlir::pto::kValue4> relations;
     for (const VMIGroupBroadcastLayoutFact &fact : *facts) {
-      relations.push_back(makeRelation(SmallVector<VMILayoutFact, 4>{
+      relations.push_back(makeRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
           operandFact(broadcast.getSourceMutable(), fact.sourceLayout),
           valueFact(broadcast.getResult(), fact.resultLayout)}));
     }
@@ -668,28 +733,31 @@ public:
 
 class VMIInterleaveTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
-    if (auto vintlv = dyn_cast<VMIVintlvOp>(op))
+    if (auto vintlv = dyn_cast<VMIVintlvOp>(op)) {
       return queryInterleave(vintlv, /*vintlv=*/true, changedValue,
                              changedLayout, changedOperand);
-    if (auto vdintlv = dyn_cast<VMIVdintlvOp>(op))
+    }
+    if (auto vdintlv = dyn_cast<VMIVdintlvOp>(op)) {
       return queryInterleave(vdintlv, /*vintlv=*/false, changedValue,
                              changedLayout, changedOperand);
+    }
     return failure();
   }
 
 private:
   template <typename OpTy>
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   queryInterleave(OpTy op, bool vintlv, Value changedValue,
                   VMILayoutAttr changedLayout,
                   OpOperand *changedOperand) const {
     auto lowType = dyn_cast<VMIVRegType>(op.getLow().getType());
-    if (!lowType)
+    if (!lowType) {
       return failure();
+    }
 
     VMIInterleaveLayoutPort port;
     if (changedOperand == &op.getLhsMutable() || changedValue == op.getLhs()) {
@@ -709,17 +777,18 @@ private:
     }
 
     VMILayoutSupport supports;
-    FailureOr<SmallVector<VMIInterleaveLayoutFact, 4>> facts =
+    FailureOr<SmallVector<VMIInterleaveLayoutFact, mlir::pto::kValue4>> facts =
         vintlv ? supports.getVintlvLayoutFactsForLayout(lowType, port,
                                                         changedLayout)
                : supports.getVdintlvLayoutFactsForLayout(lowType, port,
                                                          changedLayout);
-    if (failed(facts) || facts->empty())
+    if (failed(facts) || facts->empty()) {
       return failure();
+    }
 
-    SmallVector<VMILayoutRelation, 4> relations;
+    SmallVector<VMILayoutRelation, mlir::pto::kValue4> relations;
     for (const VMIInterleaveLayoutFact &fact : *facts) {
-      relations.push_back(makeRelation(SmallVector<VMILayoutFact, 4>{
+      relations.push_back(makeRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
           operandFact(op.getLhsMutable(), fact.lhsLayout),
           operandFact(op.getRhsMutable(), fact.rhsLayout),
           operandFact(op.getMaskMutable(), fact.maskLayout),
@@ -732,19 +801,22 @@ private:
 
 class VMIGatherTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto gather = dyn_cast<VMIGatherOp>(op);
-    if (!gather)
+    if (!gather) {
       return failure();
+    }
     if (changedValue != gather.getIndices() && changedValue != gather.getMask() &&
-        changedValue != gather.getPassthru() && changedValue != gather.getResult())
+        changedValue != gather.getPassthru() && changedValue != gather.getResult()) {
       return failure();
-    if (!changedLayout.isContiguous() || changedLayout.getLaneStride() != 1)
+    }
+    if (!changedLayout.isContiguous() || changedLayout.getLaneStride() != 1) {
       return failure();
-    return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+    }
+    return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
         operandFact(gather.getIndicesMutable(), changedLayout),
         operandFact(gather.getMaskMutable(), changedLayout),
         operandFact(gather.getPassthruMutable(), changedLayout),
@@ -754,77 +826,87 @@ public:
 
 class VMIStoreTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto store = dyn_cast<VMIStoreOp>(op);
-    if (!store || changedValue != store.getValue())
+    if (!store || changedValue != store.getValue()) {
       return failure();
+    }
 
     auto valueType = dyn_cast<VMIVRegType>(store.getValue().getType());
-    if (!valueType)
+    if (!valueType) {
       return failure();
+    }
 
     auto assignedValueType =
         VMIVRegType::get(valueType.getContext(), valueType.getElementCount(),
                          valueType.getElementType(), changedLayout);
     VMILayoutSupport supports;
     VMILayoutAttr useLayout = changedLayout;
-    if (failed(supports.getStoreLayoutFact(assignedValueType)))
+    if (failed(supports.getStoreLayoutFact(assignedValueType))) {
       useLayout = VMILayoutAttr::getContiguous(valueType.getContext());
+    }
 
-    return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+    return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
         operandFact(store.getValueMutable(), useLayout)});
   }
 };
 
 class VMIGroupStoreTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto store = dyn_cast<VMIGroupStoreOp>(op);
-    if (!store || changedValue != store.getValue())
+    if (!store || changedValue != store.getValue()) {
       return failure();
+    }
 
     auto valueType = dyn_cast<VMIVRegType>(store.getValue().getType());
-    if (!valueType)
+    if (!valueType) {
       return failure();
+    }
 
     VMILayoutSupport supports;
-    FailureOr<SmallVector<VMIGroupStoreLayoutFact, 4>> facts =
+    FailureOr<SmallVector<VMIGroupStoreLayoutFact, mlir::pto::kValue4>> facts =
         supports.getGroupStoreLayoutFactsForLayout(store, valueType,
                                                    changedLayout);
-    if (failed(facts) || facts->empty())
+    if (failed(facts) || facts->empty()) {
       return failure();
-    SmallVector<VMILayoutRelation, 4> relations;
-    for (const VMIGroupStoreLayoutFact &fact : *facts)
-      relations.push_back(makeRelation(SmallVector<VMILayoutFact, 4>{
+    }
+    SmallVector<VMILayoutRelation, mlir::pto::kValue4> relations;
+    for (const VMIGroupStoreLayoutFact &fact : *facts) {
+      relations.push_back(makeRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
           operandFact(store.getValueMutable(), fact.valueLayout)}));
+    }
     return relations;
   }
 };
 
 class VMIMaskedLoadTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto load = dyn_cast<VMIMaskedLoadOp>(op);
-    if (!load)
+    if (!load) {
       return failure();
+    }
     if (changedValue != load.getResult() && changedValue != load.getMask() &&
-        changedValue != load.getPassthru())
+        changedValue != load.getPassthru()) {
       return failure();
+    }
 
     auto resultType = dyn_cast<VMIVRegType>(load.getResult().getType());
     auto maskType = dyn_cast<VMIMaskType>(load.getMask().getType());
     auto passthruType = dyn_cast<VMIVRegType>(load.getPassthru().getType());
-    if (!resultType || !maskType || !passthruType)
+    if (!resultType || !maskType || !passthruType) {
       return failure();
+    }
 
     auto assignedResultType =
         VMIVRegType::get(resultType.getContext(), resultType.getElementCount(),
@@ -837,10 +919,11 @@ public:
         passthruType.getElementType(), changedLayout);
     VMILayoutSupport supports;
     if (failed(supports.getMaskedLoadLayoutFact(
-            assignedResultType, assignedMaskType, assignedPassthruType)))
+            assignedResultType, assignedMaskType, assignedPassthruType))) {
       return failure();
+    }
 
-    return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+    return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
         valueFact(load.getResult(), changedLayout),
         operandFact(load.getMaskMutable(), changedLayout),
         operandFact(load.getPassthruMutable(), changedLayout)});
@@ -849,20 +932,23 @@ public:
 
 class VMIMaskedStoreTransfer final : public VMILayoutTransfer {
 public:
-  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>>
   query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
         const VMILayoutPropagator &propagator,
         OpOperand *changedOperand) const override {
     auto store = dyn_cast<VMIMaskedStoreOp>(op);
-    if (!store)
+    if (!store) {
       return failure();
-    if (changedValue != store.getValue() && changedValue != store.getMask())
+    }
+    if (changedValue != store.getValue() && changedValue != store.getMask()) {
       return failure();
+    }
 
     auto valueType = dyn_cast<VMIVRegType>(store.getValue().getType());
     auto maskType = dyn_cast<VMIMaskType>(store.getMask().getType());
-    if (!valueType || !maskType)
+    if (!valueType || !maskType) {
       return failure();
+    }
 
     VMILayoutSupport supports;
     VMILayoutAttr useLayout = changedLayout;
@@ -873,10 +959,11 @@ public:
         VMIMaskType::get(maskType.getContext(), maskType.getElementCount(),
                          maskType.getGranularity(), useLayout);
     if (failed(supports.getMaskedStoreLayoutFact(assignedValueType,
-                                                 assignedMaskType)))
+                                                 assignedMaskType))) {
       useLayout = VMILayoutAttr::getContiguous(valueType.getContext());
+    }
 
-    return makeSingleRelation(SmallVector<VMILayoutFact, 4>{
+    return makeSingleRelation(SmallVector<VMILayoutFact, mlir::pto::kValue4>{
         operandFact(store.getValueMutable(), useLayout),
         operandFact(store.getMaskMutable(), useLayout)});
   }
@@ -905,32 +992,44 @@ const VMILayoutTransfer *getTransfer(Operation *op) {
   static VMIMaskedStoreTransfer maskedStoreTransfer;
 
   if (isa<VMIConstantOp, VMIBroadcastOp, VMIIotaOp, VMICreateMaskOp,
-          VMICreateGroupMaskOp, VMIConstantMaskOp>(op))
+          VMICreateGroupMaskOp, VMIConstantMaskOp>(op)) {
     return &freeResultLayoutTransfer;
-  if (isa<VMIGroupIotaOp>(op))
+  }
+  if (isa<VMIGroupIotaOp>(op)) {
     return &contiguousResultLayoutTransfer;
-  if (isa<VMILoadOp>(op))
+  }
+  if (isa<VMILoadOp>(op)) {
     return &loadTransfer;
-  if (isa<VMIDeinterleaveLoadOp>(op))
+  }
+  if (isa<VMIDeinterleaveLoadOp>(op)) {
     return &deinterleaveLoadTransfer;
-  if (isa<VMIGroupLoadOp>(op))
+  }
+  if (isa<VMIGroupLoadOp>(op)) {
     return &groupLoadTransfer;
+  }
   if (isa<VMIGroupReduceAddFOp, VMIGroupReduceMaxFOp,
           VMIGroupReduceMinFOp, VMIGroupReduceAddIOp,
-          VMIGroupReduceMaxIOp, VMIGroupReduceMinIOp>(op))
+          VMIGroupReduceMaxIOp, VMIGroupReduceMinIOp>(op)) {
     return &groupReduceTransfer;
-  if (isa<VMIGroupSlotLoadOp>(op))
+  }
+  if (isa<VMIGroupSlotLoadOp>(op)) {
     return &groupSlotLoadTransfer;
-  if (isa<VMIGroupBroadcastLoadOp>(op))
+  }
+  if (isa<VMIGroupBroadcastLoadOp>(op)) {
     return &groupBroadcastLoadTransfer;
-  if (isa<VMIGroupBroadcastOp>(op))
+  }
+  if (isa<VMIGroupBroadcastOp>(op)) {
     return &groupBroadcastTransfer;
-  if (isa<VMIVintlvOp, VMIVdintlvOp>(op))
+  }
+  if (isa<VMIVintlvOp, VMIVdintlvOp>(op)) {
     return &interleaveTransfer;
-  if (isa<VMIGatherOp>(op))
+  }
+  if (isa<VMIGatherOp>(op)) {
     return &gatherTransfer;
-  if (isa<VMIBitcastOp>(op))
+  }
+  if (isa<VMIBitcastOp>(op)) {
     return &bitcastTransfer;
+  }
   if (isa<VMIVexpdifOp>(op)) {
     return &vexpdifTransfer;
   }
@@ -943,33 +1042,43 @@ const VMILayoutTransfer *getTransfer(Operation *op) {
       auto dstElem = dstType.getElementType();
       unsigned srcBits = 0;
       unsigned dstBits = 0;
-      if (auto ft = dyn_cast<FloatType>(srcElem))
+      if (auto ft = dyn_cast<FloatType>(srcElem)) {
         srcBits = ft.getWidth();
-      else if (auto it = dyn_cast<IntegerType>(srcElem))
+      } else if (auto it = dyn_cast<IntegerType>(srcElem)) {
         srcBits = it.getWidth();
-      if (auto ft = dyn_cast<FloatType>(dstElem))
+      }
+      if (auto ft = dyn_cast<FloatType>(dstElem)) {
         dstBits = ft.getWidth();
-      else if (auto it = dyn_cast<IntegerType>(dstElem))
+      } else if (auto it = dyn_cast<IntegerType>(dstElem)) {
         dstBits = it.getWidth();
-      if (srcBits > 0 && srcBits == dstBits)
+      }
+      if (srcBits > 0 && srcBits == dstBits) {
         return &sameLayoutTransfer;
+      }
     }
     return &castTransfer;
   }
-  if (isSameLayoutOp(op))
+  if (isSameLayoutOp(op)) {
     return &sameLayoutTransfer;
-  if (isa<VMIEnsureMaskGranularityOp>(op))
+  }
+  if (isa<VMIEnsureMaskGranularityOp>(op)) {
     return &maskGranularityCastTransfer;
-  if (isCastOp(op))
+  }
+  if (isCastOp(op)) {
     return &castTransfer;
-  if (isa<VMIStoreOp>(op))
+  }
+  if (isa<VMIStoreOp>(op)) {
     return &storeTransfer;
-  if (isa<VMIGroupStoreOp>(op))
+  }
+  if (isa<VMIGroupStoreOp>(op)) {
     return &groupStoreTransfer;
-  if (isa<VMIMaskedLoadOp>(op))
+  }
+  if (isa<VMIMaskedLoadOp>(op)) {
     return &maskedLoadTransfer;
-  if (isa<VMIMaskedStoreOp>(op))
+  }
+  if (isa<VMIMaskedStoreOp>(op)) {
     return &maskedStoreTransfer;
+  }
   return nullptr;
 }
 
@@ -983,97 +1092,118 @@ bool VMILayoutPropagator::isLayoutValue(Value value) const {
 }
 
 VMILayoutAttr VMILayoutPropagator::getCurrentLayout(Value value) const {
-  if (auto type = dyn_cast<VMIVRegType>(value.getType()))
+  if (auto type = dyn_cast<VMIVRegType>(value.getType())) {
     return type.getLayoutAttr();
-  if (auto type = dyn_cast<VMIMaskType>(value.getType()))
+  }
+  if (auto type = dyn_cast<VMIMaskType>(value.getType())) {
     return type.getLayoutAttr();
+  }
   return {};
 }
 
 Type VMILayoutPropagator::getTypeWithLayout(Value value,
                                             VMILayoutAttr layout) const {
-  if (auto type = dyn_cast<VMIVRegType>(value.getType()))
+  if (auto type = dyn_cast<VMIVRegType>(value.getType())) {
     return VMIVRegType::get(ctx, type.getElementCount(),
                             type.getElementType(), layout);
-  if (auto type = dyn_cast<VMIMaskType>(value.getType()))
+  }
+  if (auto type = dyn_cast<VMIMaskType>(value.getType())) {
     return VMIMaskType::get(ctx, type.getElementCount(), type.getGranularity(),
                             layout);
+  }
   return {};
 }
 
 bool VMILayoutPropagator::canUseOperandLayout(OpOperand &operand,
                                               VMILayoutAttr layout) const {
-  if (!layout)
+  if (!layout) {
     return false;
-  if (!isLayoutValue(operand.get()))
+  }
+  if (!isLayoutValue(operand.get())) {
     return true;
+  }
   const VMILayoutTransfer *transfer = getTransfer(operand.getOwner());
-  if (!transfer)
+  if (!transfer) {
     return false;
-  FailureOr<SmallVector<VMILayoutRelation, 4>> relations = transfer->query(
+  }
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>> relations = transfer->query(
       operand.getOwner(), operand.get(), layout, *this, &operand);
-  if (failed(relations))
+  if (failed(relations)) {
     return false;
-  for (const VMILayoutRelation &relation : *relations)
-    if (relationContainsOperandLayout(relation, operand, layout))
+  }
+  for (const VMILayoutRelation &relation : *relations) {
+    if (relationContainsOperandLayout(relation, operand, layout)) {
       return true;
+    }
+  }
   return false;
 }
 
 VMILayoutAttr VMILayoutPropagator::getRequestedLayout(Value value) const {
   auto it = assignments.find(value);
-  if (it == assignments.end())
+  if (it == assignments.end()) {
     return {};
+  }
   return it->second.layout;
 }
 
 VMILayoutAttr
 VMILayoutPropagator::getRequestedOrCurrentLayout(Value value) const {
-  if (VMILayoutAttr layout = getRequestedLayout(value))
+  if (VMILayoutAttr layout = getRequestedLayout(value)) {
     return layout;
+  }
   return getCurrentLayout(value);
 }
 
 VMILayoutAttr VMILayoutPropagator::getOperandLayout(OpOperand &operand) const {
   const VMIValueLayoutAssignment *assignment = lookup(operand.get());
-  if (!assignment)
+  if (!assignment) {
     return getCurrentLayout(operand.get());
+  }
 
-  for (const VMILayoutConflict &conflict : assignment->conflicts)
-    if (conflict.operand == &operand)
+  for (const VMILayoutConflict &conflict : assignment->conflicts) {
+    if (conflict.operand == &operand) {
       return conflict.layout;
+    }
+  }
   return assignment->layout;
 }
 
 const VMIValueLayoutAssignment *
 VMILayoutPropagator::lookup(Value value) const {
   auto it = assignments.find(value);
-  if (it == assignments.end())
+  if (it == assignments.end()) {
     return nullptr;
+  }
   return &it->second;
 }
 
 void VMILayoutPropagator::addEquivalentValues(Value lhs, Value rhs) {
-  if (!isLayoutValue(lhs) || !isLayoutValue(rhs) || lhs == rhs)
+  if (!isLayoutValue(lhs) || !isLayoutValue(rhs) || lhs == rhs) {
     return;
-  if (isa<VMIVRegType>(lhs.getType()) != isa<VMIVRegType>(rhs.getType()))
+  }
+  if (isa<VMIVRegType>(lhs.getType()) != isa<VMIVRegType>(rhs.getType())) {
     return;
+  }
 
   auto addEdge = [&](Value from, Value to) {
     SmallVector<Value, 2> &values = equivalentValues[from];
-    if (!llvm::is_contained(values, to))
+    if (!llvm::is_contained(values, to)) {
       values.push_back(to);
+    }
   };
   addEdge(lhs, rhs);
   addEdge(rhs, lhs);
 }
 
 void VMILayoutPropagator::enqueue(Value value, VMILayoutAttr layout) {
-  if (!value || !layout)
+  if (!value || !layout) {
     return;
+  }
   LayoutFact fact(value, layout);
-  if (llvm::is_contained(seenFacts, fact))
+  if (llvm::is_contained(seenFacts, fact)) {
     return;
+  }
   seenFacts.push_back(fact);
   worklist.push_back(fact);
 }
@@ -1083,10 +1213,12 @@ VMILayoutPropagator::addUseConflict(OpOperand &operand,
                                     VMIValueLayoutAssignment &assignment,
                                     VMILayoutAttr layout) {
   for (VMILayoutConflict &conflict : assignment.conflicts) {
-    if (conflict.operand != &operand)
+    if (conflict.operand != &operand) {
       continue;
-    if (conflict.layout == layout)
+    }
+    if (conflict.layout == layout) {
       return success();
+    }
     return success();
   }
   assignment.conflicts.push_back(VMILayoutConflict{&operand, layout});
@@ -1095,24 +1227,31 @@ VMILayoutPropagator::addUseConflict(OpOperand &operand,
 
 bool VMILayoutPropagator::canProduceValueLayout(Value value,
                                                 VMILayoutAttr layout) const {
-  if (!layout || !isLayoutValue(value))
+  if (!layout || !isLayoutValue(value)) {
     return false;
-  if (getCurrentLayout(value) == layout)
+  }
+  if (getCurrentLayout(value) == layout) {
     return true;
-  if (isa<BlockArgument>(value))
+  }
+  if (isa<BlockArgument>(value)) {
     return isTypeRewriteable(value);
+  }
   if (auto result = dyn_cast<OpResult>(value)) {
     Operation *definingOp = result.getDefiningOp();
     const VMILayoutTransfer *transfer = getTransfer(definingOp);
-    if (!transfer)
+    if (!transfer) {
       return isTypeRewriteable(value);
-    FailureOr<SmallVector<VMILayoutRelation, 4>> relations = transfer->query(
+    }
+    FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>> relations = transfer->query(
         definingOp, value, layout, *this, /*changedOperand=*/nullptr);
-    if (failed(relations))
+    if (failed(relations)) {
       return false;
-    for (const VMILayoutRelation &relation : *relations)
-      if (relationContainsValueLayout(relation, value, layout))
+    }
+    for (const VMILayoutRelation &relation : *relations) {
+      if (relationContainsValueLayout(relation, value, layout)) {
         return true;
+      }
+    }
     return false;
   }
   return false;
@@ -1121,16 +1260,18 @@ bool VMILayoutPropagator::canProduceValueLayout(Value value,
 bool VMILayoutPropagator::canMaterializeLayout(
     Value value, VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout) const {
   static VMILayoutMaterializationTransfer materializationTransfer;
-  FailureOr<SmallVector<VMILayoutRelation, 4>> relations =
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>> relations =
       materializationTransfer.query(value, sourceLayout, resultLayout);
   return succeeded(relations) && !relations->empty();
 }
 
 LogicalResult VMILayoutPropagator::request(Value value, VMILayoutAttr layout) {
-  if (!layout)
+  if (!layout) {
     return failure();
-  if (!isLayoutValue(value))
+  }
+  if (!isLayoutValue(value)) {
     return success();
+  }
 
   auto it = assignments.find(value);
   if (it == assignments.end()) {
@@ -1140,24 +1281,28 @@ LogicalResult VMILayoutPropagator::request(Value value, VMILayoutAttr layout) {
   }
   VMIValueLayoutAssignment &assignment = it->second;
   if (!assignment.layout) {
-    if (!canProduceValueLayout(value, layout))
+    if (!canProduceValueLayout(value, layout)) {
       return success();
+    }
     assignment.layout = layout;
     enqueue(value, layout);
     return success();
   }
-  if (assignment.layout == layout)
+  if (assignment.layout == layout) {
     return success();
+  }
   return success();
 }
 
 LogicalResult VMILayoutPropagator::request(OpOperand &operand,
                                            VMILayoutAttr layout) {
-  if (!layout)
+  if (!layout) {
     return failure();
+  }
   Value value = operand.get();
-  if (!isLayoutValue(value))
+  if (!isLayoutValue(value)) {
     return success();
+  }
 
   auto it = assignments.find(value);
   if (it == assignments.end()) {
@@ -1167,44 +1312,57 @@ LogicalResult VMILayoutPropagator::request(OpOperand &operand,
   }
 
   VMIValueLayoutAssignment &assignment = it->second;
-  if (assignment.layout == layout)
+  if (assignment.layout == layout) {
     return propagateOperandFact(operand, layout);
-  if (!assignment.layout && isa<OpResult>(value)) {
-    if (failed(request(value, layout)))
-      return failure();
-    if (assignment.layout == layout)
-      return propagateOperandFact(operand, layout);
   }
-  if (failed(addUseConflict(operand, assignment, layout)))
+  if (!assignment.layout && isa<OpResult>(value)) {
+    if (failed(request(value, layout))) {
+      return failure();
+    }
+    if (assignment.layout == layout) {
+      return propagateOperandFact(operand, layout);
+    }
+  }
+  if (failed(addUseConflict(operand, assignment, layout))) {
     return failure();
-  if (getOperandLayout(operand) != layout)
+  }
+  if (getOperandLayout(operand) != layout) {
     return success();
+  }
   return propagateOperandFact(operand, layout);
 }
 
 LogicalResult VMILayoutPropagator::propagateFact(Value value,
                                                  VMILayoutAttr layout) {
-  if (!isLayoutValue(value))
+  if (!isLayoutValue(value)) {
     return success();
-
-  auto equivalentIt = equivalentValues.find(value);
-  if (equivalentIt != equivalentValues.end())
-    for (Value equivalent : equivalentIt->second)
-      if (failed(request(equivalent, layout)))
-        return failure();
-
-  if (auto result = dyn_cast<OpResult>(value)) {
-    if (failed(propagateThrough(result.getDefiningOp(), value, layout)))
-      return failure();
   }
 
-  SmallVector<OpOperand *, 8> uses;
-  for (OpOperand &use : value.getUses())
-    uses.push_back(&use);
-  for (OpOperand *use : uses)
-    if (getOperandLayout(*use) == layout &&
-        failed(propagateThrough(use->getOwner(), value, layout)))
+  auto equivalentIt = equivalentValues.find(value);
+  if (equivalentIt != equivalentValues.end()) {
+    for (Value equivalent : equivalentIt->second) {
+      if (failed(request(equivalent, layout))) {
+        return failure();
+      }
+    }
+  }
+
+  if (auto result = dyn_cast<OpResult>(value)) {
+    if (failed(propagateThrough(result.getDefiningOp(), value, layout))) {
       return failure();
+    }
+  }
+
+  SmallVector<OpOperand *, mlir::pto::kValue8> uses;
+  for (OpOperand &use : value.getUses()) {
+    uses.push_back(&use);
+  }
+  for (OpOperand *use : uses) {
+    if (getOperandLayout(*use) == layout &&
+        failed(propagateThrough(use->getOwner(), value, layout))) {
+      return failure();
+    }
+  }
 
   return success();
 }
@@ -1212,8 +1370,9 @@ LogicalResult VMILayoutPropagator::propagateFact(Value value,
 LogicalResult VMILayoutPropagator::propagateOperandFact(OpOperand &operand,
                                                         VMILayoutAttr layout) {
   OperandLayoutFact fact(&operand, layout);
-  if (llvm::is_contained(seenOperandFacts, fact))
+  if (llvm::is_contained(seenOperandFacts, fact)) {
     return success();
+  }
   seenOperandFacts.push_back(fact);
   return propagateThrough(operand.getOwner(), operand.get(), layout, &operand);
 }
@@ -1222,8 +1381,9 @@ LogicalResult VMILayoutPropagator::propagateThrough(
     Operation *op, Value changedValue, VMILayoutAttr changedLayout,
     OpOperand *changedOperand) {
   const VMILayoutTransfer *transfer = op ? getTransfer(op) : nullptr;
-  if (!transfer)
+  if (!transfer) {
     return success();
+  }
   return transfer->propagate(op, changedValue, changedLayout, *this,
                              changedOperand);
 }
@@ -1231,8 +1391,9 @@ LogicalResult VMILayoutPropagator::propagateThrough(
 LogicalResult VMILayoutPropagator::run() {
   while (!worklist.empty()) {
     LayoutFact fact = worklist.pop_back_val();
-    if (failed(propagateFact(fact.first, fact.second)))
+    if (failed(propagateFact(fact.first, fact.second))) {
       return failure();
+    }
   }
   return success();
 }
@@ -1240,37 +1401,42 @@ LogicalResult VMILayoutPropagator::run() {
 LogicalResult VMILayoutPropagator::verifyMaterializationPlan() const {
   for (Value value : orderedValues) {
     auto it = assignments.find(value);
-    if (it == assignments.end())
+    if (it == assignments.end()) {
       continue;
+    }
 
     const VMIValueLayoutAssignment &assignment = it->second;
-    if (!assignment.layout)
+    if (!assignment.layout) {
       return emitError(value.getLoc())
              << kVMIDiagLayoutContractPrefix
              << "layout assignment has conflicts but no primary layout";
+    }
 
     VMILayoutAttr currentLayout = getCurrentLayout(value);
     if (currentLayout != assignment.layout && !isTypeRewriteable(value)) {
-      if (!currentLayout)
+      if (!currentLayout) {
         return emitError(value.getLoc())
                << kVMIDiagLayoutContractPrefix
                << "cannot materialize primary VMI layout from an unassigned "
                   "boundary value";
-      if (!canMaterializeLayout(value, currentLayout, assignment.layout))
+      }
+      if (!canMaterializeLayout(value, currentLayout, assignment.layout)) {
         return emitError(value.getLoc())
                << kVMIDiagLayoutContractPrefix
                << "cannot materialize primary VMI layout "
                << assignment.layout << " from " << currentLayout;
+      }
     }
 
     for (const VMILayoutConflict &conflict : assignment.conflicts) {
-      if (!canMaterializeLayout(value, assignment.layout, conflict.layout))
+      if (!canMaterializeLayout(value, assignment.layout, conflict.layout)) {
         return emitError(conflict.operand ? conflict.operand->getOwner()->getLoc()
                                           : value.getLoc())
                << kVMIDiagLayoutContractPrefix
                << "cannot materialize requested VMI layout "
                << conflict.layout << " from assigned layout "
                << assignment.layout;
+      }
     }
   }
   return success();
@@ -1280,14 +1446,16 @@ bool VMILayoutPropagator::isTypeRewriteable(Value value) const {
   auto result = dyn_cast<OpResult>(value);
   if (result) {
     Operation *definingOp = result.getDefiningOp();
-    if (!definingOp || !scope)
+    if (!definingOp || !scope) {
       return false;
+    }
     return definingOp == scope || scope->isAncestor(definingOp);
   }
 
   auto arg = dyn_cast<BlockArgument>(value);
-  if (!arg || !scope)
+  if (!arg || !scope) {
     return false;
+  }
   Operation *parentOp = arg.getOwner()->getParentOp();
   return parentOp && (parentOp == scope || scope->isAncestor(parentOp));
 }
@@ -1297,20 +1465,25 @@ FailureOr<Value> VMILayoutPropagator::materializeAt(Value source,
                                                     RewriterBase &rewriter,
                                                     Location loc) {
   VMILayoutAttr sourceLayout = getCurrentLayout(source);
-  if (!sourceLayout)
+  if (!sourceLayout) {
     return failure();
-  if (sourceLayout == layout)
+  }
+  if (sourceLayout == layout) {
     return source;
+  }
 
   Type resultType = getTypeWithLayout(source, layout);
-  if (!resultType)
+  if (!resultType) {
     return failure();
-  if (isa<VMIVRegType>(source.getType()))
+  }
+  if (isa<VMIVRegType>(source.getType())) {
     return rewriter.create<VMIEnsureLayoutOp>(loc, resultType, source)
         .getResult();
-  if (isa<VMIMaskType>(source.getType()))
+  }
+  if (isa<VMIMaskType>(source.getType())) {
     return rewriter.create<VMIEnsureMaskLayoutOp>(loc, resultType, source)
         .getResult();
+  }
   return failure();
 }
 
@@ -1319,12 +1492,14 @@ LogicalResult VMILayoutPropagator::materializePrimary(
     RewriterBase &rewriter, DenseMap<Value, Value> &assignedValues) {
   auto sourceType = dyn_cast<VMIVRegType>(value.getType());
   auto sourceMaskType = dyn_cast<VMIMaskType>(value.getType());
-  if (!sourceType && !sourceMaskType)
+  if (!sourceType && !sourceMaskType) {
     return success();
+  }
 
   Type assignedType = getTypeWithLayout(value, assignment.layout);
-  if (!assignedType)
+  if (!assignedType) {
     return failure();
+  }
   if (getCurrentLayout(value) == assignment.layout) {
     assignedValues[value] = value;
     return success();
@@ -1338,12 +1513,14 @@ LogicalResult VMILayoutPropagator::materializePrimary(
 
   if (!getCurrentLayout(value)) {
     Operation *owner = scope;
-    if (auto result = dyn_cast<OpResult>(value))
+    if (auto result = dyn_cast<OpResult>(value)) {
       owner = result.getDefiningOp();
-    else if (auto arg = dyn_cast<BlockArgument>(value))
+    } else if (auto arg = dyn_cast<BlockArgument>(value)) {
       owner = arg.getOwner()->getParentOp();
-    if (!owner)
+    }
+    if (!owner) {
       return failure();
+    }
     return owner->emitError()
            << kVMIDiagLayoutContractPrefix
            << "cannot materialize a primary VMI layout from an unassigned "
@@ -1361,20 +1538,23 @@ LogicalResult VMILayoutPropagator::materializePrimary(
 
   FailureOr<Value> materialized =
       materializeAt(value, assignment.layout, rewriter, value.getLoc());
-  if (failed(materialized))
+  if (failed(materialized)) {
     return failure();
+  }
 
-  if (*materialized != value)
+  if (*materialized != value) {
     value.replaceAllUsesExcept(*materialized,
                                (*materialized).getDefiningOp());
+  }
   assignedValues[value] = *materialized;
   return success();
 }
 
 LogicalResult VMILayoutPropagator::materializeUseConflict(
     Value assignedValue, VMILayoutConflict conflict, RewriterBase &rewriter) {
-  if (!conflict.operand)
+  if (!conflict.operand) {
     return success();
+  }
   if (getCurrentLayout(assignedValue) == conflict.layout) {
     conflict.operand->set(assignedValue);
     return success();
@@ -1385,11 +1565,12 @@ LogicalResult VMILayoutPropagator::materializeUseConflict(
   rewriter.setInsertionPoint(owner);
   FailureOr<Value> materialized =
       materializeAt(assignedValue, conflict.layout, rewriter, owner->getLoc());
-  if (failed(materialized))
+  if (failed(materialized)) {
     return owner->emitError()
            << kVMIDiagLayoutContractPrefix
            << "cannot materialize requested VMI operand layout "
            << conflict.layout;
+  }
   conflict.operand->set(*materialized);
   return success();
 }
@@ -1398,23 +1579,28 @@ LogicalResult VMILayoutPropagator::apply(RewriterBase &rewriter) {
   DenseMap<Value, Value> assignedValues;
   for (Value value : orderedValues) {
     auto it = assignments.find(value);
-    if (it == assignments.end())
+    if (it == assignments.end()) {
       continue;
+    }
     if (failed(materializePrimary(value, it->second, rewriter,
-                                  assignedValues)))
+                                  assignedValues))) {
       return failure();
+    }
   }
 
   for (Value value : orderedValues) {
     auto it = assignments.find(value);
-    if (it == assignments.end())
+    if (it == assignments.end()) {
       continue;
+    }
     Value assignedValue = assignedValues.lookup(value);
-    if (!assignedValue)
+    if (!assignedValue) {
       assignedValue = value;
+    }
     for (VMILayoutConflict conflict : it->second.conflicts) {
-      if (failed(materializeUseConflict(assignedValue, conflict, rewriter)))
+      if (failed(materializeUseConflict(assignedValue, conflict, rewriter))) {
         return failure();
+      }
     }
   }
   return success();

--- a/lib/PTO/Transforms/VMILayoutRematerialize.cpp
+++ b/lib/PTO/Transforms/VMILayoutRematerialize.cpp
@@ -9,6 +9,7 @@
 //===- VMILayoutRematerialize.cpp - Rematerialize VMI producers ----------===//
 //===----------------------------------------------------------------------===//
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/IR/VMIUtils.h"
@@ -47,8 +48,9 @@ static bool hasConcreteLayout(VMIMaskType type) {
 static Value materializeDataLayout(Value value, VMIVRegType resultType,
                                    Location loc, OpBuilder &builder) {
   auto sourceType = dyn_cast<VMIVRegType>(value.getType());
-  if (!sourceType || sourceType == resultType)
+  if (!sourceType || sourceType == resultType) {
     return value;
+  }
 
   return builder.create<VMIEnsureLayoutOp>(loc, resultType, value).getResult();
 }
@@ -58,29 +60,33 @@ static std::optional<Value>
 rematerializeWidenExt(ExtOp op, VMIVRegType resultType, Location loc,
                       OpBuilder &builder) {
   auto sourceType = dyn_cast<VMIVRegType>(op.getSource().getType());
-  if (!sourceType || !hasConcreteLayout(resultType))
+  if (!sourceType || !hasConcreteLayout(resultType)) {
     return std::nullopt;
+  }
 
   VMILayoutSupport supports;
   FailureOr<VMILayoutAttr> sourceLayout =
       supports.getWidenSourceLayoutForResultLayout(sourceType, resultType,
                                                    resultType.getLayoutAttr());
-  if (failed(sourceLayout))
+  if (failed(sourceLayout)) {
     return std::nullopt;
+  }
 
   auto rematSourceType =
       VMIVRegType::get(sourceType.getContext(), sourceType.getElementCount(),
                        sourceType.getElementType(), *sourceLayout);
   if (sourceType != rematSourceType) {
-    if (failed(supports.getEnsureLayoutFact(sourceType, rematSourceType)))
+    if (failed(supports.getEnsureLayoutFact(sourceType, rematSourceType))) {
       return std::nullopt;
+    }
 
     FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
     FailureOr<int64_t> rematSourceArity =
         getVMIPhysicalArity(rematSourceType);
     if (failed(sourceArity) || failed(rematSourceArity) ||
-        *rematSourceArity > *sourceArity)
+        *rematSourceArity > *sourceArity) {
       return std::nullopt;
+    }
   }
   Value rematSource =
       materializeDataLayout(op.getSource(), rematSourceType, loc, builder);
@@ -94,8 +100,9 @@ static std::optional<Value> rematerializeBinaryDataOp(Operation *op,
   auto rebuild = [&](auto typedOp) -> std::optional<Value> {
     auto lhsType = dyn_cast<VMIVRegType>(typedOp.getLhs().getType());
     auto rhsType = dyn_cast<VMIVRegType>(typedOp.getRhs().getType());
-    if (!lhsType || !rhsType)
+    if (!lhsType || !rhsType) {
       return std::nullopt;
+    }
     auto lhsResultType =
         VMIVRegType::get(lhsType.getContext(), lhsType.getElementCount(),
                          lhsType.getElementType(), resultType.getLayoutAttr());
@@ -111,40 +118,57 @@ static std::optional<Value> rematerializeBinaryDataOp(Operation *op,
         .getResult();
   };
 
-  if (auto addf = dyn_cast<VMIAddFOp>(op))
+  if (auto addf = dyn_cast<VMIAddFOp>(op)) {
     return rebuild(addf);
-  if (auto addi = dyn_cast<VMIAddIOp>(op))
+  }
+  if (auto addi = dyn_cast<VMIAddIOp>(op)) {
     return rebuild(addi);
-  if (auto subf = dyn_cast<VMISubFOp>(op))
+  }
+  if (auto subf = dyn_cast<VMISubFOp>(op)) {
     return rebuild(subf);
-  if (auto subi = dyn_cast<VMISubIOp>(op))
+  }
+  if (auto subi = dyn_cast<VMISubIOp>(op)) {
     return rebuild(subi);
-  if (auto mulf = dyn_cast<VMIMulFOp>(op))
+  }
+  if (auto mulf = dyn_cast<VMIMulFOp>(op)) {
     return rebuild(mulf);
-  if (auto muli = dyn_cast<VMIMulIOp>(op))
+  }
+  if (auto muli = dyn_cast<VMIMulIOp>(op)) {
     return rebuild(muli);
-  if (auto divf = dyn_cast<VMIDivFOp>(op))
+  }
+  if (auto divf = dyn_cast<VMIDivFOp>(op)) {
     return rebuild(divf);
-  if (auto minf = dyn_cast<VMIMinFOp>(op))
+  }
+  if (auto minf = dyn_cast<VMIMinFOp>(op)) {
     return rebuild(minf);
-  if (auto mini = dyn_cast<VMIMinIOp>(op))
+  }
+  if (auto mini = dyn_cast<VMIMinIOp>(op)) {
     return rebuild(mini);
-  if (auto maxf = dyn_cast<VMIMaxFOp>(op))
+  }
+  if (auto maxf = dyn_cast<VMIMaxFOp>(op)) {
     return rebuild(maxf);
-  if (auto maxi = dyn_cast<VMIMaxIOp>(op))
+  }
+  if (auto maxi = dyn_cast<VMIMaxIOp>(op)) {
     return rebuild(maxi);
-  if (auto andi = dyn_cast<VMIAndIOp>(op))
+  }
+  if (auto andi = dyn_cast<VMIAndIOp>(op)) {
     return rebuild(andi);
-  if (auto ori = dyn_cast<VMIOrIOp>(op))
+  }
+  if (auto ori = dyn_cast<VMIOrIOp>(op)) {
     return rebuild(ori);
-  if (auto xori = dyn_cast<VMIXOrIOp>(op))
+  }
+  if (auto xori = dyn_cast<VMIXOrIOp>(op)) {
     return rebuild(xori);
-  if (auto shli = dyn_cast<VMIShLIOp>(op))
+  }
+  if (auto shli = dyn_cast<VMIShLIOp>(op)) {
     return rebuild(shli);
-  if (auto shrui = dyn_cast<VMIShRUIOp>(op))
+  }
+  if (auto shrui = dyn_cast<VMIShRUIOp>(op)) {
     return rebuild(shrui);
-  if (auto shrsi = dyn_cast<VMIShRSIOp>(op))
+  }
+  if (auto shrsi = dyn_cast<VMIShRSIOp>(op)) {
     return rebuild(shrsi);
+  }
   return std::nullopt;
 }
 
@@ -154,8 +178,9 @@ static std::optional<Value> rematerializeUnaryDataOp(Operation *op,
                                                      OpBuilder &builder) {
   auto rebuild = [&](auto typedOp) -> std::optional<Value> {
     auto sourceType = dyn_cast<VMIVRegType>(typedOp.getSource().getType());
-    if (!sourceType)
+    if (!sourceType) {
       return std::nullopt;
+    }
     auto sourceResultType = VMIVRegType::get(
         sourceType.getContext(), sourceType.getElementCount(),
         sourceType.getElementType(), resultType.getLayoutAttr());
@@ -166,25 +191,32 @@ static std::optional<Value> rematerializeUnaryDataOp(Operation *op,
         .getResult();
   };
 
-  if (auto negf = dyn_cast<VMINegFOp>(op))
+  if (auto negf = dyn_cast<VMINegFOp>(op)) {
     return rebuild(negf);
   if (auto negi = dyn_cast<VMINegIOp>(op)) {
     return rebuild(negi);
   }
   if (auto absf = dyn_cast<VMIAbsFOp>(op))
     return rebuild(absf);
-  if (auto absi = dyn_cast<VMIAbsIOp>(op))
+  }
+  if (auto absi = dyn_cast<VMIAbsIOp>(op)) {
     return rebuild(absi);
-  if (auto sqrt = dyn_cast<VMISqrtOp>(op))
+  }
+  if (auto sqrt = dyn_cast<VMISqrtOp>(op)) {
     return rebuild(sqrt);
-  if (auto exp = dyn_cast<VMIExpOp>(op))
+  }
+  if (auto exp = dyn_cast<VMIExpOp>(op)) {
     return rebuild(exp);
-  if (auto ln = dyn_cast<VMILnOp>(op))
+  }
+  if (auto ln = dyn_cast<VMILnOp>(op)) {
     return rebuild(ln);
-  if (auto relu = dyn_cast<VMIReluOp>(op))
+  }
+  if (auto relu = dyn_cast<VMIReluOp>(op)) {
     return rebuild(relu);
-  if (auto notOp = dyn_cast<VMINotOp>(op))
+  }
+  if (auto notOp = dyn_cast<VMINotOp>(op)) {
     return rebuild(notOp);
+  }
   return std::nullopt;
 }
 
@@ -194,9 +226,10 @@ static std::optional<Value> rematerializeFma(VMIFmaOp fma,
   auto lhsType = dyn_cast<VMIVRegType>(fma.getLhs().getType());
   auto rhsType = dyn_cast<VMIVRegType>(fma.getRhs().getType());
   auto accType = dyn_cast<VMIVRegType>(fma.getAcc().getType());
-  if (!lhsType || !rhsType || !accType)
+  if (!lhsType || !rhsType || !accType) {
     return std::nullopt;
-  auto makeType = [&](VMIVRegType type) {
+  }
+  auto makeType = [resultType](VMIVRegType type) {
     return VMIVRegType::get(type.getContext(), type.getElementCount(),
                             type.getElementType(), resultType.getLayoutAttr());
   };
@@ -213,35 +246,44 @@ static std::optional<Value> rematerializeDataProducer(Value value,
                                                       VMIVRegType resultType,
                                                       Location loc,
                                                       OpBuilder &builder) {
-  if (!hasConcreteLayout(resultType))
+  if (!hasConcreteLayout(resultType)) {
     return std::nullopt;
+  }
 
-  if (auto extf = value.getDefiningOp<VMIExtFOp>())
+  if (auto extf = value.getDefiningOp<VMIExtFOp>()) {
     return rematerializeWidenExt(extf, resultType, loc, builder);
-  if (auto extsi = value.getDefiningOp<VMIExtSIOp>())
+  }
+  if (auto extsi = value.getDefiningOp<VMIExtSIOp>()) {
     return rematerializeWidenExt(extsi, resultType, loc, builder);
-  if (auto extui = value.getDefiningOp<VMIExtUIOp>())
+  }
+  if (auto extui = value.getDefiningOp<VMIExtUIOp>()) {
     return rematerializeWidenExt(extui, resultType, loc, builder);
+  }
 
   if (Operation *op = value.getDefiningOp()) {
-    if (auto fma = dyn_cast<VMIFmaOp>(op))
+    if (auto fma = dyn_cast<VMIFmaOp>(op)) {
       return rematerializeFma(fma, resultType, loc, builder);
-    if (auto result = rematerializeBinaryDataOp(op, resultType, loc, builder))
+    }
+    if (auto result = rematerializeBinaryDataOp(op, resultType, loc, builder)) {
       return result;
-    if (auto result = rematerializeUnaryDataOp(op, resultType, loc, builder))
+    }
+    if (auto result = rematerializeUnaryDataOp(op, resultType, loc, builder)) {
       return result;
+    }
   }
 
   if (auto constant = value.getDefiningOp<VMIConstantOp>()) {
     auto denseAttr = dyn_cast<DenseElementsAttr>(constant.getValue());
-    if (denseAttr && denseAttr.isSplat())
+    if (denseAttr && denseAttr.isSplat()) {
       return builder.create<VMIConstantOp>(loc, resultType, constant.getValue())
           .getResult();
+    }
   }
 
-  if (auto broadcast = value.getDefiningOp<VMIBroadcastOp>())
+  if (auto broadcast = value.getDefiningOp<VMIBroadcastOp>()) {
     return builder.create<VMIBroadcastOp>(loc, resultType, broadcast.getValue())
         .getResult();
+  }
 
   if (auto iota = value.getDefiningOp<VMIIotaOp>()) {
     return builder
@@ -251,8 +293,9 @@ static std::optional<Value> rematerializeDataProducer(Value value,
 
   if (auto groupIota = value.getDefiningOp<VMIGroupIotaOp>()) {
     VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-    if (!resultLayout || !resultLayout.isContiguous())
+    if (!resultLayout || !resultLayout.isContiguous()) {
       return std::nullopt;
+    }
     return builder
         .create<VMIGroupIotaOp>(loc, resultType, groupIota.getBase(),
                                 groupIota.getOrderAttr(),
@@ -267,13 +310,15 @@ static std::optional<Value> rematerializeMaskProducer(Value value,
                                                       VMIMaskType resultType,
                                                       Location loc,
                                                       OpBuilder &builder) {
-  if (!hasConcreteLayout(resultType))
+  if (!hasConcreteLayout(resultType)) {
     return std::nullopt;
+  }
 
-  if (auto createMask = value.getDefiningOp<VMICreateMaskOp>())
+  if (auto createMask = value.getDefiningOp<VMICreateMaskOp>()) {
     return builder
         .create<VMICreateMaskOp>(loc, resultType, createMask.getActiveLanes())
         .getResult();
+  }
 
   if (auto createGroupMask = value.getDefiningOp<VMICreateGroupMaskOp>()) {
     return builder
@@ -284,24 +329,27 @@ static std::optional<Value> rematerializeMaskProducer(Value value,
         .getResult();
   }
 
-  if (auto constantMask = value.getDefiningOp<VMIConstantMaskOp>())
+  if (auto constantMask = value.getDefiningOp<VMIConstantMaskOp>()) {
     return builder
         .create<VMIConstantMaskOp>(loc, resultType, constantMask.getValueAttr())
         .getResult();
+  }
 
   return std::nullopt;
 }
 
 static bool tryReplaceDataEnsure(VMIEnsureLayoutOp ensure) {
   auto resultType = dyn_cast<VMIVRegType>(ensure.getResult().getType());
-  if (!resultType)
+  if (!resultType) {
     return false;
+  }
 
   OpBuilder builder(ensure);
   auto result = rematerializeDataProducer(ensure.getSource(), resultType,
                                           ensure->getLoc(), builder);
-  if (!result)
+  if (!result) {
     return false;
+  }
 
   ensure.getResult().replaceAllUsesWith(*result);
   ensure.erase();
@@ -310,38 +358,45 @@ static bool tryReplaceDataEnsure(VMIEnsureLayoutOp ensure) {
 
 static bool tryRematerializeTruncIThroughSourceEnsure(VMITruncIOp trunc) {
   auto resultType = dyn_cast<VMIVRegType>(trunc.getResult().getType());
-  if (!resultType || !hasConcreteLayout(resultType))
+  if (!resultType || !hasConcreteLayout(resultType)) {
     return false;
+  }
 
   auto ensure = trunc.getSource().getDefiningOp<VMIEnsureLayoutOp>();
-  if (!ensure)
+  if (!ensure) {
     return false;
+  }
 
   auto originalSourceType = dyn_cast<VMIVRegType>(ensure.getSource().getType());
-  if (!originalSourceType || !hasConcreteLayout(originalSourceType))
+  if (!originalSourceType || !hasConcreteLayout(originalSourceType)) {
     return false;
+  }
   VMILayoutAttr originalSourceLayout = originalSourceType.getLayoutAttr();
-  if (!originalSourceLayout.isDeinterleaved())
+  if (!originalSourceLayout.isDeinterleaved()) {
     return false;
+  }
 
   VMILayoutSupport supports;
   FailureOr<VMICastLayoutFact> fact = supports.getCastLayoutFactForSourceLayout(
       originalSourceType, resultType, originalSourceLayout);
-  if (failed(fact))
+  if (failed(fact)) {
     return false;
+  }
 
   unsigned resultBits =
       pto::getPTOStorageElemBitWidth(resultType.getElementType());
-  if (resultBits == 8 &&
-      !cast<IntegerType>(resultType.getElementType()).isUnsigned())
+  if (resultBits == mlir::pto::kValue8 &&
+      !cast<IntegerType>(resultType.getElementType()).isUnsigned()) {
     return false;
+  }
 
   VMILayoutAttr rematResultLayout = fact->resultLayout;
   auto rematResultType =
       VMIVRegType::get(resultType.getContext(), resultType.getElementCount(),
                        resultType.getElementType(), rematResultLayout);
-  if (rematResultType == resultType)
+  if (rematResultType == resultType) {
     return false;
+  }
 
   OpBuilder builder(trunc);
   Value remat = builder
@@ -358,14 +413,16 @@ static bool tryRematerializeTruncIThroughSourceEnsure(VMITruncIOp trunc) {
 
 template <typename EnsureOp> static bool tryReplaceMaskEnsure(EnsureOp ensure) {
   auto resultType = dyn_cast<VMIMaskType>(ensure.getResult().getType());
-  if (!resultType)
+  if (!resultType) {
     return false;
+  }
 
   OpBuilder builder(ensure);
   auto result = rematerializeMaskProducer(ensure.getSource(), resultType,
                                           ensure->getLoc(), builder);
-  if (!result)
+  if (!result) {
     return false;
+  }
 
   ensure.getResult().replaceAllUsesWith(*result);
   ensure.erase();
@@ -385,13 +442,15 @@ struct VMILayoutRematerializePass
       SmallVector<Operation *> helpers;
       module.walk([&](Operation *op) {
         if (isa<VMIEnsureLayoutOp, VMIEnsureMaskLayoutOp,
-                VMIEnsureMaskGranularityOp, VMITruncIOp>(op))
+                VMIEnsureMaskGranularityOp, VMITruncIOp>(op)) {
           helpers.push_back(op);
+        }
       });
 
       for (Operation *op : helpers) {
-        if (op->getBlock() == nullptr)
+        if (op->getBlock() == nullptr) {
           continue;
+        }
 
         if (auto ensure = dyn_cast<VMIEnsureLayoutOp>(op)) {
           changed |= tryReplaceDataEnsure(ensure);
@@ -408,8 +467,9 @@ struct VMILayoutRematerializePass
           continue;
         }
 
-        if (auto trunc = dyn_cast<VMITruncIOp>(op))
+        if (auto trunc = dyn_cast<VMITruncIOp>(op)) {
           changed |= tryRematerializeTruncIThroughSourceEnsure(trunc);
+        }
       }
     }
   }

--- a/lib/PTO/Transforms/VMILayoutSinkMaterialization.cpp
+++ b/lib/PTO/Transforms/VMILayoutSinkMaterialization.cpp
@@ -65,120 +65,154 @@ struct UnaryMaskOperand {
 
 static std::optional<BinaryVRegOperands>
 getSinkableBinaryOperands(Operation *op) {
-  if (auto addf = dyn_cast<VMIAddFOp>(op))
+  if (auto addf = dyn_cast<VMIAddFOp>(op)) {
     return BinaryVRegOperands{&addf.getLhsMutable(), &addf.getRhsMutable()};
-  if (auto addi = dyn_cast<VMIAddIOp>(op))
+  }
+  if (auto addi = dyn_cast<VMIAddIOp>(op)) {
     return BinaryVRegOperands{&addi.getLhsMutable(), &addi.getRhsMutable()};
-  if (auto subf = dyn_cast<VMISubFOp>(op))
+  }
+  if (auto subf = dyn_cast<VMISubFOp>(op)) {
     return BinaryVRegOperands{&subf.getLhsMutable(), &subf.getRhsMutable()};
-  if (auto subi = dyn_cast<VMISubIOp>(op))
+  }
+  if (auto subi = dyn_cast<VMISubIOp>(op)) {
     return BinaryVRegOperands{&subi.getLhsMutable(), &subi.getRhsMutable()};
-  if (auto mulf = dyn_cast<VMIMulFOp>(op))
+  }
+  if (auto mulf = dyn_cast<VMIMulFOp>(op)) {
     return BinaryVRegOperands{&mulf.getLhsMutable(), &mulf.getRhsMutable()};
-  if (auto muli = dyn_cast<VMIMulIOp>(op))
+  }
+  if (auto muli = dyn_cast<VMIMulIOp>(op)) {
     return BinaryVRegOperands{&muli.getLhsMutable(), &muli.getRhsMutable()};
-  if (auto divf = dyn_cast<VMIDivFOp>(op))
+  }
+  if (auto divf = dyn_cast<VMIDivFOp>(op)) {
     return BinaryVRegOperands{&divf.getLhsMutable(), &divf.getRhsMutable()};
-  if (auto minf = dyn_cast<VMIMinFOp>(op))
+  }
+  if (auto minf = dyn_cast<VMIMinFOp>(op)) {
     return BinaryVRegOperands{&minf.getLhsMutable(), &minf.getRhsMutable()};
-  if (auto mini = dyn_cast<VMIMinIOp>(op))
+  }
+  if (auto mini = dyn_cast<VMIMinIOp>(op)) {
     return BinaryVRegOperands{&mini.getLhsMutable(), &mini.getRhsMutable()};
-  if (auto maxf = dyn_cast<VMIMaxFOp>(op))
+  }
+  if (auto maxf = dyn_cast<VMIMaxFOp>(op)) {
     return BinaryVRegOperands{&maxf.getLhsMutable(), &maxf.getRhsMutable()};
-  if (auto maxi = dyn_cast<VMIMaxIOp>(op))
+  }
+  if (auto maxi = dyn_cast<VMIMaxIOp>(op)) {
     return BinaryVRegOperands{&maxi.getLhsMutable(), &maxi.getRhsMutable()};
-  if (auto andi = dyn_cast<VMIAndIOp>(op))
+  }
+  if (auto andi = dyn_cast<VMIAndIOp>(op)) {
     return BinaryVRegOperands{&andi.getLhsMutable(), &andi.getRhsMutable()};
-  if (auto ori = dyn_cast<VMIOrIOp>(op))
+  }
+  if (auto ori = dyn_cast<VMIOrIOp>(op)) {
     return BinaryVRegOperands{&ori.getLhsMutable(), &ori.getRhsMutable()};
-  if (auto xori = dyn_cast<VMIXOrIOp>(op))
+  }
+  if (auto xori = dyn_cast<VMIXOrIOp>(op)) {
     return BinaryVRegOperands{&xori.getLhsMutable(), &xori.getRhsMutable()};
-  if (auto shli = dyn_cast<VMIShLIOp>(op))
+  }
+  if (auto shli = dyn_cast<VMIShLIOp>(op)) {
     return BinaryVRegOperands{&shli.getLhsMutable(), &shli.getRhsMutable()};
-  if (auto shrui = dyn_cast<VMIShRUIOp>(op))
+  }
+  if (auto shrui = dyn_cast<VMIShRUIOp>(op)) {
     return BinaryVRegOperands{&shrui.getLhsMutable(), &shrui.getRhsMutable()};
-  if (auto shrsi = dyn_cast<VMIShRSIOp>(op))
+  }
+  if (auto shrsi = dyn_cast<VMIShRSIOp>(op)) {
     return BinaryVRegOperands{&shrsi.getLhsMutable(), &shrsi.getRhsMutable()};
+  }
   return std::nullopt;
 }
 
 static std::optional<BinaryVRegOperands>
 getSinkableCompareOperands(Operation *op) {
-  if (auto cmpf = dyn_cast<VMICmpFOp>(op))
+  if (auto cmpf = dyn_cast<VMICmpFOp>(op)) {
     return BinaryVRegOperands{&cmpf.getLhsMutable(), &cmpf.getRhsMutable()};
-  if (auto cmpi = dyn_cast<VMICmpIOp>(op))
+  }
+  if (auto cmpi = dyn_cast<VMICmpIOp>(op)) {
     return BinaryVRegOperands{&cmpi.getLhsMutable(), &cmpi.getRhsMutable()};
+  }
   return std::nullopt;
 }
 
 static std::optional<SelectOperands> getSinkableSelectOperands(Operation *op) {
-  if (auto select = dyn_cast<VMISelectOp>(op))
+  if (auto select = dyn_cast<VMISelectOp>(op)) {
     return SelectOperands{&select.getMaskMutable(),
                           &select.getTrueValueMutable(),
                           &select.getFalseValueMutable()};
+  }
   return std::nullopt;
 }
 
 static std::optional<TernaryVRegOperands>
 getSinkableTernaryOperands(Operation *op) {
-  if (auto fma = dyn_cast<VMIFmaOp>(op))
+  if (auto fma = dyn_cast<VMIFmaOp>(op)) {
     return TernaryVRegOperands{&fma.getLhsMutable(), &fma.getRhsMutable(),
                                &fma.getAccMutable()};
+  }
   return std::nullopt;
 }
 
 static std::optional<UnaryVRegOperand> getSinkableUnaryOperand(Operation *op) {
-  if (auto negf = dyn_cast<VMINegFOp>(op))
+  if (auto negf = dyn_cast<VMINegFOp>(op)) {
     return UnaryVRegOperand{&negf.getSourceMutable()};
   if (auto negi = dyn_cast<VMINegIOp>(op)) {
     return UnaryVRegOperand{&negi.getSourceMutable()};
   }
   if (auto absf = dyn_cast<VMIAbsFOp>(op))
     return UnaryVRegOperand{&absf.getSourceMutable()};
-  if (auto absi = dyn_cast<VMIAbsIOp>(op))
+  }
+  if (auto absi = dyn_cast<VMIAbsIOp>(op)) {
     return UnaryVRegOperand{&absi.getSourceMutable()};
-  if (auto sqrt = dyn_cast<VMISqrtOp>(op))
+  }
+  if (auto sqrt = dyn_cast<VMISqrtOp>(op)) {
     return UnaryVRegOperand{&sqrt.getSourceMutable()};
-  if (auto exp = dyn_cast<VMIExpOp>(op))
+  }
+  if (auto exp = dyn_cast<VMIExpOp>(op)) {
     return UnaryVRegOperand{&exp.getSourceMutable()};
-  if (auto ln = dyn_cast<VMILnOp>(op))
+  }
+  if (auto ln = dyn_cast<VMILnOp>(op)) {
     return UnaryVRegOperand{&ln.getSourceMutable()};
-  if (auto relu = dyn_cast<VMIReluOp>(op))
+  }
+  if (auto relu = dyn_cast<VMIReluOp>(op)) {
     return UnaryVRegOperand{&relu.getSourceMutable()};
-  if (auto notOp = dyn_cast<VMINotOp>(op))
+  }
+  if (auto notOp = dyn_cast<VMINotOp>(op)) {
     return UnaryVRegOperand{&notOp.getSourceMutable()};
+  }
   return std::nullopt;
 }
 
 static std::optional<BinaryMaskOperands>
 getSinkableBinaryMaskOperands(Operation *op) {
-  if (auto maskAnd = dyn_cast<VMIMaskAndOp>(op))
+  if (auto maskAnd = dyn_cast<VMIMaskAndOp>(op)) {
     return BinaryMaskOperands{&maskAnd.getLhsMutable(),
                               &maskAnd.getRhsMutable()};
-  if (auto maskOr = dyn_cast<VMIMaskOrOp>(op))
+  }
+  if (auto maskOr = dyn_cast<VMIMaskOrOp>(op)) {
     return BinaryMaskOperands{&maskOr.getLhsMutable(), &maskOr.getRhsMutable()};
-  if (auto maskXor = dyn_cast<VMIMaskXOrOp>(op))
+  }
+  if (auto maskXor = dyn_cast<VMIMaskXOrOp>(op)) {
     return BinaryMaskOperands{&maskXor.getLhsMutable(),
                               &maskXor.getRhsMutable()};
+  }
   return std::nullopt;
 }
 
 static std::optional<UnaryMaskOperand>
 getSinkableUnaryMaskOperand(Operation *op) {
-  if (auto maskNot = dyn_cast<VMIMaskNotOp>(op))
+  if (auto maskNot = dyn_cast<VMIMaskNotOp>(op)) {
     return UnaryMaskOperand{&maskNot.getSourceMutable()};
+  }
   return std::nullopt;
 }
 
 static bool isSameMaterialization(VMIEnsureLayoutOp ensure,
                                   VMIVRegType resultType) {
-  if (!ensure || !resultType)
+  if (!ensure || !resultType) {
     return false;
+  }
 
   auto sourceType = dyn_cast<VMIVRegType>(ensure.getSource().getType());
   auto ensureResultType = dyn_cast<VMIVRegType>(ensure.getResult().getType());
-  if (!sourceType || !ensureResultType)
+  if (!sourceType || !ensureResultType) {
     return false;
+  }
 
   return ensureResultType == resultType && sourceType != resultType;
 }
@@ -186,15 +220,17 @@ static bool isSameMaterialization(VMIEnsureLayoutOp ensure,
 static bool isSameMaterialization(VMIEnsureLayoutOp lhsEnsure,
                                   VMIEnsureLayoutOp rhsEnsure,
                                   VMIVRegType resultType) {
-  if (!lhsEnsure || !rhsEnsure || !resultType)
+  if (!lhsEnsure || !rhsEnsure || !resultType) {
     return false;
+  }
 
   auto lhsSourceType = dyn_cast<VMIVRegType>(lhsEnsure.getSource().getType());
   auto rhsSourceType = dyn_cast<VMIVRegType>(rhsEnsure.getSource().getType());
   auto lhsResultType = dyn_cast<VMIVRegType>(lhsEnsure.getResult().getType());
   auto rhsResultType = dyn_cast<VMIVRegType>(rhsEnsure.getResult().getType());
-  if (!lhsSourceType || !rhsSourceType || !lhsResultType || !rhsResultType)
+  if (!lhsSourceType || !rhsSourceType || !lhsResultType || !rhsResultType) {
     return false;
+  }
 
   return lhsSourceType == rhsSourceType && lhsResultType == rhsResultType &&
          lhsResultType == resultType && lhsSourceType != resultType;
@@ -204,8 +240,9 @@ static bool isSameMaterialization(VMIEnsureLayoutOp lhsEnsure,
                                   VMIEnsureLayoutOp rhsEnsure,
                                   VMIEnsureLayoutOp accEnsure,
                                   VMIVRegType resultType) {
-  if (!lhsEnsure || !rhsEnsure || !accEnsure || !resultType)
+  if (!lhsEnsure || !rhsEnsure || !accEnsure || !resultType) {
     return false;
+  }
 
   auto lhsSourceType = dyn_cast<VMIVRegType>(lhsEnsure.getSource().getType());
   auto rhsSourceType = dyn_cast<VMIVRegType>(rhsEnsure.getSource().getType());
@@ -214,8 +251,9 @@ static bool isSameMaterialization(VMIEnsureLayoutOp lhsEnsure,
   auto rhsResultType = dyn_cast<VMIVRegType>(rhsEnsure.getResult().getType());
   auto accResultType = dyn_cast<VMIVRegType>(accEnsure.getResult().getType());
   if (!lhsSourceType || !rhsSourceType || !accSourceType || !lhsResultType ||
-      !rhsResultType || !accResultType)
+      !rhsResultType || !accResultType) {
     return false;
+  }
 
   return lhsSourceType == rhsSourceType && lhsSourceType == accSourceType &&
          lhsResultType == rhsResultType && lhsResultType == accResultType &&
@@ -230,13 +268,15 @@ static bool hasEnsureLayoutSupport(VMIVRegType sourceType,
 
 template <typename EnsureOp>
 static bool isSameMaskMaterialization(EnsureOp ensure, VMIMaskType resultType) {
-  if (!ensure || !resultType)
+  if (!ensure || !resultType) {
     return false;
+  }
 
   auto sourceType = dyn_cast<VMIMaskType>(ensure.getSource().getType());
   auto ensureResultType = dyn_cast<VMIMaskType>(ensure.getResult().getType());
-  if (!sourceType || !ensureResultType)
+  if (!sourceType || !ensureResultType) {
     return false;
+  }
 
   return ensureResultType == resultType && sourceType != resultType;
 }
@@ -244,15 +284,17 @@ static bool isSameMaskMaterialization(EnsureOp ensure, VMIMaskType resultType) {
 template <typename EnsureOp>
 static bool isSameMaskMaterialization(EnsureOp lhsEnsure, EnsureOp rhsEnsure,
                                       VMIMaskType resultType) {
-  if (!lhsEnsure || !rhsEnsure || !resultType)
+  if (!lhsEnsure || !rhsEnsure || !resultType) {
     return false;
+  }
 
   auto lhsSourceType = dyn_cast<VMIMaskType>(lhsEnsure.getSource().getType());
   auto rhsSourceType = dyn_cast<VMIMaskType>(rhsEnsure.getSource().getType());
   auto lhsResultType = dyn_cast<VMIMaskType>(lhsEnsure.getResult().getType());
   auto rhsResultType = dyn_cast<VMIMaskType>(rhsEnsure.getResult().getType());
-  if (!lhsSourceType || !rhsSourceType || !lhsResultType || !rhsResultType)
+  if (!lhsSourceType || !rhsSourceType || !lhsResultType || !rhsResultType) {
     return false;
+  }
 
   return lhsSourceType == rhsSourceType && lhsResultType == rhsResultType &&
          lhsResultType == resultType && lhsSourceType != resultType;
@@ -274,21 +316,25 @@ static bool hasEnsureMaskSupport(VMIEnsureMaskGranularityOp,
 
 static bool trySinkBinaryMaterialization(Operation *op) {
   std::optional<BinaryVRegOperands> operands = getSinkableBinaryOperands(op);
-  if (!operands || op->getNumResults() != 1)
+  if (!operands || op->getNumResults() != 1) {
     return false;
+  }
 
   auto resultType = dyn_cast<VMIVRegType>(op->getResult(0).getType());
-  if (!resultType)
+  if (!resultType) {
     return false;
+  }
 
   auto lhsEnsure = operands->lhs->get().getDefiningOp<VMIEnsureLayoutOp>();
   auto rhsEnsure = operands->rhs->get().getDefiningOp<VMIEnsureLayoutOp>();
-  if (!isSameMaterialization(lhsEnsure, rhsEnsure, resultType))
+  if (!isSameMaterialization(lhsEnsure, rhsEnsure, resultType)) {
     return false;
+  }
 
   auto sourceType = cast<VMIVRegType>(lhsEnsure.getSource().getType());
-  if (!hasEnsureLayoutSupport(sourceType, resultType))
+  if (!hasEnsureLayoutSupport(sourceType, resultType)) {
     return false;
+  }
 
   OpBuilder builder(op);
   OperationState state(op->getLoc(), op->getName());
@@ -303,21 +349,25 @@ static bool trySinkBinaryMaterialization(Operation *op) {
   op->getResult(0).replaceAllUsesWith(resultEnsure.getResult());
   op->erase();
 
-  if (lhsEnsure->use_empty())
+  if (lhsEnsure->use_empty()) {
     lhsEnsure.erase();
-  if (rhsEnsure != lhsEnsure && rhsEnsure->use_empty())
+  }
+  if (rhsEnsure != lhsEnsure && rhsEnsure->use_empty()) {
     rhsEnsure.erase();
+  }
   return true;
 }
 
 static bool trySinkSelectMaterialization(Operation *op) {
   std::optional<SelectOperands> operands = getSinkableSelectOperands(op);
-  if (!operands || op->getNumResults() != 1)
+  if (!operands || op->getNumResults() != 1) {
     return false;
+  }
 
   auto resultType = dyn_cast<VMIVRegType>(op->getResult(0).getType());
-  if (!resultType)
+  if (!resultType) {
     return false;
+  }
 
   auto maskEnsure =
       operands->mask->get().getDefiningOp<VMIEnsureMaskLayoutOp>();
@@ -325,8 +375,9 @@ static bool trySinkSelectMaterialization(Operation *op) {
       operands->trueValue->get().getDefiningOp<VMIEnsureLayoutOp>();
   auto falseEnsure =
       operands->falseValue->get().getDefiningOp<VMIEnsureLayoutOp>();
-  if (!maskEnsure || !trueEnsure || !falseEnsure)
+  if (!maskEnsure || !trueEnsure || !falseEnsure) {
     return false;
+  }
 
   auto trueSourceType = dyn_cast<VMIVRegType>(trueEnsure.getSource().getType());
   auto falseSourceType =
@@ -337,24 +388,30 @@ static bool trySinkSelectMaterialization(Operation *op) {
   auto maskSourceType = dyn_cast<VMIMaskType>(maskEnsure.getSource().getType());
   auto maskResultType = dyn_cast<VMIMaskType>(maskEnsure.getResult().getType());
   if (!trueSourceType || !falseSourceType || !trueResultType ||
-      !falseResultType || !maskSourceType || !maskResultType)
+      !falseResultType || !maskSourceType || !maskResultType) {
     return false;
+  }
 
   if (trueSourceType != falseSourceType || trueResultType != falseResultType ||
-      trueResultType != resultType || trueSourceType == resultType)
+      trueResultType != resultType || trueSourceType == resultType) {
     return false;
-  if (maskResultType != operands->mask->get().getType())
+  }
+  if (maskResultType != operands->mask->get().getType()) {
     return false;
+  }
   if (maskResultType.getLayoutAttr() != resultType.getLayoutAttr() ||
-      maskSourceType.getLayoutAttr() != trueSourceType.getLayoutAttr())
+      maskSourceType.getLayoutAttr() != trueSourceType.getLayoutAttr()) {
     return false;
+  }
   if (maskSourceType.getElementCount() != trueSourceType.getElementCount() ||
       maskResultType.getElementCount() != resultType.getElementCount() ||
-      maskSourceType.getGranularity() != maskResultType.getGranularity())
+      maskSourceType.getGranularity() != maskResultType.getGranularity()) {
     return false;
+  }
   if (!hasEnsureLayoutSupport(trueSourceType, resultType) ||
-      !hasEnsureMaskSupport(maskEnsure, maskSourceType, maskResultType))
+      !hasEnsureMaskSupport(maskEnsure, maskSourceType, maskResultType)) {
     return false;
+  }
 
   OpBuilder builder(op);
   OperationState state(op->getLoc(), op->getName());
@@ -370,48 +427,58 @@ static bool trySinkSelectMaterialization(Operation *op) {
   op->getResult(0).replaceAllUsesWith(resultEnsure.getResult());
   op->erase();
 
-  if (maskEnsure->use_empty())
+  if (maskEnsure->use_empty()) {
     maskEnsure.erase();
-  if (trueEnsure->use_empty())
+  }
+  if (trueEnsure->use_empty()) {
     trueEnsure.erase();
-  if (falseEnsure != trueEnsure && falseEnsure->use_empty())
+  }
+  if (falseEnsure != trueEnsure && falseEnsure->use_empty()) {
     falseEnsure.erase();
+  }
   return true;
 }
 
 static bool trySinkCompareMaterialization(Operation *op) {
   std::optional<BinaryVRegOperands> operands = getSinkableCompareOperands(op);
-  if (!operands || op->getNumResults() != 1)
+  if (!operands || op->getNumResults() != 1) {
     return false;
+  }
 
   auto resultMaskType = dyn_cast<VMIMaskType>(op->getResult(0).getType());
-  if (!resultMaskType)
+  if (!resultMaskType) {
     return false;
+  }
 
   auto lhsEnsure = operands->lhs->get().getDefiningOp<VMIEnsureLayoutOp>();
   auto rhsEnsure = operands->rhs->get().getDefiningOp<VMIEnsureLayoutOp>();
-  if (!lhsEnsure || !rhsEnsure)
+  if (!lhsEnsure || !rhsEnsure) {
     return false;
+  }
 
   auto lhsSourceType = dyn_cast<VMIVRegType>(lhsEnsure.getSource().getType());
   auto rhsSourceType = dyn_cast<VMIVRegType>(rhsEnsure.getSource().getType());
   auto lhsResultType = dyn_cast<VMIVRegType>(lhsEnsure.getResult().getType());
   auto rhsResultType = dyn_cast<VMIVRegType>(rhsEnsure.getResult().getType());
-  if (!lhsSourceType || !rhsSourceType || !lhsResultType || !rhsResultType)
+  if (!lhsSourceType || !rhsSourceType || !lhsResultType || !rhsResultType) {
     return false;
+  }
   if (lhsSourceType != rhsSourceType || lhsResultType != rhsResultType ||
-      lhsSourceType == lhsResultType)
+      lhsSourceType == lhsResultType) {
     return false;
+  }
   if (lhsResultType.getElementCount() != resultMaskType.getElementCount() ||
-      lhsResultType.getLayoutAttr() != resultMaskType.getLayoutAttr())
+      lhsResultType.getLayoutAttr() != resultMaskType.getLayoutAttr()) {
     return false;
+  }
 
   auto sourceMaskType = VMIMaskType::get(
       op->getContext(), resultMaskType.getElementCount(),
       resultMaskType.getGranularity(), lhsSourceType.getLayoutAttr());
   VMILayoutSupport supports;
-  if (failed(supports.getEnsureMaskLayoutFact(sourceMaskType, resultMaskType)))
+  if (failed(supports.getEnsureMaskLayoutFact(sourceMaskType, resultMaskType))) {
     return false;
+  }
 
   OpBuilder builder(op);
   OperationState state(op->getLoc(), op->getName());
@@ -426,31 +493,37 @@ static bool trySinkCompareMaterialization(Operation *op) {
   op->getResult(0).replaceAllUsesWith(resultEnsure.getResult());
   op->erase();
 
-  if (lhsEnsure->use_empty())
+  if (lhsEnsure->use_empty()) {
     lhsEnsure.erase();
-  if (rhsEnsure != lhsEnsure && rhsEnsure->use_empty())
+  }
+  if (rhsEnsure != lhsEnsure && rhsEnsure->use_empty()) {
     rhsEnsure.erase();
+  }
   return true;
 }
 
 static bool trySinkTernaryMaterialization(Operation *op) {
   std::optional<TernaryVRegOperands> operands = getSinkableTernaryOperands(op);
-  if (!operands || op->getNumResults() != 1)
+  if (!operands || op->getNumResults() != 1) {
     return false;
+  }
 
   auto resultType = dyn_cast<VMIVRegType>(op->getResult(0).getType());
-  if (!resultType)
+  if (!resultType) {
     return false;
+  }
 
   auto lhsEnsure = operands->lhs->get().getDefiningOp<VMIEnsureLayoutOp>();
   auto rhsEnsure = operands->rhs->get().getDefiningOp<VMIEnsureLayoutOp>();
   auto accEnsure = operands->acc->get().getDefiningOp<VMIEnsureLayoutOp>();
-  if (!isSameMaterialization(lhsEnsure, rhsEnsure, accEnsure, resultType))
+  if (!isSameMaterialization(lhsEnsure, rhsEnsure, accEnsure, resultType)) {
     return false;
+  }
 
   auto sourceType = cast<VMIVRegType>(lhsEnsure.getSource().getType());
-  if (!hasEnsureLayoutSupport(sourceType, resultType))
+  if (!hasEnsureLayoutSupport(sourceType, resultType)) {
     return false;
+  }
 
   OpBuilder builder(op);
   OperationState state(op->getLoc(), op->getName());
@@ -466,13 +539,16 @@ static bool trySinkTernaryMaterialization(Operation *op) {
   op->getResult(0).replaceAllUsesWith(resultEnsure.getResult());
   op->erase();
 
-  if (lhsEnsure->use_empty())
+  if (lhsEnsure->use_empty()) {
     lhsEnsure.erase();
-  if (rhsEnsure != lhsEnsure && rhsEnsure->use_empty())
+  }
+  if (rhsEnsure != lhsEnsure && rhsEnsure->use_empty()) {
     rhsEnsure.erase();
+  }
   if (accEnsure != lhsEnsure && accEnsure != rhsEnsure &&
-      accEnsure->use_empty())
+      accEnsure->use_empty()) {
     accEnsure.erase();
+  }
   return true;
 }
 
@@ -480,21 +556,25 @@ template <typename EnsureOp>
 static bool trySinkBinaryMaskMaterialization(Operation *op) {
   std::optional<BinaryMaskOperands> operands =
       getSinkableBinaryMaskOperands(op);
-  if (!operands || op->getNumResults() != 1)
+  if (!operands || op->getNumResults() != 1) {
     return false;
+  }
 
   auto resultType = dyn_cast<VMIMaskType>(op->getResult(0).getType());
-  if (!resultType)
+  if (!resultType) {
     return false;
+  }
 
   auto lhsEnsure = operands->lhs->get().getDefiningOp<EnsureOp>();
   auto rhsEnsure = operands->rhs->get().getDefiningOp<EnsureOp>();
-  if (!isSameMaskMaterialization(lhsEnsure, rhsEnsure, resultType))
+  if (!isSameMaskMaterialization(lhsEnsure, rhsEnsure, resultType)) {
     return false;
+  }
 
   auto sourceType = cast<VMIMaskType>(lhsEnsure.getSource().getType());
-  if (!hasEnsureMaskSupport(lhsEnsure, sourceType, resultType))
+  if (!hasEnsureMaskSupport(lhsEnsure, sourceType, resultType)) {
     return false;
+  }
 
   OpBuilder builder(op);
   OperationState state(op->getLoc(), op->getName());
@@ -509,29 +589,35 @@ static bool trySinkBinaryMaskMaterialization(Operation *op) {
   op->getResult(0).replaceAllUsesWith(resultEnsure.getResult());
   op->erase();
 
-  if (lhsEnsure->use_empty())
+  if (lhsEnsure->use_empty()) {
     lhsEnsure.erase();
-  if (rhsEnsure != lhsEnsure && rhsEnsure->use_empty())
+  }
+  if (rhsEnsure != lhsEnsure && rhsEnsure->use_empty()) {
     rhsEnsure.erase();
+  }
   return true;
 }
 
 static bool trySinkUnaryMaterialization(Operation *op) {
   std::optional<UnaryVRegOperand> operand = getSinkableUnaryOperand(op);
-  if (!operand || op->getNumResults() != 1)
+  if (!operand || op->getNumResults() != 1) {
     return false;
+  }
 
   auto resultType = dyn_cast<VMIVRegType>(op->getResult(0).getType());
-  if (!resultType)
+  if (!resultType) {
     return false;
+  }
 
   auto sourceEnsure = operand->source->get().getDefiningOp<VMIEnsureLayoutOp>();
-  if (!isSameMaterialization(sourceEnsure, resultType))
+  if (!isSameMaterialization(sourceEnsure, resultType)) {
     return false;
+  }
 
   auto sourceType = cast<VMIVRegType>(sourceEnsure.getSource().getType());
-  if (!hasEnsureLayoutSupport(sourceType, resultType))
+  if (!hasEnsureLayoutSupport(sourceType, resultType)) {
     return false;
+  }
 
   OpBuilder builder(op);
   OperationState state(op->getLoc(), op->getName());
@@ -546,28 +632,33 @@ static bool trySinkUnaryMaterialization(Operation *op) {
   op->getResult(0).replaceAllUsesWith(resultEnsure.getResult());
   op->erase();
 
-  if (sourceEnsure->use_empty())
+  if (sourceEnsure->use_empty()) {
     sourceEnsure.erase();
+  }
   return true;
 }
 
 template <typename EnsureOp>
 static bool trySinkUnaryMaskMaterialization(Operation *op) {
   std::optional<UnaryMaskOperand> operand = getSinkableUnaryMaskOperand(op);
-  if (!operand || op->getNumResults() != 1)
+  if (!operand || op->getNumResults() != 1) {
     return false;
+  }
 
   auto resultType = dyn_cast<VMIMaskType>(op->getResult(0).getType());
-  if (!resultType)
+  if (!resultType) {
     return false;
+  }
 
   auto sourceEnsure = operand->source->get().getDefiningOp<EnsureOp>();
-  if (!isSameMaskMaterialization(sourceEnsure, resultType))
+  if (!isSameMaskMaterialization(sourceEnsure, resultType)) {
     return false;
+  }
 
   auto sourceType = cast<VMIMaskType>(sourceEnsure.getSource().getType());
-  if (!hasEnsureMaskSupport(sourceEnsure, sourceType, resultType))
+  if (!hasEnsureMaskSupport(sourceEnsure, sourceType, resultType)) {
     return false;
+  }
 
   OpBuilder builder(op);
   OperationState state(op->getLoc(), op->getName());
@@ -582,8 +673,9 @@ static bool trySinkUnaryMaskMaterialization(Operation *op) {
   op->getResult(0).replaceAllUsesWith(resultEnsure.getResult());
   op->erase();
 
-  if (sourceEnsure->use_empty())
+  if (sourceEnsure->use_empty()) {
     sourceEnsure.erase();
+  }
   return true;
 }
 
@@ -606,19 +698,22 @@ struct VMILayoutSinkMaterializationPass
       if (getSinkableBinaryOperands(op) || getSinkableCompareOperands(op) ||
           getSinkableSelectOperands(op) || getSinkableTernaryOperands(op) ||
           getSinkableUnaryOperand(op) || getSinkableBinaryMaskOperands(op) ||
-          getSinkableUnaryMaskOperand(op))
+          getSinkableUnaryMaskOperand(op)) {
         candidates.push_back(op);
+      }
     });
 
     for (Operation *op : candidates) {
-      if (op->getBlock() == nullptr)
+      if (op->getBlock() == nullptr) {
         continue;
+      }
       if (!trySinkBinaryMaterialization(op)) {
         if (!trySinkCompareMaterialization(op)) {
           if (!trySinkSelectMaterialization(op)) {
             if (!trySinkTernaryMaterialization(op)) {
-              if (!trySinkUnaryMaterialization(op))
+              if (!trySinkUnaryMaterialization(op)) {
                 trySinkMaskMaterialization(op);
+              }
             }
           }
         }

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -34,6 +34,7 @@
 
 #include "PTO/Transforms/VMILayoutSupport.h"
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/IR/VMIUtils.h"
 
@@ -45,6 +46,8 @@ using namespace mlir;
 using namespace mlir::pto;
 
 namespace {
+
+constexpr int64_t kLayoutBlockBitWidth = 256;
 
 static llvm::cl::opt<bool> preferLaneStrideNarrowing(
     "vmi-prefer-lane-stride-narrowing",
@@ -119,10 +122,10 @@ static constexpr PhysicalChunkCountPattern chunk() {
 }
 
 static constexpr uint64_t elementBitsMask(int64_t bits) {
-  return bits == 8    ? 1ull << 0
-         : bits == 16 ? 1ull << 1
-         : bits == 32 ? 1ull << 2
-         : bits == 64 ? 1ull << 3
+  return bits == mlir::pto::kValue8    ? 1ull << 0
+         : bits == mlir::pto::kValue16 ? 1ull << 1
+         : bits == mlir::pto::kValue32 ? 1ull << 2
+         : bits == mlir::pto::kValue64 ? 1ull << 3
                       : 0;
 }
 
@@ -160,21 +163,27 @@ static bool matchesElementBitsPattern(ElementBitsPattern pattern,
 
 static bool matchesElementCountPattern(ElementCountPattern pattern,
                                        int64_t count) {
-  if (pattern.any)
+  if (pattern.any) {
     return true;
-  for (int64_t i = 0; i < pattern.count; ++i)
-    if (pattern.values[i] == count)
+  }
+  for (int64_t i = 0; i < pattern.count; ++i) {
+    if (pattern.values[i] == count) {
       return true;
+    }
+  }
   return false;
 }
 
 static bool matchesPhysicalChunkCountPattern(
     PhysicalChunkCountPattern pattern, int64_t chunkCount) {
-  if (chunkCount <= 0)
+  if (chunkCount <= 0) {
     return false;
-  for (int64_t i = 0; i < pattern.count; ++i)
-    if (pattern.values[i] == chunkCount)
+  }
+  for (int64_t i = 0; i < pattern.count; ++i) {
+    if (pattern.values[i] == chunkCount) {
       return true;
+    }
+  }
   return false;
 }
 
@@ -210,8 +219,9 @@ static VMILayoutAttr materializeLayoutPattern(MLIRContext *ctx,
 
 static bool matchesLayoutPattern(MLIRContext *ctx, LayoutPattern pattern,
                                  VMILayoutAttr layout, int64_t numGroups = 0) {
-  if (!layout)
+  if (!layout) {
     return false;
+  }
   return materializeLayoutPattern(ctx, pattern, numGroups) == layout;
 }
 
@@ -265,11 +275,13 @@ static constexpr GroupBlockPattern gbFull(int64_t fullPartMultiple = 1) {
 //===----------------------------------------------------------------------===//
 
 static std::optional<int64_t> getConstantIndexValue(Value value) {
-  if (auto constant = value.getDefiningOp<arith::ConstantIndexOp>())
+  if (auto constant = value.getDefiningOp<arith::ConstantIndexOp>()) {
     return constant.value();
+  }
   if (auto constant = value.getDefiningOp<arith::ConstantIntOp>()) {
-    if (constant.getType().isIndex())
+    if (constant.getType().isIndex()) {
       return constant.value();
+    }
   }
   return std::nullopt;
 }
@@ -278,14 +290,17 @@ static FailureOr<int64_t> getGroupSizeFromNumGroups(VMIVRegType type,
                                                     int64_t numGroups,
                                                     std::string *reason) {
   auto fail = [&](const Twine &message) -> FailureOr<int64_t> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
-  if (numGroups <= 0)
+  if (numGroups <= 0) {
     return fail("requires num_groups to be positive");
-  if (type.getElementCount() % numGroups != 0)
+  }
+  if (type.getElementCount() % numGroups != 0) {
     return fail("requires num_groups to evenly divide logical lane count");
+  }
   return type.getElementCount() / numGroups;
 }
 
@@ -861,9 +876,11 @@ static bool isSameGroupBlockPattern(GroupBlockPattern lhs,
 
 static VMIGroupBlockClass
 getGroupBlockClassFromPattern(GroupBlockPattern pattern) {
-  for (const GroupBlockClassPattern &row : kGroupBlockClassPatterns)
-    if (isSameGroupBlockPattern(pattern, row.block))
+  for (const GroupBlockClassPattern &row : kGroupBlockClassPatterns) {
+    if (isSameGroupBlockPattern(pattern, row.block)) {
       return row.blockClass;
+    }
+  }
   llvm_unreachable("unsupported group block pattern");
 }
 
@@ -874,14 +891,17 @@ static bool matchesGroupBroadcastLoadMemoryPattern(
   case GroupMemoryPatternKind::Any:
     return true;
   case GroupMemoryPatternKind::Contiguous:
-    if (!stride)
+    if (!stride) {
       return false;
+    }
     return *stride == 1;
   case GroupMemoryPatternKind::BlockAligned: {
-    if (!stride)
+    if (!stride) {
       return false;
-    if (elementBits <= 0 || 256 % elementBits != 0)
+    }
+    if (elementBits <= 0 || 256 % elementBits != 0) {
       return false;
+    }
     int64_t alignedStrideElems = 256 / elementBits;
     return *stride > 0 && *stride % alignedStrideElems == 0;
   }
@@ -899,9 +919,11 @@ static bool matchesGroupLoadMemoryPattern(GroupMemoryPattern pattern,
   case GroupMemoryPatternKind::Contiguous:
     return rowStride && *rowStride == groupSize;
   case GroupMemoryPatternKind::BlockAligned: {
-    if (!rowStride || elementBits <= 0 || 256 % elementBits != 0)
+    if (!rowStride || elementBits <= 0 ||
+        kLayoutBlockBitWidth % elementBits != 0) {
       return false;
-    int64_t alignedStrideElems = 256 / elementBits;
+    }
+    int64_t alignedStrideElems = kLayoutBlockBitWidth / elementBits;
     return *rowStride > 0 && *rowStride % alignedStrideElems == 0;
   }
   }
@@ -911,35 +933,42 @@ static bool matchesGroupLoadMemoryPattern(GroupMemoryPattern pattern,
 static bool isSupportedGroupSlotMemoryLayout(VMILayoutAttr layout,
                                              int64_t numGroups) {
   if (!layout || !layout.isGroupSlots() || layout.getNumGroups() != numGroups ||
-      layout.getSlots() <= 0)
+      layout.getSlots() <= 0) {
     return false;
+  }
   for (const GroupSlotMemoryLayoutPattern &pattern :
-       kGroupSlotMemoryLayoutPatterns)
+       kGroupSlotMemoryLayoutPatterns) {
     if (matchesLayoutPattern(layout.getContext(), pattern.layout, layout,
-                             numGroups))
+                             numGroups)) {
       return true;
+    }
+  }
   return false;
 }
 
 static FailureOr<VMIGroupBlockClass> getGroupBlockClass(int64_t groupSize,
                                                         int64_t vcgBlockElems) {
-  if (vcgBlockElems <= 0)
+  if (vcgBlockElems <= 0) {
     return failure();
+  }
 
   for (const GroupBlockClassPattern &row : kGroupBlockClassPatterns) {
     GroupBlockPattern block = row.block;
     if (block.kind == GroupBlockPatternKind::FullPartMultiple) {
       int64_t fullPartElems = 8 * vcgBlockElems;
-      if (groupSize >= fullPartElems && groupSize % fullPartElems == 0)
+      if (groupSize >= fullPartElems && groupSize % fullPartElems == 0) {
         return row.blockClass;
+      }
       continue;
     }
 
     int64_t numerator = vcgBlockElems * block.numerator;
-    if (block.denominator <= 0 || numerator % block.denominator != 0)
+    if (block.denominator <= 0 || numerator % block.denominator != 0) {
       continue;
-    if (groupSize == numerator / block.denominator)
+    }
+    if (groupSize == numerator / block.denominator) {
       return row.blockClass;
+    }
   }
   return failure();
 }
@@ -967,10 +996,12 @@ static bool matchesInterleaveLayoutPattern(
     InterleaveLayoutKey key) {
   if (!matchesElementBitsPattern(pattern.elementBits,
                                  valueType.getElementType()) ||
-      !matchesPhysicalChunkCountPattern(pattern.chunks, key))
+      !matchesPhysicalChunkCountPattern(pattern.chunks, key)) {
     return false;
-  if (pattern.maxPhysicalParts <= 0)
+  }
+  if (pattern.maxPhysicalParts <= 0) {
     return true;
+  }
 
   VMILayoutAttr lhsLayout =
       materializeLayoutPattern(valueType.getContext(), pattern.lhsLayout);
@@ -985,19 +1016,22 @@ static bool matchesInterleaveLayoutPattern(
 static FailureOr<InterleaveLayoutKey>
 buildInterleaveLayoutKey(VMIVRegType valueType, std::string *reason) {
   auto fail = [&](const Twine &message) -> FailureOr<InterleaveLayoutKey> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(valueType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return fail("interleave layout requires element type with known physical "
                 "lanes per part");
+  }
   int64_t elementCount = valueType.getElementCount();
-  if (elementCount <= 0)
+  if (elementCount <= 0) {
     return fail("interleave layout requires positive logical lane count");
+  }
   int64_t physicalChunkCount =
       elementCount <= *lanesPerPart
           ? 1
@@ -1010,16 +1044,18 @@ buildInterleaveLayoutKey(VMIVRegType valueType, std::string *reason) {
 static bool matchesGroupBlockPattern(GroupBlockPattern pattern,
                                      GroupLayoutKey key) {
   if (pattern.kind == GroupBlockPatternKind::FullPartMultiple) {
-    if (pattern.numerator <= 0)
+    if (pattern.numerator <= 0) {
       return false;
+    }
     int64_t fullPartElems = key.lanesPerPart * pattern.numerator;
     return key.groupSize >= fullPartElems &&
            key.groupSize % fullPartElems == 0;
   }
 
   int64_t numerator = key.vcgBlockElems * pattern.numerator;
-  if (pattern.denominator <= 0 || numerator % pattern.denominator != 0)
+  if (pattern.denominator <= 0 || numerator % pattern.denominator != 0) {
     return false;
+  }
   return key.groupSize == numerator / pattern.denominator;
 }
 
@@ -1041,24 +1077,28 @@ buildGroupLayoutKey(VMIVRegType type, int64_t numGroups,
                     const Twine &unsupportedGroupSizeReason,
                     std::string *reason) {
   auto fail = [&](const Twine &message) -> FailureOr<GroupLayoutKey> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   FailureOr<int64_t> groupSize =
       getGroupSizeFromNumGroups(type, numGroups, reason);
-  if (failed(groupSize))
+  if (failed(groupSize)) {
     return failure();
+  }
   FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(type.getElementType());
-  if (failed(lanesPerPart) || *lanesPerPart % 8 != 0)
+  if (failed(lanesPerPart) || *lanesPerPart % mlir::pto::kValue8 != 0) {
     return fail("requires element type with known 32B VCG block width");
+  }
 
   int64_t vcgBlockElems = *lanesPerPart / 8;
   FailureOr<VMIGroupBlockClass> blockClass =
       getGroupBlockClass(*groupSize, vcgBlockElems);
-  if (failed(blockClass))
+  if (failed(blockClass)) {
     return fail(unsupportedGroupSizeReason);
+  }
 
   return GroupLayoutKey{*groupSize, *lanesPerPart, vcgBlockElems, *blockClass};
 }
@@ -1157,8 +1197,9 @@ static bool matchesVselrLayoutPattern(const VselrLayoutPattern &pattern,
       !matchesElementCountPattern(pattern.indexElements,
                                   indexType.getElementCount()) ||
       !matchesElementCountPattern(pattern.resultElements,
-                                  resultType.getElementCount()))
+                                  resultType.getElementCount())) {
     return false;
+  }
 
   FailureOr<int64_t> sourceArity =
       getPhysicalArityForLayout(sourceType, fact.sourceLayout);
@@ -1184,16 +1225,18 @@ FailureOr<VMIVselrLayoutFact>
 VMILayoutSupport::getPreferredVselrLayoutFact(
     VMIVselrOp op, std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIVselrLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   for (const VselrLayoutPattern &pattern : kVselrLayoutPatterns) {
     VMIVselrLayoutFact fact =
         materializeVselrLayoutFact(op.getContext(), pattern);
-    if (matchesVselrLayoutPattern(pattern, op, fact))
+    if (matchesVselrLayoutPattern(pattern, op, fact)) {
       return fact;
+    }
   }
   return fail("vselr requires contiguous layouts and supports N=64, 128, or "
               "256 for 8-bit, N=64 or 128 for 16-bit, and N=64 for 32-bit "
@@ -1204,8 +1247,9 @@ FailureOr<VMIVselrLayoutFact>
 VMILayoutSupport::getVselrLayoutFact(VMIVselrOp op,
                                      std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIVselrLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -1216,8 +1260,9 @@ VMILayoutSupport::getVselrLayoutFact(VMIVselrOp op,
                                   indexType.getLayoutAttr(),
                                   resultType.getLayoutAttr()};
   if (!assignedFact.sourceLayout || !assignedFact.indexLayout ||
-      !assignedFact.resultLayout)
+      !assignedFact.resultLayout) {
     return fail("vselr requires assigned source/index/result layouts");
+  }
 
   for (const VselrLayoutPattern &pattern : kVselrLayoutPatterns) {
     VMIVselrLayoutFact tableFact =
@@ -1225,8 +1270,9 @@ VMILayoutSupport::getVselrLayoutFact(VMIVselrOp op,
     if (assignedFact.sourceLayout != tableFact.sourceLayout ||
         assignedFact.indexLayout != tableFact.indexLayout ||
         assignedFact.resultLayout != tableFact.resultLayout ||
-        !matchesVselrLayoutPattern(pattern, op, assignedFact))
+        !matchesVselrLayoutPattern(pattern, op, assignedFact)) {
       continue;
+    }
     return assignedFact;
   }
   return fail("vselr requires contiguous layouts and supports N=64, 128, or "
@@ -1245,8 +1291,9 @@ VMILayoutSupport::getPreferredGroupReduceLayoutFact(VMIVRegType sourceType,
                                                     int64_t numGroups,
                                                     std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIGroupReduceLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -1255,12 +1302,14 @@ VMILayoutSupport::getPreferredGroupReduceLayoutFact(VMIVRegType sourceType,
       "group_reduce layout supports group sizes of 1/4, 1/2, 1, 2, or 4 "
       "32B VCG blocks, or full physical chunk multiples",
       reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
   for (const GroupReduceLayoutPattern &pattern : kGroupReduceLayoutPatterns) {
-    if (!matchesGroupBlockPattern(pattern.block, *key))
+    if (!matchesGroupBlockPattern(pattern.block, *key)) {
       continue;
+    }
     return materializeGroupReduceLayoutFact(sourceType.getContext(), pattern,
                                             key->groupSize, key->lanesPerPart,
                                             key->vcgBlockElems, numGroups);
@@ -1275,63 +1324,72 @@ VMILayoutSupport::getGroupReduceLayoutFactForLayouts(
     VMIVRegType sourceType, VMIMaskType maskType, VMIVRegType resultType,
     int64_t numGroups, std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIGroupReduceLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !maskLayout || !resultLayout)
+  if (!sourceLayout || !maskLayout || !resultLayout) {
     return fail("requires assigned source, mask, and result layouts");
+  }
 
   FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
       sourceType, numGroups,
       "group_reduce layout table has no row for this group size", reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
   for (const GroupReduceLayoutPattern &pattern : kGroupReduceLayoutPatterns) {
-    if (!matchesGroupBlockPattern(pattern.block, *key))
+    if (!matchesGroupBlockPattern(pattern.block, *key)) {
       continue;
+    }
     VMIGroupReduceLayoutFact candidate = materializeGroupReduceLayoutFact(
         sourceType.getContext(), pattern, key->groupSize, key->lanesPerPart,
         key->vcgBlockElems, numGroups);
     if (candidate.sourceLayout == sourceLayout &&
         candidate.maskLayout == maskLayout &&
-        candidate.resultLayout == resultLayout)
+        candidate.resultLayout == resultLayout) {
       return candidate;
+    }
   }
 
   return fail("group_reduce source/mask/result layouts do not match a legal "
               "layout table row for the group size");
 }
 
-FailureOr<SmallVector<VMIGroupReduceLayoutFact, 4>>
+FailureOr<SmallVector<VMIGroupReduceLayoutFact, mlir::pto::kValue4>>
 VMILayoutSupport::getGroupReduceLayoutFactsForLayout(
     VMIVRegType sourceType, int64_t numGroups, VMIGroupReduceLayoutPort port,
     VMILayoutAttr layout, std::string *reason) const {
   auto fail = [&](const Twine &message)
       -> FailureOr<SmallVector<VMIGroupReduceLayoutFact, 4>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned group_reduce layout query port");
+  }
 
   FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
       sourceType, numGroups,
       "group_reduce layout table has no row for this group size", reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
-  SmallVector<VMIGroupReduceLayoutFact, 4> facts;
+  SmallVector<VMIGroupReduceLayoutFact, mlir::pto::kValue4> facts;
   for (const GroupReduceLayoutPattern &pattern : kGroupReduceLayoutPatterns) {
-    if (!matchesGroupBlockPattern(pattern.block, *key))
+    if (!matchesGroupBlockPattern(pattern.block, *key)) {
       continue;
+    }
     VMIGroupReduceLayoutFact candidate = materializeGroupReduceLayoutFact(
         sourceType.getContext(), pattern, key->groupSize, key->lanesPerPart,
         key->vcgBlockElems, numGroups);
@@ -1348,13 +1406,15 @@ VMILayoutSupport::getGroupReduceLayoutFactsForLayout(
       candidateLayout = candidate.resultLayout;
       break;
     }
-    if (candidateLayout == layout)
+    if (candidateLayout == layout) {
       facts.push_back(candidate);
+    }
   }
 
-  if (facts.empty())
+  if (facts.empty()) {
     return fail("group_reduce layout query port does not match a legal layout "
                 "table row for the group size");
+  }
   return facts;
 }
 
@@ -1364,64 +1424,73 @@ VMILayoutSupport::getGroupBroadcastLayoutFactForLayouts(
     std::string *reason) const {
   auto fail =
       [&](const Twine &message) -> FailureOr<VMIGroupBroadcastLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !resultLayout)
+  if (!sourceLayout || !resultLayout) {
     return fail("requires assigned source/result layouts");
+  }
 
   FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
       resultType, numGroups,
       "group_broadcast layout table has no row for this group size", reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
   for (const GroupBroadcastLayoutPattern &pattern :
        kGroupBroadcastLayoutPatterns) {
-    if (!matchesGroupBlockPattern(pattern.block, *key))
+    if (!matchesGroupBlockPattern(pattern.block, *key)) {
       continue;
+    }
     VMIGroupBroadcastLayoutFact candidate = materializeGroupBroadcastLayoutFact(
         sourceType.getContext(), pattern, key->groupSize, key->lanesPerPart,
         key->vcgBlockElems, numGroups);
     if (candidate.sourceLayout == sourceLayout &&
-        candidate.resultLayout == resultLayout)
+        candidate.resultLayout == resultLayout) {
       return candidate;
+    }
   }
 
   return fail("source/result layouts do not match a supported group_broadcast "
               "table row");
 }
 
-FailureOr<SmallVector<VMIGroupBroadcastLayoutFact, 4>>
+FailureOr<SmallVector<VMIGroupBroadcastLayoutFact, mlir::pto::kValue4>>
 VMILayoutSupport::getGroupBroadcastLayoutFactsForLayout(
     VMIVRegType sourceType, VMIVRegType resultType, int64_t numGroups,
     VMIGroupBroadcastLayoutPort port, VMILayoutAttr layout,
     std::string *reason) const {
   auto fail = [&](const Twine &message)
       -> FailureOr<SmallVector<VMIGroupBroadcastLayoutFact, 4>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned group_broadcast layout query port");
+  }
 
   FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
       resultType, numGroups,
       "group_broadcast layout table has no row for this group size", reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
-  SmallVector<VMIGroupBroadcastLayoutFact, 4> facts;
+  SmallVector<VMIGroupBroadcastLayoutFact, mlir::pto::kValue4> facts;
   for (const GroupBroadcastLayoutPattern &pattern :
        kGroupBroadcastLayoutPatterns) {
-    if (!matchesGroupBlockPattern(pattern.block, *key))
+    if (!matchesGroupBlockPattern(pattern.block, *key)) {
       continue;
+    }
     VMIGroupBroadcastLayoutFact candidate = materializeGroupBroadcastLayoutFact(
         sourceType.getContext(), pattern, key->groupSize, key->lanesPerPart,
         key->vcgBlockElems, numGroups);
@@ -1435,13 +1504,15 @@ VMILayoutSupport::getGroupBroadcastLayoutFactsForLayout(
       candidateLayout = candidate.resultLayout;
       break;
     }
-    if (candidateLayout == layout)
+    if (candidateLayout == layout) {
       facts.push_back(candidate);
+    }
   }
 
-  if (facts.empty())
+  if (facts.empty()) {
     return fail("group_broadcast layout query port does not match a legal "
                 "layout table row for the group size");
+  }
   return facts;
 }
 
@@ -1460,19 +1531,22 @@ VMILayoutSupport::getGroupBroadcastLoadLayoutFact(VMIVRegType resultType,
                                                   std::string *reason) const {
   auto fail =
       [&](const Twine &message) -> FailureOr<VMIGroupBroadcastLoadLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!resultLayout)
+  if (!resultLayout) {
     return fail("requires assigned result layout");
+  }
 
   unsigned elementBits =
       pto::getPTOStorageElemBitWidth(resultType.getElementType());
-  if (elementBits == 0)
+  if (elementBits == 0) {
     return fail("group_broadcast_load requires known element bit width");
+  }
   std::optional<int64_t> stride =
       getConstantIndexValue(sourceGroupStride);
 
@@ -1480,21 +1554,26 @@ VMILayoutSupport::getGroupBroadcastLoadLayoutFact(VMIVRegType resultType,
       resultType, numGroups,
       "group_broadcast_load layout table has no row for this group size",
       reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
   for (const GroupBroadcastLoadLayoutPattern &pattern :
        kGroupBroadcastLoadLayoutPatterns) {
-    if (!matchesGroupBlockPattern(pattern.block, *key))
+    if (!matchesGroupBlockPattern(pattern.block, *key)) {
       continue;
-    if (!matchesElementBitsPattern(pattern.elementBits, elementBits))
+    }
+    if (!matchesElementBitsPattern(pattern.elementBits, elementBits)) {
       continue;
+    }
     if (!matchesGroupBroadcastLoadMemoryPattern(pattern.memory, stride,
-                                               elementBits))
+                                                elementBits)) {
       continue;
+    }
     if (!matchesLayoutPattern(resultType.getContext(), pattern.resultLayout,
-                              resultLayout, numGroups))
+                              resultLayout, numGroups)) {
       continue;
+    }
     return VMIGroupBroadcastLoadLayoutFact{
         getGroupBlockClassFromPattern(pattern.block),
         resultLayout,
@@ -1526,18 +1605,21 @@ VMILayoutSupport::getGroupBroadcastLoadDirectFact(
     int64_t numGroups, std::string *reason) const {
   auto fail =
       [&](const Twine &message) -> FailureOr<VMIGroupBroadcastLoadDirectFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (!isa<PtrType>(sourceType))
+  if (!isa<PtrType>(sourceType)) {
     return fail("group_broadcast_load direct lowering requires !pto.ptr source");
+  }
 
   unsigned elementBits =
       pto::getPTOStorageElemBitWidth(resultType.getElementType());
-  if (elementBits == 0)
+  if (elementBits == 0) {
     return fail("group_broadcast_load requires known element bit width");
+  }
   std::optional<int64_t> stride = getConstantIndexValue(sourceGroupStride);
 
   FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
@@ -1545,25 +1627,31 @@ VMILayoutSupport::getGroupBroadcastLoadDirectFact(
       "group_broadcast_load preferred layout table has no row for this group "
       "size",
       reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
   VMILayoutAttr existing = resultType.getLayoutAttr();
   for (const GroupBroadcastLoadDirectPattern &pattern :
        kGroupBroadcastLoadDirectPatterns) {
-    if (!matchesElementCountPattern(pattern.numGroups, numGroups))
+    if (!matchesElementCountPattern(pattern.numGroups, numGroups)) {
       continue;
-    if (!matchesGroupBlockPattern(pattern.block, *key))
+    }
+    if (!matchesGroupBlockPattern(pattern.block, *key)) {
       continue;
-    if (!matchesElementBitsPattern(pattern.elementBits, elementBits))
+    }
+    if (!matchesElementBitsPattern(pattern.elementBits, elementBits)) {
       continue;
+    }
     if (!matchesGroupBroadcastLoadMemoryPattern(pattern.memory, stride,
-                                               elementBits))
+                                                elementBits)) {
       continue;
+    }
     VMILayoutAttr resultLayout = materializeLayoutPattern(
         resultType.getContext(), pattern.resultLayout, numGroups);
-    if (existing && existing != resultLayout)
+    if (existing && existing != resultLayout) {
       continue;
+    }
     return VMIGroupBroadcastLoadDirectFact{
         pattern.kind,
         VMIGroupBroadcastLoadLayoutFact{
@@ -1609,16 +1697,18 @@ getHighPriorityCastLayoutFactImpl(VMIVRegType sourceType,
                                   bool allowLaneStrideNarrowing,
                                   std::string *reason) {
   auto [sourceBits, resultBits] = getCastElementBits(sourceType, resultType);
-  if (!allowLaneStrideNarrowing && sourceBits > resultBits)
+  if (!allowLaneStrideNarrowing && sourceBits > resultBits) {
     return failure();
+  }
 
   MLIRContext *ctx = sourceType.getContext();
   std::optional<VMICastLayoutFact> selected;
   for (const HighPriorityCastLayoutPattern &pattern :
        kHighPriorityCastLayoutPatterns) {
     if (!matchesElementBitsPattern(pattern.sourceBits, sourceBits) ||
-        !matchesElementBitsPattern(pattern.resultBits, resultBits))
+        !matchesElementBitsPattern(pattern.resultBits, resultBits)) {
       continue;
+    }
 
     VMILayoutAttr sourceLayout =
         materializeLayoutPattern(ctx, pattern.sourceLayout);
@@ -1636,11 +1726,13 @@ getHighPriorityCastLayoutFactImpl(VMIVRegType sourceType,
         !matchesPhysicalChunkCountPattern(pattern.sourceChunks,
                                           *sourceArity) ||
         !matchesPhysicalChunkCountPattern(pattern.resultChunks,
-                                          *resultArity))
+                                          *resultArity)) {
       continue;
+    }
     if (selected) {
-      if (reason)
+      if (reason) {
         *reason = "high-priority cast layout table has ambiguous matching rows";
+      }
       return failure();
     }
     selected = makeCastLayoutFact(sourceBits, resultBits, sourceLayout,
@@ -1648,20 +1740,24 @@ getHighPriorityCastLayoutFactImpl(VMIVRegType sourceType,
                                   VMICastLayoutPriority::High);
   }
   if (!selected) {
-    if (reason)
+    if (reason) {
       *reason = "requires a matching high-priority cast layout table row";
+    }
     return failure();
   }
   return *selected;
 }
 
 static int64_t getMaskGranularityBits(StringRef granularity) {
-  if (granularity == "b8")
-    return 8;
-  if (granularity == "b16")
-    return 16;
-  if (granularity == "b32")
-    return 32;
+  if (granularity == "b8") {
+    return mlir::pto::kValue8;
+  }
+  if (granularity == "b16") {
+    return mlir::pto::kValue16;
+  }
+  if (granularity == "b32") {
+    return mlir::pto::kValue32;
+  }
   return 0;
 }
 
@@ -1688,27 +1784,31 @@ static FailureOr<VMICastLayoutFact> getPreferredCastLayoutFactImpl(
   int64_t elementCount = sourceType.getElementCount();
   for (const PreferredCastLayoutPattern &pattern : patterns) {
     if (!matchesElementBitsPattern(pattern.sourceBits, sourceBits) ||
-        !matchesElementBitsPattern(pattern.resultBits, resultBits))
+        !matchesElementBitsPattern(pattern.resultBits, resultBits)) {
       continue;
+    }
     bool isExact = pattern.elementCount != 0;
-    if (isExact && pattern.elementCount != elementCount)
+    if (isExact && pattern.elementCount != elementCount) {
       continue;
+    }
     if (!selected || (isExact && !selectedIsExact)) {
       selected = &pattern;
       selectedIsExact = isExact;
       continue;
     }
     if (isExact == selectedIsExact) {
-      if (reason)
+      if (reason) {
         *reason =
             (Twine(tableName) + " has ambiguous matching rows").str();
+      }
       return failure();
     }
   }
 
   if (!selected) {
-    if (reason)
+    if (reason) {
       *reason = (Twine("requires a matching ") + tableName + " row").str();
+    }
     return failure();
   }
 
@@ -1736,21 +1836,23 @@ FailureOr<VMICastLayoutFact> VMILayoutSupport::getPreferredCastLayoutFact(
   FailureOr<VMICastLayoutFact> highPriorityFact =
       getHighPriorityCastLayoutFactImpl(sourceType, resultType,
                                         preferLaneStrideNarrowing, reason);
-  if (succeeded(highPriorityFact))
+  if (succeeded(highPriorityFact)) {
     return highPriorityFact;
+  }
   if (preferLaneStrideNarrowing) {
     FailureOr<VMICastLayoutFact> laneStrideFact =
         getPreferredLaneStrideNarrowCastLayoutFactImpl(sourceType, resultType,
                                                        reason);
-    if (succeeded(laneStrideFact))
+    if (succeeded(laneStrideFact)) {
       return laneStrideFact;
+    }
   }
   return getPreferredCastLayoutFactImpl(
       kPreferredCastLayoutPatterns, sourceType, resultType,
       "preferred cast layout table", reason);
 }
 
-FailureOr<SmallVector<VMICastLayoutFact, 4>>
+FailureOr<SmallVector<VMICastLayoutFact, mlir::pto::kValue4>>
 VMILayoutSupport::getCastLayoutFactsForLayout(VMIVRegType sourceType,
                                               VMIVRegType resultType,
                                               VMICastLayoutPort port,
@@ -1758,60 +1860,70 @@ VMILayoutSupport::getCastLayoutFactsForLayout(VMIVRegType sourceType,
                                               std::string *reason) const {
   auto fail = [&](const Twine &message)
       -> FailureOr<SmallVector<VMICastLayoutFact, 4>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   auto [sourceBits, resultBits] = getCastElementBits(sourceType, resultType);
   MLIRContext *ctx = sourceType.getContext();
-  SmallVector<VMICastLayoutFact, 4> facts;
+  SmallVector<VMICastLayoutFact, mlir::pto::kValue4> facts;
 
   int64_t numGroups =
       layout && layout.isGroupSlots() ? layout.getNumGroups() : 0;
   for (const LegalCastLayoutPattern &pattern : kLegalCastLayoutPatterns) {
     if (!matchesElementBitsPattern(pattern.sourceBits, sourceBits) ||
-        !matchesElementBitsPattern(pattern.resultBits, resultBits))
+        !matchesElementBitsPattern(pattern.resultBits, resultBits)) {
       continue;
+    }
 
     VMILayoutAttr sourceLayout =
         materializeLayoutPattern(ctx, pattern.sourceLayout, numGroups);
     VMILayoutAttr resultLayout =
         materializeLayoutPattern(ctx, pattern.resultLayout, numGroups);
-    if (!sourceLayout || !resultLayout)
+    if (!sourceLayout || !resultLayout) {
       continue;
+    }
 
-    if (port == VMICastLayoutPort::Source && sourceLayout != layout)
+    if (port == VMICastLayoutPort::Source && sourceLayout != layout) {
       continue;
-    if (port == VMICastLayoutPort::Result && resultLayout != layout)
+    }
+    if (port == VMICastLayoutPort::Result && resultLayout != layout) {
       continue;
+    }
 
     facts.push_back(
         makeCastLayoutFact(sourceBits, resultBits, sourceLayout, resultLayout));
   }
 
   if (facts.empty()) {
-    if (port == VMICastLayoutPort::Source)
+    if (port == VMICastLayoutPort::Source) {
       return fail("requires a legal cast relation for the source layout");
+    }
     return fail("requires a legal cast relation for the result layout");
   }
   return facts;
 }
 
 static FailureOr<VMICastLayoutFact>
-getUniqueCastLayoutFact(FailureOr<SmallVector<VMICastLayoutFact, 4>> facts,
+getUniqueCastLayoutFact(FailureOr<SmallVector<VMICastLayoutFact, mlir::pto::kValue4>> facts,
                         std::string *reason) {
   auto fail = [&](const Twine &message) -> FailureOr<VMICastLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
-  if (failed(facts))
+  if (failed(facts)) {
     return failure();
-  if (facts->empty())
+  }
+  if (facts->empty()) {
     return fail("cast layout query produced no layout facts");
-  if (facts->size() != 1)
+  }
+  if (facts->size() != 1) {
     return fail("cast layout query produced ambiguous layout facts");
+  }
   return facts->front();
 }
 
@@ -1839,86 +1951,100 @@ FailureOr<VMICastLayoutFact> VMILayoutSupport::getCastLayoutFactForLayouts(
     VMIVRegType sourceType, VMIVRegType resultType, VMILayoutAttr sourceLayout,
     VMILayoutAttr resultLayout, std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMICastLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  FailureOr<SmallVector<VMICastLayoutFact, 4>> facts =
+  FailureOr<SmallVector<VMICastLayoutFact, mlir::pto::kValue4>> facts =
       getCastLayoutFactsForLayout(sourceType, resultType,
                                   VMICastLayoutPort::Source, sourceLayout,
                                   reason);
-  if (failed(facts))
+  if (failed(facts)) {
     return failure();
+  }
 
   std::optional<VMICastLayoutFact> selected;
   for (const VMICastLayoutFact &fact : *facts) {
-    if (fact.resultLayout != resultLayout)
+    if (fact.resultLayout != resultLayout) {
       continue;
-    if (selected)
+    }
+    if (selected) {
       return fail("cast layout query produced ambiguous layout facts");
+    }
     selected = fact;
   }
-  if (!selected)
+  if (!selected) {
     return fail("source/result layouts do not match a legal cast table row");
+  }
   return *selected;
 }
 
-FailureOr<SmallVector<VMIMaskGranularityCastLayoutFact, 4>>
+FailureOr<SmallVector<VMIMaskGranularityCastLayoutFact, mlir::pto::kValue4>>
 VMILayoutSupport::getMaskGranularityCastLayoutFactsForLayout(
     VMIMaskType sourceType, VMIMaskType resultType, VMICastLayoutPort port,
     VMILayoutAttr layout, std::string *reason) const {
   auto fail = [&](const Twine &message)
       -> FailureOr<SmallVector<VMIMaskGranularityCastLayoutFact, 4>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (sourceType.getElementCount() != resultType.getElementCount())
+  if (sourceType.getElementCount() != resultType.getElementCount()) {
     return fail("requires source and result mask lane counts to match");
+  }
   if (!VMIMaskType::isConcreteGranularity(sourceType.getGranularity()) ||
-      !VMIMaskType::isConcreteGranularity(resultType.getGranularity()))
+      !VMIMaskType::isConcreteGranularity(resultType.getGranularity())) {
     return fail("requires concrete b8/b16/b32 source and result "
                 "granularities");
+  }
 
   int64_t sourceBits = getMaskGranularityBits(sourceType.getGranularity());
   int64_t resultBits = getMaskGranularityBits(resultType.getGranularity());
-  if (sourceBits == 0 || resultBits == 0)
+  if (sourceBits == 0 || resultBits == 0) {
     return fail("requires supported source/result mask granularities");
+  }
 
   MLIRContext *ctx = sourceType.getContext();
   int64_t numGroups =
       layout && layout.isGroupSlots() ? layout.getNumGroups() : 0;
-  SmallVector<VMIMaskGranularityCastLayoutFact, 4> facts;
+  SmallVector<VMIMaskGranularityCastLayoutFact, mlir::pto::kValue4> facts;
   for (const LegalMaskGranularityCastLayoutPattern &pattern :
        kLegalMaskGranularityCastLayoutPatterns) {
     if (!matchesMaskGranularityPattern(pattern.sourceGranularity,
                                        sourceType.getGranularity()) ||
         !matchesMaskGranularityPattern(pattern.resultGranularity,
-                                       resultType.getGranularity()))
+                                       resultType.getGranularity())) {
       continue;
+    }
 
     VMILayoutAttr sourceLayout =
         materializeLayoutPattern(ctx, pattern.sourceLayout, numGroups);
     VMILayoutAttr resultLayout =
         materializeLayoutPattern(ctx, pattern.resultLayout, numGroups);
-    if (!sourceLayout || !resultLayout)
+    if (!sourceLayout || !resultLayout) {
       continue;
+    }
 
-    if (port == VMICastLayoutPort::Source && sourceLayout != layout)
+    if (port == VMICastLayoutPort::Source && sourceLayout != layout) {
       continue;
-    if (port == VMICastLayoutPort::Result && resultLayout != layout)
+    }
+    if (port == VMICastLayoutPort::Result && resultLayout != layout) {
       continue;
+    }
 
     facts.push_back(makeMaskGranularityCastLayoutFact(
         sourceBits, resultBits, sourceLayout, resultLayout));
   }
 
   if (facts.empty()) {
-    if (port == VMICastLayoutPort::Source)
+    if (port == VMICastLayoutPort::Source) {
       return fail("requires a legal mask granularity cast relation for the "
                   "source layout");
+    }
     return fail("requires a legal mask granularity cast relation for the "
                 "result layout");
   }
@@ -1931,30 +2057,35 @@ VMILayoutSupport::getMaskGranularityCastLayoutFactForLayouts(
     VMILayoutAttr resultLayout, std::string *reason) const {
   auto fail =
       [&](const Twine &message) -> FailureOr<VMIMaskGranularityCastLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  FailureOr<SmallVector<VMIMaskGranularityCastLayoutFact, 4>> facts =
+  FailureOr<SmallVector<VMIMaskGranularityCastLayoutFact, mlir::pto::kValue4>> facts =
       getMaskGranularityCastLayoutFactsForLayout(
           sourceType, resultType, VMICastLayoutPort::Source, sourceLayout,
           reason);
-  if (failed(facts))
+  if (failed(facts)) {
     return failure();
+  }
 
   std::optional<VMIMaskGranularityCastLayoutFact> selected;
   for (const VMIMaskGranularityCastLayoutFact &fact : *facts) {
-    if (fact.resultLayout != resultLayout)
+    if (fact.resultLayout != resultLayout) {
       continue;
-    if (selected)
+    }
+    if (selected) {
       return fail("mask granularity cast layout query produced ambiguous "
                   "layout facts");
+    }
     selected = fact;
   }
-  if (!selected)
+  if (!selected) {
     return fail("source/result layouts do not match a legal mask granularity "
                 "cast table row");
+  }
   return *selected;
 }
 
@@ -1963,8 +2094,9 @@ FailureOr<VMILayoutAttr> VMILayoutSupport::getWidenSourceLayoutForResultLayout(
     VMILayoutAttr requestedResultLayout, std::string *reason) const {
   FailureOr<VMICastLayoutFact> fact = getCastLayoutFactForResultLayout(
       sourceType, resultType, requestedResultLayout, reason);
-  if (failed(fact))
+  if (failed(fact)) {
     return failure();
+  }
   return fact->sourceLayout;
 }
 
@@ -1972,19 +2104,22 @@ static FailureOr<VMIInterleaveLayoutFact> getPreferredInterleaveLayoutFactImpl(
     ArrayRef<InterleaveLayoutPattern> patterns, VMIVRegType valueType,
     std::string *reason) {
   auto fail = [&](const Twine &message) -> FailureOr<VMIInterleaveLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   FailureOr<InterleaveLayoutKey> key =
       buildInterleaveLayoutKey(valueType, reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
   for (const InterleaveLayoutPattern &pattern : patterns) {
-    if (!matchesInterleaveLayoutPattern(pattern, valueType, *key))
+    if (!matchesInterleaveLayoutPattern(pattern, valueType, *key)) {
       continue;
+    }
     return materializeInterleaveLayoutFact(valueType.getContext(), pattern,
                                            *key);
   }
@@ -1992,30 +2127,34 @@ static FailureOr<VMIInterleaveLayoutFact> getPreferredInterleaveLayoutFactImpl(
   return fail("requires a preferred interleave layout table row");
 }
 
-static FailureOr<SmallVector<VMIInterleaveLayoutFact, 4>>
+static FailureOr<SmallVector<VMIInterleaveLayoutFact, mlir::pto::kValue4>>
 getInterleaveLayoutFactsForLayoutImpl(
     ArrayRef<InterleaveLayoutPattern> patterns, VMIVRegType valueType,
     VMIInterleaveLayoutPort port, VMILayoutAttr layout,
     std::string *reason) {
   auto fail = [&](const Twine &message)
       -> FailureOr<SmallVector<VMIInterleaveLayoutFact, 4>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned interleave layout query port");
+  }
 
   FailureOr<InterleaveLayoutKey> key =
       buildInterleaveLayoutKey(valueType, reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
-  SmallVector<VMIInterleaveLayoutFact, 4> facts;
+  SmallVector<VMIInterleaveLayoutFact, mlir::pto::kValue4> facts;
   for (const InterleaveLayoutPattern &pattern : patterns) {
-    if (!matchesInterleaveLayoutPattern(pattern, valueType, *key))
+    if (!matchesInterleaveLayoutPattern(pattern, valueType, *key)) {
       continue;
+    }
     VMIInterleaveLayoutFact candidate =
         materializeInterleaveLayoutFact(valueType.getContext(), pattern, *key);
 
@@ -2037,13 +2176,15 @@ getInterleaveLayoutFactsForLayoutImpl(
       candidateLayout = candidate.highLayout;
       break;
     }
-    if (candidateLayout == layout)
+    if (candidateLayout == layout) {
       facts.push_back(candidate);
+    }
   }
 
-  if (facts.empty())
+  if (facts.empty()) {
     return fail("interleave layout query port does not match a legal layout "
                 "table row for the vector shape");
+  }
   return facts;
 }
 
@@ -2052,49 +2193,57 @@ static FailureOr<VMIInterleaveLayoutFact> getInterleaveLayoutFactForLayoutsImpl(
     VMIVRegType rhsType, VMIMaskType maskType, VMIVRegType lowType,
     VMIVRegType highType, std::string *reason) {
   auto fail = [&](const Twine &message) -> FailureOr<VMIInterleaveLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   if (lhsType.getElementCount() != rhsType.getElementCount() ||
       lhsType.getElementCount() != lowType.getElementCount() ||
       lhsType.getElementCount() != highType.getElementCount() ||
-      lhsType.getElementCount() != maskType.getElementCount())
+      lhsType.getElementCount() != maskType.getElementCount()) {
     return fail("interleave layout requires all ports to share logical lane "
                 "count");
+  }
   if (lhsType.getElementType() != rhsType.getElementType() ||
       lhsType.getElementType() != lowType.getElementType() ||
-      lhsType.getElementType() != highType.getElementType())
+      lhsType.getElementType() != highType.getElementType()) {
     return fail("interleave layout requires all data ports to share element "
                 "type");
+  }
 
   VMILayoutAttr lhsLayout = lhsType.getLayoutAttr();
   VMILayoutAttr rhsLayout = rhsType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
   VMILayoutAttr lowLayout = lowType.getLayoutAttr();
   VMILayoutAttr highLayout = highType.getLayoutAttr();
-  if (!lhsLayout || !rhsLayout || !maskLayout || !lowLayout || !highLayout)
+  if (!lhsLayout || !rhsLayout || !maskLayout || !lowLayout || !highLayout) {
     return fail("requires assigned lhs/rhs/mask/low/high layouts");
+  }
 
-  FailureOr<SmallVector<VMIInterleaveLayoutFact, 4>> facts =
+  FailureOr<SmallVector<VMIInterleaveLayoutFact, mlir::pto::kValue4>> facts =
       getInterleaveLayoutFactsForLayoutImpl(
           patterns, lhsType, VMIInterleaveLayoutPort::Lhs, lhsLayout, reason);
-  if (failed(facts))
+  if (failed(facts)) {
     return failure();
+  }
 
   std::optional<VMIInterleaveLayoutFact> selected;
   for (const VMIInterleaveLayoutFact &fact : *facts) {
     if (fact.rhsLayout != rhsLayout || fact.maskLayout != maskLayout ||
-        fact.lowLayout != lowLayout || fact.highLayout != highLayout)
+        fact.lowLayout != lowLayout || fact.highLayout != highLayout) {
       continue;
-    if (selected)
+    }
+    if (selected) {
       return fail("interleave layout query produced ambiguous layout facts");
+    }
     selected = fact;
   }
-  if (!selected)
+  if (!selected) {
     return fail("lhs/rhs/mask/low/high layouts do not match a legal "
                 "interleave layout table row");
+  }
   return *selected;
 }
 
@@ -2112,7 +2261,7 @@ VMILayoutSupport::getPreferredVdintlvLayoutFact(
                                               reason);
 }
 
-FailureOr<SmallVector<VMIInterleaveLayoutFact, 4>>
+FailureOr<SmallVector<VMIInterleaveLayoutFact, mlir::pto::kValue4>>
 VMILayoutSupport::getVintlvLayoutFactsForLayout(
     VMIVRegType valueType, VMIInterleaveLayoutPort port, VMILayoutAttr layout,
     std::string *reason) const {
@@ -2120,7 +2269,7 @@ VMILayoutSupport::getVintlvLayoutFactsForLayout(
       kVintlvLayoutPatterns, valueType, port, layout, reason);
 }
 
-FailureOr<SmallVector<VMIInterleaveLayoutFact, 4>>
+FailureOr<SmallVector<VMIInterleaveLayoutFact, mlir::pto::kValue4>>
 VMILayoutSupport::getVdintlvLayoutFactsForLayout(
     VMIVRegType valueType, VMIInterleaveLayoutPort port, VMILayoutAttr layout,
     std::string *reason) const {
@@ -2150,23 +2299,28 @@ FailureOr<VMILoadLayoutFact>
 VMILayoutSupport::getLoadLayoutFact(VMIVRegType resultType,
                                     std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMILoadLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr layout = resultType.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned result layout");
+  }
   for (const DenseMemoryLayoutPattern &pattern : kDenseLoadLayoutPatterns) {
     if (!matchesElementBitsPattern(pattern.elementBits,
-                                   resultType.getElementType()))
+                                   resultType.getElementType())) {
       continue;
+    }
     if (!matchesElementCountPattern(pattern.elementCounts,
-                                    resultType.getElementCount()))
+                                    resultType.getElementCount())) {
       continue;
-    if (!matchesLayoutPattern(resultType.getContext(), pattern.layout, layout))
+    }
+    if (!matchesLayoutPattern(resultType.getContext(), pattern.layout, layout)) {
       continue;
+    }
     return VMILoadLayoutFact{layout};
   }
 
@@ -2178,52 +2332,59 @@ VMILayoutSupport::getPreferredDeinterleaveLoadLayoutFact(
     VMIVRegType valueType, std::string *reason) const {
   auto fail =
       [&](const Twine &message) -> FailureOr<VMIDeinterleaveLoadLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   for (const DeinterleaveLoadLayoutPattern &pattern :
        kDeinterleaveLoadLayoutPatterns) {
     if (!matchesElementBitsPattern(pattern.elementBits,
-                                   valueType.getElementType()))
+                                   valueType.getElementType())) {
       continue;
+    }
     return materializeDeinterleaveLoadLayoutFact(valueType.getContext(),
                                                  pattern);
   }
   return fail("requires a preferred deinterleave_load layout table row");
 }
 
-FailureOr<SmallVector<VMIDeinterleaveLoadLayoutFact, 4>>
+FailureOr<SmallVector<VMIDeinterleaveLoadLayoutFact, mlir::pto::kValue4>>
 VMILayoutSupport::getDeinterleaveLoadLayoutFactsForLayout(
     VMIVRegType valueType, VMIDeinterleaveLoadLayoutPort port,
     VMILayoutAttr layout, std::string *reason) const {
   auto fail = [&](const Twine &message)
       -> FailureOr<SmallVector<VMIDeinterleaveLoadLayoutFact, 4>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned deinterleave_load layout query port");
+  }
 
-  SmallVector<VMIDeinterleaveLoadLayoutFact, 4> facts;
+  SmallVector<VMIDeinterleaveLoadLayoutFact, mlir::pto::kValue4> facts;
   for (const DeinterleaveLoadLayoutPattern &pattern :
        kDeinterleaveLoadLayoutPatterns) {
     if (!matchesElementBitsPattern(pattern.elementBits,
-                                   valueType.getElementType()))
+                                   valueType.getElementType())) {
       continue;
+    }
     VMIDeinterleaveLoadLayoutFact candidate =
         materializeDeinterleaveLoadLayoutFact(valueType.getContext(), pattern);
     VMILayoutAttr candidateLayout =
         port == VMIDeinterleaveLoadLayoutPort::Low ? candidate.lowLayout
                                                    : candidate.highLayout;
-    if (candidateLayout == layout)
+    if (candidateLayout == layout) {
       facts.push_back(candidate);
+    }
   }
-  if (facts.empty())
+  if (facts.empty()) {
     return fail("deinterleave_load layout query port does not match a legal "
                 "layout table row");
+  }
   return facts;
 }
 
@@ -2232,28 +2393,34 @@ VMILayoutSupport::getDeinterleaveLoadLayoutFactForLayouts(
     VMIVRegType lowType, VMIVRegType highType, std::string *reason) const {
   auto fail =
       [&](const Twine &message) -> FailureOr<VMIDeinterleaveLoadLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
   if (lowType.getElementCount() != highType.getElementCount() ||
-      lowType.getElementType() != highType.getElementType())
+      lowType.getElementType() != highType.getElementType()) {
     return fail("deinterleave_load layout requires low/high to share shape "
                 "and element type");
+  }
 
   VMILayoutAttr lowLayout = lowType.getLayoutAttr();
   VMILayoutAttr highLayout = highType.getLayoutAttr();
-  if (!lowLayout || !highLayout)
+  if (!lowLayout || !highLayout) {
     return fail("requires assigned low/high layouts");
+  }
 
-  FailureOr<SmallVector<VMIDeinterleaveLoadLayoutFact, 4>> facts =
+  FailureOr<SmallVector<VMIDeinterleaveLoadLayoutFact, mlir::pto::kValue4>> facts =
       getDeinterleaveLoadLayoutFactsForLayout(
           lowType, VMIDeinterleaveLoadLayoutPort::Low, lowLayout, reason);
-  if (failed(facts))
+  if (failed(facts)) {
     return failure();
-  for (const VMIDeinterleaveLoadLayoutFact &fact : *facts)
-    if (fact.highLayout == highLayout)
+  }
+  for (const VMIDeinterleaveLoadLayoutFact &fact : *facts) {
+    if (fact.highLayout == highLayout) {
       return fact;
+    }
+  }
   return fail("low/high layouts do not match a legal deinterleave_load layout "
               "table row");
 }
@@ -2262,23 +2429,28 @@ FailureOr<VMIStoreLayoutFact>
 VMILayoutSupport::getStoreLayoutFact(VMIVRegType valueType,
                                      std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIStoreLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr layout = valueType.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned value layout");
+  }
   for (const DenseMemoryLayoutPattern &pattern : kDenseStoreLayoutPatterns) {
     if (!matchesElementBitsPattern(pattern.elementBits,
-                                   valueType.getElementType()))
+                                   valueType.getElementType())) {
       continue;
+    }
     if (!matchesElementCountPattern(pattern.elementCounts,
-                                    valueType.getElementCount()))
+                                    valueType.getElementCount())) {
       continue;
-    if (!matchesLayoutPattern(valueType.getContext(), pattern.layout, layout))
+    }
+    if (!matchesLayoutPattern(valueType.getContext(), pattern.layout, layout)) {
       continue;
+    }
     return VMIStoreLayoutFact{layout};
   }
 
@@ -2289,27 +2461,33 @@ FailureOr<VMIStoreLayoutFact>
 VMILayoutSupport::getPreferredStoreLayoutFact(VMIVRegType valueType,
                                               std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIStoreLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (valueType.getLayoutAttr())
+  if (valueType.getLayoutAttr()) {
     return getStoreLayoutFact(valueType, reason);
+  }
 
   for (const DenseMemoryLayoutPattern &pattern : kDenseStoreLayoutPatterns) {
-    if (!pattern.preferred)
+    if (!pattern.preferred) {
       continue;
+    }
     if (!matchesElementBitsPattern(pattern.elementBits,
-                                   valueType.getElementType()))
+                                   valueType.getElementType())) {
       continue;
+    }
     if (!matchesElementCountPattern(pattern.elementCounts,
-                                    valueType.getElementCount()))
+                                    valueType.getElementCount())) {
       continue;
+    }
     VMILayoutAttr layout =
         materializeLayoutPattern(valueType.getContext(), pattern.layout);
-    if (!layout)
+    if (!layout) {
       continue;
+    }
     return VMIStoreLayoutFact{layout};
   }
 
@@ -2319,29 +2497,35 @@ VMILayoutSupport::getPreferredStoreLayoutFact(VMIVRegType valueType,
 FailureOr<VMIMaskedStoreLayoutFact> VMILayoutSupport::getMaskedStoreLayoutFact(
     VMIVRegType valueType, VMIMaskType maskType, std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIMaskedStoreLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr valueLayout = valueType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  if (!valueLayout || !maskLayout)
+  if (!valueLayout || !maskLayout) {
     return fail("requires assigned value/mask layouts");
+  }
   for (const DenseMaskedStoreLayoutPattern &pattern :
        kDenseMaskedStoreLayoutPatterns) {
     if (!matchesElementBitsPattern(pattern.elementBits,
-                                   valueType.getElementType()))
+                                   valueType.getElementType())) {
       continue;
+    }
     if (!matchesElementCountPattern(pattern.elementCounts,
-                                    valueType.getElementCount()))
+                                    valueType.getElementCount())) {
       continue;
+    }
     if (!matchesLayoutPattern(valueType.getContext(), pattern.valueLayout,
-                              valueLayout))
+                              valueLayout)) {
       continue;
+    }
     if (!matchesLayoutPattern(maskType.getContext(), pattern.maskLayout,
-                              maskLayout))
+                              maskLayout)) {
       continue;
+    }
     return VMIMaskedStoreLayoutFact{valueLayout, maskLayout};
   }
 
@@ -2354,37 +2538,45 @@ VMILayoutSupport::getPreferredMaskedStoreLayoutFact(
     VMIVRegType valueType, VMIMaskType maskType, std::string *reason) const {
   auto fail =
       [&](const Twine &message) -> FailureOr<VMIMaskedStoreLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr existingValueLayout = valueType.getLayoutAttr();
   VMILayoutAttr existingMaskLayout = maskType.getLayoutAttr();
-  if (existingValueLayout && existingMaskLayout)
+  if (existingValueLayout && existingMaskLayout) {
     return getMaskedStoreLayoutFact(valueType, maskType, reason);
+  }
 
   for (const DenseMaskedStoreLayoutPattern &pattern :
        kDenseMaskedStoreLayoutPatterns) {
-    if (!pattern.preferred)
+    if (!pattern.preferred) {
       continue;
+    }
     if (!matchesElementBitsPattern(pattern.elementBits,
-                                   valueType.getElementType()))
+                                   valueType.getElementType())) {
       continue;
+    }
     if (!matchesElementCountPattern(pattern.elementCounts,
-                                    valueType.getElementCount()))
+                                    valueType.getElementCount())) {
       continue;
+    }
 
     VMILayoutAttr valueLayout =
         materializeLayoutPattern(valueType.getContext(), pattern.valueLayout);
     VMILayoutAttr maskLayout =
         materializeLayoutPattern(maskType.getContext(), pattern.maskLayout);
-    if (!valueLayout || !maskLayout)
+    if (!valueLayout || !maskLayout) {
       continue;
-    if (existingValueLayout && existingValueLayout != valueLayout)
+    }
+    if (existingValueLayout && existingValueLayout != valueLayout) {
       continue;
-    if (existingMaskLayout && existingMaskLayout != maskLayout)
+    }
+    if (existingMaskLayout && existingMaskLayout != maskLayout) {
       continue;
+    }
     return VMIMaskedStoreLayoutFact{valueLayout, maskLayout};
   }
 
@@ -2396,30 +2588,36 @@ FailureOr<VMIMaskedLoadLayoutFact> VMILayoutSupport::getMaskedLoadLayoutFact(
     VMIVRegType resultType, VMIMaskType maskType, VMIVRegType passthruType,
     std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIMaskedLoadLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
   VMILayoutAttr passthruLayout = passthruType.getLayoutAttr();
-  if (!resultLayout || !maskLayout || !passthruLayout)
+  if (!resultLayout || !maskLayout || !passthruLayout) {
     return fail("requires assigned result/mask/passthru layouts");
+  }
   for (const DenseMaskedLoadLayoutPattern &pattern :
        kDenseMaskedLoadLayoutPatterns) {
     if (!matchesElementBitsPattern(pattern.elementBits,
-                                   resultType.getElementType()))
+                                   resultType.getElementType())) {
       continue;
+    }
     if (!matchesLayoutPattern(resultType.getContext(), pattern.resultLayout,
-                              resultLayout))
+                              resultLayout)) {
       continue;
+    }
     if (!matchesLayoutPattern(maskType.getContext(), pattern.maskLayout,
-                              maskLayout))
+                              maskLayout)) {
       continue;
+    }
     if (!matchesLayoutPattern(passthruType.getContext(),
-                              pattern.passthruLayout, passthruLayout))
+                              pattern.passthruLayout, passthruLayout)) {
       continue;
+    }
     return VMIMaskedLoadLayoutFact{resultLayout, maskLayout, passthruLayout};
   }
 
@@ -2433,14 +2631,17 @@ static LogicalResult matchEnsureLayoutPattern(VMIVRegType sourceType,
                                               VMILayoutAttr resultLayout,
                                               std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
-  if (!sourceLayout || !resultLayout)
+  if (!sourceLayout || !resultLayout) {
     return fail("requires assigned source/result layouts");
-  if (sourceLayout == resultLayout)
+  }
+  if (sourceLayout == resultLayout) {
     return success();
+  }
 
   int64_t numGroups =
       sourceLayout.isGroupSlots()
@@ -2449,17 +2650,21 @@ static LogicalResult matchEnsureLayoutPattern(VMIVRegType sourceType,
 
   for (const EnsureLayoutPattern &pattern : kEnsureLayoutPatterns) {
     if (!matchesElementBitsPattern(pattern.elementBits,
-                                   sourceType.getElementType()))
+                                   sourceType.getElementType())) {
       continue;
+    }
     if (!matchesElementCountPattern(pattern.elementCounts,
-                                    sourceType.getElementCount()))
+                                    sourceType.getElementCount())) {
       continue;
+    }
     if (!matchesLayoutPattern(sourceType.getContext(), pattern.sourceLayout,
-                              sourceLayout, numGroups))
+                              sourceLayout, numGroups)) {
       continue;
+    }
     if (!matchesLayoutPattern(resultType.getContext(), pattern.resultLayout,
-                              resultLayout, numGroups))
+                              resultLayout, numGroups)) {
       continue;
+    }
     return success();
   }
 
@@ -2473,28 +2678,35 @@ static LogicalResult matchEnsureMaskLayoutPattern(VMIMaskType sourceType,
                                                   VMILayoutAttr resultLayout,
                                                   std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
-  if (!sourceLayout || !resultLayout)
+  if (!sourceLayout || !resultLayout) {
     return fail("requires assigned source/result layouts");
-  if (sourceLayout == resultLayout)
+  }
+  if (sourceLayout == resultLayout) {
     return success();
+  }
 
   for (const EnsureMaskLayoutPattern &pattern : kEnsureMaskLayoutPatterns) {
     if (!matchesMaskGranularityPattern(pattern.granularity,
-                                       sourceType.getGranularity()))
+                                       sourceType.getGranularity())) {
       continue;
+    }
     if (!matchesElementCountPattern(pattern.elementCounts,
-                                    sourceType.getElementCount()))
+                                    sourceType.getElementCount())) {
       continue;
+    }
     if (!matchesLayoutPattern(sourceType.getContext(), pattern.sourceLayout,
-                              sourceLayout))
+                              sourceLayout)) {
       continue;
+    }
     if (!matchesLayoutPattern(resultType.getContext(), pattern.resultLayout,
-                              resultLayout))
+                              resultLayout)) {
       continue;
+    }
     return success();
   }
 
@@ -2507,8 +2719,9 @@ FailureOr<VMIEnsureLayoutFact> VMILayoutSupport::getEnsureLayoutFact(
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
   if (failed(matchEnsureLayoutPattern(sourceType, resultType, sourceLayout,
-                                      resultLayout, reason)))
+                                      resultLayout, reason))) {
     return failure();
+  }
   return VMIEnsureLayoutFact{sourceLayout, resultLayout};
 }
 
@@ -2517,26 +2730,30 @@ FailureOr<VMIEnsureMaskLayoutFact> VMILayoutSupport::getEnsureMaskLayoutFact(
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
   if (failed(matchEnsureMaskLayoutPattern(sourceType, resultType, sourceLayout,
-                                          resultLayout, reason)))
+                                          resultLayout, reason))) {
     return failure();
+  }
   return VMIEnsureMaskLayoutFact{sourceLayout, resultLayout};
 }
 
 FailureOr<VMIGroupSlotLayoutFact> VMILayoutSupport::getGroupSlotLoadLayoutFact(
     VMIVRegType resultType, int64_t numGroups, std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIGroupSlotLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr layout = resultType.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned result layout");
+  }
 
-  if (!isSupportedGroupSlotMemoryLayout(layout, numGroups))
+  if (!isSupportedGroupSlotMemoryLayout(layout, numGroups)) {
     return fail("result layout does not match a supported group_slot_load "
                 "table row");
+  }
 
   return VMIGroupSlotLayoutFact{layout, numGroups, layout.getSlots()};
 }
@@ -2553,38 +2770,46 @@ FailureOr<VMIGroupLoadLayoutFact> VMILayoutSupport::getGroupLoadLayoutFact(
     VMIVRegType resultType, Value rowStride, int64_t numGroups,
     std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIGroupLoadLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr layout = resultType.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned result layout");
+  }
 
   unsigned elementBits =
       pto::getPTOStorageElemBitWidth(resultType.getElementType());
-  if (elementBits == 0)
+  if (elementBits == 0) {
     return fail("group_load requires known element bit width");
+  }
   std::optional<int64_t> stride = getConstantIndexValue(rowStride);
 
   FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
       resultType, numGroups,
       "group_load layout table has no row for this group size", reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
   for (const GroupLoadLayoutPattern &pattern : kGroupLoadLayoutPatterns) {
-    if (!matchesElementBitsPattern(pattern.elementBits, elementBits))
+    if (!matchesElementBitsPattern(pattern.elementBits, elementBits)) {
       continue;
-    if (!matchesGroupBlockPattern(pattern.block, *key))
+    }
+    if (!matchesGroupBlockPattern(pattern.block, *key)) {
       continue;
+    }
     if (!matchesGroupLoadMemoryPattern(pattern.memory, stride, key->groupSize,
-                                       elementBits))
+                                       elementBits)) {
       continue;
+    }
     if (!matchesLayoutPattern(resultType.getContext(), pattern.resultLayout,
-                              layout))
+                              layout)) {
       continue;
+    }
     return VMIGroupLoadLayoutFact{
         getGroupBlockClassFromPattern(pattern.block), layout, key->groupSize};
   }
@@ -2596,56 +2821,66 @@ FailureOr<VMIGroupLoadLayoutFact> VMILayoutSupport::getGroupLoadLayoutFact(
 FailureOr<VMIGroupSlotLayoutFact> VMILayoutSupport::getGroupStoreLayoutFact(
     VMIVRegType valueType, int64_t numGroups, std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIGroupSlotLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr layout = valueType.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned value layout");
-  if (!isSupportedGroupSlotMemoryLayout(layout, numGroups))
+  }
+  if (!isSupportedGroupSlotMemoryLayout(layout, numGroups)) {
     return fail("value layout does not match a supported group_store table "
                 "row");
+  }
   return VMIGroupSlotLayoutFact{layout, numGroups, layout.getSlots()};
 }
 
 FailureOr<VMIGroupStoreLayoutFact> VMILayoutSupport::getGroupStoreLayoutFact(
     VMIGroupStoreOp op, VMIVRegType valueType, std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIGroupStoreLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr layout = valueType.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned value layout");
+  }
 
   int64_t numGroups = op.getNumGroupsAttr().getInt();
   if (layout.isGroupSlots()) {
-    if (failed(getGroupStoreLayoutFact(valueType, numGroups, reason)))
+    if (failed(getGroupStoreLayoutFact(valueType, numGroups, reason))) {
       return failure();
+    }
     return VMIGroupStoreLayoutFact{layout};
   }
 
-  if (pto::getPTOStorageElemBitWidth(valueType.getElementType()) == 0)
+  if (pto::getPTOStorageElemBitWidth(valueType.getElementType()) == 0) {
     return fail("group_store requires known element bit width");
+  }
 
   FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
       valueType, numGroups,
       "group_store layout table has no row for this group size", reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
   std::optional<int64_t> rowStride =
       getConstantIndexValue(op.getRowStride());
   for (const GroupStoreLayoutPattern &pattern : kGroupStoreLayoutPatterns) {
-    if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride))
+    if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride)) {
       continue;
+    }
     if (!matchesLayoutPattern(valueType.getContext(), pattern.valueLayout,
-                              layout))
+                              layout)) {
       continue;
+    }
     VMIGroupStoreLayoutFact fact =
         materializeGroupStoreLayoutFact(valueType.getContext(), pattern, *key);
     fact.valueLayout = layout;
@@ -2656,40 +2891,45 @@ FailureOr<VMIGroupStoreLayoutFact> VMILayoutSupport::getGroupStoreLayoutFact(
               "supported group_store table row");
 }
 
-FailureOr<SmallVector<VMIGroupStoreLayoutFact, 4>>
+FailureOr<SmallVector<VMIGroupStoreLayoutFact, mlir::pto::kValue4>>
 VMILayoutSupport::getGroupStoreLayoutFactsForLayout(
     VMIGroupStoreOp op, VMIVRegType valueType, VMILayoutAttr layout,
     std::string *reason) const {
   auto fail = [&](const Twine &message)
       -> FailureOr<SmallVector<VMIGroupStoreLayoutFact, 4>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned group_store value layout");
+  }
 
   MLIRContext *ctx = valueType.getContext();
   auto sourceType = VMIVRegType::get(ctx, valueType.getElementCount(),
                                     valueType.getElementType(), layout);
   FailureOr<VMIGroupStoreLayoutFact> directFact =
       getGroupStoreLayoutFact(op, sourceType, nullptr);
-  if (succeeded(directFact))
-    return SmallVector<VMIGroupStoreLayoutFact, 4>{*directFact};
+  if (succeeded(directFact)) {
+    return SmallVector<VMIGroupStoreLayoutFact, mlir::pto::kValue4>{*directFact};
+  }
 
   FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
       valueType, op.getNumGroupsAttr().getInt(),
       "group_store layout table has no row for this group size", reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
   std::optional<int64_t> rowStride =
       getConstantIndexValue(op.getRowStride());
-  SmallVector<VMIGroupStoreLayoutFact, 4> facts;
+  SmallVector<VMIGroupStoreLayoutFact, mlir::pto::kValue4> facts;
   for (const GroupStoreLayoutPattern &pattern : kGroupStoreLayoutPatterns) {
-    if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride))
+    if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride)) {
       continue;
+    }
 
     VMILayoutAttr useLayout =
         materializeLayoutPattern(ctx, pattern.valueLayout);
@@ -2697,22 +2937,25 @@ VMILayoutSupport::getGroupStoreLayoutFactsForLayout(
         facts, [&](const VMIGroupStoreLayoutFact &fact) {
           return fact.valueLayout == useLayout;
         });
-    if (!useLayout || duplicate)
+    if (!useLayout || duplicate) {
       continue;
+    }
 
     auto useType = VMIVRegType::get(ctx, valueType.getElementCount(),
                                    valueType.getElementType(), useLayout);
-    if (failed(getEnsureLayoutFact(sourceType, useType, nullptr)))
+    if (failed(getEnsureLayoutFact(sourceType, useType, nullptr))) {
       continue;
+    }
     VMIGroupStoreLayoutFact fact =
         materializeGroupStoreLayoutFact(ctx, pattern, *key);
     fact.valueLayout = useLayout;
     facts.push_back(fact);
   }
 
-  if (facts.empty())
+  if (facts.empty()) {
     return fail("value layout cannot be used directly or materialized to a "
                 "supported group_store layout table row");
+  }
   return facts;
 }
 
@@ -2720,8 +2963,9 @@ FailureOr<VMIGroupStoreLayoutFact>
 VMILayoutSupport::getPreferredGroupStoreLayoutFact(
     VMIGroupStoreOp op, VMIVRegType valueType, std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIGroupStoreLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2736,33 +2980,40 @@ VMILayoutSupport::getPreferredGroupStoreLayoutFact(
         VMILayoutAttr::getGroupSlots(ctx, numGroups, packedSlots ? 8 : 1);
     auto assignedType = VMIVRegType::get(
         ctx, valueType.getElementCount(), valueType.getElementType(), layout);
-    if (succeeded(getGroupStoreLayoutFact(op, assignedType, nullptr)))
+    if (succeeded(getGroupStoreLayoutFact(op, assignedType, nullptr))) {
       return VMIGroupStoreLayoutFact{layout};
+    }
   }
 
-  if (pto::getPTOStorageElemBitWidth(valueType.getElementType()) == 0)
+  if (pto::getPTOStorageElemBitWidth(valueType.getElementType()) == 0) {
     return fail("group_store requires known element bit width");
+  }
   FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
       valueType, numGroups,
       "group_store preferred layout table has no row for this group size",
       reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
   std::optional<int64_t> rowStride =
       getConstantIndexValue(op.getRowStride());
   const GroupStoreLayoutPattern *selected = nullptr;
   for (const GroupStoreLayoutPattern &pattern : kGroupStoreLayoutPatterns) {
-    if (pattern.priority == GroupStoreLayoutPriority::LegalOnly)
+    if (pattern.priority == GroupStoreLayoutPriority::LegalOnly) {
       continue;
-    if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride))
+    }
+    if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride)) {
       continue;
+    }
     if (!selected || static_cast<unsigned>(pattern.priority) >
-                         static_cast<unsigned>(selected->priority))
+                         static_cast<unsigned>(selected->priority)) {
       selected = &pattern;
+    }
   }
-  if (selected)
+  if (selected) {
     return materializeGroupStoreLayoutFact(ctx, *selected, *key);
+  }
 
   return fail("value type, group size, and row_stride do not match a "
               "preferred group_store table row");
@@ -2772,31 +3023,37 @@ FailureOr<VMIGroupStoreLayoutFact>
 VMILayoutSupport::getHighPriorityGroupStoreLayoutFact(
     VMIGroupStoreOp op, VMIVRegType valueType, std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIGroupStoreLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (pto::getPTOStorageElemBitWidth(valueType.getElementType()) == 0)
+  if (pto::getPTOStorageElemBitWidth(valueType.getElementType()) == 0) {
     return fail("group_store requires known element bit width");
+  }
   FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
       valueType, op.getNumGroupsAttr().getInt(),
       "high-priority group_store layout table has no row for this group size",
       reason);
-  if (failed(key))
+  if (failed(key)) {
     return failure();
+  }
 
   std::optional<int64_t> rowStride =
       getConstantIndexValue(op.getRowStride());
   for (const GroupStoreLayoutPattern &pattern : kGroupStoreLayoutPatterns) {
-    if (pattern.priority != GroupStoreLayoutPriority::High)
+    if (pattern.priority != GroupStoreLayoutPriority::High) {
       continue;
-    if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride))
+    }
+    if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride)) {
       continue;
+    }
     VMIGroupStoreLayoutFact fact = materializeGroupStoreLayoutFact(
         valueType.getContext(), pattern, *key);
-    if (!fact.valueLayout)
+    if (!fact.valueLayout) {
       continue;
+    }
     return fact;
   }
 
@@ -2812,8 +3069,9 @@ static LogicalResult getGroupReduceAddSupportImpl(VMIVRegType sourceType,
   FailureOr<VMIGroupReduceLayoutFact> fact =
       VMILayoutSupport().getGroupReduceLayoutFactForLayouts(
           sourceType, maskType, resultType, numGroups, reason);
-  if (failed(fact))
+  if (failed(fact)) {
     return failure();
+  }
   return success();
 }
 
@@ -2951,8 +3209,9 @@ FailureOr<VMIBitcastLayoutFact>
 VMILayoutSupport::getBitcastLayoutFact(VMIBitcastOp op,
                                        std::string *reason) const {
   auto fail = [&](const Twine &message) -> FailureOr<VMIBitcastLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2960,10 +3219,12 @@ VMILayoutSupport::getBitcastLayoutFact(VMIBitcastOp op,
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !resultLayout)
+  if (!sourceLayout || !resultLayout) {
     return fail("requires assigned source and result layouts");
-  if (sourceLayout != resultLayout)
+  }
+  if (sourceLayout != resultLayout) {
     return fail("requires matching source and result layouts");
+  }
 
   int64_t numGroups =
       sourceLayout.isGroupSlots() ? sourceLayout.getNumGroups() : 0;
@@ -2971,8 +3232,9 @@ VMILayoutSupport::getBitcastLayoutFact(VMIBitcastOp op,
       pto::getPTOStorageElemBitWidth(sourceType.getElementType());
   unsigned resultElementBits =
       pto::getPTOStorageElemBitWidth(resultType.getElementType());
-  if (sourceElementBits == 0 || resultElementBits == 0)
+  if (sourceElementBits == 0 || resultElementBits == 0) {
     return fail("requires source and result with known storage element width");
+  }
   // Equal-width bitcast is layout-transparent for any identical layout.  Only
   // width-changing bitcast needs a table row because not every layout has a
   // representation-preserving carrier reinterpretation across element widths.
@@ -2987,59 +3249,68 @@ VMILayoutSupport::getBitcastLayoutFact(VMIBitcastOp op,
         break;
       }
     }
-    if (!matchedLayout)
+    if (!matchedLayout) {
       return fail("width-changing bitcast layout does not match a bitcast "
                   "layout table row");
+    }
   }
 
   return VMIBitcastLayoutFact{sourceLayout, resultLayout};
 }
 
-FailureOr<SmallVector<VMIBitcastLayoutFact, 4>>
+FailureOr<SmallVector<VMIBitcastLayoutFact, mlir::pto::kValue4>>
 VMILayoutSupport::getBitcastLayoutFactsForLayout(
     VMIVRegType sourceType, VMIVRegType resultType, VMICastLayoutPort port,
     VMILayoutAttr layout, std::string *reason) const {
   auto fail = [&](const Twine &message)
       -> FailureOr<SmallVector<VMIBitcastLayoutFact, 4>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (!layout)
+  if (!layout) {
     return fail("requires an assigned bitcast query layout");
+  }
 
   unsigned sourceElementBits =
       pto::getPTOStorageElemBitWidth(sourceType.getElementType());
   unsigned resultElementBits =
       pto::getPTOStorageElemBitWidth(resultType.getElementType());
-  if (sourceElementBits == 0 || resultElementBits == 0)
+  if (sourceElementBits == 0 || resultElementBits == 0) {
     return fail("requires source and result with known storage element width");
+  }
 
-  if (sourceElementBits == resultElementBits)
-    return SmallVector<VMIBitcastLayoutFact, 4>{
+  if (sourceElementBits == resultElementBits) {
+    return SmallVector<VMIBitcastLayoutFact, mlir::pto::kValue4>{
         VMIBitcastLayoutFact{layout, layout}};
+  }
 
   int64_t numGroups = layout.isGroupSlots() ? layout.getNumGroups() : 0;
   MLIRContext *ctx = sourceType.getContext();
-  SmallVector<VMIBitcastLayoutFact, 4> facts;
+  SmallVector<VMIBitcastLayoutFact, mlir::pto::kValue4> facts;
   for (const WidthChangingBitcastLayoutPattern &pattern :
        kWidthChangingBitcastLayoutPatterns) {
     VMILayoutAttr candidate =
         materializeLayoutPattern(ctx, pattern.layout, numGroups);
-    if (!candidate)
+    if (!candidate) {
       continue;
-    if (port == VMICastLayoutPort::Source && candidate != layout)
+    }
+    if (port == VMICastLayoutPort::Source && candidate != layout) {
       continue;
-    if (port == VMICastLayoutPort::Result && candidate != layout)
+    }
+    if (port == VMICastLayoutPort::Result && candidate != layout) {
       continue;
+    }
     facts.push_back(VMIBitcastLayoutFact{candidate, candidate});
   }
 
   if (facts.empty()) {
-    if (port == VMICastLayoutPort::Source)
+    if (port == VMICastLayoutPort::Source) {
       return fail(
           "requires a legal width-changing bitcast source layout relation");
+    }
     return fail(
         "requires a legal width-changing bitcast result layout relation");
   }
@@ -3056,13 +3327,15 @@ static FailureOr<VMIHistogramLayoutFact>
 getHistogramLayoutFactImpl(OpTy op, ArrayRef<HistogramLayoutPattern> patterns,
                            StringRef opName, std::string *reason) {
   auto fail = [&](const Twine &message) -> FailureOr<VMIHistogramLayoutFact> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (patterns.empty())
+  if (patterns.empty()) {
     return fail(opName + " histogram layout table has no row");
+  }
 
   auto accType = cast<VMIVRegType>(op.getAcc().getType());
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
@@ -3073,16 +3346,18 @@ getHistogramLayoutFactImpl(OpTy op, ArrayRef<HistogramLayoutPattern> patterns,
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!accLayout || !sourceLayout || !maskLayout || !resultLayout)
+  if (!accLayout || !sourceLayout || !maskLayout || !resultLayout) {
     return fail("requires assigned acc/source/mask/result layouts");
+  }
 
   MLIRContext *ctx = op.getContext();
   for (const HistogramLayoutPattern &pattern : patterns) {
     if (!matchesLayoutPattern(ctx, pattern.accLayout, accLayout) ||
         !matchesLayoutPattern(ctx, pattern.sourceLayout, sourceLayout) ||
         !matchesLayoutPattern(ctx, pattern.maskLayout, maskLayout) ||
-        !matchesLayoutPattern(ctx, pattern.resultLayout, resultLayout))
+        !matchesLayoutPattern(ctx, pattern.resultLayout, resultLayout)) {
       continue;
+    }
 
     VMIHistogramLayoutFact fact;
     fact.accLayout = accLayout;

--- a/lib/PTO/Transforms/VMILegalizeArithSelect.cpp
+++ b/lib/PTO/Transforms/VMILegalizeArithSelect.cpp
@@ -68,13 +68,15 @@ struct VMILegalizeArithSelectPass
     SmallVector<arith::SelectOp> selects;
     module.walk([&](arith::SelectOp select) {
       if (isVMIValueType(select.getResult().getType()) &&
-          hasScalarI1Condition(select))
+          hasScalarI1Condition(select)) {
         selects.push_back(select);
+      }
     });
 
     for (arith::SelectOp select : llvm::reverse(selects)) {
-      if (select->getBlock() != nullptr)
+      if (select->getBlock() != nullptr) {
         rewriteSelectToIf(select);
+      }
     }
   }
 };

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -84,6 +84,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/Passes.h"
@@ -106,14 +107,21 @@ namespace pto {
 using namespace mlir;
 using namespace mlir::pto;
 
+namespace {
+constexpr unsigned kIndexBitWidth = 64;
+constexpr int64_t kSingleGroupCount = 1;
+constexpr int64_t kDecimalRadix = 10;
+}
+
 //===----------------------------------------------------------------------===//
 // Helpers
 //===----------------------------------------------------------------------===//
 
 /// Returns the string name of a predicate mode, defaulting to "zero".
 static StringRef getPmodeOrDefault(Operation *op, StringRef attrName = "pmode") {
-  if (auto attr = op->getAttrOfType<StringAttr>(attrName))
+  if (auto attr = op->getAttrOfType<StringAttr>(attrName)) {
     return attr.getValue();
+  }
   return "zero";
 }
 
@@ -152,16 +160,19 @@ static std::string mapCmpPredicate(StringRef cmp, Type elemType,
                                    bool isFloat) {
   if (isFloat) {
     // Already ordered/unordered — pass through.
-    if (cmp.starts_with("o") || cmp.starts_with("u"))
+    if (cmp.starts_with("o") || cmp.starts_with("u")) {
       return cmp.str();
+    }
     return ("o" + cmp).str(); // e.g. "lt" → "olt"
   }
   // Integer.
-  if (cmp.starts_with("s") || cmp.starts_with("u"))
+  if (cmp.starts_with("s") || cmp.starts_with("u")) {
     return cmp.str();
+  }
   // eq/ne are valid for both fp and int without prefix.
-  if (cmp == "eq" || cmp == "ne")
+  if (cmp == "eq" || cmp == "ne") {
     return cmp.str();
+  }
   auto intType = dyn_cast<IntegerType>(elemType);
   if (intType && !intType.isSigned()) {
     return ("u" + cmp).str(); // e.g. "lt" -> "ult"
@@ -183,8 +194,9 @@ static Type getVMIElementType(Value v) {
 
 /// Return the storage bit width for VMI element types (float / float-like / int).
 static unsigned getVMIElementBitWidth(Type type) {
-  if (isa<IndexType>(type))
-    return 64;
+  if (isa<IndexType>(type)) {
+    return kIndexBitWidth;
+  }
   return pto::getPTOStorageElemBitWidth(type);
 }
 
@@ -198,8 +210,9 @@ static StringRef classifyCvtDirection(Type srcElem, Type dstElem) {
   unsigned srcBits = getVMIElementBitWidth(srcElem);
   unsigned dstBits = getVMIElementBitWidth(dstElem);
 
-  if (srcFp && dstFp)
+  if (srcFp && dstFp) {
     return dstBits > srcBits ? "widen_fp" : "narrow_fp";
+  }
   if (srcFp && !dstFp) {
     if (auto intTy = dyn_cast<IntegerType>(dstElem))
       return intTy.isSigned() ? "fptosi" : "fptoui";
@@ -230,8 +243,9 @@ static LogicalResult
 lowerBinaryIgnoringMask(
     UnifiedOp op,
     function_ref<Value(Location, Type, Value, Value)> createLegacy) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
   Location loc = op.getLoc();
   Type resultType = op.getResult().getType();
   Value lhs = op.getLhs();
@@ -248,8 +262,9 @@ template <typename UnifiedOp>
 static LogicalResult
 lowerMaskedUnary(UnifiedOp op, OpBuilder &builder,
                  function_ref<Value(Location, Type, Value)> createLegacy) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   Location loc = op.getLoc();
   Type resultType = op.getResult().getType();
@@ -271,27 +286,33 @@ lowerMaskedUnary(UnifiedOp op, OpBuilder &builder,
 /// active_lanes is a constant >= the mask lane count.
 static bool isAllActiveSeed(Value seed) {
   Operation *def = seed.getDefiningOp();
-  if (!def)
+  if (!def) {
     return false;
-  if (isa<VMIPsetOp>(def))
+  }
+  if (isa<VMIPsetOp>(def)) {
     return true;
+  }
   if (auto cm = dyn_cast<VMICreateMaskOp>(def)) {
     auto maskTy = cast<VMIMaskType>(cm.getResult().getType());
-    if (auto cst = cm.getActiveLanes().getDefiningOp<arith::ConstantOp>())
-      if (auto ia = dyn_cast<IntegerAttr>(cst.getValue()))
+    if (auto cst = cm.getActiveLanes().getDefiningOp<arith::ConstantOp>()) {
+      if (auto ia = dyn_cast<IntegerAttr>(cst.getValue())) {
         return ia.getInt() >= maskTy.getElementCount();
+      }
+    }
   }
   return false;
 }
 
 static bool isCompactGroupCount(int64_t count) {
-  return count == 1 || count == 2 || count == 4 || count == 8;
+  return count == kSingleGroupCount || count == mlir::pto::kValue2 ||
+         count == mlir::pto::kValue4 || count == mlir::pto::kValue8;
 }
 
 /// Lower vcmp to cmpf/cmpi + mask_and.
 static LogicalResult lowerVCmp(VMIVcmpOp op, OpBuilder &builder) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   Location loc = op.getLoc();
   Type elemType = getVMIElementType(op.getLhs());
@@ -317,11 +338,12 @@ static LogicalResult lowerVCmp(VMIVcmpOp op, OpBuilder &builder) {
 
   // mask_and with seed — skipped when the seed is all-active (identity AND).
   Value result = rawMask;
-  if (!isAllActiveSeed(op.getSeed()))
+  if (!isAllActiveSeed(op.getSeed())) {
     result = builder
                  .create<VMIMaskAndOp>(loc, op.getResult().getType(), rawMask,
                                        op.getSeed())
                  .getResult();
+  }
 
   op.getResult().replaceAllUsesWith(result);
   op->erase();
@@ -330,8 +352,9 @@ static LogicalResult lowerVCmp(VMIVcmpOp op, OpBuilder &builder) {
 
 /// Lower vcmps to broadcast scalar + cmpf/cmpi + mask_and.
 static LogicalResult lowerVCmps(VMIVcmpsOp op, OpBuilder &builder) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   Location loc = op.getLoc();
   Type srcVmiType = op.getSrc().getType();
@@ -363,11 +386,12 @@ static LogicalResult lowerVCmps(VMIVcmpsOp op, OpBuilder &builder) {
 
   // 3. mask_and with seed — skipped when the seed is all-active (identity AND).
   Value result = rawMask;
-  if (!isAllActiveSeed(op.getSeed()))
+  if (!isAllActiveSeed(op.getSeed())) {
     result = builder
                  .create<VMIMaskAndOp>(loc, op.getResult().getType(), rawMask,
                                        op.getSeed())
                  .getResult();
+  }
 
   op.getResult().replaceAllUsesWith(result);
   op->erase();
@@ -380,8 +404,9 @@ static LogicalResult lowerVCmps(VMIVcmpsOp op, OpBuilder &builder) {
 
 /// Lower vcvt by dispatching on src→dst element types.
 static LogicalResult lowerVCvt(VMICvtOp op, OpBuilder &builder) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   Type srcElem = getVMIElementType(op.getSource());
   Type dstElem = getVMIElementType(op.getResult());
@@ -422,12 +447,13 @@ static LogicalResult lowerVCvt(VMICvtOp op, OpBuilder &builder) {
     if (auto intTy = dyn_cast<IntegerType>(srcElem)) {
       useSigned = intTy.isSigned();
     }
-    if (useSigned)
+    if (useSigned) {
       result =
           builder.create<VMIExtSIOp>(loc, resultType, source).getResult();
-    else
+    } else {
       result =
           builder.create<VMIExtUIOp>(loc, resultType, source).getResult();
+}
   } else if (direction == "narrow_int") {
     result =
         builder.create<VMITruncIOp>(loc, resultType, source, saturateAttr)
@@ -487,10 +513,11 @@ static LogicalResult lowerVLoad(VMIvLoadOp op, OpBuilder &builder) {
     auto resultVMIType = cast<VMIVRegType>(resultType);
     auto elemType = resultVMIType.getElementType();
     unsigned bits = 32;
-    if (auto it = dyn_cast<IntegerType>(elemType))
+    if (auto it = dyn_cast<IntegerType>(elemType)) {
       bits = it.getWidth();
-    else if (auto ft = dyn_cast<FloatType>(elemType))
+    } else if (auto ft = dyn_cast<FloatType>(elemType)) {
       bits = ft.getWidth();
+    }
     auto gran = StringAttr::get(builder.getContext(),
                                 bits <= 8 ? "b8" : bits <= 16 ? "b16" : "b32");
     auto maskType = VMIMaskType::get(builder.getContext(),
@@ -511,8 +538,9 @@ static LogicalResult lowerVLoad(VMIvLoadOp op, OpBuilder &builder) {
   }
 
   // pmode="merge" cannot be expressed by legacy load + select — skip.
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   StringAttr distModeAttr = op.getDistModeAttr();
   StringRef distMode =
@@ -576,8 +604,9 @@ static LogicalResult lowerVStore(VMIvStoreOp op, OpBuilder &builder) {
   // pmode="merge" (inactive lanes retain the prior destination contents)
   // cannot be expressed by the legacy store family, whose writes are governed
   // purely by the mask. Skip instead of silently dropping the attribute.
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   // Group mode: vstore {group=C} → group_store
   if (op.getGroupAttr()) {
@@ -599,10 +628,11 @@ static LogicalResult lowerVStore(VMIvStoreOp op, OpBuilder &builder) {
     } else {
       auto elemType = valueType.getElementType();
       unsigned bits = 32;
-      if (auto it = dyn_cast<IntegerType>(elemType))
+      if (auto it = dyn_cast<IntegerType>(elemType)) {
         bits = it.getWidth();
-      else if (auto ft = dyn_cast<FloatType>(elemType))
+      } else if (auto ft = dyn_cast<FloatType>(elemType)) {
         bits = ft.getWidth();
+      }
       auto gran = StringAttr::get(builder.getContext(),
                                   bits <= 8 ? "b8" : bits <= 16 ? "b16" : "b32");
       auto maskType = VMIMaskType::get(builder.getContext(),
@@ -633,8 +663,9 @@ static LogicalResult lowerVStore(VMIvStoreOp op, OpBuilder &builder) {
   auto values = op.getValues();
 
   if (distMode == "continuous") {
-    if (values.empty())
+    if (values.empty()) {
       return failure();
+    }
     Value mask = op.getMask().empty() ? Value() : op.getMask().front();
     auto valueType = cast<VMIVRegType>(values[0].getType());
     int64_t numGroups = valueType.getElementCount();
@@ -644,7 +675,6 @@ static LogicalResult lowerVStore(VMIvStoreOp op, OpBuilder &builder) {
     // group_store currently has no dynamic predication operand.
     bool allActive = !mask || isAllActiveSeed(mask);
     bool compact = isCompactGroupCount(numGroups);
-
     if (compact && allActive) {
       Value unitStride = builder.create<arith::ConstantIndexOp>(loc, 1);
       builder.create<VMIGroupStoreOp>(loc, values[0], dest, offset, unitStride,
@@ -659,8 +689,9 @@ static LogicalResult lowerVStore(VMIvStoreOp op, OpBuilder &builder) {
       builder.create<VMIStoreOp>(loc, values[0], dest, offset);
     }
   } else if (distMode == "dintlv") {
-    if (values.size() < 2)
+    if (values.size() < mlir::pto::kValue2) {
       return failure();
+    }
     builder.create<VMIInterleaveStoreOp>(loc, values[0], values[1], dest,
                                          offset);
   } else {
@@ -708,12 +739,14 @@ static LogicalResult lowerPge(VMIPgeOp op, OpBuilder &builder) {
     if (!numStr.empty()) {
       int64_t parsed = 0;
       for (char c : numStr) {
-        if (c < '0' || c > '9')
+        if (c < '0' || c > '9') {
           break;
-        parsed = parsed * 10 + (c - '0');
+        }
+        parsed = parsed * kDecimalRadix + (c - '0');
       }
-      if (parsed > 0)
+      if (parsed > 0) {
         numLanes = parsed;
+      }
     }
   }
 
@@ -750,14 +783,16 @@ static LogicalResult lowerPge(VMIPgeOp op, OpBuilder &builder) {
 
 template <typename ReductionOp>
 static std::optional<int64_t> getReductionNumGroups(ReductionOp op) {
-  if (auto groupAttr = op.getGroupAttr())
+  if (auto groupAttr = op.getGroupAttr()) {
     return groupAttr.getInt();
+  }
 
   // A full reduction is one logical group. Keep the alias decision local to
   // the reduction instead of relying on a downstream store to mutate it.
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
-  if (!resultType.getLayoutAttr())
+  if (!resultType.getLayoutAttr()) {
     return 1;
+  }
   return std::nullopt;
 }
 
@@ -765,8 +800,9 @@ static std::optional<int64_t> getReductionNumGroups(ReductionOp op) {
 /// group_reduce_addf/group_reduce_addi.  Always succeeds for valid input
 /// (vcadd verifier guarantees reassoc for float, and group 整除 source lanes).
 static LogicalResult lowerVCadd(VMIvcaddOp op, OpBuilder &builder) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   Type elemType = sourceType.getElementType();
@@ -779,34 +815,36 @@ static LogicalResult lowerVCadd(VMIvcaddOp op, OpBuilder &builder) {
   if (std::optional<int64_t> numGroups = getReductionNumGroups(op)) {
     // Group reduce path
     Value result;
-    if (isFloat)
+    if (isFloat) {
       result =
           builder
               .create<VMIGroupReduceAddFOp>(loc, resultType, source, mask,
                                             builder.getI64IntegerAttr(*numGroups),
                                             op.getReassocAttr())
               .getResult();
-    else
+    } else {
       result =
           builder
               .create<VMIGroupReduceAddIOp>(loc, resultType, source, mask,
                                             builder.getI64IntegerAttr(*numGroups))
               .getResult();
+}
     op.getResult().replaceAllUsesWith(result);
   } else {
     // Full reduce path
     Value result;
-    if (isFloat)
+    if (isFloat) {
       result =
           builder
               .create<VMIReduceAddFOp>(loc, resultType, source, mask,
                                        op.getReassocAttr())
               .getResult();
-    else
+    } else {
       result =
           builder
               .create<VMIReduceAddIOp>(loc, resultType, source, mask)
               .getResult();
+}
     op.getResult().replaceAllUsesWith(result);
   }
   op->erase();
@@ -815,8 +853,9 @@ static LogicalResult lowerVCadd(VMIvcaddOp op, OpBuilder &builder) {
 
 /// Lower vcmax to legacy full or grouped float/integer maximum reduction.
 static LogicalResult lowerVcmax(VMIvcmaxOp op, OpBuilder &builder) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   Type elemType = sourceType.getElementType();
@@ -829,32 +868,34 @@ static LogicalResult lowerVcmax(VMIvcmaxOp op, OpBuilder &builder) {
   if (std::optional<int64_t> numGroups = getReductionNumGroups(op)) {
     // Group reduce path
     Value result;
-    if (isFloat)
+    if (isFloat) {
       result =
           builder
               .create<VMIGroupReduceMaxFOp>(loc, resultType, source, mask,
                                             builder.getI64IntegerAttr(*numGroups))
               .getResult();
-    else
+    } else {
       result =
           builder
               .create<VMIGroupReduceMaxIOp>(loc, resultType, source, mask,
                                             builder.getI64IntegerAttr(*numGroups))
               .getResult();
+}
     op.getResult().replaceAllUsesWith(result);
     op->erase();
     return success();
   }
 
   Value result;
-  if (isFloat)
+  if (isFloat) {
     result = builder
                  .create<VMIReduceMaxFOp>(loc, resultType, source, mask)
                  .getResult();
-  else
+  } else {
     result = builder
                  .create<VMIReduceMaxIOp>(loc, resultType, source, mask)
                  .getResult();
+}
   op.getResult().replaceAllUsesWith(result);
   op->erase();
   return success();
@@ -862,8 +903,9 @@ static LogicalResult lowerVcmax(VMIvcmaxOp op, OpBuilder &builder) {
 
 /// Lower vcmin to legacy full or grouped float/integer minimum reduction.
 static LogicalResult lowerVcmin(VMIvcminOp op, OpBuilder &builder) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   Type elemType = sourceType.getElementType();
@@ -875,32 +917,34 @@ static LogicalResult lowerVcmin(VMIvcminOp op, OpBuilder &builder) {
 
   if (std::optional<int64_t> numGroups = getReductionNumGroups(op)) {
     Value result;
-    if (isFloat)
+    if (isFloat) {
       result = builder
                    .create<VMIGroupReduceMinFOp>(
                        loc, resultType, source, mask,
                        builder.getI64IntegerAttr(*numGroups))
                    .getResult();
-    else
+    } else {
       result = builder
                    .create<VMIGroupReduceMinIOp>(
                        loc, resultType, source, mask,
                        builder.getI64IntegerAttr(*numGroups))
                    .getResult();
+}
     op.getResult().replaceAllUsesWith(result);
     op->erase();
     return success();
   }
 
   Value result;
-  if (isFloat)
+  if (isFloat) {
     result = builder
                  .create<VMIReduceMinFOp>(loc, resultType, source, mask)
                  .getResult();
-  else
+  } else {
     result = builder
                  .create<VMIReduceMinIOp>(loc, resultType, source, mask)
                  .getResult();
+}
   op.getResult().replaceAllUsesWith(result);
   op->erase();
   return success();
@@ -915,13 +959,15 @@ static LogicalResult lowerVcmin(VMIvcminOp op, OpBuilder &builder) {
 /// Legacy fma is floating-point only; integer vmula has no legacy equivalent
 /// and is skipped (falls through to VMIToVPTO).
 static LogicalResult lowerVmula(VMIVmulaOp op, OpBuilder &builder) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   Type resultType = op.getResult().getType();
   auto vmiType = cast<VMIVRegType>(resultType);
-  if (!isFloatType(vmiType.getElementType()))
+  if (!isFloatType(vmiType.getElementType())) {
     return failure();
+  }
 
   Location loc = op.getLoc();
   // fma computes lhs*rhs + acc, matching vmula's acc + lhs*rhs.
@@ -937,13 +983,15 @@ static LogicalResult lowerVmula(VMIVmulaOp op, OpBuilder &builder) {
 /// Lower vaxpy (alpha*x + y) to broadcast(alpha) + legacy fma.
 /// alpha is a scalar float, broadcast to a vector before the fma.
 static LogicalResult lowerVaxpy(VMIVaxpyOp op, OpBuilder &builder) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   Type resultType = op.getResult().getType();
   auto vmiType = cast<VMIVRegType>(resultType);
-  if (!isFloatType(vmiType.getElementType()))
+  if (!isFloatType(vmiType.getElementType())) {
     return failure();
+  }
 
   Location loc = op.getLoc();
   Value alphaVec = builder
@@ -992,8 +1040,9 @@ static LogicalResult lowerPlt(VMIPltOp op, OpBuilder &builder) {
 /// operand for inactive lanes; pmode="zero" is modelled with a zero passthru.
 /// pmode="merge" (preserve OLD_DEST) has no SSA passthru and is skipped.
 static LogicalResult lowerVgather(VMIVgatherOp op, OpBuilder &builder) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   Location loc = op.getLoc();
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
@@ -1016,8 +1065,9 @@ static LogicalResult lowerVgather(VMIVgatherOp op, OpBuilder &builder) {
 /// Lower vscatter to legacy scatter.  Legacy scatter only writes active lanes
 /// (mask-governed), matching vscatter's default/zero pmode; merge is skipped.
 static LogicalResult lowerVscatter(VMIVscatterOp op, OpBuilder &builder) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   Location loc = op.getLoc();
   builder.create<VMIScatterOp>(loc, op.getValue(), op.getDestination(),
@@ -1033,8 +1083,9 @@ static LogicalResult lowerVscatter(VMIVscatterOp op, OpBuilder &builder) {
 /// Lower vlrelu (x>0 ? x : slope*x) to max(x,0) + slope*min(x,0).
 /// slope is a scalar float broadcast to a vector.
 static LogicalResult lowerVlrelu(VMIVlreluOp op, OpBuilder &builder) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   Location loc = op.getLoc();
   Type resultType = op.getResult().getType();
@@ -1061,8 +1112,9 @@ static LogicalResult lowerVlrelu(VMIVlreluOp op, OpBuilder &builder) {
 /// Lower vprelu (max(x,0) + alpha*min(x,0)) to legacy max/min/mul/add.
 /// alpha is a per-lane vector (no broadcast needed).
 static LogicalResult lowerVprelu(VMIVpreluOp op, OpBuilder &builder) {
-  if (hasMergePmode(op))
+  if (hasMergePmode(op)) {
     return failure();
+  }
 
   Location loc = op.getLoc();
   Type resultType = op.getResult().getType();
@@ -1105,7 +1157,7 @@ struct VMILowerUnifiedToLegacyPass
 
 void VMILowerUnifiedToLegacyPass::runOnOperation() {
   ModuleOp module = getOperation();
-  SmallVector<Operation *, 128> worklist;
+  SmallVector<Operation *, mlir::pto::kValue128> worklist;
 
   // Collect all unified VMI ops (walk encounters them in IR order).
   module.walk([&](Operation *op) {
@@ -1132,8 +1184,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
         // Category C8 — indexed gather / scatter
         isa<VMIVgatherOp, VMIVscatterOp>(op) ||
         // Category C9 — fused activation / softmax (legacy chains)
-        isa<VMIVlreluOp, VMIVpreluOp>(op))
+        isa<VMIVlreluOp, VMIVpreluOp>(op)) {
       worklist.push_back(op);
+    }
 
     // Category D — no legacy equivalent (require direct VMIToVPTO lowering):
     //   plt, vector-scalar ops, vaddc/vaddcs, vintlv, vdintlv, vselr,
@@ -1151,8 +1204,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
 
   // Process consumers before producers to avoid stale producer uses.
   for (Operation *op : llvm::reverse(worklist)) {
-    if (!op->getBlock())
+    if (!op->getBlock()) {
       continue;
+    }
     OpBuilder builder(op);
 
     // ---- Category A: pure syntactic renames ----
@@ -1162,8 +1216,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
       // group>1 lowers to the internal contiguous-only group_iota producer.
       builder.setInsertionPoint(op);
       StringAttr orderAttr;
-      if (auto order = vop.getOrder())
+      if (auto order = vop.getOrder()) {
         orderAttr = builder.getStringAttr(*order);
+      }
 
       Type resultType = vop.getResult().getType();
       IntegerAttr groupAttr = vop.getGroupAttr();
@@ -1310,8 +1365,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
       // pmode="merge" cannot be expressed by the legacy stride store; leave
       // the op for VMIToVPTO (which has no vsstb pattern) so the conversion
       // fails loudly instead of silently dropping the attribute.
-      if (hasMergePmode(vop))
+      if (hasMergePmode(vop)) {
         continue;
+      }
       Value repeatStride = builder.create<arith::ConstantOp>(
           vop.getLoc(), builder.getI16IntegerAttr(0));
       builder.create<VMIStrideStoreOp>(
@@ -1379,8 +1435,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
     if (auto vop = dyn_cast<VMIVaddOp>(op)) {
       Type elemType = getVMIElementType(vop.getResult());
       auto createLegacy = [&](Location loc, Type ty, Value lhs, Value rhs) -> Value {
-        if (isFloatType(elemType))
+        if (isFloatType(elemType)) {
           return builder.create<VMIAddFOp>(loc, ty, lhs, rhs).getResult();
+        }
         return builder.create<VMIAddIOp>(loc, ty, lhs, rhs).getResult();
       };
       (void)lowerBinaryIgnoringMask(vop, createLegacy);
@@ -1390,8 +1447,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
     if (auto vop = dyn_cast<VMIVsubOp>(op)) {
       Type elemType = getVMIElementType(vop.getResult());
       auto createLegacy = [&](Location loc, Type ty, Value lhs, Value rhs) -> Value {
-        if (isFloatType(elemType))
+        if (isFloatType(elemType)) {
           return builder.create<VMISubFOp>(loc, ty, lhs, rhs).getResult();
+        }
         return builder.create<VMISubIOp>(loc, ty, lhs, rhs).getResult();
       };
       (void)lowerBinaryIgnoringMask(vop, createLegacy);
@@ -1401,8 +1459,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
     if (auto vop = dyn_cast<VMIVmulOp>(op)) {
       Type elemType = getVMIElementType(vop.getResult());
       auto createLegacy = [&](Location loc, Type ty, Value lhs, Value rhs) -> Value {
-        if (isFloatType(elemType))
+        if (isFloatType(elemType)) {
           return builder.create<VMIMulFOp>(loc, ty, lhs, rhs).getResult();
+        }
         return builder.create<VMIMulIOp>(loc, ty, lhs, rhs).getResult();
       };
       (void)lowerBinaryIgnoringMask(vop, createLegacy);
@@ -1423,8 +1482,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
       Type elemType = getVMIElementType(vop.getResult());
       auto createLegacy = [&](Location loc, Type ty, Value lhs,
                               Value rhs) -> Value {
-        if (isFloatType(elemType))
+        if (isFloatType(elemType)) {
           return builder.create<VMIMinFOp>(loc, ty, lhs, rhs).getResult();
+        }
         return builder.create<VMIMinIOp>(loc, ty, lhs, rhs).getResult();
       };
       (void)lowerBinaryIgnoringMask(vop, createLegacy);
@@ -1435,8 +1495,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
       Type elemType = getVMIElementType(vop.getResult());
       auto createLegacy = [&](Location loc, Type ty, Value lhs,
                               Value rhs) -> Value {
-        if (isFloatType(elemType))
+        if (isFloatType(elemType)) {
           return builder.create<VMIMaxFOp>(loc, ty, lhs, rhs).getResult();
+        }
         return builder.create<VMIMaxIOp>(loc, ty, lhs, rhs).getResult();
       };
       (void)lowerBinaryIgnoringMask(vop, createLegacy);
@@ -1514,8 +1575,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
       auto createLegacy = [&](Location loc, Type ty, Value lhs,
                               Value rhs) -> Value {
         auto intType = cast<IntegerType>(elemType);
-        if (!intType.isSigned())
+        if (!intType.isSigned()) {
           return builder.create<VMIShRUIOp>(loc, ty, lhs, rhs).getResult();
+        }
         return builder.create<VMIShRSIOp>(loc, ty, lhs, rhs).getResult();
       };
       (void)lowerBinaryIgnoringMask(vop, createLegacy);
@@ -1555,8 +1617,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
               builder.create<VMIAndIOp>(loc, iTy, asI, maskVec).getResult();
           return builder.create<VMIBitcastOp>(loc, ty, cleared).getResult();
         }
-        if (isFloatType(elemType))
+        if (isFloatType(elemType)) {
           return builder.create<VMIAbsFOp>(loc, ty, src).getResult();
+        }
         return builder.create<VMIAbsIOp>(loc, ty, src).getResult();
       };
       (void)lowerMaskedUnary(vop, builder, createLegacy);

--- a/lib/PTO/Transforms/VMIMaskGranularityAssignment.cpp
+++ b/lib/PTO/Transforms/VMIMaskGranularityAssignment.cpp
@@ -16,6 +16,7 @@
 // rematerializes cheap mask producers at the use site or inserts
 // pto.vmi.ensure_mask_granularity.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/IR/VMIUtils.h"
@@ -44,6 +45,11 @@ using namespace mlir::pto;
 
 namespace {
 
+constexpr unsigned kMaskGranularity8Bit = 8;
+constexpr unsigned kMaskGranularity16Bit = 16;
+constexpr unsigned kMaskGranularity32Bit = 32;
+constexpr unsigned kInvalidMaskId = ~0U;
+
 struct MaskNode {
   Value value;
   VMIMaskType type;
@@ -57,18 +63,19 @@ struct MaskUseRequest {
 };
 
 static unsigned getElementBitWidth(Type type) {
-  if (isa<IndexType>(type))
-    return 64;
+  if (isa<IndexType>(type)) {
+    return mlir::pto::kValue64;
+  }
   return pto::getPTOStorageElemBitWidth(type);
 }
 
 static StringRef getMaskGranularityForElement(Type elementType) {
   switch (getElementBitWidth(elementType)) {
-  case 8:
+  case kMaskGranularity8Bit:
     return "b8";
-  case 16:
+  case kMaskGranularity16Bit:
     return "b16";
-  case 32:
+  case kMaskGranularity32Bit:
     return "b32";
   default:
     return "";
@@ -76,14 +83,16 @@ static StringRef getMaskGranularityForElement(Type elementType) {
 }
 
 static bool containsVMIType(Type type) {
-  if (isa<VMIVRegType, VMIMaskType>(type))
+  if (isa<VMIVRegType, VMIMaskType>(type)) {
     return true;
+  }
   if (auto functionType = dyn_cast<FunctionType>(type)) {
     return llvm::any_of(functionType.getInputs(), containsVMIType) ||
            llvm::any_of(functionType.getResults(), containsVMIType);
   }
-  if (auto shapedType = dyn_cast<ShapedType>(type))
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
     return containsVMIType(shapedType.getElementType());
+  }
   return false;
 }
 
@@ -93,21 +102,24 @@ struct MaskGranularitySolver {
 
   unsigned addMaskValue(Value value) {
     auto type = dyn_cast<VMIMaskType>(value.getType());
-    if (!type)
-      return ~0U;
+    if (!type) {
+      return kInvalidMaskId;
+    }
     auto [it, inserted] = maskIds.try_emplace(value, maskNodes.size());
     if (inserted) {
       std::string granularity;
-      if (VMIMaskType::isConcreteGranularity(type.getGranularity()))
+      if (VMIMaskType::isConcreteGranularity(type.getGranularity())) {
         granularity = type.getGranularity().str();
+      }
       maskNodes.push_back(MaskNode{value, type, it->second, granularity});
     }
     return it->second;
   }
 
   unsigned findMask(unsigned id) {
-    if (maskNodes[id].parent == id)
+    if (maskNodes[id].parent == id) {
       return id;
+    }
     maskNodes[id].parent = findMask(maskNodes[id].parent);
     return maskNodes[id].parent;
   }
@@ -115,64 +127,77 @@ struct MaskGranularitySolver {
   LogicalResult uniteMask(Value lhs, Value rhs, Operation *op) {
     unsigned lhsId = addMaskValue(lhs);
     unsigned rhsId = addMaskValue(rhs);
-    if (lhsId == ~0U || rhsId == ~0U)
+    if (lhsId == kInvalidMaskId || rhsId == kInvalidMaskId) {
       return success();
+    }
     unsigned lhsRoot = findMask(lhsId);
     unsigned rhsRoot = findMask(rhsId);
-    if (lhsRoot == rhsRoot)
+    if (lhsRoot == rhsRoot) {
       return success();
+    }
 
     MaskNode &lhsNode = maskNodes[lhsRoot];
     MaskNode &rhsNode = maskNodes[rhsRoot];
     if (!lhsNode.granularity.empty() && !rhsNode.granularity.empty() &&
-        lhsNode.granularity != rhsNode.granularity)
+        lhsNode.granularity != rhsNode.granularity) {
       return op->emitError() << kVMIDiagLayoutContractPrefix
                              << "conflicting mask granularities "
                              << lhsNode.granularity << " and "
                              << rhsNode.granularity;
+    }
 
     rhsNode.parent = lhsRoot;
-    if (lhsNode.granularity.empty())
+    if (lhsNode.granularity.empty()) {
       lhsNode.granularity = rhsNode.granularity;
+    }
     return success();
   }
 
   LogicalResult requestMask(Value mask, StringRef granularity, Operation *op) {
     unsigned id = addMaskValue(mask);
-    if (id == ~0U)
+    if (id == ~0U) {
       return success();
-    if (granularity.empty())
+    }
+    if (granularity.empty()) {
       return op->emitError() << kVMIDiagLayoutContractPrefix
                              << "cannot infer concrete mask granularity";
+    }
     MaskNode &node = maskNodes[findMask(id)];
-    if (!node.granularity.empty() && node.granularity != granularity)
+    if (!node.granularity.empty() && node.granularity != granularity) {
       return op->emitError()
              << kVMIDiagLayoutContractPrefix
              << "conflicting mask granularities " << node.granularity << " and "
              << granularity;
+    }
     node.granularity = granularity.str();
     return success();
   }
 
   LogicalResult requestMaskUse(OpOperand &operand, StringRef granularity,
                                Operation *op) {
-    if (!isa<VMIMaskType>(operand.get().getType()))
+    if (!isa<VMIMaskType>(operand.get().getType())) {
       return success();
-    if (granularity.empty())
+    }
+    if (granularity.empty()) {
       return op->emitError() << kVMIDiagLayoutContractPrefix
                              << "cannot infer concrete mask use granularity";
+    }
     maskUseRequests.push_back(MaskUseRequest{&operand, granularity.str()});
     return success();
   }
 
   LogicalResult collect() {
     module.walk([&](Operation *op) {
-      for (Value result : op->getResults())
+      for (Value result : op->getResults()) {
         addMaskValue(result);
-      for (Region &region : op->getRegions())
-        for (Block &block : region)
-          for (BlockArgument arg : block.getArguments())
+      }
+      for (Region &region : op->getRegions()) {
+        for (Block &block : region) {
+          for (BlockArgument arg : block.getArguments()) {
             addMaskValue(arg);
+          }
+        }
+      }
     });
     return success();
   }
@@ -181,90 +206,104 @@ struct MaskGranularitySolver {
     WalkResult result = module.walk([&](Operation *op) -> WalkResult {
       if (auto maskAnd = dyn_cast<VMIMaskAndOp>(op)) {
         if (failed(uniteMask(maskAnd.getLhs(), maskAnd.getRhs(), op)) ||
-            failed(uniteMask(maskAnd.getLhs(), maskAnd.getResult(), op)))
+            failed(uniteMask(maskAnd.getLhs(), maskAnd.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto maskOr = dyn_cast<VMIMaskOrOp>(op)) {
         if (failed(uniteMask(maskOr.getLhs(), maskOr.getRhs(), op)) ||
-            failed(uniteMask(maskOr.getLhs(), maskOr.getResult(), op)))
+            failed(uniteMask(maskOr.getLhs(), maskOr.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto maskXor = dyn_cast<VMIMaskXOrOp>(op)) {
         if (failed(uniteMask(maskXor.getLhs(), maskXor.getRhs(), op)) ||
-            failed(uniteMask(maskXor.getLhs(), maskXor.getResult(), op)))
+            failed(uniteMask(maskXor.getLhs(), maskXor.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto maskNot = dyn_cast<VMIMaskNotOp>(op)) {
-        if (failed(uniteMask(maskNot.getSource(), maskNot.getResult(), op)))
+        if (failed(uniteMask(maskNot.getSource(), maskNot.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto ensure = dyn_cast<VMIEnsureMaskLayoutOp>(op)) {
-        if (failed(uniteMask(ensure.getSource(), ensure.getResult(), op)))
+        if (failed(uniteMask(ensure.getSource(), ensure.getResult(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto cmpf = dyn_cast<VMICmpFOp>(op)) {
         auto lhsType = cast<VMIVRegType>(cmpf.getLhs().getType());
         if (failed(requestMask(
                 cmpf.getResult(),
-                getMaskGranularityForElement(lhsType.getElementType()), op)))
+                getMaskGranularityForElement(lhsType.getElementType()), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto cmpi = dyn_cast<VMICmpIOp>(op)) {
         auto lhsType = cast<VMIVRegType>(cmpi.getLhs().getType());
         if (failed(requestMask(
                 cmpi.getResult(),
-                getMaskGranularityForElement(lhsType.getElementType()), op)))
+                getMaskGranularityForElement(lhsType.getElementType()), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto select = dyn_cast<VMISelectOp>(op)) {
         auto resultType = cast<VMIVRegType>(select.getResult().getType());
         if (failed(requestMaskUse(
                 select.getMaskMutable(),
-                getMaskGranularityForElement(resultType.getElementType()), op)))
+                getMaskGranularityForElement(resultType.getElementType()), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vecScalar = dyn_cast<VMIAddSOp>(op)) {
         if (failed(requestMaskUseForSource(vecScalar.getMaskMutable(),
-                                           vecScalar.getSrc(), op)))
+                                           vecScalar.getSrc(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vecScalar = dyn_cast<VMIMulSOp>(op)) {
         if (failed(requestMaskUseForSource(vecScalar.getMaskMutable(),
-                                           vecScalar.getSrc(), op)))
+                                           vecScalar.getSrc(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vecScalar = dyn_cast<VMIMaxSOp>(op)) {
         if (failed(requestMaskUseForSource(vecScalar.getMaskMutable(),
-                                           vecScalar.getSrc(), op)))
+                                           vecScalar.getSrc(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vecScalar = dyn_cast<VMIMinSOp>(op)) {
         if (failed(requestMaskUseForSource(vecScalar.getMaskMutable(),
-                                           vecScalar.getSrc(), op)))
+                                           vecScalar.getSrc(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vecScalar = dyn_cast<VMIShlSOp>(op)) {
         if (failed(requestMaskUseForSource(vecScalar.getMaskMutable(),
-                                           vecScalar.getSrc(), op)))
+                                           vecScalar.getSrc(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vecScalar = dyn_cast<VMIShrSOp>(op)) {
         if (failed(requestMaskUseForSource(vecScalar.getMaskMutable(),
-                                           vecScalar.getSrc(), op)))
+                                           vecScalar.getSrc(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vexpdif = dyn_cast<VMIVexpdifOp>(op)) {
@@ -274,218 +313,253 @@ struct MaskGranularitySolver {
         return WalkResult::advance();
       }
       if (auto vmull = dyn_cast<VMIVmullOp>(op)) {
-        if (failed(requestMaskUse(vmull.getMaskMutable(), "b32", op)))
+        if (failed(requestMaskUse(vmull.getMaskMutable(), "b32", op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto addc = dyn_cast<VMIVaddcOp>(op)) {
         if (failed(requestMaskUse(addc.getMaskMutable(), "b32", op)) ||
-            failed(requestMask(addc.getCarry(), "b32", op)))
+            failed(requestMask(addc.getCarry(), "b32", op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto addcs = dyn_cast<VMIVaddcsOp>(op)) {
         if (failed(requestMaskUse(addcs.getCarryInMutable(), "b32", op)) ||
             failed(requestMaskUse(addcs.getMaskMutable(), "b32", op)) ||
-            failed(requestMask(addcs.getCarry(), "b32", op)))
+            failed(requestMask(addcs.getCarry(), "b32", op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto activePrefix = dyn_cast<VMIActivePrefixIndexOp>(op)) {
         auto resultType = cast<VMIVRegType>(activePrefix.getResult().getType());
         if (failed(requestMaskUse(
                 activePrefix.getMaskMutable(),
-                getMaskGranularityForElement(resultType.getElementType()), op)))
+                getMaskGranularityForElement(resultType.getElementType()), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto compress = dyn_cast<VMICompressOp>(op)) {
         auto resultType = cast<VMIVRegType>(compress.getResult().getType());
         if (failed(requestMaskUse(
                 compress.getMaskMutable(),
-                getMaskGranularityForElement(resultType.getElementType()), op)))
+                getMaskGranularityForElement(resultType.getElementType()), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vintlv = dyn_cast<VMIVintlvOp>(op)) {
         if (failed(requestMaskUseForSource(vintlv.getMaskMutable(),
-                                           vintlv.getLhs(), op)))
+                                           vintlv.getLhs(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto vdintlv = dyn_cast<VMIVdintlvOp>(op)) {
         if (failed(requestMaskUseForSource(vdintlv.getMaskMutable(),
-                                           vdintlv.getLhs(), op)))
+                                           vdintlv.getLhs(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIReduceAddIOp>(op)) {
         if (failed(requestMaskUseForSource(reduce.getMaskMutable(),
-                                           reduce.getSource(), op)))
+                                           reduce.getSource(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIReduceAddFOp>(op)) {
         if (failed(requestMaskUseForSource(reduce.getMaskMutable(),
-                                           reduce.getSource(), op)))
+                                           reduce.getSource(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIReduceMaxFOp>(op)) {
         if (failed(requestMaskUseForSource(reduce.getMaskMutable(),
-                                           reduce.getSource(), op)))
+                                           reduce.getSource(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIReduceMinFOp>(op)) {
         if (failed(requestMaskUseForSource(reduce.getMaskMutable(),
-                                           reduce.getSource(), op)))
+                                           reduce.getSource(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIReduceMaxIOp>(op)) {
         if (failed(requestMaskUseForSource(reduce.getMaskMutable(),
-                                           reduce.getSource(), op)))
+                                           reduce.getSource(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIReduceMinIOp>(op)) {
         if (failed(requestMaskUseForSource(reduce.getMaskMutable(),
-                                           reduce.getSource(), op)))
+                                           reduce.getSource(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIGroupReduceAddFOp>(op)) {
         if (failed(requestMaskUseForSource(reduce.getMaskMutable(),
-                                           reduce.getSource(), op)))
+                                           reduce.getSource(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIGroupReduceMaxFOp>(op)) {
         if (failed(requestMaskUseForSource(reduce.getMaskMutable(),
-                                           reduce.getSource(), op)))
+                                           reduce.getSource(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIGroupReduceMinFOp>(op)) {
         if (failed(requestMaskUseForSource(reduce.getMaskMutable(),
-                                           reduce.getSource(), op)))
+                                           reduce.getSource(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIGroupReduceAddIOp>(op)) {
         if (failed(requestMaskUseForSource(reduce.getMaskMutable(),
-                                           reduce.getSource(), op)))
+                                           reduce.getSource(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIGroupReduceMaxIOp>(op)) {
         if (failed(requestMaskUseForSource(reduce.getMaskMutable(),
-                                           reduce.getSource(), op)))
+                                           reduce.getSource(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto reduce = dyn_cast<VMIGroupReduceMinIOp>(op)) {
         if (failed(requestMaskUseForSource(reduce.getMaskMutable(),
-                                           reduce.getSource(), op)))
+                                           reduce.getSource(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto hist = dyn_cast<VMIVdhistOp>(op)) {
-        if (failed(requestMaskUse(hist.getMaskMutable(), "b8", op)))
+        if (failed(requestMaskUse(hist.getMaskMutable(), "b8", op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto hist = dyn_cast<VMIVchistOp>(op)) {
-        if (failed(requestMaskUse(hist.getMaskMutable(), "b8", op)))
+        if (failed(requestMaskUse(hist.getMaskMutable(), "b8", op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto load = dyn_cast<VMIStrideLoadOp>(op)) {
         auto resultType = cast<VMIVRegType>(load.getResult().getType());
         if (failed(requestMaskUse(
                 load.getMaskMutable(),
-                getMaskGranularityForElement(resultType.getElementType()), op)))
+                getMaskGranularityForElement(resultType.getElementType()), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto load = dyn_cast<VMIMaskedLoadOp>(op)) {
         auto resultType = cast<VMIVRegType>(load.getResult().getType());
         if (failed(requestMaskUse(
                 load.getMaskMutable(),
-                getMaskGranularityForElement(resultType.getElementType()), op)))
+                getMaskGranularityForElement(resultType.getElementType()), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto gather = dyn_cast<VMIGatherOp>(op)) {
         auto resultType = cast<VMIVRegType>(gather.getResult().getType());
         if (failed(requestMaskUse(
                 gather.getMaskMutable(),
-                getMaskGranularityForElement(resultType.getElementType()), op)))
+                getMaskGranularityForElement(resultType.getElementType()), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto load = dyn_cast<VMIExpandLoadOp>(op)) {
         auto resultType = cast<VMIVRegType>(load.getResult().getType());
         if (failed(requestMaskUse(
                 load.getMaskMutable(),
-                getMaskGranularityForElement(resultType.getElementType()), op)))
+                getMaskGranularityForElement(resultType.getElementType()), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto store = dyn_cast<VMIMaskedStoreOp>(op)) {
         if (failed(requestMaskUseForSource(store.getMaskMutable(),
-                                           store.getValue(), op)))
+                                           store.getValue(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto store = dyn_cast<VMIStrideStoreOp>(op)) {
         if (failed(requestMaskUseForSource(store.getMaskMutable(),
-                                           store.getValue(), op)))
+                                           store.getValue(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto scatter = dyn_cast<VMIScatterOp>(op)) {
         if (failed(requestMaskUseForSource(scatter.getMaskMutable(),
-                                           scatter.getValue(), op)))
+                                           scatter.getValue(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto store = dyn_cast<VMICompressStoreOp>(op)) {
         if (failed(requestMaskUseForSource(store.getMaskMutable(),
-                                           store.getValue(), op)))
+                                           store.getValue(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-        if (failed(addIfConstraints(ifOp)))
+        if (failed(addIfConstraints(ifOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto executeOp = dyn_cast<scf::ExecuteRegionOp>(op)) {
-        if (failed(addExecuteRegionConstraints(executeOp)))
+        if (failed(addExecuteRegionConstraints(executeOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto indexSwitchOp = dyn_cast<scf::IndexSwitchOp>(op)) {
-        if (failed(addIndexSwitchConstraints(indexSwitchOp)))
+        if (failed(addIndexSwitchConstraints(indexSwitchOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
-        if (failed(addWhileConstraints(whileOp)))
+        if (failed(addWhileConstraints(whileOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto forOp = dyn_cast<scf::ForOp>(op)) {
-        if (failed(addForConstraints(forOp)))
+        if (failed(addForConstraints(forOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto branchOp = dyn_cast<cf::BranchOp>(op)) {
         if (failed(addBranchConstraints(branchOp.getDest(),
-                                        branchOp.getDestOperands(), op)))
+                                        branchOp.getDestOperands(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto condBranchOp = dyn_cast<cf::CondBranchOp>(op)) {
@@ -493,29 +567,34 @@ struct MaskGranularitySolver {
                                         condBranchOp.getTrueDestOperands(),
                                         op)) ||
             failed(addBranchConstraints(condBranchOp.getFalseDest(),
-                                        condBranchOp.getFalseOperands(), op)))
+                                        condBranchOp.getFalseOperands(), op))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto switchOp = dyn_cast<cf::SwitchOp>(op)) {
         if (failed(addBranchConstraints(switchOp.getDefaultDestination(),
-                                        switchOp.getDefaultOperands(), op)))
+                                        switchOp.getDefaultOperands(), op))) {
           return WalkResult::interrupt();
+        }
         for (auto [dest, operands] : llvm::zip(switchOp.getCaseDestinations(),
                                                switchOp.getCaseOperands())) {
-          if (failed(addBranchConstraints(dest, operands, op)))
+          if (failed(addBranchConstraints(dest, operands, op))) {
             return WalkResult::interrupt();
+          }
         }
         return WalkResult::advance();
       }
       if (auto returnOp = dyn_cast<func::ReturnOp>(op)) {
-        if (failed(addReturnConstraints(returnOp)))
+        if (failed(addReturnConstraints(returnOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (auto callOp = dyn_cast<func::CallOp>(op)) {
-        if (failed(addCallConstraints(callOp)))
+        if (failed(addCallConstraints(callOp))) {
           return WalkResult::interrupt();
+        }
         return WalkResult::advance();
       }
       if (op->getName().getStringRef() == "func.call_indirect" &&
@@ -543,8 +622,9 @@ struct MaskGranularitySolver {
   LogicalResult requestMaskUseForSource(OpOperand &mask, Value source,
                                         Operation *op) {
     auto sourceType = dyn_cast<VMIVRegType>(source.getType());
-    if (!sourceType)
+    if (!sourceType) {
       return success();
+    }
     return requestMaskUse(mask,
                           getMaskGranularityForElement(
                               sourceType.getElementType()),
@@ -559,14 +639,17 @@ struct MaskGranularitySolver {
     for (OpResult result : ifOp->getResults()) {
       unsigned resultNo = result.getResultNumber();
       for (Region *region : {&ifOp.getThenRegion(), &ifOp.getElseRegion()}) {
-        if (region->empty())
+        if (region->empty()) {
           continue;
+        }
         auto yieldOp = dyn_cast<scf::YieldOp>(region->front().getTerminator());
-        if (!yieldOp || resultNo >= yieldOp.getNumOperands())
+        if (!yieldOp || resultNo >= yieldOp.getNumOperands()) {
           continue;
+        }
         if (failed(uniteEquivalentValues(result, yieldOp.getOperand(resultNo),
-                                         ifOp)))
+                                         ifOp))) {
           return failure();
+        }
       }
     }
     return success();
@@ -575,21 +658,25 @@ struct MaskGranularitySolver {
   LogicalResult addYieldConstraints(ResultRange results, scf::YieldOp yieldOp,
                                     Operation *op) {
     for (auto [index, result] : llvm::enumerate(results)) {
-      if (index >= yieldOp.getNumOperands())
+      if (index >= yieldOp.getNumOperands()) {
         break;
-      if (failed(uniteEquivalentValues(result, yieldOp.getOperand(index), op)))
+      }
+      if (failed(uniteEquivalentValues(result, yieldOp.getOperand(index), op))) {
         return failure();
+      }
     }
     return success();
   }
 
   LogicalResult addExecuteRegionConstraints(scf::ExecuteRegionOp executeOp) {
     WalkResult result = executeOp.getRegion().walk([&](scf::YieldOp yieldOp) {
-      if (yieldOp->getParentOp() != executeOp.getOperation())
+      if (yieldOp->getParentOp() != executeOp.getOperation()) {
         return WalkResult::advance();
+      }
       if (failed(
-              addYieldConstraints(executeOp->getResults(), yieldOp, executeOp)))
+              addYieldConstraints(executeOp->getResults(), yieldOp, executeOp))) {
         return WalkResult::interrupt();
+      }
       return WalkResult::advance();
     });
     return failure(result.wasInterrupted());
@@ -598,17 +685,20 @@ struct MaskGranularitySolver {
   LogicalResult addIndexSwitchConstraints(scf::IndexSwitchOp indexSwitchOp) {
     auto addBlockTerminator = [&](Block &block) -> LogicalResult {
       auto yieldOp = dyn_cast<scf::YieldOp>(block.getTerminator());
-      if (!yieldOp)
+      if (!yieldOp) {
         return success();
+      }
       return addYieldConstraints(indexSwitchOp->getResults(), yieldOp,
                                  indexSwitchOp);
     };
-
-    if (failed(addBlockTerminator(indexSwitchOp.getDefaultBlock())))
+    if (failed(addBlockTerminator(indexSwitchOp.getDefaultBlock()))) {
       return failure();
-    for (unsigned idx = 0, e = indexSwitchOp.getNumCases(); idx < e; ++idx)
-      if (failed(addBlockTerminator(indexSwitchOp.getCaseBlock(idx))))
+    }
+    for (unsigned idx = 0, e = indexSwitchOp.getNumCases(); idx < e; ++idx) {
+      if (failed(addBlockTerminator(indexSwitchOp.getCaseBlock(idx)))) {
         return failure();
+      }
+    }
     return success();
   }
 
@@ -628,21 +718,25 @@ struct MaskGranularitySolver {
 
   LogicalResult addBranchConstraints(Block *dest, OperandRange operands,
                                      Operation *op) {
-    if (!dest)
+    if (!dest) {
       return success();
+    }
     for (auto [index, operand] : llvm::enumerate(operands)) {
-      if (index >= dest->getNumArguments())
+      if (index >= dest->getNumArguments()) {
         break;
-      if (failed(uniteEquivalentValues(operand, dest->getArgument(index), op)))
+      }
+      if (failed(uniteEquivalentValues(operand, dest->getArgument(index), op))) {
         return failure();
+      }
     }
     return success();
   }
 
   LogicalResult addReturnConstraints(func::ReturnOp returnOp) {
     auto func = returnOp->getParentOfType<func::FuncOp>();
-    if (!func)
+    if (!func) {
       return success();
+    }
 
     auto it = firstReturnOperandsByFunc.find(func);
     if (it == firstReturnOperandsByFunc.end()) {
@@ -653,11 +747,13 @@ struct MaskGranularitySolver {
 
     ArrayRef<Value> firstOperands = it->second;
     for (auto [index, operand] : llvm::enumerate(returnOp.getOperands())) {
-      if (index >= firstOperands.size())
+      if (index >= firstOperands.size()) {
         break;
+      }
       if (failed(
-              uniteEquivalentValues(firstOperands[index], operand, returnOp)))
+              uniteEquivalentValues(firstOperands[index], operand, returnOp))) {
         return failure();
+      }
     }
     return success();
   }
@@ -674,31 +770,36 @@ struct MaskGranularitySolver {
   }
 
   LogicalResult addCallConstraints(func::CallOp callOp) {
-    if (!hasVMIValueTypes(callOp))
+    if (!hasVMIValueTypes(callOp)) {
       return success();
+    }
 
     auto callee = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
         callOp, callOp.getCalleeAttr());
-    if (!callee || callee.empty())
+    if (!callee || callee.empty()) {
       return callOp.emitError()
              << kVMIDiagLayoutContractPrefix
              << "VMI typed call requires a direct internal callee with a body";
+    }
 
     for (auto [operand, argument] :
          llvm::zip(callOp.getOperands(), callee.getArguments())) {
-      if (failed(uniteEquivalentValues(operand, argument, callOp)))
+      if (failed(uniteEquivalentValues(operand, argument, callOp))) {
         return failure();
+      }
     }
 
     SmallVector<func::ReturnOp> returns;
     callee.walk([&](func::ReturnOp returnOp) { returns.push_back(returnOp); });
     for (func::ReturnOp returnOp : returns) {
       for (auto [index, result] : llvm::enumerate(callOp.getResults())) {
-        if (index >= returnOp.getNumOperands())
+        if (index >= returnOp.getNumOperands()) {
           break;
+        }
         if (failed(uniteEquivalentValues(result, returnOp.getOperand(index),
-                                         callOp)))
+                                         callOp))) {
           return failure();
+        }
       }
     }
     return success();
@@ -719,42 +820,50 @@ struct MaskGranularitySolver {
     SmallVector<Type> resultTypes;
     bool found = false;
     module.walk([&](func::CallOp call) {
-      if (call.getCallee() != func.getSymName())
+      if (call.getCallee() != func.getSymName()) {
         return;
+      }
       if (!found) {
         resultTypes.assign(call.getResultTypes().begin(),
                            call.getResultTypes().end());
         found = true;
         return;
       }
-      if (resultTypes.size() != call.getNumResults())
+      if (resultTypes.size() != call.getNumResults()) {
         return;
-      for (auto [index, type] : llvm::enumerate(call.getResultTypes()))
-        if (index < resultTypes.size() && resultTypes[index] != type)
+      }
+      for (auto [index, type] : llvm::enumerate(call.getResultTypes())) {
+        if (index < resultTypes.size() && resultTypes[index] != type) {
           resultTypes[index] = {};
+        }
+      }
     });
     return found ? resultTypes : SmallVector<Type>{};
   }
 
   void rewriteFunctionType() {
     module.walk([&](func::FuncOp func) {
-      if (func.empty())
+      if (func.empty()) {
         return;
+      }
 
       SmallVector<Type> inputs;
       inputs.reserve(func.getNumArguments());
-      for (BlockArgument arg : func.getArguments())
+      for (BlockArgument arg : func.getArguments()) {
         inputs.push_back(arg.getType());
+      }
 
       SmallVector<Type> results;
       SmallVector<Type> callResultTypes = getCallResultTypes(func);
       auto it = firstReturnOperandsByFunc.find(func);
       if (!callResultTypes.empty()) {
-        for (Type type : callResultTypes)
+        for (Type type : callResultTypes) {
           results.push_back(type ? type : Type{});
+        }
       } else if (it != firstReturnOperandsByFunc.end()) {
-        for (Value operand : it->second)
+        for (Value operand : it->second) {
           results.push_back(operand.getType());
+        }
       } else {
         FunctionType functionType = func.getFunctionType();
         for (Type type : functionType.getResults()) {
@@ -772,9 +881,11 @@ struct MaskGranularitySolver {
         }
       }
 
-      for (auto [index, type] : llvm::enumerate(results))
-        if (!type)
+      for (auto [index, type] : llvm::enumerate(results)) {
+        if (!type) {
           results[index] = func.getFunctionType().getResult(index);
+        }
+      }
 
       func.setFunctionType(FunctionType::get(ctx, inputs, results));
     });
@@ -785,10 +896,12 @@ struct MaskGranularitySolver {
     for (MaskUseRequest request : maskUseRequests) {
       Value value = request.operand->get();
       auto sourceType = dyn_cast<VMIMaskType>(value.getType());
-      if (!sourceType)
+      if (!sourceType) {
         continue;
-      if (sourceType.getGranularity() == request.granularity)
+      }
+      if (sourceType.getGranularity() == request.granularity) {
         continue;
+      }
 
       builder.setInsertionPoint(request.operand->getOwner());
       auto resultType = VMIMaskType::get(ctx, sourceType.getElementCount(),
@@ -796,9 +909,10 @@ struct MaskGranularitySolver {
                                          sourceType.getLayoutAttr());
       Value current = rematerializeMaskProducer(
           value, resultType, request.operand->getOwner()->getLoc(), builder);
-      if (!current)
+      if (!current) {
         current = builder.create<VMIEnsureMaskGranularityOp>(
             request.operand->getOwner()->getLoc(), resultType, value);
+      }
       request.operand->set(current);
     }
     return success();
@@ -806,33 +920,38 @@ struct MaskGranularitySolver {
 
   Value rematerializeMaskProducer(Value value, VMIMaskType resultType,
                                   Location loc, OpBuilder &builder) {
-    if (auto createMask = value.getDefiningOp<VMICreateMaskOp>())
+    if (auto createMask = value.getDefiningOp<VMICreateMaskOp>()) {
       return builder
           .create<VMICreateMaskOp>(loc, resultType, createMask.getActiveLanes())
           .getResult();
+    }
 
-    if (auto createGroupMask = value.getDefiningOp<VMICreateGroupMaskOp>())
+    if (auto createGroupMask = value.getDefiningOp<VMICreateGroupMaskOp>()) {
       return builder
           .create<VMICreateGroupMaskOp>(
               loc, resultType, createGroupMask.getActiveElemsPerGroup(),
               createGroupMask.getNumGroupsAttr(),
               createGroupMask.getGroupSizeAttr())
           .getResult();
+    }
 
-    if (auto constantMask = value.getDefiningOp<VMIConstantMaskOp>())
+    if (auto constantMask = value.getDefiningOp<VMIConstantMaskOp>()) {
       return builder
           .create<VMIConstantMaskOp>(loc, resultType,
                                      constantMask.getValueAttr())
           .getResult();
+    }
 
     return {};
   }
 
   LogicalResult run() {
-    if (failed(collect()))
+    if (failed(collect())) {
       return failure();
-    if (failed(addConstraints()))
+    }
+    if (failed(addConstraints())) {
       return failure();
+    }
     rewriteMaskTypes();
     rewriteFunctionType();
     return insertMaskUseMaterializations();
@@ -852,8 +971,9 @@ struct VMIMaskGranularityAssignmentPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(VMIMaskGranularityAssignmentPass)
 
   void runOnOperation() override {
-    if (failed(MaskGranularitySolver(getOperation()).run()))
+    if (failed(MaskGranularitySolver(getOperation()).run())) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/VMIPreAssignmentCombine.cpp
+++ b/lib/PTO/Transforms/VMIPreAssignmentCombine.cpp
@@ -34,11 +34,14 @@ using namespace mlir::pto;
 namespace {
 
 static std::optional<int64_t> getConstantIndexValue(Value value) {
-  if (auto constant = value.getDefiningOp<arith::ConstantIndexOp>())
+  if (auto constant = value.getDefiningOp<arith::ConstantIndexOp>()) {
     return constant.value();
-  if (auto constant = value.getDefiningOp<arith::ConstantOp>())
-    if (auto integerAttr = dyn_cast<IntegerAttr>(constant.getValue()))
+  }
+  if (auto constant = value.getDefiningOp<arith::ConstantOp>()) {
+    if (auto integerAttr = dyn_cast<IntegerAttr>(constant.getValue())) {
       return integerAttr.getInt();
+    }
+  }
   return std::nullopt;
 }
 
@@ -46,18 +49,21 @@ static LogicalResult canonicalizeContiguousGroupLoads(ModuleOp module) {
   SmallVector<VMIGroupLoadOp> loads;
   module.walk([&](VMIGroupLoadOp load) {
     auto resultType = dyn_cast<VMIVRegType>(load.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return;
+    }
 
     int64_t numGroups = load.getNumGroupsAttr().getInt();
     int64_t laneCount = resultType.getElementCount();
-    if (numGroups <= 0 || laneCount % numGroups != 0)
+    if (numGroups <= 0 || laneCount % numGroups != 0) {
       return;
+    }
 
     std::optional<int64_t> rowStride =
         getConstantIndexValue(load.getRowStride());
-    if (rowStride && *rowStride == laneCount / numGroups)
+    if (rowStride && *rowStride == laneCount / numGroups) {
       loads.push_back(load);
+    }
   });
 
   OpBuilder builder(module.getContext());
@@ -76,22 +82,26 @@ static LogicalResult fuseGroupSlotBroadcastLoads(ModuleOp module) {
   SmallVector<VMIGroupBroadcastOp> broadcasts;
   module.walk([&](VMIGroupBroadcastOp broadcast) {
     auto load = broadcast.getSource().getDefiningOp<VMIGroupSlotLoadOp>();
-    if (!load || !load.getResult().hasOneUse())
+    if (!load || !load.getResult().hasOneUse()) {
       return;
+    }
     if (load.getNumGroupsAttr().getInt() !=
-        broadcast.getNumGroupsAttr().getInt())
+        broadcast.getNumGroupsAttr().getInt()) {
       return;
+    }
 
-    if (!isa<VMIVRegType>(broadcast.getResult().getType()))
+    if (!isa<VMIVRegType>(broadcast.getResult().getType())) {
       return;
+    }
     broadcasts.push_back(broadcast);
   });
 
   OpBuilder builder(module.getContext());
   for (VMIGroupBroadcastOp broadcast : broadcasts) {
     auto load = broadcast.getSource().getDefiningOp<VMIGroupSlotLoadOp>();
-    if (!load)
+    if (!load) {
       continue;
+    }
 
     builder.setInsertionPoint(broadcast);
     auto fused = builder.create<VMIGroupBroadcastLoadOp>(
@@ -100,8 +110,9 @@ static LogicalResult fuseGroupSlotBroadcastLoads(ModuleOp module) {
         broadcast.getNumGroupsAttr());
     broadcast.getResult().replaceAllUsesWith(fused.getResult());
     broadcast.erase();
-    if (load->use_empty())
+    if (load->use_empty()) {
       load.erase();
+    }
   }
   return success();
 }
@@ -110,8 +121,9 @@ struct VMIPreAssignmentCombinePass
     : pto::impl::VMIPreAssignmentCombineBase<VMIPreAssignmentCombinePass> {
   void runOnOperation() override {
     if (failed(canonicalizeContiguousGroupLoads(getOperation())) ||
-        failed(fuseGroupSlotBroadcastLoads(getOperation())))
+        failed(fuseGroupSlotBroadcastLoads(getOperation()))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/VPTOBufferMaterialization.cpp
+++ b/lib/PTO/Transforms/VPTOBufferMaterialization.cpp
@@ -70,7 +70,6 @@ Value materializeBufferPointer(Value value, Type elementType,
   auto ptrMemorySpace =
       getNormalizedPtrMemorySpace(memorySpace, rewriter.getContext());
   auto ptrType = PtrType::get(rewriter.getContext(), elementType, ptrMemorySpace);
-
   if (value.getType() == ptrType) {
     return value;
   }

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/Passes.h"
@@ -53,9 +54,10 @@ static pto::AddressSpaceAttr getPointerMemorySpace(Attribute memorySpace,
   if (auto addrSpace = dyn_cast_or_null<pto::AddressSpaceAttr>(memorySpace)) {
     return addrSpace;
   }
-  if (auto intAttr = dyn_cast_or_null<IntegerAttr>(memorySpace))
+  if (auto intAttr = dyn_cast_or_null<IntegerAttr>(memorySpace)) {
     return pto::AddressSpaceAttr::get(
         ctx, static_cast<pto::AddressSpace>(intAttr.getInt()));
+  }
   return pto::AddressSpaceAttr::get(ctx, pto::AddressSpace::GM);
 }
 
@@ -158,10 +160,11 @@ static Value offsetBufferPointer(Value basePtr, Type elementType,
   }
 
   Value offsetIndex = elementOffset;
-  if (!offsetIndex.getType().isIndex())
+  if (!offsetIndex.getType().isIndex()) {
     offsetIndex = rewriter.create<arith::IndexCastUIOp>(loc,
                                                         rewriter.getIndexType(),
                                                         elementOffset);
+  }
   return rewriter.create<pto::AddPtrOp>(loc, basePtr.getType(), basePtr,
                                         offsetIndex);
 }
@@ -185,8 +188,9 @@ static SmallVector<pto::DmaLoopConfig> collectLoopConfigs(ValueRange counts,
   SmallVector<pto::DmaLoopConfig> loops;
   loops.reserve(counts.size());
   for (auto [count, srcStride, dstStride] :
-       llvm::zip(counts, srcStrides, dstStrides))
+       llvm::zip(counts, srcStrides, dstStrides)) {
     loops.push_back({count, srcStride, dstStride});
+  }
   return loops;
 }
 
@@ -214,10 +218,11 @@ static Value offsetPointerByBytes(Value basePtr, Value byteOffset,
   Value bytePtr =
       rewriter.create<pto::CastPtrOp>(loc, bytePtrType, basePtrValue);
   Value offsetIndex = byteOffset;
-  if (!offsetIndex.getType().isIndex())
+  if (!offsetIndex.getType().isIndex()) {
     offsetIndex =
         rewriter.create<arith::IndexCastUIOp>(loc, rewriter.getIndexType(),
                                               offsetIndex);
+  }
   Value advanced =
       rewriter.create<pto::AddPtrOp>(loc, bytePtrType, bytePtr, offsetIndex);
   return rewriter.create<pto::CastPtrOp>(loc, ptrType, advanced);
@@ -229,7 +234,7 @@ static Value offsetPointerByBytes(Value basePtr, Value byteOffset,
   if (!fpc) {
     return {};
   }
-  if (fpc.getType().isInteger(64)) {
+  if (fpc.getType().isInteger(mlir::pto::kValue64)) {
     return fpc;
   }
   if (isa<pto::PtrType>(fpc.getType())) {
@@ -243,7 +248,7 @@ static Value materializeI64Value(Value value, PatternRewriter &rewriter,
   if (!value) {
     return {};
   }
-  if (value.getType().isInteger(64)) {
+  if (value.getType().isInteger(mlir::pto::kValue64)) {
     return value;
   }
   if (auto intType = dyn_cast<IntegerType>(value.getType())) {
@@ -297,7 +302,7 @@ static Value materializeAccStoreClipPayload(Value value, Type destinationElement
 
   Value widened;
   if (auto dstIntType = dyn_cast<IntegerType>(destinationElementType);
-      dstIntType && dstIntType.isUnsignedInteger(8)) {
+      dstIntType && dstIntType.isUnsignedInteger(mlir::pto::kValue8)) {
     widened = rewriter.create<arith::ExtUIOp>(loc, rewriter.getI64Type(), value);
   } else {
     widened = rewriter.create<arith::ExtSIOp>(loc, rewriter.getI64Type(), value);
@@ -309,7 +314,7 @@ static Value materializeAccStoreClipPayload(Value value, Type destinationElement
 
 static Value getI64Constant(Location loc, PatternRewriter &rewriter,
                             uint64_t value) {
-  return rewriter.create<arith::ConstantIntOp>(loc, value, 64);
+  return rewriter.create<arith::ConstantIntOp>(loc, value, mlir::pto::kValue64);
 }
 
 static Value deriveMxScaleDestination(Value dataDestination,
@@ -369,7 +374,7 @@ static Value buildAccStoreFpcValue(Location loc, Value preQuant,
     case pto::AccStoreQuantPreMode::QF322BF16PreVec:
     case pto::AccStoreQuantPreMode::QS322BF16PreVec:
       if (Value quantPtr = materializeI64Value(preQuant, rewriter, loc)) {
-        quantAddr = encodeFixpipeBufferAddr(quantPtr, /*unitShift=*/7);
+        quantAddr = encodeFixpipeBufferAddr(quantPtr, /*unitShift=*/mlir::pto::kValue7);
       }
       break;
     default:
@@ -380,7 +385,7 @@ static Value buildAccStoreFpcValue(Location loc, Value preQuant,
   Value reluAddr;
   if (preReluMode && *preReluMode == pto::ReluPreMode::VectorRelu) {
     if (Value reluPtr = materializeI64Value(preRelu, rewriter, loc)) {
-      reluAddr = encodeFixpipeBufferAddr(reluPtr, /*unitShift=*/6);
+      reluAddr = encodeFixpipeBufferAddr(reluPtr, /*unitShift=*/mlir::pto::kValue6);
     }
   }
 
@@ -451,8 +456,9 @@ static void configureAccStoreScalarPreOps(Location loc, Value preQuant,
   if (clipValue) {
     if (Value clip = materializeAccStoreClipPayload(clipValue,
                                                     destinationElementType,
-                                                    rewriter, loc))
+                                                    rewriter, loc)) {
       rewriter.create<pto::SetFixClipReluOp>(loc, clip);
+    }
   }
 }
 
@@ -468,12 +474,14 @@ static Value configureAccStoreCtrl(Location loc, bool allowAtomic,
   Value originalCtrl = rewriter.create<pto::GetCtrlOp>(loc);
   Value ctrl = originalCtrl;
   uint64_t clearMaskValue = 0;
-  if (allowAtomic && atomicType && atomicOp)
-    clearMaskValue |= (static_cast<uint64_t>(0x7) << 6) |
-                      (static_cast<uint64_t>(0x3) << 9);
-  if (satMode)
-    clearMaskValue |= (static_cast<uint64_t>(1) << 48) |
-                      (static_cast<uint64_t>(1) << 50);
+  if (allowAtomic && atomicType && atomicOp) {
+    clearMaskValue |= (static_cast<uint64_t>(0x7) << mlir::pto::kValue6) |
+                      (static_cast<uint64_t>(0x3) << mlir::pto::kValue9);
+  }
+  if (satMode) {
+    clearMaskValue |= (static_cast<uint64_t>(1) << mlir::pto::kValue48) |
+                      (static_cast<uint64_t>(1) << mlir::pto::kValue50);
+  }
   Value clearMask = getI64Constant(loc, rewriter, clearMaskValue);
   Value fullMask = getI64Constant(loc, rewriter, ~static_cast<uint64_t>(0));
   Value keepMask = rewriter.create<arith::XOrIOp>(loc, clearMask, fullMask);
@@ -488,12 +496,12 @@ static Value configureAccStoreCtrl(Location loc, bool allowAtomic,
   if (satMode && *satMode == pto::AccStoreSatMode::NoSat) {
     ctrl = rewriter.create<arith::OrIOp>(
         loc, ctrl, getI64Constant(loc, rewriter,
-                                  static_cast<uint64_t>(1) << 48));
+                                  static_cast<uint64_t>(1) << mlir::pto::kValue48));
   }
   if (satMode && *satMode == pto::AccStoreSatMode::SatPreserveNan) {
     ctrl = rewriter.create<arith::OrIOp>(
         loc, ctrl, getI64Constant(loc, rewriter,
-                                  static_cast<uint64_t>(1) << 50));
+                                  static_cast<uint64_t>(1) << mlir::pto::kValue50));
   }
   rewriter.create<pto::SetCtrlOp>(loc, ctrl);
   return originalCtrl;
@@ -572,21 +580,21 @@ static FailureOr<Value> packMadXt(Location loc, Value m, Value n, Value k,
   };
 
   Value xt = mI64;
-  xt = bitOr(xt, shl(kI64, 12));
-  xt = bitOr(xt, shl(nI64, 24));
+  xt = bitOr(xt, shl(kI64, mlir::pto::kValue12));
+  xt = bitOr(xt, shl(nI64, mlir::pto::kValue24));
   if (unitFlagMode) {
     uint64_t unitFlagCtrl =
         *unitFlagMode == pto::MadUnitFlagMode::CheckOnly ? 2 : 3;
-    xt = bitOr(xt, shl(constant(unitFlagCtrl), 55));
+    xt = bitOr(xt, shl(constant(unitFlagCtrl), mlir::pto::kValue55));
   }
   if (disableGemv) {
-    xt = bitOr(xt, shl(constant(1), 61));
+    xt = bitOr(xt, shl(constant(1), mlir::pto::kValue61));
   }
   if (cmatrixSource) {
-    xt = bitOr(xt, shl(constant(1), 62));
+    xt = bitOr(xt, shl(constant(1), mlir::pto::kValue62));
   }
   if (cmatrixInit) {
-    xt = bitOr(xt, shl(constant(1), 63));
+    xt = bitOr(xt, shl(constant(1), mlir::pto::kValue63));
   }
   return xt;
 }
@@ -606,20 +614,20 @@ static Value buildMadSemanticCtrl(Location loc, Value ctrl,
                                   std::optional<pto::MadSatMode> satMode,
                                   bool hasNDir,
                                   PatternRewriter &rewriter) {
-  ctrl = setCtrlBit(loc, ctrl, 45, isHif8, rewriter);
+  ctrl = setCtrlBit(loc, ctrl, mlir::pto::kValue45, isHif8, rewriter);
   if (tf32Mode) {
-    ctrl = setCtrlBit(loc, ctrl, 46, true, rewriter);
-    ctrl = setCtrlBit(loc, ctrl, 47,
+    ctrl = setCtrlBit(loc, ctrl, mlir::pto::kValue46, true, rewriter);
+    ctrl = setCtrlBit(loc, ctrl, mlir::pto::kValue47,
                       *tf32Mode == pto::Tf32Mode::RoundAway, rewriter);
   } else {
-    ctrl = setCtrlBit(loc, ctrl, 46, false, rewriter);
-    ctrl = setCtrlBit(loc, ctrl, 47, false, rewriter);
+    ctrl = setCtrlBit(loc, ctrl, mlir::pto::kValue46, false, rewriter);
+    ctrl = setCtrlBit(loc, ctrl, mlir::pto::kValue47, false, rewriter);
   }
   if (satMode) {
-    ctrl = setCtrlBit(loc, ctrl, 48, *satMode == pto::MadSatMode::NoSat,
+    ctrl = setCtrlBit(loc, ctrl, mlir::pto::kValue48, *satMode == pto::MadSatMode::NoSat,
                       rewriter);
   }
-  ctrl = setCtrlBit(loc, ctrl, 51, hasNDir, rewriter);
+  ctrl = setCtrlBit(loc, ctrl, mlir::pto::kValue51, hasNDir, rewriter);
   return ctrl;
 }
 
@@ -856,7 +864,7 @@ deriveLoadCbufToCbControl(Location loc, Value k, Value n, Type elementType,
                           Value mStart, Value kStart, bool transpose,
                           PatternRewriter &rewriter) {
   unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(elementType);
-  if (elemBitWidth == 0 || (elemBitWidth % 8) != 0) {
+  if (elemBitWidth == 0 || (elemBitWidth % mlir::pto::kValue8) != 0) {
     return failure();
   }
   uint64_t elemBytes = elemBitWidth / 8;
@@ -871,8 +879,9 @@ deriveLoadCbufToCbControl(Location loc, Value k, Value n, Type elementType,
     return rewriter.create<arith::DivUIOp>(loc, sum, constant(divisor));
   };
   auto maybeScaleS4KCoord = [&](Value value) -> Value {
-    if (!isFp4Packed)
+    if (!isFp4Packed) {
       return value;
+    }
     // load_cbuf_to_*_s4 interprets K-axis coordinates in packed s4 units.
     // The generic wrapper math above first derives K positions from storage
     // bytes, where one fp4x2 element carries two logical fp4 values, so fp4
@@ -917,7 +926,7 @@ deriveLoadCbufToCaControl(Location loc, Value m, Value k, Type elementType,
                           Value mStart, Value kStart, bool transpose,
                           PatternRewriter &rewriter) {
   unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(elementType);
-  if (elemBitWidth == 0 || (elemBitWidth % 8) != 0) {
+  if (elemBitWidth == 0 || (elemBitWidth % mlir::pto::kValue8) != 0) {
     return failure();
   }
   uint64_t elemBytes = elemBitWidth / 8;
@@ -932,8 +941,9 @@ deriveLoadCbufToCaControl(Location loc, Value m, Value k, Type elementType,
     return rewriter.create<arith::DivUIOp>(loc, sum, constant(divisor));
   };
   auto maybeScaleS4KCoord = [&](Value value) -> Value {
-    if (!isFp4Packed)
+    if (!isFp4Packed) {
       return value;
+    }
     // load_cbuf_to_*_s4 interprets K-axis coordinates in packed s4 units.
     // The generic wrapper math above first derives K positions from storage
     // bytes, where one fp4x2 element carries two logical fp4 values, so fp4
@@ -978,7 +988,7 @@ deriveLoadCbufToCaMxControl(Location loc, Value m, Value k, Type elementType,
                             Value startRow, Value startCol,
                             PatternRewriter &rewriter) {
   unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(elementType);
-  if (elemBitWidth == 0 || (elemBitWidth % 8) != 0) {
+  if (elemBitWidth == 0 || (elemBitWidth % mlir::pto::kValue8) != 0) {
     return failure();
   }
   uint64_t elemBytes = elemBitWidth / 8;
@@ -1008,7 +1018,7 @@ deriveLoadCbufToCbMxControl(Location loc, Value k, Value n, Type elementType,
                             Value startRow, Value startCol,
                             PatternRewriter &rewriter) {
   unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(elementType);
-  if (elemBitWidth == 0 || (elemBitWidth % 8) != 0) {
+  if (elemBitWidth == 0 || (elemBitWidth % mlir::pto::kValue8) != 0) {
     return failure();
   }
   uint64_t elemBytes = elemBitWidth / 8;
@@ -1087,9 +1097,10 @@ struct ExpandUvldPattern : public OpRewritePattern<pto::UvldOp> {
     }
 
     Value basePtr = materializeBufferPointer(op.getSource(), rewriter, op.getLoc());
-    if (!basePtr)
+    if (!basePtr) {
       return op.emitOpError(
           "requires a recoverable pointer base for uvld expansion");
+    }
 
     Value loadPtr = offsetBufferPointer(basePtr, vecType.getElementType(),
                                        op.getOffset(), rewriter, op.getLoc());
@@ -1144,20 +1155,23 @@ static LogicalResult lowerMadSemanticOp(pto::MadSemanticOpInterface op,
                                         PatternRewriter &rewriter) {
   std::optional<pto::MadUnitFlagMode> unitFlagMode;
   if (auto unitFlagModeAttr =
-          dyn_cast_or_null<pto::MadUnitFlagModeAttr>(op.getUnitFlagModeAttr()))
+          dyn_cast_or_null<pto::MadUnitFlagModeAttr>(op.getUnitFlagModeAttr())) {
     unitFlagMode = unitFlagModeAttr.getValue();
+  }
 
   std::optional<pto::Tf32Mode> tf32Mode;
   if (op.supportsTf32Mode()) {
     if (auto tf32ModeAttr =
-            dyn_cast_or_null<pto::Tf32ModeAttr>(op.getTf32ModeAttr()))
+            dyn_cast_or_null<pto::Tf32ModeAttr>(op.getTf32ModeAttr())) {
       tf32Mode = tf32ModeAttr.getValue();
+    }
   }
 
   std::optional<pto::MadSatMode> satMode;
   if (auto satModeAttr =
-          dyn_cast_or_null<pto::MadSatModeAttr>(op.getSatModeAttr()))
+          dyn_cast_or_null<pto::MadSatModeAttr>(op.getSatModeAttr())) {
     satMode = satModeAttr.getValue();
+  }
 
   bool isHif8 = false;
   if (auto lhsPtr = dyn_cast<pto::PtrType>(op.getLhs().getType())) {
@@ -1224,9 +1238,9 @@ struct ExpandDmaLoadPattern : public OpRewritePattern<pto::MteGmUbOp> {
     Value loop2Size = one;
 
     if (dmaArch == DmaArch::A5) {
-      hwLoops = ArrayRef<pto::DmaLoopConfig>(loops).take_front(2);
+      hwLoops = ArrayRef<pto::DmaLoopConfig>(loops).take_front(mlir::pto::kValue2);
       swLoops = ArrayRef<pto::DmaLoopConfig>(loops).drop_front(hwLoops.size());
-      if (hwLoops.size() == 2) {
+      if (hwLoops.size() == mlir::pto::kValue2) {
         rewriter.create<pto::SetLoop2StrideOutToUbOp>(
             loc, hwLoops[0].srcStride, hwLoops[0].dstStride);
         loop2Size = hwLoops[0].count;
@@ -1252,11 +1266,11 @@ struct ExpandDmaLoadPattern : public OpRewritePattern<pto::MteGmUbOp> {
 
     Value leftPadding = op.getLeftPaddingCount();
     if (!leftPadding) {
-      leftPadding = rewriter.create<arith::ConstantIntOp>(loc, 0, 64);
+      leftPadding = rewriter.create<arith::ConstantIntOp>(loc, 0, mlir::pto::kValue64);
     }
     Value rightPadding = op.getRightPaddingCount();
     if (!rightPadding) {
-      rightPadding = rewriter.create<arith::ConstantIntOp>(loc, 0, 64);
+      rightPadding = rewriter.create<arith::ConstantIntOp>(loc, 0, mlir::pto::kValue64);
     }
     Value dataSelect = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getI1Type(),
@@ -1284,8 +1298,9 @@ struct ExpandDmaLoadPattern : public OpRewritePattern<pto::MteGmUbOp> {
           }
         });
     if (dmaArch == DmaArch::A5 &&
-        shouldRestoreDmaLoopSize(loop1Count, loop2Size))
+        shouldRestoreDmaLoopSize(loop1Count, loop2Size)) {
       rewriter.create<pto::SetLoopSizeOutToUbOp>(loc, one, one);
+    }
     rewriter.eraseOp(op);
     return success();
   }
@@ -1312,10 +1327,10 @@ struct ExpandDmaStorePattern : public OpRewritePattern<pto::MteUbGmOp> {
     Value loop2Size = one;
 
     if (dmaArch == DmaArch::A5) {
-      hwLoops = ArrayRef<pto::DmaLoopConfig>(loops).take_front(2);
+      hwLoops = ArrayRef<pto::DmaLoopConfig>(loops).take_front(mlir::pto::kValue2);
       swLoops =
           ArrayRef<pto::DmaLoopConfig>(loops).drop_front(hwLoops.size());
-      if (hwLoops.size() == 2) {
+      if (hwLoops.size() == mlir::pto::kValue2) {
         rewriter.create<pto::SetLoop2StrideUbToOutOp>(
             loc, hwLoops[0].srcStride, hwLoops[0].dstStride);
         loop2Size = hwLoops[0].count;
@@ -1353,8 +1368,9 @@ struct ExpandDmaStorePattern : public OpRewritePattern<pto::MteUbGmOp> {
               l2CacheCtl, op.getNburstDstStride(), op.getNburstSrcStride());
         });
     if (dmaArch == DmaArch::A5 &&
-        shouldRestoreDmaLoopSize(loop1Count, loop2Size))
+        shouldRestoreDmaLoopSize(loop1Count, loop2Size)) {
       rewriter.create<pto::SetLoopSizeUbToOutOp>(loc, one, one);
+    }
     rewriter.eraseOp(op);
     return success();
   }
@@ -1398,13 +1414,13 @@ struct ExpandCubeLoadPattern : public OpRewritePattern<pto::MteGmL1Op> {
         collectLoopConfigs(op.getLoopCounts(), op.getLoopSrcStrides(),
                            op.getLoopDstStrides());
     ArrayRef<pto::DmaLoopConfig> hwLoops =
-        ArrayRef<pto::DmaLoopConfig>(loops).take_front(2);
+        ArrayRef<pto::DmaLoopConfig>(loops).take_front(mlir::pto::kValue2);
     ArrayRef<pto::DmaLoopConfig> swLoops =
         ArrayRef<pto::DmaLoopConfig>(loops).drop_front(hwLoops.size());
 
     Value loop1Count;
     Value loop2Count = one;
-    if (hwLoops.size() == 2) {
+    if (hwLoops.size() == mlir::pto::kValue2) {
       rewriter.create<pto::SetLoop2StrideOutToL1Op>(
           loc,
           packLoopPair(loc, hwLoops[0].srcStride, hwLoops[0].dstStride,
@@ -1440,9 +1456,10 @@ struct ExpandCubeLoadPattern : public OpRewritePattern<pto::MteGmL1Op> {
               loc, source, destination, op.getNBurst(), op.getLenBurst(),
               op.getNburstSrcStride(), op.getNburstDstStride());
         });
-    if (loop1Count && (!isKnownOne(loop1Count) || !isKnownOne(loop2Count)))
+    if (loop1Count && (!isKnownOne(loop1Count) || !isKnownOne(loop2Count))) {
       rewriter.create<pto::SetLoopSizeOutToL1Op>(
           loc, packLoopSize(loc, one, one, rewriter));
+    }
     rewriter.eraseOp(op);
     return success();
   }
@@ -1575,17 +1592,19 @@ struct ExpandLeftLoadPattern : public OpRewritePattern<pto::MteL1L0aOp> {
       return rewriter.notifyMatchFailure(op, "expected pointer-like destination");
     }
     FailureOr<LoadCbufToCbControl> control = [&]() -> FailureOr<LoadCbufToCbControl> {
-      if (op.getMStart())
+      if (op.getMStart()) {
         return LoadCbufToCbControl{op.getMStart(), op.getKStart(),
                                    op.getMStep(), op.getKStep(),
                                    op.getSrcStride(), op.getDstStride()};
+}
       return deriveLoadCbufToCaControl(
           loc, op.getM(), op.getK(), elementType, op.getStartRow(),
           op.getStartCol(), op.getTranspose(), rewriter);
     }();
-    if (failed(control))
+    if (failed(control)) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to derive load_cbuf_to_ca control");
+}
     if (pto::isPTOFloat4PackedType(elementType)) {
       rewriter.create<pto::LoadCbufToCaS4Op>(
           loc, source, destination, control->mStart,
@@ -1622,17 +1641,19 @@ struct ExpandRightLoadPattern : public OpRewritePattern<pto::MteL1L0bOp> {
       return rewriter.notifyMatchFailure(op, "expected pointer-like destination");
     }
     FailureOr<LoadCbufToCbControl> control = [&]() -> FailureOr<LoadCbufToCbControl> {
-      if (op.getMStart())
+      if (op.getMStart()) {
         return LoadCbufToCbControl{op.getMStart(), op.getKStart(),
                                    op.getMStep(), op.getKStep(),
                                    op.getSrcStride(), op.getDstStride()};
+}
       return deriveLoadCbufToCbControl(
           loc, op.getK(), op.getN(), elementType, op.getStartRow(),
           op.getStartCol(), op.getTranspose(), rewriter);
     }();
-    if (failed(control))
+    if (failed(control)) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to derive load_cbuf_to_cb control");
+}
     if (pto::isPTOFloat4PackedType(elementType)) {
       rewriter.create<pto::LoadCbufToCbS4Op>(
           loc, source, destination, control->mStart,
@@ -1668,28 +1689,32 @@ struct ExpandLeftLoadMxPattern : public OpRewritePattern<pto::MteL1L0aMxOp> {
       return rewriter.notifyMatchFailure(op, "expected pointer-like destination");
     }
     destination = deriveMxScaleDestination(destination, rewriter, loc);
-    if (!destination)
+    if (!destination) {
       return rewriter.notifyMatchFailure(
           op, "failed to derive MX scale destination pointer");
+    }
 
     LoadCbufToMxControl control;
     if (op.getXStart()) {
       if (!op.getYStart() || !op.getXStep() || !op.getYStep() ||
-          !op.getSrcStride() || !op.getDstStride())
+          !op.getSrcStride() || !op.getDstStride()) {
         return rewriter.notifyMatchFailure(op,
                                            "expected complete full MX operands");
+      }
       control = {op.getXStart(), op.getYStart(), op.getXStep(), op.getYStep(),
                  op.getSrcStride(), op.getDstStride()};
     } else {
-      if (!op.getM() || !op.getK() || !op.getStartRow() || !op.getStartCol())
+      if (!op.getM() || !op.getK() || !op.getStartRow() || !op.getStartCol()) {
         return rewriter.notifyMatchFailure(
             op, "expected complete shape-derived MX operands");
+      }
       FailureOr<LoadCbufToMxControl> derived = deriveLoadCbufToCaMxControl(
           loc, op.getM(), op.getK(), sourceType.getElementType(),
           op.getStartRow(), op.getStartCol(), rewriter);
-      if (failed(derived))
+      if (failed(derived)) {
         return rewriter.notifyMatchFailure(
             op, "failed to derive load_cbuf_to_ca_mx control");
+      }
       control = *derived;
     }
 
@@ -1719,28 +1744,32 @@ struct ExpandRightLoadMxPattern : public OpRewritePattern<pto::MteL1L0bMxOp> {
       return rewriter.notifyMatchFailure(op, "expected pointer-like destination");
     }
     destination = deriveMxScaleDestination(destination, rewriter, loc);
-    if (!destination)
+    if (!destination) {
       return rewriter.notifyMatchFailure(
           op, "failed to derive MX scale destination pointer");
+    }
 
     LoadCbufToMxControl control;
     if (op.getXStart()) {
       if (!op.getYStart() || !op.getXStep() || !op.getYStep() ||
-          !op.getSrcStride() || !op.getDstStride())
+          !op.getSrcStride() || !op.getDstStride()) {
         return rewriter.notifyMatchFailure(op,
                                            "expected complete full MX operands");
+      }
       control = {op.getXStart(), op.getYStart(), op.getXStep(), op.getYStep(),
                  op.getSrcStride(), op.getDstStride()};
     } else {
-      if (!op.getK() || !op.getN() || !op.getStartRow() || !op.getStartCol())
+      if (!op.getK() || !op.getN() || !op.getStartRow() || !op.getStartCol()) {
         return rewriter.notifyMatchFailure(
             op, "expected complete shape-derived MX operands");
+      }
       FailureOr<LoadCbufToMxControl> derived = deriveLoadCbufToCbMxControl(
           loc, op.getK(), op.getN(), sourceType.getElementType(),
           op.getStartRow(), op.getStartCol(), rewriter);
-      if (failed(derived))
+      if (failed(derived)) {
         return rewriter.notifyMatchFailure(
             op, "failed to derive load_cbuf_to_cb_mx control");
+      }
       control = *derived;
     }
 
@@ -1775,8 +1804,9 @@ struct ExpandAccStorePattern : public OpRewritePattern<pto::MteL0cL1Op> {
     if (Value fpc = buildAccStoreFpcValue(loc, op.getPreQuant(),
                                           op.getPreQuantMode(),
                                           op.getPreRelu(),
-                                          op.getPreReluMode(), rewriter))
+                                          op.getPreReluMode(), rewriter)) {
       rewriter.create<pto::SetFpcOp>(loc, fpc);
+    }
     Value originalCtrl =
         configureAccStoreCtrl(loc, /*allowAtomic=*/false, std::nullopt,
                               std::nullopt, op.getSatMode(), rewriter);
@@ -1874,8 +1904,9 @@ struct ExpandAccStoreGmPattern : public OpRewritePattern<pto::MteL0cGmOp> {
     if (Value fpc = buildAccStoreFpcValue(loc, op.getPreQuant(),
                                           op.getPreQuantMode(),
                                           op.getPreRelu(),
-                                          op.getPreReluMode(), rewriter))
+                                          op.getPreReluMode(), rewriter)) {
       rewriter.create<pto::SetFpcOp>(loc, fpc);
+    }
     Value originalCtrl =
         configureAccStoreCtrl(loc, /*allowAtomic=*/true, op.getAtomicType(),
                               op.getAtomicOp(), op.getSatMode(), rewriter);
@@ -1972,8 +2003,9 @@ struct ExpandAccStoreUbPattern : public OpRewritePattern<pto::MteL0cUbOp> {
     if (Value fpc = buildAccStoreFpcValue(loc, op.getPreQuant(),
                                           op.getPreQuantMode(),
                                           op.getPreRelu(),
-                                          op.getPreReluMode(), rewriter))
+                                          op.getPreReluMode(), rewriter)) {
       rewriter.create<pto::SetFpcOp>(loc, fpc);
+    }
     Value originalCtrl =
         configureAccStoreCtrl(loc, /*allowAtomic=*/false, std::nullopt,
                               std::nullopt, op.getSatMode(), rewriter);

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -108,13 +108,15 @@ static Type getLLVMCompatibleVectorType(ArrayRef<int64_t> shape,
 }
 
 static Type normalizePayloadTypeForLLVMLowering(Type type, Builder &builder) {
-  if (pto::isPTOHiFloat8x2Type(type))
+  if (pto::isPTOHiFloat8x2Type(type)) {
     return getLLVMCompatibleVectorType(
         {2}, LLVM::LLVMHiFloat8Type::get(builder.getContext()));
+}
   // bf16x2 is a 4-byte packed pair; lower it as an opaque i32 so vregs whose
   // element type is bf16x2 get a valid LLVM type.
-  if (pto::isPTOBF16x2Type(type))
+  if (pto::isPTOBF16x2Type(type)) {
     return builder.getI32Type();
+}
   if (Type lowpType = getLowPrecisionLLVMType(type, builder.getContext()))
   {
     return lowpType;
@@ -158,8 +160,9 @@ static Type normalizeGEPElementTypeForLLVMLowering(Type type,
   }
   if (isa<LLVM::LLVMHiFloat8Type, LLVM::LLVMFloat8E4M3Type,
           LLVM::LLVMFloat8E5M2Type, LLVM::LLVMFloat4E1M2x2Type,
-          LLVM::LLVMFloat4E2M1x2Type>(type))
+          LLVM::LLVMFloat4E2M1x2Type>(type)) {
     return builder.getI8Type();
+  }
 
   if (auto vecType = dyn_cast<VectorType>(type)) {
     Type normalizedElement =
@@ -193,10 +196,12 @@ static Type convertVPTOType(Type type, Builder &builder) {
     return getLLVMCompatibleVectorType({vecType.getElementCount()},
                                        elementType);
   }
-  if (isa<pto::MaskType>(type))
+  if (isa<pto::MaskType>(type)) {
     return VectorType::get({256}, builder.getI1Type());
-  if (isa<pto::AlignType>(type))
+  }
+  if (isa<pto::AlignType>(type)) {
     return VectorType::get({32}, builder.getI8Type());
+  }
   if (isa<pto::StructType>(type))
   {
     return LLVM::LLVMPointerType::get(builder.getContext());
@@ -266,8 +271,9 @@ static bool hasVPTOConvertibleType(Type type) {
   }
   if (isa<pto::VRegType, pto::MaskType, pto::AlignType, pto::PtrType,
           pto::StructType>(type) ||
-      pto::isPTOLowPrecisionType(type))
+      pto::isPTOLowPrecisionType(type)) {
     return true;
+  }
   if (auto vecType = dyn_cast<VectorType>(type))
   {
     return hasVPTOConvertibleType(vecType.getElementType());
@@ -281,8 +287,9 @@ static bool hasVPTOConvertibleType(TypeRange types) {
 
 static Value materializeVPTOCast(OpBuilder &builder, Type resultType,
                                  ValueRange inputs, Location loc) {
-  if (inputs.size() != 1)
+  if (inputs.size() != 1) {
     return {};
+  }
   return builder
       .create<UnrealizedConversionCastOp>(loc, TypeRange{resultType}, inputs)
       .getResult(0);
@@ -323,8 +330,9 @@ static LLVM::LLVMStructType getVPTOStructStorageType(pto::StructType structType,
     if (!frame.materialize) {
       worklist.push_back({frame.type, true});
       for (Type fieldType : frame.type.getFieldTypes()) {
-        if (auto nestedStruct = dyn_cast<pto::StructType>(fieldType))
+        if (auto nestedStruct = dyn_cast<pto::StructType>(fieldType)) {
           worklist.push_back({nestedStruct, false});
+        }
       }
       continue;
     }
@@ -616,23 +624,29 @@ static FailureOr<StringRef> buildMadTypedCalleeName(MLIRContext *context,
     return StringAttr::get(context, "llvm.hivm.MAD.f322f32.c310").getValue();
   }
   if (isSignedOrSignlessInteger(dyn_cast<IntegerType>(lhsElem), 8) &&
-      rhs == "s8" && dst == "s32")
+      rhs == "s8" && dst == "s32") {
     return StringAttr::get(context, "llvm.hivm.MAD.s8.c310").getValue();
+  }
   if (isMadE4M3ElementType(lhsElem) && isMadE4M3ElementType(rhsElem) &&
-      dst == "f32")
+      dst == "f32") {
     return StringAttr::get(context, "llvm.hivm.MAD.e4m3e4m3.c310").getValue();
+  }
   if (isMadE4M3ElementType(lhsElem) && isMadE5M2ElementType(rhsElem) &&
-      dst == "f32")
+      dst == "f32") {
     return StringAttr::get(context, "llvm.hivm.MAD.e4m3e5m2.c310").getValue();
+  }
   if (isMadE5M2ElementType(lhsElem) && isMadE4M3ElementType(rhsElem) &&
-      dst == "f32")
+      dst == "f32") {
     return StringAttr::get(context, "llvm.hivm.MAD.e5m2e4m3.c310").getValue();
+  }
   if (isMadE5M2ElementType(lhsElem) && isMadE5M2ElementType(rhsElem) &&
-      dst == "f32")
+      dst == "f32") {
     return StringAttr::get(context, "llvm.hivm.MAD.e5m2e5m2.c310").getValue();
+  }
   if (pto::isPTOHiFloat8Type(lhsElem) && pto::isPTOHiFloat8Type(rhsElem) &&
-      dst == "f32")
+      dst == "f32") {
     return StringAttr::get(context, "llvm.hivm.MAD.e4m3e4m3.c310").getValue();
+  }
   if (lhsElem.isF16() && rhs == "s4")
   {
     return StringAttr::get(context, "llvm.hivm.MAD.f16s4.c310").getValue();
@@ -820,11 +834,13 @@ static Type getLowpPayloadCarrierType(Type vectorLikeType,
   Type elementType = getElementTypeFromVectorLike(vectorLikeType);
   std::optional<LowpPayloadABI> abi =
       getLowpPayloadABI(elementType, context);
-  if (!abi)
+  if (!abi) {
     return {};
+  }
   auto lanes = getElementCountFromVectorLike(vectorLikeType);
-  if (!lanes)
+  if (!lanes) {
     return {};
+  }
   return VectorType::get({*lanes}, abi->llvmElementType);
 }
 
@@ -864,8 +880,9 @@ static Value castFromPayloadABI(
 static std::string getAtomicElementTypeFragment(Type type,
                                                 Attribute signednessAttr) {
   if (auto vecType = dyn_cast<VectorType>(type)) {
-    if (vecType.getRank() != 1 || vecType.getDimSize(0) != 2)
+    if (vecType.getRank() != 1 || vecType.getDimSize(0) != 2) {
       return {};
+    }
     if (vecType.getElementType().isF16())
     {
       return "f16x2";
@@ -889,10 +906,12 @@ static std::string getAtomicElementTypeFragment(Type type,
     return "fp32";
   }
   auto intType = dyn_cast<IntegerType>(type);
-  if (!intType)
+  if (!intType) {
     return {};
-  if (intType.getWidth() != 32 && intType.getWidth() != 64)
+  }
+  if (intType.getWidth() != 32 && intType.getWidth() != 64) {
     return {};
+  }
   if (signednessAttr) {
     auto signedness = cast<pto::SignednessAttr>(signednessAttr).getValue();
     return std::string(signedness == pto::Signedness::Unsigned ? "u" : "s") +
@@ -919,8 +938,9 @@ static std::string getL0LoadElementFragment(Type type) {
       StringRef(lower).contains("e8m0") ||
       StringRef(lower).contains("hif8") ||
       StringRef(lower).contains("e1m2x2") ||
-      StringRef(lower).contains("e2m1x2"))
+      StringRef(lower).contains("e2m1x2")) {
     return "s8";
+  }
   return {};
 }
 
@@ -965,8 +985,9 @@ static std::string getShuffleIntrinsicTypeFragment(Type type) {
   }
   if (auto vecType = dyn_cast<VectorType>(type)) {
     if (vecType.getRank() == 1 && vecType.getDimSize(0) == 2 &&
-        vecType.getElementType().isF16())
+        vecType.getElementType().isF16()) {
       return "v2f16";
+    }
   }
   return {};
 }
@@ -974,8 +995,9 @@ static std::string getShuffleIntrinsicTypeFragment(Type type) {
 static std::string getReduxIntrinsicTypeFragment(Type type,
                                                  Attribute signednessAttr) {
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.getWidth() != 32)
+    if (intType.getWidth() != 32) {
       return {};
+    }
     bool isUnsigned = false;
     if (signednessAttr) {
       isUnsigned = cast<pto::SignednessAttr>(signednessAttr).getValue() ==
@@ -1153,8 +1175,9 @@ static bool isCompatibleScalarForSemanticType(Type semanticType,
 }
 
 static std::string getCopyElementFragment(Type elementType) {
-  if (!elementType)
+  if (!elementType) {
     return {};
+  }
   if (elementType.isF16())
   {
     return "f16";
@@ -1209,16 +1232,18 @@ static std::string getCopyElementFragment(Type elementType) {
 }
 
 static std::string getNd2NzCopyElementFragment(Type elementType) {
-  if (!elementType)
+  if (!elementType) {
     return {};
+  }
   std::string typeText;
   llvm::raw_string_ostream os(typeText);
   elementType.print(os);
   os.flush();
   std::string lower = StringRef(typeText).lower();
   if (StringRef(lower).contains("e4m3") || StringRef(lower).contains("e5m2") ||
-      StringRef(lower).contains("e8m0") || StringRef(lower).contains("hif8"))
+      StringRef(lower).contains("e8m0") || StringRef(lower).contains("hif8")) {
     return "U8";
+  }
   if (StringRef(lower).contains("e1m2x2") || StringRef(lower).contains("e2m1x2"))
   {
     return "U8";
@@ -1381,11 +1406,13 @@ static std::optional<uint64_t> parsePartImmediate(StringRef part) {
 
 static std::optional<uint64_t> parseVcvtPartImmediate(StringRef part) {
   if (part == "EVEN" || part == "PART_EVEN" || part == "P0" ||
-      part == "PART_P0")
+      part == "PART_P0") {
     return 0;
+  }
   if (part == "ODD" || part == "PART_ODD" || part == "P1" ||
-      part == "PART_P1")
+      part == "PART_P1") {
     return 1;
+  }
   if (part == "P2" || part == "PART_P2")
   {
     return 2;
@@ -2023,8 +2050,9 @@ static Value packBlockRepeatStride(Operation *anchor, Value blockStride,
   Value blockI32 = castIntegerLikeTo(anchor, blockStride, builder.getI32Type());
   Value repeatI32 =
       castIntegerLikeTo(anchor, repeatStride, builder.getI32Type());
-  if (!blockI32 || !repeatI32)
+  if (!blockI32 || !repeatI32) {
     return {};
+  }
 
   auto c16 = builder.create<arith::ConstantIntOp>(anchor->getLoc(), 16, 32);
   auto blockShifted =
@@ -2105,8 +2133,9 @@ packCopyGmToUbConfig0(Operation *anchor, ValueRange operands) {
   Value dataSelect = castIntegerLikeTo(anchor, operands[7], builder.getI64Type());
   Value cacheCtl = getI64Operand(8);
   if (!sid || !nBurst || !lenBurst || !leftPadding || !rightPadding ||
-      !dataSelect || !cacheCtl)
+      !dataSelect || !cacheCtl) {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -2546,8 +2575,9 @@ static FailureOr<Value> packCopyCbufToBtConfig(Operation *anchor,
   Value sourceGapI64 = castIntegerLikeTo(anchor, sourceGap, builder.getI64Type());
   Value dstGapI64 = castIntegerLikeTo(anchor, dstGap, builder.getI64Type());
   if (!convControlI64 || !nBurstI64 || !lenBurstI64 || !sourceGapI64 ||
-      !dstGapI64)
+      !dstGapI64) {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -2804,12 +2834,13 @@ static FailureOr<Value> convertElementOffsetToBytes(Operation *anchor, Value off
   {
     bitWidth = intType.getWidth();
   }
-  else if (isLowpPayloadElementType(elementType))
+  else if (isLowpPayloadElementType(elementType)) {
     bitWidth = 8;
-  else if (auto floatType = dyn_cast<FloatType>(elementType))
+  } else if (auto floatType = dyn_cast<FloatType>(elementType)) {
     bitWidth = floatType.getWidth();
-  else if (pto::isPTOBF16x2Type(elementType))
+  } else if (pto::isPTOBF16x2Type(elementType)) {
     bitWidth = 32;
+}
   if (bitWidth == 0 || bitWidth % 8 != 0)
   {
     return failure();
@@ -2845,11 +2876,11 @@ materializeDynamicPltMask(ConversionPatternRewriter &rewriter,
     if (intType.getWidth() == 32)
     {
       calleeName = StringRef("llvm.hivm.plt.b32.v300");
-    }
-    else if (intType.getWidth() == 16)
+    } else if (intType.getWidth() == 16) {
       calleeName = StringRef("llvm.hivm.plt.b16.v300");
-    else if (intType.getWidth() == 8)
+    } else if (intType.getWidth() == 8) {
       calleeName = StringRef("llvm.hivm.plt.b8.v300");
+    }
   }
   if (calleeName.empty())
   {
@@ -3027,11 +3058,13 @@ static FailureOr<StringRef> buildVselrCallee(MLIRContext *context,
 
   std::string vec = getElementTypeFragment(elemType);
   if (auto floatType = dyn_cast<FloatType>(elemType);
-      floatType && floatType.isF32())
+      floatType && floatType.isF32()) {
     vec = "u32";
+  }
   if (std::optional<LowpPayloadABI> abi =
-          getLowpPayloadABI(elemType, context))
+          getLowpPayloadABI(elemType, context)) {
     vec = abi->intrinsicElementFragment.str();
+  }
   if (vec.empty())
   {
     return failure();
@@ -3517,13 +3550,13 @@ static FailureOr<StringRef> buildL1CacheLoadCallee(MLIRContext *context,
     if (intType.getWidth() == 8)
     {
       elem = "s8";
-    }
-    else if (intType.getWidth() == 16)
+    } else if (intType.getWidth() == 16) {
       elem = "s16";
-    else if (intType.getWidth() == 32)
+    } else if (intType.getWidth() == 32) {
       elem = "s32";
-    else if (intType.getWidth() == 64)
+    } else if (intType.getWidth() == 64) {
       elem = "s64";
+    }
   } else if (resultType.isF16() || resultType.isBF16()) {
     elem = "s16";
   } else if (resultType.isF32()) {
@@ -3538,11 +3571,11 @@ static FailureOr<StringRef> buildL1CacheLoadCallee(MLIRContext *context,
     if (totalBits == 16)
     {
       elem = "s16";
-    }
-    else if (totalBits == 32)
+    } else if (totalBits == 32) {
       elem = "s32";
-    else if (totalBits == 64)
+    } else if (totalBits == 64) {
       elem = "s64";
+    }
   }
   if (elem.empty())
   {
@@ -3563,13 +3596,13 @@ static FailureOr<StringRef> buildL1CacheStoreCallee(MLIRContext *context,
     if (intType.getWidth() == 8)
     {
       elem = "b8";
-    }
-    else if (intType.getWidth() == 16)
+    } else if (intType.getWidth() == 16) {
       elem = "b16";
-    else if (intType.getWidth() == 32)
+    } else if (intType.getWidth() == 32) {
       elem = "b32";
-    else if (intType.getWidth() == 64)
+    } else if (intType.getWidth() == 64) {
       elem = "b64";
+    }
   } else if (valueType.isF16() || valueType.isBF16()) {
     elem = "b16";
   } else if (valueType.isF32()) {
@@ -3584,11 +3617,11 @@ static FailureOr<StringRef> buildL1CacheStoreCallee(MLIRContext *context,
     if (totalBits == 16)
     {
       elem = "b16";
-    }
-    else if (totalBits == 32)
+    } else if (totalBits == 32) {
       elem = "b32";
-    else if (totalBits == 64)
+    } else if (totalBits == 64) {
       elem = "b64";
+    }
   }
   if (elem.empty())
   {
@@ -3659,8 +3692,9 @@ static std::string getLLVMFloatBuiltinFragment(Type type) {
   }
 
   auto vecType = dyn_cast<VectorType>(type);
-  if (!vecType || vecType.getRank() != 1 || vecType.getDimSize(0) != 2)
+  if (!vecType || vecType.getRank() != 1 || vecType.getDimSize(0) != 2) {
     return {};
+  }
   Type elementType = vecType.getElementType();
   if (elementType.isF16())
   {
@@ -3681,8 +3715,9 @@ static std::string getHIVMFloatBuiltinFragment(Type type) {
   }
 
   auto vecType = dyn_cast<VectorType>(type);
-  if (!vecType || vecType.getRank() != 1 || vecType.getDimSize(0) != 2)
+  if (!vecType || vecType.getRank() != 1 || vecType.getDimSize(0) != 2) {
     return {};
+  }
   Type elementType = vecType.getElementType();
   if (elementType.isF16())
   {
@@ -3809,8 +3844,9 @@ FailureOr<StringRef> buildBinaryScalarMathCallee<pto::FMinOp>(MLIRContext *conte
                                                               Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
   if (elem != "f16" && elem != "f32" && elem != "bf16" &&
-      elem != "v2f16" && elem != "v2bf16")
+      elem != "v2f16" && elem != "v2bf16") {
     return failure();
+  }
   return StringAttr::get(context, "llvm.minnum." + elem).getValue();
 }
 
@@ -3819,8 +3855,9 @@ FailureOr<StringRef> buildBinaryScalarMathCallee<pto::FMaxOp>(MLIRContext *conte
                                                               Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
   if (elem != "f16" && elem != "f32" && elem != "bf16" &&
-      elem != "v2f16" && elem != "v2bf16")
+      elem != "v2f16" && elem != "v2bf16") {
     return failure();
+  }
   return StringAttr::get(context, "llvm.maxnum." + elem).getValue();
 }
 
@@ -3847,12 +3884,14 @@ static FailureOr<StringRef> buildFmaCallee(MLIRContext *context, Type valueType)
 static std::string getConvertScalarFragment(Type type,
                                             Attribute signednessAttr) {
   if (auto vecType = dyn_cast<VectorType>(type)) {
-    if (vecType.getRank() != 1 || vecType.getDimSize(0) != 2)
+    if (vecType.getRank() != 1 || vecType.getDimSize(0) != 2) {
       return {};
+    }
     Type elementType = vecType.getElementType();
     if (std::string elem = getLowPrecisionElementFragment(elementType);
-        !elem.empty() && !pto::isPTOFloat4PackedType(elementType))
+        !elem.empty() && !pto::isPTOFloat4PackedType(elementType)) {
       return elem + "x2";
+    }
     if (elementType.isF32())
     {
       return "f32x2";
@@ -3885,8 +3924,9 @@ static std::string getConvertScalarFragment(Type type,
   }
   auto intType = dyn_cast<IntegerType>(type);
   if (!intType || (intType.getWidth() != 32 && intType.getWidth() != 64) ||
-      !signednessAttr)
+      !signednessAttr) {
     return {};
+  }
   auto signedness = cast<pto::SignednessAttr>(signednessAttr).getValue();
   return std::string(signedness == pto::Signedness::Unsigned ? "u" : "s") +
          std::to_string(intType.getWidth());
@@ -4093,8 +4133,9 @@ static FailureOr<StringRef> buildCopyGmToUbCallee(MLIRContext *context,
   auto getElementSuffix = [&]() -> std::string {
     if ((isa<IntegerType>(elementType) &&
          cast<IntegerType>(elementType).getWidth() == 64) ||
-        elementType.isF64())
+        elementType.isF64()) {
       return "s32";
+    }
     return getCopyElementFragment(elementType);
   };
 
@@ -4124,9 +4165,10 @@ static FailureOr<StringRef> buildCopyGmToUbCallee(MLIRContext *context,
 
 static StringRef buildCopyUbToGmCallee(MLIRContext *context,
                                        const std::string &march) {
-  if (march == "dav-c220-vec")
+  if (march == "dav-c220-vec") {
     return StringAttr::get(context, "llvm.hivm.MOV.UB.TO.OUT.v220.1")
         .getValue();
+  }
   return StringAttr::get(context, "llvm.hivm.MOV.UB.TO.OUT.ALIGN.V2.DV")
       .getValue();
 }
@@ -4210,8 +4252,9 @@ buildCopyGmToCbufMultiNd2NzCallee(MLIRContext *context, Type sourceType) {
 
 static std::string getDn2NzCopyElementFragment(Type type) {
   auto ptrType = dyn_cast<pto::PtrType>(type);
-  if (!ptrType)
+  if (!ptrType) {
     return {};
+  }
 
   Type elementType = ptrType.getElementType();
   std::string typeText;
@@ -4220,8 +4263,9 @@ static std::string getDn2NzCopyElementFragment(Type type) {
   os.flush();
   std::string lower = StringRef(typeText).lower();
   if (StringRef(lower).contains("e4m3") || StringRef(lower).contains("e5m2") ||
-      StringRef(lower).contains("e8m0") || StringRef(lower).contains("hif8"))
+      StringRef(lower).contains("e8m0") || StringRef(lower).contains("hif8")) {
     return "u8";
+  }
 
   if (elementType.isF16() || elementType.isBF16())
   {
@@ -4357,12 +4401,14 @@ static FailureOr<StringRef> buildCopyMatrixCcToUbCallee(MLIRContext *context,
     return failure();
   }
   Type dstElem = ptrType.getElementType();
-  if (dstElem.isF16())
+  if (dstElem.isF16()) {
     return StringAttr::get(context, "llvm.hivm.FIX.L0C.TO.UB.f322f16.EXT")
         .getValue();
-  if (dstElem.isF32())
+  }
+  if (dstElem.isF32()) {
     return StringAttr::get(context, "llvm.hivm.FIX.L0C.TO.UB.f32.EXT")
         .getValue();
+  }
   return failure();
 }
 
@@ -4373,15 +4419,18 @@ static FailureOr<StringRef> buildCopyCbufToBtCallee(pto::CopyCbufToBtOp op) {
     return failure();
   }
   Type srcElem = ptrType.getElementType();
-  if (srcElem.isF16())
+  if (srcElem.isF16()) {
     return StringAttr::get(op.getContext(), "llvm.hivm.MOV.L1.TO.BT.f16")
         .getValue();
-  if (srcElem.isBF16())
+  }
+  if (srcElem.isBF16()) {
     return StringAttr::get(op.getContext(), "llvm.hivm.MOV.L1.TO.BT.bf16")
         .getValue();
-  if (srcElem.isF32())
+  }
+  if (srcElem.isF32()) {
     return StringAttr::get(op.getContext(), "llvm.hivm.MOV.L1.TO.BT.f32")
         .getValue();
+  }
   if (auto intType = dyn_cast<IntegerType>(srcElem);
       intType && intType.getWidth() == 32) {
     return StringAttr::get(op.getContext(), "llvm.hivm.MOV.L1.TO.BT.s32")
@@ -4491,10 +4540,11 @@ static FailureOr<StringRef> buildInterleaveCallee(MLIRContext *context,
   // lane shuffle, so the <N x i32> intrinsic serves the <N x bf16x2> type.
   if (pto::isPTOBF16x2Type(getElementTypeFromVectorLike(resultType))) {
     auto lanes = getElementCountFromVectorLike(resultType);
-    if (lanes)
+    if (lanes) {
       return StringAttr::get(context, "llvm.hivm." + stem.str() + ".v" +
                                           std::to_string(*lanes) + "i32")
           .getValue();
+}
   }
   return buildLaneTypedCallee(context, resultType, stem, "");
 }
@@ -4739,11 +4789,9 @@ buildBlockStridedMemoryCallee(MLIRContext *context, Type vectorType,
   if (auto intType = dyn_cast<IntegerType>(elementType))
   {
     element = "i" + std::to_string(intType.getWidth());
-  }
-  else if (isLowpPayloadElementType(elementType))
+  } else if (isLowpPayloadElementType(elementType)) {
     element = "i8";
-  else
-  {
+  } else {
     element = getMemoryElementTypeFragment(elementType);
   }
   if (element.empty())
@@ -4927,8 +4975,9 @@ static FailureOr<StringRef> buildVmulscvtCallee(MLIRContext *context,
     return failure();
   }
   if (!inputElemType.isF32() || !resultElemType.isF16() || *inputLanes != 64 ||
-      *resultLanes != 128)
+      *resultLanes != 128) {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vmulscvt.v128f16").getValue();
 }
 
@@ -4940,10 +4989,11 @@ static FailureOr<StringRef> buildVciCallee(MLIRContext *context, Type resultType
   {
     return failure();
   }
-  if (vec == "f16" || vec == "f32")
+  if (vec == "f16" || vec == "f32") {
     return StringAttr::get(context, "llvm.hivm.vci.v" + std::to_string(*lanes) +
                                         vec + "." + vec)
         .getValue();
+  }
   return StringAttr::get(context,
                          "llvm.hivm.vci.v" + std::to_string(*lanes) + vec)
       .getValue();
@@ -5017,11 +5067,9 @@ static FailureOr<Value> packVmrgsort4SourceAddr(Operation *anchor, Value source0
   if (elemType.isF16())
   {
     addrShift = 3;
-  }
-  else if (elemType.isF32())
+  } else if (elemType.isF32()) {
     addrShift = 3;
-  else
-  {
+  } else {
     return failure();
   }
 
@@ -5451,9 +5499,10 @@ public:
 
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert unary result type");
+    }
 
     Value input = adaptor.getOperands()[0];
     Value mask = adaptor.getOperands()[1];
@@ -5684,9 +5733,10 @@ public:
     StringRef stem = getBinaryMaskedStem<BinaryOp>();
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert binary result type");
+    }
 
     Value lhs = adaptor.getOperands()[0];
     Value rhs = adaptor.getOperands()[1];
@@ -5715,9 +5765,10 @@ public:
         if (failed(calleeName)) {
           Type carrierType = getLowpPayloadCarrierType(
               op.getResult().getType(), rewriter.getContext());
-          if (!carrierType)
+          if (!carrierType) {
             return rewriter.notifyMatchFailure(
                 op, "unsupported low-precision binary payload ABI");
+          }
           callResultType = carrierType;
           callLhs = castToPayloadABI(op.getLoc(), lhs,
                                      op.getResult().getType(), rewriter);
@@ -5764,17 +5815,19 @@ public:
     StringRef stem = getTernaryMaskedStem<TernaryOp>();
     FailureOr<StringRef> calleeName =
         buildLaneTypedCallee(op.getContext(), op.getResult().getType(), stem, ".m");
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported ternary VPTO signature");
+    }
 
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
     Type expectedMaskType =
         this->getTypeConverter()->convertType(op.getMask().getType());
-    if (!resultType || !expectedMaskType)
+    if (!resultType || !expectedMaskType) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert ternary VPTO types");
+    }
 
     Value acc = adaptor.getAcc();
     Value lhs = adaptor.getLhs();
@@ -5822,21 +5875,24 @@ public:
         this->getTypeConverter()->convertType(op.getResult().getType());
     Type carryType =
         this->getTypeConverter()->convertType(op->getResult(1).getType());
-    if (!resultType || !carryType)
+    if (!resultType || !carryType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert carry result types");
+    }
 
     SmallVector<Value> callArgs;
     callArgs.append(adaptor.getOperands().begin(), adaptor.getOperands().end());
     const size_t expectedArgCount = hasCarryInput<CarryOp>() ? 4 : 3;
     if (callArgs.size() != expectedArgCount || callArgs[0].getType() != resultType ||
-        callArgs[1].getType() != resultType || callArgs.back().getType() != carryType)
+        callArgs[1].getType() != resultType || callArgs.back().getType() != carryType) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected converted carry operand types");
+    }
     if constexpr (hasCarryInput<CarryOp>()) {
-      if (callArgs[2].getType() != carryType)
+      if (callArgs[2].getType() != carryType) {
         return rewriter.notifyMatchFailure(
             op, "unexpected converted carry input operand type");
+      }
     }
 
     auto call = rewriter.create<func::CallOp>(
@@ -5871,11 +5927,10 @@ public:
     }
 
     FailureOr<StringRef> calleeName = failure();
-    if constexpr (isGmUb)
+    if constexpr (isGmUb) {
       calleeName = buildCopyGmToUbCallee(op.getContext(), op.getSource().getType(),
                                          march, hasPadding);
-    else
-    {
+    } else {
       calleeName = buildCopyUbToGmCallee(op.getContext(), march);
     }
     if (failed(calleeName))
@@ -5902,10 +5957,9 @@ public:
     if (useA3NonPadded)
     {
       config0 = packCopyGmToUbCfgV220(op, adaptor.getOperands());
-    }
-    else if (useA3UbGm)
+    } else if (useA3UbGm) {
       config0 = packCopyUbToGmCfgV220(op, adaptor.getOperands());
-    else if constexpr (isGmUb) {
+    } else if constexpr (isGmUb) {
       config0 = packCopyGmToUbConfig0(op, adaptor.getOperands());
       config1 = packCopyGmToUbConfig1(op, adaptor.getOperands());
     } else {
@@ -5953,33 +6007,32 @@ public:
     auto ptrType = mlir::cast<pto::PtrType>(op.getSrc0().getType());
     Type elemType = ptrType.getElementType();
     std::string elemFrag = getElementTypeFragment(elemType);
-    if (elemFrag.empty())
+    if (elemFrag.empty()) {
       return rewriter.notifyMatchFailure(
           op, "unsupported element type for ubuf binary op");
+    }
 
     std::string calleeName;
     if constexpr (std::is_same_v<UBOp, pto::UBVaddOp>)
     {
       calleeName = "llvm.hivm.VADD." + elemFrag;
-    }
-    else if constexpr (std::is_same_v<UBOp, pto::UBVsubOp>)
+    } else if constexpr (std::is_same_v<UBOp, pto::UBVsubOp>) {
       calleeName = "llvm.hivm.VSUB." + elemFrag;
-    else if constexpr (std::is_same_v<UBOp, pto::UBVmulOp>)
+    } else if constexpr (std::is_same_v<UBOp, pto::UBVmulOp>) {
       calleeName = "llvm.hivm.VMUL." + elemFrag;
-    else if constexpr (std::is_same_v<UBOp, pto::UBVdivOp>)
+    } else if constexpr (std::is_same_v<UBOp, pto::UBVdivOp>) {
       calleeName = "llvm.hivm.VDIV." + elemFrag;
-    else if constexpr (std::is_same_v<UBOp, pto::UBVmaxOp>)
+    } else if constexpr (std::is_same_v<UBOp, pto::UBVmaxOp>) {
       calleeName = "llvm.hivm.VMAX." + elemFrag;
-    else if constexpr (std::is_same_v<UBOp, pto::UBVminOp>)
+    } else if constexpr (std::is_same_v<UBOp, pto::UBVminOp>) {
       calleeName = "llvm.hivm.VMIN." + elemFrag;
-    else if constexpr (std::is_same_v<UBOp, pto::UBVandOp>)
+    } else if constexpr (std::is_same_v<UBOp, pto::UBVandOp>) {
       calleeName = "llvm.hivm.VAND." + elemFrag;
-    else if constexpr (std::is_same_v<UBOp, pto::UBVorOp>)
+    } else if constexpr (std::is_same_v<UBOp, pto::UBVorOp>) {
       calleeName = "llvm.hivm.VOR." + elemFrag;
-    else if constexpr (std::is_same_v<UBOp, pto::UBVaddReluOp>)
+    } else if constexpr (std::is_same_v<UBOp, pto::UBVaddReluOp>) {
       calleeName = "llvm.hivm.VADDRELU." + elemFrag;
-    else
-    {
+    } else {
       return rewriter.notifyMatchFailure(op, "unsupported ubuf binary op");
     }
 
@@ -5989,9 +6042,10 @@ public:
     if (!dst || !src0 || !src1 ||
         !isa<LLVM::LLVMPointerType>(dst.getType()) ||
         !isa<LLVM::LLVMPointerType>(src0.getType()) ||
-        !isa<LLVM::LLVMPointerType>(src1.getType()))
+        !isa<LLVM::LLVMPointerType>(src1.getType())) {
       return rewriter.notifyMatchFailure(
           op, "unexpected converted ubuf binary operand types");
+    }
 
     Location loc = op.getLoc();
     auto i64Ty = rewriter.getI64Type();
@@ -6055,26 +6109,25 @@ public:
     auto ptrType = mlir::cast<pto::PtrType>(op.getSrc().getType());
     Type elemType = ptrType.getElementType();
     std::string elemFrag = getElementTypeFragment(elemType);
-    if (elemFrag.empty())
+    if (elemFrag.empty()) {
       return rewriter.notifyMatchFailure(
           op, "unsupported element type for ubuf shift op");
+    }
 
     if (elemFrag == "s16")
     {
       elemFrag = "u16";
-    }
-    else if (elemFrag == "s32")
+    } else if (elemFrag == "s32") {
       elemFrag = "u32";
+    }
 
     std::string calleeName;
     if constexpr (std::is_same_v<ShiftOp, pto::UBVshlOp>)
     {
       calleeName = "llvm.hivm.VSHL." + elemFrag;
-    }
-    else if constexpr (std::is_same_v<ShiftOp, pto::UBVshrOp>)
+    } else if constexpr (std::is_same_v<ShiftOp, pto::UBVshrOp>) {
       calleeName = "llvm.hivm.VSHR." + elemFrag;
-    else
-    {
+    } else {
       return rewriter.notifyMatchFailure(op, "unsupported ubuf shift op");
     }
 
@@ -6082,9 +6135,10 @@ public:
     Value src = adaptor.getSrc();
     if (!dst || !src ||
         !isa<LLVM::LLVMPointerType>(dst.getType()) ||
-        !isa<LLVM::LLVMPointerType>(src.getType()))
+        !isa<LLVM::LLVMPointerType>(src.getType())) {
       return rewriter.notifyMatchFailure(
           op, "unexpected converted ubuf shift operand types");
+    }
 
     Location loc = op.getLoc();
     auto i64Ty = rewriter.getI64Type();
@@ -6162,24 +6216,23 @@ public:
     auto ptrType = mlir::cast<pto::PtrType>(op.getSrc().getType());
     Type elemType = ptrType.getElementType();
     std::string elemFrag = getElementTypeFragment(elemType);
-    if (elemFrag.empty())
+    if (elemFrag.empty()) {
       return rewriter.notifyMatchFailure(
           op, "unsupported element type for ubuf scalar mul op");
+    }
 
     // Scalar-tile ops keep signed intrinsic names (s16/s32).
     std::string calleeName;
     if constexpr (std::is_same_v<ScalarOp, pto::UBVmulSOp>)
     {
       calleeName = "llvm.hivm.VMULS." + elemFrag;
-    }
-    else if constexpr (std::is_same_v<ScalarOp, pto::UBVaddSOp>)
+    } else if constexpr (std::is_same_v<ScalarOp, pto::UBVaddSOp>) {
       calleeName = "llvm.hivm.VADDS." + elemFrag;
-    else if constexpr (std::is_same_v<ScalarOp, pto::UBVmaxSOp>)
+    } else if constexpr (std::is_same_v<ScalarOp, pto::UBVmaxSOp>) {
       calleeName = "llvm.hivm.VMAXS." + elemFrag;
-    else if constexpr (std::is_same_v<ScalarOp, pto::UBVminSOp>)
+    } else if constexpr (std::is_same_v<ScalarOp, pto::UBVminSOp>) {
       calleeName = "llvm.hivm.VMINS." + elemFrag;
-    else
-    {
+    } else {
       return rewriter.notifyMatchFailure(op, "unsupported ubuf scalar binary op");
     }
 
@@ -6187,9 +6240,10 @@ public:
     Value src = adaptor.getSrc();
     if (!dst || !src ||
         !isa<LLVM::LLVMPointerType>(dst.getType()) ||
-        !isa<LLVM::LLVMPointerType>(src.getType()))
+        !isa<LLVM::LLVMPointerType>(src.getType())) {
       return rewriter.notifyMatchFailure(
           op, "unexpected converted ubuf scalar binary operand types");
+    }
 
     Location loc = op.getLoc();
     auto i64Ty = rewriter.getI64Type();
@@ -6271,11 +6325,9 @@ public:
     if (elemType.isF32() || elemType.isInteger(32))
     {
       suffix = "u32";
-    }
-    else if (elemType.isF16() || elemType.isInteger(16))
+    } else if (elemType.isF16() || elemType.isInteger(16)) {
       suffix = "u16";
-    else
-    {
+    } else {
       return rewriter.notifyMatchFailure(op, "unsupported element type for ubuf vdup");
     }
 
@@ -6341,9 +6393,10 @@ public:
     auto ptrType = mlir::cast<pto::PtrType>(op.getSrc().getType());
     Type elemType = ptrType.getElementType();
     std::string elemFrag = getElementTypeFragment(elemType);
-    if (elemFrag.empty())
+    if (elemFrag.empty()) {
       return rewriter.notifyMatchFailure(
           op, "unsupported element type for ubuf unary op");
+    }
 
     if (elemFrag == "s16")
     {
@@ -6354,24 +6407,23 @@ public:
     if constexpr (std::is_same_v<UnaryOp, pto::UBVnotOp>)
     {
       calleeName = "llvm.hivm.VNOT." + elemFrag;
-    }
-    else if constexpr (std::is_same_v<UnaryOp, pto::UBVabsOp>)
+    } else if constexpr (std::is_same_v<UnaryOp, pto::UBVabsOp>) {
       calleeName = "llvm.hivm.VABS." + elemFrag;
-    else if constexpr (std::is_same_v<UnaryOp, pto::UBVreluOp>) {
-      if (elemFrag == "u16" || elemFrag == "u32")
+    } else if constexpr (std::is_same_v<UnaryOp, pto::UBVreluOp>) {
+      if (elemFrag == "u16" || elemFrag == "u32") {
         return rewriter.notifyMatchFailure(
             op, "VRELU not available for unsigned integer types");
+      }
       calleeName = "llvm.hivm.VRELU." + elemFrag;
-    } else if constexpr (std::is_same_v<UnaryOp, pto::UBVexpOp>)
+    } else if constexpr (std::is_same_v<UnaryOp, pto::UBVexpOp>) {
       calleeName = "llvm.hivm.VEXP." + elemFrag;
-    else if constexpr (std::is_same_v<UnaryOp, pto::UBVlnOp>)
+    } else if constexpr (std::is_same_v<UnaryOp, pto::UBVlnOp>) {
       calleeName = "llvm.hivm.VLN." + elemFrag;
-    else if constexpr (std::is_same_v<UnaryOp, pto::UBVsqrtOp>)
+    } else if constexpr (std::is_same_v<UnaryOp, pto::UBVsqrtOp>) {
       calleeName = "llvm.hivm.VSQRT." + elemFrag;
-    else if constexpr (std::is_same_v<UnaryOp, pto::UBVrsqrtOp>)
+    } else if constexpr (std::is_same_v<UnaryOp, pto::UBVrsqrtOp>) {
       calleeName = "llvm.hivm.VRSQRT." + elemFrag;
-    else
-    {
+    } else {
       return rewriter.notifyMatchFailure(op, "unsupported ubuf unary op");
     }
 
@@ -6379,9 +6431,10 @@ public:
     Value src = adaptor.getSrc();
     if (!dst || !src ||
         !isa<LLVM::LLVMPointerType>(dst.getType()) ||
-        !isa<LLVM::LLVMPointerType>(src.getType()))
+        !isa<LLVM::LLVMPointerType>(src.getType())) {
       return rewriter.notifyMatchFailure(
           op, "unexpected converted ubuf unary operand types");
+    }
 
     Location loc = op.getLoc();
     auto i64Ty = rewriter.getI64Type();
@@ -6579,8 +6632,9 @@ public:
       return rewriter.notifyMatchFailure(op, "expected converted operands");
     }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
-        !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
+        !isa<LLVM::LLVMPointerType>(destinationRaw.getType())) {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
+    }
 
     constexpr unsigned cbufAddressSpace =
         static_cast<unsigned>(pto::AddressSpace::MAT);
@@ -6637,8 +6691,9 @@ public:
       return rewriter.notifyMatchFailure(op, "expected converted operands");
     }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
-        !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
+        !isa<LLVM::LLVMPointerType>(destinationRaw.getType())) {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
+    }
 
     constexpr unsigned ubufAddressSpace =
         static_cast<unsigned>(pto::AddressSpace::VEC);
@@ -6685,8 +6740,9 @@ static LogicalResult lowerMadRawOp(pto::MadRawOpInterface op,
   Value biasRaw = op.hasBiasOperand() ? convertedOperands[3] : Value();
   Value xt = convertedOperands[op.hasBiasOperand() ? 4 : 3];
   if (!lhsRaw || !rhsRaw || !dstRaw || !xt ||
-      (op.hasBiasOperand() && !biasRaw))
+      (op.hasBiasOperand() && !biasRaw)) {
     return rewriter.notifyMatchFailure(op, "expected converted mad raw operands");
+  }
 
   if (!isa<LLVM::LLVMPointerType>(lhsRaw.getType()) ||
       !isa<LLVM::LLVMPointerType>(rhsRaw.getType()) ||
@@ -6724,9 +6780,10 @@ static LogicalResult lowerMadRawOp(pto::MadRawOpInterface op,
   FailureOr<StringRef> calleeName =
       op.isMadMxFamily() ? buildMxMadCallee(op.getContext(), op)
                          : buildOrdinaryMadCallee(op.getContext(), op);
-  if (failed(calleeName))
+  if (failed(calleeName)) {
     return rewriter.notifyMatchFailure(
         op, "unsupported mad element types for raw dispatch");
+  }
 
   Value callDst = *dst;
   if (biasRaw)
@@ -6815,16 +6872,18 @@ public:
 
     FailureOr<StringRef> calleeName =
         buildCopyGmToCbufCallee(op.getContext(), op.getSource().getType());
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported copy_gm_to_cbuf element type");
+    }
     FailureOr<Value> config0 =
         packCopyGmToCbufConfig0(op, nBurst, lenBurst);
     FailureOr<Value> config1 =
         packCopyGmToCbufConfig1(op, srcStride, dstStride);
-    if (failed(config0) || failed(config1))
+    if (failed(config0) || failed(config1)) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to pack copy_gm_to_cbuf config");
+    }
 
     auto funcType = rewriter.getFunctionType(
         TypeRange{destination->getType(), source->getType(), i64Ty, i64Ty},
@@ -6860,8 +6919,9 @@ public:
       return rewriter.notifyMatchFailure(op, "expected converted operands");
     }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
-        !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
+        !isa<LLVM::LLVMPointerType>(destinationRaw.getType())) {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
+    }
 
     constexpr unsigned gmAddressSpace =
         static_cast<unsigned>(pto::AddressSpace::GM);
@@ -6896,9 +6956,10 @@ public:
       }
       return buildCopyGmToCbufMultiDn2NzCallee(ctx, sourceType);
     }(op.getContext(), op.getSource().getType());
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(
           op, "unsupported copy_gm_to_cbuf_multi element type");
+    }
 
     Type i64Ty = rewriter.getI64Type();
     auto funcType = rewriter.getFunctionType(
@@ -6934,8 +6995,9 @@ public:
       return rewriter.notifyMatchFailure(op, "expected converted operands");
     }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
-        !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
+        !isa<LLVM::LLVMPointerType>(destinationRaw.getType())) {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
+    }
 
     constexpr unsigned cbufAddressSpace =
         static_cast<unsigned>(pto::AddressSpace::MAT);
@@ -6998,8 +7060,9 @@ public:
       return rewriter.notifyMatchFailure(op, "expected converted operands");
     }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
-        !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
+        !isa<LLVM::LLVMPointerType>(destinationRaw.getType())) {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
+    }
 
     constexpr unsigned cbufAddressSpace =
         static_cast<unsigned>(pto::AddressSpace::MAT);
@@ -7057,8 +7120,9 @@ public:
     Value srcStride = adaptor.getSrcStride();
     Value dstStride = adaptor.getDstStride();
     if (!sourceRaw || !destinationRaw || !mStart || !kStart || !mStep ||
-        !kStep || !srcStride || !dstStride)
+        !kStep || !srcStride || !dstStride) {
       return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
 
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
         !isa<LLVM::LLVMPointerType>(destinationRaw.getType())) {
@@ -7092,9 +7156,10 @@ public:
 
     FailureOr<StringRef> calleeName =
         buildLoadCbufToCaCallee(op.getContext(), op.getSource().getType());
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported load_cbuf_to_ca element type");
+    }
     auto funcType = rewriter.getFunctionType(
         TypeRange{destination->getType(), source->getType(), i64Ty, i64Ty,
                   i64Ty},
@@ -7129,8 +7194,9 @@ public:
       return rewriter.notifyMatchFailure(op, "expected converted operands");
     }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
-        !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
+        !isa<LLVM::LLVMPointerType>(destinationRaw.getType())) {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
+    }
 
     constexpr unsigned cbufAddressSpace =
         static_cast<unsigned>(pto::AddressSpace::MAT);
@@ -7171,9 +7237,10 @@ public:
                                         op.getSource().getType())
             : buildLoadCbufToCbS4Callee(op.getContext(),
                                         op.getSource().getType());
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(
           op, "unsupported load_cbuf_to_*_s4 element type");
+    }
     Type i64Ty = rewriter.getI64Type();
     auto funcType = rewriter.getFunctionType(
         TypeRange{destination->getType(), source->getType(), i64Ty, i64Ty,
@@ -7212,8 +7279,9 @@ public:
     Value srcStride = adaptor.getSrcStride();
     Value dstStride = adaptor.getDstStride();
     if (!sourceRaw || !destinationRaw || !mStart || !kStart || !mStep ||
-        !kStep || !srcStride || !dstStride)
+        !kStep || !srcStride || !dstStride) {
       return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
 
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
         !isa<LLVM::LLVMPointerType>(destinationRaw.getType())) {
@@ -7248,9 +7316,10 @@ public:
 
     FailureOr<StringRef> calleeName =
         buildLoadCbufToCbCallee(op.getContext(), op.getSource().getType());
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported load_cbuf_to_cb element type");
+    }
     auto funcType = rewriter.getFunctionType(
         TypeRange{destination->getType(), source->getType(), i64Ty, i64Ty,
                   i64Ty},
@@ -7284,11 +7353,13 @@ public:
     if (!srcRaw || !dstRaw || !adaptor.getXStartPosition() ||
         !adaptor.getYStartPosition() || !adaptor.getXStep() ||
         !adaptor.getYStep() || !adaptor.getSrcStride() ||
-        !adaptor.getDstStride())
+        !adaptor.getDstStride()) {
       return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
     if (!isa<LLVM::LLVMPointerType>(srcRaw.getType()) ||
-        !isa<LLVM::LLVMPointerType>(dstRaw.getType()))
+        !isa<LLVM::LLVMPointerType>(dstRaw.getType())) {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
+    }
 
     constexpr unsigned cbufAddressSpace =
         static_cast<unsigned>(pto::AddressSpace::MAT);
@@ -7303,9 +7374,10 @@ public:
 
     Type sourceElemType = cast<pto::PtrType>(op.getSource().getType()).getElementType();
     unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(sourceElemType);
-    if (elemBitWidth == 0 || (elemBitWidth % 8) != 0)
+    if (elemBitWidth == 0 || (elemBitWidth % 8) != 0) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported load_cbuf_to_ca_mx element type");
+    }
     FailureOr<Value> config0 =
         packLoadCbufToCaConfig0(op, adaptor.getXStartPosition(),
                                 adaptor.getYStartPosition(), adaptor.getXStep(),
@@ -7313,9 +7385,10 @@ public:
     FailureOr<Value> config1 =
         packLoadCbufToCaConfig1(op, adaptor.getSrcStride(),
                                 adaptor.getDstStride());
-    if (failed(config0) || failed(config1))
+    if (failed(config0) || failed(config1)) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to pack load_cbuf_to_ca_mx config");
+    }
     auto i64Ty = rewriter.getI64Type();
     Value dstAddr = rewriter.create<LLVM::PtrToIntOp>(op.getLoc(), i64Ty, *dst);
 
@@ -7351,11 +7424,13 @@ public:
     if (!srcRaw || !dstRaw || !adaptor.getXStartPosition() ||
         !adaptor.getYStartPosition() || !adaptor.getXStep() ||
         !adaptor.getYStep() || !adaptor.getSrcStride() ||
-        !adaptor.getDstStride())
+        !adaptor.getDstStride()) {
       return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
     if (!isa<LLVM::LLVMPointerType>(srcRaw.getType()) ||
-        !isa<LLVM::LLVMPointerType>(dstRaw.getType()))
+        !isa<LLVM::LLVMPointerType>(dstRaw.getType())) {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
+    }
 
     constexpr unsigned cbufAddressSpace =
         static_cast<unsigned>(pto::AddressSpace::MAT);
@@ -7370,9 +7445,10 @@ public:
 
     Type sourceElemType = cast<pto::PtrType>(op.getSource().getType()).getElementType();
     unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(sourceElemType);
-    if (elemBitWidth == 0 || (elemBitWidth % 8) != 0)
+    if (elemBitWidth == 0 || (elemBitWidth % 8) != 0) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported load_cbuf_to_cb_mx element type");
+    }
     FailureOr<Value> config0 =
         packLoadCbufToCbConfig0(op, adaptor.getXStartPosition(),
                                 adaptor.getYStartPosition(), adaptor.getXStep(),
@@ -7380,9 +7456,10 @@ public:
     FailureOr<Value> config1 =
         packLoadCbufToCbConfig1(op, adaptor.getSrcStride(),
                                 adaptor.getDstStride());
-    if (failed(config0) || failed(config1))
+    if (failed(config0) || failed(config1)) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to pack load_cbuf_to_cb_mx config");
+    }
     auto i64Ty = rewriter.getI64Type();
     Value dstAddr = rewriter.create<LLVM::PtrToIntOp>(op.getLoc(), i64Ty, *dst);
 
@@ -7479,8 +7556,9 @@ public:
       return rewriter.notifyMatchFailure(op, "expected converted operands");
     }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
-        !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
+        !isa<LLVM::LLVMPointerType>(destinationRaw.getType())) {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
+    }
 
     constexpr unsigned ccAddressSpace =
         static_cast<unsigned>(pto::AddressSpace::ACC);
@@ -7510,9 +7588,10 @@ public:
             ? FailureOr<StringRef>(buildCopyMatrixCcToCbufCallee(op.getContext()))
             : buildCopyMatrixCcToUbCallee(op.getContext(),
                                           op.getDestination().getType());
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(
           op, "unsupported copy_matrix_cc_to_{cbuf,ub} element type");
+    }
     auto funcType = rewriter.getFunctionType(
         TypeRange{destination->getType(), source->getType(), i64Ty, i64Ty},
         TypeRange{});
@@ -7543,15 +7622,17 @@ public:
     StringRef stem = getVecScalarMaskedStem<VecScalarOp>();
     FailureOr<StringRef> calleeName =
         buildLaneTypedCallee(op.getContext(), op.getResult().getType(), stem, ".x");
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported vec-scalar VPTO signature");
+    }
 
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert vec-scalar result type");
+    }
 
     Value input = adaptor.getOperands()[0];
     Value scalar = adaptor.getOperands()[1];
@@ -7592,9 +7673,10 @@ public:
     StringRef stem = getReductionUnaryStem<ReductionOp>();
     FailureOr<StringRef> calleeName =
         buildLaneTypedCallee(op.getContext(), op.getResult().getType(), stem, ".x");
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported reduction VPTO signature");
+    }
 
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
@@ -7692,17 +7774,19 @@ public:
     FailureOr<StringRef> calleeName =
         buildExtremaPredicateCallee<ExtremaOp>(op.getContext(),
                                                op.getValue().getType());
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(
           op, "unsupported extrema-predicate VPTO signature");
+    }
 
     Type valueType =
         this->getTypeConverter()->convertType(op.getValue().getType());
     Type predicateType =
         this->getTypeConverter()->convertType(op.getPredicate().getType());
-    if (!valueType || !predicateType)
+    if (!valueType || !predicateType) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert extrema-predicate result types");
+    }
 
     Value input = adaptor.getInput();
     Value mask = adaptor.getMask();
@@ -7740,18 +7824,20 @@ public:
     FailureOr<StringRef> calleeName = buildLaneTypedCalleeFromInput(
         op.getContext(), op.getInput().getType(),
         getReductionUnaryStem<ReductionOp>(), ".x");
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported widening reduction VPTO signature");
+    }
 
     Type inputType =
         this->getTypeConverter()->convertType(op.getInput().getType());
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
     Type maskType = this->getTypeConverter()->convertType(op.getMask().getType());
-    if (!inputType || !resultType || !maskType)
+    if (!inputType || !resultType || !maskType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert widening reduction types");
+    }
 
     Value input = adaptor.getInput();
     Value mask = adaptor.getMask();
@@ -7842,9 +7928,10 @@ public:
     }
 
     Value mask = adaptor.getMask();
-    if (!mask || mask.getType() != maskType)
+    if (!mask || mask.getType() != maskType) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected converted vdup mask type");
+    }
 
     SmallVector<Value> callArgs;
     bool vectorInput = isa<VectorType, pto::VRegType>(op.getInput().getType());
@@ -7867,9 +7954,10 @@ public:
       FailureOr<Value> normalizedScalar =
           normalizeVdupScalarOperand(rewriter, op.getLoc(), adaptor.getInput(),
                                      op.getResult().getType());
-      if (failed(normalizedScalar))
+      if (failed(normalizedScalar)) {
         return rewriter.notifyMatchFailure(op,
                                            "failed to normalize scalar vdup input");
+      }
       Value scalarForCall = normalizeByteScalarOperandForHivmCall(
           rewriter, op.getLoc(), *normalizedScalar, scalarType);
       callArgs.push_back(scalarForCall);
@@ -7916,9 +8004,10 @@ public:
     Value scalar = adaptor.getValue();
     Type expectedScalarType =
         this->getTypeConverter()->convertType(op.getValue().getType());
-    if (!scalar || !expectedScalarType || scalar.getType() != expectedScalarType)
+    if (!scalar || !expectedScalarType || scalar.getType() != expectedScalarType) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected converted vbr operand type");
+    }
 
     scalar = normalizeByteScalarOperandForHivmCall(
         rewriter, op.getLoc(), scalar,
@@ -7955,14 +8044,16 @@ public:
     }
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected converted vselr result type");
+    }
     auto lanes = getElementCountFromVectorLike(resultType);
     Type resultElementType = getElementTypeFromVectorLike(resultType);
-    if (!lanes || !resultElementType)
+    if (!lanes || !resultElementType) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected converted vselr result type");
+    }
 
     Type intrinsicResultType = resultType;
     if (auto floatType = dyn_cast<FloatType>(resultElementType);
@@ -7970,24 +8061,28 @@ public:
       intrinsicResultType = VectorType::get({*lanes}, rewriter.getI32Type());
     }
     if (Type carrierType = getLowpPayloadCarrierType(
-            op.getResult().getType(), rewriter.getContext()))
+            op.getResult().getType(), rewriter.getContext())) {
       intrinsicResultType = carrierType;
+    }
 
     Type indexType = this->getTypeConverter()->convertType(op.getSrc1().getType());
-    if (!indexType)
+    if (!indexType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert vselr index type");
+    }
 
     Value src0 = adaptor.getSrc0();
     Value src1 = adaptor.getSrc1();
-    if (!src0 || !src1 || src1.getType() != indexType)
+    if (!src0 || !src1 || src1.getType() != indexType) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected converted vselr operand types");
+    }
 
     if (src0.getType() != intrinsicResultType) {
-      if (src0.getType() != resultType)
+      if (src0.getType() != resultType) {
         return rewriter.notifyMatchFailure(op,
                                            "unexpected converted vselr source type");
+      }
       src0 = rewriter.create<LLVM::BitcastOp>(op.getLoc(), intrinsicResultType, src0);
     }
 
@@ -8021,9 +8116,10 @@ public:
   matchAndRewrite(pto::PnotOp op, pto::PnotOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert pnot result type");
+    }
 
     Value input = adaptor.getInput();
     Value mask = adaptor.getMask();
@@ -8061,9 +8157,10 @@ public:
     StringRef stem = std::is_same_v<InterleaveOp, pto::VintlvOp> ? "vintlv" : "vdintlv";
     FailureOr<StringRef> calleeName =
         buildInterleaveCallee(op.getContext(), op.getLow().getType(), stem);
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported interleave VPTO signature");
+    }
 
     Type lowType = this->getTypeConverter()->convertType(op.getLow().getType());
     Type highType = this->getTypeConverter()->convertType(op.getHigh().getType());
@@ -8105,19 +8202,22 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert predicate-pack result type");
+    }
 
     auto part = parseHiLoPartImmediate(op.getPart());
-    if (!part)
+    if (!part) {
       return rewriter.notifyMatchFailure(
           op, "unsupported predicate-pack part immediate");
+    }
 
     Value input = adaptor.getInput();
-    if (!input || input.getType() != resultType)
+    if (!input || input.getType() != resultType) {
       return rewriter.notifyMatchFailure(
           op, "unexpected converted predicate-pack operand type");
+    }
 
     Value partValue = rewriter.create<arith::ConstantOp>(
         op.getLoc(), rewriter.getI32IntegerAttr(*part));
@@ -8149,16 +8249,18 @@ public:
                                                                : "vzunpack";
     FailureOr<StringRef> calleeName = buildUnpackCallee(
         op.getContext(), op.getSrc().getType(), op.getResult().getType(), stem);
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported unpack VPTO signature");
+    }
 
     Type srcType = this->getTypeConverter()->convertType(op.getSrc().getType());
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!srcType || !resultType)
+    if (!srcType || !resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert unpack types");
+    }
 
     Value src = adaptor.getSrc();
     if (!src || src.getType() != srcType) {
@@ -8251,9 +8353,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert predicate-mask result type");
+    }
 
     Value src0 = adaptor.getSrc0();
     Value src1 = adaptor.getSrc1();
@@ -8291,12 +8394,14 @@ public:
   matchAndRewrite(ReorderOp op, typename ReorderOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     SmallVector<Type> resultTypes;
-    if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes)))
+    if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes))) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert predicate-pair-reorder result types");
-    if (resultTypes.size() != 2 || resultTypes[0] != resultTypes[1])
+    }
+    if (resultTypes.size() != 2 || resultTypes[0] != resultTypes[1]) {
       return rewriter.notifyMatchFailure(
           op, "unexpected predicate-pair-reorder converted result types");
+    }
 
     Value lhs = adaptor.getLhs();
     Value rhs = adaptor.getRhs();
@@ -8343,19 +8448,22 @@ public:
     FailureOr<StringRef> calleeName =
         buildVcmpCallee(op.getContext(), inputType, op.getCmpMode(),
                         isScalarCompare);
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported compare VPTO signature");
+    }
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     Type maskType =
         this->getTypeConverter()->convertType(op.getMask().getType());
-    if (!resultType || !maskType)
+    if (!resultType || !maskType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert compare result type");
-    if (resultType != maskType)
+    }
+    if (resultType != maskType) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected compare mask conversion");
+    }
 
     SmallVector<Value> callArgs;
     callArgs.append(adaptor.getOperands().begin(), adaptor.getOperands().end());
@@ -8437,15 +8545,17 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
-                                                      resultTypes)))
+                                                      resultTypes))) {
       return rewriter.notifyMatchFailure(op, "failed to convert pltm result type");
+    }
 
     Value loop = adaptor.getLoop();
     Value bound = adaptor.getBound();
     if (!loop || !bound || !loop.getType().isInteger(16) ||
-        !bound.getType().isInteger(32))
+        !bound.getType().isInteger(32)) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected converted pltm operand types");
+    }
 
     StringRef calleeName = buildPltmCallee<PltmOp>(op.getContext());
     auto funcType = rewriter.getFunctionType(
@@ -8586,9 +8696,10 @@ public:
 
     bool usePostIntrinsic = static_cast<bool>(op.getUpdatedBase());
     if (usePostIntrinsic) {
-      if (resultTypes.size() != 2 || resultTypes[1] != adaptor.getSource().getType())
+      if (resultTypes.size() != 2 || resultTypes[1] != adaptor.getSource().getType()) {
         return rewriter.notifyMatchFailure(op,
                                            "unsupported vlds post-update results");
+      }
     } else if (resultTypes.size() != 1) {
       return rewriter.notifyMatchFailure(op, "unsupported vlds result count");
     }
@@ -8623,10 +8734,11 @@ public:
     Value loaded = castFromPayloadABI(
         op.getLoc(), call.getResult(0), ptoResultType, resultTypes[0],
         rewriter);
-    if (usePostIntrinsic)
+    if (usePostIntrinsic) {
       rewriter.replaceOp(op, ValueRange{loaded, call.getResult(1)});
-    else
+    } else {
       rewriter.replaceOp(op, ValueRange{loaded});
+}
     return success();
   }
 
@@ -8704,10 +8816,11 @@ public:
     Value high = castFromPayloadABI(
         op.getLoc(), call.getResult(1), op.getHigh().getType(), resultTypes[1],
         rewriter);
-    if (usePostIntrinsic)
+    if (usePostIntrinsic) {
       rewriter.replaceOp(op, ValueRange{low, high, call.getResult(2)});
-    else
+    } else {
       rewriter.replaceOp(op, ValueRange{low, high});
+}
     return success();
   }
 
@@ -8736,8 +8849,9 @@ public:
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
                                                       resultTypes)) ||
-        resultTypes.size() != (usePostIntrinsic ? 2u : 1u))
+        resultTypes.size() != (usePostIntrinsic ? 2u : 1u)) {
       return rewriter.notifyMatchFailure(op, "failed to convert vsldb result type");
+    }
 
     Type callResultType = getPayloadABIType(
         op.getResult().getType(), resultTypes[0], rewriter.getContext());
@@ -8768,10 +8882,11 @@ public:
     Value result = castFromPayloadABI(
         op.getLoc(), call.getResult(0), op.getResult().getType(), resultTypes[0],
         rewriter);
-    if (usePostIntrinsic)
+    if (usePostIntrinsic) {
       rewriter.replaceOp(op, ValueRange{result, call.getResult(1)});
-    else
+    } else {
       rewriter.replaceOp(op, ValueRange{result});
+}
     return success();
   }
 
@@ -8821,9 +8936,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto sourceType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getSource().getType());
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!sourceType || !resultType)
+    if (!sourceType || !resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "expected converted vldas operand/result types");
+    }
 
     StringRef calleeName = buildVldasCallee(op.getContext());
     auto funcType =
@@ -8882,9 +8998,10 @@ public:
       Type elementType = getElementTypeFromVectorLike(op.getResult().getType());
       auto incrementBytes =
           convertElementOffsetToBytes(op, adaptor.getIncrement(), elementType);
-      if (failed(incrementBytes))
+      if (failed(incrementBytes)) {
         return rewriter.notifyMatchFailure(op,
                                            "failed to convert vldus increment");
+      }
       args.push_back(*incrementBytes);
     }
     SmallVector<Type> argTypes;
@@ -8959,17 +9076,19 @@ public:
     }
     auto destType =
         dyn_cast<LLVM::LLVMPointerType>(adaptor.getDestination().getType());
-    if (!destType || !adaptor.getOffset().getType().isInteger(32))
+    if (!destType || !adaptor.getOffset().getType().isInteger(32)) {
       return rewriter.notifyMatchFailure(op,
                                          "expected converted spr store operands");
+    }
 
     bool usePostIntrinsic = op.getUpdatedBase() != nullptr;
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
                                                       resultTypes)) ||
-        resultTypes.size() != (usePostIntrinsic ? 1u : 0u))
+        resultTypes.size() != (usePostIntrinsic ? 1u : 0u)) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert spr store result types");
+    }
 
     StringRef calleeName =
         buildSprStoreCallee<SprStoreOp>(op.getContext(), usePostIntrinsic);
@@ -9019,9 +9138,9 @@ public:
     if (auto ptrType = dyn_cast<pto::PtrType>(op.getDestination().getType()))
     {
       offsetElementType = ptrType.getElementType();
-    }
-    else if (auto memrefType = dyn_cast<BaseMemRefType>(op.getDestination().getType()))
+    } else if (auto memrefType = dyn_cast<BaseMemRefType>(op.getDestination().getType())) {
       offsetElementType = memrefType.getElementType();
+    }
     auto offsetBytes =
         convertElementOffsetToBytes(op, adaptor.getOffset(), offsetElementType);
     auto basePtr = dyn_cast<LLVM::LLVMPointerType>(adaptor.getDestination().getType());
@@ -9043,14 +9162,16 @@ public:
 
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
-                                                      resultTypes)))
+                                                      resultTypes))) {
       return rewriter.notifyMatchFailure(op, "failed to convert vsts result types");
+    }
     bool usePostIntrinsic = static_cast<bool>(op.getUpdatedBase());
     if (usePostIntrinsic) {
       if (resultTypes.size() != 1 ||
-          resultTypes[0] != adaptor.getDestination().getType())
+          resultTypes[0] != adaptor.getDestination().getType()) {
         return rewriter.notifyMatchFailure(op,
                                            "unsupported vsts post-update result");
+      }
     } else if (!resultTypes.empty()) {
       return rewriter.notifyMatchFailure(op, "unsupported vsts result count");
     }
@@ -9116,15 +9237,17 @@ public:
 
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
-                                                      resultTypes)))
+                                                      resultTypes))) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert vsstb result types");
+    }
     bool usePostIntrinsic = static_cast<bool>(op.getUpdatedBase());
     if (usePostIntrinsic) {
       if (resultTypes.size() != 1 ||
-          resultTypes[0] != adaptor.getDestination().getType())
+          resultTypes[0] != adaptor.getDestination().getType()) {
         return rewriter.notifyMatchFailure(
             op, "unsupported vsstb post-update result");
+      }
     } else if (!resultTypes.empty()) {
       return rewriter.notifyMatchFailure(op, "unsupported vsstb result count");
     }
@@ -9291,9 +9414,10 @@ public:
 
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
-                                                      resultTypes)))
+                                                      resultTypes))) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert vstus result types");
+    }
     bool usePostIntrinsic = static_cast<bool>(op.getBaseOut());
     auto baseType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getBase().getType());
     if (!baseType || resultTypes.size() != (usePostIntrinsic ? 2u : 1u) ||
@@ -9305,9 +9429,10 @@ public:
 
     FailureOr<StringRef> calleeName =
         buildVstusCallee(op.getContext(), op.getValue().getType());
-    if (usePostIntrinsic)
+    if (usePostIntrinsic) {
       calleeName =
           buildVstusPostCallee(op.getContext(), op.getValue().getType());
+    }
     if (failed(calleeName))
     {
       return rewriter.notifyMatchFailure(op, "unsupported vstus signature");
@@ -9437,9 +9562,10 @@ public:
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
                                                       resultTypes)) ||
-        resultTypes.size() != (usePostIntrinsic ? 1u : 0u))
+        resultTypes.size() != (usePostIntrinsic ? 1u : 0u)) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert vstas result types");
+    }
 
     StringRef calleeName =
         buildVstasCallee(op.getContext(), usePostIntrinsic);
@@ -9482,9 +9608,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type elemType = getElementTypeFromVectorLike(op.getResult().getType());
     auto basePtr = dyn_cast<LLVM::LLVMPointerType>(adaptor.getSource().getType());
-    if (!elemType || !basePtr)
+    if (!elemType || !basePtr) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected converted vgather2 operand types");
+    }
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
@@ -9508,9 +9635,10 @@ public:
     {
       return rewriter.notifyMatchFailure(op, "unsupported vgather2 offsets carrier");
     }
-    if (offsets.getType() != *offsetsCarrierType)
+    if (offsets.getType() != *offsetsCarrierType) {
       offsets = rewriter.create<LLVM::BitcastOp>(op.getLoc(), *offsetsCarrierType,
                                                  offsets);
+    }
 
     auto funcType = rewriter.getFunctionType(
         TypeRange{adaptor.getSource().getType(), *offsetsCarrierType,
@@ -9541,9 +9669,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto basePtr = dyn_cast<LLVM::LLVMPointerType>(adaptor.getSource().getType());
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!basePtr || !resultType)
+    if (!basePtr || !resultType) {
       return rewriter.notifyMatchFailure(op,
-          "unexpected converted vgather2_bc operand/result types");
+                                         "unexpected converted vgather2_bc operand/result types");
+    }
 
     FailureOr<StringRef> calleeName =
         buildVgather2BcCallee(op.getContext(), op.getResult().getType());
@@ -9581,9 +9710,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto basePtr = dyn_cast<LLVM::LLVMPointerType>(adaptor.getSource().getType());
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!basePtr || !resultType)
+    if (!basePtr || !resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected converted vgatherb operand/result types");
+    }
 
     FailureOr<StringRef> calleeName =
         buildVgatherbCallee(op.getContext(), op.getResult().getType());
@@ -9622,9 +9752,10 @@ public:
     Type elemType = getElementTypeFromVectorLike(op.getValue().getType());
     auto basePtr =
         dyn_cast<LLVM::LLVMPointerType>(adaptor.getDestination().getType());
-    if (!elemType || !basePtr)
+    if (!elemType || !basePtr) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected converted vscatter operand types");
+    }
 
     FailureOr<StringRef> calleeName =
         buildVscatterCallee(op.getContext(), op.getValue().getType());
@@ -9718,9 +9849,10 @@ public:
     {
       return rewriter.notifyMatchFailure(op, "vmulscvt requires valid rnd attr");
     }
-    if (*roundMode != 1)
+    if (*roundMode != 1) {
       return rewriter.notifyMatchFailure(
           op, "current vmulscvt lowering only supports rnd A");
+    }
 
     auto part = parsePartImmediate(op.getPart());
     if (!part)
@@ -9730,9 +9862,10 @@ public:
 
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert vmulscvt result type");
+    }
 
     FailureOr<StringRef> calleeName =
         buildVmulscvtCallee(op.getContext(), op.getInput().getType(),
@@ -9794,14 +9927,15 @@ public:
     if (auto intType = dyn_cast<IntegerType>(resultElemType)) {
       if (intType.getWidth() == 8) {
         Type loweredIndexType = rewriter.getI16Type();
-        if (intType.isUnsigned())
+        if (intType.isUnsigned()) {
           indexValue = rewriter.create<arith::ExtUIOp>(op.getLoc(),
                                                        loweredIndexType,
                                                        indexValue);
-        else
+        } else {
           indexValue = rewriter.create<arith::ExtSIOp>(op.getLoc(),
                                                        loweredIndexType,
                                                        indexValue);
+}
       }
     }
 
@@ -9886,9 +10020,10 @@ public:
     auto srcType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getSource().getType());
     auto idxType =
         dyn_cast<LLVM::LLVMPointerType>(adaptor.getIndices().getType());
-    if (!dstType || !srcType || !idxType)
+    if (!dstType || !srcType || !idxType) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected converted vbitsort operand types");
+    }
 
     FailureOr<Value> config = packVbitsortConfig(op, adaptor.getRepeatTimes());
     if (failed(config))
@@ -9940,18 +10075,20 @@ public:
         dyn_cast<LLVM::LLVMPointerType>(adaptor.getSource2().getType());
     auto src3Type =
         dyn_cast<LLVM::LLVMPointerType>(adaptor.getSource3().getType());
-    if (!dstType || !src0Type || !src1Type || !src2Type || !src3Type)
+    if (!dstType || !src0Type || !src1Type || !src2Type || !src3Type) {
       return rewriter.notifyMatchFailure(
           op, "unexpected converted vmrgsort4 operand types");
+    }
 
     Type elemType =
         cast<pto::PtrType>(op.getDestination().getType()).getElementType();
     FailureOr<Value> packedSrc = packVmrgsort4SourceAddr(
         op, adaptor.getSource0(), adaptor.getSource1(), adaptor.getSource2(),
         adaptor.getSource3(), elemType);
-    if (failed(packedSrc))
+    if (failed(packedSrc)) {
       return rewriter.notifyMatchFailure(
           op, "failed to pack vmrgsort4 source addresses");
+    }
 
     FailureOr<Value> dst = reinterpretPointerToAddrSpace(op, adaptor.getDestination(), 6);
     if (failed(dst))
@@ -10099,9 +10236,10 @@ public:
     }
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert vbitcast result type");
+}
     rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, resultType,
                                                  adaptor.getInput());
     return success();
@@ -10120,9 +10258,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert pbitcast result type");
+    }
     if (adaptor.getInput().getType() != resultType) {
       return rewriter.notifyMatchFailure(
           op, "pbitcast expects identical lowered input/result types");
@@ -10191,27 +10330,31 @@ public:
     auto llvmDestType =
         dyn_cast<LLVM::LLVMPointerType>(adaptor.getDestination().getType());
     Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
-    if (!llvmDestType || !valueType)
+    if (!llvmDestType || !valueType) {
       return rewriter.notifyMatchFailure(
           op, "expected converted predicate-store operand types");
+    }
 
     auto dist = parsePredicateStoreDistImmediate(op.getDist());
-    if (!dist)
+    if (!dist) {
       return rewriter.notifyMatchFailure(
           op, "unsupported predicate-store dist immediate");
+    }
 
     Value offset = castIntegerLikeTo(op, adaptor.getOffset(), rewriter.getI32Type());
-    if (!offset)
+    if (!offset) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert predicate-store offset to i32");
+    }
 
     bool usePostIntrinsic = op.getUpdatedBase() != nullptr;
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
                                                       resultTypes)) ||
-        resultTypes.size() != (usePostIntrinsic ? 1u : 0u))
+        resultTypes.size() != (usePostIntrinsic ? 1u : 0u)) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert predicate-store result types");
+    }
 
     StringRef calleeName =
         getPredicateStoreCallee<StoreOp>(op.getContext(), usePostIntrinsic);
@@ -10263,22 +10406,26 @@ public:
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
                                                       resultTypes)) ||
-        resultTypes.size() != (usePostIntrinsic ? 2u : 1u))
+        resultTypes.size() != (usePostIntrinsic ? 2u : 1u)) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert predicate-load result types");
-    if (!llvmSourceType)
+    }
+    if (!llvmSourceType) {
       return rewriter.notifyMatchFailure(
           op, "expected converted predicate-load operand/result types");
+    }
 
     auto dist = parsePredicateLoadDistImmediate(op.getDist());
-    if (!dist)
+    if (!dist) {
       return rewriter.notifyMatchFailure(
           op, "unsupported predicate-load dist immediate");
+    }
 
     Value offset = castIntegerLikeTo(op, adaptor.getOffset(), rewriter.getI32Type());
-    if (!offset)
+    if (!offset) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert predicate-load offset to i32");
+    }
 
     StringRef calleeName =
         getPredicateLoadCallee<LoadOp>(op.getContext(), usePostIntrinsic);
@@ -10323,9 +10470,10 @@ public:
     } else {
       packed = packLoopPair(op, adaptor.getFirst(), adaptor.getSecond());
     }
-    if (failed(packed))
+    if (failed(packed)) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to pack loop configuration");
+    }
 
     StringRef calleeName = buildSetLoopCallee<LoopOp>(op.getContext());
     auto funcType =
@@ -10354,9 +10502,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     FailureOr<Value> encoded =
         encodeMovPadValue(op.getLoc(), adaptor.getValue(), rewriter);
-    if (failed(encoded))
+    if (failed(encoded)) {
       return rewriter.notifyMatchFailure(
           op, "expected 8/16/32-bit integer or float mov-pad payload");
+    }
 
     StringRef calleeName = buildUnaryConfigCallee<ConfigOp>(op.getContext());
     auto funcType =
@@ -10519,10 +10668,11 @@ static std::string buildSimtKeepResumeConstraints(
     {
       os << ",";
     }
-    if (physicalReg.registerCount == 2)
+    if (physicalReg.registerCount == 2) {
       os << "={TPERL" << physicalReg.baseRegister / 2 << "}";
-    else
+    } else {
       os << "={TPER" << physicalReg.baseRegister << "}";
+}
   }
   if (tieInputs) {
     for (size_t index = 0; index < physicalRegs.size(); ++index)
@@ -10575,17 +10725,18 @@ static Value packSimtKeepResumePayload(Location loc, Value value,
                                        ConversionPatternRewriter &rewriter) {
   Type type = value.getType();
   std::optional<unsigned> width = getSimtKeepResumeBitWidth(type);
-  if (!width)
+  if (!width) {
     return {};
+  }
 
   Type intType = rewriter.getIntegerType(*width);
   Value bits = value;
   if (!isa<IntegerType>(type))
   {
     bits = rewriter.create<LLVM::BitcastOp>(loc, intType, value);
-  }
-  else if (bits.getType() != intType)
+  } else if (bits.getType() != intType) {
     bits = rewriter.create<LLVM::BitcastOp>(loc, intType, bits);
+  }
   if (*width < 32)
   {
     return rewriter.create<LLVM::ZExtOp>(loc, rewriter.getI32Type(), bits);
@@ -10601,17 +10752,18 @@ static Value unpackSimtKeepResumePayload(Location loc, Value value,
                                          Type resultType,
                                          ConversionPatternRewriter &rewriter) {
   std::optional<unsigned> width = getSimtKeepResumeBitWidth(resultType);
-  if (!width)
+  if (!width) {
     return {};
+  }
 
   Type intType = rewriter.getIntegerType(*width);
   Value bits = value;
   if (*width < 32)
   {
     bits = rewriter.create<LLVM::TruncOp>(loc, intType, bits);
-  }
-  else if (bits.getType() != intType)
+  } else if (bits.getType() != intType) {
     bits = rewriter.create<LLVM::BitcastOp>(loc, intType, bits);
+  }
 
   if (isa<IntegerType>(resultType)) {
     if (bits.getType() == resultType)
@@ -10677,9 +10829,10 @@ public:
   matchAndRewrite(pto::KeepOp op, pto::KeepOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     (void)adaptor;
-    if (hasPreviousSameOp(op.getOperation()))
+    if (hasPreviousSameOp(op.getOperation())) {
       return rewriter.notifyMatchFailure(
           op, "only the first keep in a contiguous group is lowered");
+    }
 
     SmallVector<pto::KeepOp, 4> keepOps = collectConsecutiveOps(op);
     SmallVector<Value, 4> payloads;
@@ -10692,30 +10845,34 @@ public:
         return rewriter.notifyMatchFailure(keep, "payload is not remapped");
       }
       payload = packSimtKeepResumePayload(keep.getLoc(), payload, rewriter);
-      if (!payload)
+      if (!payload) {
         return rewriter.notifyMatchFailure(
             keep, "expected integer scalar up to 64 bits or f16/bf16/f32");
+      }
       int64_t slot = keep.getSlot();
       unsigned registerCount =
           getSimtKeepResumeRegisterCount(payload.getType());
-      if (!isValidSimtKeepResumeSlot(slot, registerCount))
+      if (!isValidSimtKeepResumeSlot(slot, registerCount)) {
         return rewriter.notifyMatchFailure(
             keep,
             "slot must be in range [0, 122] and 64-bit slots must be even");
+      }
       logicalSlots.push_back({slot, registerCount});
       payloads.push_back(payload);
       asmResultTypes.push_back(payload.getType());
     }
     FailureOr<SmallVector<SimtKeepResumePhysicalRegister, 4>> physicalRegs =
         computeSimtKeepResumePhysicalRegs(logicalSlots);
-    if (failed(physicalRegs))
+    if (failed(physicalRegs)) {
       return rewriter.notifyMatchFailure(
           op, "keep slots must map to valid non-overlapping SIMT registers");
+    }
 
     Type asmResultType = asmResultTypes.front();
-    if (asmResultTypes.size() > 1)
+    if (asmResultTypes.size() > 1) {
       asmResultType =
           LLVM::LLVMStructType::getLiteral(op.getContext(), asmResultTypes);
+    }
     rewriter.setInsertionPoint(op);
     rewriter.create<LLVM::InlineAsmOp>(
         op.getLoc(), TypeRange{asmResultType}, payloads, "",
@@ -10740,33 +10897,37 @@ public:
   matchAndRewrite(pto::ResumeOp op, pto::ResumeOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     (void)adaptor;
-    if (hasPreviousSameOp(op.getOperation()))
+    if (hasPreviousSameOp(op.getOperation())) {
       return rewriter.notifyMatchFailure(
           op, "only the first resume in a contiguous group is lowered");
+    }
 
     SmallVector<pto::ResumeOp, 4> resumeOps = collectConsecutiveOps(op);
     SmallVector<std::pair<int64_t, unsigned>, 4> logicalSlots;
     SmallVector<Type, 4> asmResultTypes;
     for (pto::ResumeOp resume : resumeOps) {
       Type resultType = getTypeConverter()->convertType(resume.getType());
-      if (!resultType || !getSimtKeepResumeBitWidth(resultType))
+      if (!resultType || !getSimtKeepResumeBitWidth(resultType)) {
         return rewriter.notifyMatchFailure(
             resume, "expected integer scalar up to 64 bits or f16/bf16/f32");
+      }
       int64_t slot = resume.getSlot();
       unsigned registerCount = getSimtKeepResumeRegisterCount(resultType);
-      if (!isValidSimtKeepResumeSlot(slot, registerCount))
+      if (!isValidSimtKeepResumeSlot(slot, registerCount)) {
         return rewriter.notifyMatchFailure(
             resume,
             "slot must be in range [0, 122] and 64-bit slots must be even");
+      }
       logicalSlots.push_back({slot, registerCount});
       asmResultTypes.push_back(rewriter.getIntegerType(
           *getSimtKeepResumeBitWidth(resultType) > 32 ? 64 : 32));
     }
     FailureOr<SmallVector<SimtKeepResumePhysicalRegister, 4>> physicalRegs =
         computeSimtKeepResumePhysicalRegs(logicalSlots);
-    if (failed(physicalRegs))
+    if (failed(physicalRegs)) {
       return rewriter.notifyMatchFailure(
           op, "resume slots must map to valid non-overlapping SIMT registers");
+    }
 
     Type asmResultType = asmResultTypes.front();
     if (asmResultTypes.size() > 1) {
@@ -10970,9 +11131,10 @@ public:
       eventValue = getI64Constant(rewriter, op.getLoc(), eventIdAttr.getInt());
     } else {
       Value eventIdDyn = adaptor.getEventIdDyn();
-      if (!eventIdDyn)
+      if (!eventIdDyn) {
         return rewriter.notifyMatchFailure(
             op, "expected static or dynamic event-id operand");
+      }
 
       eventValue = castIntegerLikeTo(op, eventIdDyn, rewriter.getI64Type());
       if (!eventValue) {
@@ -11168,14 +11330,16 @@ public:
       pipe = pipeAttr.getPipe();
     } else {
       auto opTypeOr = parseSyncOpTypeLikeAttr(op.getOpTypeAttr());
-      if (failed(opTypeOr))
+      if (failed(opTypeOr)) {
         return rewriter.notifyMatchFailure(
             op, "buffer sync expects pipe/sync_op_type/pipe_event_type attr");
+      }
       pipe = mapSyncOpTypeToPipe(*opTypeOr);
     }
-    if (!isConcreteSyncPipe(pipe))
+    if (!isConcreteSyncPipe(pipe)) {
       return rewriter.notifyMatchFailure(op,
                                          "buffer sync op_type cannot map to concrete pipe");
+    }
 
     auto pipeImm = parsePipeImmediate(stringifyPIPE(pipe));
     if (!pipeImm)
@@ -11221,14 +11385,16 @@ public:
       pipe = pipeAttr.getPipe();
     } else {
       auto opTypeOr = parseSyncOpTypeLikeAttr(op.getOpTypeAttr());
-      if (failed(opTypeOr))
+      if (failed(opTypeOr)) {
         return rewriter.notifyMatchFailure(
             op, "buffer sync expects pipe/sync_op_type/pipe_event_type attr");
+      }
       pipe = mapSyncOpTypeToPipe(*opTypeOr);
     }
-    if (!isConcreteSyncPipe(pipe))
+    if (!isConcreteSyncPipe(pipe)) {
       return rewriter.notifyMatchFailure(
           op, "buffer sync op_type cannot map to concrete pipe");
+    }
 
     auto pipeImm = parsePipeImmediate(stringifyPIPE(pipe));
     if (!pipeImm)
@@ -11238,13 +11404,15 @@ public:
 
     Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipeImm);
     Value bufIdDyn = adaptor.getBufId();
-    if (!bufIdDyn)
+    if (!bufIdDyn) {
       return rewriter.notifyMatchFailure(
           op, "expected dynamic buf-id operand");
+    }
     Value bufIdValue = castIntegerLikeTo(op, bufIdDyn, rewriter.getI64Type());
-    if (!bufIdValue)
+    if (!bufIdValue) {
       return rewriter.notifyMatchFailure(
           op, "failed to cast dynamic buf-id to i64");
+    }
 
     bool isGetBuf =
         std::is_same_v<BufDynSyncOp, pto::GetBufDynOp>;
@@ -11280,9 +11448,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     (void)adaptor;
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert runtime-query result type");
+    }
 
     StringRef calleeName = buildRuntimeQueryCallee<QueryOp>(op.getContext());
     auto funcType = rewriter.getFunctionType(TypeRange{}, TypeRange{resultType});
@@ -11312,16 +11481,18 @@ public:
     (void)adaptor;
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert block runtime-query result type");
+    }
 
     auto funcOp = op->template getParentOfType<func::FuncOp>();
     bool isSimtEntry =
         funcOp && funcOp->hasAttr(pto::kPTOSimtEntryAttrName);
-    if (isSimtEntry && !resultType.isInteger(64))
+    if (isSimtEntry && !resultType.isInteger(64)) {
       return rewriter.notifyMatchFailure(
           op, "SIMT block runtime-query expects an i64 PTO result");
+    }
 
     StringRef calleeName =
         isSimtEntry ? buildSimtBlockQueryCallee<QueryOp>(op.getContext())
@@ -11506,9 +11677,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = this->getTypeConverter()->convertType(op.getOld().getType());
     Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
-    if (!resultType || !valueType || resultType != valueType)
+    if (!resultType || !valueType || resultType != valueType) {
       return rewriter.notifyMatchFailure(op,
                                          "unexpected atomic operand/result type");
+    }
 
     Type ptrType = this->getTypeConverter()->convertType(op.getPtr().getType());
     if (!ptrType)
@@ -11561,8 +11733,9 @@ public:
         this->getTypeConverter()->convertType(op.getCompare().getType());
     Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
     if (!resultType || !compareType || !valueType || resultType != compareType ||
-        resultType != valueType)
+        resultType != valueType) {
       return rewriter.notifyMatchFailure(op, "unexpected atomic CAS type");
+    }
 
     Type ptrType = this->getTypeConverter()->convertType(op.getPtr().getType());
     if (!ptrType)
@@ -11612,13 +11785,15 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
-                                                      resultTypes)))
+                                                      resultTypes))) {
       return rewriter.notifyMatchFailure(op, "failed to convert scalar result types");
+    }
 
     SmallVector<Type> operandTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getOperandTypes(),
-                                                      operandTypes)))
+                                                      operandTypes))) {
       return rewriter.notifyMatchFailure(op, "failed to convert scalar operand types");
+    }
 
     StringRef calleeName = buildScalarIntrinsicCallee<ScalarOp>(op.getContext());
     auto funcType = rewriter.getFunctionType(operandTypes, resultTypes);
@@ -11647,8 +11822,9 @@ public:
     Type lhsType = getTypeConverter()->convertType(op.getLhs().getType());
     Type rhsType = getTypeConverter()->convertType(op.getRhs().getType());
     if (!resultType || !lhsType || !rhsType || lhsType != resultType ||
-        rhsType != resultType)
+        rhsType != resultType) {
       return rewriter.notifyMatchFailure(op, "unexpected mulhi type");
+    }
 
     pto::Signedness signedness = op.getSignednessAttr().getValue();
     FailureOr<StringRef> calleeName =
@@ -11665,8 +11841,9 @@ public:
     }
 
     if (!op.getResult().getType().isInteger(64) ||
-        signedness != pto::Signedness::Signed)
+        signedness != pto::Signedness::Signed) {
       return rewriter.notifyMatchFailure(op, "unsupported mulhi signature");
+    }
 
     FailureOr<StringRef> unsignedCalleeName =
         buildMulhiCallee(op.getContext(), op.getResult().getType(),
@@ -11727,9 +11904,10 @@ public:
     FailureOr<StringRef> calleeName =
         buildMulI32ToI64Callee(op.getContext(),
                                op.getSignednessAttr().getValue());
-    if (failed(calleeName))
+    if (failed(calleeName)) {
       return rewriter.notifyMatchFailure(op,
                                          "unsupported mul_i32toi64 signature");
+    }
 
     auto funcType =
         rewriter.getFunctionType(TypeRange{lhsType, rhsType}, TypeRange{resultType});
@@ -11836,8 +12014,9 @@ public:
     Type lhsType = this->getTypeConverter()->convertType(op.getLhs().getType());
     Type rhsType = this->getTypeConverter()->convertType(op.getRhs().getType());
     if (!resultType || !lhsType || !rhsType ||
-        lhsType != rhsType || lhsType != resultType)
+        lhsType != rhsType || lhsType != resultType) {
       return rewriter.notifyMatchFailure(op, "unexpected binary scalar math type");
+    }
 
     FailureOr<StringRef> calleeName =
         buildBinaryScalarMathCallee<BinaryOp>(op.getContext(), op.getLhs().getType());
@@ -11874,8 +12053,9 @@ public:
     Type rhsType = this->getTypeConverter()->convertType(op.getRhs().getType());
     Type accType = this->getTypeConverter()->convertType(op.getAcc().getType());
     if (!resultType || !lhsType || !rhsType || !accType ||
-        lhsType != rhsType || lhsType != accType || lhsType != resultType)
+        lhsType != rhsType || lhsType != accType || lhsType != resultType) {
       return rewriter.notifyMatchFailure(op, "unexpected fma scalar math type");
+    }
 
     FailureOr<StringRef> calleeName = buildFmaCallee(op.getContext(),
                                                      op.getLhs().getType());
@@ -11909,9 +12089,10 @@ public:
   matchAndRewrite(pto::ConvertOp op, pto::ConvertOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = getTypeConverter()->convertType(op.getDst().getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert result type");
+    }
 
     FailureOr<StringRef> calleeName =
         buildConvertCallee(op.getContext(), op.getSrc().getType(),
@@ -11958,9 +12139,10 @@ public:
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
                                                       resultTypes)) ||
-        resultTypes.size() != 4)
+        resultTypes.size() != 4) {
       return rewriter.notifyMatchFailure(
           op, "failed to convert get_vms4_sr result types");
+    }
 
     StringRef calleeName = buildRuntimeQueryCallee<pto::GetVms4SrOp>(
         op.getContext());
@@ -11976,9 +12158,10 @@ public:
     Value raw = call.getResult(0);
     for (unsigned i = 0; i < 4; ++i) {
       Value shifted = raw;
-      if (i != 0)
+      if (i != 0) {
         shifted = rewriter.create<arith::ShRUIOp>(
             op.getLoc(), raw, getI64Constant(rewriter, op.getLoc(), i * 16));
+      }
       counts.push_back(rewriter.create<arith::TruncIOp>(
           op.getLoc(), resultTypes[i], shifted));
     }
@@ -12037,8 +12220,9 @@ public:
       return rewriter.notifyMatchFailure(op, "expected single-operand single-result cast");
     }
     if (!hasVPTOConvertibleType(op->getOperandTypes()) &&
-        !hasVPTOConvertibleType(op->getResultTypes()))
+        !hasVPTOConvertibleType(op->getResultTypes())) {
       return rewriter.notifyMatchFailure(op, "no VPTO convertible types");
+    }
 
     Type convertedResultType =
         getTypeConverter()->convertType(op.getResult(0).getType());
@@ -12100,15 +12284,17 @@ public:
     (void)adaptor;
     auto resultType = dyn_cast<LLVM::LLVMPointerType>(
         getTypeConverter()->convertType(op.getS().getType()));
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "expected LLVM pointer result type");
+    }
     auto structType = cast<pto::StructType>(op.getS().getType());
     Type storageType = getVPTOStructStorageType(structType, rewriter);
     auto parentFunc = op->getParentOfType<func::FuncOp>();
-    if (!parentFunc)
+    if (!parentFunc) {
       return rewriter.notifyMatchFailure(
           op, "expected struct declaration inside a function");
+    }
 
     // A non-entry alloca is a dynamic stack allocation. Keep one stack slot per
     // declaration per function invocation even when the declaration is nested
@@ -12185,9 +12371,10 @@ public:
   LogicalResult
   matchAndRewrite(arith::SelectOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!op.getCondition().getType().isInteger(1))
+    if (!op.getCondition().getType().isInteger(1)) {
       return rewriter.notifyMatchFailure(
           op, "only scalar i1 conditions supported for VPTO arith.select");
+    }
 
     Type convertedResultType =
         getTypeConverter()->convertType(op.getResult().getType());
@@ -12199,9 +12386,10 @@ public:
     Value trueValue = adaptor.getTrueValue();
     Value falseValue = adaptor.getFalseValue();
     if (trueValue.getType() != convertedResultType ||
-        falseValue.getType() != convertedResultType)
+        falseValue.getType() != convertedResultType) {
       return rewriter.notifyMatchFailure(
           op, "converted true/false values must match result type");
+    }
 
     rewriter.replaceOpWithNewOp<arith::SelectOp>(
         op, convertedResultType, adaptor.getCondition(), trueValue,
@@ -12225,9 +12413,10 @@ public:
     }
 
     Value offset = adaptor.getOffset();
-    if (offset.getType().isIndex())
+    if (offset.getType().isIndex()) {
       offset = rewriter.create<arith::IndexCastUIOp>(op.getLoc(),
                                                      rewriter.getI64Type(), offset);
+    }
 
     auto gep = rewriter.create<LLVM::GEPOp>(
         op.getLoc(), llvmPtrType,
@@ -12249,9 +12438,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type convertedResultType =
         getTypeConverter()->convertType(op.getResult().getType());
-    if (!convertedResultType)
+    if (!convertedResultType) {
       return rewriter.notifyMatchFailure(op,
                                          "could not convert castptr result type");
+    }
 
     Value input = adaptor.getInput();
     Type inputType = input.getType();
@@ -12275,9 +12465,10 @@ public:
         return success();
       }
       auto sourcePtrType = dyn_cast<LLVM::LLVMPointerType>(inputType);
-      if (!sourcePtrType)
+      if (!sourcePtrType) {
         return rewriter.notifyMatchFailure(op,
                                            "expected integer, memref, or LLVM pointer input");
+      }
       if (sourcePtrType.getAddressSpace() == llvmPtrType.getAddressSpace()) {
         rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, llvmPtrType, input);
         return success();
@@ -12313,14 +12504,16 @@ public:
 
     Type convertedValueType =
         getTypeConverter()->convertType(op.getValue().getType());
-    if (!convertedValueType)
+    if (!convertedValueType) {
       return rewriter.notifyMatchFailure(op,
                                          "could not convert load_scalar result type");
+    }
 
     Value offset = adaptor.getOffset();
-    if (offset.getType().isIndex())
+    if (offset.getType().isIndex()) {
       offset = rewriter.create<arith::IndexCastUIOp>(op.getLoc(),
                                                      rewriter.getI64Type(), offset);
+    }
 
     Value elemPtr = adaptor.getPtr();
     if (!matchPattern(offset, m_Zero())) {
@@ -12353,9 +12546,10 @@ public:
     }
 
     Value offset = adaptor.getOffset();
-    if (offset.getType().isIndex())
+    if (offset.getType().isIndex()) {
       offset = rewriter.create<arith::IndexCastUIOp>(op.getLoc(),
                                                      rewriter.getI64Type(), offset);
+    }
 
     Value elemPtr = adaptor.getPtr();
     if (!matchPattern(offset, m_Zero())) {
@@ -12396,9 +12590,10 @@ public:
     }
 
     Value offset = adaptor.getOffset();
-    if (offset.getType().isIndex())
+    if (offset.getType().isIndex()) {
       offset = rewriter.create<arith::IndexCastUIOp>(op.getLoc(),
                                                      rewriter.getI64Type(), offset);
+    }
 
     Value elemPtr = adaptor.getPtr();
     if (!matchPattern(offset, m_Zero())) {
@@ -12461,9 +12656,10 @@ static Value convertLdgCallResult(Location loc, Type valueType,
                                   ConversionPatternRewriter &rewriter) {
   if (auto intType = dyn_cast<IntegerType>(valueType)) {
     unsigned width = intType.getWidth();
-    if (width == 8 || width == 16)
+    if (width == 8 || width == 16) {
       return rewriter.create<arith::TruncIOp>(
           loc, rewriter.getIntegerType(width), callResult);
+    }
     return callResult;
   }
 
@@ -12472,9 +12668,10 @@ static Value convertLdgCallResult(Location loc, Type valueType,
         rewriter.create<arith::TruncIOp>(loc, rewriter.getI16Type(), callResult);
     return rewriter.create<LLVM::BitcastOp>(loc, convertedValueType, payload);
   }
-  if (valueType.isF32() || valueType.isF64())
+  if (valueType.isF32() || valueType.isF64()) {
     return rewriter.create<LLVM::BitcastOp>(loc, convertedValueType,
                                             callResult);
+  }
   if (pto::isPTOFloat8Type(valueType) || pto::isPTOHiFloat8Type(valueType)) {
     Value payload =
         rewriter.create<arith::TruncIOp>(loc, rewriter.getI8Type(), callResult);
@@ -12517,9 +12714,10 @@ public:
     }
 
     Value offset = adaptor.getOffset();
-    if (offset.getType().isIndex())
+    if (offset.getType().isIndex()) {
       offset = rewriter.create<arith::IndexCastUIOp>(op.getLoc(),
                                                      rewriter.getI64Type(), offset);
+    }
 
     Value elemPtr = adaptor.getPtr();
     if (!matchPattern(offset, m_Zero())) {
@@ -12590,9 +12788,10 @@ public:
     }
 
     Value offset = adaptor.getOffset();
-    if (offset.getType().isIndex())
+    if (offset.getType().isIndex()) {
       offset = rewriter.create<arith::IndexCastUIOp>(op.getLoc(),
                                                      rewriter.getI64Type(), offset);
+    }
 
     Value elemPtr = adaptor.getPtr();
     if (!matchPattern(offset, m_Zero())) {
@@ -12643,15 +12842,18 @@ static Value convertStgValue(Location loc, Type valueType, Value value,
   }
   if (pto::isPTOPackedLdgStgVectorType(valueType)) {
     unsigned totalBits = pto::getPTOPackedLdgStgTotalBits(valueType);
-    if (totalBits == 16)
+    if (totalBits == 16) {
       return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getF16Type(),
                                               value);
-    if (totalBits == 32)
+    }
+    if (totalBits == 32) {
       return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getI32Type(),
                                               value);
-    if (totalBits == 64)
+    }
+    if (totalBits == 64) {
       return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getI64Type(),
                                               value);
+    }
   }
   return value;
 }
@@ -12673,9 +12875,10 @@ public:
     }
 
     Value offset = adaptor.getOffset();
-    if (offset.getType().isIndex())
+    if (offset.getType().isIndex()) {
       offset = rewriter.create<arith::IndexCastUIOp>(op.getLoc(),
                                                      rewriter.getI64Type(), offset);
+    }
 
     Value elemPtr = adaptor.getPtr();
     if (!matchPattern(offset, m_Zero())) {
@@ -12744,21 +12947,24 @@ public:
     if (auto allocaOp = dyn_cast<LLVM::AllocaOp>(op))
     {
       propertyType = allocaOp.getElemType();
-    }
-    else if (auto gepOp = dyn_cast<LLVM::GEPOp>(op))
+    } else if (auto gepOp = dyn_cast<LLVM::GEPOp>(op)) {
       propertyType = gepOp.getElemType();
+    }
     if (!hasVPTOConvertibleType(op->getOperandTypes()) &&
         !hasVPTOConvertibleType(op->getResultTypes()) &&
-        !hasVPTOConvertibleType(propertyType))
+        !hasVPTOConvertibleType(propertyType)) {
       return failure();
-    if (op->getNumRegions() != 0)
+    }
+    if (op->getNumRegions() != 0) {
       return rewriter.notifyMatchFailure(
           op, "region ops with VPTO types are handled structurally");
+    }
 
     SmallVector<Type> convertedResultTypes;
     if (failed(typeConverter->convertTypes(op->getResultTypes(),
-                                           convertedResultTypes)))
+                                           convertedResultTypes))) {
       return rewriter.notifyMatchFailure(op, "failed to convert result types");
+    }
     OperationState state(op->getLoc(), op->getName());
     state.addOperands(operands);
     state.addTypes(convertedResultTypes);
@@ -12768,9 +12974,10 @@ public:
     Operation *converted = rewriter.create(state);
     if (propertyType) {
       Type convertedPropertyType = typeConverter->convertType(propertyType);
-      if (!convertedPropertyType)
+      if (!convertedPropertyType) {
         return rewriter.notifyMatchFailure(
             op, "failed to convert LLVM element type");
+      }
       if (auto allocaOp = dyn_cast<LLVM::AllocaOp>(converted))
       {
         allocaOp.setElemType(convertedPropertyType);
@@ -13249,13 +13456,15 @@ static void foldVPTOTypeCasts(ModuleOp module, TypeConverter &typeConverter) {
       return;
     }
     if (!hasVPTOConvertibleType(castOp->getOperandTypes()) &&
-        !hasVPTOConvertibleType(castOp->getResultTypes()))
+        !hasVPTOConvertibleType(castOp->getResultTypes())) {
       return;
+    }
     Type convertedResultType =
         typeConverter.convertType(castOp.getResult(0).getType());
     if (convertedResultType &&
-        convertedResultType == castOp.getOperand(0).getType())
+        convertedResultType == castOp.getOperand(0).getType()) {
       castsToFold.push_back(castOp);
+    }
   });
   for (UnrealizedConversionCastOp castOp : castsToFold) {
     castOp.getResult(0).replaceAllUsesWith(castOp.getOperand(0));
@@ -13398,11 +13607,11 @@ static void normalizeFuncSignaturesForOfficialLLVMLowering(ModuleOp module) {
       continue;
     }
     Block &entry = funcOp.getBody().front();
-    for (auto [arg, newType] : llvm::zip(entry.getArguments(), newInputs))
-      if (arg.getType() != newType)
-      {
+    for (auto [arg, newType] : llvm::zip(entry.getArguments(), newInputs)) {
+      if (arg.getType() != newType) {
         arg.setType(newType);
       }
+    }
   }
 }
 
@@ -13476,13 +13685,11 @@ makeDeviceEmissionOptions(const VPTOEmissionOptions &baseOptions,
     if (options.march == "dav-c220-vec")
     {
       options.defaultTargetFeatures = kC220VecTargetFeatures.str();
-    }
-    else if (options.march == "dav-c220-cube")
+    } else if (options.march == "dav-c220-cube") {
       options.defaultTargetFeatures = kC220CubeTargetFeatures.str();
-    else if (kind == FunctionKernelKind::Cube)
+    } else if (kind == FunctionKernelKind::Cube) {
       options.defaultTargetFeatures = kCubeTargetFeatures.str();
-    else
-    {
+    } else {
       options.defaultTargetFeatures = kVecTargetFeatures.str();
     }
   }
@@ -13529,11 +13736,9 @@ static void mergeDeviceModulesByKernelKind(ModuleOp module) {
     if (*kernelKind == FunctionKernelKind::Vector)
     {
       target = &vectorModule;
-    }
-    else if (*kernelKind == FunctionKernelKind::Cube)
+    } else if (*kernelKind == FunctionKernelKind::Cube) {
       target = &cubeModule;
-    else
-    {
+    } else {
       continue;
     }
 
@@ -13570,10 +13775,9 @@ static LogicalResult renameKernelFunctionsForKernelKind(ModuleOp module,
   if (*kernelKind == FunctionKernelKind::Vector)
   {
     suffix = kVectorSuffix;
-  }
-  else if (*kernelKind == FunctionKernelKind::Cube)
+  } else if (*kernelKind == FunctionKernelKind::Cube) {
     suffix = kCubeSuffix;
-  else {
+  } else {
     diagOS << "VPTO LLVM emission failed: unsupported "
            << FunctionKernelKindAttr::name << "\n";
     return failure();
@@ -13749,8 +13953,9 @@ emitDeviceLLVMModule(ModuleOp deviceModule, StringRef kernelKind,
                      const VPTOEmissionOptions &options,
                      const llvm::StringSet<llvm::BumpPtrAllocator> &simtEntryNames,
                      llvm::raw_ostream &diagOS) {
-  if (!deviceModule)
+  if (!deviceModule) {
     return EmittedLLVMModule{};
+  }
   if (failed(applyQueriedTargetAttrs(deviceModule, options, diagOS)))
   {
     return failure();

--- a/lib/PTO/Transforms/VPTOLLVMEmitterDispatcher.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitterDispatcher.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/VPTOLLVMEmitter.h"
 #include "PTO/Support/CANNVersion.h"
@@ -16,7 +17,7 @@ static bool usesCANN900Lowering(const VPTOEmissionOptions &options) {
   const bool isC220 = options.march == "dav-c220-vec" ||
                       options.march == "dav-c220-cube";
   return !isC220 &&
-         options.cannVersion >= CANNVersion::release(9, 0, 0);
+         options.cannVersion >= CANNVersion::release(mlir::pto::kValue9, 0, 0);
 }
 
 static bool containsLdStDev(ModuleOp module) {

--- a/lib/PTO/Transforms/VPTOLLVMEmitterHelper.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitterHelper.cpp
@@ -17,6 +17,7 @@
 // https://discourse.llvm.org/t/matchandrewrite-hiding-virtual-functions/84933/8
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/VPTOLLVMEmitterHelper.h"
 
 #include "PTO/IR/PTO.h"
@@ -202,7 +203,7 @@ static bool satisfiesAIVectorScopeLatchPostcondition(llvm::Loop *loop) {
     return false;
   }
 
-  llvm::SmallVector<llvm::BasicBlock *, 4> preds(llvm::predecessors(latch));
+  llvm::SmallVector<llvm::BasicBlock *, mlir::pto::kValue4> preds(llvm::predecessors(latch));
   if (preds.size() != 1) {
     return false;
   }
@@ -224,7 +225,7 @@ static LogicalResult ensureDummyPredForAIVectorScopeLatch(
     return failure();
   }
 
-  llvm::SmallVector<llvm::BasicBlock *, 4> preds(llvm::predecessors(latch));
+  llvm::SmallVector<llvm::BasicBlock *, mlir::pto::kValue4> preds(llvm::predecessors(latch));
   if (preds.empty()) {
     diagOS << "VPTO LLVM emission failed: aivscope latch has no predecessor\n";
     return failure();
@@ -288,8 +289,8 @@ queryDefaultTargetAttrs(const VPTOEmissionOptions &options,
   }
   const std::string &bishengPath = *bisheng;
 
-  llvm::SmallString<64> inputPath;
-  llvm::SmallString<64> outputPath;
+  llvm::SmallString<mlir::pto::kValue64> inputPath;
+  llvm::SmallString<mlir::pto::kValue64> outputPath;
   int inputFD = -1;
   int outputFD = -1;
   if (auto ec = llvm::sys::fs::createTemporaryFile("ptoas-vpto-target-query",
@@ -319,7 +320,7 @@ queryDefaultTargetAttrs(const VPTOEmissionOptions &options,
   llvm::sys::Process::SafelyCloseFileDescriptor(inputFD);
   llvm::sys::Process::SafelyCloseFileDescriptor(outputFD);
 
-  llvm::SmallString<128> stderrPath;
+  llvm::SmallString<mlir::pto::kValue128> stderrPath;
   int stderrFD = -1;
   if (auto ec = llvm::sys::fs::createTemporaryFile("ptoas-vpto-target-query",
                                                    "stderr", stderrFD,
@@ -409,7 +410,7 @@ void materializeVecScopeCarrierLoops(ModuleOp module) {
   (void)ctx->getOrLoadDialect<scf::SCFDialect>();
   ensureAIVScopeDummyDecl(module);
 
-  SmallVector<pto::VecScopeOp, 16> scopes;
+  SmallVector<pto::VecScopeOp, mlir::pto::kValue16> scopes;
   module.walk([&](pto::VecScopeOp vecScope) { scopes.push_back(vecScope); });
 
   IRRewriter rewriter(module.getContext());
@@ -437,7 +438,7 @@ void materializeVecScopeCarrierLoops(ModuleOp module) {
     rewriter.eraseOp(vecScope);
   }
 
-  SmallVector<pto::StrictVecScopeOp, 16> strictScopes;
+  SmallVector<pto::StrictVecScopeOp, mlir::pto::kValue16> strictScopes;
   module.walk([&](pto::StrictVecScopeOp strictVecScope) {
     strictScopes.push_back(strictVecScope);
   });
@@ -488,7 +489,7 @@ LogicalResult attachAIVectorScopeMetadata(llvm::Module &llvmModule,
     llvm::DominatorTree dt(function);
     llvm::LoopInfo loopInfo(dt);
 
-    llvm::SmallVector<llvm::CallInst *, 4> dummyCalls;
+    llvm::SmallVector<llvm::CallInst *, mlir::pto::kValue4> dummyCalls;
     for (llvm::BasicBlock &block : function) {
       for (llvm::Instruction &inst : block) {
         auto *call = dyn_cast<llvm::CallInst>(&inst);
@@ -565,16 +566,21 @@ LogicalResult attachAIVectorScopeMetadata(llvm::Module &llvmModule,
 }
 
 constexpr uint32_t getSimtMaxRegistersForThreads(uint32_t maxThreads) {
-  if (maxThreads > 1024) {
-    return 16;
+  constexpr uint32_t kThreadsPerRegisterTier = 256;
+  constexpr uint32_t kSmallestSimtRegisterBudget = 16;
+  constexpr uint32_t kSmallSimtRegisterBudget = 32;
+  constexpr uint32_t kMediumSimtRegisterBudget = 64;
+  constexpr uint32_t kLargestSimtRegisterBudget = 128;
+  if (maxThreads > 4 * kThreadsPerRegisterTier) {
+    return kSmallestSimtRegisterBudget;
   }
-  if (maxThreads > 512) {
-    return 32;
+  if (maxThreads > 2 * kThreadsPerRegisterTier) {
+    return kSmallSimtRegisterBudget;
   }
-  if (maxThreads > 256) {
-    return 64;
+  if (maxThreads > kThreadsPerRegisterTier) {
+    return kMediumSimtRegisterBudget;
   }
-  return 128;
+  return kLargestSimtRegisterBudget;
 }
 
 void attachHIVMKernelAnnotations(llvm::Module &llvmModule,
@@ -583,8 +589,8 @@ void attachHIVMKernelAnnotations(llvm::Module &llvmModule,
 
   llvm::NamedMDNode *annotations =
       llvmModule.getOrInsertNamedMetadata("hivm.annotations");
-  llvm::LLVMContext &ctx = llvmModule.getContext();
-  llvm::Type *i32Ty = llvm::Type::getInt32Ty(ctx);
+  llvm::LLVMContext *ctx = &llvmModule.getContext();
+  llvm::Type *i32Ty = llvm::Type::getInt32Ty(*ctx);
   llvm::Constant *one = llvm::ConstantInt::get(i32Ty, 1);
 
   llvm::StringMap<uint32_t> simtMaxThreadsByName;
@@ -624,28 +630,31 @@ void attachHIVMKernelAnnotations(llvm::Module &llvmModule,
     return false;
   };
 
-  auto addAnnotation = [&](llvm::Function &function, llvm::StringRef kind) {
+  auto addAnnotation = [annotations, ctx, one](llvm::Function &function,
+                                                llvm::StringRef kind) {
     llvm::Metadata *ops[] = {
         llvm::ValueAsMetadata::get(&function),
-        llvm::MDString::get(ctx, kind),
+        llvm::MDString::get(*ctx, kind),
         llvm::ConstantAsMetadata::get(one)};
-    annotations->addOperand(llvm::MDNode::get(ctx, ops));
+    annotations->addOperand(llvm::MDNode::get(*ctx, ops));
   };
 
-  auto addHIVMModuleI32Annotation = [&](llvm::StringRef kind, uint32_t value) {
+  auto addHIVMModuleI32Annotation = [annotations, ctx, i32Ty](
+                                            llvm::StringRef kind,
+                                            uint32_t value) {
     llvm::Metadata *ops[] = {
-        nullptr, llvm::MDString::get(ctx, kind),
+        nullptr, llvm::MDString::get(*ctx, kind),
         llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(i32Ty, value))};
-    annotations->addOperand(llvm::MDNode::getDistinct(ctx, ops));
+    annotations->addOperand(llvm::MDNode::getDistinct(*ctx, ops));
   };
 
-  auto addLLVMFunctionI32Annotation = [&](llvm::Function &function,
-                                          llvm::StringRef kind,
-                                          uint32_t value) {
+  auto addLLVMFunctionI32Annotation = [ctx, i32Ty](llvm::Function &function,
+                                                    llvm::StringRef kind,
+                                                    uint32_t value) {
     llvm::Metadata *ops[] = {
-        llvm::MDString::get(ctx, kind),
+        llvm::MDString::get(*ctx, kind),
         llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(i32Ty, value))};
-    function.addMetadata("annotation", *llvm::MDNode::get(ctx, ops));
+    function.addMetadata("annotation", *llvm::MDNode::get(*ctx, ops));
   };
 
   for (llvm::Function &function : llvmModule) {

--- a/lib/PTO/Transforms/VPTOOptimizeVcvt.cpp
+++ b/lib/PTO/Transforms/VPTOOptimizeVcvt.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/Passes.h"
@@ -101,13 +102,13 @@ static bool isZeroGapLoad(Value value, AlignedUnsignedWidening widening) {
     return false;
   }
 
-  if (widening.payloadBits == 8 && widening.carrierBits == 16) {
+  if (widening.payloadBits == mlir::pto::kValue8 && widening.carrierBits == 16) {
     return *dist == "UNPK_B8";
   }
-  if (widening.payloadBits == 16 && widening.carrierBits == 32) {
+  if (widening.payloadBits == mlir::pto::kValue16 && widening.carrierBits == 32) {
     return *dist == "UNPK_B16";
   }
-  if (widening.payloadBits == 8 && widening.carrierBits == 32) {
+  if (widening.payloadBits == mlir::pto::kValue8 && widening.carrierBits == 32) {
     return *dist == "UNPK4";
   }
   return false;
@@ -140,8 +141,8 @@ static bool isZeroGapNarrowingVcvt(Value value,
   if (!part) {
     return false;
   }
-  return (inputBits == resultBits * 2 && *part == "EVEN") ||
-         (inputBits == resultBits * 4 && *part == "P0");
+  return (inputBits == resultBits * mlir::pto::kValue2 && *part == "EVEN") ||
+         (inputBits == resultBits * mlir::pto::kValue4 && *part == "P0");
 }
 
 // Deliberately admit only instructions that construct a carrier by zero
@@ -172,7 +173,7 @@ static bool isCanonicalZeroGapCarrier(Value value,
   unsigned resultBits =
       getPTOStorageElemBitWidth(resultType.getElementType());
   if (sourceBits == 0 || resultBits != widening.carrierBits ||
-      resultBits != sourceBits * 2 || widening.payloadBits > sourceBits) {
+      resultBits != sourceBits * mlir::pto::kValue2 || widening.payloadBits > sourceBits) {
     return false;
   }
 
@@ -211,9 +212,9 @@ matchAlignedUnsignedWidening(VcvtOp op) {
   if (!part) {
     return std::nullopt;
   }
-  if ((resultBits == inputBits * 2 && *part != "EVEN") ||
-      (resultBits == inputBits * 4 && *part != "P0") ||
-      (resultBits != inputBits * 2 && resultBits != inputBits * 4)) {
+  if ((resultBits == inputBits * mlir::pto::kValue2 && *part != "EVEN") ||
+      (resultBits == inputBits * mlir::pto::kValue4 && *part != "P0") ||
+      (resultBits != inputBits * mlir::pto::kValue2 && resultBits != inputBits * 4)) {
     return std::nullopt;
   }
 

--- a/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
+++ b/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
@@ -6,7 +6,12 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
 #include "PTO/IR/PTO.h"
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -21,10 +26,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/MathExtras.h"
-#include <cstdint>
-#include <limits>
-#include <memory>
-#include <optional>
+
 
 namespace mlir {
 namespace pto {
@@ -38,6 +40,9 @@ using namespace mlir;
 namespace {
 // A hardware block is 32 bytes; block-strided ops count in these units.
 static constexpr int64_t kBlockSizeBytes = 32;
+static constexpr unsigned kIndexBitWidth = 64;
+static constexpr int64_t kSignedI8Min = -128;
+static constexpr int64_t kSignedI8Max = 127;
 
 // Loop-varying integer addresses must be normalized to this width before this
 // pass may turn them into pointer recurrences. Other widths are left for a
@@ -129,10 +134,10 @@ static std::optional<int64_t> addPtrUnitBytes(Value base) {
     return std::nullopt;
   }
   unsigned bits = elemTy.getIntOrFloatBitWidth();
-  if (bits == 0 || bits % 8 != 0) {
+  if (bits == 0 || bits % mlir::pto::kValue8 != 0) {
     return std::nullopt;
   }
-  return static_cast<int64_t>(bits / 8);
+  return static_cast<int64_t>(bits / mlir::pto::kValue8);
 }
 
 // Bytes covered by one unit of the op's strideOperand. Some units depend on
@@ -462,10 +467,11 @@ static bool divideAffineForm(AffineForm &form, int64_t divisor) {
   if (divisor <= 0 || form.constant % divisor != 0) {
     return false;
   }
-  for (const AffineTerm &term : form.terms)
+  for (const AffineTerm &term : form.terms) {
     if (term.coeff % divisor != 0) {
       return false;
     }
+  }
   form.constant /= divisor;
   for (AffineTerm &term : form.terms) {
     term.coeff /= divisor;
@@ -569,8 +575,9 @@ static std::optional<LinearDecomp> decomposeLinear(Value v,
 
   // v is loop-invariant or constant → {0, v}
   if (forOp.isDefinedOutsideOfLoop(v) ||
-      defOp->hasTrait<OpTrait::ConstantLike>())
+      defOp->hasTrait<OpTrait::ConstantLike>()) {
     return record(LinearDecomp{0, makeLeaf(v)});
+  }
 
   // v = addi(a, b) → {ca + cb, ia + ib}
   // v = subi(a, b) → {ca - cb, ia - ib}
@@ -670,8 +677,9 @@ static StrideResult getIterArgIncrement(Value v, scf::ForOp forOp) {
   while (true) {
     if (auto blockArg = dyn_cast<BlockArgument>(current)) {
       if (blockArg.getOwner() != forOp.getBody() ||
-          blockArg.getArgNumber() == 0)
+          blockArg.getArgNumber() == 0) {
         return {StrideStatus::NotIterArg, nullptr};
+      }
 
       unsigned idx = blockArg.getArgNumber() - 1;
       auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
@@ -691,8 +699,9 @@ static StrideResult getIterArgIncrement(Value v, scf::ForOp forOp) {
 
     Operation *defOp = current.getDefiningOp();
     if (!defOp || forOp.isDefinedOutsideOfLoop(current) ||
-        defOp->hasTrait<OpTrait::ConstantLike>())
+        defOp->hasTrait<OpTrait::ConstantLike>()) {
       return {StrideStatus::NotIterArg, nullptr};
+    }
 
     if (isa<arith::IndexCastUIOp, arith::IndexCastOp>(defOp)) {
       if (!castPreservesLoopDelta(defOp, forOp)) {
@@ -742,7 +751,7 @@ using DeltaCache = DenseMap<Value, StrideExprRef>;
 
 static unsigned integerLikeBitWidth(Type type) {
   if (type.isIndex()) {
-    return 64;
+    return kIndexBitWidth;
   }
   return cast<IntegerType>(type).getWidth();
 }
@@ -799,9 +808,10 @@ getConstantIterArgIncrement(BlockArgument iterArg, scf::ForOp forOp,
       increment = addOp.getLhs();
     }
     auto constant = increment ? getConstantAPInt(increment) : std::nullopt;
-    if (constant)
+    if (constant) {
       return isUnsigned ? static_cast<__int128>(constant->getZExtValue())
                         : static_cast<__int128>(constant->getSExtValue());
+    }
   }
 
   if (auto subOp = yielded.getDefiningOp<arith::SubIOp>()) {
@@ -812,8 +822,9 @@ getConstantIterArgIncrement(BlockArgument iterArg, scf::ForOp forOp,
     if (constant) {
       int64_t signedConstant = constant->getSExtValue();
       if (signedConstant ==
-          -(int64_t{1} << (kCanonicalAddressWidth - 1)))
+          -(int64_t{1} << (kCanonicalAddressWidth - 1))) {
         return std::nullopt;
+      }
       return -static_cast<__int128>(signedConstant);
     }
   }
@@ -855,8 +866,9 @@ static bool canonicalAddressRecurrenceDoesNotWrap(Value input,
   } else {
     auto iterArg = dyn_cast<BlockArgument>(input);
     if (!iterArg || iterArg.getOwner() != forOp.getBody() ||
-        iterArg.getArgNumber() == 0)
+        iterArg.getArgNumber() == 0) {
       return false;
+    }
     unsigned idx = iterArg.getArgNumber() - 1;
     auto initial = getConstantAPInt(forOp.getInitArgs()[idx]);
     auto step = getConstantIterArgIncrement(iterArg, forOp, isUnsigned);
@@ -873,10 +885,11 @@ static bool canonicalAddressRecurrenceDoesNotWrap(Value input,
   __int128 final = initial + increment * static_cast<__int128>(*tripCount);
   __int128 minValue = std::min(initial, final);
   __int128 maxValue = std::max(initial, final);
-  if (isUnsigned)
+  if (isUnsigned) {
     return minValue >= 0 &&
            maxValue <=
                static_cast<__int128>(llvm::maxUIntN(kCanonicalAddressWidth));
+  }
   return minValue >= -static_cast<__int128>(uint64_t{1}
                                             << (kCanonicalAddressWidth - 1)) &&
          maxValue <= static_cast<__int128>(
@@ -890,12 +903,14 @@ static bool canonicalAddressRecurrenceDoesNotWrap(Value input,
 // recurrence. Narrowing casts retain the existing constant-IV range proof.
 static bool castPreservesLoopDelta(Operation *castOp, scf::ForOp forOp) {
   Value input = castOp->getOperand(0);
-  if (forOp.isDefinedOutsideOfLoop(input))
+  if (forOp.isDefinedOutsideOfLoop(input)) {
     return true; // Both the cast value and its delta (zero) are invariant.
+  }
 
   if (castOp->getResult(0).getType().isIndex() &&
-      isa<IntegerType>(input.getType()))
+      isa<IntegerType>(input.getType())) {
     return canonicalAddressRecurrenceDoesNotWrap(input, castOp, forOp);
+  }
 
   unsigned inputWidth = integerLikeBitWidth(input.getType());
   unsigned resultWidth = integerLikeBitWidth(castOp->getResult(0).getType());
@@ -913,14 +928,16 @@ static bool castPreservesLoopDelta(Operation *castOp, scf::ForOp forOp) {
   if (!lower || !upper || !step || *step <= 0) {
     return false;
   }
-  if (*lower >= *upper)
+  if (*lower >= *upper) {
     return true; // Empty loop.
+  }
 
   int64_t maxIV = *upper - 1;
-  if (isa<arith::IndexCastUIOp>(castOp))
+  if (isa<arith::IndexCastUIOp>(castOp)) {
     return *lower >= 0 &&
            llvm::isUIntN(resultWidth, static_cast<uint64_t>(*lower)) &&
            llvm::isUIntN(resultWidth, static_cast<uint64_t>(maxIV));
+  }
   return llvm::isIntN(resultWidth, *lower) && llvm::isIntN(resultWidth, maxIV);
 }
 
@@ -1136,9 +1153,10 @@ static Value normalizeAddPtrOffsetToIndex(Value offset, StrideUnit strideUnit,
   if (offset.getType().isIndex()) {
     return offset;
   }
-  if (strideUnit == StrideUnit::Block)
+  if (strideUnit == StrideUnit::Block) {
     return builder.create<arith::IndexCastUIOp>(loc, builder.getIndexType(),
                                                 offset);
+  }
   return builder.create<arith::IndexCastOp>(loc, builder.getIndexType(),
                                             offset);
 }
@@ -1167,9 +1185,10 @@ static Value createInitialPtr(Value base, Value strideOperand,
   if (unitBytes != elemBytes) {
     if (unitBytes % elemBytes == 0) {
       Value soIndex = strideOperand;
-      if (strideOperand.getType() != builder.getIndexType())
+      if (strideOperand.getType() != builder.getIndexType()) {
         soIndex = builder.create<arith::IndexCastUIOp>(
             loc, builder.getIndexType(), strideOperand);
+      }
       Value factor =
           builder.create<arith::ConstantIndexOp>(loc, unitBytes / elemBytes);
       scaledOffset = builder.create<arith::MulIOp>(loc, soIndex, factor);
@@ -1303,10 +1322,11 @@ static bool canHoistBefore(Value v, Operation *insertPt, scf::ForOp forOp,
   if (!isPure(defOp)) {
     return false;
   }
-  for (Value operand : defOp->getOperands())
+  for (Value operand : defOp->getOperands()) {
     if (!canHoistBefore(operand, insertPt, forOp, memo)) {
       return false;
     }
+  }
   memo[v] = true;
   return true;
 }
@@ -1320,8 +1340,9 @@ static Value hoistBefore(Value v, Operation *insertPt, scf::ForOp forOp,
   }
   Operation *defOp = v.getDefiningOp();
   if (!defOp || defOp->getBlock() != insertPt->getBlock() ||
-      defOp->isBeforeInBlock(insertPt))
+      defOp->isBeforeInBlock(insertPt)) {
     return v;
+  }
   auto it = memo.find(v);
   if (it != memo.end()) {
     return it->second;
@@ -1395,9 +1416,10 @@ static Value materializeConst(int64_t c, Type ty, Location loc,
   if (ty.isIndex()) {
     v = builder.create<arith::ConstantIndexOp>(loc, c);
   }
-  else
+  else {
     v = builder.create<arith::ConstantIntOp>(loc, c,
                                              ty.getIntOrFloatBitWidth());
+}
   cache[key] = v;
   return v;
 }
@@ -1410,10 +1432,11 @@ static Value materializeConst(int64_t c, Type ty, Location loc,
 static bool constantsFitType(const StrideExprRef &e, Type wantType) {
   switch (e->kind) {
   case StrideExpr::Kind::Const: {
-    if (!wantType || wantType.isIndex())
+    if (!wantType || wantType.isIndex()) {
       return true; // index is 64-bit, always holds an int64_t
+    }
     unsigned bitWidth = wantType.getIntOrFloatBitWidth();
-    return bitWidth >= 64 || llvm::isIntN(bitWidth, e->constant);
+    return bitWidth >= mlir::pto::kValue64 || llvm::isIntN(bitWidth, e->constant);
   }
   case StrideExpr::Kind::Leaf:
     return true;
@@ -1438,7 +1461,7 @@ static bool satisfiesStrideConstraint(const StrideExprRef &stride,
     return false;
   }
   return constraint == StrideConstraint::Constant ||
-         (*constant >= -128 && *constant <= 127);
+         (*constant >= kSignedI8Min && *constant <= kSignedI8Max);
 }
 
 // Emit `e` at the builder's current insertion point.  Sub-expressions are
@@ -1521,10 +1544,11 @@ static bool canHoistBefore(Value v, Operation *insertPt,
   if (!defOp || defOp->getBlock() != insertPt->getBlock() || !isPure(defOp)) {
     return false;
   }
-  for (Value operand : defOp->getOperands())
+  for (Value operand : defOp->getOperands()) {
     if (!canHoistBefore(operand, insertPt, dominance, memo)) {
       return false;
     }
+  }
   memo[v] = true;
   return true;
 }
@@ -1540,9 +1564,10 @@ static Value hoistBefore(Value v, Operation *insertPt, DominanceInfo &dominance,
 
   Operation *defOp = v.getDefiningOp();
   SmallVector<Value> newOperands;
-  for (Value operand : defOp->getOperands())
+  for (Value operand : defOp->getOperands()) {
     newOperands.push_back(
         hoistBefore(operand, insertPt, dominance, builder, memo));
+  }
 
   builder.setInsertionPoint(insertPt);
   Operation *cloned = builder.clone(*defOp);
@@ -1739,10 +1764,11 @@ static scf::ForOp pruneDeadLoopCarriedValues(scf::ForOp forOp,
   // rather than attempting a second control-flow-sensitive liveness analysis
   // here.
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    if (!isPure(&op))
+    if (!isPure(&op)) {
       for (Value operand : op.getOperands()) {
         markLive(operand);
       }
+    }
     if (op.getNumRegions() != 0) {
       op.walk([&markLive](Operation *nested) {
         for (Value operand : nested->getOperands()) {
@@ -1757,8 +1783,9 @@ static scf::ForOp pruneDeadLoopCarriedValues(scf::ForOp forOp,
     Value value = worklist.pop_back_val();
     if (auto blockArg = dyn_cast<BlockArgument>(value)) {
       if (blockArg.getOwner() != forOp.getBody() ||
-          blockArg.getArgNumber() == 0)
+          blockArg.getArgNumber() == 0) {
         continue;
+      }
       unsigned idx = blockArg.getArgNumber() - 1;
       if (!keepIterArg[idx]) {
         keepIterArg[idx] = true;
@@ -1782,10 +1809,11 @@ static scf::ForOp pruneDeadLoopCarriedValues(scf::ForOp forOp,
 
   SmallVector<Value> newInitArgs;
   newInitArgs.reserve(numIterArgs);
-  for (auto [idx, init] : llvm::enumerate(forOp.getInitArgs()))
+  for (auto [idx, init] : llvm::enumerate(forOp.getInitArgs())) {
     if (keepIterArg[idx]) {
       newInitArgs.push_back(init);
     }
+  }
 
   builder.setInsertionPoint(forOp);
   auto newForOp = builder.create<scf::ForOp>(
@@ -1796,10 +1824,11 @@ static scf::ForOp pruneDeadLoopCarriedValues(scf::ForOp forOp,
   IRMapping mapping;
   mapping.map(forOp.getInductionVar(), newForOp.getInductionVar());
   unsigned newArgIdx = 0;
-  for (auto [idx, oldArg] : llvm::enumerate(forOp.getRegionIterArgs()))
+  for (auto [idx, oldArg] : llvm::enumerate(forOp.getRegionIterArgs())) {
     if (keepIterArg[idx]) {
       mapping.map(oldArg, newForOp.getRegionIterArgs()[newArgIdx++]);
     }
+  }
 
   builder.setInsertionPointToStart(newForOp.getBody());
   for (Operation &op : forOp.getBody()->without_terminator()) {
@@ -1813,10 +1842,11 @@ static scf::ForOp pruneDeadLoopCarriedValues(scf::ForOp forOp,
 
   SmallVector<Value> newYields;
   newYields.reserve(newInitArgs.size());
-  for (auto [idx, yielded] : llvm::enumerate(yieldOp.getOperands()))
+  for (auto [idx, yielded] : llvm::enumerate(yieldOp.getOperands())) {
     if (keepIterArg[idx]) {
       newYields.push_back(mapping.lookupOrDefault(yielded));
     }
+  }
   builder.setInsertionPointToEnd(newForOp.getBody());
   builder.create<scf::YieldOp>(yieldOp.getLoc(), newYields);
 
@@ -1988,13 +2018,13 @@ static StrideExprRef buildSequentialExpr(Value value,
     result = makeSub(buildSequentialExpr(sub.getLhs(), cache),
                      buildSequentialExpr(sub.getRhs(), cache));
   } else if (auto mul = dyn_cast_or_null<arith::MulIOp>(defOp)) {
-    if (auto lhsConst = getConstantIntValue(mul.getLhs()))
+    if (auto lhsConst = getConstantIntValue(mul.getLhs())) {
       result = makeMul(makeConst(*lhsConst),
                        buildSequentialExpr(mul.getRhs(), cache));
-    else if (auto rhsConst = getConstantIntValue(mul.getRhs()))
+    } else if (auto rhsConst = getConstantIntValue(mul.getRhs())) {
       result = makeMul(buildSequentialExpr(mul.getLhs(), cache),
                        makeConst(*rhsConst));
-    else {
+    } else {
       result = makeLeaf(value);
     }
   } else if (isa_and_nonnull<arith::IndexCastOp, arith::IndexCastUIOp>(defOp)) {
@@ -2054,8 +2084,9 @@ static std::optional<SequentialStep>
 analyzeSequentialStep(const SequentialCandidate &previous,
                       const SequentialCandidate &current) {
   if (previous.elemBytes != current.elemBytes ||
-      previous.unitBytes != current.unitBytes)
+      previous.unitBytes != current.unitBytes) {
     return std::nullopt;
+  }
 
   StrideExprRef deltaBase = makeSub(current.baseOffset, previous.baseOffset);
   StrideExprRef deltaStride = makeSub(current.strideExpr, previous.strideExpr);
@@ -2083,7 +2114,7 @@ struct SequentialRun {
 
 static bool validateSequentialRun(SequentialRun &run,
                                   DominanceInfo &dominance) {
-  if (run.candidates.size() < 3) {
+  if (run.candidates.size() < mlir::pto::kValue3) {
     return false;
   }
 
@@ -2099,8 +2130,9 @@ static bool validateSequentialRun(SequentialRun &run,
       !satisfiesStrideConstraint(run.step,
                                  first->info->strideConstraint) ||
       !canScaleInitialOffset(initialOffsetOperand, first->elemBytes,
-                             first->unitBytes))
+                             first->unitBytes)) {
     return false;
+  }
 
   for (SequentialCandidate *candidate : run.candidates) {
     Type candidateStrideType =
@@ -2178,8 +2210,9 @@ static void collectCumulativeOffsetOps(Value value,
                                        DenseSet<Operation *> &ops) {
   Operation *defOp = value.getDefiningOp();
   if (!isa_and_nonnull<arith::AddIOp, arith::SubIOp>(defOp) ||
-      !ops.insert(defOp).second)
+      !ops.insert(defOp).second) {
     return;
+  }
   for (Value operand : defOp->getOperands()) {
     collectCumulativeOffsetOps(operand, ops);
   }
@@ -2198,7 +2231,7 @@ static bool allUsesDisappearAfterRewrite(Operation *op,
 static bool cumulativeOffsetChainDefinitelyDies(
     const SequentialRun &run, DenseSet<Operation *> &deadOps) {
   for (SequentialCandidate *candidate :
-       llvm::drop_begin(run.candidates, 2)) {
+       llvm::drop_begin(run.candidates, mlir::pto::kValue2)) {
     if (candidate->strideOperand) {
       collectCumulativeOffsetOps(candidate->strideOperand, deadOps);
     }
@@ -2240,10 +2273,11 @@ static bool isStepMaterializationCostNeutral(
     clonedOps.insert(atom->castOp);
     SmallVector<Value> leaves;
     collectLeaves(atom, leaves);
-    for (Value leaf : leaves)
+    for (Value leaf : leaves) {
       if (!collectLatePureDefinitions(leaf, first->op, dominance, clonedOps)) {
         return false;
       }
+    }
   } else if (atom->kind == StrideExpr::Kind::Leaf &&
              !collectLatePureDefinitions(atom->leaf, first->op, dominance,
                                          clonedOps)) {
@@ -2271,15 +2305,17 @@ static bool isProfitableDirectSymbolicLeafRun(
   // validateSequentialRun already enforces N >= 3. This class intentionally
   // has no higher length threshold, so an N3 run may be accepted.
   if (run.stepForm.constant != 0 || run.stepForm.terms.size() != 1 ||
-      run.stepForm.terms.front().coeff != 1)
+      run.stepForm.terms.front().coeff != 1) {
     return false;
+  }
 
   // This class covers a direct fixed base with offsets 0, step, 2*step, ...
   // Dynamic base chains are handled independently above.
   if (!llvm::all_of(run.candidates, [](SequentialCandidate *candidate) {
         return candidate->base == candidate->rootBase;
-      }))
+      })) {
     return false;
+  }
   Value firstStrideOperand = run.candidates.front()->strideOperand;
   auto firstOffset = firstStrideOperand
                          ? getConstantIntValue(firstStrideOperand)
@@ -2312,8 +2348,9 @@ static void collectNestedBlocks(Operation *op, pto::VecScopeOp owner,
       blocks.push_back(&block);
       for (Operation &nested : block) {
         if (auto nestedScope = dyn_cast<pto::VecScopeOp>(nested);
-            nestedScope && nestedScope != owner)
+            nestedScope && nestedScope != owner) {
           continue;
+        }
         collectNestedBlocks(&nested, owner, blocks);
       }
     }
@@ -2427,10 +2464,11 @@ static void processSequentialBlock(Block *block, DominanceInfo &dominance,
   }
 
   DenseMap<Operation *, unsigned> opToRun;
-  for (auto [runIdx, run] : llvm::enumerate(runs))
+  for (auto [runIdx, run] : llvm::enumerate(runs)) {
     for (SequentialCandidate *candidate : run.candidates) {
       opToRun[candidate->op] = runIdx;
     }
+  }
 
   // Rewrite in original program order so interleaved buckets maintain separate
   // pointer chains without invalidating one another.
@@ -2544,7 +2582,6 @@ private:
       StrideExprRef deltaOffset =
           strideOperand ? getStride(strideOperand, forOp, deltaCache)
                         : makeConst(0);
-
       if (!deltaBase || !deltaOffset) {
         continue;
       }
@@ -2590,8 +2627,9 @@ private:
         DenseMap<Value, bool> canCache;
         if (!llvm::all_of(leaves, [&](Value l) {
               return canHoistBefore(l, &op, forOp, canCache);
-            }))
+            })) {
           continue;
+        }
         DenseMap<Value, Value> hoistMemo;
         finalExpr = makeAvailableAt(total, &op, forOp, builder, hoistMemo);
       }

--- a/lib/PTO/Transforms/VPTOSplitCVModule.cpp
+++ b/lib/PTO/Transforms/VPTOSplitCVModule.cpp
@@ -45,26 +45,31 @@ static bool isVPTOBackendModule(ModuleOp module) {
 
 static bool hasConflictingContainerAttrs(ModuleOp outer, ModuleOp child) {
   for (NamedAttribute attr : child->getAttrs()) {
-    if (attr.getName() == SymbolTable::getSymbolAttrName())
+    if (attr.getName() == SymbolTable::getSymbolAttrName()) {
       continue;
+    }
     Attribute outerValue = outer->getAttr(attr.getName());
-    if (outerValue && outerValue != attr.getValue())
+    if (outerValue && outerValue != attr.getValue()) {
       return true;
+    }
   }
   return false;
 }
 
 static bool flattenSingleUnpartitionedChild(ModuleOp module) {
   SmallVector<Operation *> topLevelOps;
-  for (Operation &op : module.getBodyRegion().front().getOperations())
+  for (Operation &op : module.getBodyRegion().front().getOperations()) {
     topLevelOps.push_back(&op);
-  if (topLevelOps.size() != 1)
+  }
+  if (topLevelOps.size() != 1) {
     return false;
+  }
 
   auto child = dyn_cast<ModuleOp>(topLevelOps.front());
   if (!child || !isVPTOBackendModule(child) || hasKernelKind(child) ||
-      !hasCVSections(child) || hasConflictingContainerAttrs(module, child))
+      !hasCVSections(child) || hasConflictingContainerAttrs(module, child)) {
     return false;
+  }
 
   SmallVector<NamedAttribute> childAttrs(child->getAttrs().begin(),
                                          child->getAttrs().end());
@@ -72,9 +77,11 @@ static bool flattenSingleUnpartitionedChild(ModuleOp module) {
   childBody.takeBody(child.getBodyRegion());
   child.erase();
   module.getBodyRegion().takeBody(childBody);
-  for (NamedAttribute attr : childAttrs)
-    if (attr.getName() != SymbolTable::getSymbolAttrName())
+  for (NamedAttribute attr : childAttrs) {
+    if (attr.getName() != SymbolTable::getSymbolAttrName()) {
       module->setAttr(attr.getName(), attr.getValue());
+    }
+  }
   return true;
 }
 
@@ -83,8 +90,9 @@ static bool isSectionSplitCandidate(func::FuncOp funcOp);
 static bool hasCVSections(ModuleOp module) {
   bool found = false;
   module.walk([&](func::FuncOp funcOp) {
-    if (found || !isSectionSplitCandidate(funcOp))
+    if (found || !isSectionSplitCandidate(funcOp)) {
       return WalkResult::advance();
+    }
     WalkResult result = funcOp.walk([&](Operation *op) {
       if (isa<SectionCubeOp, SectionVectorOp>(op)) {
         found = true;
@@ -101,8 +109,9 @@ static bool hasCVSections(ModuleOp module) {
 static bool hasSectionKind(ModuleOp module, FunctionKernelKind kind) {
   bool found = false;
   module.walk([&](func::FuncOp funcOp) {
-    if (found || !isSectionSplitCandidate(funcOp))
+    if (found || !isSectionSplitCandidate(funcOp)) {
       return WalkResult::advance();
+    }
     WalkResult result = funcOp.walk([&](Operation *op) {
       bool matches = kind == FunctionKernelKind::Cube
                          ? isa<SectionCubeOp>(op)
@@ -153,8 +162,9 @@ static bool isSectionSplitCandidate(func::FuncOp funcOp) {
 static LogicalResult verifyNoNestedSections(ModuleOp module) {
   LogicalResult status = success();
   module.walk([&](Operation *op) {
-    if (failed(status) || !isa<SectionCubeOp, SectionVectorOp>(op))
+    if (failed(status) || !isa<SectionCubeOp, SectionVectorOp>(op)) {
       return WalkResult::advance();
+    }
     Operation *parent = op->getParentOp();
     while (parent) {
       if (isa<SectionCubeOp, SectionVectorOp>(parent)) {
@@ -171,39 +181,46 @@ static LogicalResult verifyNoNestedSections(ModuleOp module) {
 static void eraseUnusedSimtEntries(ModuleOp module) {
   SmallVector<ModuleOp> symbolTables{module};
   module.walk([&](ModuleOp nested) {
-    if (nested != module)
+    if (nested != module) {
       symbolTables.push_back(nested);
+    }
   });
 
   for (ModuleOp symbolTableModule : symbolTables) {
     SymbolTable symbolTable(symbolTableModule);
     SmallVector<func::FuncOp> deadEntries;
     for (func::FuncOp funcOp : symbolTableModule.getOps<func::FuncOp>()) {
-      if (!funcOp->hasAttr(kPTOSimtEntryAttrName))
+      if (!funcOp->hasAttr(kPTOSimtEntryAttrName)) {
         continue;
+      }
       auto uses = symbolTable.getSymbolUses(funcOp, symbolTableModule);
-      if (uses && uses->empty())
+      if (uses && uses->empty()) {
         deadEntries.push_back(funcOp);
+      }
     }
-    for (func::FuncOp funcOp : deadEntries)
+    for (func::FuncOp funcOp : deadEntries) {
       funcOp.erase();
+    }
   }
 }
 
 static LogicalResult verifyExplicitKernelKindMatchesSections(ModuleOp module) {
   auto kindAttr = module->getAttrOfType<FunctionKernelKindAttr>(
       FunctionKernelKindAttr::name);
-  if (!kindAttr)
+  if (!kindAttr) {
     return success();
+  }
   bool expectsCube = kindAttr.getKernelKind() == FunctionKernelKind::Cube;
   LogicalResult status = success();
   module.walk([&](Operation *op) {
-    if (failed(status))
+    if (failed(status)) {
       return WalkResult::interrupt();
+    }
     bool isCube = isa<SectionCubeOp>(op);
     bool isVector = isa<SectionVectorOp>(op);
-    if (!isCube && !isVector)
+    if (!isCube && !isVector) {
       return WalkResult::advance();
+    }
     if (isCube != expectsCube) {
       status = op->emitError(
           "conflicts with explicit pto.kernel_kind on its module");
@@ -217,8 +234,9 @@ static LogicalResult verifyExplicitKernelKindMatchesSections(ModuleOp module) {
 static LogicalResult verifySectionSplitCandidatesUseSections(ModuleOp module) {
   LogicalResult status = success();
   module.walk([&](func::FuncOp funcOp) {
-    if (failed(status) || !isSectionSplitCandidate(funcOp))
+    if (failed(status) || !isSectionSplitCandidate(funcOp)) {
       return WalkResult::advance();
+    }
     if (!hasAnySection(funcOp)) {
       status = funcOp.emitOpError(
           "must contain pto.section.cube or pto.section.vector in section "
@@ -235,12 +253,14 @@ eraseSectionSplitCandidatesWithoutSectionKind(ModuleOp module,
                                               FunctionKernelKind kind) {
   SmallVector<func::FuncOp> eraseFuncs;
   module.walk([&](func::FuncOp funcOp) {
-    if (isSectionSplitCandidate(funcOp) && !hasSectionKind(funcOp, kind))
+    if (isSectionSplitCandidate(funcOp) && !hasSectionKind(funcOp, kind)) {
       eraseFuncs.push_back(funcOp);
+    }
   });
 
-  for (func::FuncOp funcOp : eraseFuncs)
+  for (func::FuncOp funcOp : eraseFuncs) {
     funcOp.erase();
+  }
 }
 
 static void replaceSectionWithBody(Operation *sectionOp) {
@@ -257,24 +277,29 @@ static void rewriteSectionsForKind(ModuleOp module, FunctionKernelKind kind) {
   SmallVector<Operation *> inlineSections;
   module.walk([&](Operation *op) {
     if (kind == FunctionKernelKind::Cube) {
-      if (isa<SectionVectorOp>(op))
+      if (isa<SectionVectorOp>(op)) {
         eraseSections.push_back(op);
-      else if (isa<SectionCubeOp>(op))
+      } else if (isa<SectionCubeOp>(op)) {
         inlineSections.push_back(op);
+      }
     } else {
-      if (isa<SectionCubeOp>(op))
+      if (isa<SectionCubeOp>(op)) {
         eraseSections.push_back(op);
-      else if (isa<SectionVectorOp>(op))
+      } else if (isa<SectionVectorOp>(op)) {
         inlineSections.push_back(op);
+      }
     }
   });
 
-  for (Operation *op : eraseSections)
+  for (Operation *op : eraseSections) {
     op->erase();
-  for (Operation *op : inlineSections)
+  }
+  for (Operation *op : inlineSections) {
     replaceSectionWithBody(op);
-  if (!eraseSections.empty() || !inlineSections.empty())
+  }
+  if (!eraseSections.empty() || !inlineSections.empty()) {
     eraseUnusedSimtEntries(module);
+  }
 }
 
 static ModuleOp cloneModuleForKind(ModuleOp source, FunctionKernelKind kind,
@@ -291,52 +316,65 @@ static ModuleOp cloneModuleForKind(ModuleOp source, FunctionKernelKind kind,
 static LogicalResult materializeExplicitKernelKindSections(ModuleOp module) {
   auto kindAttr = module->getAttrOfType<FunctionKernelKindAttr>(
       FunctionKernelKindAttr::name);
-  if (!kindAttr)
+  if (!kindAttr) {
     return success();
+  }
   if (failed(verifyNoNestedSections(module)) ||
-      failed(verifyExplicitKernelKindMatchesSections(module)))
+      failed(verifyExplicitKernelKindMatchesSections(module))) {
     return failure();
+  }
   rewriteSectionsForKind(module, kindAttr.getKernelKind());
   return success();
 }
 
 static LogicalResult splitCVModule(ModuleOp module) {
   flattenSingleUnpartitionedChild(module);
-  if (hasKernelKind(module))
+  if (hasKernelKind(module)) {
     return materializeExplicitKernelKindSections(module);
+  }
   if (hasKernelKindChildModule(module)) {
     for (ModuleOp child : module.getOps<ModuleOp>()) {
-      if (!hasKernelKind(child))
+      if (!hasKernelKind(child)) {
         continue;
-      if (failed(materializeExplicitKernelKindSections(child)))
+      }
+      if (failed(materializeExplicitKernelKindSections(child))) {
         return failure();
+      }
     }
     return success();
   }
-  if (!hasCVSections(module))
+  if (!hasCVSections(module)) {
     return success();
-  if (failed(verifyNoNestedSections(module)))
+  }
+  if (failed(verifyNoNestedSections(module))) {
     return failure();
-  if (failed(verifySectionSplitCandidatesUseSections(module)))
+  }
+  if (failed(verifySectionSplitCandidatesUseSections(module))) {
     return failure();
+  }
   bool needVector = hasSectionKind(module, FunctionKernelKind::Vector);
   bool needCube = hasSectionKind(module, FunctionKernelKind::Cube);
-  if (!needVector && !needCube)
+  if (!needVector && !needCube) {
     return success();
+  }
 
   SmallVector<NamedAttribute> outerAttrs;
   outerAttrs.reserve(module->getAttrs().size());
-  for (NamedAttribute attr : module->getAttrs())
-    if (attr.getName() != SymbolTable::getSymbolAttrName())
+  for (NamedAttribute attr : module->getAttrs()) {
+    if (attr.getName() != SymbolTable::getSymbolAttrName()) {
       outerAttrs.push_back(attr);
+    }
+  }
 
   auto outer = ModuleOp::create(module.getLoc());
   outer->setAttrs(DictionaryAttr::get(module.getContext(), outerAttrs));
   OpBuilder builder(outer.getBody(), outer.getBody()->end());
-  if (needVector)
+  if (needVector) {
     cloneModuleForKind(module, FunctionKernelKind::Vector, builder);
-  if (needCube)
+  }
+  if (needCube) {
     cloneModuleForKind(module, FunctionKernelKind::Cube, builder);
+  }
 
   module.getBodyRegion().takeBody(outer.getBodyRegion());
   module->setAttrs(outer->getAttrs());
@@ -346,8 +384,9 @@ static LogicalResult splitCVModule(ModuleOp module) {
 struct VPTOSplitCVModulePass
     : public mlir::pto::impl::VPTOSplitCVModuleBase<VPTOSplitCVModulePass> {
   void runOnOperation() override {
-    if (failed(splitCVModule(getOperation())))
+    if (failed(splitCVModule(getOperation()))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/tools/ptoas/NativeModule.cpp
+++ b/tools/ptoas/NativeModule.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "ptoas.h"
 
 #include "PTOModule.h"
@@ -60,9 +61,10 @@ public:
       py::tuple result = getCompilerRuntime().attr("materialize")(
           request.target, request.op, request.operandSpecsJson,
           request.contextAttrsJson, request.candidateId, contextOwner);
-      if (result.size() != 2)
+      if (result.size() != mlir::pto::kValue2) {
         throw py::value_error(
             "PTODSL materialize() must return (module, entry_symbol)");
+      }
 
       // MlirModule is a non-owning handle. Keep result[0] alive until the
       // complete source module has been cloned into C++ ownership.

--- a/tools/ptoas/ObjectEmission.cpp
+++ b/tools/ptoas/ObjectEmission.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "ObjectEmission.h"
 
 #include "PTO/Transforms/VPTOLLVMEmitter.h"
@@ -161,7 +162,7 @@ static std::optional<std::string> getEnvPath(llvm::StringRef name) {
 }
 
 static std::string joinPath(llvm::StringRef lhs, llvm::StringRef rhs) {
-  llvm::SmallString<256> joined(lhs);
+  llvm::SmallString<mlir::pto::kValue256> joined(lhs);
   llvm::sys::path::append(joined, rhs);
   return std::string(joined.str());
 }
@@ -172,7 +173,7 @@ static std::optional<std::string> parseCANNVersionInfo(llvm::StringRef path) {
     return std::nullopt;
   }
   llvm::StringRef content = buffer.get()->getBuffer();
-  llvm::SmallVector<llvm::StringRef, 16> lines;
+  llvm::SmallVector<llvm::StringRef, mlir::pto::kValue16> lines;
   content.split(lines, '\n');
   for (llvm::StringRef line : lines) {
     line = line.trim();
@@ -252,16 +253,16 @@ static void addPTOISAIncludeDirs(llvm::SmallVectorImpl<std::string> &dirs,
   }
 }
 
-static llvm::SmallVector<std::string, 8>
+static llvm::SmallVector<std::string, mlir::pto::kValue8>
 discoverCppIncludeDirs(llvm::StringRef ascendHome,
                        llvm::raw_ostream &diagOS,
                        std::string &ptoIsaPath) {
-  llvm::SmallVector<std::string, 8> includeDirs;
+  llvm::SmallVector<std::string, mlir::pto::kValue8> includeDirs;
   if (auto env = getEnvPath("PTO_ISA_PATH")) {
     ptoIsaPath = *env;
-  }
-  else if (auto env = getEnvPath("PTO_ISA_ROOT"))
+  } else if (auto env = getEnvPath("PTO_ISA_ROOT")) {
     ptoIsaPath = *env;
+  }
 
   addPTOISAIncludeDirs(includeDirs, ptoIsaPath);
   addExistingIncludeDir(includeDirs, joinPath(ascendHome, "include"));
@@ -374,12 +375,14 @@ public:
     }
     std::string rawVectorObjPath;
     if (failed(tempFiles.create("ptoas-device-vector-raw", ".o",
-                                rawVectorObjPath, diagOS)))
+                                rawVectorObjPath, diagOS))) {
       return false;
+    }
     if (failed(mlir::pto::emitVPTOVectorDeviceObject(
             *module, vectorLLPath, rawVectorObjPath, toolchain, stderrPath,
-            diagOS)))
+            diagOS))) {
       return false;
+    }
     if (vfsimtSizeFixMode == mlir::pto::VFSIMTSizeFixMode::Off) {
       vectorObjPath = std::move(rawVectorObjPath);
       return true;
@@ -387,8 +390,9 @@ public:
 
     std::string patchedVectorObjPath;
     if (failed(tempFiles.create("ptoas-device-vector-patched", ".o",
-                                patchedVectorObjPath, diagOS)))
+                                patchedVectorObjPath, diagOS))) {
       return false;
+    }
     mlir::FailureOr<mlir::pto::VFSIMTSizePatchResult> result =
         mlir::pto::verifyAndPatchVFSIMTSize(
             *module, rawVectorObjPath, patchedVectorObjPath,
@@ -402,7 +406,7 @@ public:
 
   bool mergeDeviceObjects(const mlir::pto::CANNToolchain &toolchain,
                           llvm::raw_ostream &diagOS) {
-    llvm::SmallVector<std::string, 2> deviceObjPaths;
+    llvm::SmallVector<std::string, mlir::pto::kValue2> deviceObjPaths;
     if (!cubeObjPath.empty()) {
       deviceObjPaths.push_back(cubeObjPath);
     }
@@ -414,8 +418,9 @@ public:
       return false;
     }
     if (failed(tempFiles.create("ptoas-device-merged", ".o",
-                                mergedDeviceObjPath, diagOS)))
+                                mergedDeviceObjPath, diagOS))) {
       return false;
+    }
     return ::mergeDeviceObjects(deviceObjPaths, mergedDeviceObjPath,
                                 toolchain.ldLldPath, stderrPath, diagOS);
   }
@@ -425,8 +430,9 @@ public:
                        llvm::StringRef targetCPU,
                        llvm::raw_ostream &diagOS) {
     if (failed(tempFiles.create("ptoas-host-stub", ".o", hostStubObjPath,
-                                diagOS)))
+                                diagOS))) {
       return false;
+    }
     return compileHostStubToObject(stubPath, hostStubObjPath, moduleId,
                                    targetCPU, toolchain, mergedDeviceObjPath,
                                    stderrPath, diagOS);
@@ -445,7 +451,7 @@ public:
   bool repackFatObj(const mlir::pto::CANNToolchain &toolchain,
                     llvm::StringRef moduleId, llvm::StringRef targetCPU,
                     llvm::StringRef outPath, llvm::raw_ostream &diagOS) {
-    llvm::SmallVector<std::string, 16> args = {
+    llvm::SmallVector<std::string, mlir::pto::kValue16> args = {
         toolchain.cceLdPath,
         toolchain.ldLldPath,
         "-x",
@@ -488,12 +494,12 @@ static bool runCommandWithStderr(llvm::StringRef program,
                                  llvm::raw_ostream &diagOS,
                                  llvm::StringRef what,
                                  std::optional<llvm::StringRef> stdinPath) {
-  llvm::SmallVector<llvm::StringRef, 16> args;
+  llvm::SmallVector<llvm::StringRef, mlir::pto::kValue16> args;
   args.reserve(ownedArgs.size());
   for (const std::string &arg : ownedArgs) {
     args.push_back(arg);
   }
-  llvm::SmallVector<std::optional<llvm::StringRef>, 3> redirects = {
+  llvm::SmallVector<std::optional<llvm::StringRef>, mlir::pto::kValue3> redirects = {
       stdinPath, stderrPath, stderrPath};
 
   std::string execErr;
@@ -525,7 +531,7 @@ static bool compileDeviceLLVMToObject(llvm::StringRef llPath,
                                       llvm::StringRef bishengPath,
                                       llvm::StringRef stderrPath,
                                       llvm::raw_ostream &diagOS) {
-  llvm::SmallVector<std::string, 24> args = {
+  llvm::SmallVector<std::string, mlir::pto::kValue24> args = {
       bishengPath.str(),
       std::string("--cce-aicore-arch=") + targetCPU.str(),
       "--cce-aicore-only",
@@ -578,7 +584,7 @@ static bool compileCppDeviceSourceToObject(
     llvm::StringRef cppPath, llvm::StringRef outObjPath,
     llvm::StringRef targetCPU, const mlir::pto::CANNToolchain &toolchain,
     llvm::StringRef stderrPath, llvm::raw_ostream &diagOS) {
-  llvm::SmallVector<std::string, 32> args = {
+  llvm::SmallVector<std::string, mlir::pto::kValue32> args = {
       toolchain.bishengPath,
       "-xcce",
       "-fenable-matrix",
@@ -618,7 +624,7 @@ static bool compileCppDeviceSourceToFatobj(
     llvm::StringRef cppPath, llvm::StringRef outObjPath,
     const mlir::pto::CANNToolchain &toolchain,
     llvm::StringRef stderrPath, llvm::raw_ostream &diagOS) {
-  llvm::SmallVector<std::string, 32> args = {
+  llvm::SmallVector<std::string, mlir::pto::kValue32> args = {
       toolchain.bishengPath,
       "-xcce",
       "-fenable-matrix",
@@ -683,7 +689,7 @@ static bool compileHostStubToObject(llvm::StringRef stubPath,
   std::string hostTriple = llvm::sys::getProcessTriple();
   std::string hostTargetCPU = resolveHostTargetCPU();
 
-  llvm::SmallVector<std::string, 32> args = {
+  llvm::SmallVector<std::string, mlir::pto::kValue32> args = {
       toolchain.bishengCc1Path,
       "-cc1",
       "-triple",
@@ -783,7 +789,7 @@ static bool mergeDeviceObjects(llvm::ArrayRef<std::string> deviceObjPaths,
     return false;
   }
 
-  llvm::SmallVector<std::string, 16> args = {
+  llvm::SmallVector<std::string, mlir::pto::kValue16> args = {
       ldLldPath.str(),
       "-m",
       "aicorelinux",
@@ -810,7 +816,7 @@ static bool linkFatobjFiles(llvm::ArrayRef<std::string> fatobjPaths,
     return false;
   }
 
-  llvm::SmallVector<std::string, 32> args = {
+  llvm::SmallVector<std::string, mlir::pto::kValue32> args = {
       toolchain.bishengPath,
       "--cce-fatobj-link",
       "--cce-aicore-arch=dav-c310",
@@ -841,7 +847,7 @@ mlir::LogicalResult
 mlir::pto::TempFileRegistry::create(llvm::StringRef prefix,
                                     llvm::StringRef suffix, std::string &path,
                                     llvm::raw_ostream &diagOS) {
-  llvm::SmallString<128> tempPath;
+  llvm::SmallString<mlir::pto::kValue128> tempPath;
   int fd = -1;
   std::error_code ec =
       llvm::sys::fs::createTemporaryFile(prefix, suffix, fd, tempPath);
@@ -883,7 +889,7 @@ mlir::pto::CANNToolchain::create(llvm::raw_ostream &diagOS) {
       joinPath(toolchain.ascendHomePath, "tools/bisheng_compiler/bin");
   toolchain.cannVersionString =
       discoverCANNVersion(toolchain.ascendHomePath).value_or("9.0.0-beta.1");
-  llvm::SmallVector<std::string, 8> cppIncludeDirs = discoverCppIncludeDirs(
+  llvm::SmallVector<std::string, mlir::pto::kValue8> cppIncludeDirs = discoverCppIncludeDirs(
       toolchain.ascendHomePath, diagOS, toolchain.ptoIsaPath);
   toolchain.cppIncludeDirs.assign(cppIncludeDirs.begin(),
                                   cppIncludeDirs.end());
@@ -917,7 +923,7 @@ mlir::pto::CANNToolchain::validate(llvm::raw_ostream &diagOS) const {
 
 llvm::StringRef mlir::pto::CANNToolchain::vptoPublicABISuffix(
     ObjectEmissionDeviceTarget target) const {
-  const bool usesNewABI = cannVersion >= CANNVersion{9, 0, 0, 2};
+  const bool usesNewABI = cannVersion >= kCANN900Beta2Version;
   switch (target) {
   case ObjectEmissionDeviceTarget::Vector:
     return usesNewABI ? llvm::StringRef(".vector") : llvm::StringRef("_mix_aiv");
@@ -1011,8 +1017,9 @@ mlir::LogicalResult mlir::pto::emitFatobjCCE(
   std::string stderrPath;
   if (failed(tempFiles.create("ptoas-emitc", ".cpp", cppPath, diagOS)) ||
       failed(tempFiles.create("ptoas-emitc-fatobj", ".log", stderrPath,
-                              diagOS)))
+                              diagOS))) {
     return failure();
+  }
   return emitCppFatobj(cppSource, cppPath, outputPath, toolchain, stderrPath,
                        diagOS);
 }
@@ -1055,8 +1062,9 @@ static mlir::LogicalResult applyVPTOLLVMABINames(llvm::Module &module,
     }
     llvm::StringRef name = function.getName();
     if (name.empty() || isVPTOKernelABISymbol(name) ||
-        isLegacyVPTOPublicABISymbol(name))
+        isLegacyVPTOPublicABISymbol(name)) {
       continue;
+    }
     if (failed(renameLLVMFunction(module, name, (name + suffix).str(), diagOS))) {
       return mlir::failure();
     }
@@ -1071,8 +1079,9 @@ mlir::LogicalResult mlir::pto::emitVPTOVectorDeviceObject(
   if (failed(applyVPTOLLVMABINames(
           module,
           toolchain.vptoPublicABISuffix(ObjectEmissionDeviceTarget::Vector),
-          diagOS)))
+          diagOS))) {
     return failure();
+  }
   if (failed(writeLLVMModule(module, llPath, diagOS))) {
     return failure();
   }
@@ -1091,8 +1100,9 @@ mlir::LogicalResult mlir::pto::emitVPTOCubeDeviceObject(
   if (failed(applyVPTOLLVMABINames(
           module,
           toolchain.vptoPublicABISuffix(ObjectEmissionDeviceTarget::Cube),
-          diagOS)))
+          diagOS))) {
     return failure();
+  }
   if (failed(writeLLVMModule(module, llPath, diagOS))) {
     return failure();
   }
@@ -1126,16 +1136,18 @@ mlir::LogicalResult mlir::pto::emitFatobjLLVM(
     return failure();
   }
   if (!artifacts.emitVectorObject(vectorModule, toolchain,
-                                  vfsimtSizeFixMode, diagOS))
+                                  vfsimtSizeFixMode, diagOS)) {
     return failure();
+  }
   if (!artifacts.mergeDeviceObjects(toolchain, diagOS)) {
     return failure();
   }
 
   constexpr llvm::StringLiteral targetCPU = "dav-c310";
   if (!artifacts.compileHostStubToFatobj(toolchain, moduleId, targetCPU,
-                                         outputPath, diagOS))
+                                         outputPath, diagOS)) {
     return failure();
+  }
   return success();
 }
 
@@ -1199,8 +1211,9 @@ mlir::LogicalResult mlir::pto::emitFatobjLLVMWithRuntime(
     return failure();
   }
   if (!artifacts.emitVectorObject(vectorModule, *toolchain,
-                                  vfsimtSizeFixMode, diagOS))
+                                  vfsimtSizeFixMode, diagOS)) {
     return failure();
+  }
 
   if (!artifacts.mergeDeviceObjects(*toolchain, diagOS)) {
     return failure();
@@ -1213,8 +1226,9 @@ mlir::LogicalResult mlir::pto::emitFatobjLLVMWithRuntime(
   }
 
   if (!artifacts.repackFatObj(*toolchain, moduleId, hostTargetCPU,
-                              outputFile.getFilename(), diagOS))
+                              outputFile.getFilename(), diagOS)) {
     return failure();
+  }
   outputFile.keep();
   return success();
 }

--- a/tools/ptoas/ObjectEmission.h
+++ b/tools/ptoas/ObjectEmission.h
@@ -9,6 +9,7 @@
 #ifndef PTOAS_OBJECT_EMISSION_H
 #define PTOAS_OBJECT_EMISSION_H
 
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Support/CANNVersion.h"
 #include "VFSIMTSizePatcher.h"
 
@@ -52,7 +53,7 @@ public:
   std::string bishengCompilerBinDirPath;
   std::string ptoIsaPath;
   std::string cannVersionString;
-  CANNVersion cannVersion = CANNVersion{9, 0, 0, 1};
+  CANNVersion cannVersion = kDefaultCANNVersion;
   std::vector<std::string> cppIncludeDirs;
 };
 
@@ -71,7 +72,7 @@ public:
                        std::string &path, llvm::raw_ostream &diagOS);
 
 private:
-  llvm::SmallVector<std::string, 8> paths;
+  llvm::SmallVector<std::string, mlir::pto::kValue8> paths;
 };
 
 LogicalResult writeLLVMModule(llvm::Module &module, llvm::StringRef path,

--- a/tools/ptoas/VFSIMTSizePatcher.cpp
+++ b/tools/ptoas/VFSIMTSizePatcher.cpp
@@ -8,6 +8,8 @@
 
 #include "VFSIMTSizePatcher.h"
 
+#include "PTO/Support/CodeConstants.h"
+
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallVector.h"
@@ -48,11 +50,21 @@ using mlir::pto::VFSIMTSizePatchResult;
 
 constexpr uint16_t kHiIPUMachine = 0x1029;
 constexpr uint64_t kInstructionBytes = 4;
+constexpr uint64_t kVFSIMTCallSequenceBytes = 24;
+constexpr uint64_t kMOVIOffsetFromVFSIMTBytes = 20;
+constexpr uint64_t kFirstMOVKOffsetFromVFSIMTBytes = 16;
+constexpr uint64_t kSecondMOVKOffsetFromVFSIMTBytes = 12;
+constexpr uint64_t kSHLIOffsetFromVFSIMTBytes = 8;
+constexpr uint64_t kADDOffsetFromVFSIMTBytes = 4;
 constexpr uint64_t kInvalidVFSIMTSize = 0xffff;
 constexpr unsigned kVFSIMTSizeShift = 37;
 constexpr uint64_t kVFSIMTSizeMask = UINT64_C(0xffff) << kVFSIMTSizeShift;
 constexpr unsigned kVFSIMTRegisterShift = 16;
 constexpr unsigned kScalarDestinationShift = 17;
+constexpr unsigned kADDSourceRegisterShift = 7;
+constexpr unsigned kADDTargetRegisterShift = 12;
+constexpr unsigned kMOVKChunkBitWidth = 16;
+constexpr unsigned kRelativeWordOffsetBitWidth = 48;
 constexpr uint64_t kScalarRegisterMask = UINT64_C(0x1f);
 constexpr uint64_t kVFSIMTJoinOffsetMask = UINT64_C(0x3ff);
 constexpr uint64_t kVFSIMTExitModeMask = UINT64_C(1) << 10;
@@ -99,7 +111,7 @@ struct PatchRecord {
 
 struct ObjectPatchAnalysis {
   std::unique_ptr<llvm::MemoryBuffer> buffer;
-  llvm::SmallVector<PatchRecord, 4> plan;
+  llvm::SmallVector<PatchRecord, mlir::pto::kValue4> plan;
 };
 
 static void emitError(llvm::raw_ostream &diagOS, const llvm::Twine &message) {
@@ -137,15 +149,16 @@ static std::string getSIMTEntrySymbolName(llvm::StringRef functionName) {
   return (functionName + "_simt_entry").str();
 }
 
-static FailureOr<llvm::SmallVector<SimtCallSite, 4>>
+static FailureOr<llvm::SmallVector<SimtCallSite, mlir::pto::kValue4>>
 collectManifest(llvm::Module &module, llvm::raw_ostream &diagOS) {
   // The LLVM module is the source of truth for allowed caller/callee pairs.
   // Refuse calls that cannot later be matched unambiguously to ELF symbols.
-  llvm::SmallVector<SimtCallSite, 4> manifest;
+  llvm::SmallVector<SimtCallSite, mlir::pto::kValue4> manifest;
   for (llvm::Function &caller : module) {
     if (caller.isDeclaration() ||
-        caller.getCallingConv() == llvm::CallingConv::SimtEntry)
+        caller.getCallingConv() == llvm::CallingConv::SimtEntry) {
       continue;
+    }
     for (llvm::BasicBlock &block : caller) {
       for (llvm::Instruction &instruction : block) {
         auto *call = llvm::dyn_cast<llvm::CallBase>(&instruction);
@@ -280,8 +293,9 @@ decodeMOVKChunk(uint32_t instruction, unsigned chunk, unsigned targetRegister) {
   const uint32_t expected = chunk == 1 ? 0x07410000 : 0x07810000;
   if ((instruction & kMOVKFixedMask) != expected ||
       ((instruction >> kScalarDestinationShift) & kScalarRegisterMask) !=
-          targetRegister)
+          targetRegister) {
     return std::nullopt;
+  }
   return static_cast<uint16_t>(instruction);
 }
 
@@ -302,60 +316,73 @@ static std::optional<uint64_t> decodeTargetAddress(StringRef bytes,
   // targetRegister comes from the VF_SIMT encoding. The sequence computes:
   //   target PC = address of MOV PC + sign_extend(relativeWords) * 4.
   // Reject any other sequence instead of guessing its target.
-  if (instructionOffset < 24) {
+  if (instructionOffset < kVFSIMTCallSequenceBytes) {
     return std::nullopt;
   }
   // Follow the register named by VF_SIMT back through MOVI/MOVK/SHLI/ADD.
   const unsigned targetRegister =
       (instruction >> kVFSIMTRegisterShift) & kScalarRegisterMask;
   const uint64_t movPc = llvm::support::endian::read32le(
-      reinterpret_cast<const uint8_t *>(bytes.data() + instructionOffset - 24));
+      reinterpret_cast<const uint8_t *>(bytes.data() + instructionOffset -
+                                        kVFSIMTCallSequenceBytes));
   const uint64_t movi = llvm::support::endian::read32le(
-      reinterpret_cast<const uint8_t *>(bytes.data() + instructionOffset - 20));
+      reinterpret_cast<const uint8_t *>(bytes.data() + instructionOffset -
+                                        kMOVIOffsetFromVFSIMTBytes));
   const uint32_t movk1 = llvm::support::endian::read32le(
-      reinterpret_cast<const uint8_t *>(bytes.data() + instructionOffset - 16));
+      reinterpret_cast<const uint8_t *>(bytes.data() + instructionOffset -
+                                        kFirstMOVKOffsetFromVFSIMTBytes));
   const uint32_t movk2 = llvm::support::endian::read32le(
-      reinterpret_cast<const uint8_t *>(bytes.data() + instructionOffset - 12));
+      reinterpret_cast<const uint8_t *>(bytes.data() + instructionOffset -
+                                        kSecondMOVKOffsetFromVFSIMTBytes));
   const uint64_t shli = llvm::support::endian::read32le(
-      reinterpret_cast<const uint8_t *>(bytes.data() + instructionOffset - 8));
+      reinterpret_cast<const uint8_t *>(bytes.data() + instructionOffset -
+                                        kSHLIOffsetFromVFSIMTBytes));
   const uint64_t add = llvm::support::endian::read32le(
-      reinterpret_cast<const uint8_t *>(bytes.data() + instructionOffset - 4));
-
+      reinterpret_cast<const uint8_t *>(bytes.data() + instructionOffset -
+                                        kADDOffsetFromVFSIMTBytes));
   if ((movPc & 0xffc1ffff) != 0x02000880 ||
       (movi & 0xffc10000) != 0x07000000 ||
       (shli & 0xffc1ffff) != 0x02c00202 ||
-      (add & 0xffc0007f) != 0x00000001)
+      (add & 0xffc0007f) != 0x00000001) {
     return std::nullopt;
+  }
   if (((movi >> kScalarDestinationShift) & kScalarRegisterMask) !=
           targetRegister ||
       ((shli >> kScalarDestinationShift) & kScalarRegisterMask) !=
           targetRegister ||
       ((add >> kScalarDestinationShift) & kScalarRegisterMask) !=
           targetRegister ||
-      ((add >> 12) & kScalarRegisterMask) != targetRegister)
+      ((add >> kADDTargetRegisterShift) & kScalarRegisterMask) !=
+          targetRegister) {
     return std::nullopt;
+  }
 
   const unsigned pcRegister =
       (movPc >> kScalarDestinationShift) & kScalarRegisterMask;
-  const unsigned addSourceRegister = (add >> 7) & kScalarRegisterMask;
+  const unsigned addSourceRegister =
+      (add >> kADDSourceRegisterShift) & kScalarRegisterMask;
   if (pcRegister != addSourceRegister) {
     return std::nullopt;
   }
 
   std::optional<uint16_t> upper1 = decodeMOVKChunk(movk1, 1, targetRegister);
-  std::optional<uint16_t> upper2 = decodeMOVKChunk(movk2, 2, targetRegister);
+  std::optional<uint16_t> upper2 = decodeMOVKChunk(movk2, mlir::pto::kValue2, targetRegister);
   if (!upper1 || !upper2) {
     return std::nullopt;
   }
 
   // MOVI and the optional MOVK instructions form a signed 48-bit word offset.
   const uint64_t encodedRelativeWords = (movi & 0xffff) |
-                                        (static_cast<uint64_t>(*upper1) << 16) |
-                                        (static_cast<uint64_t>(*upper2) << 32);
-  const int64_t relativeWords = llvm::SignExtend64<48>(encodedRelativeWords);
+                                        (static_cast<uint64_t>(*upper1)
+                                         << kMOVKChunkBitWidth) |
+                                        (static_cast<uint64_t>(*upper2)
+                                         << 2 * kMOVKChunkBitWidth);
+  const int64_t relativeWords =
+      llvm::SignExtend64<kRelativeWordOffsetBitWidth>(encodedRelativeWords);
   // MOV PC observes the PC of the first instruction in this materialization
   // sequence; SHLI converts the signed word offset to a byte offset.
-  const uint64_t pcAddress = callerAddress + instructionOffset - 24;
+  const uint64_t pcAddress =
+      callerAddress + instructionOffset - kVFSIMTCallSequenceBytes;
   const int64_t byteOffset = relativeWords * kInstructionBytes;
   if (byteOffset < 0) {
     const uint64_t magnitude = static_cast<uint64_t>(-byteOffset);
@@ -365,12 +392,13 @@ static std::optional<uint64_t> decodeTargetAddress(StringRef bytes,
     return pcAddress - magnitude;
   }
   if (static_cast<uint64_t>(byteOffset) >
-      std::numeric_limits<uint64_t>::max() - pcAddress)
+      std::numeric_limits<uint64_t>::max() - pcAddress) {
     return std::nullopt;
+  }
   return pcAddress + static_cast<uint64_t>(byteOffset);
 }
 
-static FailureOr<llvm::SmallVector<DecodedCallSite, 4>>
+static FailureOr<llvm::SmallVector<DecodedCallSite, mlir::pto::kValue4>>
 decodeCallSites(const ELFFunction &caller, StringRef objectBytes,
                 llvm::raw_ostream &diagOS) {
   // Restrict decoding to the caller symbol. Searching the whole text section
@@ -384,7 +412,7 @@ decodeCallSites(const ELFFunction &caller, StringRef objectBytes,
     return failure();
   }
   StringRef bytes = objectBytes.substr(fileOffset, caller.size);
-  llvm::SmallVector<DecodedCallSite, 4> callSites;
+  llvm::SmallVector<DecodedCallSite, mlir::pto::kValue4> callSites;
   for (uint64_t offset = 0; offset + sizeof(uint64_t) <= bytes.size();
        offset += kInstructionBytes) {
     uint64_t instruction = llvm::support::endian::read64le(
@@ -430,7 +458,7 @@ validateObjectHeader(const llvm::object::ELFObjectFileBase &object,
   return success();
 }
 
-static FailureOr<llvm::SmallVector<PatchRecord, 4>>
+static FailureOr<llvm::SmallVector<PatchRecord, mlir::pto::kValue4>>
 buildPatchPlan(llvm::ArrayRef<SimtCallSite> manifest,
                const llvm::StringMap<ELFFunction> &functions,
                StringRef objectBytes, llvm::raw_ostream &diagOS) {
@@ -442,7 +470,7 @@ buildPatchPlan(llvm::ArrayRef<SimtCallSite> manifest,
     callsByCaller[call.callerName].push_back(&call);
   }
 
-  llvm::SmallVector<PatchRecord, 4> plan;
+  llvm::SmallVector<PatchRecord, mlir::pto::kValue4> plan;
   for (auto &entry : callsByCaller) {
     auto callerIt = functions.find(entry.first);
     if (callerIt == functions.end()) {
@@ -460,7 +488,7 @@ buildPatchPlan(llvm::ArrayRef<SimtCallSite> manifest,
       const ELFFunction *callee = nullptr;
       bool observed = false;
     };
-    llvm::SmallVector<ResolvedCall, 4> resolvedCalls;
+    llvm::SmallVector<ResolvedCall, mlir::pto::kValue4> resolvedCalls;
     resolvedCalls.reserve(calls.size());
     for (const SimtCallSite *call : calls) {
       auto calleeIt = functions.find(call->calleeName);
@@ -488,8 +516,9 @@ buildPatchPlan(llvm::ArrayRef<SimtCallSite> manifest,
           llvm::find_if(resolvedCalls, [&](const ResolvedCall &item) {
             return item.callee->name == callee.name;
           });
-      if (existing == resolvedCalls.end())
+      if (existing == resolvedCalls.end()) {
         resolvedCalls.push_back({call, &callee, false});
+      }
     }
 
     for (const DecodedCallSite &decodedCall : *decoded) {
@@ -623,8 +652,9 @@ analyzeObject(llvm::ArrayRef<SimtCallSite> manifest, StringRef objectPath,
   }
   auto plan = buildPatchPlan(manifest, *functions, buffer->getBuffer(), diagOS);
   if (failed(plan) ||
-      failed(validateNoRelocationOverlap(*object, *plan, diagOS)))
+      failed(validateNoRelocationOverlap(*object, *plan, diagOS))) {
     return failure();
+  }
   return ObjectPatchAnalysis{std::move(buffer), std::move(*plan)};
 }
 
@@ -775,8 +805,9 @@ FailureOr<VFSIMTSizePatchResult> mlir::pto::verifyAndPatchVFSIMTSize(
     return failure();
   }
   if (failed(validatePatchedBytes(analysis->buffer->getBuffer(), patchedBytes,
-                                  analysis->plan, diagOS)))
+                                  analysis->plan, diagOS))) {
     return failure();
+  }
   if (failed(writePatchedObject(patchedObjectPath, patchedBytes, diagOS))) {
     return failure();
   }

--- a/tools/ptoas/VPTOHostStubEmission.cpp
+++ b/tools/ptoas/VPTOHostStubEmission.cpp
@@ -20,6 +20,12 @@ using namespace mlir;
 
 namespace {
 
+constexpr unsigned kBooleanBitWidth = 1;
+constexpr unsigned kByteBitWidth = 8;
+constexpr unsigned kShortBitWidth = 16;
+constexpr unsigned kIntBitWidth = 32;
+constexpr unsigned kLongLongBitWidth = 64;
+
 struct VPTOKernelStubDecl {
   std::string logicalName;
   SmallVector<std::string> argTypes;
@@ -41,14 +47,14 @@ static std::string getStubScalarCType(Type type) {
   }
   if (auto intType = dyn_cast<IntegerType>(type)) {
     switch (intType.getWidth()) {
-    case 1:
-    case 8:
+    case kBooleanBitWidth:
+    case kByteBitWidth:
       return "signed char";
-    case 16:
+    case kShortBitWidth:
       return "short";
-    case 32:
+    case kIntBitWidth:
       return "int";
-    case 64:
+    case kLongLongBitWidth:
       return "long long";
     default:
       return "long long";

--- a/tools/ptoas/driver.cpp
+++ b/tools/ptoas/driver.cpp
@@ -6,24 +6,30 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-#include "ptoas.h"
-
+#include <cstddef>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 #include "ObjectEmission.h"
 #include "PTO/IR/PTO.h"
+#include "PTO/Support/CodeConstants.h"
 #include "PTO/Transforms/Passes.h"
 #include "VPTOHostStubEmission.h"
+#include "ptoas.h"
+#include "ptobc/ptobc_decode.h"
 #include "mlir/AsmParser/AsmParser.h"
 #include "mlir/AsmParser/AsmParserState.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/AsmState.h"
-#include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Verifier.h"
-#include "mlir/Pass/PassManager.h"
 #include "mlir/Parser/Parser.h"
-#include "ptobc/ptobc_decode.h"
+#include "mlir/Pass/PassManager.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
@@ -39,11 +45,7 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/raw_ostream.h"
-#include <cstring>
-#include <memory>
-#include <optional>
-#include <string>
-#include <vector>
+
 
 using namespace mlir;
 using mlir::pto::PTOASContext;
@@ -111,19 +113,24 @@ static bool isSupportedPTOASArch(llvm::StringRef archValue) {
   return archValue == "a2" || archValue == "a3" || archValue == "a5";
 }
 
+constexpr size_t kArchRegexCaptureGroupCount = 3;
+constexpr size_t kPTOBCMagicSize = 6;
+
 static std::optional<std::string>
 detectPTOASTextualModuleArch(llvm::StringRef text) {
-  llvm::SmallVector<llvm::StringRef, 4> matches;
+  llvm::SmallVector<llvm::StringRef, mlir::pto::kValue4> matches;
   llvm::Regex archRegex(
       R"ptoarch("?(pto\.target_arch)"?[[:space:]]*=[[:space:]]*"([[:alpha:][:digit:]_]+)")ptoarch");
-  if (!archRegex.match(text, &matches) || matches.size() < 3) {
+  if (!archRegex.match(text, &matches) ||
+      matches.size() < kArchRegexCaptureGroupCount) {
     return std::nullopt;
   }
-  return normalizePTOASArch(matches[2]);
+  return normalizePTOASArch(matches[mlir::pto::kValue2]);
 }
 
 static bool isPTOBCBuffer(llvm::StringRef buffer) {
-  return buffer.size() >= 6 && std::memcmp(buffer.data(), "PTOBC\0", 6) == 0;
+  return buffer.size() >= kPTOBCMagicSize &&
+         std::memcmp(buffer.data(), "PTOBC\0", kPTOBCMagicSize) == 0;
 }
 
 static std::unique_ptr<llvm::MemoryBuffer> readInputBuffer() {
@@ -229,12 +236,14 @@ loadInputModule(std::unique_ptr<llvm::MemoryBuffer> inputBuffer,
     }
     module = decodePTOBCModule(buffer, context);
   } else {
-    if (!resolveTextInputArch(buffer, cliArchSpecified, arch))
+    if (!resolveTextInputArch(buffer, cliArchSpecified, arch)) {
       return {};
+    }
     module = parseTextualModule(std::move(inputBuffer), context, arch);
   }
-  if (!module)
+  if (!module) {
     return {};
+  }
 
   Operation *moduleOp = module.get().getOperation();
   if (cliArchSpecified) {
@@ -363,8 +372,9 @@ static void copyModuleAttrsToJobModule(ModuleOp source, ModuleOp jobModule) {
   for (NamedAttribute attr : source->getAttrs()) {
     StringRef attrName = attr.getName().getValue();
     if (attrName == SymbolTable::getSymbolAttrName() ||
-        attrName == "pto.backend")
+        attrName == "pto.backend") {
       continue;
+    }
     jobModule->setAttr(attr.getName(), attr.getValue());
   }
 }
@@ -428,8 +438,9 @@ findSiblingSourceFunction(ModuleOp outer, ModuleOp targetChild,
         continue;
       }
       if (allowLogicalNameMatch &&
-          mlir::pto::getPTODSLLogicalNameOrSymbolName(funcOp) == symbolName)
+          mlir::pto::getPTODSLLogicalNameOrSymbolName(funcOp) == symbolName) {
         logicalMatches.push_back(funcOp);
+      }
     }
   }
 
@@ -519,7 +530,7 @@ static void rewriteExportedFunctionToLogicalWrapper(func::FuncOp exportedFunc,
 static LogicalResult
 verifyInChildLogicalWrapperAmbiguity(ModuleOp targetChild,
                                      ArrayRef<func::FuncOp> exportedFuncs) {
-  llvm::SmallDenseMap<StringRef, SmallVector<func::FuncOp, 2>> grouped;
+  llvm::SmallDenseMap<StringRef, SmallVector<func::FuncOp, mlir::pto::kValue2>> grouped;
   for (func::FuncOp exportedFunc : exportedFuncs) {
     auto kernelKindAttr =
         exportedFunc->getAttrOfType<mlir::pto::FunctionKernelKindAttr>(
@@ -674,7 +685,7 @@ static std::string summarizeMixedChildModule(ModuleOp module) {
     os << "kernel_kind=" << kindAttr.getValue() << " ";
   }
 
-  SmallVector<std::string, 4> exportedNames;
+  SmallVector<std::string, mlir::pto::kValue4> exportedNames;
   for (func::FuncOp funcOp : module.getOps<func::FuncOp>()) {
     auto visibility = funcOp->getAttrOfType<StringAttr>("sym_visibility");
     if (visibility && visibility.getValue() == "private") {
@@ -708,8 +719,9 @@ static void dumpFailedMixedChildCompileUnit(llvm::StringRef backendName,
                                             ModuleOp module) {
   llvm::errs() << "Error: mixed-backend child module compilation failed"
                << " [" << backendName << "]";
-  if (!summary.empty())
+  if (!summary.empty()) {
     llvm::errs() << " {" << summary << "}";
+  }
   llvm::errs() << "\n";
   llvm::errs() << "// ----- failed mixed-backend child compile unit ----- //\n";
   module.print(llvm::errs());
@@ -811,7 +823,7 @@ mlir::pto::PTOASContext::initializeToolchain(llvm::raw_ostream &diagOS) {
     diagOS << "Warning: unable to parse CANN version: "
            << discovered->cannVersionString
            << "; defaulting detected version to 9.0.0-beta.1.\n";
-    parsedVersion = CANNVersion{9, 0, 0, 1};
+    parsedVersion = kDefaultCANNVersion;
   }
   CANNVersion effectiveVersion =
       selectEffectiveOutputCANNVersion(*parsedVersion,
@@ -999,7 +1011,7 @@ public:
       : fatobjPaths(fatobjPaths) {}
 
   LogicalResult run(PTOASContext &context) {
-    if (fatobjPaths.size() < 2) {
+    if (fatobjPaths.size() < mlir::pto::kValue2) {
       llvm::errs()
           << "Error: mixed backend link requires at least two fatobjs.\n";
       return failure();
@@ -1028,7 +1040,7 @@ LogicalResult EmitCBackendJob::run(PTOASContext &context) {
   ModuleOp op = module.get();
   op->setAttr("pto.backend", StringAttr::get(op.getContext(), "emitc"));
 
-  SmallVector<ModuleOp, 4> children(op.getOps<ModuleOp>());
+  SmallVector<ModuleOp, mlir::pto::kValue4> children(op.getOps<ModuleOp>());
   if (!isUserVisibleIROutputRequested() && children.size() == 1 &&
       isBackendPartitionedContainer(op)) {
     FailureOr<OwningOpRef<ModuleOp>> jobModuleOr =
@@ -1045,8 +1057,9 @@ LogicalResult EmitCBackendJob::run(PTOASContext &context) {
 
   if (mlir::pto::compilePTOASModule(*compileUnit, context,
                                     mlir::pto::PTOBackend::EmitC, result,
-                                    /*emitVPTOHostStub=*/false) != 0)
+                                    /*emitVPTOHostStub=*/false) != 0) {
     return failure();
+  }
   if (result.kind != mlir::pto::PTOASCompileResultKind::Text) {
     llvm::errs() << "Error: EmitC backend job produced non-text output.\n";
     return failure();
@@ -1060,7 +1073,7 @@ LogicalResult VPTOBackendJob::run(PTOASContext &context) {
   ModuleOp op = module.get();
   op->setAttr("pto.backend", StringAttr::get(op.getContext(), "vpto"));
 
-  SmallVector<ModuleOp, 4> children(op.getOps<ModuleOp>());
+  SmallVector<ModuleOp, mlir::pto::kValue4> children(op.getOps<ModuleOp>());
   // PTODSL emits a backend-partitioned outer container even when there is only
   // one child module.  For object compilation, the actual VPTO compile unit is
   // the normalized child job module with outer attributes/imports folded in.
@@ -1084,8 +1097,9 @@ LogicalResult VPTOBackendJob::run(PTOASContext &context) {
   bool emitHostStub = hasPTOEntry(op);
   if (mlir::pto::compilePTOASModule(
           *compileUnit, context, mlir::pto::PTOBackend::VPTO, result,
-          emitHostStub) != 0)
+          emitHostStub) != 0) {
     return failure();
+  }
   if (result.kind == mlir::pto::PTOASCompileResultKind::Text) {
     return success();
   }
@@ -1102,8 +1116,9 @@ LogicalResult VPTOBackendJob::run(PTOASContext &context) {
 
   std::string moduleId = context.allocModuleId();
   if (failed(emitVPTOLLVMFatobj(result, context, moduleId,
-                                context.getOutputPath())))
+                                context.getOutputPath()))) {
     return failure();
+  }
 
   result.reset();
   result.kind = mlir::pto::PTOASCompileResultKind::MixedObject;
@@ -1127,8 +1142,9 @@ static LogicalResult emitVPTOLLVMFatobj(
           jobResult.vptoCubeModule.module.get(),
           jobResult.vptoVectorModule.module.get(), stubSource,
           outputPath, moduleId, *toolchain, context.getTempFiles(),
-          context.getVFSIMTSizeFixMode(), llvm::errs())))
+          context.getVFSIMTSizeFixMode(), llvm::errs()))) {
     return failure();
+  }
   return success();
 }
 
@@ -1137,7 +1153,7 @@ static LogicalResult collectChildJobs(
     bool cliBackendOverride,
     PTOASContext &context, SmallVectorImpl<std::string> &fatobjPaths,
     SmallVectorImpl<std::unique_ptr<BackendChildJob>> &backendJobs) {
-  SmallVector<ModuleOp, 4> children(module.getOps<ModuleOp>());
+  SmallVector<ModuleOp, mlir::pto::kValue4> children(module.getOps<ModuleOp>());
   for (ModuleOp child : children) {
     std::optional<mlir::pto::PTOBackend> childBackend;
     if (failed(parseDriverBackendAttr(child.getOperation(), childBackend))) {
@@ -1159,13 +1175,14 @@ static LogicalResult collectChildJobs(
     mlir::pto::PTOBackend effectiveBackend =
         cliBackendOverride ? defaultBackend
                            : childBackend.value_or(defaultBackend);
-    if (effectiveBackend == mlir::pto::PTOBackend::VPTO)
+    if (effectiveBackend == mlir::pto::PTOBackend::VPTO) {
       backendJobs.push_back(std::make_unique<VPTOBackendChildJob>(
           std::move(jobModule), std::move(summary), context.allocModuleId(),
           fatobjPaths));
-    else
+    } else {
       backendJobs.push_back(std::make_unique<EmitCBackendChildJob>(
           std::move(jobModule), std::move(summary), fatobjPaths));
+}
   }
   return success();
 }
@@ -1177,10 +1194,11 @@ static LogicalResult resolveSingleBackend(
     std::optional<mlir::pto::PTOBackend> &singleBackend) {
   singleBackend = std::nullopt;
   if (cliBackendSpecified) {
-    SmallVector<ModuleOp, 4> children(module.getOps<ModuleOp>());
+    SmallVector<ModuleOp, mlir::pto::kValue4> children(module.getOps<ModuleOp>());
     if (!isUserVisibleIROutputRequested() && children.size() > 1 &&
-        isBackendPartitionedContainer(module))
+        isBackendPartitionedContainer(module)) {
       return success();
+    }
     singleBackend = defaultBackend;
     return success();
   }
@@ -1189,7 +1207,7 @@ static LogicalResult resolveSingleBackend(
     return success();
   }
 
-  SmallVector<ModuleOp, 4> children(module.getOps<ModuleOp>());
+  SmallVector<ModuleOp, mlir::pto::kValue4> children(module.getOps<ModuleOp>());
   if (!isUserVisibleIROutputRequested() && children.size() > 1) {
     if (!isBackendPartitionedContainer(module)) {
       llvm::errs() << "Error: mixed pto.backend fatobj mode expects either a "
@@ -1248,8 +1266,9 @@ static LogicalResult buildBackendInfo(ModuleOp module, bool cliBackendSpecified,
 
   if (failed(resolveSingleBackend(cliBackendSpecified, moduleBackend,
                                   backendInfo.defaultBackend, module,
-                                  backendInfo.singleBackend)))
+                                  backendInfo.singleBackend))) {
     return failure();
+  }
 
   if (backendInfo.singleBackend) {
     backendInfo.requiresToolchain =
@@ -1289,12 +1308,13 @@ static LogicalResult runPTOASJobs(OwningOpRef<ModuleOp> &module,
     return singleJob.run(context);
   }
 
-  SmallVector<std::unique_ptr<BackendChildJob>, 4> backendJobs;
-  SmallVector<std::string, 4> fatobjPaths;
+  SmallVector<std::unique_ptr<BackendChildJob>, mlir::pto::kValue4> backendJobs;
+  SmallVector<std::string, mlir::pto::kValue4> fatobjPaths;
   if (failed(collectChildJobs(module.get(), backendInfo.defaultBackend,
                               backendInfo.cliBackendOverride,
-                              context, fatobjPaths, backendJobs)))
+                              context, fatobjPaths, backendJobs))) {
     return failure();
+  }
 
   result.reset();
   result.kind = mlir::pto::PTOASCompileResultKind::MixedObject;
@@ -1364,8 +1384,9 @@ static int runPTOASDriver(int argc, char **argv,
   std::optional<mlir::pto::CANNVersion> outputCANNVersionOverride;
   if (!parseRequestedOutputCANNVersion(mlir::pto::cannOutputVersion,
                                        outputCANNVersionOverride,
-                                       llvm::errs()))
+                                       llvm::errs())) {
     return 1;
+  }
 
   std::unique_ptr<PTOASContext> context;
   if (borrowedContext) {

--- a/tools/ptoas/ptoas.h
+++ b/tools/ptoas/ptoas.h
@@ -9,6 +9,9 @@
 #ifndef PTOAS_H
 #define PTOAS_H
 
+#include <memory>
+#include <optional>
+#include <string>
 #include "ObjectEmission.h"
 #include "PTO/Compiler/CompilerApi.h"
 #include "PTO/Transforms/VPTOLLVMEmitter.h"
@@ -18,9 +21,7 @@
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CommandLine.h"
-#include <memory>
-#include <optional>
-#include <string>
+
 
 namespace mlir {
 class AsmParserState;
@@ -104,7 +105,7 @@ private:
   VFSIMTSizeFixMode vfsimtSizeFixMode = VFSIMTSizeFixMode::Auto;
   int argc = 0;
   char **argv = nullptr;
-  CANNVersion cannVersion = CANNVersion{9, 0, 0, 1};
+  CANNVersion cannVersion = kDefaultCANNVersion;
   std::optional<CANNVersion> outputCANNVersionOverride;
   std::optional<CANNToolchain> toolchain;
   TempFileRegistry tempFiles;

--- a/tools/ptobc/src/canonical_printer.cpp
+++ b/tools/ptobc/src/canonical_printer.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "ptobc/canonical_printer.h"
 
 #include <mlir/Dialect/Arith/IR/Arith.h>
@@ -134,7 +135,9 @@ static std::string renameSSAInText(const std::string &text,
 
     // Parse SSA identifier after '%'.
     size_t j = i + 1;
-    while (j < text.size() && isSSAIdentChar(text[j])) ++j;
+    while (j < text.size() && isSSAIdentChar(text[j])) {
+      ++j;
+    }
     if (j == i + 1) {
       out.push_back('%');
       continue;
@@ -174,7 +177,9 @@ static void collectSSADefsFromSignature(const std::string &line,
       continue;
     }
     size_t j = i + 1;
-    while (j < rpar && isSSAIdentChar(line[j])) ++j;
+    while (j < rpar && isSSAIdentChar(line[j])) {
+      ++j;
+    }
     if (j == i + 1) {
       continue;
     }
@@ -191,9 +196,11 @@ static bool parseConstantLine(const std::string &line, std::string &imm, std::st
   // We don't try to parse attributes on constants.
   static const std::regex re(R"(^[ \t]*%[-a-zA-Z$._0-9]+[ \t]*=[ \t]*arith\.constant[ \t]+(.+?)[ \t]*:[ \t]*([^ \t]+)(?:[ \t]+loc\(.+\))?[ \t]*$)");
   std::smatch m;
-  if (!std::regex_match(line, m, re)) return false;
+  if (!std::regex_match(line, m, re)) {
+    return false;
+  }
   imm = m[1].str();
-  ty = m[2].str();
+  ty = m[mlir::pto::kValue2].str();
   return true;
 }
 
@@ -227,8 +234,9 @@ static bool findConstantDefinition(const std::vector<std::string> &lines,
       continue;
     }
     size_t end = pos + 1;
-    while (end < line.size() && isSSAIdentChar(line[end]))
+    while (end < line.size() && isSSAIdentChar(line[end])) {
       ++end;
+    }
     if (line.substr(pos + 1, end - (pos + 1)) != name) {
       continue;
     }
@@ -243,14 +251,16 @@ static std::string getCanonicalSSAName(const std::vector<std::string> &lines,
                                        uint64_t &nextNonConst) {
   std::string imm;
   std::string ty;
-  if (!findConstantDefinition(lines, oldName, imm, ty))
+  if (!findConstantDefinition(lines, oldName, imm, ty)) {
     return std::to_string(nextNonConst++);
+  }
 
   std::string base = canonicalConstBaseName(imm, ty);
   int &count = constCounts[base];
   std::string newName = base;
-  if (count > 0)
+  if (count > 0) {
     newName += "_" + std::to_string(count);
+  }
   ++count;
   return newName;
 }
@@ -273,14 +283,22 @@ static std::string canonicalizeSSANames(const std::string &printed) {
     // Op results at start of line.
     // e.g. "  %12 = ..." or "  %c0 = ..." or "%0:2 = ...".
     size_t pos = ln.find('%');
-    if (pos == std::string::npos) continue;
+    if (pos == std::string::npos) {
+      continue;
+    }
     // Require this to be a definition: '%' must appear before '='.
     size_t eq = ln.find('=');
-    if (eq == std::string::npos || pos > eq) continue;
+    if (eq == std::string::npos || pos > eq) {
+      continue;
+    }
 
     size_t j = pos + 1;
-    while (j < ln.size() && isSSAIdentChar(ln[j])) ++j;
-    if (j == pos + 1) continue;
+    while (j < ln.size() && isSSAIdentChar(ln[j])) {
+      ++j;
+    }
+    if (j == pos + 1) {
+      continue;
+    }
     defs.push_back(ln.substr(pos + 1, j - (pos + 1)));
   }
 
@@ -289,8 +307,9 @@ static std::string canonicalizeSSANames(const std::string &printed) {
 
   std::unordered_map<std::string, int> constCounts;
   uint64_t nextNonConst = 0;
-  for (const auto &old : defs)
+  for (const auto &old : defs) {
     ren.emplace(old, getCanonicalSSAName(lines, old, constCounts, nextNonConst));
+  }
 
   return renameSSAInText(printed, ren);
 }
@@ -304,21 +323,33 @@ static void canonicalizeScalarFloatConstants(mlir::ModuleOp module,
 
   module.walk([&](mlir::Operation *op) {
     auto cst = llvm::dyn_cast<mlir::arith::ConstantOp>(op);
-    if (!cst) return;
+    if (!cst) {
+      return;
+    }
 
     auto f = llvm::dyn_cast<mlir::FloatAttr>(cst.getValue());
-    if (!f) return;
+    if (!f) {
+      return;
+    }
 
     // Only canonicalize scalar float constants.
-    if (!llvm::isa<mlir::FloatType>(cst.getType())) return;
+    if (!llvm::isa<mlir::FloatType>(cst.getType())) {
+      return;
+    }
 
     auto it = locMap.find(op);
-    if (it == locMap.end()) return;
+    if (it == locMap.end()) {
+      return;
+    }
 
     unsigned lineNo = it->second.first;
-    if (lineNo == 0) return;
+    if (lineNo == 0) {
+      return;
+    }
     size_t idx = size_t(lineNo - 1);
-    if (idx >= lines.size()) return;
+    if (idx >= lines.size()) {
+      return;
+    }
 
     std::smatch m;
     if (!std::regex_match(lines[idx], m, re)) {
@@ -328,7 +359,7 @@ static void canonicalizeScalarFloatConstants(mlir::ModuleOp module,
     }
 
     std::string lit = hexFloatLiteral(f);
-    lines[idx] = m[1].str() + lit + m[3].str();
+    lines[idx] = m[1].str() + lit + m[mlir::pto::kValue3].str();
   });
 }
 
@@ -340,8 +371,12 @@ std::string printModuleCanonical(mlir::ModuleOp module,
   mlir::OpPrintingFlags flags;
   flags.useLocalScope();
   flags.assumeVerified();
-  if (opt.generic) flags.printGenericOpForm();
-  if (opt.printDebugInfo) flags.enableDebugInfo(true, /*prettyForm=*/false);
+  if (opt.generic) {
+    flags.printGenericOpForm();
+  }
+  if (opt.printDebugInfo) {
+    flags.enableDebugInfo(true, /*prettyForm=*/false);
+  }
 
   mlir::AsmState::LocationMap locMap;
   mlir::AsmState state(module.getOperation(), flags, &locMap);

--- a/tools/ptobc/src/leb128.cpp
+++ b/tools/ptobc/src/leb128.cpp
@@ -30,7 +30,9 @@ void writeULEB128(uint64_t value, std::vector<uint8_t>& out) {
   do {
     uint8_t byte = static_cast<uint8_t>(value & kLeb128PayloadMask);
     value >>= kLeb128PayloadBits;
-    if (value != 0) byte |= kLeb128ContinuationBit;
+    if (value != 0) {
+      byte |= kLeb128ContinuationBit;
+    }
     out.push_back(byte);
   } while (value != 0);
 }
@@ -56,9 +58,13 @@ size_t readULEB128(const uint8_t* data, size_t size, uint64_t& value) {
   for (size_t i = 0; i < size; ++i) {
     uint8_t byte = data[i];
     value |= (uint64_t(byte & kLeb128PayloadMask) << shift);
-    if ((byte & kLeb128ContinuationBit) == 0) return i + 1;
+    if ((byte & kLeb128ContinuationBit) == 0) {
+      return i + 1;
+    }
     shift += kLeb128PayloadBits;
-    if (shift > kInt64MaxShift) throw std::runtime_error("ULEB128 too large");
+    if (shift > kInt64MaxShift) {
+      throw std::runtime_error("ULEB128 too large");
+    }
   }
   throw std::runtime_error("Unexpected EOF in ULEB128");
 }
@@ -72,10 +78,16 @@ size_t readSLEB128(const uint8_t* data, size_t size, int64_t& value) {
     byte = data[i];
     value |= (int64_t(byte & kLeb128PayloadMask) << shift);
     shift += kLeb128PayloadBits;
-    if ((byte & kLeb128ContinuationBit) == 0) break;
-    if (shift > kInt64MaxShift) throw std::runtime_error("SLEB128 too large");
+    if ((byte & kLeb128ContinuationBit) == 0) {
+      break;
+    }
+    if (shift > kInt64MaxShift) {
+      throw std::runtime_error("SLEB128 too large");
+    }
   }
-  if (i == size) throw std::runtime_error("Unexpected EOF in SLEB128");
+  if (i == size) {
+    throw std::runtime_error("Unexpected EOF in SLEB128");
+  }
 
   // sign extend
   if ((shift < kInt64BitWidth) && (byte & kLeb128SignBit)) {

--- a/tools/ptobc/src/main.cpp
+++ b/tools/ptobc/src/main.cpp
@@ -54,8 +54,9 @@ constexpr int kUsageExitCode = 2;
 static std::vector<std::string> collectArguments(int argc, char *argv[]) {
   std::vector<std::string> args;
   args.reserve(static_cast<size_t>(argc));
-  for (int i = 0; i < argc; ++i)
+  for (int i = 0; i < argc; ++i) {
     args.emplace_back(argv[i]);
+  }
   return args;
 }
 
@@ -63,23 +64,28 @@ static std::vector<std::string> collectArguments(int argc, char *argv[]) {
 
 static std::optional<CommandLineOptions>
 parseCommandLine(const std::vector<std::string> &args) {
-  if (args.size() < kCommandArgumentCount)
+  if (args.size() < kCommandArgumentCount) {
     return std::nullopt;
+  }
 
   CommandLineOptions options{args[kCommandArgumentIndex], "", ""};
-  if (options.cmd != "encode" && options.cmd != "decode")
+  if (options.cmd != "encode" && options.cmd != "decode") {
     return options;
-  if (args.size() < kFullCommandArgumentCount)
+  }
+  if (args.size() < kFullCommandArgumentCount) {
     return std::nullopt;
+  }
 
   options.input = args[kInputArgumentIndex];
   for (size_t i = kFirstOptionArgumentIndex; i < args.size(); ++i) {
     const std::string &arg = args[i];
-    if (arg == "-o" && i + kNextArgumentOffset < args.size())
+    if (arg == "-o" && i + kNextArgumentOffset < args.size()) {
       options.output = args[++i];
+    }
   }
-  if (options.output.empty())
+  if (options.output.empty()) {
     return std::nullopt;
+  }
   return options;
 }
 
@@ -126,10 +132,12 @@ int main(int argc, char **argv) {
   }
 
   try {
-    if (options->cmd == "encode")
+    if (options->cmd == "encode") {
       return runEncode(*options);
-    if (options->cmd == "decode")
+    }
+    if (options->cmd == "decode") {
       return runDecode(*options);
+    }
     usage();
     return kUsageExitCode;
   } catch (const std::exception& e) {

--- a/tools/ptobc/src/mlir_encode.cpp
+++ b/tools/ptobc/src/mlir_encode.cpp
@@ -9,6 +9,7 @@
 //===- mlir_encode.cpp ----------------------------------------------------===//
 //===----------------------------------------------------------------------===//
 
+#include "PTO/Support/CodeConstants.h"
 #include "ptobc/mlir_helpers.h"
 #include "ptobc/ptobc_format.h"
 
@@ -92,28 +93,35 @@ static bool shouldEncodeViaGenericV0CompatibilityShim(mlir::Operation &op) {
   // pto.tci / pto.trowexpandadd forms without tmp. Newer tmp-operand forms
   // must not reuse those schemas or older .ptobc files would become
   // undecodable, so serialize the new forms through the generic v0 opcode.
-  if (auto tci = llvm::dyn_cast<mlir::pto::TCIOp>(&op))
+  if (auto tci = llvm::dyn_cast<mlir::pto::TCIOp>(&op)) {
     return static_cast<bool>(tci.getTmp());
-  if (auto trowexpandadd = llvm::dyn_cast<mlir::pto::TRowExpandAddOp>(&op))
+  }
+  if (auto trowexpandadd = llvm::dyn_cast<mlir::pto::TRowExpandAddOp>(&op)) {
     return static_cast<bool>(trowexpandadd.getTmp());
+  }
   // tquant.mx intentionally has no v0 known-op schema. Preserve its complete
   // operand and attribute dictionary through the existing generic record even
   // when PTOBC_ALLOW_GENERIC is not enabled globally.
-  if (llvm::isa<mlir::pto::TQuantMxOp>(&op))
+  if (llvm::isa<mlir::pto::TQuantMxOp>(&op)) {
     return true;
+  }
   // The compact v0 schemas for these ops predate their optional pre-quant
   // operands. Keep the shipped fixed payloads unchanged and use the generic
   // opcode for forms that cannot be represented by those schemas.
-  if (auto textract = llvm::dyn_cast<mlir::pto::TExtractOp>(&op))
+  if (auto textract = llvm::dyn_cast<mlir::pto::TExtractOp>(&op)) {
     return static_cast<bool>(textract.getPreQuantScalar());
-  if (auto tinsert = llvm::dyn_cast<mlir::pto::TInsertOp>(&op))
+  }
+  if (auto tinsert = llvm::dyn_cast<mlir::pto::TInsertOp>(&op)) {
     return static_cast<bool>(tinsert.getPreQuantScalar());
+  }
   if (auto tmov = llvm::dyn_cast<mlir::pto::TMovOp>(&op)) {
     if (mlir::pto::classifyTMovForm(tmov.getFp()) ==
-        mlir::pto::TMovForm::XToZz)
+        mlir::pto::TMovForm::XToZz) {
       return true;
-    if (tmov.getPreQuantScalar())
+    }
+    if (tmov.getPreQuantScalar()) {
       return true;
+    }
     // The removed pto.tmov.fp op carried only src/fp/dst. Its legacy opcode
     // would silently discard mode/relu semantics when read by an older PTOAS.
     // The pre-unification pto.tmov op already understood fp plus these attrs,
@@ -124,40 +132,50 @@ static bool shouldEncodeViaGenericV0CompatibilityShim(mlir::Operation &op) {
   // Result-bearing non-fp forms are readable by older unified pto.tstore
   // readers through generic v0. The fp form is rejected separately because
   // no pre-unification operation represented both fp and a result.
-  if (auto tstore = llvm::dyn_cast<mlir::pto::TStoreOp>(&op))
+  if (auto tstore = llvm::dyn_cast<mlir::pto::TStoreOp>(&op)) {
     return tstore->getNumResults() != 0;
+  }
   if (llvm::isa<mlir::pto::CmoCacheInvalidOp, mlir::pto::FenceBarrierAllOp>(
-          &op))
+          &op)) {
     return true;
+  }
   // The aiv_subblockid operand extends pipe transfer forms after the v0
   // known-op schemas were fixed. Keep the legacy compact payloads unchanged
   // and route only the new optional-operand forms through generic encoding.
-  if (auto push = llvm::dyn_cast<mlir::pto::TPushToAicOp>(&op))
+  if (auto push = llvm::dyn_cast<mlir::pto::TPushToAicOp>(&op)) {
     return static_cast<bool>(push.getAivSubblockid());
-  if (auto pop = llvm::dyn_cast<mlir::pto::TPopFromAicOp>(&op))
+  }
+  if (auto pop = llvm::dyn_cast<mlir::pto::TPopFromAicOp>(&op)) {
     return static_cast<bool>(pop.getAivSubblockid());
-  if (auto push = llvm::dyn_cast<mlir::pto::TPushOp>(&op))
+  }
+  if (auto push = llvm::dyn_cast<mlir::pto::TPushOp>(&op)) {
     return static_cast<bool>(push.getAivSubblockid());
-  if (auto pop = llvm::dyn_cast<mlir::pto::TPopOp>(&op))
+  }
+  if (auto pop = llvm::dyn_cast<mlir::pto::TPopOp>(&op)) {
     return static_cast<bool>(pop.getAivSubblockid());
+  }
   return false;
 }
 
 static std::optional<uint16_t> getLegacyFpWireOpcode(mlir::Operation &op) {
-  if (auto textract = llvm::dyn_cast<mlir::pto::TExtractOp>(&op))
+  if (auto textract = llvm::dyn_cast<mlir::pto::TExtractOp>(&op)) {
     return textract.getFp() ? std::optional<uint16_t>(kTExtractFpWireOpcode)
                             : std::nullopt;
-  if (auto tinsert = llvm::dyn_cast<mlir::pto::TInsertOp>(&op))
+  }
+  if (auto tinsert = llvm::dyn_cast<mlir::pto::TInsertOp>(&op)) {
     return tinsert.getFp() ? std::optional<uint16_t>(kTInsertFpWireOpcode)
                            : std::nullopt;
-  if (auto tmov = llvm::dyn_cast<mlir::pto::TMovOp>(&op))
+  }
+  if (auto tmov = llvm::dyn_cast<mlir::pto::TMovOp>(&op)) {
     return tmov.getFp() && canUseLegacyTMovFpWireOpcode(tmov)
                ? std::optional<uint16_t>(kTMovFpWireOpcode)
                : std::nullopt;
-  if (auto tstore = llvm::dyn_cast<mlir::pto::TStoreOp>(&op))
+  }
+  if (auto tstore = llvm::dyn_cast<mlir::pto::TStoreOp>(&op)) {
     return tstore.getFp() && canUseLegacyTStoreFpWireOpcode(tstore)
                ? std::optional<uint16_t>(kTStoreFpWireOpcode)
                : std::nullopt;
+  }
   return std::nullopt;
 }
 
@@ -166,14 +184,16 @@ getUnsupportedV0EncodingReason(mlir::Operation &op) {
   if (auto tmov = llvm::dyn_cast<mlir::pto::TMovOp>(&op);
       tmov && mlir::pto::classifyTMovForm(tmov.getFp()) ==
                   mlir::pto::TMovForm::Fp &&
-      tmov->getNumResults() != 0)
+      tmov->getNumResults() != 0) {
     return "pto.tmov fp with a result cannot be represented safely in "
            "PTO-BC v0; legacy opcode 0x1039 would silently drop the result, "
            "and PTOAS backends do not lower the generic result-bearing form";
+  }
 
   auto tstore = llvm::dyn_cast<mlir::pto::TStoreOp>(&op);
-  if (!tstore || !tstore.getFp() || canUseLegacyTStoreFpWireOpcode(tstore))
+  if (!tstore || !tstore.getFp() || canUseLegacyTStoreFpWireOpcode(tstore)) {
     return std::nullopt;
+  }
 
   return "pto.tstore fp with a result or non-default atomicType/reluPreMode "
          "cannot be represented safely in PTO-BC v0; legacy opcode 0x1066 "
@@ -201,7 +221,9 @@ static uint64_t internType(PTOBCFile& f, mlir::Type t) {
   f.strings.intern(s);
   // type ids are 1-based
   for (size_t i = 0; i < f.typeAsm.size(); ++i) {
-    if (f.typeAsm[i] == s) return i + 1;
+    if (f.typeAsm[i] == s) {
+      return i + 1;
+    }
   }
   f.typeAsm.push_back(s);
   return f.typeAsm.size();
@@ -210,18 +232,21 @@ static uint64_t internType(PTOBCFile& f, mlir::Type t) {
 static mlir::DictionaryAttr stripAttrs(mlir::MLIRContext *ctx,
                                        mlir::DictionaryAttr dict,
                                        llvm::ArrayRef<llvm::StringRef> keys) {
-  if (!dict || dict.empty() || keys.empty())
+  if (!dict || dict.empty() || keys.empty()) {
     return dict;
+  }
 
-  llvm::SmallVector<mlir::NamedAttribute, 8> keep;
+  llvm::SmallVector<mlir::NamedAttribute, mlir::pto::kValue8> keep;
   keep.reserve(dict.size());
   for (auto na : dict) {
-    if (llvm::is_contained(keys, na.getName().getValue()))
+    if (llvm::is_contained(keys, na.getName().getValue())) {
       continue;
+    }
     keep.push_back(na);
   }
-  if (keep.size() == dict.size())
+  if (keep.size() == dict.size()) {
     return dict;
+  }
   return mlir::DictionaryAttr::get(ctx, keep);
 }
 
@@ -253,29 +278,36 @@ static bool isFrontendPipeOpWithDefaultId(mlir::Operation &op) {
 static mlir::DictionaryAttr
 dropDefaultZeroPipeIdForV0Encoding(mlir::Operation &op,
                                    mlir::DictionaryAttr dict) {
-  if (!dict || dict.empty() || !isFrontendPipeOpWithDefaultId(op))
+  if (!dict || dict.empty() || !isFrontendPipeOpWithDefaultId(op)) {
     return dict;
+  }
 
   auto idAttr = dict.getAs<mlir::IntegerAttr>("id");
-  if (!idAttr || idAttr.getInt() != 0)
+  if (!idAttr || idAttr.getInt() != 0) {
     return dict;
+  }
 
   llvm::SmallVector<mlir::NamedAttribute, kNamedAttributeInlineCapacity> keep;
   keep.reserve(dict.size());
   for (auto attr : dict) {
-    if (attr.getName() == "id")
+    if (attr.getName() == "id") {
       continue;
+    }
     keep.push_back(attr);
   }
   return mlir::DictionaryAttr::get(op.getContext(), keep);
 }
 
 static uint64_t internAttr(PTOBCFile& f, mlir::DictionaryAttr dict) {
-  if (!dict || dict.empty()) return 0;
+  if (!dict || dict.empty()) {
+    return 0;
+  }
   std::string s = printAttrDict(dict);
   f.strings.intern(s);
   for (size_t i = 0; i < f.attrAsm.size(); ++i) {
-    if (f.attrAsm[i] == s) return i + 1;
+    if (f.attrAsm[i] == s) {
+      return i + 1;
+    }
   }
   f.attrAsm.push_back(s);
   return f.attrAsm.size();
@@ -318,8 +350,9 @@ buildScalarConstantDebugName(mlir::Value value,
                              std::unordered_map<std::string, int> &constCounts) {
   auto cst = llvm::dyn_cast_or_null<mlir::arith::ConstantOp>(
       value.getDefiningOp());
-  if (!cst)
+  if (!cst) {
     return std::nullopt;
+  }
 
   mlir::Attribute attr = cst.getValue();
   std::string typeName = printType(value.getType());
@@ -328,16 +361,18 @@ buildScalarConstantDebugName(mlir::Value value,
     baseName = "c" + hexFloatLiteral(floatAttr) + "_" + typeName;
   } else if (auto intAttr = llvm::dyn_cast<mlir::IntegerAttr>(attr)) {
     baseName = "c" + apIntToSignedDecimal(intAttr.getValue());
-    if (typeName != "index")
+    if (typeName != "index") {
       baseName += "_" + typeName;
+    }
   } else {
     return std::nullopt;
   }
 
   int &count = constCounts[baseName];
   std::string name = baseName;
-  if (count > 0)
+  if (count > 0) {
     name += "_" + std::to_string(count);
+  }
   ++count;
   return name;
 }
@@ -371,7 +406,9 @@ struct Encoder {
   uint64_t allocValueId(mlir::Value v) {
     uint64_t id = valueId.size();
     auto [it, inserted] = valueId.try_emplace(v, id);
-    if (!inserted) throw std::runtime_error("value already has an id");
+    if (!inserted) {
+      throw std::runtime_error("value already has an id");
+    }
     valueById.push_back(v);
     return it->second;
   }
@@ -379,7 +416,9 @@ struct Encoder {
   uint64_t internDbgFile(llvm::StringRef path) {
     auto p = path.str();
     auto it = dbgFileIdByPath.find(p);
-    if (it != dbgFileIdByPath.end()) return it->second;
+    if (it != dbgFileIdByPath.end()) {
+      return it->second;
+    }
 
     uint64_t sid = file.strings.intern(p);
     uint64_t fileId = file.dbgFiles.size();
@@ -389,10 +428,14 @@ struct Encoder {
   }
 
   void recordOpLocation(uint64_t opId, mlir::Operation &op) {
-    if (!emitDebugInfo) return;
+    if (!emitDebugInfo) {
+      return;
+    }
     auto loc = op.getLoc();
     auto flc = llvm::dyn_cast<mlir::FileLineColLoc>(loc);
-    if (!flc) return;
+    if (!flc) {
+      return;
+    }
 
     uint64_t fileId = internDbgFile(flc.getFilename().getValue());
     uint64_t sl = flc.getLine();
@@ -404,7 +447,9 @@ struct Encoder {
   }
 
   void finalizeValueNamesForFunction() {
-    if (!emitDebugInfo) return;
+    if (!emitDebugInfo) {
+      return;
+    }
     // Deterministic value names for DebugInfo.
     std::unordered_map<std::string, int> constCounts;
 
@@ -424,7 +469,9 @@ struct Encoder {
       std::copy(payload.begin(), payload.end(), key.begin() + 1);
     }
     auto it = constIdByKey.find(key);
-    if (it != constIdByKey.end()) return it->second;
+    if (it != constIdByKey.end()) {
+      return it->second;
+    }
     uint64_t id = file.consts.size();
     file.consts.push_back(ConstEntry{tag, payload});
     constIdByKey.emplace(std::move(key), id);
@@ -495,7 +542,9 @@ void Encoder::encodeBlock(mlir::Block& block, Buffer& out) {
 
   // ops count
   size_t opCount = 0;
-  for (auto& op : block.getOperations()) (void)op, ++opCount;
+  for (auto& op : block.getOperations()) {
+    (void)op, ++opCount;
+  }
   writeULEB128(opCount, out.bytes);
 
   for (auto& op : block.getOperations()) {
@@ -512,8 +561,9 @@ void Encoder::encodeKnownOpImmediates(
     return;
   case 0x01: {
     auto cmp = llvm::dyn_cast<mlir::arith::CmpIOp>(&op);
-    if (!cmp)
+    if (!cmp) {
       throw std::runtime_error("imm_kind=cmpi_pred but op is not arith.cmpi");
+    }
     uint8_t predicate = 0;
     switch (cmp.getPredicate()) {
     case mlir::arith::CmpIPredicate::eq:
@@ -546,8 +596,9 @@ void Encoder::encodeKnownOpImmediates(
     auto src = op.getAttrOfType<mlir::pto::SyncOpTypeAttr>("src_op");
     auto dst = op.getAttrOfType<mlir::pto::SyncOpTypeAttr>("dst_op");
     auto event = op.getAttrOfType<mlir::pto::EventAttr>("event_id");
-    if (!src || !dst || !event)
+    if (!src || !dst || !event) {
       throw std::runtime_error("event op missing src_op/dst_op/event_id attrs");
+    }
     uint8_t srcValue = uint8_t(src.getOpType());
     uint8_t dstValue = uint8_t(dst.getOpType());
     uint8_t eventValue = uint8_t(event.getEvent());
@@ -559,8 +610,9 @@ void Encoder::encodeKnownOpImmediates(
   }
   case 0x05: {
     auto cst = llvm::dyn_cast<mlir::arith::ConstantOp>(&op);
-    if (!cst)
+    if (!cst) {
       throw std::runtime_error("imm_kind=const_id but op is not arith.constant");
+    }
 
     mlir::Attribute attr = cst.getValue();
     uint64_t constId = 0;
@@ -583,9 +635,10 @@ void Encoder::encodeKnownOpImmediates(
   }
   case 0x06: {
     auto mtv = llvm::dyn_cast<mlir::pto::MakeTensorViewOp>(&op);
-    if (!mtv)
+    if (!mtv) {
       throw std::runtime_error(
           "imm_kind=make_tensor_view but op is not pto.make_tensor_view");
+    }
     uint8_t listMode = 0;
     out.appendU8(listMode);
     writeULEB128(mtv.getShape().size(), out.bytes);
@@ -596,9 +649,10 @@ void Encoder::encodeKnownOpImmediates(
   }
   case 0x07: {
     auto pv = llvm::dyn_cast<mlir::pto::PartitionViewOp>(&op);
-    if (!pv)
+    if (!pv) {
       throw std::runtime_error(
           "imm_kind=partition_view but op is not pto.partition_view");
+    }
     uint8_t listMode = 0;
     out.appendU8(listMode);
     writeULEB128(pv.getOffsets().size(), out.bytes);
@@ -609,16 +663,20 @@ void Encoder::encodeKnownOpImmediates(
   }
   case 0x08: {
     auto at = llvm::dyn_cast<mlir::pto::AllocTileOp>(&op);
-    if (!at)
+    if (!at) {
       throw std::runtime_error(
           "imm_kind=alloc_tile but op is not pto.alloc_tile");
+    }
     uint8_t mask = 0;
-    if (at.getValidRow())
+    if (at.getValidRow()) {
       mask |= 0x1;
-    if (at.getValidCol())
+    }
+    if (at.getValidCol()) {
       mask |= 0x2;
-    if (at.getAddr())
+    }
+    if (at.getAddr()) {
       mask |= 0x4;
+    }
     out.appendU8(mask);
     imms.push_back(mask);
     return;
@@ -638,8 +696,9 @@ void Encoder::encodeKnownOpOperands(
       throw std::runtime_error("operand count mismatch for op: " +
                                op.getName().getStringRef().str());
     }
-    for (auto value : op.getOperands())
+    for (auto value : op.getOperands()) {
       writeULEB128(getValueId(value), out.bytes);
+    }
   };
   auto emitLegacyIndexedTscatterOperands = [&]() {
     auto tscatter = llvm::dyn_cast<mlir::pto::TScatterOp>(&op);
@@ -660,8 +719,9 @@ void Encoder::encodeKnownOpOperands(
   };
   auto emitLegacyFpOperands = [&]() {
     auto emit = [&](llvm::ArrayRef<mlir::Value> operands) {
-      for (mlir::Value value : operands)
+      for (mlir::Value value : operands) {
         writeULEB128(getValueId(value), out.bytes);
+      }
     };
     switch (variantInfo.opcode) {
     case kTExtractFpWireOpcode: {
@@ -690,41 +750,47 @@ void Encoder::encodeKnownOpOperands(
       return false;
     }
   };
-
-  if (emitLegacyFpOperands())
+  if (emitLegacyFpOperands()) {
     return;
+  }
 
   switch (info.operand_mode) {
   case 0x00:
-    if (emitLegacyIndexedTscatterOperands())
+    if (emitLegacyIndexedTscatterOperands()) {
       return;
+    }
     emitOperands(info.num_operands);
     return;
   case 0x01: {
     auto count =
         ptobc::v0::lookupOperandsByVariant(variantInfo.opcode, variantInfo.variant);
-    if (!count)
+    if (!count) {
       throw std::runtime_error("missing by-variant operand count");
+    }
     emitOperands(*count);
     return;
   }
   case 0x02:
     writeULEB128(op.getNumOperands(), out.bytes);
-    for (auto value : op.getOperands())
+    for (auto value : op.getOperands()) {
       writeULEB128(getValueId(value), out.bytes);
+    }
     return;
   case 0x03: {
-    if (imms.size() < kSegmentedOperandImmediateCount)
+    if (imms.size() < kSegmentedOperandImmediateCount) {
       throw std::runtime_error("segmented operands missing immediates");
-    if (imms[0] != 0)
+    }
+    if (imms[0] != 0) {
       throw std::runtime_error(
           "list_mode=1 not implemented in ptobc encoder yet");
-    emitOperands(size_t(info.num_operands) + size_t(imms[1]) + size_t(imms[2]));
+    }
+    emitOperands(size_t(info.num_operands) + size_t(imms[1]) + size_t(imms[mlir::pto::kValue2]));
     return;
   }
   case 0x04: {
-    if (imms.empty())
+    if (imms.empty()) {
       throw std::runtime_error("optmask operands missing immediate");
+    }
     uint8_t mask = uint8_t(imms.front());
     emitOperands(((mask & 0x1) ? 1 : 0) + ((mask & 0x2) ? 1 : 0) +
                  ((mask & 0x4) ? 1 : 0));
@@ -738,21 +804,24 @@ void Encoder::encodeKnownOpOperands(
 void Encoder::encodeKnownOp(mlir::Operation &op, Buffer &out,
                             const ptobc::v0::OpInfo &info,
                             const ptobc::v0::OpcodeAndVariant &variantInfo) {
-  for (auto result : op.getResults())
+  for (auto result : op.getResults()) {
     allocValueId(result);
+  }
 
   out.appendU16LE(variantInfo.opcode);
   mlir::DictionaryAttr dict = op.getAttrDictionary();
   dict = stripKnownImmediateAttrs(op.getContext(), dict, info);
-  if (omitsDerivedOperandSegmentsInV0(variantInfo.opcode))
+  if (omitsDerivedOperandSegmentsInV0(variantInfo.opcode)) {
     dict = stripAttrs(op.getContext(), dict, {"operandSegmentSizes"});
+  }
   // The assembly printer omits default pipe ids on transfer/free ops. Keep v0
   // byte roundtrips stable by using the same representation while encoding.
   dict = dropDefaultZeroPipeIdForV0Encoding(op, dict);
   writeULEB128(internAttr(file, dict), out.bytes);
 
-  if (info.has_variant_u8)
+  if (info.has_variant_u8) {
     out.appendU8(variantInfo.variant);
+  }
 
   WordVector imms;
   encodeKnownOpImmediates(op, out, info, variantInfo, imms);
@@ -763,12 +832,14 @@ void Encoder::encodeKnownOp(mlir::Operation &op, Buffer &out,
       throw std::runtime_error("result count mismatch for op: " +
                                op.getName().getStringRef().str());
     }
-    for (auto result : op.getResults())
+    for (auto result : op.getResults()) {
       writeULEB128(internType(file, result.getType()), out.bytes);
+    }
   } else if (info.result_type_mode == 0x02) {
     writeULEB128(op.getNumResults(), out.bytes);
-    for (auto result : op.getResults())
+    for (auto result : op.getResults()) {
       writeULEB128(internType(file, result.getType()), out.bytes);
+    }
   } else if (info.result_type_mode != 0x00) {
     throw std::runtime_error("unknown result_type_mode in v0 schema");
   }
@@ -777,8 +848,9 @@ void Encoder::encodeKnownOp(mlir::Operation &op, Buffer &out,
     throw std::runtime_error("region count mismatch for op: " +
                              op.getName().getStringRef().str());
   }
-  for (auto &region : op.getRegions())
+  for (auto &region : op.getRegions()) {
     encodeRegion(region, out);
+  }
 }
 
 void Encoder::encodeGenericOp(mlir::Operation &op, Buffer &out) {
@@ -795,12 +867,14 @@ void Encoder::encodeGenericOp(mlir::Operation &op, Buffer &out) {
   }
 
   writeULEB128(op.getNumOperands(), out.bytes);
-  for (auto operand : op.getOperands())
+  for (auto operand : op.getOperands()) {
     writeULEB128(getValueId(operand), out.bytes);
+  }
 
   writeULEB128(op.getNumRegions(), out.bytes);
-  for (auto &region : op.getRegions())
+  for (auto &region : op.getRegions()) {
     encodeRegion(region, out);
+  }
 }
 
 void Encoder::encodeOp(mlir::Operation& op, Buffer& out) {
@@ -810,8 +884,9 @@ void Encoder::encodeOp(mlir::Operation& op, Buffer& out) {
   }
 
   auto fullName = op.getName().getStringRef();
-  if (auto reason = getUnsupportedV0EncodingReason(op))
+  if (auto reason = getUnsupportedV0EncodingReason(op)) {
     throw std::runtime_error(*reason);
+  }
 
   if (auto tscatter = llvm::dyn_cast<mlir::pto::TScatterOp>(&op)) {
     uint16_t opcode = tscatter.getMaskPatternAttr()
@@ -820,9 +895,10 @@ void Encoder::encodeOp(mlir::Operation& op, Buffer& out) {
     auto variantInfo =
         ptobc::v0::OpcodeAndVariant{opcode, /*hasVariant=*/0, /*variant=*/0};
     const auto *info = ptobc::v0::lookupByOpcode(opcode);
-    if (!info)
+    if (!info) {
       throw std::runtime_error("missing v0 opcode schema for op: " +
                                fullName.str());
+    }
     encodeKnownOp(op, out, *info, variantInfo);
     return;
   }
@@ -836,9 +912,10 @@ void Encoder::encodeOp(mlir::Operation& op, Buffer& out) {
     auto variantInfo =
         ptobc::v0::OpcodeAndVariant{*opcode, /*hasVariant=*/0, /*variant=*/0};
     const auto *info = ptobc::v0::lookupByOpcode(*opcode);
-    if (!info)
+    if (!info) {
       throw std::runtime_error("missing legacy FP v0 opcode schema for op: " +
                                fullName.str());
+    }
     encodeKnownOp(op, out, *info, variantInfo);
     return;
   }
@@ -846,9 +923,10 @@ void Encoder::encodeOp(mlir::Operation& op, Buffer& out) {
   auto variantInfo = ptobc::v0::lookupOpcodeAndVariantByFullName(fullName);
   if (variantInfo) {
     const auto *info = ptobc::v0::lookupByOpcode(variantInfo->opcode);
-    if (!info)
+    if (!info) {
       throw std::runtime_error("missing v0 opcode schema for op: " +
                                fullName.str());
+    }
     encodeKnownOp(op, out, *info, *variantInfo);
     return;
   }

--- a/tools/ptobc/src/mlir_helpers.cpp
+++ b/tools/ptobc/src/mlir_helpers.cpp
@@ -46,20 +46,26 @@ std::string printAttrDict(mlir::DictionaryAttr a) {
 
 mlir::Type parseType(mlir::MLIRContext& ctx, const std::string& s) {
   mlir::Type t = mlir::parseType(s, &ctx);
-  if (!t) throw std::runtime_error("failed to parse type: " + s);
+  if (!t) {
+    throw std::runtime_error("failed to parse type: " + s);
+  }
   return t;
 }
 
 mlir::Attribute parseAttr(mlir::MLIRContext& ctx, const std::string& s) {
   mlir::Attribute a = mlir::parseAttribute(s, &ctx);
-  if (!a) throw std::runtime_error("failed to parse attr: " + s);
+  if (!a) {
+    throw std::runtime_error("failed to parse attr: " + s);
+  }
   return a;
 }
 
 mlir::DictionaryAttr parseAttrDict(mlir::MLIRContext& ctx, const std::string& s) {
   auto a = parseAttr(ctx, s);
   auto d = mlir::dyn_cast<mlir::DictionaryAttr>(a);
-  if (!d) throw std::runtime_error("attr is not a dictionary: " + s);
+  if (!d) {
+    throw std::runtime_error("attr is not a dictionary: " + s);
+  }
   return d;
 }
 

--- a/tools/ptobc/src/ptobc_decode_print.cpp
+++ b/tools/ptobc/src/ptobc_decode_print.cpp
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
+#include "PTO/Support/CodeConstants.h"
 #include "ptobc/mlir_helpers.h"
 #include "ptobc/ptobc_format.h"
 #include "ptobc/leb128.h"
@@ -71,7 +72,9 @@ struct Reader {
   const uint8_t* end;
 
   uint8_t readU8() {
-    if (p >= end) throw std::runtime_error("EOF");
+    if (p >= end) {
+      throw std::runtime_error("EOF");
+    }
     return *p++;
   }
   uint16_t readU16LE() {
@@ -103,7 +106,9 @@ struct Reader {
   }
 
   std::vector<uint8_t> readBytes(size_t n) {
-    if (size_t(end - p) < n) throw std::runtime_error("EOF");
+    if (size_t(end - p) < n) {
+      throw std::runtime_error("EOF");
+    }
     std::vector<uint8_t> out(p, p + n);
     p += n;
     return out;
@@ -120,7 +125,9 @@ static void parseStringsSection(const std::vector<uint8_t>& data, std::vector<st
     auto bs = r.readBytes(len);
     strings.emplace_back(reinterpret_cast<const char*>(bs.data()), bs.size());
   }
-  if (r.p != r.end) throw std::runtime_error("trailing bytes in STRINGS");
+  if (r.p != r.end) {
+    throw std::runtime_error("trailing bytes in STRINGS");
+  }
 }
 
 struct TypeEntry { uint8_t tag; std::string asmStr; };
@@ -201,7 +208,9 @@ static DebugInfo parseDebugInfoSection(const std::vector<uint8_t>& data) {
     di.snippets.push_back({fid, opid, ssid});
   }
 
-  if (r.p != r.end) throw std::runtime_error("trailing bytes in DEBUGINFO");
+  if (r.p != r.end) {
+    throw std::runtime_error("trailing bytes in DEBUGINFO");
+  }
   return di;
 }
 
@@ -217,12 +226,18 @@ static void parseTypesSection(const std::vector<uint8_t>& data,
   for (uint64_t i = 0; i < cnt; ++i) {
     uint8_t tag = r.readU8();
     uint8_t flags = r.readU8();
-    if ((flags & 0x1) == 0) throw std::runtime_error("type missing asm");
+    if ((flags & 0x1) == 0) {
+      throw std::runtime_error("type missing asm");
+    }
     uint64_t sid = r.readULEB();
-    if (sid >= strings.size()) throw std::runtime_error("bad asm_sid");
+    if (sid >= strings.size()) {
+      throw std::runtime_error("bad asm_sid");
+    }
     types.push_back({tag, strings[sid]});
   }
-  if (r.p != r.end) throw std::runtime_error("trailing bytes in TYPES");
+  if (r.p != r.end) {
+    throw std::runtime_error("trailing bytes in TYPES");
+  }
 }
 
 static void parseAttrsSection(const std::vector<uint8_t>& data,
@@ -236,12 +251,18 @@ static void parseAttrsSection(const std::vector<uint8_t>& data,
   for (uint64_t i = 0; i < cnt; ++i) {
     uint8_t tag = r.readU8();
     uint8_t flags = r.readU8();
-    if ((flags & 0x1) == 0) throw std::runtime_error("attr missing asm");
+    if ((flags & 0x1) == 0) {
+      throw std::runtime_error("attr missing asm");
+    }
     uint64_t sid = r.readULEB();
-    if (sid >= strings.size()) throw std::runtime_error("bad asm_sid");
+    if (sid >= strings.size()) {
+      throw std::runtime_error("bad asm_sid");
+    }
     attrs.push_back({tag, strings[sid]});
   }
-  if (r.p != r.end) throw std::runtime_error("trailing bytes in ATTRS");
+  if (r.p != r.end) {
+    throw std::runtime_error("trailing bytes in ATTRS");
+  }
 }
 
 static void parseConstPoolSection(const std::vector<uint8_t>& data,
@@ -273,7 +294,9 @@ static void parseConstPoolSection(const std::vector<uint8_t>& data,
     } else if (tag == 0x03) {
       // index vec (not yet needed for sample decoding)
       uint64_t n = r.readULEB();
-      for (uint64_t j = 0; j < n; ++j) (void)r.readSLEB();
+      for (uint64_t j = 0; j < n; ++j) {
+        (void)r.readSLEB();
+      }
       ConstEntryParsed e;
       e.tag = tag;
       consts.push_back(std::move(e));
@@ -292,7 +315,9 @@ static void parseConstPoolSection(const std::vector<uint8_t>& data,
     }
   }
 
-  if (r.p != r.end) throw std::runtime_error("trailing bytes in CONSTPOOL");
+  if (r.p != r.end) {
+    throw std::runtime_error("trailing bytes in CONSTPOOL");
+  }
 }
 
 struct BuildCtx {
@@ -311,13 +336,19 @@ struct BuildCtx {
 };
 
 static mlir::Type getType(BuildCtx& bc, uint64_t tid) {
-  if (tid >= bc.types->size()) throw std::runtime_error("bad type_id");
+  if (tid >= bc.types->size()) {
+    throw std::runtime_error("bad type_id");
+  }
   return parseType(*bc.ctx, (*bc.types)[tid].asmStr);
 }
 
 static mlir::DictionaryAttr getAttrDict(BuildCtx& bc, uint64_t aid) {
-  if (aid == 0) return mlir::DictionaryAttr::get(bc.ctx);
-  if (aid >= bc.attrs->size()) throw std::runtime_error("bad attr_id");
+  if (aid == 0) {
+    return mlir::DictionaryAttr::get(bc.ctx);
+  }
+  if (aid >= bc.attrs->size()) {
+    throw std::runtime_error("bad attr_id");
+  }
   return parseAttrDict(*bc.ctx, (*bc.attrs)[aid].asmStr);
 }
 
@@ -339,13 +370,15 @@ static mlir::Attribute buildFloatConstAttr(BuildCtx &bc,
                                            const ConstEntryParsed &entry) {
   auto ty = getType(bc, entry.typeId);
   auto floatType = mlir::dyn_cast<mlir::FloatType>(ty);
-  if (!floatType)
+  if (!floatType) {
     throw std::runtime_error("ConstFloatBits type is not FloatType");
+  }
 
   unsigned bitWidth = floatType.getWidth();
   unsigned byteLen = (bitWidth + 7) / 8;
-  if (entry.floatBytes.size() != byteLen)
+  if (entry.floatBytes.size() != byteLen) {
     throw std::runtime_error("ConstFloatBits byte_len mismatch");
+  }
 
   llvm::APInt bits = rebuildAPIntFromBytes(entry.floatBytes, bitWidth);
   llvm::APFloat value(floatType.getFloatSemantics(), bits);
@@ -356,21 +389,27 @@ static mlir::Attribute buildIntegerConstAttr(BuildCtx &bc,
                                              const ConstEntryParsed &entry) {
   auto ty = getType(bc, entry.typeId);
   auto intType = mlir::dyn_cast<mlir::IntegerType>(ty);
-  if (!intType)
+  if (!intType) {
     throw std::runtime_error("ConstIntBits type is not IntegerType");
+  }
 
   unsigned bitWidth = intType.getWidth();
   unsigned byteLen = (bitWidth + 7) / 8;
-  if (entry.intBytes.size() != byteLen)
+  if (entry.intBytes.size() != byteLen) {
     throw std::runtime_error("ConstIntBits byte_len mismatch");
+  }
 
   llvm::APInt bits = rebuildAPIntFromBytes(entry.intBytes, bitWidth);
   return mlir::IntegerAttr::get(intType, bits);
 }
 
 static mlir::Attribute buildConstAttr(BuildCtx &bc, uint64_t constId) {
-  if (!bc.consts) throw std::runtime_error("constpool not available");
-  if (constId >= bc.consts->size()) throw std::runtime_error("const_id out of range");
+  if (!bc.consts) {
+    throw std::runtime_error("constpool not available");
+  }
+  if (constId >= bc.consts->size()) {
+    throw std::runtime_error("const_id out of range");
+  }
   const auto &e = (*bc.consts)[constId];
 
   if (e.tag == 0x01) {
@@ -379,45 +418,54 @@ static mlir::Attribute buildConstAttr(BuildCtx &bc, uint64_t constId) {
     if (mlir::isa<mlir::IndexType>(ty)) {
       return mlir::IntegerAttr::get(ty, e.intValue);
     }
-    if (!it) throw std::runtime_error("ConstInt type is not integer/index");
+    if (!it) {
+      throw std::runtime_error("ConstInt type is not integer/index");
+    }
     return mlir::IntegerAttr::get(ty, e.intValue);
   }
 
-  if (e.tag == 0x02)
+  if (e.tag == 0x02) {
     return buildFloatConstAttr(bc, e);
+  }
 
-  if (e.tag == 0x04)
+  if (e.tag == 0x04) {
     return buildIntegerConstAttr(bc, e);
+  }
 
   throw std::runtime_error("unsupported const tag");
 }
 
 static void addAttrDictionary(mlir::OperationState &state,
                               mlir::DictionaryAttr dict) {
-  for (auto attr : dict)
+  for (auto attr : dict) {
     state.addAttribute(attr.getName(), attr.getValue());
+  }
 }
 
 static void registerDecodedOp(BuildCtx &bc, uint64_t opId, mlir::Operation *op) {
-  if (!bc.opsById)
+  if (!bc.opsById) {
     return;
-  if (opId >= bc.opsById->size())
+  }
+  if (opId >= bc.opsById->size()) {
     bc.opsById->resize(opId + 1, nullptr);
+  }
   (*bc.opsById)[opId] = op;
 }
 
 static void assignDecodedResults(BuildCtx &bc, size_t resStart,
                                  mlir::Operation *op, size_t numResults) {
-  for (size_t i = 0; i < numResults; ++i)
+  for (size_t i = 0; i < numResults; ++i) {
     bc.values[resStart + i] = op->getResult(i);
+  }
 }
 
 static llvm::SmallVector<uint64_t, kValueIdInlineCapacity>
 readValueIds(Reader &r, size_t count) {
   llvm::SmallVector<uint64_t, kValueIdInlineCapacity> ids;
   ids.reserve(count);
-  for (size_t i = 0; i < count; ++i)
+  for (size_t i = 0; i < count; ++i) {
     ids.push_back(r.readULEB());
+  }
   return ids;
 }
 
@@ -468,9 +516,11 @@ static llvm::SmallVector<uint64_t, kValueIdInlineCapacity>
 readKnownOperandIds(BuildCtx &bc, Reader &r, uint16_t opcode, uint8_t variant,
                     const ptobc::v0::OpInfo &info,
                     const KnownOpImmediates &imms) {
-  auto reorderLegacyIndexedTscatter = [&](llvm::SmallVector<uint64_t, 8> ids) {
-    if (opcode != 0x1056 || ids.size() != 3)
+  auto reorderLegacyIndexedTscatter = [opcode](
+                                       llvm::SmallVector<uint64_t, 8> ids) {
+    if (opcode != 0x1056 || ids.size() != 3) {
       return ids;
+    }
     // Historical v0 indexed tscatter payload is (src, indexes, dst), while the
     // current IR operand order is (src, dst, indexes).
     return llvm::SmallVector<uint64_t, 8>{ids[0], ids[2], ids[1]};
@@ -480,15 +530,17 @@ readKnownOperandIds(BuildCtx &bc, Reader &r, uint16_t opcode, uint8_t variant,
     return reorderLegacyIndexedTscatter(readValueIds(r, info.num_operands));
   case 0x01: {
     auto count = ptobc::v0::lookupOperandsByVariant(opcode, variant);
-    if (!count)
+    if (!count) {
       throw std::runtime_error("missing by-variant operand count");
+    }
     return reorderLegacyIndexedTscatter(readValueIds(r, *count));
   }
   case 0x02:
     return reorderLegacyIndexedTscatter(readValueIds(r, r.readULEB()));
   case 0x03:
-    if (imms.listMode != 0)
+    if (imms.listMode != 0) {
       throw std::runtime_error("list_mode=1 not supported yet");
+    }
     return reorderLegacyIndexedTscatter(
         readValueIds(r, size_t(info.num_operands) + size_t(imms.n1) +
                             size_t(imms.n2)));
@@ -508,8 +560,9 @@ materializeOperands(BuildCtx &bc, llvm::ArrayRef<uint64_t> operandIds) {
   llvm::SmallVector<mlir::Value, kOperandInlineCapacity> operands;
   operands.reserve(operandIds.size());
   for (uint64_t valueId : operandIds) {
-    if (valueId >= bc.values.size())
+    if (valueId >= bc.values.size()) {
       throw std::runtime_error("operand value_id out of range");
+    }
     operands.push_back(bc.values[valueId]);
   }
   return operands;
@@ -520,50 +573,51 @@ static void normalizeLegacyFpOperandOrder(
     llvm::SmallVectorImpl<mlir::Value> &operands) {
   if ((opcode == kTExtractFpWireOpcode ||
        opcode == kTInsertFpWireOpcode) &&
-      operands.size() == 5) {
+      operands.size() == mlir::pto::kValue5) {
     // Legacy wire order: src, fp, row, col, dst.
-    llvm::SmallVector<mlir::Value, 5> reordered{
+    llvm::SmallVector<mlir::Value, mlir::pto::kValue5> reordered{
         operands[0], operands[2], operands[3], operands[4], operands[1]};
     operands.assign(reordered.begin(), reordered.end());
     return;
   }
   if ((opcode == kTMovFpWireOpcode || opcode == kTStoreFpWireOpcode) &&
-      operands.size() == 3) {
+      operands.size() == mlir::pto::kValue3) {
     // Legacy wire order: src, fp, dst.
-    llvm::SmallVector<mlir::Value, 3> reordered{operands[0], operands[2],
+    llvm::SmallVector<mlir::Value, mlir::pto::kValue3> reordered{operands[0], operands[2],
                                                 operands[1]};
     operands.assign(reordered.begin(), reordered.end());
   }
 }
 
-static std::optional<llvm::SmallVector<int32_t, 6>>
+static std::optional<llvm::SmallVector<int32_t, mlir::pto::kValue6>>
 getUnifiedOperandSegments(uint16_t opcode,
                           llvm::ArrayRef<mlir::Value> operands) {
   switch (opcode) {
   case kTExtractOpcode:
-    return llvm::SmallVector<int32_t, 6>{1, 1, 1, 1, 0, 0};
+    return llvm::SmallVector<int32_t, mlir::pto::kValue6>{1, 1, 1, 1, 0, 0};
   case kTExtractFpWireOpcode:
-    return llvm::SmallVector<int32_t, 6>{1, 1, 1, 1, 1, 0};
+    return llvm::SmallVector<int32_t, mlir::pto::kValue6>{1, 1, 1, 1, 1, 0};
   case kTInsertOpcode:
-    return llvm::SmallVector<int32_t, 6>{1, 1, 1, 1, 0, 0};
+    return llvm::SmallVector<int32_t, mlir::pto::kValue6>{1, 1, 1, 1, 0, 0};
   case kTInsertFpWireOpcode:
-    return llvm::SmallVector<int32_t, 6>{1, 1, 1, 1, 1, 0};
+    return llvm::SmallVector<int32_t, mlir::pto::kValue6>{1, 1, 1, 1, 1, 0};
   case kTMovOpcode:
-    return llvm::SmallVector<int32_t, 6>{1, 1, 0, 0};
+    return llvm::SmallVector<int32_t, mlir::pto::kValue6>{1, 1, 0, 0};
   case kTMovFpWireOpcode:
-    return llvm::SmallVector<int32_t, 6>{1, 1, 1, 0};
+    return llvm::SmallVector<int32_t, mlir::pto::kValue6>{1, 1, 1, 0};
   case kTStoreOpcode:
-    if (operands.size() == 2)
-      return llvm::SmallVector<int32_t, 6>{1, 1, 0, 0};
-    if (operands.size() == 3) {
+    if (operands.size() == mlir::pto::kValue2) {
+      return llvm::SmallVector<int32_t, mlir::pto::kValue6>{1, 1, 0, 0};
+    }
+    if (operands.size() == mlir::pto::kValue3) {
       const bool thirdIsFp =
           mlir::isa<mlir::pto::TileBufType>(operands.back().getType());
-      return llvm::SmallVector<int32_t, 6>{1, 1, thirdIsFp ? 1 : 0,
+      return llvm::SmallVector<int32_t, mlir::pto::kValue6>{1, 1, thirdIsFp ? 1 : 0,
                                            thirdIsFp ? 0 : 1};
     }
     return std::nullopt;
   case kTStoreFpWireOpcode:
-    return llvm::SmallVector<int32_t, 6>{1, 1, 1, 0};
+    return llvm::SmallVector<int32_t, mlir::pto::kValue6>{1, 1, 1, 0};
   default:
     return std::nullopt;
   }
@@ -606,8 +660,9 @@ static mlir::Operation *buildGenericOpFromReader(BuildCtx &bc, Reader &r,
                                                  uint64_t opId,
                                                  uint64_t attrId) {
   uint64_t nameSid = r.readULEB();
-  if (nameSid >= bc.strings->size())
+  if (nameSid >= bc.strings->size()) {
     throw std::runtime_error("bad op_name sid");
+  }
   std::string opName = (*bc.strings)[nameSid];
 
   uint64_t nres = r.readULEB();
@@ -628,15 +683,17 @@ static mlir::Operation *buildGenericOpFromReader(BuildCtx &bc, Reader &r,
   state.addOperands(operands);
   state.addTypes(resultTypes);
   addAttrDictionary(state, getAttrDict(bc, attrId));
-  for (uint64_t i = 0; i < nreg; ++i)
+  for (uint64_t i = 0; i < nreg; ++i) {
     (void)state.addRegion();
+  }
 
   mlir::Operation *op = mlir::Operation::create(state);
   block.getOperations().push_back(op);
   registerDecodedOp(bc, opId, op);
   assignDecodedResults(bc, resStart, op, nres);
-  for (uint64_t i = 0; i < nreg; ++i)
+  for (uint64_t i = 0; i < nreg; ++i) {
     buildRegionInto(bc, r, op->getRegion(i));
+  }
   return op;
 }
 
@@ -671,8 +728,9 @@ static mlir::Operation *buildKnownOpFromReader(BuildCtx &bc, Reader &r,
                                                uint16_t opcode,
                                                uint64_t attrId) {
   const auto *info = ptobc::v0::lookupByOpcode(opcode);
-  if (!info)
+  if (!info) {
     throw std::runtime_error("missing opcode schema");
+  }
 
   uint8_t variant = info->has_variant_u8 ? r.readU8() : 0;
   KnownOpImmediates imms = readKnownOpImmediates(r, *info);
@@ -685,31 +743,36 @@ static mlir::Operation *buildKnownOpFromReader(BuildCtx &bc, Reader &r,
   switch (info->result_type_mode) {
   case 0x00:
     resultTypes.reserve(numResults);
-    for (uint64_t i = 0; i < numResults; ++i)
+    for (uint64_t i = 0; i < numResults; ++i) {
       resultTypes.push_back(mlir::NoneType::get(bc.ctx));
+    }
     break;
   case 0x01:
     resultTypes.reserve(numResults);
-    for (uint64_t i = 0; i < numResults; ++i)
+    for (uint64_t i = 0; i < numResults; ++i) {
       resultTypes.push_back(getType(bc, r.readULEB()));
+    }
     break;
   case 0x02:
     numResults = r.readULEB();
     resultTypes.reserve(numResults);
-    for (uint64_t i = 0; i < numResults; ++i)
+    for (uint64_t i = 0; i < numResults; ++i) {
       resultTypes.push_back(getType(bc, r.readULEB()));
+    }
     break;
   default:
     throw std::runtime_error("unknown result_type_mode");
   }
 
   const size_t resStart = bc.values.size();
-  for (uint64_t i = 0; i < numResults; ++i)
+  for (uint64_t i = 0; i < numResults; ++i) {
     bc.values.push_back(mlir::Value());
+  }
 
   const char *opNameC = ptobc::v0::fullNameFromOpcodeVariant(opcode, variant);
-  if (!opNameC)
+  if (!opNameC) {
     throw std::runtime_error("failed to map opcode->name");
+  }
 
   mlir::OperationState state(mlir::UnknownLoc::get(bc.ctx), opNameC);
   state.addOperands(operands);
@@ -717,30 +780,37 @@ static mlir::Operation *buildKnownOpFromReader(BuildCtx &bc, Reader &r,
   addAttrDictionary(state, getAttrDict(bc, attrId));
   auto unifiedOperandSegments = getUnifiedOperandSegments(opcode, operands);
   addImmediateAttrs(bc, state, *info, imms);
-  for (unsigned i = 0; i < info->num_regions; ++i)
+  for (unsigned i = 0; i < info->num_regions; ++i) {
     (void)state.addRegion();
+  }
 
   mlir::Operation *op = mlir::Operation::create(state);
   // In MLIR 21, AttrSizedOperandSegments is stored as an inherent property.
   // OperationState's generic attribute list does not initialize it, so update
   // the generated property storage directly after creating the registered op.
-  if (unifiedOperandSegments)
+  if (unifiedOperandSegments) {
     setUnifiedOperandSegmentProperty(op, opcode, *unifiedOperandSegments);
+  }
   block.getOperations().push_back(op);
   registerDecodedOp(bc, opId, op);
   assignDecodedResults(bc, resStart, op, numResults);
-  for (unsigned i = 0; i < info->num_regions; ++i)
+  for (unsigned i = 0; i < info->num_regions; ++i) {
     buildRegionInto(bc, r, op->getRegion(i));
+  }
   return op;
 }
 
 static void buildOpList(BuildCtx& bc, Reader& r, mlir::Block& block) {
   const bool dbg = debugEnabled();
   uint64_t opcnt = r.readULEB();
-  if (dbg) llvm::errs() << "[ptobc]   ops=" << opcnt << "\n";
+  if (dbg) {
+    llvm::errs() << "[ptobc]   ops=" << opcnt << "\n";
+  }
 
   for (uint64_t oi = 0; oi < opcnt; ++oi) {
-    if (dbg) llvm::errs() << "[ptobc]    op[" << oi << "]...\n";
+    if (dbg) {
+      llvm::errs() << "[ptobc]    op[" << oi << "]...\n";
+    }
     const uint64_t opId = bc.nextOpId ? (*bc.nextOpId)++ : 0;
 
     uint16_t opcode = r.readU16LE();
@@ -757,15 +827,21 @@ static void buildOpList(BuildCtx& bc, Reader& r, mlir::Block& block) {
 static void buildRegionInto(BuildCtx& bc, Reader& r, mlir::Region& region) {
   const bool dbg = debugEnabled();
   uint64_t bcnt = r.readULEB();
-  if (dbg) llvm::errs() << "[ptobc] region: blocks=" << bcnt << "\n";
+  if (dbg) {
+    llvm::errs() << "[ptobc] region: blocks=" << bcnt << "\n";
+  }
   region.getBlocks().clear();
 
   for (uint64_t bi = 0; bi < bcnt; ++bi) {
-    if (dbg) llvm::errs() << "[ptobc]  block[" << bi << "]...\n";
+    if (dbg) {
+      llvm::errs() << "[ptobc]  block[" << bi << "]...\n";
+    }
     auto* block = new mlir::Block();
 
     uint64_t nargs = r.readULEB();
-    if (dbg) llvm::errs() << "[ptobc]   nargs=" << nargs << "\n";
+    if (dbg) {
+      llvm::errs() << "[ptobc]   nargs=" << nargs << "\n";
+    }
     for (uint64_t ai = 0; ai < nargs; ++ai) {
       uint64_t tid = r.readULEB();
       auto ty = getType(bc, tid);
@@ -799,16 +875,18 @@ static uint64_t readModuleHeader(Reader &r, bool dbg) {
     llvm::errs() << "[ptobc] module: moduleAttrId=" << moduleAttrId
                  << " globals=" << globalCount << "\n";
   }
-  if (globalCount != 0)
+  if (globalCount != 0) {
     throw std::runtime_error("globals not supported");
+  }
   return moduleAttrId;
 }
 
 static std::vector<FuncDecl> readFunctionDecls(BuildCtx &bc, Reader &r,
                                                bool dbg) {
   uint64_t funcCount = r.readULEB();
-  if (dbg)
+  if (dbg) {
     llvm::errs() << "[ptobc] module: funcs=" << funcCount << "\n";
+  }
 
   std::vector<FuncDecl> decls;
   decls.reserve(funcCount);
@@ -817,10 +895,12 @@ static std::vector<FuncDecl> readFunctionDecls(BuildCtx &bc, Reader &r,
     uint64_t ftypeId = r.readULEB();
     uint8_t flags = r.readU8();
     uint64_t fattrId = r.readULEB();
-    if (nameSid >= bc.strings->size())
+    if (nameSid >= bc.strings->size()) {
       throw std::runtime_error("bad func name sid");
-    if (ftypeId >= bc.types->size())
+    }
+    if (ftypeId >= bc.types->size()) {
       throw std::runtime_error("bad func type id");
+    }
 
     if (dbg) {
       llvm::errs() << "[ptobc] func[" << i << "]: nameSid=" << nameSid
@@ -830,8 +910,9 @@ static std::vector<FuncDecl> readFunctionDecls(BuildCtx &bc, Reader &r,
 
     auto type = parseType(*bc.ctx, bc.types->at(ftypeId).asmStr);
     auto funcType = mlir::dyn_cast<mlir::FunctionType>(type);
-    if (!funcType)
+    if (!funcType) {
       throw std::runtime_error("func type parse failed");
+    }
     decls.push_back(
         {bc.strings->at(nameSid), funcType, getAttrDict(bc, fattrId), flags});
   }
@@ -839,16 +920,18 @@ static std::vector<FuncDecl> readFunctionDecls(BuildCtx &bc, Reader &r,
 }
 
 static void applyAttrDictionary(mlir::Operation *op, mlir::DictionaryAttr dict) {
-  for (auto attr : dict)
+  for (auto attr : dict) {
     op->setAttr(attr.getName(), attr.getValue());
+  }
 }
 
 static void buildFunctionBody(BuildCtx &bc, Reader &r, mlir::func::FuncOp fn,
                               uint8_t flags, bool dbg,
                               std::vector<std::vector<mlir::Operation *>> *opsByFuncOut) {
   if ((flags & 0x1) != 0) {
-    if (opsByFuncOut)
+    if (opsByFuncOut) {
       opsByFuncOut->push_back({});
+    }
     return;
   }
 
@@ -862,8 +945,9 @@ static void buildFunctionBody(BuildCtx &bc, Reader &r, mlir::func::FuncOp fn,
     llvm::errs() << "[ptobc] func body built ok: values=" << bc.values.size()
                  << " ops=" << opsById.size() << "\n";
   }
-  if (opsByFuncOut)
+  if (opsByFuncOut) {
     opsByFuncOut->push_back(std::move(opsById));
+  }
 }
 
 static mlir::ModuleOp decodeToModule(mlir::MLIRContext& ctx,
@@ -886,17 +970,22 @@ static mlir::ModuleOp decodeToModule(mlir::MLIRContext& ctx,
   applyAttrDictionary(module.getOperation(), getAttrDict(bc, moduleAttrId));
 
   for (const auto &decl : decls) {
-    if (dbg)
+    if (dbg) {
       llvm::errs() << "[ptobc] building func body: " << decl.name << "\n";
+    }
     auto fn = mlir::func::FuncOp::create(mlir::UnknownLoc::get(&ctx), decl.name,
                                          decl.type);
-    if (dbg) llvm::errs() << "[ptobc] created func op\n";
+    if (dbg) {
+      llvm::errs() << "[ptobc] created func op\n";
+    }
     applyAttrDictionary(fn, decl.attrs);
     buildFunctionBody(bc, r, fn, decl.flags, dbg, opsByFuncOut);
     module.push_back(fn);
   }
 
-  if (r.p != r.end) throw std::runtime_error("trailing bytes in MODULE");
+  if (r.p != r.end) {
+    throw std::runtime_error("trailing bytes in MODULE");
+  }
   return module;
 }
 
@@ -904,9 +993,10 @@ static std::pair<uint8_t, std::vector<uint8_t>> readSection(Reader &r, bool dbg)
   uint8_t sid = r.readU8();
   uint32_t sectionLen = r.readU32LE();
   auto bytes = r.readBytes(sectionLen);
-  if (dbg)
+  if (dbg) {
     llvm::errs() << "[ptobc] section id=" << unsigned(sid)
                  << " len=" << sectionLen << "\n";
+  }
   return {sid, bytes};
 }
 
@@ -915,17 +1005,21 @@ static void applyDebugLocations(mlir::MLIRContext &ctx,
                                 const DebugInfo &dbgInfo,
                                 const std::vector<std::vector<mlir::Operation *>> &opsByFunc) {
   for (const auto &location : dbgInfo.locations) {
-    if (location.funcId >= opsByFunc.size())
+    if (location.funcId >= opsByFunc.size()) {
       continue;
+    }
     const auto &ops = opsByFunc[location.funcId];
-    if (location.opId >= ops.size())
+    if (location.opId >= ops.size()) {
       continue;
+    }
     mlir::Operation *op = ops[location.opId];
-    if (!op || location.fileId >= dbgInfo.files.size())
+    if (!op || location.fileId >= dbgInfo.files.size()) {
       continue;
+    }
     const auto &file = dbgInfo.files[location.fileId];
-    if (file.pathSid >= strings.size())
+    if (file.pathSid >= strings.size()) {
       continue;
+    }
     op->setLoc(mlir::FileLineColLoc::get(&ctx, strings[file.pathSid],
                                          unsigned(location.sl),
                                          unsigned(location.sc)));
@@ -935,21 +1029,26 @@ static void applyDebugLocations(mlir::MLIRContext &ctx,
 mlir::OwningOpRef<mlir::ModuleOp>
 decodePTOBCToModule(llvm::ArrayRef<uint8_t> fileBytes, mlir::MLIRContext &ctx) {
   const bool dbg = debugEnabled();
-  if (fileBytes.size() < kPTOBCHeaderSize)
+  if (fileBytes.size() < kPTOBCHeaderSize) {
     throw std::runtime_error("file too small");
-  if (std::memcmp(fileBytes.data(), kPTOBCMagic, kPTOBCMagicSize) != 0)
+  }
+  if (std::memcmp(fileBytes.data(), kPTOBCMagic, kPTOBCMagicSize) != 0) {
     throw std::runtime_error("bad magic");
+  }
 
   Reader versionReader{fileBytes.data() + kPTOBCVersionOffset,
                        fileBytes.data() + fileBytes.size()};
   uint16_t ver = versionReader.readU16LE();
-  if (ver != kVersionV0) throw std::runtime_error("unsupported version");
+  if (ver != kVersionV0) {
+    throw std::runtime_error("unsupported version");
+  }
 
   Reader payloadLengthReader{fileBytes.data() + kPTOBCPayloadLengthOffset,
                              fileBytes.data() + fileBytes.size()};
   uint32_t payloadLen = payloadLengthReader.readU32LE();
-  if (payloadLen != fileBytes.size() - kPTOBCHeaderSize)
+  if (payloadLen != fileBytes.size() - kPTOBCHeaderSize) {
     throw std::runtime_error("payload_len mismatch");
+  }
 
   Reader r{fileBytes.data() + kPTOBCHeaderSize,
            fileBytes.data() + fileBytes.size()};
@@ -964,7 +1063,9 @@ decodePTOBCToModule(llvm::ArrayRef<uint8_t> fileBytes, mlir::MLIRContext &ctx) {
   while (r.p != r.end) {
     auto [sid, sec] = readSection(r, dbg);
     if (sid == kSectionDebugInfo) {
-      if (dbgInfo) throw std::runtime_error("duplicate DEBUGINFO section");
+      if (dbgInfo) {
+        throw std::runtime_error("duplicate DEBUGINFO section");
+      }
       dbgInfo = parseDebugInfoSection(sec);
     } else if (sid == kSectionExtra) {
       // Ignore EXTRA payload for now.
@@ -996,21 +1097,26 @@ decodePTOBCToModule(llvm::ArrayRef<uint8_t> fileBytes, mlir::MLIRContext &ctx) {
   (void)ctx.getOrLoadDialect<mlir::scf::SCFDialect>();
   (void)ctx.getOrLoadDialect<mlir::pto::PTODialect>();
 
-  if (dbg) llvm::errs() << "[ptobc] decoding module...\n";
+  if (dbg) {
+    llvm::errs() << "[ptobc] decoding module...\n";
+  }
 
   std::vector<std::vector<mlir::Operation*>> opsByFunc;
   auto module = decodeToModule(ctx, strings, types, attrs, d4, d6, dbgInfo ? &opsByFunc : nullptr);
 
   // Apply op locations from DEBUGINFO (best-effort).
-  if (dbgInfo)
+  if (dbgInfo) {
     applyDebugLocations(ctx, strings, *dbgInfo, opsByFunc);
+  }
 
   return module;
 }
 
 void decodeFileToPTO(const std::string& inPath, const std::string& outPath) {
   const bool dbg = debugEnabled();
-  if (dbg) llvm::errs() << "[ptobc] decode: reading file: " << inPath << "\n";
+  if (dbg) {
+    llvm::errs() << "[ptobc] decode: reading file: " << inPath << "\n";
+  }
   auto data = readFile(inPath);
 
   mlir::DialectRegistry registry;
@@ -1025,7 +1131,9 @@ void decodeFileToPTO(const std::string& inPath, const std::string& outPath) {
 
   auto module = decodePTOBCToModule(data, ctx);
 
-  if (dbg) llvm::errs() << "[ptobc] decoded module ok; printing...\n";
+  if (dbg) {
+    llvm::errs() << "[ptobc] decoded module ok; printing...\n";
+  }
 
   CanonicalPrintOptions opt;
   opt.generic = (std::getenv("PTOBC_PRINT_GENERIC") != nullptr);
@@ -1034,10 +1142,14 @@ void decodeFileToPTO(const std::string& inPath, const std::string& outPath) {
 
   std::string out = printModuleCanonical(module.get(), opt);
 
-  if (dbg) llvm::errs() << "[ptobc] writing output: " << outPath << "\n";
+  if (dbg) {
+    llvm::errs() << "[ptobc] writing output: " << outPath << "\n";
+  }
   std::ofstream ofs(outPath);
   ofs << out;
-  if (!out.empty() && out.back() != '\n') ofs << "\n";
+  if (!out.empty() && out.back() != '\n') {
+    ofs << "\n";
+  }
 }
 
 } // namespace ptobc

--- a/tools/ptobc/src/ptobc_format.cpp
+++ b/tools/ptobc/src/ptobc_format.cpp
@@ -52,7 +52,9 @@ void Buffer::appendU32LE(uint32_t v) {
 
 uint64_t StringTable::intern(const std::string& s) {
   auto it = toId.find(s);
-  if (it != toId.end()) return it->second;
+  if (it != toId.end()) {
+    return it->second;
+  }
   uint64_t id = fromId.size();
   fromId.push_back(s);
   toId.emplace(s, id);
@@ -63,7 +65,9 @@ static std::vector<uint8_t> buildSection(uint8_t id, const std::vector<uint8_t>&
   Buffer b;
   b.appendU8(id);
   b.appendU32LE(uint32_t(data.size()));
-  if (!data.empty()) b.append(data.data(), data.size());
+  if (!data.empty()) {
+    b.append(data.data(), data.size());
+  }
   return std::move(b.bytes);
 }
 
@@ -108,7 +112,9 @@ std::vector<uint8_t> PTOBCFile::buildConstPoolSection() const {
   writeULEB128(consts.size(), b.bytes);
   for (const auto &c : consts) {
     b.appendU8(c.tag);
-    if (!c.payload.empty()) b.append(c.payload.data(), c.payload.size());
+    if (!c.payload.empty()) {
+      b.append(c.payload.data(), c.payload.size());
+    }
   }
   return b.bytes;
 }
@@ -123,7 +129,9 @@ std::vector<uint8_t> PTOBCFile::buildDebugInfoSection() const {
     b.appendU8(f.hashKind);
     if (f.hashKind != 0) {
       writeULEB128(f.hashBytes.size(), b.bytes);
-      if (!f.hashBytes.empty()) b.append(f.hashBytes.data(), f.hashBytes.size());
+      if (!f.hashBytes.empty()) {
+        b.append(f.hashBytes.data(), f.hashBytes.size());
+      }
     }
   }
 
@@ -197,14 +205,18 @@ std::vector<uint8_t> PTOBCFile::serialize() const {
 
 std::vector<uint8_t> readFile(const std::string& path) {
   std::ifstream ifs(path, std::ios::binary);
-  if (!ifs) throw std::runtime_error("Failed to open: " + path);
+  if (!ifs) {
+    throw std::runtime_error("Failed to open: " + path);
+  }
   std::vector<uint8_t> buf((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
   return buf;
 }
 
 void writeFile(const std::string& path, const std::vector<uint8_t>& data) {
   std::ofstream ofs(path, std::ios::binary);
-  if (!ofs) throw std::runtime_error("Failed to write: " + path);
+  if (!ofs) {
+    throw std::runtime_error("Failed to write: " + path);
+  }
   ofs.write(reinterpret_cast<const char*>(data.data()), data.size());
 }
 


### PR DESCRIPTION
## Summary

- Apply the `codecheck.md` C/C++ rules to production sources only.
- Address G.CNS.02, G.FMT.11-CPP, G.FMT.17-CPP, G.CMT.04-CPP, G.INC.07-CPP, and confirmed G.INC.12-CPP cases.
- Add typed shared constants for repeated numeric literals and retain the required lambda capture fixes.

## Validation

- On 144: `ninja -C build-sim PTOASCompiler` completed and linked `libPTOASCompiler.so`.
- On 144: the existing `predicate_pack.py` simulator run had previously passed all cases in this checkout; a final rerun was blocked before test execution by the isolated checkout's missing `ptoas/mlir/ir.py` Python binding module.
- Local compilation and tests were intentionally not run.
- `example` and `test` sources were excluded.
