### PR TITLE
fix(pto): resolve subviews of tpop tiles

### DIFF
--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -746,9 +746,13 @@ def PTOValidateIntToPtrUses : Pass<"pto-validate-inttoptr-uses", "func::FuncOp">
 }
 
 def PTOResolveBufferSelect : Pass<"pto-resolve-buffer-select", "ModuleOp"> {
-  let summary = "Resolve multi-buffer slot selections to addressed tile handles";
+  let summary = "Resolve tile views and multi-buffer selections to addressed handles";
   let description = [{
-    Primarily consumes tile-native `pto.multi_tile_get %src[%k]` operations.
+    Consumes tile-native `pto.subview` operations rooted at an addressed
+    `pto.alloc_tile` or a runtime-bound `pto.declare_tile`, and
+    `pto.multi_tile_get %src[%k]` operations. Subviews become zero-copy
+    addressed `pto.alloc_tile` handles after folding their physical offset.
+
     The source `pto.alloc_multi_tile` carries either planner-assigned physical
     slot addresses or a level3 base address. Each selection is replaced by a
     `pto.alloc_tile` carrying the selected address; constant slots select one

--- a/lib/PTO/Transforms/PTOResolveBufferSelect.cpp
+++ b/lib/PTO/Transforms/PTOResolveBufferSelect.cpp
@@ -8,12 +8,15 @@
 
 //===- PTOResolveBufferSelect.cpp -----------------------------------------===//
 //
-// Lowering for multi-buffer slot selection.
+// Lowering for tile-native buffer views and multi-buffer slot selection.
 //
-// Consumes tile-native `pto.multi_tile_get` operations after memory planning.
-// Constant slots become addressed `pto.alloc_tile` handles directly; dynamic
-// slots select an address through an N-way `arith.select` chain. The user SSA
-// remains the slot selector; this pass does not synthesize `iv mod N`.
+// Consumes tile-native `pto.subview` and `pto.multi_tile_get` operations after
+// memory planning. Subviews rooted at `pto.alloc_tile` reuse the planned
+// address, while subviews rooted at `pto.declare_tile` materialize the runtime
+// address assigned by a preceding pipe operation. Constant multi-buffer slots
+// become addressed `pto.alloc_tile` handles directly; dynamic slots select an
+// address through an N-way `arith.select` chain. The user SSA remains the slot
+// selector; this pass does not synthesize `iv mod N`.
 //
 //===----------------------------------------------------------------------===//
 
@@ -168,6 +171,22 @@ static Value computeTileAddress(Value value, IRRewriter &rewriter,
   if (auto alloc = value.getDefiningOp<pto::AllocTileOp>()) {
     return ensureI64(alloc.getAddr(), rewriter, loc);
   }
+  if (value.getDefiningOp<pto::DeclareTileOp>()) {
+    auto tileType = dyn_cast<pto::TileBufType>(value.getType());
+    if (!tileType) {
+      return {};
+    }
+    auto memorySpace =
+        dyn_cast_or_null<pto::AddressSpaceAttr>(tileType.getMemorySpace());
+    if (!memorySpace) {
+      return {};
+    }
+    auto ptrType = pto::PtrType::get(rewriter.getContext(),
+                                     tileType.getElementType(), memorySpace);
+    Value ptr =
+        rewriter.create<pto::TileBufAddrOp>(loc, ptrType, value).getDst();
+    return rewriter.create<pto::PtrToIntOp>(loc, ptr).getResult();
+  }
   if (auto subview = value.getDefiningOp<pto::SubViewOp>()) {
     Value base = computeTileAddress(subview.getSource(), rewriter, loc);
     auto sourceType = subview.getSource().getType();
@@ -256,8 +275,8 @@ static LogicalResult resolveTileNativeSubviews(ModuleOp module,
     rewriter.setInsertionPoint(op);
     Value addr = computeTileAddress(op.getResult(), rewriter, op.getLoc());
     // A tile function argument is a symbolic runtime-bound handle. Keep its
-    // subview tile-native; only planned local roots can be normalized to an
-    // addressed alloc_tile here.
+    // subview tile-native; only planned local roots and declare_tile handles
+    // assigned by preceding pipe operations can be normalized here.
     if (!addr) {
       continue;
     }

--- a/test/lit/pto/issue1251_subview_of_tpop_a3.pto
+++ b/test/lit/pto/issue1251_subview_of_tpop_a3.pto
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-level=level3 --enable-insert-sync \
+// RUN:   --mlir-print-ir-after=pto-resolve-buffer-select %s -o /dev/null 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=IR
+// RUN: ptoas --pto-level=level3 --enable-insert-sync %s -o - 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=EMITC
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @repro_aic(%out: !pto.ptr<f32>, %pipe_gm: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %c32 = arith.constant 32 : index
+    %c128 = arith.constant 128 : index
+    %buf = pto.import_reserved_buffer {
+      name = "c2v_slot_buffer", peer_func = @repro_aiv
+    } -> i32
+    pto.aic_initialize_pipe {dir_mask = 1, slot_size = 16384}
+        (gm_slot_buffer = %pipe_gm : !pto.ptr<f32>,
+         c2v_consumer_buf = %buf : i32,
+         v2c_consumer_buf = %c0_i32 : i32)
+    %acc = pto.alloc_tile addr = %c0_i64 valid_row = %c32 valid_col = %c128 :
+      !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=128, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tpush_to_aiv(%acc :
+      !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=128, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 1}
+    return
+  }
+
+  func.func @repro_aiv(%out: !pto.ptr<f32>, %pipe_gm: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i32 = arith.constant 0 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c32 = arith.constant 32 : index
+    %c128 = arith.constant 128 : index
+    %view = pto.make_tensor_view %out, shape = [%c32, %c128],
+        strides = [%c128, %c1] {layout = #pto.layout<nd>} :
+        !pto.tensor_view<?x?xf32>
+    %buf = pto.reserve_buffer {
+      name = "c2v_slot_buffer", size = 131072,
+      location = #pto.address_space<vec>, auto = false, base = 0
+    } -> i32
+    pto.aiv_initialize_pipe {dir_mask = 1, slot_size = 16384}
+        (gm_slot_buffer = %pipe_gm : !pto.ptr<f32>,
+         c2v_consumer_buf = %buf : i32,
+         v2c_consumer_buf = %c0_i32 : i32)
+    %shard = pto.tpop_from_aic {split = 1} ->
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %sub = pto.subview %shard[%c0, %c0] sizes [8, 128] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0> ->
+      !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %pview = pto.partition_view %view, offsets = [%c0, %c0],
+        sizes = [%c8, %c128] : !pto.tensor_view<?x?xf32> ->
+        !pto.partition_tensor_view<8 x 128 x f32>
+    pto.tstore ins(%sub :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%pview : !pto.partition_tensor_view<8 x 128 x f32>)
+    pto.tfree_from_aic {split = 1}
+    return
+  }
+}
+
+// IR-LABEL: func.func @repro_aiv
+// IR: %[[SHARD:.*]] = pto.declare_tile
+// IR: pto.tpop(%[[SHARD]],
+// IR: %[[BASE_PTR:.*]] = pto.tile_buf_addr %[[SHARD]]
+// IR: %[[BASE_I64:.*]] = pto.ptrtoint %[[BASE_PTR]]
+// IR: %[[ADDR:.*]] = arith.addi %[[BASE_I64]],
+// IR: %[[SUB:.*]] = pto.alloc_tile addr = %[[ADDR]] {pto.view_semantics = "subview"}
+// IR: pto.tstore ins(%[[SUB]]
+
+// EMITC-LABEL: AICORE void repro_aiv(
+// EMITC-NOT: TEXTRACT(
+// EMITC: TPOP<
+// EMITC-NOT: TEXTRACT(
+// EMITC: .data()
+// EMITC-NOT: TEXTRACT(
+// EMITC: TASSIGN(
+// EMITC-NOT: TEXTRACT(
+// EMITC: TSTORE(
+// EMITC-NOT: TEXTRACT(


### PR DESCRIPTION
## Summary

- resolve `pto.subview` operations rooted at the runtime-bound `pto.declare_tile` produced for `tpop`
- materialize the popped tile address before folding the subview offset into an addressed tile handle
- add an A3 regression test for issue #1251 that verifies the zero-copy path without a `TEXTRACT` workaround

## Validation

- LLVM/MLIR 19.1.7 compiler build: passed
- focused issue regression: 1/1 passed
- subview regression suite: 25/25 passed
- full `check-pto`: 1785 passed, 1 unsupported, 0 failed
- generated A3 C++ compiled with Bisheng against PTO-ISA `83d01313`

Fixes #1251
