### PR TITLE
[VMI perf issue]  BF16 widen multiply slower than CCE for certain shapes

### DIFF
--- a/docs/repro/bf16_widen_multiply/.gitignore
+++ b/docs/repro/bf16_widen_multiply/.gitignore
@@ -1,0 +1,2 @@
+outputs/
+__pycache__/

--- a/docs/repro/bf16_widen_multiply/BUG_REPORT.md
+++ b/docs/repro/bf16_widen_multiply/BUG_REPORT.md
@@ -1,0 +1,5 @@
+# PTOAS bug report: BF16 widen and multiply
+
+The VMI lowering of contiguous BF16-to-FP32 conversion followed by FP32 multiply is 4.8-8.5% slower than an equivalent direct CCE implementation on the larger measured workloads. The included CCE and PTODSL sources are self-contained and use the same grid, tiled data movement, launch ABI, and correctness oracle.
+
+Please improve VMI lowering or scheduling so this operation reaches `CCE/VMI >= 0.98`.

--- a/docs/repro/bf16_widen_multiply/README.md
+++ b/docs/repro/bf16_widen_multiply/README.md
@@ -1,0 +1,32 @@
+# VMI performance issue: BF16 widen and multiply
+
+This standalone reproducer compares direct CCE and PTODSL implementations of one vector operation. Both paths use BF16 inputs, an FP32 output, 64-lane vector chunks, and the same 64-core direct grid.
+
+```text
+fp32_out[i] = float(bf16_a[i]) * float(bf16_b[i])
+```
+
+The CCE source is [`bf16_widen_multiply_cce.asc`](fixtures/bf16_widen_multiply_cce.asc). The VMI source is [`bf16_widen_multiply_vmi.py`](fixtures/bf16_widen_multiply_vmi.py) and imports only `ptodsl.pto`. `benchmark.py` compiles, links, launches, checks both outputs against `float(a) * float(b)`, and event-times the same ctypes stream ABI.
+
+## Reproduce
+
+Use CANN `9.1.0-beta.3` and PTOAS revision `83e3799f`.
+
+```bash
+source /path/to/cann/set_env.sh
+ACL_DEVICE_ID=0 bash check.sh compile
+ACL_DEVICE_ID=0 bash check.sh benchmark
+```
+
+## Observed result
+
+Production measurements for the same primitive were:
+
+| Elements | Direct CCE us | VMI us | CCE/VMI |
+|---:|---:|---:|---:|
+| 8192 | 1.421 | 1.423 | 0.999 |
+| 28672 | 1.488 | 1.455 | 1.023 |
+| 131072 | 1.835 | 2.007 | 0.915 |
+| 262144 | 2.101 | 2.207 | 0.952 |
+
+The requested target is `CCE/VMI >= 0.98` for the larger contiguous cases.

--- a/docs/repro/bf16_widen_multiply/benchmark.py
+++ b/docs/repro/bf16_widen_multiply/benchmark.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Build, launch, validate, and time direct CCE and PTODSL VMI kernels."""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import torch
+import torch_npu  # noqa: F401
+
+HERE = Path(__file__).parent
+OUT = HERE / "outputs"
+ELEMENTS = 131072
+ELEMENTS_PER_CORE = 2048
+GRID = ELEMENTS // ELEMENTS_PER_CORE
+UB_BYTES = ELEMENTS_PER_CORE * 8
+DEVICE = f"npu:{os.environ.get('ACL_DEVICE_ID', '0')}"
+WARMUP, SAMPLES = 8, 30
+
+
+def command(argv: list[str]) -> None:
+    subprocess.run(argv, check=True)
+
+
+def bisheng() -> str:
+    return os.environ.get("BISHENG", f"{os.environ['ASCEND_HOME_PATH']}/bin/bisheng")
+
+
+def includes() -> list[str]:
+    root = os.environ["ASCEND_HOME_PATH"]
+    return ["-I" + str(HERE / "fixtures"), "-I" + root + "/include", "-I" + root + "/aarch64-linux/tikcpp/tikcfw", "-I" + root + "/aarch64-linux/tikcpp/tikcfw/impl", "-I" + root + "/aarch64-linux/tikcpp/tikcfw/interface"]
+
+
+def link(objects: list[Path], library: Path) -> Path:
+    root = os.environ["ASCEND_HOME_PATH"]
+    command([bisheng(), "--cce-fatobj-link", "-shared", "-fPIC", *map(str, objects), "-L" + root + "/aarch64-linux/lib64", "-Wl,-rpath," + root + "/aarch64-linux/lib64", "-Wl,--no-as-needed", "-lruntime", "-o", str(library)])
+    return library
+
+
+def build_cce() -> Path:
+    OUT.mkdir(exist_ok=True)
+    body, host = OUT / "cce.o", OUT / "cce_host.o"
+    command([bisheng(), "-O2", "-fPIC", "-std=c++17", "--npu-arch=dav-3510", *includes(), "-c", str(HERE / "fixtures/bf16_widen_multiply_cce.asc"), "-o", str(body)])
+    source = OUT / "cce_host.cpp"
+    source.write_text(f'''#include <stdint.h>
+extern "C" __global__ [aicore] void bf16_widen_multiply_cce(__gm__ uint16_t*, __gm__ uint16_t*, __gm__ float*);
+extern "C" void launch_cce(void* stream, void* a, void* b, void* out) {{
+  bf16_widen_multiply_cce<<<{GRID}, {UB_BYTES}, stream>>>((__gm__ uint16_t*)a, (__gm__ uint16_t*)b, (__gm__ float*)out);
+}}
+''')
+    command([bisheng(), "-xcce", "-Xhost-start", "-Xhost-end", "-fPIC", "-O2", "-std=c++17", "--cce-aicore-arch=dav-c310", "-c", str(source), "-o", str(host)])
+    return link([body, host], OUT / "libbf16_cce.so")
+
+
+def build_vmi() -> Path:
+    OUT.mkdir(exist_ok=True)
+    if "PTOAS_BIN" not in os.environ:
+        candidates = [Path(sys.executable).parent / "ptoas", Path(os.environ.get("CONDA_PREFIX", "")) / "bin/ptoas"]
+        candidate = next((path for path in candidates if path.is_file()), None)
+        os.environ["PTOAS_BIN"] = str(candidate) if candidate else (shutil.which("ptoas") or "")
+    if not os.environ["PTOAS_BIN"]:
+        raise RuntimeError("ptoas is not on PATH; set PTOAS_BIN to the pinned PTOAS executable")
+    sys.path.insert(0, str(HERE.parents[2] / "ptodsl"))
+    import ptoas
+    import site
+    for base in site.getsitepackages():
+        bindings = str(Path(base) / "ptoas")
+        if bindings not in ptoas.__path__: ptoas.__path__.append(bindings)
+    from ptodsl._runtime.native_build import _compile_launch_cpp, _link_shared_library, _run_ptoas
+    source = HERE / "fixtures/bf16_widen_multiply_vmi.py"
+    loader = SourceFileLoader("bf16_widen_multiply_vmi", str(source))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec); loader.exec_module(module)
+    mlir = OUT / "vmi.mlir"; mlir.write_text(module.bf16_widen_multiply_vmi.compile().mlir_text())
+    body, host = OUT / "vmi.o", OUT / "vmi_host.o"
+    _run_ptoas(mlir, body, target_arch="a5", backend="vpto", pto_level="level3")
+    host_source = OUT / "vmi_host.cpp"
+    host_source.write_text(f'''#include <stdint.h>
+extern "C" __global__ [aicore] void bf16_widen_multiply_vmi(__gm__ uint16_t*, __gm__ uint16_t*, __gm__ float*);
+extern "C" void launch_vmi(void* stream, void* a, void* b, void* out) {{
+  bf16_widen_multiply_vmi<<<{GRID}, {UB_BYTES}, stream>>>((__gm__ uint16_t*)a, (__gm__ uint16_t*)b, (__gm__ float*)out);
+}}
+''')
+    _compile_launch_cpp(host_source, host, kernel_kind="vector", target_arch="a5", export_macro="BF16_VMI_EXPORTS")
+    _link_shared_library(host, body, OUT / "libbf16_vmi.so", kernel_kind="vector")
+    return OUT / "libbf16_vmi.so"
+
+
+def stream_ptr() -> int:
+    return int(torch_npu._C._npu_getCurrentRawStream(torch.npu.current_device()))
+
+
+def median_us(fn) -> float:
+    for _ in range(WARMUP): fn()
+    torch.npu.synchronize(); samples = []
+    for _ in range(SAMPLES):
+        start, end = torch.npu.Event(enable_timing=True), torch.npu.Event(enable_timing=True)
+        start.record(); fn(); end.record(); samples.append((start, end))
+    torch.npu.synchronize()
+    return sorted(start.elapsed_time(end) * 1000.0 for start, end in samples)[len(samples) // 2]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(); parser.add_argument("--compile-only", action="store_true")
+    args = parser.parse_args()
+    if args.compile_only:
+        build_cce(); build_vmi(); print("PASS: direct CCE and standalone PTODSL VMI libraries built"); return
+    torch.npu.set_device(DEVICE)
+    cce, vmi = ctypes.CDLL(str(build_cce())), ctypes.CDLL(str(build_vmi()))
+    for fn in (cce.launch_cce, vmi.launch_vmi): fn.argtypes = [ctypes.c_void_p] * 4
+    a = torch.randn(ELEMENTS, dtype=torch.bfloat16, device=DEVICE); b = torch.randn_like(a)
+    cce_out = torch.empty(ELEMENTS, dtype=torch.float32, device=DEVICE); vmi_out = torch.empty_like(cce_out)
+    def cce_run(): cce.launch_cce(ctypes.c_void_p(stream_ptr()), ctypes.c_void_p(a.data_ptr()), ctypes.c_void_p(b.data_ptr()), ctypes.c_void_p(cce_out.data_ptr()))
+    def vmi_run(): vmi.launch_vmi(ctypes.c_void_p(stream_ptr()), ctypes.c_void_p(a.data_ptr()), ctypes.c_void_p(b.data_ptr()), ctypes.c_void_p(vmi_out.data_ptr()))
+    cce_run(); vmi_run(); torch.npu.synchronize()
+    reference = a.float() * b.float()
+    torch.testing.assert_close(cce_out, reference, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(vmi_out, reference, rtol=1e-3, atol=1e-3)
+    cce_us, vmi_us = median_us(cce_run), median_us(vmi_run)
+    print(f"correctness=PASS elements={ELEMENTS} grid={GRID} CCE_us={cce_us:.3f} VMI_us={vmi_us:.3f} CCE_over_VMI={cce_us / vmi_us:.4f}")
+
+
+if __name__ == "__main__": main()

--- a/docs/repro/bf16_widen_multiply/check.sh
+++ b/docs/repro/bf16_widen_multiply/check.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; MODE="${1:-all}"
+if [[ -n "${CANN_ENV:-}" ]]; then source "$CANN_ENV"; elif [[ -z "${ASCEND_HOME_PATH:-}" ]]; then echo "set CANN_ENV or source the CANN environment" >&2; exit 2; fi
+PYTHON_BIN="${PYTHON_BIN:-$(command -v python)}"
+compile() { "$PYTHON_BIN" "$HERE/benchmark.py" --compile-only; rg -q 'pto\.vmi\.vcvt' "$HERE/outputs/vmi.mlir"; echo "PASS: direct CCE and PTODSL VMI sources compile"; }
+run() { if [[ -n "${ACL_DEVICE_ID:-}" ]]; then task-submit --device "$ACL_DEVICE_ID" --run "source '${CANN_ENV:-${ASCEND_HOME_PATH}/set_env.sh}'; ACL_DEVICE_ID=$ACL_DEVICE_ID '$PYTHON_BIN' '$HERE/benchmark.py'"; else "$PYTHON_BIN" "$HERE/benchmark.py"; fi; }
+case "$MODE" in compile) compile;; correctness|benchmark) run;; all) compile; run;; *) echo "usage: $0 [all|compile|correctness|benchmark]" >&2; exit 2;; esac

--- a/docs/repro/bf16_widen_multiply/fixtures/a5_runtime.hpp
+++ b/docs/repro/bf16_widen_multiply/fixtures/a5_runtime.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <stdio.h>
+#include "acl/acl.h"
+#include "kernel_operator.h"
+#include "simt_api/asc_bf16.h"
+#include "simt_api/asc_fp16.h"
+#include "simt_api/asc_fp8.h"
+#include "simt_api/asc_simt.h"
+
+using fp8_e4_t = float8_e4m3_t;
+// Keep this distinct spelling so the small wrapper header can retain the
+// compiler's native float8_e5m2_t specialization without a duplicate.
+struct fp8_e5_t { uint8_t bits; };
+using fp8_e8_t = uint8_t;

--- a/docs/repro/bf16_widen_multiply/fixtures/a5_simd.hpp
+++ b/docs/repro/bf16_widen_multiply/fixtures/a5_simd.hpp
@@ -1,0 +1,714 @@
+#pragma once
+
+#include "kernel_operator.h"
+#include "simt_api/asc_fp8.h"
+
+namespace simd_inst {
+template <typename T> struct vec {};
+
+template <> struct vec<float> {
+  using type = vector_f32;
+};
+template <> struct vec<half> {
+  using type = vector_f16;
+};
+
+#if (__NPU_ARCH__ == 3510)
+template <> struct vec<bfloat16_t> {
+  using type = vector_bf16;
+};
+template <> struct vec<fp8_e4_t> {
+  using type = vector_f8e4m3;
+};
+// template <> struct vec<float8_e4m3_t> {
+//   using type = vector_f8e4m3;
+// };
+template <> struct vec<float8_e5m2_t> {
+  using type = vector_f8e5m2;
+};
+template <> struct vec<float8_e8m0_t> {
+  using type = vector_f8e8m0;
+};
+template <> struct vec<float4_e2m1x2_t> {
+  using type = vector_f4e2m1x2;
+};
+template <> struct vec<float4_e1m2x2_t> {
+  using type = vector_f4e1m2x2;
+};
+#endif
+
+template <> struct vec<uint32_t> {
+  using type = vector_u32;
+};
+
+template <> struct vec<uint16_t> {
+  using type = vector_u16;
+};
+
+template <> struct vec<uint8_t> {
+  using type = vector_u8;
+};
+
+template <> struct vec<int32_t> {
+  using type = vector_s32;
+};
+
+template <> struct vec<int16_t> {
+  using type = vector_s16;
+};
+
+template <> struct vec<int8_t> {
+  using type = vector_s8;
+};
+
+template <> struct vec<int64_t> {
+  using type = vector_s64;
+};
+
+template <> struct vec<uint64_t> {
+  using type = vector_u64;
+};
+
+template <typename SrcVec> struct vec_pair {
+  SrcVec v0;
+  SrcVec v1;
+};
+
+template <typename T> using vec_t = typename vec<T>::type;
+
+template <typename SrcVec> struct widen_vec {
+  using type = SrcVec;
+};
+
+template <> struct widen_vec<vector_s8> {
+  using type = vector_s16;
+};
+
+template <> struct widen_vec<vector_u8> {
+  using type = vector_u16;
+};
+
+template <> struct widen_vec<vector_s16> {
+  using type = vector_s32;
+};
+
+template <> struct widen_vec<vector_u16> {
+  using type = vector_u32;
+};
+
+template <typename SrcVec> using widen_vec_t = typename widen_vec<SrcVec>::type;
+
+template <typename T, typename Offset, typename Dist>
+__simd_callee__ inline vec_t<T> vlds(__ubuf__ T *src, Offset offset,
+                                     Dist dist) {
+  vec_t<T> dst;
+  ::vlds(dst, src, offset, dist);
+  return dst;
+}
+
+// Dual-dest memory load (ASC DIST_DINTLV_B16). Prefer ::vld(dst0,dst1,...)
+// which wraps ::vlds on dav-3510; matches asc_loadalign_v2_impl.h.
+template <typename T, typename Dist>
+__simd_callee__ inline vec_pair<vec_t<T>> vld_x2(__ubuf__ T *src, Dist dist) {
+  vec_pair<vec_t<T>> dst;
+  ::vld(dst.v0, dst.v1, src, dist);
+  return dst;
+}
+
+template <typename T, typename Offset, typename Dist>
+__simd_callee__ inline vec_pair<vec_t<T>> vld_x2(__ubuf__ T *src, Offset offset,
+                                                 Dist dist) {
+  vec_pair<vec_t<T>> dst;
+  ::vld(dst.v0, dst.v1, src, offset, dist);
+  return dst;
+}
+
+template <typename T>
+__simd_callee__ inline vec_t<T> vgatherb(__ubuf__ T *base, vector_u32 idx) {
+  vec_t<T> dst;
+  ::vgatherb(dst, base, idx);
+  return dst;
+}
+
+template <typename T>
+__simd_callee__ inline vec_t<T> vgatherb(__ubuf__ T *base, vector_u32 idx,
+                                         vector_bool mask) {
+  vec_t<T> dst;
+  ::vgatherb(dst, base, idx, mask);
+  return dst;
+}
+
+template <typename T, typename IdxVec>
+__simd_callee__ inline vec_t<T> vgather2(__ubuf__ T *base, IdxVec idx,
+                                         vector_bool mask) {
+  vec_t<T> dst;
+  ::vgather2(dst, base, idx, mask);
+  return dst;
+}
+
+template <typename IdxVec>
+__simd_callee__ inline widen_vec_t<vec_t<int8_t>>
+vgather2(__ubuf__ int8_t *base, IdxVec idx, vector_bool mask) {
+  widen_vec_t<vec_t<int8_t>> dst;
+  ::vgather2(dst, base, idx, mask);
+  return dst;
+}
+
+template <typename IdxVec>
+__simd_callee__ inline widen_vec_t<vec_t<uint8_t>>
+vgather2(__ubuf__ uint8_t *base, IdxVec idx, vector_bool mask) {
+  widen_vec_t<vec_t<uint8_t>> dst;
+  ::vgather2(dst, base, idx, mask);
+  return dst;
+}
+
+template <typename T, typename IdxVec>
+__simd_callee__ inline void vscatter(vec_t<T> data, __ubuf__ T *base,
+                                     IdxVec idx, vector_bool mask) {
+  ::vscatter(data, base, idx, mask);
+}
+
+__simd_callee__ inline vector_bool pand(vector_bool src_0, vector_bool src_1,
+                                        vector_bool mask) {
+  vector_bool dst;
+  ::pand(dst, src_0, src_1, mask);
+  return dst;
+}
+
+__simd_callee__ inline vector_bool por(vector_bool src_0, vector_bool src_1,
+                                       vector_bool mask) {
+  vector_bool dst;
+  ::por(dst, src_0, src_1, mask);
+  return dst;
+}
+
+__simd_callee__ inline vector_bool pxor(vector_bool src_0, vector_bool src_1,
+                                        vector_bool mask) {
+  vector_bool dst;
+  ::pxor(dst, src_0, src_1, mask);
+  return dst;
+}
+
+__simd_callee__ inline vector_bool pnot(vector_bool src, vector_bool mask) {
+  vector_bool dst;
+  ::pnot(dst, src, mask);
+  return dst;
+}
+
+__simd_callee__ inline vector_bool psel(vector_bool src_0, vector_bool src_1,
+                                        vector_bool mask) {
+  vector_bool dst;
+  ::psel(dst, src_0, src_1, mask);
+  return dst;
+}
+
+// f16→f32, f8→f32, i32→f32: ::vcvt(dst, src, mask, part/round, mode)
+template <typename U, typename SrcVec, typename Part, typename Mode>
+__simd_callee__ inline vec_t<U> vcvt(SrcVec src, vector_bool srcMask, Part part,
+                                     Mode mode) {
+  vec_t<U> dst;
+  ::vcvt(dst, src, srcMask, part, mode);
+  return dst;
+}
+
+// f32→i32: ::vcvt(dst, src, mask, round, rs, mode)
+template <typename U, typename SrcVec, typename RoundMode, typename Rs,
+          typename Mode>
+__simd_callee__ inline vec_t<U> vcvt(SrcVec src, vector_bool srcMask,
+                                     RoundMode roundingMode, Rs rsMode,
+                                     Mode mode) {
+  vec_t<U> dst;
+  ::vcvt(dst, src, srcMask, roundingMode, rsMode, mode);
+  return dst;
+}
+
+// f32→f16, f32→f8, f16→f8: ::vcvt(dst, src, mask, round, rs, part, mode)
+template <typename U, typename SrcVec, typename RoundMode, typename Rs,
+          typename Part, typename Mode>
+__simd_callee__ inline vec_t<U> vcvt(SrcVec src, vector_bool srcMask,
+                                     RoundMode roundingMode, Rs rsMode,
+                                     Part part, Mode mode) {
+  vec_t<U> dst;
+  ::vcvt(dst, src, srcMask, roundingMode, rsMode, part, mode);
+  return dst;
+}
+
+template <typename SrcVec>
+__simd_callee__ inline vec_pair<SrcVec> vdintlv(SrcVec src_0, SrcVec src_1) {
+  vec_pair<SrcVec> dst;
+  ::vdintlv(dst.v0, dst.v1, src_0, src_1);
+  return dst;
+}
+
+template <typename SrcVec>
+__simd_callee__ inline vec_pair<SrcVec> vintlv(SrcVec src_0, SrcVec src_1) {
+  vec_pair<SrcVec> dst;
+  ::vintlv(dst.v0, dst.v1, src_0, src_1);
+  return dst;
+}
+
+// -- Binary arithmetic
+// ----------------------------------------------------------
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vadd(SrcVec src_0, SrcVec src_1, vector_bool mask,
+                                   Mode mode) {
+  SrcVec dst;
+  ::vadd(dst, src_0, src_1, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vsub(SrcVec src_0, SrcVec src_1, vector_bool mask,
+                                   Mode mode) {
+  SrcVec dst;
+  ::vsub(dst, src_0, src_1, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vmul(SrcVec src_0, SrcVec src_1, vector_bool mask,
+                                   Mode mode) {
+  SrcVec dst;
+  ::vmul(dst, src_0, src_1, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline void vmula(SrcVec *dst, SrcVec src_0, SrcVec src_1,
+                                  vector_bool mask, Mode mode) {
+  ::vmula(*dst, src_0, src_1, mask, mode);
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline void vmadd(SrcVec *dst, SrcVec src_0, SrcVec src_1,
+                                  vector_bool mask, Mode mode) {
+  ::vmadd(*dst, src_0, src_1, mask, mode);
+}
+
+template <typename SrcVec, typename ScalarT, typename Mode>
+__simd_callee__ inline void vaxpy(SrcVec *dst, SrcVec src, ScalarT scalar,
+                                  vector_bool mask, Mode mode) {
+  ::vaxpy(*dst, src, scalar, mask, mode);
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vdiv(SrcVec src_0, SrcVec src_1, vector_bool mask,
+                                   Mode mode) {
+  SrcVec dst;
+  ::vdiv(dst, src_0, src_1, mask, mode);
+  return dst;
+}
+
+// ============================================================================
+// Precision division matching Ascend DivPrecisionImpl / torch.npu behavior.
+// This intentionally keeps hardware FTZ/special-value behavior and only applies
+// the 0ULP error-correction core.
+// ============================================================================
+
+// Precision f32 division exposed under the historical vdiv_precise name.
+template <typename Mode>
+__simd_callee__ inline vector_f32 vdiv_precise(vector_f32 src0, vector_f32 src1,
+                                               vector_bool mask, Mode mode) {
+  constexpr uint32_t infNanBound = 0xff800000u;
+  constexpr uint32_t signBitNum = 0x80000000u;
+
+  vector_f32 regNegZero;
+  ::vdup((vector_u32 &)regNegZero, signBitNum, mask, mode);
+
+  vector_f32 z;
+  ::vdiv(z, src0, src1, mask, mode);
+
+  vector_u32 infNan;
+  ::vor(infNan, (vector_u32 &)z, (vector_u32 &)regNegZero, mask, mode);
+
+  vector_f32 tmpDst = z;
+
+  vector_bool zeroCmp;
+  ::vcmps_eq(zeroCmp, z, 0.0f, mask);
+  vector_bool infNanCmp;
+  ::vcmps_ge(infNanCmp, infNan, infNanBound, mask);
+  ::por(infNanCmp, infNanCmp, zeroCmp, mask);
+
+  vector_f32 y;
+  ::vmuls(y, src1, -1.0f, mask, mode);
+  vector_f32 r = src0;
+  ::vmula(r, z, y, mask, mode);
+
+  vector_f32 rPre, rNext, zPre, zNext;
+  ::vadds((vector_s32 &)zPre, (vector_s32 &)z, -1, mask, mode);
+  ::vadds((vector_s32 &)zNext, (vector_s32 &)z, 1, mask, mode);
+
+  rPre = src0;
+  rNext = src0;
+  ::vmula(rPre, zPre, y, mask, mode);
+  ::vmula(rNext, zNext, y, mask, mode);
+
+  ::vabs(r, r, mask, mode);
+  ::vabs(rPre, rPre, mask, mode);
+  ::vabs(rNext, rNext, mask, mode);
+
+  vector_bool cmpMaskReg;
+  ::vcmp_lt(cmpMaskReg, r, rPre, mask);
+  ::vsel(r, r, rPre, cmpMaskReg);
+  ::vsel(z, z, zPre, cmpMaskReg);
+
+  ::vcmp_lt(cmpMaskReg, rNext, r, mask);
+  ::vsel(z, zNext, z, cmpMaskReg);
+
+  vector_f32 dst;
+  ::vsel(dst, tmpDst, z, infNanCmp);
+  return dst;
+}
+
+template <typename Mode>
+__simd_callee__ inline void vdiv_precise(vector_f32 &dst, vector_f32 src0,
+                                         vector_f32 src1, vector_bool mask,
+                                         Mode mode) {
+  (void)mode;
+  // The in-place overload implements MODE_MERGING: update active lanes while
+  // preserving the old destination value for inactive lanes.
+  vector_f32 result = vdiv_precise(src0, src1, mask, MODE_ZEROING);
+  ::vsel(dst, result, dst, mask);
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vmax(SrcVec src_0, SrcVec src_1, vector_bool mask,
+                                   Mode mode) {
+  SrcVec dst;
+  ::vmax(dst, src_0, src_1, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vmin(SrcVec src_0, SrcVec src_1, vector_bool mask,
+                                   Mode mode) {
+  SrcVec dst;
+  ::vmin(dst, src_0, src_1, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vand(SrcVec src_0, SrcVec src_1, vector_bool mask,
+                                   Mode mode) {
+  SrcVec dst;
+  ::vand(dst, src_0, src_1, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vor(SrcVec src_0, SrcVec src_1, vector_bool mask,
+                                  Mode mode) {
+  SrcVec dst;
+  ::vor(dst, src_0, src_1, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vxor(SrcVec src_0, SrcVec src_1, vector_bool mask,
+                                   Mode mode) {
+  SrcVec dst;
+  ::vxor(dst, src_0, src_1, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename ShiftVec, typename Mode>
+__simd_callee__ inline SrcVec vshl(SrcVec src_0, ShiftVec src_1,
+                                   vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vshl(dst, src_0, src_1, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename ShiftVec, typename Mode>
+__simd_callee__ inline SrcVec vshr(SrcVec src_0, ShiftVec src_1,
+                                   vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vshr(dst, src_0, src_1, mask, mode);
+  return dst;
+}
+
+// -- Unary
+// ----------------------------------------------------------------------
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vln(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vln(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vsqrt(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vsqrt(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vabs(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vabs(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vneg(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vneg(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vrelu(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vrelu(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vnot(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vnot(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vexp(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vexp(dst, src, mask, mode);
+  return dst;
+}
+
+// -- Cross-lane reductions
+// ------------------------------------------------------
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vcpadd(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vcpadd(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline widen_vec_t<SrcVec> vcadd(SrcVec src, vector_bool mask,
+                                                 Mode mode) {
+  widen_vec_t<SrcVec> dst;
+  ::vcadd(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vcmax(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vcmax(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vcmin(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vcmin(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vcgadd(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vcgadd(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vcgmax(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vcgmax(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vcgmin(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vcgmin(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vsqz(SrcVec src, vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vsqz(dst, src, mask, mode);
+  return dst;
+}
+
+// -- Index ramp / compare
+// ------------------------------------------------------------
+
+// index ramp: T = int32_t / float / ...; returns dst[lane] = index (+/-) lane
+template <typename T, typename Order>
+__simd_callee__ inline vec_t<T> vci(T index, Order order) {
+  vec_t<T> dst;
+  ::vci(dst, index, order);
+  return dst;
+}
+
+#define __SIMD_INST_VCMP(OP)                                                   \
+  template <typename SrcVec>                                                   \
+  __simd_callee__ inline vector_bool vcmp_##OP(SrcVec src_0, SrcVec src_1,     \
+                                               vector_bool mask) {             \
+    vector_bool dst;                                                           \
+    ::vcmp_##OP(dst, src_0, src_1, mask);                                      \
+    return dst;                                                                \
+  }                                                                            \
+  template <typename SrcVec, typename ScalarT>                                 \
+  __simd_callee__ inline vector_bool vcmps_##OP(SrcVec src, ScalarT scalar,    \
+                                                vector_bool mask) {            \
+    vector_bool dst;                                                           \
+    ::vcmps_##OP(dst, src, scalar, mask);                                      \
+    return dst;                                                                \
+  }
+__SIMD_INST_VCMP(eq)
+__SIMD_INST_VCMP(ne)
+__SIMD_INST_VCMP(gt)
+__SIMD_INST_VCMP(ge)
+__SIMD_INST_VCMP(lt)
+__SIMD_INST_VCMP(le)
+#undef __SIMD_INST_VCMP
+
+// -- Broadcast
+// ------------------------------------------------------------------
+
+// scalar broadcast: T = float / half / int32_t / ...
+template <typename T, typename Mode>
+__simd_callee__ inline vec_t<T> vdup(T src, vector_bool mask, Mode mode) {
+  vec_t<T> dst;
+  ::vdup(dst, src, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename Pos, typename Mode>
+__simd_callee__ inline SrcVec vdupv(SrcVec src, vector_bool mask, Pos pos,
+                                    Mode mode) {
+  SrcVec dst;
+  ::vdup(dst, src, mask, pos, mode);
+  return dst;
+}
+
+// -- Select
+// ---------------------------------------------------------------------
+
+template <typename SrcVec>
+__simd_callee__ inline SrcVec vsel(SrcVec src_0, SrcVec src_1,
+                                   vector_bool mask) {
+  SrcVec dst;
+  ::vsel(dst, src_0, src_1, mask);
+  return dst;
+}
+
+template <typename SrcVec, typename IdxVec>
+__simd_callee__ inline SrcVec vselr(SrcVec src, IdxVec idx) {
+  SrcVec dst;
+  ::vselr(dst, src, idx);
+  return dst;
+}
+
+// -- Scalar-vector ops
+// ----------------------------------------------------------
+
+template <typename SrcVec, typename ScalarT, typename Mode>
+__simd_callee__ inline SrcVec vadds(SrcVec src, ScalarT scalar,
+                                    vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vadds(dst, src, scalar, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename ScalarT, typename Mode>
+__simd_callee__ inline SrcVec vmaxs(SrcVec src, ScalarT scalar,
+                                    vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vmaxs(dst, src, scalar, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename ScalarT, typename Mode>
+__simd_callee__ inline SrcVec vmins(SrcVec src, ScalarT scalar,
+                                    vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vmins(dst, src, scalar, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename ScalarT, typename Mode>
+__simd_callee__ inline SrcVec vmuls(SrcVec src, ScalarT scalar,
+                                    vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vmuls(dst, src, scalar, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename ScalarT, typename Mode>
+__simd_callee__ inline SrcVec vshls(SrcVec src, ScalarT scalar,
+                                    vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vshls(dst, src, scalar, mask, mode);
+  return dst;
+}
+
+template <typename SrcVec, typename ScalarT, typename Mode>
+__simd_callee__ inline SrcVec vshrs(SrcVec src, ScalarT scalar,
+                                    vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vshrs(dst, src, scalar, mask, mode);
+  return dst;
+}
+
+// -- Exponential difference
+// -----------------------------------------------------
+
+template <typename SrcVec, typename Part>
+__simd_callee__ inline SrcVec vexpdif(SrcVec src_0, SrcVec src_1,
+                                      vector_bool mask, Part part) {
+  SrcVec dst;
+  ::vexpdif(dst, src_0, src_1, mask, part);
+  return dst;
+}
+
+template <typename SrcVec, typename Mode>
+__simd_callee__ inline SrcVec vabsdif(SrcVec src_0, SrcVec src_1,
+                                      vector_bool mask, Mode mode) {
+  SrcVec dst;
+  ::vabsdif(dst, src_0, src_1, mask, mode);
+  return dst;
+}
+
+template <typename U, typename SrcVec, typename Part>
+__simd_callee__ inline vec_t<U> vpack(SrcVec src, Part part) {
+  vec_t<U> dst;
+  ::vpack(dst, src, part);
+  return dst;
+}
+
+template <typename T>
+__simd_callee__ inline void vsstb(vec_t<T> src, __ubuf__ T *base,
+                                  int32_t stride, vector_bool mask) {
+  ::vsstb(src, base, stride, mask);
+}
+
+template <typename T, typename Post>
+__simd_callee__ inline __ubuf__ T *vsstb(vec_t<T> src, __ubuf__ T *base,
+                                         int32_t stride, vector_bool mask,
+                                         Post post) {
+  ::vsstb(src, base, stride, mask, post);
+  return base;
+}
+
+template <typename T, typename Dist>
+__simd_callee__ inline void vsts(vec_t<T> data, __ubuf__ T *base,
+                                 int32_t offset, Dist dist, vector_bool mask) {
+  ::vsts(data, base, offset, dist, mask);
+}
+
+template <typename T> __simd_callee__ inline void mem_bar(T mem_type) {
+  ::mem_bar(mem_type);
+}
+
+} // namespace simd_inst

--- a/docs/repro/bf16_widen_multiply/fixtures/a5_vector.hpp
+++ b/docs/repro/bf16_widen_multiply/fixtures/a5_vector.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+// Only the typed vector forms exercised by the direct CCE control.
+#include "a5_runtime.hpp"
+namespace a5 {
+template <typename T> struct vec;
+template <> struct vec<float> { using type = vector_f32; };
+#if (__NPU_ARCH__ == 3510)
+template <> struct vec<bfloat16_t> { using type = vector_bf16; };
+template <> struct vec<fp8_e4_t> { using type = vector_f8e4m3; };
+#endif
+template <> struct vec<uint16_t> { using type = vector_u16; };
+template <typename T> using vec_t = typename vec<T>::type;
+template <typename T> struct pair { T v0; T v1; };
+template <typename T, typename O, typename D> __simd_callee__ inline vec_t<T>
+vlds(__ubuf__ T *p, O o, D d) { vec_t<T> x; ::vlds(x, p, o, d); return x; }
+template <typename U, typename S, typename P, typename M> __simd_callee__ inline vec_t<U>
+vcvt(S x, vector_bool m, P p, M z) { vec_t<U> y; ::vcvt(y, x, m, p, z); return y; }
+template <typename U, typename S, typename R, typename RS, typename P, typename M> __simd_callee__ inline vec_t<U>
+vcvt(S x, vector_bool m, R r, RS rs, P p, M z) { vec_t<U> y; ::vcvt(y, x, m, r, rs, p, z); return y; }
+template <typename V> __simd_callee__ inline pair<V> vintlv(V x, V y) { pair<V> z; ::vintlv(z.v0, z.v1, x, y); return z; }
+template <typename V, typename M> __simd_callee__ inline V vmul(V x, V y, vector_bool m, M z) { V r; ::vmul(r,x,y,m,z); return r; }
+template <typename V, typename M> __simd_callee__ inline V vmax(V x, V y, vector_bool m, M z) { V r; ::vmax(r,x,y,m,z); return r; }
+template <typename V, typename M> __simd_callee__ inline V vand(V x, V y, vector_bool m, M z) { V r; ::vand(r,x,y,m,z); return r; }
+template <typename V, typename M> __simd_callee__ inline V vdiv(V x, V y, vector_bool m, M z) { V r; ::vdiv(r,x,y,m,z); return r; }
+// Keep the generated reference's correctly-rounded f32 division sequence.
+// It is deliberately local to this small standalone fixture.
+template <typename M> __simd_callee__ inline vector_f32
+vdiv_precise(vector_f32 x, vector_f32 y, vector_bool mask, M mode) {
+  constexpr uint32_t kInfNan = 0xff800000u, kSign = 0x80000000u;
+  vector_f32 sign, q, original, neg_y, residual, q_prev, q_next;
+  vector_u32 bits;
+  ::vdup((vector_u32 &)sign, kSign, mask, mode);
+  ::vdiv(q, x, y, mask, mode); original = q;
+  ::vor(bits, (vector_u32 &)q, (vector_u32 &)sign, mask, mode);
+  vector_bool zero, special, keep_original, choose_prev;
+  ::vcmps_eq(zero, q, 0.0f, mask);
+  ::vcmps_ge(special, (vector_u32 &)bits, kInfNan, mask);
+  ::por(keep_original, special, zero, mask);
+  ::vmuls(neg_y, y, -1.0f, mask, mode);
+  residual = x; ::vmula(residual, q, neg_y, mask, mode);
+  ::vadds((vector_s32 &)q_prev, (vector_s32 &)q, -1, mask, mode);
+  ::vadds((vector_s32 &)q_next, (vector_s32 &)q, 1, mask, mode);
+  vector_f32 r_prev = x, r_next = x;
+  ::vmula(r_prev, q_prev, neg_y, mask, mode);
+  ::vmula(r_next, q_next, neg_y, mask, mode);
+  ::vabs(residual, residual, mask, mode);
+  ::vabs(r_prev, r_prev, mask, mode);
+  ::vabs(r_next, r_next, mask, mode);
+  ::vcmp_lt(choose_prev, residual, r_prev, mask);
+  ::vsel(residual, residual, r_prev, choose_prev);
+  ::vsel(q, q, q_prev, choose_prev);
+  ::vcmp_lt(choose_prev, r_next, residual, mask);
+  ::vsel(q, q_next, q, choose_prev);
+  vector_f32 result; ::vsel(result, original, q, keep_original);
+  return result;
+}
+template <typename T, typename M> __simd_callee__ inline vec_t<T> vdup(T x, vector_bool m, M z) { vec_t<T> r; ::vdup(r,x,m,z); return r; }
+template <typename T, typename D> __simd_callee__ inline void vsts(vec_t<T> x, __ubuf__ T *p, int o, D d, vector_bool m) { ::vsts(x,p,o,d,m); }
+template <typename T> __simd_callee__ inline void mem_bar(T x) { ::mem_bar(x); }
+}  // namespace a5

--- a/docs/repro/bf16_widen_multiply/fixtures/bf16_widen_multiply_cce.asc
+++ b/docs/repro/bf16_widen_multiply/fixtures/bf16_widen_multiply_cce.asc
@@ -1,0 +1,38 @@
+#include "a5_runtime.hpp"
+#include "a5_simd.hpp"
+
+__simd_vf__ inline void bf16_widen_multiply_vf(__ubuf__ bfloat16_t* a_ub, __ubuf__ bfloat16_t* b_ub, __ubuf__ float* out_ub) {
+  constexpr int kElementsPerCore = 2048;
+  vector_bool mask16 = pset_b16(PAT_ALL);
+  vector_bool mask32 = pset_b32(PAT_ALL);
+  for (int lane = 0; lane < kElementsPerCore; lane += 128) {
+    auto a_pair = simd_inst::vld_x2<bfloat16_t>(a_ub + lane, DINTLV_B16);
+    auto b_pair = simd_inst::vld_x2<bfloat16_t>(b_ub + lane, DINTLV_B16);
+    auto a0 = simd_inst::vcvt<float>(a_pair.v0, mask16, PART_EVEN, MODE_ZEROING);
+    auto a1 = simd_inst::vcvt<float>(a_pair.v1, mask16, PART_EVEN, MODE_ZEROING);
+    auto b0 = simd_inst::vcvt<float>(b_pair.v0, mask16, PART_EVEN, MODE_ZEROING);
+    auto b1 = simd_inst::vcvt<float>(b_pair.v1, mask16, PART_EVEN, MODE_ZEROING);
+    simd_inst::vsts(simd_inst::vmul(a0, b0, mask32, MODE_ZEROING), out_ub + lane, 0, NORM_B32, mask32);
+    simd_inst::vsts(simd_inst::vmul(a1, b1, mask32, MODE_ZEROING), out_ub + lane + 64, 0, NORM_B32, mask32);
+  }
+}
+
+extern "C" __global__ __vector__ void bf16_widen_multiply_cce(
+    __gm__ bfloat16_t* a, __gm__ bfloat16_t* b, __gm__ float* out) {
+  AscendC::InitSocState();
+  constexpr int kElementsPerCore = 2048;
+  __ubuf__ uint8_t* raw = (__ubuf__ uint8_t*)0;
+  __ubuf__ bfloat16_t* a_ub = (__ubuf__ bfloat16_t*)raw;
+  __ubuf__ bfloat16_t* b_ub = a_ub + kElementsPerCore;
+  __ubuf__ float* out_ub = (__ubuf__ float*)(b_ub + kElementsPerCore);
+  int offset = ((int)blockIdx.x) * kElementsPerCore;
+  copy_gm_to_ubuf_align_v2((__ubuf__ uint8_t*)a_ub, (__gm__ uint8_t*)(a + offset), 0, 1, 4096, 0, 0, 0, 0, 4096, 4096);
+  copy_gm_to_ubuf_align_v2((__ubuf__ uint8_t*)b_ub, (__gm__ uint8_t*)(b + offset), 0, 1, 4096, 0, 0, 0, 0, 4096, 4096);
+  AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(0);
+  AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(0);
+  bf16_widen_multiply_vf(a_ub, b_ub, out_ub);
+  AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(0);
+  AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(0);
+  copy_ubuf_to_gm_align_v2((__gm__ void*)(out + offset), (__ubuf__ void*)out_ub,
+                            0, 1, kElementsPerCore * sizeof(float), 0, 0, 0);
+}

--- a/docs/repro/bf16_widen_multiply/fixtures/bf16_widen_multiply_vmi.py
+++ b/docs/repro/bf16_widen_multiply/fixtures/bf16_widen_multiply_vmi.py
@@ -1,0 +1,27 @@
+"""Standalone PTODSL VMI implementation of BF16 widen and FP32 multiply."""
+
+from ptodsl import pto
+
+ELEMENTS_PER_CORE = 2048
+UB_BYTES = ELEMENTS_PER_CORE * 8
+
+
+@pto.jit(name="bf16_widen_multiply_vmi", kernel_kind="vector", target="a5", mode="explicit")
+def bf16_widen_multiply_vmi(a: pto.ptr(pto.bf16, "gm"), b: pto.ptr(pto.bf16, "gm"), out: pto.ptr(pto.f32, "gm")):
+    raw = pto.castptr(pto.const(0, dtype=pto.i64), pto.ptr(pto.ui8, "ub"))
+    a_ub = pto.castptr(raw, pto.ptr(pto.bf16, "ub"))
+    b_ub = pto.castptr(pto.addptr(raw, ELEMENTS_PER_CORE * 2), pto.ptr(pto.bf16, "ub"))
+    out_ub = pto.castptr(pto.addptr(raw, ELEMENTS_PER_CORE * 4), pto.ptr(pto.f32, "ub"))
+    offset = pto.get_block_idx() * ELEMENTS_PER_CORE
+    pto.mte_gm_ub(pto.addptr(a, offset), a_ub, 0, ELEMENTS_PER_CORE * 2, nburst=(1, ELEMENTS_PER_CORE * 2, ELEMENTS_PER_CORE * 2))
+    pto.mte_gm_ub(pto.addptr(b, offset), b_ub, 0, ELEMENTS_PER_CORE * 2, nburst=(1, ELEMENTS_PER_CORE * 2, ELEMENTS_PER_CORE * 2))
+    pto.set_flag("MTE2", "V", event_id=0)
+    pto.wait_flag("MTE2", "V", event_id=0)
+    mask = pto.vmi.create_mask(64, size=64)
+    for lane in range(0, ELEMENTS_PER_CORE, 64):
+        a_f32 = pto.vmi.vcvt(pto.vmi.vload(pto.addptr(a_ub, lane), 0, size=64), to_dtype=pto.f32)
+        b_f32 = pto.vmi.vcvt(pto.vmi.vload(pto.addptr(b_ub, lane), 0, size=64), to_dtype=pto.f32)
+        pto.vmi.vstore(pto.vmi.vmul(a_f32, b_f32, mask), pto.addptr(out_ub, lane), 0, mask)
+    pto.set_flag("V", "MTE3", event_id=0)
+    pto.wait_flag("V", "MTE3", event_id=0)
+    pto.mte_ub_gm(out_ub, pto.addptr(out, offset), ELEMENTS_PER_CORE * 4, nburst=(1, ELEMENTS_PER_CORE * 4, ELEMENTS_PER_CORE * 4))


### PR DESCRIPTION
See `docs/repro/bf16_widen_multiply/README.md`. Worst shape is slower by 8%

Might be tile scheduling / pipelining or benchmark launcher issue, not SIMD VF issue.