### PR TITLE
Normalize indirect pointer-table loads

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -109,6 +109,7 @@ std::unique_ptr<Pass> createPTOFusionLoadStoreElisionPass();
 std::unique_ptr<Pass> createPTOUnrollAfterLoopFusionPass();
 std::unique_ptr<Pass> createPTOFlattenFusionRegionPass();
 std::unique_ptr<Pass> createVPTOPtrNormalizePass();
+std::unique_ptr<Pass> createPTOIndirectPtrNormalizePass();
 std::unique_ptr<Pass> createVPTOPtrCastCleanupPass();
 std::unique_ptr<Pass> createVPTOCombineReductionsPass();
 std::unique_ptr<Pass> createVPTOOptimizeVcvtPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -1379,6 +1379,20 @@ def VPTOPtrNormalize
                            "mlir::arith::ArithDialect"];
 }
 
+def PTOIndirectPtrNormalize : Pass<"pto-indirect-ptr-normalize", "ModuleOp"> {
+  let summary = "Normalize pointer-table loads to ui64 loads and inttoptr";
+  let description = [{
+    Converts function arguments of type !pto.ptr<!pto.ptr<T>, space> into
+    !pto.ptr<ui64, space> address tables. Loads from those tables become a
+    ui64 load followed by pto.inttoptr to !pto.ptr<T>. This keeps the typed
+    pointer semantics in frontend PTO IR while making the ABI explicit before
+    later PTO transforms and EmitC lowering.
+  }];
+  let constructor = "mlir::pto::createPTOIndirectPtrNormalizePass()";
+  let dependentDialects = ["mlir::func::FuncDialect",
+                           "mlir::pto::PTODialect"];
+}
+
 def VPTOPtrCastCleanup
     : Pass<"vpto-ptr-cast-cleanup", "ModuleOp"> {
   let summary = "Collapse transient ptr-memref-ptr bridge casts after VPTO ptr normalization";

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -42,6 +42,7 @@ add_mlir_dialect_library(PTOTransforms
   VPTOLLVMEmitterDispatcher.cpp
   VPTOLLVMEmitterHelper.cpp
   VPTOPtrNormalize.cpp
+  PTOIndirectPtrNormalize.cpp
   VPTOPtrCastCleanup.cpp
   VPTOCombineReductions.cpp
   VPTOOptimizeVcvt.cpp

--- a/lib/PTO/Transforms/PTOIndirectPtrNormalize.cpp
+++ b/lib/PTO/Transforms/PTOIndirectPtrNormalize.cpp
@@ -1,11 +1,10 @@
 // Copyright (c) 2026 Huawei Technologies Co., Ltd.
-// This program is free software; you can redistribute it and/or modify it under the terms of
-// the CANN Open Software License Agreement Version 2.0 (the "License").
-// Please refer to the License for details. You may obtain a copy of the License at
-// https://www.hiascend.com/document/detail/en/CANNCommunityEdition/82RC1alpha001/license
-// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
-// See the License in the root of the software repository for the full text of the License.
+// See LICENSE in the root of the software repository for the full text of the License.
 
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
@@ -38,18 +37,22 @@ static LogicalResult normalizeFunction(func::FuncOp func) {
 
   for (BlockArgument arg : func.getArguments()) {
     auto tableTy = dyn_cast<pto::PtrType>(arg.getType());
-    if (!tableTy)
+    if (!tableTy) {
       continue;
+    }
     auto pointee = dyn_cast<pto::PtrType>(tableTy.getElementType());
-    if (!pointee)
+    if (!pointee) {
       continue;
-    if (isa<pto::PtrType>(pointee.getElementType()))
+    }
+    if (isa<pto::PtrType>(pointee.getElementType())) {
       return func.emitError()
              << "pointer tables support one level of indirection only";
+    }
 
     for (OpOperand &use : arg.getUses()) {
       auto load = dyn_cast<pto::LoadScalarOp>(use.getOwner());
-      if (!load || use.getOperandNumber() != 0) {
+      bool isPointerOperand = use.getOperandNumber() == 0;
+      if (!load || !isPointerOperand) {
         return func.emitError()
                << "indirect pointer-table argument must only be used as the "
                   "pointer operand of pto.load_scalar";
@@ -59,8 +62,9 @@ static LogicalResult normalizeFunction(func::FuncOp func) {
     tables.push_back({arg, tableTy});
   }
 
-  if (tables.empty())
+  if (tables.empty()) {
     return success();
+  }
 
   MLIRContext *ctx = func.getContext();
   auto ui64 = IntegerType::get(ctx, 64, IntegerType::Unsigned);
@@ -71,14 +75,17 @@ static LogicalResult normalizeFunction(func::FuncOp func) {
 
   for (IndirectLoad candidate : loads) {
     auto op = candidate.op;
-    if (op.getPtr() != candidate.table)
-      return op.emitError("indirect pointer-table load must use the table argument directly");
+    bool isDirectTableLoad = op.getPtr() == candidate.table;
+    if (!isDirectTableLoad) {
+      return op.emitError(
+          "indirect pointer-table load must use the table argument directly");
+    }
 
     OpBuilder builder(op);
     auto raw = builder.create<pto::LoadScalarOp>(
         op.getLoc(), ui64, candidate.table, op.getOffset());
-    auto ptr = builder.create<pto::IntToPtrOp>(
-        op.getLoc(), candidate.pointee, raw.getValue());
+    auto ptr = builder.create<pto::IntToPtrOp>(op.getLoc(), candidate.pointee,
+                                               raw.getValue());
     op.getValue().replaceAllUsesWith(ptr.getResult());
     op.erase();
   }

--- a/lib/PTO/Transforms/PTOIndirectPtrNormalize.cpp
+++ b/lib/PTO/Transforms/PTOIndirectPtrNormalize.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software; you can redistribute it and/or modify it under the terms of
+// the CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may obtain a copy of the License at
+// https://www.hiascend.com/document/detail/en/CANNCommunityEdition/82RC1alpha001/license
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See the License in the root of the software repository for the full text of the License.
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOINDIRECTPTRNORMALIZE
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+struct IndirectLoad {
+  pto::LoadScalarOp op;
+  BlockArgument table;
+  pto::PtrType pointee;
+};
+
+static LogicalResult normalizeFunction(func::FuncOp func) {
+  SmallVector<IndirectLoad> loads;
+  SmallVector<std::pair<BlockArgument, pto::PtrType>> tables;
+
+  for (BlockArgument arg : func.getArguments()) {
+    auto tableTy = dyn_cast<pto::PtrType>(arg.getType());
+    if (!tableTy)
+      continue;
+    auto pointee = dyn_cast<pto::PtrType>(tableTy.getElementType());
+    if (!pointee)
+      continue;
+    if (isa<pto::PtrType>(pointee.getElementType()))
+      return func.emitError()
+             << "pointer tables support one level of indirection only";
+
+    for (OpOperand &use : arg.getUses()) {
+      auto load = dyn_cast<pto::LoadScalarOp>(use.getOwner());
+      if (!load || use.getOperandNumber() != 0) {
+        return func.emitError()
+               << "indirect pointer-table argument must only be used as the "
+                  "pointer operand of pto.load_scalar";
+      }
+      loads.push_back({load, arg, pointee});
+    }
+    tables.push_back({arg, tableTy});
+  }
+
+  if (tables.empty())
+    return success();
+
+  MLIRContext *ctx = func.getContext();
+  auto ui64 = IntegerType::get(ctx, 64, IntegerType::Unsigned);
+  for (auto [arg, oldTy] : tables) {
+    auto addressTableTy = pto::PtrType::get(ctx, ui64, oldTy.getMemorySpace());
+    arg.setType(addressTableTy);
+  }
+
+  for (IndirectLoad candidate : loads) {
+    auto op = candidate.op;
+    if (op.getPtr() != candidate.table)
+      return op.emitError("indirect pointer-table load must use the table argument directly");
+
+    OpBuilder builder(op);
+    auto raw = builder.create<pto::LoadScalarOp>(
+        op.getLoc(), ui64, candidate.table, op.getOffset());
+    auto ptr = builder.create<pto::IntToPtrOp>(
+        op.getLoc(), candidate.pointee, raw.getValue());
+    op.getValue().replaceAllUsesWith(ptr.getResult());
+    op.erase();
+  }
+  return success();
+}
+
+struct PTOIndirectPtrNormalizePass
+    : public pto::impl::PTOIndirectPtrNormalizeBase<
+          PTOIndirectPtrNormalizePass> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PTOIndirectPtrNormalizePass)
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    for (func::FuncOp func : module.getOps<func::FuncOp>()) {
+      if (failed(normalizeFunction(func))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOIndirectPtrNormalizePass() {
+  return std::make_unique<PTOIndirectPtrNormalizePass>();
+}

--- a/lib/PTO/Transforms/PTOIndirectPtrNormalize.cpp
+++ b/lib/PTO/Transforms/PTOIndirectPtrNormalize.cpp
@@ -68,10 +68,14 @@ static LogicalResult normalizeFunction(func::FuncOp func) {
 
   MLIRContext *ctx = func.getContext();
   auto ui64 = IntegerType::get(ctx, 64, IntegerType::Unsigned);
+  SmallVector<Type> inputs(func.getFunctionType().getInputs());
   for (auto [arg, oldTy] : tables) {
     auto addressTableTy = pto::PtrType::get(ctx, ui64, oldTy.getMemorySpace());
+    inputs[arg.getArgNumber()] = addressTableTy;
     arg.setType(addressTableTy);
   }
+  func.setFunctionType(FunctionType::get(
+      ctx, inputs, func.getFunctionType().getResults()));
 
   for (IndirectLoad candidate : loads) {
     auto op = candidate.op;

--- a/ptodsl/docs/user_guide/06-scalar-and-pointer-ops.md
+++ b/ptodsl/docs/user_guide/06-scalar-and-pointer-ops.md
@@ -368,6 +368,12 @@ These are the scalar-path counterparts of the vector math operations covered in 
 
 Typed pointers (Section 4.4) carry both an element type and a memory space. This section covers the operations that create and manipulate them.
 
+Pointer-table types may use one level of indirection, for example
+`pto.ptr(pto.ptr(pto.f32, "gm"), "gm")`. The PTO frontend preserves this
+typed form while tracing. Before backend lowering, PTOAS canonicalizes a
+pointer-table load to a `ui64` address load followed by `pto.inttoptr`; the
+runtime ABI therefore stores device addresses as 64-bit values.
+
 ### Obtaining pointers: as_ptr()
 
 Tiles and tensor views expose their base address via `as_ptr()`:

--- a/ptodsl/ptodsl/_types.py
+++ b/ptodsl/ptodsl/_types.py
@@ -95,7 +95,10 @@ class _PtrDescriptor(_DType):
         self._space = space
 
     def resolve(self) -> Type:
-        elem = _ensure_tensor_storage_dtype(self._elem, context="pto.ptr(...)")
+        if isinstance(self._elem, _PtrDescriptor):
+            elem = self._elem.resolve()
+        else:
+            elem = _ensure_tensor_storage_dtype(self._elem, context="pto.ptr(...)")
         space_enum = _normalize_address_space(self._space)
         if space_enum is None:
             raise ValueError(

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -4572,6 +4572,11 @@ def main() -> None:
             "f8e8m0 pointers should be valid for L1 scale storage",
         )
         expect(
+            "!pto.ptr<!pto.ptr<f32, gm>, gm>"
+            == str(pto.ptr(pto.ptr(pto.f32, "gm"), "gm").resolve()),
+            "pointer-table types should support one level of indirection",
+        )
+        expect(
             str(pto.vreg_type(256, pto.f8e4m3).resolve()) == "!pto.vreg<256xf8E4M3FN>",
             "low-precision vreg types should be valid for vector micro-ops",
         )

--- a/test/lit/pto/indirect_ptr_normalize.pto
+++ b/test/lit/pto/indirect_ptr_normalize.pto
@@ -1,0 +1,15 @@
+// RUN: ptoas --pto-arch=a3 --mlir-print-ir-after=pto-indirect-ptr-normalize %s -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @load_ptr_table(%table: !pto.ptr<!pto.ptr<f32, gm>, gm>) {
+    %c0 = arith.constant 0 : index
+    %p = pto.load_scalar %table[%c0]
+      : !pto.ptr<!pto.ptr<f32, gm>, gm> -> !pto.ptr<f32, gm>
+    return
+  }
+}
+
+// CHECK: IR Dump After PTOIndirectPtrNormalize
+// CHECK-LABEL: func.func @load_ptr_table(%[[TABLE:.*]]: !pto.ptr<ui64, gm>)
+// CHECK: %[[RAW:.*]] = pto.load_scalar %[[TABLE]][%{{.*}}] : !pto.ptr<ui64, gm> -> ui64
+// CHECK: %[[PTR:.*]] = pto.inttoptr %[[RAW]] : ui64 -> !pto.ptr<f32, gm>

--- a/test/lit/pto/indirect_ptr_normalize.pto
+++ b/test/lit/pto/indirect_ptr_normalize.pto
@@ -5,6 +5,8 @@ module {
     %c0 = arith.constant 0 : index
     %p = pto.load_scalar %table[%c0]
       : !pto.ptr<!pto.ptr<f32, gm>, gm> -> !pto.ptr<f32, gm>
+    %value = arith.constant 0.0 : f32
+    pto.store_scalar %value, %p[%c0] : !pto.ptr<f32, gm>, f32
     return
   }
 }

--- a/test/lit/pto/indirect_ptr_normalize.pto
+++ b/test/lit/pto/indirect_ptr_normalize.pto
@@ -10,6 +10,7 @@ module {
 }
 
 // CHECK: IR Dump After PTOIndirectPtrNormalize
-// CHECK-LABEL: func.func @load_ptr_table(%[[TABLE:.*]]: !pto.ptr<ui64, gm>)
+// CHECK-LABEL: func.func @load_ptr_table(
+// CHECK-SAME: %[[TABLE:.*]]: !pto.ptr<ui64, gm>)
 // CHECK: %[[RAW:.*]] = pto.load_scalar %[[TABLE]][%{{.*}}] : !pto.ptr<ui64, gm> -> ui64
 // CHECK: %[[PTR:.*]] = pto.inttoptr %[[RAW]] : ui64 -> !pto.ptr<f32, gm>

--- a/test/lit/pto/indirect_ptr_normalize.pto
+++ b/test/lit/pto/indirect_ptr_normalize.pto
@@ -14,5 +14,5 @@ module {
 // CHECK: IR Dump After PTOIndirectPtrNormalize
 // CHECK-LABEL: func.func @load_ptr_table(
 // CHECK-SAME: %[[TABLE:.*]]: !pto.ptr<ui64, gm>)
-// CHECK: %[[RAW:.*]] = pto.load_scalar %[[TABLE]][%{{.*}}] : !pto.ptr<ui64, gm> -> ui64
-// CHECK: %[[PTR:.*]] = pto.inttoptr %[[RAW]] : ui64 -> !pto.ptr<f32, gm>
+// CHECK: %[[RAW:.*]] = pto.load_scalar %[[TABLE]][%{{.*}}] : <ui64, gm> -> ui64
+// CHECK: %[[PTR:.*]] = pto.inttoptr %[[RAW]] : ui64 -> <f32, gm>

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -3576,6 +3576,7 @@ int mlir::pto::compilePTOASModule(
   //pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOVerifyTFreePass());
   pm.addPass(pto::createPTOInferValidatePipeInitPass());
   pm.addNestedPass<mlir::func::FuncOp>(pto::createLoweringSyncToPipePass());
+  pm.addPass(pto::createPTOIndirectPtrNormalizePass());
   if (!disableInferLayout) {
     pm.addNestedPass<mlir::func::FuncOp>(pto::createInferPTOLayoutPass());
   }


### PR DESCRIPTION
## Related issue

Related to #1219, specifically the first item: GM/UB loads through an indirect address table.

This PR does not close the meta issue because the remaining quantization performance items are outside its scope.

## Summary

- Allow PTODSL to describe one-level `ptr<ptr<T>>` pointer tables.
- Add `pto-indirect-ptr-normalize` to canonicalize pointer-table function arguments to `ptr<ui64>`.
- Rewrite pointer-valued `pto.load_scalar` operations as a `ui64` load followed by `pto.inttoptr`.
- Keep the normalized function signature and entry block argument types consistent.
- Document the 64-bit address-table ABI and add PTODSL/IR regression coverage.

## Scope

- Supports one level of pointer indirection.
- Requires the pointer-table argument to be used directly as the pointer operand of `pto.load_scalar`.

## Validation

- PTOAS CI `build-and-test` passed, including all 1805 lit tests and `indirect_ptr_normalize.pto`.
- PTODSL Python tests and PTO-BC tests passed in CI.
- x86_64 and aarch64 wheel builds passed.
- License and changed-code compliance checks passed.