### PR TITLE
feat(vpto): Add vexpdif fusion pass

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -106,6 +106,7 @@ std::unique_ptr<Pass>
 createPTOLowLevelLoopFusionPass(const PTOLowLevelLoopFusionOptions &options = {});
 std::unique_ptr<Pass> createPTOFusionPredicateElisionPass();
 std::unique_ptr<Pass> createPTOFusionLoadStoreElisionPass();
+std::unique_ptr<Pass> createPTOVexpdifFusionPass();
 std::unique_ptr<Pass> createPTOUnrollAfterLoopFusionPass();
 std::unique_ptr<Pass> createPTOFlattenFusionRegionPass();
 std::unique_ptr<Pass> createVPTOPtrNormalizePass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -1339,6 +1339,18 @@ def PTOFusionLoadStoreElision
                            "mlir::scf::SCFDialect"];
 }
 
+def PTOVexpdifFusion : Pass<"pto-vexpdif-fusion", "func::FuncOp"> {
+  let summary = "Fuse VPTO vsub and vexp into vexpdif";
+  let description = [{
+    Performs fusion after TileOp expansion and fusion-local load/store
+    elimination. The pass rewrites an f32 `vsub` followed by an f32 `vexp`
+    with the same mask into `vexpdif`.
+  }];
+  let constructor = "mlir::pto::createPTOVexpdifFusionPass()";
+  let dependentDialects = ["mlir::func::FuncDialect",
+                           "mlir::pto::PTODialect"];
+}
+
 def PTOUnrollAfterLoopFusion
     : Pass<"pto-unroll-after-loop-fusion", "func::FuncOp"> {
   let summary = "Partial-unroll the innermost scf.for inside pto.fusion_region "

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -35,6 +35,7 @@ add_mlir_dialect_library(PTOTransforms
   TileFusion/PTOLowLevelLoopFusion.cpp
   TileFusion/PTOFusionPredicateElision.cpp
   TileFusion/PTOFusionLoadStoreElision.cpp
+  TileFusion/PTOVexpdifFusion.cpp
   TileFusion/PTOUnrollAfterLoopFusion.cpp
   TileFusion/PTOFlattenFusionRegion.cpp
   VPTOLLVMEmitter.cpp

--- a/lib/PTO/Transforms/TileFusion/PTOVexpdifFusion.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVexpdifFusion.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOVEXPDIFFUSION
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::pto;
+
+namespace {
+
+static bool hasMatchingF32Types(VsubOp sub, VexpOp exp) {
+  auto lhsType = dyn_cast<VRegType>(sub.getLhs().getType());
+  auto rhsType = dyn_cast<VRegType>(sub.getRhs().getType());
+  auto subResultType = dyn_cast<VRegType>(sub.getResult().getType());
+  auto expSourceType = dyn_cast<VRegType>(exp.getInput().getType());
+  auto expResultType = dyn_cast<VRegType>(exp.getResult().getType());
+  if (!lhsType || !rhsType || !subResultType || !expSourceType ||
+      !expResultType) {
+    return false;
+  }
+
+  return lhsType.getElementType().isF32() &&
+         rhsType.getElementType().isF32() &&
+         subResultType.getElementType().isF32() &&
+         expSourceType.getElementType().isF32() &&
+         expResultType.getElementType().isF32() && lhsType == rhsType &&
+         rhsType == subResultType && subResultType == expSourceType &&
+         expSourceType == expResultType;
+}
+
+static bool canFuse(VsubOp sub, VexpOp exp) {
+  if (!sub.getResult().hasOneUse() || sub.getResult() != exp.getInput()) {
+    return false;
+  }
+  if (sub.getMask() != exp.getMask()) {
+    return false;
+  }
+  return hasMatchingF32Types(sub, exp);
+}
+
+static void fuseVsubVexp(FusionRegionOp fusionRegion) {
+  SmallVector<VexpOp> candidates;
+  fusionRegion.walk([&](VexpOp exp) {
+    auto sub = exp.getInput().getDefiningOp<VsubOp>();
+    if (sub && canFuse(sub, exp)) {
+      candidates.push_back(exp);
+    }
+  });
+
+  OpBuilder builder(fusionRegion.getContext());
+  for (VexpOp exp : candidates) {
+    auto sub = exp.getInput().getDefiningOp<VsubOp>();
+    if (!sub || !canFuse(sub, exp)) {
+      continue;
+    }
+
+    builder.setInsertionPoint(exp);
+    auto fused = builder.create<VexpdifOp>(
+        exp.getLoc(), exp.getResult().getType(), sub.getLhs(), sub.getRhs(),
+        exp.getMask(), builder.getStringAttr("ODD"));
+    exp.getResult().replaceAllUsesWith(fused.getResult());
+    exp.erase();
+    sub.erase();
+  }
+}
+
+struct PTOVexpdifFusionPass
+    : pto::impl::PTOVexpdifFusionBase<PTOVexpdifFusionPass> {
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isExternal()) {
+      return;
+    }
+
+    SmallVector<FusionRegionOp, 8> fusionRegions;
+    func.walk<WalkOrder::PostOrder>(
+        [&](FusionRegionOp fusionRegion) { fusionRegions.push_back(fusionRegion); });
+
+    for (FusionRegionOp fusionRegion : fusionRegions) {
+      fuseVsubVexp(fusionRegion);
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOVexpdifFusionPass() {
+  return std::make_unique<PTOVexpdifFusionPass>();
+}

--- a/lib/PTO/Transforms/TileFusion/PTOVexpdifFusion.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVexpdifFusion.cpp
@@ -48,7 +48,8 @@ static bool hasMatchingF32Types(VsubOp sub, VexpOp exp) {
 }
 
 static bool canFuse(VsubOp sub, VexpOp exp) {
-  if (!sub.getResult().hasOneUse() || sub.getResult() != exp.getInput()) {
+  // Fuse conservatively only when vexp is the sole user.
+  if (!sub.getResult().hasOneUse()) {
     return false;
   }
   if (sub.getMask() != exp.getMask()) {
@@ -57,16 +58,19 @@ static bool canFuse(VsubOp sub, VexpOp exp) {
   return hasMatchingF32Types(sub, exp);
 }
 
-static void fuseVsubVexp(FusionRegionOp fusionRegion) {
+static void fuseVsubVexp(func::FuncOp func) {
   SmallVector<VexpOp> candidates;
-  fusionRegion.walk([&](VexpOp exp) {
+  func.walk([&](VexpOp exp) {
+    if (!exp->getParentOfType<FusionRegionOp>()) {
+      return;
+    }
     auto sub = exp.getInput().getDefiningOp<VsubOp>();
     if (sub && canFuse(sub, exp)) {
       candidates.push_back(exp);
     }
   });
 
-  OpBuilder builder(fusionRegion.getContext());
+  OpBuilder builder(func.getContext());
   for (VexpOp exp : candidates) {
     auto sub = exp.getInput().getDefiningOp<VsubOp>();
     if (!sub || !canFuse(sub, exp)) {
@@ -74,8 +78,9 @@ static void fuseVsubVexp(FusionRegionOp fusionRegion) {
     }
 
     builder.setInsertionPoint(exp);
+    Location fusedLoc = builder.getFusedLoc({sub.getLoc(), exp.getLoc()});
     auto fused = builder.create<VexpdifOp>(
-        exp.getLoc(), exp.getResult().getType(), sub.getLhs(), sub.getRhs(),
+        fusedLoc, exp.getResult().getType(), sub.getLhs(), sub.getRhs(),
         exp.getMask(), builder.getStringAttr("ODD"));
     exp.getResult().replaceAllUsesWith(fused.getResult());
     exp.erase();
@@ -87,17 +92,7 @@ struct PTOVexpdifFusionPass
     : pto::impl::PTOVexpdifFusionBase<PTOVexpdifFusionPass> {
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal()) {
-      return;
-    }
-
-    SmallVector<FusionRegionOp, 8> fusionRegions;
-    func.walk<WalkOrder::PostOrder>(
-        [&](FusionRegionOp fusionRegion) { fusionRegions.push_back(fusionRegion); });
-
-    for (FusionRegionOp fusionRegion : fusionRegions) {
-      fuseVsubVexp(fusionRegion);
-    }
+    fuseVsubVexp(func);
   }
 };
 

--- a/test/lit/tile_fusion/pto_vexpdif_fusion.pto
+++ b/test/lit/tile_fusion/pto_vexpdif_fusion.pto
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. THIS SOFTWARE IS PROVIDED ON AN
+// "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// Positive case for the pto-vexpdif-fusion pass over a real ptoas pipeline.
+// A single-use f32 tsub + texp sequence lowers to vsub + vexp inside a
+// pto.fusion_region and is fused into pto.vexpdif ("ODD"). vexpdif fusion is
+// enabled by default; pass --enable-vexpdif-fusion=false to opt out.
+
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-vexpdif-fusion --emit-vpto %s --mlir-print-ir-after=pto-vexpdif-fusion -o /dev/null 2>&1 | FileCheck %s
+
+module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vexpdif_fusion() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %sub = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %result = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tsub ins(%a, %b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                          !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%sub : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.texp ins(%sub : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%result : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @vexpdif_fusion(
+// CHECK: pto.fusion_region
+// CHECK: pto.vexpdif {{.*}} "ODD"
+// CHECK-NOT: pto.vsub
+// CHECK-NOT: pto.vexp {{.*}} :

--- a/test/lit/tile_fusion/pto_vexpdif_fusion.pto
+++ b/test/lit/tile_fusion/pto_vexpdif_fusion.pto
@@ -13,9 +13,23 @@
 // enabled by default; pass --enable-vexpdif-fusion=false to opt out.
 
 // RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-vexpdif-fusion --emit-vpto %s --mlir-print-ir-after=pto-vexpdif-fusion -o /dev/null 2>&1 | FileCheck %s
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-vexpdif-fusion --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s --check-prefix=LLVM
 
 module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-  func.func @vexpdif_fusion() {
+  func.func @vexpdif_fusion(%dst_ptr : !pto.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
     %a = pto.alloc_tile
       : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
@@ -34,6 +48,8 @@ module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
              outs(%sub : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.texp ins(%sub : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
              outs(%result : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%result : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
     return
   }
 }
@@ -43,3 +59,6 @@ module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
 // CHECK: pto.vexpdif {{.*}} "ODD"
 // CHECK-NOT: pto.vsub
 // CHECK-NOT: pto.vexp {{.*}} :
+
+// LLVM-LABEL: define void @vexpdif_fusion
+// LLVM: call {{.*}} @llvm.hivm.vexpdif

--- a/test/lit/tile_fusion/pto_vexpdif_fusion_f16.pto
+++ b/test/lit/tile_fusion/pto_vexpdif_fusion_f16.pto
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. THIS SOFTWARE IS PROVIDED ON AN
+// "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// Negative case for the pto-vexpdif-fusion pass over a real ptoas pipeline.
+// An f16 tsub + texp chain lowers to vsub + vexp over !pto.vreg<128xf16>.
+// canFuse only accepts f32 element types, so the chain is left as vsub + vexp
+// even though vexpdif fusion is enabled by default.
+
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-vexpdif-fusion --emit-vpto %s --mlir-print-ir-after=pto-vexpdif-fusion -o /dev/null 2>&1 | FileCheck %s
+
+module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vexpdif_f16() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %sub = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %result = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tsub ins(%a, %b : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                          !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%sub : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.texp ins(%sub : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%result : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @vexpdif_f16(
+// CHECK: pto.vsub {{.*}} !pto.vreg<128xf16>
+// CHECK: pto.vexp {{.*}} !pto.vreg<128xf16>
+// CHECK-NOT: pto.vexpdif

--- a/test/lit/tile_fusion/pto_vexpdif_fusion_mask.pto
+++ b/test/lit/tile_fusion/pto_vexpdif_fusion_mask.pto
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. THIS SOFTWARE IS PROVIDED ON AN
+// "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// Negative cases for the pto-vexpdif-fusion pass. The pass fuses a f32
+// `vsub` followed by a f32 `vexp` into `vexpdif` only when both ops share the
+// same mask. These cases exercise the two `canFuse` rejection branches:
+//   - @different_masks : identical f32 types but distinct mask SSA values.
+//   - @bf16_inputs     : same mask but non-f32 element type (bf16).
+// @same_mask_f32 is a positive control that must still fuse.
+
+// RUN: pto-test-opt %s -pto-vexpdif-fusion | FileCheck %s
+
+module {
+  func.func @different_masks(%a : !pto.vreg<64xf32>, %b : !pto.vreg<64xf32>) -> !pto.vreg<64xf32> {
+    %res = pto.fusion_region {
+      %m1 = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %m2 = pto.pset_b32 "PAT_H" : !pto.mask<b32>
+      %sub = pto.vsub %a, %b, %m1 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+      %exp = pto.vexp %sub, %m2 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+      pto.yield(%exp) : (!pto.vreg<64xf32>) -> ()
+    } : !pto.vreg<64xf32>
+    return %res : !pto.vreg<64xf32>
+  }
+
+  func.func @same_mask_f32(%a : !pto.vreg<64xf32>, %b : !pto.vreg<64xf32>) -> !pto.vreg<64xf32> {
+    %res = pto.fusion_region {
+      %m = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %sub = pto.vsub %a, %b, %m : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+      %exp = pto.vexp %sub, %m : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+      pto.yield(%exp) : (!pto.vreg<64xf32>) -> ()
+    } : !pto.vreg<64xf32>
+    return %res : !pto.vreg<64xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @different_masks(
+// CHECK: pto.vsub
+// CHECK: pto.vexp
+// CHECK-NOT: pto.vexpdif
+
+// CHECK-LABEL: func.func @same_mask_f32(
+// CHECK: pto.vexpdif {{.*}} "ODD"
+// CHECK-NOT: pto.vsub
+// CHECK-NOT: pto.vexp {{.*}} :

--- a/test/lit/tile_fusion/pto_vexpdif_fusion_mask.pto
+++ b/test/lit/tile_fusion/pto_vexpdif_fusion_mask.pto
@@ -9,9 +9,8 @@
 
 // Negative cases for the pto-vexpdif-fusion pass. The pass fuses a f32
 // `vsub` followed by a f32 `vexp` into `vexpdif` only when both ops share the
-// same mask. These cases exercise the two `canFuse` rejection branches:
+// same mask. The negative case exercises the mask-mismatch rejection branch:
 //   - @different_masks : identical f32 types but distinct mask SSA values.
-//   - @bf16_inputs     : same mask but non-f32 element type (bf16).
 // @same_mask_f32 is a positive control that must still fuse.
 
 // RUN: pto-test-opt %s -pto-vexpdif-fusion | FileCheck %s

--- a/test/lit/tile_fusion/pto_vexpdif_fusion_multiuse.pto
+++ b/test/lit/tile_fusion/pto_vexpdif_fusion_multiuse.pto
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. THIS SOFTWARE IS PROVIDED ON AN
+// "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// Negative case for the pto-vexpdif-fusion pass over a real ptoas pipeline.
+// The tsub result also feeds a tadd, so after lowering the vsub result has two
+// users (vexp and vadd). canFuse requires the vsub result to have a single
+// use, so the vsub + vexp chain is preserved (no vexpdif) even with
+// --enable-vexpdif-fusion.
+
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-vexpdif-fusion=true --emit-vpto %s --mlir-print-ir-after=pto-vexpdif-fusion -o /dev/null 2>&1 | FileCheck %s --check-prefix=FUSE
+
+module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vexpdif_multiuse() {
+    %a = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %sub = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %result = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %extra = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tsub ins(%a, %b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                          !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%sub : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.texp ins(%sub : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%result : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tadd ins(%sub, %result : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                          !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%extra : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// FUSE-LABEL: func.func @vexpdif_multiuse(
+// FUSE: pto.vsub
+// FUSE: pto.vexp
+// FUSE: pto.vadd
+// FUSE-NOT: pto.vexpdif

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -552,6 +552,11 @@ static llvm::cl::opt<bool> enableTileOpExpand(
         "--pto-backend=vpto."),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> enableVexpdifFusion(
+    "enable-vexpdif-fusion",
+    llvm::cl::desc("Enable vsub + vexp fusion into vexpdif"),
+    llvm::cl::init(true));
+
 static llvm::cl::opt<llvm::cl::boolOrDefault> enableOpFusion(
     "enable-op-fusion",
     llvm::cl::desc("Control A5 tile fusion on level2/level3. Disabled by "
@@ -3146,6 +3151,10 @@ static void lowerPTOToVPTOBackend(PassManager &pm, ModuleOp module) {
         pto::createPTOFusionPredicateElisionPass());
     kernelModulePM.addNestedPass<mlir::func::FuncOp>(
         pto::createPTOFusionLoadStoreElisionPass());
+    if (enableVexpdifFusion) {
+      kernelModulePM.addNestedPass<mlir::func::FuncOp>(
+          pto::createPTOVexpdifFusionPass());
+    }
     if (enableUnrollAfterLoopFusion) {
       kernelModulePM.addNestedPass<mlir::func::FuncOp>(
           pto::createPTOUnrollAfterLoopFusionPass());
@@ -3153,6 +3162,10 @@ static void lowerPTOToVPTOBackend(PassManager &pm, ModuleOp module) {
       kernelModulePM.addPass(mlir::createCSEPass());
       kernelModulePM.addNestedPass<mlir::func::FuncOp>(
           pto::createPTOFusionLoadStoreElisionPass());
+      if (enableVexpdifFusion) {
+        kernelModulePM.addNestedPass<mlir::func::FuncOp>(
+            pto::createPTOVexpdifFusionPass());
+      }
     }
     kernelModulePM.addNestedPass<mlir::func::FuncOp>(
         pto::createPTOFlattenFusionRegionPass());

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -3162,6 +3162,8 @@ static void lowerPTOToVPTOBackend(PassManager &pm, ModuleOp module) {
       kernelModulePM.addPass(mlir::createCSEPass());
       kernelModulePM.addNestedPass<mlir::func::FuncOp>(
           pto::createPTOFusionLoadStoreElisionPass());
+      // Unrolling and the cleanup passes above can expose new vsub + vexp
+      // patterns, so run vexpdif fusion again before flattening the regions.
       if (enableVexpdifFusion) {
         kernelModulePM.addNestedPass<mlir::func::FuncOp>(
             pto::createPTOVexpdifFusionPass());


### PR DESCRIPTION
Implements vsub + vexp fusion into vexpdif.

  - Adds the `pto-vexpdif-fusion` pass and `--enable-vexpdif-fusion` option.
  - Fuses single-use f32 `vsub + vexp` chains with matching masks inside fusion regions.
  - Runs the fusion again after loop unrolling and cleanup, which may expose new fusion opportunities.
  - Covers f32 fusion, f16 non-fusion, mask mismatch, and multiple-use protection.