### PR TITLE
fix(ptodsl): normalize DMA pad integer signedness

### DIFF
--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -154,6 +154,10 @@ this chapter documents the underlying canonical operations.
 - `nburst` is always required.
 - `loop` groups are ordered from inner (wrapping `nburst`) to outer.
 - If `pad` specifies either left or right count, both must be provided.
+- `pad_value` may be an 8/16/32-bit integer scalar (signless, signed, or
+  unsigned) or an `f16`/`bf16`/`f32` scalar. Signed/unsigned integer pads are
+  normalized to their signless bit pattern when the op is built; the pad value
+  is encoded into `SET.MOV.PAD.VAL` as raw bits, so signedness carries no meaning.
 
 **Example** — load a 32×32 f32 tile from contiguous GM into contiguous UB:
 

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -64,6 +64,7 @@ from ._types import (
     _materialize_integer_literal,
     _normalize_address_space,
     _resolve,
+    _strip_integer_signedness,
     mask_type,
     part_tensor_view_type,
     part_tensor_view_type_from_dims,
@@ -5187,9 +5188,18 @@ def _normalize_dma_pad(pad, *, context: str):
         pad_value, left_count, right_count = pad
     else:
         raise TypeError(f"{context} expects pad to have length 1 or 3")
+    if hasattr(pad_value, "type"):
+        # The pad value is encoded as a raw bit pattern into SET.MOV.PAD.VAL,
+        # so signedness is irrelevant to the backend. Normalize explicit
+        # signed/unsigned integer pads (ui8/si8/...) to the signless
+        # counterpart the IR verifier accepts, preserving the bit pattern.
+        pad_value = _strip_integer_signedness(unwrap_surface_value(pad_value))
+    else:
+        pad_value = materialize_scalar_literal(
+            pad_value, F32Type.get(), context=f"{context} pad[0]"
+        )
     return (
-        materialize_scalar_literal(pad_value, F32Type.get(), context=f"{context} pad[0]")
-        if not hasattr(pad_value, "type") else unwrap_surface_value(pad_value),
+        pad_value,
         _coerce_i64(left_count, context=f"{context} pad[1]"),
         _coerce_i64(right_count, context=f"{context} pad[2]"),
     )

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -3617,6 +3617,16 @@ def ast_runtime_index_bitwise_event_probe():
 
 
 @pto.jit(target="a5", mode="explicit")
+def ui8_pad_surface_probe():
+    """Explicit ui8 pointer + ui8 pad value must compile (issue #1245)."""
+    zero = pto.const(0, dtype=pto.i64)
+    gm_src = pto.castptr(zero, pto.ptr(pto.ui8, "gm"))
+    ub_dst = pto.castptr(zero, pto.ptr(pto.ui8, "ub"))
+    pad_value = pto.const(0, dtype=pto.ui8)
+    pto.mte_gm_ub(gm_src, ub_dst, 0, 3, nburst=(1, 3, 32), pad=(pad_value, 0, 29))
+
+
+@pto.jit(target="a5", mode="explicit")
 def public_data_movement_surface_probe():
     zero_u64 = pto.const(0, dtype=pto.ui64)
     gm_src = pto.castptr(zero_u64, pto.ptr(pto.f16, "gm"))
@@ -4433,6 +4443,7 @@ def main() -> None:
     explicit_runtime_index_integer_bitwise_event_probe.verify()
     ast_runtime_index_bitwise_event_probe.verify()
     public_data_movement_surface_probe.verify()
+    ui8_pad_surface_probe.verify()
     fixed_width_integer_specialization_probe.verify()
     public_vector_conversion_surface_probe.verify()
     vdup_surface_probe.verify()
@@ -7140,6 +7151,8 @@ def main() -> None:
         "AST runtime index bitwise event specialization",
     )
     data_movement_surface_text = public_data_movement_surface_probe.compile().mlir_text()
+    ui8_pad_surface_text = ui8_pad_surface_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(ui8_pad_surface_text, "ui8 pad value specialization")
     expect_parse_roundtrip_and_verify(data_movement_surface_text, "public data movement surface specialization")
     vector_conversion_surface_text = public_vector_conversion_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(vector_conversion_surface_text, "public vector conversion surface specialization")
@@ -7632,6 +7645,10 @@ def main() -> None:
     expect(
         re.search(r"pto\.mte_ub_gm [^\n]+ nburst\([^)]+\) l2_cache_ctl\(%c15[^)\n]*\)", data_movement_surface_text) is not None,
         "mte_ub_gm(..., l2_cache='wtsred') should map to the l2_cache_ctl group",
+    )
+    expect(
+        re.search(r"pto\.mte_gm_ub [^\n]+ pad\([^)]*\) [^\n]*pad i8", ui8_pad_surface_text) is not None,
+        "ui8 pad value should be normalized to a signless i8 scalar for SET.MOV.PAD.VAL encoding (issue #1245)",
     )
     expect("pto.mte_ub_ub" in data_movement_surface_text, "public grouped UB->UB wrapper should lower to pto.mte_ub_ub")
     expect("pto.mte_ub_l1" in data_movement_surface_text, "public grouped UB->L1 wrapper should lower to pto.mte_ub_l1")


### PR DESCRIPTION
## Summary
- normalize signed and unsigned integer DMA pad values to signless storage types
- add a ui8 DMA padding regression
- document DMA pad scalar type and raw-bit semantics

## Validation
- check-pto (1784 passed, 1 unsupported)
- check-dsl (39 passed)

Fixes #1245