### PR TITLE
fix(vpto): normalize vector shift counts

### DIFF
--- a/docs/isa/micro-isa/07-binary-vector-ops.md
+++ b/docs/isa/micro-isa/07-binary-vector-ops.md
@@ -216,7 +216,7 @@ for (int i = 0; i < N; i++)
 
 ### `pto.vshl`
 
-- **syntax:** `%result = pto.vshl %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vshl %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxsiW>, !pto.mask<G> -> !pto.vreg<NxT>` where `W` is the bit width of `T`
 - **A5 types:** all integer types
 
 ```c
@@ -227,27 +227,31 @@ for (int i = 0; i < N; i++)
 - **inputs:** `%lhs` supplies the shifted value, `%rhs` supplies the per-lane
   shift amount, and `%mask` selects active lanes.
 - **outputs:** `%result` is the shifted vector.
-- **constraints and limitations:** Integer element types only. Shift counts
-  SHOULD stay within `[0, bitwidth(T) - 1]`; out-of-range behavior is target-
-  defined unless the verifier narrows it further.
+- **constraints and limitations:** Integer element types only. `%rhs` must use
+  signed `siW` elements with the same lane count and bit width as `%lhs`; the
+  result type must exactly match `%lhs`. Shift counts SHOULD stay within
+  `[0, bitwidth(T) - 1]`; out-of-range behavior is target-defined unless the
+  verifier narrows it further.
 
 ---
 
 ### `pto.vshr`
 
-- **syntax:** `%result = pto.vshr %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
+- **syntax:** `%result = pto.vshr %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxsiW>, !pto.mask<G> -> !pto.vreg<NxT>` where `W` is the bit width of `T`
 - **A5 types:** all integer types
 
 ```c
 for (int i = 0; i < N; i++)
-    dst[i] = src0[i] >> src1[i];  // arithmetic for signed, logical for unsigned
+    dst[i] = src0[i] >> src1[i];
 ```
 
 - **inputs:** `%lhs` supplies the shifted value, `%rhs` supplies the per-lane
   shift amount, and `%mask` selects active lanes.
 - **outputs:** `%result` is the shifted vector.
-- **constraints and limitations:** Integer element types only. Signedness of the
-  element type determines arithmetic vs logical behavior.
+- **constraints and limitations:** Integer element types only. `%rhs` must use
+  signed `siW` elements with the same lane count and bit width as `%lhs`; the
+  result type must exactly match `%lhs`. The current VPTO contract does not
+  define arithmetic versus logical right-shift behavior.
 
 ---
 

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -6357,26 +6357,66 @@ LogicalResult VmaddOp::verify() {
   }
   return success();
 }
-LogicalResult VshlOp::verify() {
-  if (failed(verifyBinaryVecOp(*this))) {
+// Shared verifier for vshl/vshr. Shift counts use a signed integer vreg.
+// DSL frontends must bitcast signless or unsigned count vectors to this
+// canonical form.
+template <typename BinaryOp>
+static LogicalResult verifyShiftVecOp(BinaryOp op) {
+  const bool hasInvalidOperandType =
+      failed(verifyVRegTypeLike(op, op.getLhs().getType(), "lhs type")) ||
+      failed(verifyVRegTypeLike(op, op.getRhs().getType(), "rhs type")) ||
+      failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type")) ||
+      failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type"));
+  if (hasInvalidOperandType) {
     return failure();
   }
-  auto lhsType = cast<VRegType>(getLhs().getType());
+  if (failed(verifyNonLowPrecisionVRegElementTypeLike(
+          op.getOperation(), op.getLhs().getType(), "lhs type"))) {
+    return failure();
+  }
+
+  auto lhsType = cast<VRegType>(op.getLhs().getType());
+  auto rhsType = cast<VRegType>(op.getRhs().getType());
+  auto resultType = cast<VRegType>(op.getResult().getType());
+
+  // Shifting is only meaningful for integer vectors.
   if (!isa<IntegerType>(lhsType.getElementType())) {
-    return emitOpError("requires integer vector element type");
+    return op.emitOpError("requires integer vector element type");
+  }
+
+  // Result type must match lhs exactly.
+  if (lhsType != resultType) {
+    return op.emitOpError("requires matching result register vector shape");
+  }
+
+  // Shift count must have the same lane count and element bitwidth as the
+  // shifted data.
+  const bool hasMismatchedLaneCount =
+      lhsType.getElementCount() != rhsType.getElementCount();
+  if (hasMismatchedLaneCount) {
+    return op.emitOpError("requires matching lane count for shift count");
+  }
+  auto lhsElem = cast<IntegerType>(lhsType.getElementType());
+  auto rhsElem = dyn_cast<IntegerType>(rhsType.getElementType());
+  if (!rhsElem) {
+    return op.emitOpError(
+        "requires integer vector element type for shift count");
+  }
+  const bool hasMismatchedElementBitwidth =
+      rhsElem.getWidth() != lhsElem.getWidth();
+  if (hasMismatchedElementBitwidth) {
+    return op.emitOpError(
+        "requires shift count with matching element bitwidth");
+  }
+  if (!rhsElem.isSigned()) {
+    return op.emitOpError(
+        "requires shift count to use a signed integer element type");
   }
   return success();
 }
-LogicalResult VshrOp::verify() {
-  if (failed(verifyBinaryVecOp(*this))) {
-    return failure();
-  }
-  auto lhsType = cast<VRegType>(getLhs().getType());
-  if (!isa<IntegerType>(lhsType.getElementType())) {
-    return emitOpError("requires integer vector element type");
-  }
-  return success();
-}
+
+LogicalResult VshlOp::verify() { return verifyShiftVecOp(*this); }
+LogicalResult VshrOp::verify() { return verifyShiftVecOp(*this); }
 LogicalResult VaddcOp::verify() { return verifyCarryVecOp(*this); }
 LogicalResult VsubcOp::verify() { return verifyCarryVecOp(*this); }
 LogicalResult VaddcsOp::verify() { return verifyCarryVecOpWithInput(*this); }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8584,6 +8584,79 @@ struct OneToNVMIBinaryOpPattern : OneToNOpConversionPattern<SourceOp> {
   }
 };
 
+// VPTO vector shifts require a signed shift-count carrier regardless of the
+// signedness of the value being shifted. Preserve the count bits with a
+// bitcast before creating the physical shift operation.
+template <typename SourceOp, typename TargetOp>
+struct OneToNVMIShiftOpPattern : OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      SourceOp op,
+      typename OpConversionPattern<SourceOp>::OneToNOpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    ValueRange lhsParts = adaptor.getLhs();
+    ValueRange rhsParts = adaptor.getRhs();
+    FailureOr<SmallVector<Type>> maybeResultTypes =
+        getConvertedResultTypes(op, 0, *this->getTypeConverter());
+    if (failed(maybeResultTypes)) {
+      return failure();
+    }
+    SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
+    const bool hasMismatchedPhysicalArity =
+        lhsParts.size() != rhsParts.size() ||
+        lhsParts.size() != resultTypes.size();
+    if (hasMismatchedPhysicalArity) {
+      return rewriter.notifyMatchFailure(op, "physical shift arity mismatch");
+    }
+
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (auto [lhs, rhs, resultType] :
+         llvm::zip_equal(lhsParts, rhsParts, resultTypes)) {
+      auto resultVRegType = dyn_cast<VRegType>(resultType);
+      auto rhsVRegType = dyn_cast<VRegType>(rhs.getType());
+      auto rhsElementType =
+          rhsVRegType ? dyn_cast<IntegerType>(rhsVRegType.getElementType())
+                      : IntegerType();
+      const bool hasInvalidPhysicalPart =
+          !resultVRegType || lhs.getType() != resultType || !rhsElementType;
+      if (hasInvalidPhysicalPart) {
+        return rewriter.notifyMatchFailure(
+            op, "physical shift part type mismatch");
+      }
+
+      auto signedElementType = IntegerType::get(
+          rewriter.getContext(), rhsElementType.getWidth(),
+          IntegerType::SignednessSemantics::Signed);
+      auto signedRhsType = VRegType::get(
+          rewriter.getContext(), rhsVRegType.getElementCount(),
+          signedElementType);
+      FailureOr<Value> signedRhs =
+          bitcastVReg(op.getLoc(), rhs, signedRhsType, rewriter);
+      if (failed(signedRhs)) {
+        return rewriter.notifyMatchFailure(
+            op, "unable to normalize physical shift-count type");
+      }
+
+      FailureOr<Value> mask =
+          createAllTrueMaskForVReg(op.getLoc(), resultVRegType, rewriter);
+      if (failed(mask)) {
+        return rewriter.notifyMatchFailure(
+            op, "unsupported element type for all-true shift mask");
+      }
+      results.push_back(
+          rewriter
+              .create<TargetOp>(op.getLoc(), resultType, lhs, *signedRhs, *mask)
+              .getResult());
+    }
+
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+};
+
 template <typename SourceOp, typename TargetOp>
 struct OneToNVMIVecScalarOpPattern : OneToNOpConversionPattern<SourceOp> {
   using OneToNOpConversionPattern<SourceOp>::OneToNOpConversionPattern;
@@ -12397,9 +12470,9 @@ void populateVMIConversionPatterns(
       OneToNVMIBinaryOpPattern<VMIAndIOp, VandOp>,
       OneToNVMIBinaryOpPattern<VMIOrIOp, VorOp>,
       OneToNVMIBinaryOpPattern<VMIXOrIOp, VxorOp>,
-      OneToNVMIBinaryOpPattern<VMIShLIOp, VshlOp>,
-      OneToNVMIBinaryOpPattern<VMIShRUIOp, VshrOp>,
-      OneToNVMIBinaryOpPattern<VMIShRSIOp, VshrOp>,
+      OneToNVMIShiftOpPattern<VMIShLIOp, VshlOp>,
+      OneToNVMIShiftOpPattern<VMIShRUIOp, VshrOp>,
+      OneToNVMIShiftOpPattern<VMIShRSIOp, VshrOp>,
       OneToNVMIUnaryOpPattern<VMINotOp, VnotOp>,
       OneToNVMICmpOpPattern<VMICmpFOp>, OneToNVMICmpOpPattern<VMICmpIOp>,
       OneToNVMISelectOpPattern, OneToNVMIVselrOpPattern,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8588,13 +8588,13 @@ struct OneToNVMIBinaryOpPattern : OneToNOpConversionPattern<SourceOp> {
 // signedness of the value being shifted. Preserve the count bits with a
 // bitcast before creating the physical shift operation.
 template <typename SourceOp, typename TargetOp>
-struct OneToNVMIShiftOpPattern : OpConversionPattern<SourceOp> {
-  using OpConversionPattern<SourceOp>::OpConversionPattern;
+struct OneToNVMIShiftOpPattern : OneToNOpConversionPattern<SourceOp> {
+  using OneToNOpConversionPattern<SourceOp>::OneToNOpConversionPattern;
 
   LogicalResult matchAndRewrite(
       SourceOp op,
-      typename OpConversionPattern<SourceOp>::OneToNOpAdaptor adaptor,
-      ConversionPatternRewriter &rewriter) const override {
+      typename OneToNOpConversionPattern<SourceOp>::OpAdaptor adaptor,
+      OneToNPatternRewriter &rewriter) const override {
     ValueRange lhsParts = adaptor.getLhs();
     ValueRange rhsParts = adaptor.getRhs();
     FailureOr<SmallVector<Type>> maybeResultTypes =

--- a/ptodsl/docs/user_guide/08-compute-operations.md
+++ b/ptodsl/docs/user_guide/08-compute-operations.md
@@ -1701,6 +1701,12 @@ exp_vec = pto.vexp(s_row, col_mask)
 | `pto.vshl(vec, shift, mask) -> VRegType` | `vec << shift` (per-element) |
 | `pto.vshr(vec, shift, mask) -> VRegType` | `vec >> shift` (per-element) |
 
+For `pto.vshl` and `pto.vshr`, `vec` must use an integer element type. The
+`shift` vector must have the same lane count and element bit width as `vec`.
+PTODSL normalizes `shift` to signed `siW`, where `W` is the element bit width;
+the result has the same type as `vec`. The right-shift mode of `pto.vshr` is
+not defined by the current contract.
+
 ---
 
 ### 8.2.3 Vector-scalar ops

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -1859,6 +1859,37 @@ def _emit_binary_vec_op(op_ctor, lhs, rhs, mask):
     )
 
 
+def _normalize_shift_count_vector(rhs, *, context: str):
+    """Reinterpret an integer shift-count vector as its signed type."""
+    raw_type = unwrap_surface_value(rhs).type
+    # Preserve generated-wrapper dispatch tests, which intentionally use mock
+    # values instead of MLIR SSA values. Real PTODSL values always carry Type.
+    if not isinstance(raw_type, Type):
+        return rhs
+    _, element_type = _infer_vreg_metadata(rhs)
+    if not IntegerType.isinstance(element_type):
+        raise TypeError(f"{context} requires an integer shift-count vector")
+    integer_type = IntegerType(element_type)
+    signed_type = IntegerType.get_signed(integer_type.width)
+    if element_type == signed_type:
+        return rhs
+    return vbitcast(rhs, signed_type)
+
+
+def _emit_shift_vec_op(op_ctor, lhs, rhs, mask):
+    context = f"pto.{_surface_name_for_op_ctor(op_ctor)}(...)"
+    _reject_low_precision_vreg_operands(lhs, rhs, context=context)
+    normalized_rhs = _normalize_shift_count_vector(rhs, context=context)
+    return wrap_surface_value(
+        op_ctor(
+            unwrap_surface_value(lhs).type,
+            unwrap_surface_value(lhs),
+            unwrap_surface_value(normalized_rhs),
+            unwrap_surface_value(mask),
+        ).result
+    )
+
+
 def _emit_vec_scalar_masked_op(op_ctor, inp, scalar, mask, *, context: str):
     _reject_low_precision_vreg_operands(inp, context=f"pto.{context}(...)")
     scalar_value = _coerce_scalar_like_vector_element(inp, scalar, context=context)
@@ -1941,12 +1972,12 @@ def vtrc(inp, mask, *, rnd="Z"):
 
 def vshl(lhs, rhs, mask):
     """``pto.vshl`` – element-wise shift left."""
-    return _emit_binary_vec_op(_pto.VshlOp, lhs, rhs, mask)
+    return _emit_shift_vec_op(_pto.VshlOp, lhs, rhs, mask)
 
 
 def vshr(lhs, rhs, mask):
     """``pto.vshr`` – element-wise shift right."""
-    return _emit_binary_vec_op(_pto.VshrOp, lhs, rhs, mask)
+    return _emit_shift_vec_op(_pto.VshrOp, lhs, rhs, mask)
 
 
 def vcmax(v, mask):

--- a/ptodsl/tests/test_shift_count_normalization.py
+++ b/ptodsl/tests/test_shift_count_normalization.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import re
+
+from ptodsl import pto
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def shift_count_normalization_probe():
+    unsigned_tile = pto.alloc_tile(shape=[1, 64], dtype=pto.ui32)
+    signed_tile = pto.alloc_tile(shape=[1, 64], dtype=pto.si32)
+    signless_tile = pto.alloc_tile(shape=[1, 64], dtype=pto.i32)
+    offset = pto.const(0, dtype=pto.index)
+    active_lanes = pto.const(64, dtype=pto.i32)
+    mask, _ = pto.make_mask(pto.ui32, active_lanes)
+    unsigned_value = pto.vlds(unsigned_tile.as_ptr(), offset)
+    signless_count = pto.vlds(signless_tile.as_ptr(), offset)
+    signed_value = pto.vlds(signed_tile.as_ptr(), offset)
+    unsigned_count = pto.vlds(unsigned_tile.as_ptr(), offset)
+    _ = pto.vshr(unsigned_value, signless_count, mask)
+    _ = pto.vshl(signed_value, unsigned_count, mask)
+
+
+def main() -> None:
+    mlir_text = shift_count_normalization_probe.compile().mlir_text()
+    expect(
+        mlir_text.count("pto.vbitcast") == 2,
+        "each non-signed shift count must be normalized with pto.vbitcast",
+    )
+    expect(
+        re.search(
+            r"pto\.vshr [^:]+ : !pto\.vreg<64xui32>, "
+            r"!pto\.vreg<64xsi32>, !pto\.mask<b32> -> !pto\.vreg<64xui32>",
+            mlir_text,
+        ) is not None,
+        "vshr must consume a signed i32 shift-count vector",
+    )
+    expect(
+        re.search(
+            r"pto\.vshl [^:]+ : !pto\.vreg<64xsi32>, "
+            r"!pto\.vreg<64xsi32>, !pto\.mask<b32> -> !pto\.vreg<64xsi32>",
+            mlir_text,
+        ) is not None,
+        "vshl must consume a signed i32 shift-count vector",
+    )
+    print("ptodsl_shift_count_normalization: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/lit/vmi_new/vmi_to_vpto_shli.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_shli.pto
@@ -25,8 +25,10 @@ module {
 // CHECK-SAME: %[[AMOUNT0:[^,]+]]: !pto.vreg<128xi16>
 // CHECK-SAME: %[[AMOUNT1:[^)]+]]: !pto.vreg<128xi16>
 // CHECK-SAME: -> (!pto.vreg<128xi16>, !pto.vreg<128xi16>)
-// CHECK-DAG: %[[SHL0:.*]] = pto.vshl %[[VALUE0]], %[[AMOUNT0]], {{.*}} : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
-// CHECK-DAG: %[[SHL1:.*]] = pto.vshl %[[VALUE1]], %[[AMOUNT1]], {{.*}} : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+// CHECK-DAG: %[[COUNT0:.*]] = pto.vbitcast %[[AMOUNT0]] : !pto.vreg<128xi16> -> !pto.vreg<128xsi16>
+// CHECK-DAG: %[[COUNT1:.*]] = pto.vbitcast %[[AMOUNT1]] : !pto.vreg<128xi16> -> !pto.vreg<128xsi16>
+// CHECK-DAG: %[[SHL0:.*]] = pto.vshl %[[VALUE0]], %[[COUNT0]], {{.*}} : !pto.vreg<128xi16>, !pto.vreg<128xsi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+// CHECK-DAG: %[[SHL1:.*]] = pto.vshl %[[VALUE1]], %[[COUNT1]], {{.*}} : !pto.vreg<128xi16>, !pto.vreg<128xsi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
 // CHECK: return %[[SHL0]], %[[SHL1]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_shrui.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_shrui.pto
@@ -30,8 +30,10 @@ module {
 // LOWER-SAME: %[[AMOUNT0:[^,]+]]: !pto.vreg<128xui16>
 // LOWER-SAME: %[[AMOUNT1:[^)]+]]: !pto.vreg<128xui16>
 // LOWER-SAME: -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>)
-// LOWER-DAG: %[[SHR0:.*]] = pto.vshr %[[VALUE0]], %[[AMOUNT0]], {{.*}} : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
-// LOWER-DAG: %[[SHR1:.*]] = pto.vshr %[[VALUE1]], %[[AMOUNT1]], {{.*}} : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+// LOWER-DAG: %[[COUNT0:.*]] = pto.vbitcast %[[AMOUNT0]] : !pto.vreg<128xui16> -> !pto.vreg<128xsi16>
+// LOWER-DAG: %[[COUNT1:.*]] = pto.vbitcast %[[AMOUNT1]] : !pto.vreg<128xui16> -> !pto.vreg<128xsi16>
+// LOWER-DAG: %[[SHR0:.*]] = pto.vshr %[[VALUE0]], %[[COUNT0]], {{.*}} : !pto.vreg<128xui16>, !pto.vreg<128xsi16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+// LOWER-DAG: %[[SHR1:.*]] = pto.vshr %[[VALUE1]], %[[COUNT1]], {{.*}} : !pto.vreg<128xui16>, !pto.vreg<128xsi16>, !pto.mask<b16> -> !pto.vreg<128xui16>
 // LOWER: return %[[SHR0]], %[[SHR1]]
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.

--- a/test/lit/vpto/vshift_mixed_signedness_verify.pto
+++ b/test/lit/vpto/vshift_mixed_signedness_verify.pto
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guard the vshl/vshr shift-count contract: rhs is always signed, while lhs
+// and result retain their data types.
+// RUN: split-file %s %t
+// RUN: ptoas --pto-arch=a5 --emit-pto-ir %t/signed_rhs.pto -o - 2>&1 | FileCheck %s --check-prefix=SIGNED
+// RUN: not ptoas --pto-arch=a5 --emit-pto-ir %t/signless_rhs.pto -o - 2>&1 | FileCheck %s --check-prefix=SIGNLESS
+// RUN: not ptoas --pto-arch=a5 --emit-pto-ir %t/unsigned_rhs.pto -o - 2>&1 | FileCheck %s --check-prefix=UNSIGNED
+
+// SIGNED: pto.vshr
+// SIGNED: pto.vshl
+
+//--- signed_rhs.pto
+module {
+  func.func @signed_shift_counts(
+      %ui_lhs: !pto.vreg<64xui32>,
+      %si_lhs: !pto.vreg<64xsi32>,
+      %count: !pto.vreg<64xsi32>,
+      %mask: !pto.mask<b32>) -> (!pto.vreg<64xui32>, !pto.vreg<64xsi32>) {
+    %shr = pto.vshr %ui_lhs, %count, %mask
+        : !pto.vreg<64xui32>, !pto.vreg<64xsi32>, !pto.mask<b32>
+        -> !pto.vreg<64xui32>
+    %shl = pto.vshl %si_lhs, %count, %mask
+        : !pto.vreg<64xsi32>, !pto.vreg<64xsi32>, !pto.mask<b32>
+        -> !pto.vreg<64xsi32>
+    return %shr, %shl : !pto.vreg<64xui32>, !pto.vreg<64xsi32>
+  }
+}
+
+//--- signless_rhs.pto
+module {
+  func.func @reject_signless_count(
+      %lhs: !pto.vreg<64xui32>,
+      %rhs: !pto.vreg<64xi32>,
+      %mask: !pto.mask<b32>) -> !pto.vreg<64xui32> {
+    %result = pto.vshr %lhs, %rhs, %mask
+        : !pto.vreg<64xui32>, !pto.vreg<64xi32>, !pto.mask<b32>
+        -> !pto.vreg<64xui32>
+    return %result : !pto.vreg<64xui32>
+  }
+}
+
+// SIGNLESS: error: 'pto.vshr' op requires shift count to use a signed integer element type
+
+//--- unsigned_rhs.pto
+module {
+  func.func @reject_unsigned_count_for_signed_data(
+      %lhs: !pto.vreg<64xsi32>,
+      %rhs: !pto.vreg<64xui32>,
+      %mask: !pto.mask<b32>) -> !pto.vreg<64xsi32> {
+    %result = pto.vshl %lhs, %rhs, %mask
+        : !pto.vreg<64xsi32>, !pto.vreg<64xui32>, !pto.mask<b32>
+        -> !pto.vreg<64xsi32>
+    return %result : !pto.vreg<64xsi32>
+  }
+}
+
+// UNSIGNED: error: 'pto.vshl' op requires shift count to use a signed integer element type

--- a/test/vpto/cases/micro-op/binary-vector/vshl/kernel.pto
+++ b/test/vpto/cases/micro-op/binary-vector/vshl/kernel.pto
@@ -32,7 +32,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
       scf.for %offset_m0 = %c0_m0 to %c1024_m0 step %c128_m0 {
         %lhs_m0 = pto.vlds %ub_lhs_m0[%offset_m0] : !pto.ptr<ui16, ub> -> !pto.vreg<128xui16>
         %rhs_m0 = pto.vlds %ub_rhs_m0[%offset_m0] : !pto.ptr<ui16, ub> -> !pto.vreg<128xui16>
-        %out_m0 = pto.vshl %lhs_m0, %rhs_m0, %mask_m0 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+        %rhs_signed_m0 = pto.vbitcast %rhs_m0 : !pto.vreg<128xui16> -> !pto.vreg<128xsi16>
+        %out_m0 = pto.vshl %lhs_m0, %rhs_signed_m0, %mask_m0 : !pto.vreg<128xui16>, !pto.vreg<128xsi16>, !pto.mask<b16> -> !pto.vreg<128xui16>
         pto.vsts %out_m0, %ub_out_m0[%offset_m0], %mask_m0 : !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
       }
     }
@@ -78,7 +79,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
       scf.for %offset_m1 = %c0_m1 to %c1024_m1 step %c64_m1 {
         %lhs_m1 = pto.vlds %ub_lhs_m1[%offset_m1] : !pto.ptr<ui32, ub> -> !pto.vreg<64xui32>
         %rhs_m1 = pto.vlds %ub_rhs_m1[%offset_m1] : !pto.ptr<ui32, ub> -> !pto.vreg<64xui32>
-        %out_m1 = pto.vshl %lhs_m1, %rhs_m1, %mask_m1 : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
+        %rhs_signed_m1 = pto.vbitcast %rhs_m1 : !pto.vreg<64xui32> -> !pto.vreg<64xsi32>
+        %out_m1 = pto.vshl %lhs_m1, %rhs_signed_m1, %mask_m1 : !pto.vreg<64xui32>, !pto.vreg<64xsi32>, !pto.mask<b32> -> !pto.vreg<64xui32>
         pto.vsts %out_m1, %ub_out_m1[%offset_m1], %mask_m1 : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
       }
     }
@@ -122,7 +124,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
       scf.for %offset_m2 = %c0_m2 to %c1024_m2 step %c128_m2 {
         %lhs_m2 = pto.vlds %ub_lhs_m2[%offset_m2] : !pto.ptr<ui16, ub> -> !pto.vreg<128xui16>
         %rhs_m2 = pto.vlds %ub_rhs_m2[%offset_m2] : !pto.ptr<ui16, ub> -> !pto.vreg<128xui16>
-        %out_m2 = pto.vshl %lhs_m2, %rhs_m2, %mask_m2 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+        %rhs_signed_m2 = pto.vbitcast %rhs_m2 : !pto.vreg<128xui16> -> !pto.vreg<128xsi16>
+        %out_m2 = pto.vshl %lhs_m2, %rhs_signed_m2, %mask_m2 : !pto.vreg<128xui16>, !pto.vreg<128xsi16>, !pto.mask<b16> -> !pto.vreg<128xui16>
         pto.vsts %out_m2, %ub_out_m2[%offset_m2], %mask_m2 : !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
       }
     }

--- a/test/vpto/cases/micro-op/binary-vector/vshr/kernel.pto
+++ b/test/vpto/cases/micro-op/binary-vector/vshr/kernel.pto
@@ -32,7 +32,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
       scf.for %offset_m0 = %c0_m0 to %c1024_m0 step %c128_m0 {
         %lhs_m0 = pto.vlds %ub_lhs_m0[%offset_m0] : !pto.ptr<ui16, ub> -> !pto.vreg<128xui16>
         %rhs_m0 = pto.vlds %ub_rhs_m0[%offset_m0] : !pto.ptr<ui16, ub> -> !pto.vreg<128xui16>
-        %out_m0 = pto.vshr %lhs_m0, %rhs_m0, %mask_m0 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+        %rhs_signed_m0 = pto.vbitcast %rhs_m0 : !pto.vreg<128xui16> -> !pto.vreg<128xsi16>
+        %out_m0 = pto.vshr %lhs_m0, %rhs_signed_m0, %mask_m0 : !pto.vreg<128xui16>, !pto.vreg<128xsi16>, !pto.mask<b16> -> !pto.vreg<128xui16>
         pto.vsts %out_m0, %ub_out_m0[%offset_m0], %mask_m0 : !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
       }
     }
@@ -120,7 +121,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
       scf.for %offset_m2 = %c0_m2 to %c1024_m2 step %c128_m2 {
         %lhs_m2 = pto.vlds %ub_lhs_m2[%offset_m2] : !pto.ptr<ui16, ub> -> !pto.vreg<128xui16>
         %rhs_m2 = pto.vlds %ub_rhs_m2[%offset_m2] : !pto.ptr<ui16, ub> -> !pto.vreg<128xui16>
-        %out_m2 = pto.vshr %lhs_m2, %rhs_m2, %mask_m2 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+        %rhs_signed_m2 = pto.vbitcast %rhs_m2 : !pto.vreg<128xui16> -> !pto.vreg<128xsi16>
+        %out_m2 = pto.vshr %lhs_m2, %rhs_signed_m2, %mask_m2 : !pto.vreg<128xui16>, !pto.vreg<128xsi16>, !pto.mask<b16> -> !pto.vreg<128xui16>
         pto.vsts %out_m2, %ub_out_m2[%offset_m2], %mask_m2 : !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
       }
     }


### PR DESCRIPTION
## Summary
- require signed vector shift-count carriers while preserving lhs/result types
- normalize PTODSL and VMI-to-VPTO shift counts with bitcasts
- cover signedness verification and lowering regressions

## Validation
- cmake --build /home/zhangzhendong/ptoas-workspace/builds/issue-1220 --target pto-test-opt -j8
- llvm-lit: vmi_to_vpto_shrui, vmi_to_vpto_shli, vmi_to_vpto_shrsi, vshift_mixed_signedness_verify
- ptodsl/tests/test_vector_cube_ops.py
- ptodsl/tests/test_shift_count_normalization.py
- ptodsl/tests/test_vmi_vshr_signedness.py

Fixes: #1220