### PR TITLE
fix: support A5 i16 pto.vdiv via SoftOps and reject unsupported integer vdiv

### DIFF
--- a/docs/isa/micro-isa/07-binary-vector-ops.md
+++ b/docs/isa/micro-isa/07-binary-vector-ops.md
@@ -85,7 +85,8 @@ for (int i = 0; i < N; i++)
 ### `pto.vdiv`
 
 - **syntax:** `%result = pto.vdiv %lhs, %rhs, %mask : !pto.vreg<NxT>, !pto.vreg<NxT>, !pto.mask<G> -> !pto.vreg<NxT>`
-- **A5 types:** f16, f32; i32 is materialized through the A5 software library.
+- **A5 types:** f16, f32; only signed or signless i16/i32 are materialized
+  through the A5 software library.
 
 ```c
 for (int i = 0; i < N; i++)
@@ -95,13 +96,17 @@ for (int i = 0; i < N; i++)
 - **inputs:** `%lhs` is the numerator, `%rhs` is the denominator, and `%mask`
   selects active lanes.
 - **outputs:** `%result` is the lane-wise quotient.
-- **constraints and limitations:** i32 division is rounded toward zero and is
-  exact for every nonzero denominator, including values outside f32's exact
-  range. It is expanded late to a PTODSL SoftOps implementation because the
-  released BiSheng toolchain cannot lower the integer HiVM intrinsic reliably.
-  The overflowing pair `INT32_MIN / -1` follows the target's two's-complement
-  result representation. Division by zero is undefined. Active floating-point
-  denominators containing `+0` or `-0` follow the target's exceptional behavior.
+- **constraints and limitations:** i16 and i32 division is rounded toward zero
+  and is exact for every nonzero denominator, including values outside f32's
+  exact range. It is expanded late to a PTODSL SoftOps implementation because
+  the released BiSheng toolchain cannot lower the integer HiVM intrinsic
+  reliably; unsigned integer variants (ui16/ui32) and other integer element
+  widths are rejected at compile time on A5 rather than reaching the
+  unsupported integer HiVM path. The overflowing
+  pairs `INT16_MIN / -1` and `INT32_MIN / -1` follow the target's
+  two's-complement result representation. Division by zero is undefined.
+  Active floating-point denominators containing `+0` or `-0` follow the
+  target's exceptional behavior.
 
 ---
 

--- a/lib/PTO/Transforms/PTOExpandSoftLib.cpp
+++ b/lib/PTO/Transforms/PTOExpandSoftLib.cpp
@@ -46,25 +46,44 @@ namespace {
 static constexpr llvm::StringLiteral kSoftLibInstanceAttr =
     "pto.softlib.instance";
 
-static bool isSignedI32VReg(Type type) {
+// Element widths the A5 Software Library implements for pto.vdiv.  Signed and
+// signless forms are both accepted; unsigned vectors are intentionally not.
+static bool isSoftLibVdivIntegerVReg(Type type) {
   auto vreg = dyn_cast<VRegType>(type);
-  if (!vreg)
+  if (!vreg) {
     return false;
+  }
   auto integer = dyn_cast<IntegerType>(vreg.getElementType());
-  return integer && integer.getWidth() == 32 &&
+  if (!integer) {
+    return false;
+  }
+  return (integer.getWidth() == 16 || integer.getWidth() == 32) &&
          (integer.isSigned() || integer.isSignless());
 }
 
-static StringRef getIntegerDtype(VdivOp op) {
+// Integer-element pto.vdiv on A5 must be handled here (SoftOps or an explicit
+// compile-time rejection).  Floating-point vdiv is native and is left alone.
+static bool isIntegerVdiv(Operation *op) {
+  auto vdiv = dyn_cast<VdivOp>(op);
+  if (!vdiv) {
+    return false;
+  }
+  auto vreg = dyn_cast<VRegType>(vdiv.getResult().getType());
+  if (!vreg) {
+    return false;
+  }
+  return isa<IntegerType>(vreg.getElementType());
+}
+
+static std::string getIntegerDtype(VdivOp op) {
   auto vreg = cast<VRegType>(op.getLhs().getType());
   auto integer = cast<IntegerType>(vreg.getElementType());
-  return integer.isSigned() ? StringRef("si32") : StringRef("i32");
+  return (integer.isSigned() ? "si" : "i") + std::to_string(integer.getWidth());
 }
 
 static std::string buildVdivRequestJson(VdivOp op) {
   auto vreg = cast<VRegType>(op.getLhs().getType());
-  std::string json = "{\"dtype\":\"" + getIntegerDtype(op).str() +
-                     "\",\"lanes\":";
+  std::string json = "{\"dtype\":\"" + getIntegerDtype(op) + "\",\"lanes\":";
   json += std::to_string(vreg.getElementCount());
   json += ",\"mask\":\"";
   json += cast<MaskType>(op.getMask().getType()).getGranularity().str();
@@ -76,8 +95,9 @@ static std::string uniqueSoftLibName(ModuleOp module, StringRef base) {
   std::string stem = std::string("__pto_soft_") + base.str();
   unsigned suffix = 0;
   std::string name = stem;
-  while (module.lookupSymbol<func::FuncOp>(name))
+  while (module.lookupSymbol<func::FuncOp>(name)) {
     name = stem + "_" + std::to_string(++suffix);
+  }
   return name;
 }
 
@@ -114,24 +134,30 @@ struct PTOExpandSoftLibPass
     func::FuncOp importedEntry;
     LogicalResult materializationResult = service->materialize(
         request, context, [&](ModuleOp source, StringRef entrySymbol) {
-          if (!source || source.getContext() != &context)
+          bool materializeSourceReady =
+              source && source.getContext() == &context;
+          if (!materializeSourceReady) {
             return failure();
+          }
           func::FuncOp sourceEntry = source.lookupSymbol<func::FuncOp>(entrySymbol);
-          if (!sourceEntry)
+          if (!sourceEntry) {
             return failure();
+          }
 
           SymbolTable symbols(module);
           SmallVector<func::FuncOp> sourceFunctions;
-          for (func::FuncOp fn : source.getOps<func::FuncOp>())
+          for (func::FuncOp fn : source.getOps<func::FuncOp>()) {
             sourceFunctions.push_back(fn);
+          }
 
           llvm::StringMap<std::string> renames;
           for (func::FuncOp fn : sourceFunctions) {
             std::string name = fn == sourceEntry
                                    ? functionName
                                    : functionName + "__" + fn.getSymName().str();
-            if (symbols.lookup(name))
+            if (symbols.lookup(name)) {
               return failure();
+            }
             renames[fn.getSymName()] = name;
           }
 
@@ -145,19 +171,24 @@ struct PTOExpandSoftLibPass
             copy->setAttr(kSoftLibInstanceAttr, UnitAttr::get(&context));
             cloned.push_back(copy);
           }
-          for (func::FuncOp fn : cloned)
-            for (const auto &rename : renames)
+          for (func::FuncOp fn : cloned) {
+            for (const auto &rename : renames) {
               if (failed(SymbolTable::replaceAllSymbolUses(
                       StringAttr::get(&context, rename.getKey()),
-                      StringAttr::get(&context, rename.getValue()), fn)))
+                      StringAttr::get(&context, rename.getValue()), fn))) {
                 return failure();
+              }
+            }
+          }
           importedEntry = module.lookupSymbol<func::FuncOp>(functionName);
           return importedEntry ? success() : failure();
         });
-    if (failed(materializationResult) || !importedEntry)
+    bool softLibReady = succeeded(materializationResult) && importedEntry;
+    if (!softLibReady) {
       return op->emitError() << "failed to materialize SoftOps implementation for "
                              << requestOp,
              failure();
+    }
 
     OpBuilder builder(op);
     auto call = builder.create<func::CallOp>(op->getLoc(), importedEntry,
@@ -181,7 +212,7 @@ struct PTOExpandSoftLibPass
                                 MLIRContext &context, StringRef target,
                                 const std::shared_ptr<SoftLibService> &service) {
     auto vreg = cast<VRegType>(op.getLhs().getType());
-    std::string stem = "vdiv_" + getIntegerDtype(op).str() + "_" +
+    std::string stem = "vdiv_" + getIntegerDtype(op) + "_" +
                        std::to_string(vreg.getElementCount());
     return materializeCall(op, module, context, target, "pto.vdiv",
                            buildVdivRequestJson(op), stem,
@@ -192,19 +223,23 @@ struct PTOExpandSoftLibPass
   void runOnOperation() override {
     ModuleOp module = getOperation();
     ModuleOp topLevel = getTopLevelModuleOp(module);
-    if (!isTargetArchA5(topLevel))
+    if (!isTargetArchA5(topLevel)) {
       return;
+    }
     StringRef targetArch = "a5";
-    if (auto attr = topLevel->getAttrOfType<StringAttr>("pto.target_arch"))
+    if (auto attr = topLevel->getAttrOfType<StringAttr>("pto.target_arch")) {
       targetArch = attr.getValue();
+    }
     SmallVector<Operation *> candidates;
     module.walk([&](Operation *op) {
-      if (isa<SinOp, CosOp>(op) ||
-          (isa<VdivOp>(op) && isSignedI32VReg(op->getResult(0).getType())))
+      bool isSoftLibCandidate = isa<SinOp, CosOp>(op) || isIntegerVdiv(op);
+      if (isSoftLibCandidate) {
         candidates.push_back(op);
+      }
     });
-    if (candidates.empty())
+    if (candidates.empty()) {
       return;
+    }
     auto service = SoftLibRuntime::getService();
     if (!service) {
       module.emitError("PTOExpandSoftLib requires an initialized PTODSL SoftLib runtime");
@@ -213,19 +248,37 @@ struct PTOExpandSoftLibPass
     }
     for (Operation *op : candidates) {
       if (auto vdiv = dyn_cast<VdivOp>(op)) {
-        if (!isSignedI32VReg(vdiv.getLhs().getType()) ||
-            !isSignedI32VReg(vdiv.getRhs().getType()) ||
-            vdiv.getLhs().getType() != vdiv.getRhs().getType() ||
-            vdiv.getLhs().getType() != vdiv.getResult().getType() ||
-            vdiv.getMask().getType() != MaskType::get(&getContext(), "b32")) {
-          vdiv.emitError(
-              "A5 SoftOps pto.vdiv requires matching signed i32 vectors and a b32 mask");
+        auto resultVreg = dyn_cast<VRegType>(vdiv.getResult().getType());
+        if (!resultVreg) {
+          vdiv.emitError("A5 pto.vdiv requires a vector result");
+          signalPassFailure();
+          continue;
+        }
+        auto integer = dyn_cast<IntegerType>(resultVreg.getElementType());
+        auto expectedMask = integer && integer.getWidth() == 16
+                                ? "b16"
+                                : "b32";
+        bool lhsLegal = isSoftLibVdivIntegerVReg(vdiv.getLhs().getType());
+        bool rhsLegal = isSoftLibVdivIntegerVReg(vdiv.getRhs().getType());
+        bool sameType = vdiv.getLhs().getType() == vdiv.getRhs().getType() &&
+                        vdiv.getLhs().getType() == vdiv.getResult().getType();
+        bool maskMatches =
+            vdiv.getMask().getType() == MaskType::get(&getContext(), expectedMask);
+        if (!lhsLegal || !rhsLegal || !sameType || !maskMatches) {
+          vdiv.emitError() << "A5 integer pto.vdiv is not supported for "
+                           << vdiv.getResult().getType() << " with mask "
+                           << vdiv.getMask().getType() << "; only signed or "
+                           << "signless i16 vectors with a b16 mask and i32 "
+                           << "vectors with a b32 mask are materialized through "
+                           << "the A5 Software Library, and f16/f32 pto.vdiv "
+                           << "uses the native vector instruction";
           signalPassFailure();
           continue;
         }
         if (failed(materializeVdiv(vdiv, module, getContext(), targetArch,
-                                   service)))
+                                   service))) {
           signalPassFailure();
+        }
         continue;
       }
       if (!op->getResult(0).getType().isF32() || !op->getOperand(0).getType().isF32()) {
@@ -235,8 +288,9 @@ struct PTOExpandSoftLibPass
       }
       StringRef opName = isa<SinOp>(op) ? "pto.sin" : "pto.cos";
       if (failed(materializeTrig(op, module, getContext(), targetArch, opName,
-                                 service)))
+                                 service))) {
         signalPassFailure();
+      }
     }
   }
 };

--- a/lib/SoftOps/__init__.py
+++ b/lib/SoftOps/__init__.py
@@ -8,7 +8,7 @@
 
 """PTODSL software-operation libraries shared by TileOps and late lowering."""
 
-from .div_int import div_i32_soft
+from .div_int import div_i16_soft, div_i32_soft
 from .trig import cos_f32_soft, sin_f32_soft
 
-__all__ = ["div_i32_soft", "sin_f32_soft", "cos_f32_soft"]
+__all__ = ["div_i16_soft", "div_i32_soft", "sin_f32_soft", "cos_f32_soft"]

--- a/lib/SoftOps/div_int.py
+++ b/lib/SoftOps/div_int.py
@@ -103,3 +103,110 @@ def div_i32_soft(vec, scalar_vec, mask):
     negative_quotient = pto.vneg(signed_bits, active_mask)
     signed_quotient = pto.vsel(signed_bits, negative_quotient, positive)
     return pto.vsel(pto.vbr(neg_one), signed_quotient, zero_mask)
+
+
+def div_i16_soft(vec, scalar_vec, mask):
+    """Compute signed i16 division without relying on integer ``vdiv``.
+
+    Each 128-lane i16 operand is widened into two 64-lane u32 halves through
+    b16 interleave plus a 2:1 ``vcvt`` (the VPTO vcvt contract conserves total
+    vector bits, so a straight i16->f32 conversion at the same lane count is
+    not expressible). The quotient magnitude is estimated from a 65536-scaled
+    f32 reciprocal in the u32 domain, narrowed back to u16 through ``vdintlv``,
+    and corrected against the exact remainder. The result is exact for every
+    nonzero int16 divisor; division by zero is intentionally undefined.
+    """
+    result_dtype = pto.si16 if str(vec.type).endswith("xsi16>") else pto.i16
+    zero = result_dtype(0)
+    neg_one = result_dtype(-1)
+    ui16_zero = pto.ui16(0)
+    ui16_one = pto.ui16(1)
+    fp32_one = pto.f32(1.0)
+    fp32_65536 = pto.f32(65536.0)
+    full_b16 = pto.pset_b16(pto.PAT.ALL)
+    full_b32 = pto.pset_b32(pto.PAT.ALL)
+
+    zero_mask = pto.vcmps(scalar_vec, zero, mask, pto.CmpMode.EQ)
+    active_mask = pto.pnot(zero_mask, mask)
+
+    abs_x = pto.vbitcast(pto.vabs(vec, active_mask), pto.ui16)
+    abs_y = pto.vbitcast(pto.vabs(scalar_vec, active_mask), pto.ui16)
+    x_xor_y = pto.vxor(vec, scalar_vec, active_mask)
+    positive = pto.vcmps(x_xor_y, zero, active_mask, pto.CmpMode.GE)
+
+    zero_u16 = pto.vbr(ui16_zero)
+    false_mask = pto.pset_b16(pto.PAT.ALLF)
+    # The even/odd 2:1 cvt below consumes the interleaved b16 predicate in the
+    # interleaved lane order, so the active mask must be re-interleaved the same
+    # way the data is: bit 2k of low_mask / high_mask maps to original lane k
+    # (mirrors pintlv_b32 in div_i32_soft).
+    low_mask, high_mask = pto.pintlv_b16(active_mask, false_mask)
+    vy_lower_u16, vy_higher_u16 = pto.vintlv(abs_y, zero_u16)
+    vx_lower_u16, vx_higher_u16 = pto.vintlv(abs_x, zero_u16)
+    vy_lower_u32 = pto.vcvt(
+        vy_lower_u16, pto.ui32, low_mask, part=pto.VcvtPartMode.EVEN
+    )
+    vy_higher_u32 = pto.vcvt(
+        vy_higher_u16, pto.ui32, high_mask, part=pto.VcvtPartMode.EVEN
+    )
+    vx_lower_u32 = pto.vcvt(
+        vx_lower_u16, pto.ui32, low_mask, part=pto.VcvtPartMode.EVEN
+    )
+    vx_higher_u32 = pto.vcvt(
+        vx_higher_u16, pto.ui32, high_mask, part=pto.VcvtPartMode.EVEN
+    )
+    active_low = pto.vcmps(
+        vy_lower_u32, pto.ui32(0), full_b32, pto.CmpMode.NE
+    )
+    active_high = pto.vcmps(
+        vy_higher_u32, pto.ui32(0), full_b32, pto.CmpMode.NE
+    )
+
+    lower_f32 = pto.vcvt(
+        pto.vbitcast(vy_lower_u32, pto.i32), pto.f32, active_low,
+        rnd=pto.VcvtRoundMode.F,
+    )
+    higher_f32 = pto.vcvt(
+        pto.vbitcast(vy_higher_u32, pto.i32), pto.f32, active_high,
+        rnd=pto.VcvtRoundMode.F,
+    )
+    lower_recip = pto.vdiv(pto.vbr(fp32_one), lower_f32, active_low)
+    higher_recip = pto.vdiv(pto.vbr(fp32_one), higher_f32, active_high)
+    lower_scaled = pto.vmul(lower_recip, pto.vbr(fp32_65536), active_low)
+    higher_scaled = pto.vmul(higher_recip, pto.vbr(fp32_65536), active_high)
+    lower_v = pto.vbitcast(
+        pto.vcvt(
+            lower_scaled, pto.i32, active_low,
+            rnd=pto.VcvtRoundMode.F, sat=pto.VcvtSatMode.NOSAT,
+        ),
+        pto.ui32,
+    )
+    higher_v = pto.vbitcast(
+        pto.vcvt(
+            higher_scaled, pto.i32, active_high,
+            rnd=pto.VcvtRoundMode.F, sat=pto.VcvtSatMode.NOSAT,
+        ),
+        pto.ui32,
+    )
+    q_lower = pto.vmul(lower_v, vx_lower_u32, active_low)
+    q_higher = pto.vmul(higher_v, vx_higher_u32, active_high)
+    _, q_tmp = pto.vdintlv(
+        pto.vbitcast(q_lower, pto.ui16),
+        pto.vbitcast(q_higher, pto.ui16),
+    )
+
+    yq = pto.vmul(q_tmp, abs_y, active_mask)
+    remainder = pto.vsub(abs_x, yq, active_mask)
+    for _ in range(2):
+        ge = pto.vcmp(remainder, abs_y, active_mask, pto.CmpMode.GE)
+        remainder = pto.vsel(
+            pto.vsub(remainder, abs_y, active_mask), remainder, ge
+        )
+        q_tmp = pto.vsel(
+            pto.vadds(q_tmp, ui16_one, active_mask), q_tmp, ge
+        )
+
+    signed_bits = pto.vbitcast(q_tmp, result_dtype)
+    negative_quotient = pto.vneg(signed_bits, active_mask)
+    signed_quotient = pto.vsel(signed_bits, negative_quotient, positive)
+    return pto.vsel(pto.vbr(neg_one), signed_quotient, zero_mask)

--- a/ptodsl/ptodsl/softlib/_compiler_runtime.py
+++ b/ptodsl/ptodsl/softlib/_compiler_runtime.py
@@ -38,13 +38,17 @@ def materialize(target: str, op: str, operand_specs_json: str, context):
         specs = json.loads(operand_specs_json)
     except json.JSONDecodeError as exc:
         raise ValueError(f"invalid SoftLib materialization request: {exc}") from exc
-    if op == "pto.vdiv" and specs.get("dtype") in {"i32", "si32"}:
-        lanes = int(specs.get("lanes", 64))
-        mask_bits = specs.get("mask", "b32")
-        module_name = "div_i32_soft"
-        helper = getattr(importlib.import_module("SoftOps"), module_name)
+    if op == "pto.vdiv" and specs.get("dtype") in {"i16", "si16", "i32", "si32"}:
         dtype = specs["dtype"]
-        integer_dtype = pto.si32 if dtype == "si32" else pto.i32
+        lanes = int(specs.get("lanes", 128 if dtype in {"i16", "si16"} else 64))
+        mask_bits = specs.get("mask", "b16" if dtype in {"i16", "si16"} else "b32")
+        module_name = "div_i16_soft" if dtype in {"i16", "si16"} else "div_i32_soft"
+        helper = getattr(importlib.import_module("SoftOps"), module_name)
+        integer_dtype = (
+            (pto.si16 if dtype == "si16" else pto.i16)
+            if dtype in {"i16", "si16"}
+            else (pto.si32 if dtype == "si32" else pto.i32)
+        )
         arg_types = [
             vreg_type(lanes, integer_dtype),
             vreg_type(lanes, integer_dtype),

--- a/test/dsl-st/vdiv_i16.py
+++ b/test/dsl-st/vdiv_i16.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""
+A5 signed i16 vector division simulator ST (issue 1241).
+
+Exercises ``pto.vdiv`` on ``!pto.vreg<128xi16>`` with a full ``b16`` mask. On A5
+the 16-bit integer HiVM VDIV intrinsic is not supported, so the backend
+materializes the Software Library implementation (u32-domain f32 reciprocal
+plus exact remainder correction) and the kernel must terminate with C-style
+truncating signed division results.
+"""
+
+import numpy as np
+
+from common import auto_main, golden_output_case
+from ptodsl import pto
+
+
+COLS = 128
+# Nonzero denominators covering powers of two, small values, and non-power
+# magnitudes.  |numerator| < 32768 avoids the INT16_MIN / -1 overflow pair.
+DENOMINATORS = np.array(
+    [14, -14, 3, -3, 133, -133, 1, -1, 128, -128, 7, -7, 1024, -1024, 4096, -4096],
+    dtype=np.int16,
+)
+
+
+@pto.jit(
+    name="vdiv_i16_kernel",
+    kernel_kind="vector",
+    target="a5",
+    mode="explicit",
+    insert_sync=False,
+)
+def vdiv_i16_kernel(
+    lhs_ptr: pto.ptr(pto.i16, "gm"),
+    rhs_ptr: pto.ptr(pto.i16, "gm"),
+    out_ptr: pto.ptr(pto.i16, "gm"),
+):
+    total = COLS
+    offsets = [0, 0, 0, 0, 0]
+    lhs_view = pto.make_tensor_view(
+        lhs_ptr,
+        shape=[1, 1, 1, 1, COLS],
+        strides=[total, total, total, total, 1],
+    )
+    rhs_view = pto.make_tensor_view(
+        rhs_ptr,
+        shape=[1, 1, 1, 1, COLS],
+        strides=[total, total, total, total, 1],
+    )
+    out_view = pto.make_tensor_view(
+        out_ptr,
+        shape=[1, 1, 1, 1, COLS],
+        strides=[total, total, total, total, 1],
+    )
+    lhs_part = pto.partition_view(
+        lhs_view, offsets=offsets, sizes=[1, 1, 1, 1, COLS]
+    )
+    rhs_part = pto.partition_view(
+        rhs_view, offsets=offsets, sizes=[1, 1, 1, 1, COLS]
+    )
+    out_part = pto.partition_view(
+        out_view, offsets=offsets, sizes=[1, 1, 1, 1, COLS]
+    )
+
+    lhs_tile = pto.alloc_tile(
+        shape=[1, COLS],
+        dtype=pto.i16,
+        addr=0,
+        valid_shape=[1, COLS],
+        blayout="RowMajor",
+    )
+    rhs_tile = pto.alloc_tile(
+        shape=[1, COLS],
+        dtype=pto.i16,
+        addr=2048,
+        valid_shape=[1, COLS],
+        blayout="RowMajor",
+    )
+    dst_tile = pto.alloc_tile(
+        shape=[1, COLS],
+        dtype=pto.i16,
+        addr=4096,
+        valid_shape=[1, COLS],
+        blayout="RowMajor",
+    )
+
+    pto.tile.load(lhs_part, lhs_tile)
+    pto.tile.load(rhs_part, rhs_tile)
+    pto.set_flag("MTE2", "V", event_id=0)
+    pto.wait_flag("MTE2", "V", event_id=0)
+
+    with pto.tileop():
+        mask16 = pto.pset_b16(pto.MaskPattern.ALL)
+        lhs_v = pto.vlds(lhs_tile[0, 0:])
+        rhs_v = pto.vlds(rhs_tile[0, 0:])
+        quotient = pto.vdiv(lhs_v, rhs_v, mask16)
+        pto.vsts(quotient, dst_tile.as_ptr(), 0, mask16, dist="NORM_B16")
+
+    pto.set_flag("V", "MTE3", event_id=0)
+    pto.wait_flag("V", "MTE3", event_id=0)
+    pto.tile.store(dst_tile, out_part)
+
+
+def make_inputs():
+    rng = np.random.RandomState(0x1241)
+    x = rng.randint(-30000, 30000, size=(1, COLS)).astype(np.int16)
+    y = np.resize(DENOMINATORS, (1, COLS)).astype(np.int16)
+    return [x, y]
+
+
+def make_expected(x, y):
+    x32 = np.asarray(x, dtype=np.int32)
+    y32 = np.asarray(y, dtype=np.int32)
+    # C-style signed division truncating toward zero.  numpy ``//`` floors on
+    # negatives, so compute the magnitude first (floor == trunc on positives)
+    # and attach the sign afterwards.
+    qabs = np.abs(x32) // np.abs(y32)
+    q = np.where((x32 < 0) ^ (y32 < 0), -qabs, qabs)
+    return q.astype(np.int16)
+
+
+CASES = [
+    golden_output_case(
+        "vdiv_i16_soft_128_full_mask",
+        vdiv_i16_kernel,
+        inputs=make_inputs,
+        expected=make_expected,
+        rtol=0.0,
+        atol=0.0,
+    ),
+]
+
+
+auto_main(globals())

--- a/test/dsl-st/vdiv_i16_partial_masks.py
+++ b/test/dsl-st/vdiv_i16_partial_masks.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""A5 i16 pto.vdiv with partial (non-PAT_ALL) b16 masks.
+
+The A5 softlib splits the 128-lane i16 problem through vintlv/vcvt and must
+re-interleave the active mask with pintlv_b16 the same way; otherwise lanes
+gated by the wrong predicate bits produce wrong quotients (regression for
+issue #1241 review: only PAT_ALL was covered before).  Cases here exercise a
+prefix (PAT_VL64 / PAT_VL2), an arbitrary data-dependent predicate, and a mask
+that spans the 64-lane boundary with a leading hole.
+
+Each kernel first writes a sentinel over the whole tile with an unmasked store
+and then overwrites the active lanes masked, so GM content is deterministic
+regardless of leftover UB state from the previous kernel.
+"""
+import numpy as np
+
+from common import auto_main, golden_output_case
+from ptodsl import pto
+
+COLS = 128
+BASE = 80  # lhs values 80..207 so no quotient is 0 (sentinels are 0)
+RHS = 3
+
+
+def _build_kernel(name, mask_builder):
+    @pto.jit(
+        name=name,
+        kernel_kind="vector",
+        target="a5",
+        mode="explicit",
+        insert_sync=False,
+    )
+    def kernel(
+        lhs_ptr: pto.ptr(pto.i16, "gm"),
+        rhs_ptr: pto.ptr(pto.i16, "gm"),
+        out_ptr: pto.ptr(pto.i16, "gm"),
+    ):
+        total = COLS
+        offsets = [0, 0, 0, 0, 0]
+        lhs_view = pto.make_tensor_view(
+            lhs_ptr, shape=[1, 1, 1, 1, COLS],
+            strides=[total, total, total, total, 1],
+        )
+        rhs_view = pto.make_tensor_view(
+            rhs_ptr, shape=[1, 1, 1, 1, COLS],
+            strides=[total, total, total, total, 1],
+        )
+        out_view = pto.make_tensor_view(
+            out_ptr, shape=[1, 1, 1, 1, COLS],
+            strides=[total, total, total, total, 1],
+        )
+        lhs_part = pto.partition_view(lhs_view, offsets=offsets, sizes=[1, 1, 1, 1, COLS])
+        rhs_part = pto.partition_view(rhs_view, offsets=offsets, sizes=[1, 1, 1, 1, COLS])
+        out_part = pto.partition_view(out_view, offsets=offsets, sizes=[1, 1, 1, 1, COLS])
+
+        lhs_tile = pto.alloc_tile(shape=[1, COLS], dtype=pto.i16, addr=0,
+                                  valid_shape=[1, COLS], blayout="RowMajor")
+        rhs_tile = pto.alloc_tile(shape=[1, COLS], dtype=pto.i16, addr=2048,
+                                  valid_shape=[1, COLS], blayout="RowMajor")
+        dst_tile = pto.alloc_tile(shape=[1, COLS], dtype=pto.i16, addr=4096,
+                                  valid_shape=[1, COLS], blayout="RowMajor")
+
+        pto.tile.load(lhs_part, lhs_tile)
+        pto.tile.load(rhs_part, rhs_tile)
+        pto.set_flag("MTE2", "V", event_id=0)
+        pto.wait_flag("MTE2", "V", event_id=0)
+
+        with pto.tileop():
+            full_mask = pto.pset_b16(pto.MaskPattern.ALL)
+            lhs_v = pto.vlds(lhs_tile[0, 0:])
+            rhs_v = pto.vlds(rhs_tile[0, 0:])
+            sentinel = pto.vbr(pto.i16(0))
+            pto.vsts(sentinel, dst_tile.as_ptr(), 0, full_mask, dist="NORM_B16")
+            mask = mask_builder(lhs_v)
+            quotient = pto.vdiv(lhs_v, rhs_v, mask)
+            pto.vsts(quotient, dst_tile.as_ptr(), 0, mask, dist="NORM_B16")
+
+        pto.set_flag("V", "MTE3", event_id=0)
+        pto.wait_flag("V", "MTE3", event_id=0)
+        pto.tile.store(dst_tile, out_part)
+
+    return kernel
+
+
+def _make_inputs():
+    x = (np.arange(COLS, dtype=np.int32) + BASE).astype(np.int16).reshape(1, COLS)
+    y = np.full((1, COLS), RHS, dtype=np.int16)
+    return [x, y]
+
+
+def _cases():
+    x = (np.arange(COLS, dtype=np.int32) + BASE).astype(np.int32)
+    q_full = (x // RHS).astype(np.int16).reshape(1, COLS)
+
+    def expect(active_mask_np):
+        expected = np.zeros((1, COLS), dtype=np.int16).reshape(-1)
+        expected[active_mask_np] = q_full.reshape(-1)[active_mask_np]
+        return expected.reshape(1, COLS)
+
+    out = []
+
+    def add_case(name, mask_builder, active_mask_np):
+        out.append(
+            golden_output_case(
+                name,
+                _build_kernel(name, mask_builder),
+                inputs=_make_inputs,
+                expected=lambda a, b, am=active_mask_np: expect(am),
+                rtol=0.0,
+                atol=0.0,
+            )
+        )
+
+    # Prefix masks.
+    v64 = np.zeros(COLS, dtype=bool)
+    v64[:64] = True
+    add_case("vdiv_i16_mask_vl64", lambda v: pto.pset_b16(pto.MaskPattern.VL64), v64)
+
+    v2 = np.zeros(COLS, dtype=bool)
+    v2[:2] = True
+    add_case("vdiv_i16_mask_vl2", lambda v: pto.pset_b16(pto.MaskPattern.VL2), v2)
+
+    # Arbitrary data-dependent predicate: lhs < 120 -> lanes 0..39.
+    sparse = x < 120
+    add_case(
+        "vdiv_i16_mask_sparse",
+        lambda v: pto.vcmps(v, pto.i16(120), pto.pset_b16(pto.MaskPattern.ALL),
+                            pto.CmpMode.LT),
+        sparse,
+    )
+
+    # Crosses the 64-lane boundary with a leading hole: lhs >= 96 -> lanes 16..127.
+    cross = x >= 96
+    add_case(
+        "vdiv_i16_mask_cross_boundary",
+        lambda v: pto.vcmps(v, pto.i16(96), pto.pset_b16(pto.MaskPattern.ALL),
+                            pto.CmpMode.GE),
+        cross,
+    )
+
+    return out
+
+
+CASES = _cases()
+
+
+auto_main(globals())

--- a/test/lit/vpto/issue_1241_vdiv_i16_reject.pto
+++ b/test/lit/vpto/issue_1241_vdiv_i16_reject.pto
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Regression test for issue 1241: an A5 integer pto.vdiv whose element type is
+// not materialized by the Software Library (unsigned variants, non-matching
+// masks) must fail at compile time instead of lowering to the unsupported
+// integer HiVM VDIV intrinsic and hanging the device at runtime.  The SoftLib
+// materializes only signed or signless 16/32-bit integer vdiv; unsigned
+// variants of the same widths (ui16/ui32) and other integer widths (e.g. i8,
+// whose vregs are legal) are rejected here.  This case uses the unsigned ui16
+// variant.
+
+// RUN: ! ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
+
+// CHECK: error: A5 integer pto.vdiv is not supported for '!pto.vreg<128xui16>' with mask '!pto.mask<b16>'
+// CHECK: only signed or signless i16 vectors with a b16 mask and i32 vectors with a b32 mask
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @issue_1241_vdiv_ui16(%lhs: !pto.vreg<128xui16>,
+                                 %rhs: !pto.vreg<128xui16>,
+                                 %dst: !pto.ptr<ui16, ub>,
+                                 %mask: !pto.mask<b16>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %quotient = pto.vdiv %lhs, %rhs, %mask :
+      !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+    pto.vsts %quotient, %dst[%c0], %mask :
+      !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
+    return
+  }
+}

--- a/test/lit/vpto/issue_1241_vdiv_i16_soft_lowering.pto
+++ b/test/lit/vpto/issue_1241_vdiv_i16_soft_lowering.pto
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Regression test for issue 1241: A5 signed i16 pto.vdiv must be expanded to
+// the Software Library implementation (u32-domain f32 reciprocal + exact
+// remainder correction) instead of the unsupported integer HiVM VDIV
+// intrinsic, which hung the device at runtime.
+
+// RUN: ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @issue_1241_vdiv_i16(%lhs: !pto.vreg<128xsi16>,
+                                  %rhs: !pto.vreg<128xsi16>,
+                                  %dst: !pto.ptr<si16, ub>,
+                                  %mask: !pto.mask<b16>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %quotient = pto.vdiv %lhs, %rhs, %mask :
+      !pto.vreg<128xsi16>, !pto.vreg<128xsi16>, !pto.mask<b16> -> !pto.vreg<128xsi16>
+    pto.vsts %quotient, %dst[%c0], %mask :
+      !pto.vreg<128xsi16>, !pto.ptr<si16, ub>, !pto.mask<b16>
+    return
+  }
+}
+
+// CHECK-LABEL: define void @issue_1241_vdiv_i16_mix_aiv
+// The integer HiVM VDIV intrinsic must never be emitted for i16.
+// CHECK-NOT: @llvm.hivm.vdiv.s.x.v128s16
+// CHECK-NOT: @llvm.hivm.vdiv.u.x.v128s16
+// The active mask is re-interleaved with the data (pintlv.b16) so the
+// vintlv/vcvt half-split gates the original lane order (partial masks).
+// CHECK: @llvm.hivm.pintlv.b16
+// The software fallback works in the u32 domain through an f32 reciprocal...
+// CHECK: call <64 x float> @llvm.hivm.vdiv.s.x.v64f32
+// CHECK: call <128 x i16> @llvm.hivm.vsel.v128i16
+// CHECK-NOT: @llvm.hivm.vdiv.s.x.v128s16
+// CHECK-NOT: @llvm.hivm.vdiv.u.x.v128s16


### PR DESCRIPTION
## Summary

Fixes #1241 — A5 signed **i16** `pto.vdiv` on `!pto.vreg<128xi16>` compiled and linked but the kernel **hung at runtime** (`aclrtSynchronizeStream` never returned, NPU pinned at 100%, device Alarm).

## Root cause

Only signed **i32**/b32 vdiv was intercepted by `PTOExpandSoftLibPass` (the issue #1181 fix, commit 4c52ba86). i16 vdiv fell through to the unsupported integer HiVM VDIV intrinsic (`llvm.hivm.vdiv.s.x.v128s16`), which the A5 micro-ISA cannot execute — the micro-ISA doc already documented A5 vdiv as f16/f32 + i32 softlib, but the contract was never enforced, so the unsupported intrinsic silently reached the device and hung it.

## Changes

**Step 1 — compile-time rejection (contract enforcement)**
- `lib/PTO/Transforms/PTOExpandSoftLib.cpp`: widened the softlib interception window to signed/signless **i16 and i32** vdiv (`isSoftLibVdivIntegerVReg`), validated operand/mask consistency, and emit a hard compile error for any other A5 integer `pto.vdiv` (e.g. unsigned variants, mismatched masks) instead of lowering it.

**Step 2 — i16 vdiv via the Software Library**
- `lib/SoftOps/div_int.py`: added `div_i16_soft` mirroring the TileLang-validated u16 soft-division algorithm — b16 interleave + 2:1 `vcvt(EVEN)` widening into the u32 domain, 65536-scaled f32 reciprocal via f32 `pto.vdiv`, high-16 narrowing back through `vdintlv`, two exact remainder-correction passes, and sign restoration with C-style truncation semantics.
- `lib/SoftOps/__init__.py` / `ptodsl/ptodsl/softlib/_compiler_runtime.py`: export and dispatch `div_i16_soft` for i16 (default 128 lanes / b16 mask).

**Tests & docs**
- `test/lit/vpto/issue_1241_vdiv_i16_reject.pto` — unsigned ui16 vdiv must fail at compile time on A5.
- `test/lit/vpto/issue_1241_vdiv_i16_soft_lowering.pto` — i16 vdiv lowers to the f32 soft implementation; no `vdiv.s.x.v128s16`.
- `test/dsl-st/vdiv_i16.py` — 1×128 i16 tile, 16 divisor magnitudes, exact C-style truncation (rtol=atol=0).
- `docs/isa/micro-isa/07-binary-vector-ops.md` — A5 vdiv types line now lists i16/i32 softlib materialization and the compile-time rejection of other integer widths.

## Validation

| Layer | Machine | Result |
|---|---|---|
| Full build (LLVM 19.1.7) | 238 (x86_64) / dev-481211 (aarch64) | PASS, 0 FAILED |
| Full lit suite (incl. both new tests) | 238 | 1786/1787 PASS |
| New lit tests | dev-481211 (aarch64) | PASS |
| CANN simulator `Ascend950PR_9599` dsl-st | 238 (`vdiv_i16.py`) | PASS, all lanes exact |
| **A5 hardware** (Ascend950PR, NPU0) dsl-st | 238 | PASS — kernel terminates, no hang |

All 128 lanes matched the exact truncated quotient (verified against a bit-exact numpy mirror of the algorithm; an initial 43-lane "off-by-one" report was traced to a floor-vs-truncation bug in the test's expected-value function, not the implementation).

Note: 144 / `a5` hosts were unreachable during validation; the CANN simulator and A5 hardware checks were run on 238 (same LLVM19 toolchain, full A5 simulator set, Ascend950PR cards).