### PR TITLE
feat(vmi): 合法化物理访存并融合 stateful stream

### DIFF
--- a/docs/designs/vmi-physical-memory-access-legalization-design.md
+++ b/docs/designs/vmi-physical-memory-access-legalization-design.md
@@ -1,0 +1,900 @@
+# VMI 物理访存规划与 VPTO 合法化设计
+
+## 1. 状态与结论
+
+本文档定义 VMI 访存在完成 layout assignment 后，如何先形成与具体 VPTO
+指令无关的物理访存计划，再根据 A5 dist 约束、地址证明和内存安全条件选择
+direct dist、stateful stream 或 point access。
+
+设计采用以下流水：
+
+```text
+VMI op + assigned layout
+  -> physical access planning
+  -> plan normalization and local coalescing
+  -> VPTO memory legalization
+  -> VPTO memory operations
+  -> VPTOStatefulStreamFusion
+  -> LLVM emitter
+```
+
+本次将 planning 和 legalization 实现为 `vmi-to-vpto` 内部的两个 C++ 阶段，
+不增加可见的中间 IR，也不增加新的 pass。只有当计划需要被其他 pass 持久化、
+检查或跨 op 改写时，才重新评估是否值得引入中间 dialect。
+
+本设计不引入 `VPTOFallbackKind`。fallback 不是语义事实，不能作为核心模型。
+legalizer 应根据以下事实推导实现：
+
+- VMI 操作实际访问的有序内存元素；
+- 内存元素与物理寄存器值之间的映射；
+- direct dist 的 ISA contract；
+- 地址对齐证明；
+- 候选实现的真实读取和写入范围；
+- predicate 是否生效；
+- 相邻访问是否可以形成同一条 stateful stream。
+
+## 2. 背景问题
+
+当前 `VMIToVPTO.cpp` 中，VMI 语义物化、地址分析、dist 选择、寄存器重排和
+stateful stream 构造分散在不同 lowering 分支中。例如：
+
+- NORM load/store 分支会检查 32B 对齐，并在无法证明时生成 stateful 访问；
+- UNPK/PK 分支会直接生成对应 dist，尚未统一检查 mode-specific alignment；
+- DINTLV/INTLV 分支会直接生成 x2 dist；
+- E2B 分支会直接生成 E2B load；
+- group store 分支分别实现 aligned store、packed stateful store 和 1PT store；
+- dist token、element width 和硬件立即数在 verifier、lowering 和 emitter 中重复维护。
+
+这种结构会造成三个问题：
+
+1. 指令选择发生得过早。生成多个 1PT 后，后续 pass 很难恢复它们是否来自同一个
+   连续逻辑 payload，以及应从哪些 carrier lane 取值。
+2. direct dist 和 fallback 可能使用不同的内存 footprint。例如 E2B 只读取少量
+   group scalar，而普通 `vldus` 会形成一个完整 VL 的 load；如果没有额外可读范围
+   证明，这不是无条件安全的替换。
+3. 相同 ISA 事实可能在不同分支中得到不同解释，尤其是 BRC 的自然对齐、dist 的
+   predicate 行为和 x2 操作的双 packet footprint。
+
+因此需要先回答“语义上必须访问哪些字节”，再回答“目标 ISA 用什么指令访问”。
+
+## 3. 目标与非目标
+
+### 3.1 目标
+
+1. 统一描述所有现有 VPTO vector load/store dist 的 token、方向、arity、element
+   width、对齐、内存 footprint、predicate 行为和寄存器映射。
+2. 让 VMI memory lowering 先产生物理访问事实，再统一做指令合法化。
+3. 在仍保留 VMI layout 和 carrier-lane 信息时，合并真正连续的 point access。
+4. 对无法证明 direct dist 对齐的访问，在内存安全和语义允许时生成 stateful
+   load/store。
+5. 在同一个 VMI 访问计划内部直接生成完整 stateful 流：load 使用
+   `vldas -> multiple vldus`，store 使用
+   `init_align -> multiple vstus -> vstas`。
+6. 继续使用 `PTOAddressAnalysis` 的 typed address language 证明对齐、地址差和循环
+   迭代间连续性，不建立第二套地址求解器。
+7. 保持 `VPTOStatefulStreamFusion` 为后置 VPTO 优化，只处理已经合法化的 stateful
+   流。
+
+### 3.2 非目标
+
+- 不让地址分析理解 dist、layout 或成本模型。
+- 不让 `VPTOStatefulStreamFusion` 恢复 VMI 语义或选择 dist。
+- 不把任意 masked store 转换成无 mask 的 `vstus`。
+- 不允许为了使用 `vldus` 而无证明地扩大可观察读取范围。
+- 不跨有可观察 memory effect 的 op 重排访问。
+- 不在首期重新设计 VMI layout assignment。
+- 不假设物理 vector 固定为 256B；所有 VL 相关规则使用实际物理 vector byte size。
+
+## 4. 层次与职责
+
+### 4.1 VMI physical access planner
+
+planner 负责：
+
+- 将已分配 layout 的逻辑 VMI memory op 解释成有序内存 segment；
+- 描述每个 segment 的地址、元素类型、访问覆盖形状和逻辑长度；
+- 描述有序内存元素与输入/输出物理 values 之间的映射；
+- 记录 load 可被证明安全读取的范围；
+- 保留生成寄存器 pack/unpack/select 所需的信息。
+
+planner 不负责：
+
+- 选择 `vlds`、`vstus` 或 1PT；
+- 判断某个 dist 地址是否合法；
+- 创建 VPTO memory op；
+- 管理 align SSA state。
+
+planner 可以引用 conversion adaptor 已经提供的物理 values 和 types。为避免提前锁死
+direct PK/UNPK 路径，planner 不应先无条件生成 pack/unpack IR。
+
+### 4.2 Plan normalizer
+
+normalizer 只在同一个原始 VMI op 的有序 segment 内工作，负责：
+
+- 删除静态零长度 segment；
+- 计算或查询相邻 segment 的 byte difference；
+- 在地址相邻、顺序一致、映射可组合、覆盖兼容且容量合法时合并 segment；
+- 区分连续访问、连续前缀、任意 predicate 和真正稀疏访问；
+- 保留不能证明连续的原始顺序。
+
+它不跨 VMI op 合并，不跨 memory effect 重排，也不因为两个地址“看起来相似”而假设
+alias 或连续。
+
+### 4.3 VPTO memory legalizer
+
+legalizer 负责：
+
+- 用共享 dist contract 查找能直接表达 register mapping 的候选指令；
+- 使用 `PTOAddressAnalysis` 证明候选指令要求的地址对齐；
+- 检查候选路径的读取/写入范围和 predicate 行为是否保持 VMI 语义；
+- 选择 direct dist、stateful stream、自然对齐 point access 或发出诊断；
+- 仅在 fallback 路径需要时物化显式寄存器重排；
+- 为一个 plan 内的连续访问建立一条 align SSA chain。
+
+### 4.4 VPTOStatefulStreamFusion
+
+该 pass 只处理已经生成的 VPTO stateful 流：
+
+- 合并 basic block 内可证明连续且中间无冲突 effect 的流；
+- 将可证明迭代间连续的流改写成 loop-carried align/base state；
+- 保证 load 和 store align state 的 SSA 顺序及终止操作正确。
+
+该 pass 不理解 UNPK、PK、E2B、DINTLV、INTLV 或 VMI layout。fusion 实现主体位于
+`VPTOStatefulStreamFusion.cpp`，与 `VMIToVPTO.cpp` 中的 plan/legalization 职责分离。
+
+## 5. 共享 VPTO Dist Contract
+
+### 5.1 为什么需要共享 contract
+
+共享 contract 的价值不是给分支命名，而是让 verifier、VMI lowering、其他 VPTO
+优化和 emitter 从同一份 ISA 事实得到结论。它必须能被通用查询消费，否则只是一层
+间接调用。
+
+共享 contract 位于：
+
+```text
+include/PTO/IR/VPTOMemoryDist.h
+lib/PTO/IR/VPTOMemoryDist.cpp
+```
+
+概念接口：
+
+```cpp
+enum class VPTOMemoryOpFamily {
+  Load,
+  LoadX2,
+  Store,
+  StoreX2,
+};
+
+enum class VPTOPredicatePolicy {
+  Applied,
+  Ignored,
+  NotPresent,
+};
+
+struct VPTOMemoryDistContract {
+  VPTOMemoryOpFamily family;
+  VPTOMemoryDist dist;
+  unsigned registerArity;
+  VPTOPredicatePolicy predicatePolicy;
+  VPTOMemoryTransferMapping transfer;
+
+  FailureOr<int64_t>
+  getRequiredAlignmentBytes(int64_t vectorBytes) const;
+
+  FailureOr<int64_t>
+  getFullActiveFootprintBytes(int64_t vectorBytes,
+                              int64_t elementBytes) const;
+
+  FailureOr<int64_t>
+  getDependencyGranularityBytes(int64_t vectorBytes,
+                                int64_t elementBytes) const;
+};
+```
+
+contract 必须区分：
+
+```text
+required alignment      指令有效地址的合法性要求
+semantic footprint      指令语义实际读取或写入的数据范围
+dependency granularity  memory dependence 分析使用的覆盖粒度
+physical read envelope  实现为得到结果实际可能读取的相对地址区间
+```
+
+不能用一个 `maximumMemoryBytes` 同时表示这些概念。semantic footprint 和
+dependency granularity 属于 direct dist contract；physical read envelope 还取决于
+所选指令序列，例如 stateful load 同时包含 `vldas` 和后续 `vldus`，应由 candidate
+implementation 描述。
+
+### 5.2 A5 对齐事实
+
+以下规则来自 A5 `visa.txt` 的 load/store alignment table。令 `V` 为实际物理
+vector byte size：
+
+| Family | Dist | Required alignment | Full-active semantic footprint |
+|---|---|---:|---:|
+| Load | NORM | 32B | `V` |
+| Load | BRC_B8/B16/B32 | 1/2/4B | 1/2/4B |
+| Load | E2B_B16 | `V / 16` | `V / 16` |
+| Load | E2B_B32 | `V / 8` | `V / 8` |
+| Load | UNPK_B8/B16/B32 | `min(32, V / 2)` | `V / 2` |
+| Load | UNPK4 | `min(32, V / 4)` | `V / 4` |
+| LoadX2 | DINTLV_B8/B16/B32 | 32B | `2 * V` |
+| Store | NORM_B8/B16/B32 | 32B | up to `V`, controlled by predicate |
+| Store | 1PT_B8/B16/B32 | 1/2/4B | 1/2/4B |
+| Store | PK_B16/B32/B64 | `min(32, V / 2)` | up to `V / 2` |
+| Store | PK4_B32 | `min(32, V / 4)` | up to `V / 4` |
+| StoreX2 | INTLV_B8/B16/B32 | 32B | `2 * V` |
+
+`US/DS/BRC_BLK/BDINTLV/SPLT/MRG` 也必须进入共享 registry，避免 verifier 与 emitter
+继续漂移；上表只列本次 VMI memory legalization 首期会迁移的 mode。
+
+对典型 `V = 256B`：
+
+```text
+E2B_B16 alignment = 16B
+E2B_B32 alignment = 32B
+UNPK alignment    = 32B
+UNPK4 alignment   = 32B
+PK alignment      = 32B
+PK4 alignment     = 32B
+```
+
+BRC 必须保留两个不同事实：
+
+```text
+BRC_B32 address validity = 4B alignment
+BRC hardware dependency  = containing 32B block
+```
+
+因此 4B 对齐但非 32B 对齐的 BRC_B32 仍是合法 direct BRC，不能转成 `vldus`。
+
+### 5.3 Token 与 target encoding
+
+共享层负责：
+
+- token 到 typed dist 的解析；
+- dist 是否支持给定 op family 和访问 element width；
+- 对齐、footprint、predicate 和 mapping 查询。
+- 在显式选择 A5 profile 时，提供 typed dist 到 A5 immediate 的唯一映射。
+
+这里的访问 element width 不是无条件等同于 `vreg` carrier width。尤其 store 的
+`NORM_B32`、`PK_B64` 等显式 token 描述物理访问或 lane compact 语义；合法 producer
+可以使用更宽的 carrier type。只有省略 store dist、需要选择默认 NORM token 时，
+才根据 carrier width 推导 `NORM_B8/B16/B32`。verifier 和 emitter 必须遵守同一边界。
+
+A5 LLVM emitter 不再维护独立的 token parser 或编码 switch，而是显式查询 A5
+profile contract 中的 immediate。这样 verifier、lowering 和两个 emitter 使用同一条
+registry 记录，同时避免把 A5 immediate 误当成跨 target 的通用语义。
+
+本文 contract 的 alignment 数值是 A5 profile 的事实。typed dist、token 和 observable
+mapping 可以共享；未来若其他 target profile 的 alignment 或支持集不同，查询必须显式
+选择 profile，不能静默复用 A5 数值。
+
+## 6. Physical Access Plan 数据模型
+
+### 6.1 地址和访问覆盖
+
+概念结构如下，具体 C++ 命名可在实现时按现有风格调整：
+
+```cpp
+struct VMIPlannedAddress {
+  Value base;
+  Value elementOffset;
+  Type elementType;
+};
+
+enum class VMIMemoryCoverageKind {
+  Dense,
+  Prefix,
+  Predicate,
+};
+
+struct VMIMemoryCoverage {
+  VMIMemoryCoverageKind kind;
+  OpFoldResult elementCount;
+  Value predicate;
+};
+
+struct VMIPhysicalMemorySegment {
+  VMIPlannedAddress address;
+  VMIMemoryCoverage coverage;
+  VMIRegisterTransfer transfer;
+  VMIReadSafety readSafety;
+};
+
+struct VMIPhysicalAccessPlan {
+  VPTOMemoryDirection direction;
+  SmallVector<VMIPhysicalMemorySegment> segments;
+};
+```
+
+当前 `VMIToVPTO.cpp` 已有一套较窄的 `VMIMemoryAccessPlan`、
+`VMIMemoryLaneAddressMap` 和 `VMIMemorySafeReadProof`，主要服务 identity layout 和
+static memref full-read 判断。实现时应演进并替换这套结构，而不是在旁边长期保留第二套
+同义 plan。旧结构中的 `fallbackDecision` 只表示某个局部 lowering 当前是否缺少实现，
+不是本文所需的 legalization 语义，也不应扩展成 dist fallback 枚举。
+
+地址继续保留 typed base、element offset 和 element type。plan normalizer 通过
+`PTOAddressAnalysis` 将差值换算成 bytes；不要提前把所有地址改写成无类型的整数
+byte arithmetic。
+
+覆盖含义：
+
+- `Dense`：segment 中每个元素都必须访问；
+- `Prefix`：只访问从起始地址开始的连续前缀，长度可以是静态或动态值；
+- `Predicate`：任意 predicate 决定哪些固定位置被访问，可能存在洞。
+
+稀疏 group store 通常表示为多个单元素 Dense segment，而不是把 stride 隐藏在
+register mapping 中。
+
+### 6.2 Register transfer 是语义映射
+
+register transfer 描述“内存序号 k 对应哪个物理 value/lane”，而不是“调用哪个
+fallback helper”。建议用带参数的代数数据类型或 `std::variant` 表达：
+
+```cpp
+using VMIRegisterTransfer = std::variant<
+    IdentityTransfer,
+    LaneExpandTransfer,
+    LowBitsCompactTransfer,
+    GroupRepeatTransfer,
+    DeinterleaveTransfer,
+    InterleaveTransfer,
+    LaneSelectionTransfer>;
+```
+
+示例：
+
+```text
+UNPK load
+  memory: one compact Dense segment
+  transfer: LaneExpand{factor = 2 or 4}
+
+PK store
+  memory: one compact Dense/Prefix segment
+  transfer: LowBitsCompact{factor = 2 or 4}
+
+E2B load
+  memory: compact group scalars
+  transfer: GroupRepeat{groups, lanesPerGroup}
+
+DINTLV load
+  memory: two-vector-width Dense segment
+  transfer: Deinterleave{factor = 2}
+
+unit-stride slots=1 group store
+  memory: one Dense segment
+  transfer: LaneSelection{one source carrier lane per memory ordinal}
+
+sparse slots=1 group store
+  memory: multiple one-element Dense segments
+  transfer: one selected lane for each segment
+```
+
+该模型的约束是：对相同 plan，direct dist 和显式重排后的 fallback 必须实现同一个
+transfer。测试应验证 mapping 本身，而不只检查最后出现了哪个 dist token。
+
+### 6.3 Load safety
+
+load plan 必须记录相对有效地址可以证明安全读取的区间，而不只记录 VMI 语义所需
+长度：
+
+```cpp
+struct VMIByteInterval {
+  int64_t begin;
+  int64_t end;
+};
+
+struct VMIReadSafety {
+  std::optional<VMIByteInterval> provenReadableEnvelope;
+};
+```
+
+这里 `[begin, end)` 相对 semantic effective address 表示，允许 `begin < 0`。具体
+实现也可以复用现有 safe-read 判定并按 candidate 查询，而不是把区间存入 plan。
+必要的不变量是：
+
+```text
+candidate physical read envelope <= proven readable envelope
+```
+
+如果没有额外证明，默认只允许读取 semantic footprint。
+
+这是 E2B/UNPK fallback 的关键：
+
+- E2B_B16 direct load 对 `V=256B` 只读取 16B；
+- E2B_B32 direct load 只读取 32B；
+- UNPK direct load 只读取 `V/2`；
+- `vldus` 会形成一个完整 `V` 大小的 load result；
+- `vldas` 还会读取包含起始地址的 32B 对齐块。
+
+因此 stateful load candidate 必须检查 `vldas + vldus` 的联合 physical read
+envelope，而不只是检查 `[address, address + V)`。对于起始地址 32B remainder 未知的
+保守模型，envelope 可能延伸到 semantic address 之前最多 31B，并延伸到完整结果所需
+范围之后。只有该联合范围被证明安全时，`vldus + explicit mapping` 才可用。否则
+legalizer 必须选择精确的自然对齐访问组合，例如多个 BRC/point load，或在当前目标
+没有合理精确路径时给出明确诊断。不能为了优化而静默 overread。
+
+现有 `VMIMemorySafeReadProof` 只证明 static memref 中从 constant offset 开始的 identity
+full-vector 范围，尚未覆盖起始地址之前的 aligned-block read，也不能表达 direct
+E2B/UNPK 与 stateful candidate 的不同 envelope。它必须在接入 load fallback 前扩展。
+此外，physical lane count 可计算只说明结果寄存器形状已知，不构成 safe-read 证明；
+proof 失败时不能因为 `lanesPerPart` 可计算而继续选择会扩大读取的 candidate。
+
+store 不允许超出 semantic footprint 写入。`vstus` 的 byte count 由 advance/size
+operand 控制，它只存 source vector 的低位连续前缀，因此适合 Dense 或 Prefix store，
+不适合任意 Predicate store。
+
+## 7. Plan 规范化与 Point 合并
+
+### 7.1 连续性证明
+
+两个相邻 segment 只有同时满足以下条件才可合并：
+
+1. 地址来自可证明相同的 pointer root/provenance；
+2. `next - current` 的 byte difference 可证明等于 current semantic span；
+3. memory order 与 register transfer order 一致；
+4. 两段覆盖均为 Dense，或可组合成一个无洞 Prefix；
+5. 合并后 payload 不超过候选指令和 stateful access 的容量；
+6. 不需要重排或跨越其他 memory effect。
+
+证明通过现有 `PTOAddressAnalysis`/`PTOValueEvolutionAnalysis` 完成。ISA dist 规则不进入
+地址分析；地址分析只回答 root、byte difference、alignment 和 loop delta 等事实。
+
+### 7.2 1PT_B32 示例
+
+可合并：
+
+```text
+base + 0  : one b32 from carrier0 lane0
+base + 4  : one b32 from carrier1 lane0
+base + 8  : one b32 from carrier2 lane0
+base + 12 : one b32 from carrier3 lane0
+```
+
+normalizer 得到一个 16B Dense segment，legalizer 先按 LaneSelection 形成一个 vreg 低
+16B payload：
+
+```text
+32B-aligned and legal masked-prefix store -> one NORM store
+otherwise                            -> one 16B vstus stream
+```
+
+不可合并：
+
+```text
+base + 0  : one b32
+base + 32 : one b32
+base + 64 : one b32
+base + 96 : one b32
+```
+
+这些地址不连续，应保留自然 4B 对齐的 1PT_B32。是否地址本身能证明 32B 对齐与是否
+连续是两个独立问题。
+
+## 8. Legalization 算法
+
+### 8.1 候选选择顺序
+
+对规范化后的 segment，legalizer 按以下顺序处理：
+
+```text
+1. 根据 direction、transfer、physical types 和 coverage 查询 direct dist。
+2. 检查 direct dist 的 element type、arity、predicate policy 和 footprint。
+3. 查询 required alignment，并用 PTOAddressAnalysis 证明有效地址对齐。
+4. direct candidate 全部合法时，发射 direct dist。
+5. 否则枚举语义等价的通用实现：
+     load  = exact/safe continuous load + explicit register transform
+     store = explicit register transform + exact continuous store
+6. 对通用实现检查 read envelope、write footprint、coverage 和容量。
+7. 相邻连续实现共享同一条 stateful align/base chain。
+8. 只有真正稀疏的自然对齐访问保留 point form。
+9. 无合法实现时，诊断应包含失败的对齐、footprint 或 safety 条件。
+```
+
+direct dist 是合法化候选，不是 plan 中预先指定的结果。可使用 cost/preference 保持
+当前目标上的 direct dist 优先级，但成本不能绕过语义和安全检查。
+
+### 8.2 各类访问
+
+#### NORM
+
+```text
+known 32B alignment -> direct NORM
+otherwise           -> stateful continuous access
+```
+
+load stateful 路径仍需满足完整 VL read 的安全条件。store 可以用 `vstus` 精确写入
+Dense/Prefix 的低位连续 payload。
+
+#### UNPK
+
+```text
+required alignment proven
+  -> direct UNPK
+
+alignment not proven and stateful read envelope proven safe
+  -> vldus full vector
+  -> explicit lane expansion using only semantic input portion
+
+otherwise
+  -> exact naturally aligned load sequence if available
+  -> or diagnostic
+```
+
+不能把 direct UNPK 的 `V/2` read 无条件替换成 `V` read。
+
+#### PK
+
+```text
+required alignment proven and predicate semantics match
+  -> direct PK
+
+Dense/Prefix coverage
+  -> explicit low-bit compact materialization
+  -> vstus with exact compact byte count
+
+arbitrary Predicate coverage
+  -> keep predicate-aware direct/normal path
+  -> do not use vstus unless values and destination addresses can both be
+     legally compacted without changing the VMI memory mapping
+```
+
+#### E2B
+
+```text
+E2B alignment proven
+  -> direct E2B
+
+alignment not proven and stateful read envelope proven safe
+  -> vldus
+  -> explicit group-repeat materialization
+
+stateful read envelope not safe
+  -> exact scalar/BRC load sequence plus group-repeat materialization
+  -> or diagnostic if the exact path is unsupported/unprofitable by policy
+```
+
+E2B_B8 不存在，不能从 element width 推导出该 token。
+
+#### BRC
+
+```text
+b8/b16/b32 natural alignment proven
+  -> direct BRC
+```
+
+BRC 不要求 32B 地址对齐。dependency analyzer 必须按 containing 32B block 建模硬件
+访问冲突范围；共享 contract 为该 consumer 提供 granularity 事实。
+
+#### DINTLV
+
+```text
+known 32B alignment -> direct DINTLV x2
+otherwise:
+  vldas
+  vldus packet0, advance V
+  vldus packet1, advance V
+  explicit deinterleave
+```
+
+两个 `vldus` 各自读取 V，合计与 direct DINTLV 的 `2*V` semantic footprint 一致；
+`vldas` 还会读取起始地址所在的 aligned block，因此仍需按 VMI load safety contract
+检查整个 stateful candidate 的联合 physical read envelope。
+
+#### INTLV
+
+```text
+known 32B alignment and full-store semantics
+  -> direct INTLV x2
+otherwise:
+  explicit interleave into packet0 and packet1
+  init_align
+  vstus packet0, size V
+  vstus packet1, size V
+  vstas
+```
+
+ISA 中 INTLV predicate 被忽略，所以只有 VMI 语义要求完整写入两个 packet 时才能选择
+direct INTLV。tail 或任意 predicate store 必须走能保持覆盖语义的路径。
+
+### 8.3 Stateful stream 构造
+
+plan 内 stateful store：
+
+```text
+init_align
+vstus segment0, exact size0
+vstus segment1, exact size1
+...
+vstas
+```
+
+`vstus` 的 size/advance 是 byte count 的硬件语义。VPTO 当前用 typed element unit
+表达 offset 时，legalizer 必须验证 byte count 可被 pointer/value element byte size
+整除，再创建对应 element count；不能混用 bytes 和 elements。
+
+plan 内 stateful load：
+
+```text
+vldas base
+vldus packet0, advance0
+vldus packet1, advance1
+...
+```
+
+每个 `vldus` 结果大小为 V，advance 只决定下一次 base/alignment state，并不把本次
+物理读取缩短为 advance 大小。
+
+## 9. 与 PTOAddressAnalysis 的边界
+
+地址分析提供：
+
+- `base + typed element offset` 的 N-byte alignment 证明；
+- 同 root 地址之间的 known byte difference；
+- loop iteration 的 address delta；
+- cast、constant、affine add/sub/mul 和 no-wrap 所支持的 typed expression 证明。
+
+memory legalizer 提供：
+
+- 某个 dist 需要多少 alignment；
+- segment semantic span 是多少；
+- 哪些 segment 允许合并；
+- 哪种指令和 register transform 可实现该 plan；
+- 候选路径是否扩大 read/write envelope。
+
+如果 plan normalizer 需要比较尚未物化为 VPTO op 的 `(base, elementOffset)`，应在
+`PTOAddressAnalysis` 中增加基于同一 typed expression core 的地址构造/差值查询，
+而不是在 `VMIToVPTO.cpp` 再写 constant-only 地址解析器。该 API 只回答地址事实，
+不接受 dist 参数。
+
+## 10. 实现组织
+
+建议分阶段形成以下结构：
+
+```text
+include/PTO/IR/VPTOMemoryDist.h
+lib/PTO/IR/VPTOMemoryDist.cpp
+  shared dist parsing and semantic contract
+
+lib/PTO/Transforms/VMIPhysicalMemoryAccess.h
+  private plan/mapping data structures
+
+lib/PTO/Transforms/VMIPhysicalMemoryAccess.cpp
+  normalization, direct candidate matching, memory legalization
+
+lib/PTO/Transforms/VMIToVPTO.cpp
+  op-specific plan construction and non-memory physicalization
+
+lib/PTO/Transforms/VPTOStatefulStreamFusion.cpp
+  complete post-legalization stream fusion implementation
+```
+
+为降低首轮重构风险，plan structs 和第一批 legalizer helper 可以先作为
+`VMIToVPTO.cpp` 的私有实现，并在第二个 memory family 接入后抽取到独立文件。
+验收标准是多个 family 真正调用同一 legalizer，而不是为了文件数量提前抽象。
+
+## 11. 迁移计划
+
+### 阶段 A：共享事实，不改 lowering 行为
+
+1. 增加 typed dist enum、parser 和 contract。
+2. 将 VPTO verifier 的 dist token、element type、mask granularity 检查接入 contract。
+3. 将 `VPTOCANN900LLVMEmitter` 和仍在构建范围内的 `VPTOLLVMEmitter` string parser
+   改为 typed dist 后的 exhaustive encoding。
+4. 审计 `VPTOOptimizeVcvt`、`PTOValidateVPTOIR` 等其余 dist string consumer。
+5. 为所有现有 token 增加 contract 单元或 lit 覆盖。
+
+### 阶段 B：建立 plan/legalizer 基线
+
+1. 引入 address、coverage、read safety 和 register transfer 数据结构。
+2. 将现有窄 `VMIMemoryAccessPlan` 演进到新结构，不保留平行 plan。
+3. 修正 safe-read gating：proof unknown/failed 不得退化为“lane count 可计算即安全”。
+4. 迁移普通 contiguous NORM load/store。
+5. 保持现有 aligned/unaligned 输出不变，验证两阶段框架没有行为漂移。
+6. 建立 plan normalization 的 same-root/known-difference 测试。
+
+### 阶段 C：group store 与 point 合并
+
+1. 迁移 unit-stride slots=1 和 compact group store。
+2. 将 carrier lane selection 保留到 plan 中。
+3. 合并连续 4 x 1PT_B32 为一个 16B Dense payload。
+4. 保留非连续 point store。
+5. 覆盖 aligned NORM、unaligned stateful 和 sparse 1PT 三种输出。
+
+### 阶段 D：UNPK/PK
+
+1. 迁移 lane-stride dense load/store。
+2. 使用实际 V 计算 `min(32, V/2)` 和 `min(32, V/4)`。
+3. 增加 UNPK full-VL safe-read 条件。
+4. 增加 PK Prefix 与 arbitrary Predicate 的区分。
+
+### 阶段 E：BRC/E2B
+
+1. BRC 使用自然 1/2/4B alignment，单独覆盖 dependency granularity。
+2. E2B 使用 `V/16` 或 `V/8` alignment。
+3. direct E2B 不满足对齐时，按 read safety 选择 vldus 或 exact scalar/BRC 方案。
+4. 保持 assigned physical layout 决定 E2B mapping，不在 lowering 中重新选择 layout。
+
+### 阶段 F：DINTLV/INTLV
+
+1. 迁移 x2 direct path。
+2. 增加两个连续 packet 共享 align chain 的 fallback。
+3. 验证 INTLV predicate ignored 条件。
+4. 覆盖 multichunk 和 partial/tail rejection/fallback。
+
+### 阶段 G：收口与文件边界
+
+1. 审计 `VMIToVPTO.cpp` 中所有 `VldsOp`、`VstsOp`、`Vldsx2Op`、`Vstsx2Op`、
+   `VldusOp` 和 `VstusOp` 创建点。
+2. 未迁移创建点必须注明为何不属于 vector dist legalization。
+3. 将 stateful fusion 实现完整迁移到独立 pass 文件。
+4. 删除被统一 legalizer 替代的局部对齐和 stream helper。
+
+## 12. 测试与性能验证
+
+### 12.1 Contract 测试
+
+必须覆盖：
+
+```text
+BRC_B32 at 4B but not 32B alignment -> legal direct BRC
+E2B_B16 at 16B but not 32B          -> legal direct E2B
+E2B_B32 at only 16B                 -> direct E2B illegal
+UNPK/PK with non-default V          -> alignment derived from actual V
+1PT_B32                             -> 4B natural alignment
+DINTLV/INTLV                        -> 32B and arity 2
+INTLV/1PT predicate                 -> ignored
+```
+
+### 12.2 Plan 测试
+
+测试 planner/normalizer 的事实，而不只检查最终指令：
+
+- unit-stride group store 形成一个 Dense segment；
+- non-unit-stride group store 形成多个 point segment；
+- 四个连续 b32 point 合并为 16B segment；
+- 不同 root、unknown difference 或有洞的 point 不合并；
+- tail 是 Prefix，不是 arbitrary Predicate；
+- E2B semantic footprint 是 compact group scalar bytes；
+- DINTLV/INTLV semantic footprint 是两个物理 packet。
+
+若不增加 debug IR，可用 focused C++ test；若项目继续以 lit 为主，可增加仅用于测试的
+plan printer，但生产 pipeline 不依赖该 printer。
+
+### 12.3 End-to-end lit
+
+每个 family 至少覆盖：
+
+- 最小合法对齐；
+- 低于最小对齐但自然对齐；
+- unknown alignment；
+- static UB pointer + aligned element stride；
+- multi-packet stream；
+- safe overread 与 unsafe overread；
+- prefix mask 与 arbitrary predicate；
+- loop iteration stream fusion；
+- 无残留 VMI type/op 和合法 VPTO verifier/emitter 输出。
+
+测试中非对齐不是默认噪声。若 case 的目的不是测试 non-alignment，应使用静态 UB base
+和能证明所需 alignment 的 element-unit stride。
+
+### 12.4 CA 性能验证
+
+功能验证通过后，使用已验证的 CA model 流程比较：
+
+```text
+16B contiguous store payload:
+  4 x 1PT_B32
+  one independent stateful stream
+  loop-carried fused stateful stream
+
+dist fallback:
+  aligned direct dist
+  unaligned exact/safe fallback
+```
+
+load side 统一使用语义相同且安全的输入准备，避免把额外 `vldus` 或过量 1PT 混入被测
+store 序列。报告 instruction count、busy/latency、循环迭代数和 steady-state 每迭代
+开销，不能只给两列汇总而隐藏 warm-up/finalize 成本。
+
+## 13. 正确性不变量
+
+实现和 review 必须逐项满足：
+
+1. **Footprint preservation**：store 不多写一个 byte；load 的扩大读取有明确 safe-read
+   证明。
+2. **Order preservation**：内存元素顺序和 register transfer 顺序一致。
+3. **Coverage preservation**：Dense、Prefix、Predicate 不得互相偷换。
+4. **Alignment legality**：每条 direct dist 使用自身 contract，不统一强制 32B，也不
+   因 unknown alignment 直接假设合法。
+5. **Predicate legality**：predicate ignored 的 dist 只能用于 VMI 语义本来就是 full
+   access 的情况。
+6. **Typed units**：bytes、pointer elements、vector elements 和 32B blocks 显式换算。
+7. **Vector-size independence**：不硬编码 256B。
+8. **State ownership**：每条 stateful 流的 align/base state 在 SSA 上线性传递并正确
+   终止。
+9. **Analysis boundary**：PTOAddressAnalysis 只证明地址事实，不决定指令或收益。
+10. **Fusion boundary**：local legalizer 处理单个 plan，StatefulStreamFusion 处理跨
+    plan/跨迭代融合。
+11. **No recovered semantics**：生成 point op 之前完成可合并性判断；后续 pass 不依赖
+    从低层指令猜回 carrier mapping。
+12. **Diagnostic completeness**：没有合法路径时说明是 alignment、coverage、read
+    envelope、unsupported mapping 还是 target support 导致失败。
+
+## 14. 方案自检
+
+### 14.1 一致性
+
+- 与 VMI layout 边界一致：layout assignment 决定物理 lane mapping，memory planner
+  只消费 assigned layout，不暗中重选 layout。
+- 与 PTOAddressAnalysis 设计一致：复用 typed expression、pointer provenance 和 byte
+  difference，不新增常量专用地址系统。
+- 与 StatefulStreamFusion 边界一致：legalizer 创建合法流，fusion 只证明并合并流。
+- 与 emitter 边界一致：共享通用 dist 语义；A5 immediate 只存在于显式 A5 profile
+  contract 中，target emitter 负责选择并消费该 profile。
+- 与当前 pipeline 一致：`vmi-to-vpto` 后继续运行 `vpto-stateful-stream-fusion`，不要求
+  新增 pass 顺序。
+
+### 14.2 ISA 准确性
+
+- BRC 使用自然 1/2/4B 地址对齐，不误用 32B；同时保留 32B dependency granularity。
+- E2B 只支持 B16/B32，alignment 分别为 `V/16`、`V/8`。
+- UNPK/PK alignment 使用 `min(32, V/2)`，UNPK4/PK4 使用 `min(32, V/4)`。
+- DINTLV/INTLV 使用两个 register/packet，地址要求 32B。
+- 1PT_B32 表示一个 32-bit point，要求 4B，不是 32-byte store。
+- `vstus` 写低位 size-byte 连续前缀并更新 base；`vldus` 返回完整 V 大小的数据，
+  advance 不限制本次读取大小。
+- INTLV 和 1PT 的 predicate ignored 行为进入 contract，不由 lowering 猜测。
+
+### 14.3 语义正确性
+
+- arbitrary masked store 不会被无 mask stateful store 替换。
+- E2B/UNPK fallback 不会无证明 overread。
+- stateful load safety 同时覆盖 `vldas` 的 containing block 和 `vldus` 的 vector read。
+- group store 只有在地址连续且 lane selection 可按内存顺序拼成 payload 时才合并。
+- sparse group store 即使含多个 1PT，也不会因“存在 1PT”而被错误视为连续。
+- direct 和 fallback 使用相同 register transfer，避免 footprint 与结果 layout 脱节。
+
+### 14.4 可实施性
+
+- 第一阶段只集中现有 dist table，不要求重写 VMI lowering，可单独验证和回退。
+- NORM 是最小 plan/legalizer 试点，已有 aligned/stateful 行为可作为等价基线。
+- group store、UNPK/PK、E2B、x2 family 可逐个迁移，每一步都有独立 lit 边界。
+- plan 首期为 pass 内 C++ 对象，不涉及 dialect、parser、serializer 或跨 pass lifetime。
+- 现有窄 `VMIMemoryAccessPlan` 可作为演进起点，但其 identity/static safe-read proof
+  不能直接作为完整 legalizer 的正确性依据。
+- 现有 `isKnownAddressAligned`、known address difference 和 loop delta 能覆盖首批查询；
+  只有 raw planned address pair 查询不足时才扩展同一 analysis framework。
+- 最终审计所有 memory op creation site，避免出现新旧决策系统长期并存。
+
+### 14.5 已知风险与控制
+
+| Risk | Consequence | Control |
+|---|---|---|
+| Mapping model too generic | 变成无实际 consumer 的抽象层 | 每增加一种 mapping，至少两个实现候选或一个 direct/fallback 对必须消费它 |
+| Planning emits register IR too early | 丢失 direct dist 机会 | transfer 保持 declarative，legalizer 决定何时 materialize |
+| Stateful load overread | 越界或错误 memory effect | 显式 read-envelope check，unknown 默认为不允许扩大 |
+| Existing safe-read proof is treated as complete | 忽略 `vldas` 前向块读取或 proof failure | 演进原结构并让 proof 结果直接 gate candidate selection |
+| Predicate semantics drift | inactive address 被写入 | predicate policy 进入 shared contract，coverage 进入 plan |
+| Address analysis duplication | 等价表达式结论不一致 | 所有新 query 基于 PTOValueEvolution/PTOAddressAnalysis typed expressions |
+| One-shot large refactor | 门禁难以定位 | 按 A-G 阶段迁移，每阶段保持全量 `vmi_new` 通过 |
+| String token drift remains | verifier/emitter 支持集不一致 | 审计所有 dist string consumer，typed parser 成为唯一入口 |
+
+## 15. 完成标准
+
+设计完成落地需同时满足：
+
+1. 所有现有 vector memory dist 均有共享 contract，verifier 与 emitter 不再分别解析
+   支持集。
+2. NORM、group store、UNPK/PK、BRC/E2B、DINTLV/INTLV 均通过 plan/legalizer。
+3. 每个 direct dist 在发射前完成 mode-specific alignment 和 predicate 检查。
+4. 每个 stateful fallback 有 footprint/coverage/read-safety 证明。
+5. 连续 point store 在 plan 阶段合并，真正稀疏访问保持 point form。
+6. 单 plan 多 packet 使用一条 stateful stream，跨 plan/跨迭代由独立 fusion pass 合并。
+7. `VMIToVPTO.cpp` 不再包含 dist-specific 地址判断和重复 align stream 管理分支。
+8. 全量 `test/lit/vmi_new`、compliance checker、LLVM emission 和 CA 功能验证通过。
+9. 性能报告覆盖真实 16B payload 的 1PT、独立 stateful 和迭代间 fused stateful 三组
+   steady-state 对比。

--- a/docs/isa/vmi-isa/01-load-store.md
+++ b/docs/isa/vmi-isa/01-load-store.md
@@ -73,7 +73,7 @@ declaring the memory access pattern. Default is `"continuous"`.
 
   | `dist_mode` | Physical lowering |
   |---|---|
-  | `"continuous"` | `K × pto.vlds {dist="NORM"}` (element-width-independent `NORM` load) |
+  | `"continuous"` | Known 32B-aligned addresses use the aligned fast path; other effective UB addresses use an unaligned sequence with lowering-managed alignment state |
   | `"dintlv"` | `K × pto.vldsx2 {dist="DINTLV_B*"}` (deinterleaved dual load; suffix from `Ptr<T>`) |
   | `"brc"` | `1 × pto.vlds {dist="BRC_B*"}` or `BRC_BLK`; broadcast-axis (1-reg backing, replicate-read) |
 
@@ -125,6 +125,9 @@ declaring the memory access pattern. Default is `"continuous"`.
   - **A5 loads are unpredicated.** A tail mask associated with a `vload` is
     never lowered as a masked load. It migrates to the consuming compute op or
     to a `vstore`.
+  - Continuous loads support effective UB addresses that are not 32B-aligned.
+    Alignment state is managed by the lowering and is not part of the VMI
+    programming model.
   - `dist_mode` and layout inference are orthogonal: `pto.as` may still
     rewrite the physical layout of a `continuous` load to serve a downstream
     consumer (e.g. a grouped reduce).
@@ -205,7 +208,7 @@ declaring the memory access pattern. Default is `"continuous"`.
 
   | `dist_mode` | Physical lowering |
   |---|---|
-  | `"continuous"` | `K × pto.vsts {dist="NORM_B*"}` |
+  | `"continuous"` | Known 32B-aligned addresses use the aligned fast path; unmasked accesses to other effective UB addresses use an unaligned sequence with lowering-managed alignment state |
   | `"intlv"` | `K × pto.vstsx2 {dist="INTLV_B*"}` (interleaved dual store; suffix from `Ptr<T>`) |
 
   **Group mode** (`{group = C}` + `stride`): row-strided tile store. Not combinable with
@@ -217,6 +220,13 @@ declaring the memory access pattern. Default is `"continuous"`.
   defaults to 0. `%block_stride` is a dynamic `i16` operand. An explicit
   `mask` is applied; if absent an implicit all-active mask is used. Not
   combinable with `dist_mode` or `group`.
+
+  Continuous unmasked stores support effective UB addresses that are not
+  32B-aligned, including a final prefix tail. Alignment state and the required
+  final flush are managed by lowering and are not part of the VMI programming
+  model. Explicit sparse-mask stores still use the predicated store path and
+  require their target alignment constraints to be statically provable;
+  otherwise the access is unsupported.
 
 - **examples:**
 

--- a/include/PTO/Analysis/PTOAddressAnalysis.h
+++ b/include/PTO/Analysis/PTOAddressAnalysis.h
@@ -47,6 +47,24 @@ struct PTOAddressExpr {
   int64_t elementBytes = 0;
 };
 
+/// Prove that a pointer plus an element offset is aligned to the requested
+/// byte boundary. Pointer block arguments are assumed to satisfy their
+/// address-space ABI alignment; derived addptr/cast expressions are accepted
+/// only when their byte remainder can be proven.
+bool isKnownAddressAligned(Value pointer, Value elementOffset,
+                           Type elementType, int64_t alignmentBytes);
+
+/// Return the proven byte remainder of a pointer plus an element offset for
+/// the requested byte boundary. Unknown remainders return std::nullopt.
+std::optional<int64_t>
+getKnownAddressRemainderBytes(Value pointer, Value elementOffset,
+                              Type elementType, int64_t alignmentBytes);
+
+/// Return the proven byte difference `to - from` for pointers with the same
+/// element type and root pointer. Unknown or non-affine differences return
+/// std::nullopt.
+std::optional<int64_t> getKnownAddressDifferenceBytes(Value from, Value to);
+
 /// Function-scoped AnalysisManager analysis that builds typed AddressExprs and
 /// provides exact byte/unit deltas without materializing IR.
 class PTOAddressAnalysis {

--- a/include/PTO/IR/VPTOMemoryDist.h
+++ b/include/PTO/IR/VPTOMemoryDist.h
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef PTO_IR_VPTOMEMORYDIST_H
+#define PTO_IR_VPTOMEMORYDIST_H
+
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace mlir::pto {
+
+enum class VPTOMemoryOpFamily {
+  Load,
+  LoadX2,
+  Store,
+  StoreX2,
+};
+
+enum class VPTOMemoryDist {
+  LoadNorm,
+  BrcB8,
+  BrcB16,
+  BrcB32,
+  UsB8,
+  UsB16,
+  DsB8,
+  DsB16,
+  BlockDeinterleave,
+  DeinterleaveB8,
+  DeinterleaveB16,
+  DeinterleaveB32,
+  UnpackB8,
+  UnpackB16,
+  UnpackB32,
+  BroadcastBlock,
+  ElementToBlockB16,
+  ElementToBlockB32,
+  Unpack4B8,
+  Split4ChannelB8,
+  Split2ChannelB8,
+  Split2ChannelB16,
+  StoreNormB8,
+  StoreNormB16,
+  StoreNormB32,
+  OnePointB8,
+  OnePointB16,
+  OnePointB32,
+  PackB16,
+  PackB32,
+  PackB64,
+  InterleaveB8,
+  InterleaveB16,
+  InterleaveB32,
+  Pack4B32,
+  Merge4ChannelB8,
+  Merge2ChannelB8,
+  Merge2ChannelB16,
+};
+
+enum class VPTOPredicatePolicy {
+  NotPresent,
+  Applied,
+  Ignored,
+};
+
+enum class VPTOMemoryTransferKind {
+  Identity,
+  ScalarBroadcast,
+  Upsample2,
+  Downsample2,
+  BlockDeinterleave2,
+  ElementDeinterleave2,
+  LaneExpand2,
+  BlockBroadcast,
+  ElementToBlock,
+  LaneExpand4,
+  SplitChannel,
+  Point,
+  LaneCompact2,
+  ElementInterleave2,
+  LaneCompact4,
+  MergeChannel,
+};
+
+enum class VPTOMemorySizeRule {
+  Element,
+  Block,
+  Vector,
+  VectorTimes2,
+  VectorDiv2,
+  VectorDiv4,
+  VectorDiv8,
+  VectorDiv16,
+};
+
+struct VPTOMemoryDistContract {
+  VPTOMemoryOpFamily family;
+  VPTOMemoryDist dist;
+  llvm::StringRef token;
+  unsigned operandElementBits;
+  uint64_t a5Immediate;
+  unsigned registerArity;
+  VPTOPredicatePolicy predicatePolicy;
+  VPTOMemoryTransferKind transfer;
+  VPTOMemorySizeRule alignmentRule;
+  VPTOMemorySizeRule footprintRule;
+  llvm::StringRef maskGranularity;
+
+  std::optional<int64_t> getRequiredAlignmentBytes(int64_t vectorBytes) const;
+
+  std::optional<int64_t> getFullActiveFootprintBytes(int64_t vectorBytes) const;
+
+  int64_t getDependencyGranularityBytes(int64_t vectorBytes) const;
+
+  bool isOnePointStore() const;
+};
+
+/// Look up a dist token for an operation family. Empty load/store tokens denote
+/// the corresponding NORM form, selected using `defaultElementBits` when the
+/// family has width-specific defaults. An explicit token carries its own
+/// physical element width; it is independent of the vreg carrier element type.
+const VPTOMemoryDistContract *
+lookupVPTOMemoryDist(VPTOMemoryOpFamily family, llvm::StringRef token,
+                     std::optional<unsigned> defaultElementBits = std::nullopt);
+
+const VPTOMemoryDistContract *getVPTOMemoryDistContract(VPTOMemoryDist dist);
+
+} // namespace mlir::pto
+
+#endif // PTO_IR_VPTOMEMORYDIST_H

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -142,6 +142,7 @@ std::unique_ptr<Pass> createVMILegalizeArithSelectPass();
 std::unique_ptr<Pass> createVMILowerUnifiedToLegacyPass();
 std::unique_ptr<Pass> createVMINormalizeSignlessIntToUnsignedPass();
 std::unique_ptr<Pass> createVMIToVPTOPass();
+std::unique_ptr<Pass> createVPTOStatefulStreamFusionPass();
 std::unique_ptr<Pass> createPTOExpandSoftLibPass();
 std::unique_ptr<Pass> createInsertTemplateAttributesPass();
 std::unique_ptr<Pass> createExpandTileOpPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -1250,6 +1250,18 @@ def VMIToVPTO : Pass<"vmi-to-vpto", "ModuleOp"> {
                            "mlir::scf::SCFDialect"];
 }
 
+def VPTOStatefulStreamFusion : Pass<"vpto-stateful-stream-fusion", "ModuleOp"> {
+  let summary = "Fuse compatible VPTO stateful load and store streams";
+  let description = [{
+    Fuses adjacent VPTO streams that thread alignment state through SSA. Load
+    streams use vldas/vldus and store streams use init_align/vstus with a
+    matching flush. Fusion requires provably contiguous addresses and does not
+    cross observable memory effects or control flow.
+  }];
+  let constructor = "mlir::pto::createVPTOStatefulStreamFusionPass()";
+  let dependentDialects = ["mlir::pto::PTODialect"];
+}
+
 def PTOExpandSoftLib : Pass<"pto-expand-soft-lib", "ModuleOp"> {
   let summary = "Expand VPTO operations that lack native target support";
   let description = [{

--- a/include/PTO/Transforms/VPTOStatefulStreamFusion.h
+++ b/include/PTO/Transforms/VPTOStatefulStreamFusion.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef PTO_TRANSFORMS_VPTOSTATEFULSTREAMFUSION_H
+#define PTO_TRANSFORMS_VPTOSTATEFULSTREAMFUSION_H
+
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir::pto {
+
+void runVPTOStatefulStreamFusion(ModuleOp module);
+
+} // namespace mlir::pto
+
+#endif

--- a/lib/PTO/Analysis/PTOAddressAnalysis.cpp
+++ b/lib/PTO/Analysis/PTOAddressAnalysis.cpp
@@ -11,12 +11,36 @@
 #include "PTO/Analysis/PTOAddressAnalysis.h"
 
 #include "PTO/IR/PTO.h"
+#include "PTO/IR/PTOTypeUtils.h"
+#include "PTO/Support/CodeConstants.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/Pass/AnalysisManager.h"
+#include "llvm/Support/MathExtras.h"
+
+#include <numeric>
 
 using namespace mlir;
 using namespace mlir::pto;
 
 namespace {
+
+static std::optional<int64_t> getElementBytes(Value pointer) {
+  Type elementType;
+  if (auto pointerType = dyn_cast<PtrType>(pointer.getType())) {
+    elementType = pointerType.getElementType();
+  } else if (auto memrefType = dyn_cast<BaseMemRefType>(pointer.getType())) {
+    elementType = memrefType.getElementType();
+  } else {
+    return std::nullopt;
+  }
+  unsigned bitWidth = getPTOStorageElemBitWidth(elementType);
+  if (bitWidth == 0 || bitWidth % mlir::pto::kValue8 != 0) {
+    return std::nullopt;
+  }
+  return static_cast<int64_t>(bitWidth / mlir::pto::kValue8);
+}
 
 static PTOAnalysisResult<PTOTypedExprRef>
 scaleExpression(const PTOTypedExprRef &expression, int64_t numerator,
@@ -51,7 +75,263 @@ static bool isZero(const PTOTypedExprRef &expression) {
   return constant && *constant == 0;
 }
 
+static std::optional<int64_t> getConstantIndexValue(Value value) {
+  IntegerAttr attr;
+  if (!matchPattern(value, m_Constant(&attr))) {
+    return std::nullopt;
+  }
+  if (!attr.getValue().isSignedIntN(64)) {
+    return std::nullopt;
+  }
+  return attr.getValue().getSExtValue();
+}
+
+static int64_t normalizeRemainder(int64_t value, int64_t modulus) {
+  int64_t remainder = value % modulus;
+  return remainder < 0 ? remainder + modulus : remainder;
+}
+
+static std::optional<int64_t>
+getKnownIndexRemainder(Value value, int64_t modulus, unsigned depth = 0) {
+  if (modulus <= 1) {
+    return 0;
+  }
+  if (depth > 8) {
+    return std::nullopt;
+  }
+  if (auto constant = getConstantIndexValue(value)) {
+    return normalizeRemainder(*constant, modulus);
+  }
+
+  if (auto blockArgument = dyn_cast<BlockArgument>(value)) {
+    auto forOp = dyn_cast_or_null<scf::ForOp>(
+        blockArgument.getOwner()->getParentOp());
+    if (forOp) {
+      bool isInductionVariable = forOp.getInductionVar() == value;
+      if (!isInductionVariable) {
+        return std::nullopt;
+      }
+      auto lower =
+          getKnownIndexRemainder(forOp.getLowerBound(), modulus, depth + 1);
+      auto step =
+          getKnownIndexRemainder(forOp.getStep(), modulus, depth + 1);
+      if (lower && step && *step == 0) {
+        return lower;
+      }
+    }
+  }
+
+  if (auto cast = value.getDefiningOp<arith::IndexCastOp>()) {
+    return getKnownIndexRemainder(cast.getIn(), modulus, depth + 1);
+  }
+  if (auto cast = value.getDefiningOp<arith::IndexCastUIOp>()) {
+    return getKnownIndexRemainder(cast.getIn(), modulus, depth + 1);
+  }
+  if (auto cast = value.getDefiningOp<arith::ExtSIOp>()) {
+    return getKnownIndexRemainder(cast.getIn(), modulus, depth + 1);
+  }
+  if (auto cast = value.getDefiningOp<arith::ExtUIOp>()) {
+    return getKnownIndexRemainder(cast.getIn(), modulus, depth + 1);
+  }
+  if (auto cast = value.getDefiningOp<UnrealizedConversionCastOp>()) {
+    bool isSingleCast = cast->getNumOperands() == 1 &&
+                        cast->getNumResults() == 1;
+    if (isSingleCast) {
+      return getKnownIndexRemainder(cast.getOperand(0), modulus, depth + 1);
+    }
+  }
+
+  if (auto add = value.getDefiningOp<arith::AddIOp>()) {
+    auto lhs = getKnownIndexRemainder(add.getLhs(), modulus, depth + 1);
+    auto rhs = getKnownIndexRemainder(add.getRhs(), modulus, depth + 1);
+    return lhs && rhs ? std::optional<int64_t>(normalizeRemainder(
+                              *lhs + *rhs, modulus))
+                      : std::nullopt;
+  }
+  if (auto sub = value.getDefiningOp<arith::SubIOp>()) {
+    auto lhs = getKnownIndexRemainder(sub.getLhs(), modulus, depth + 1);
+    auto rhs = getKnownIndexRemainder(sub.getRhs(), modulus, depth + 1);
+    return lhs && rhs ? std::optional<int64_t>(normalizeRemainder(
+                              *lhs - *rhs, modulus))
+                      : std::nullopt;
+  }
+  if (auto mul = value.getDefiningOp<arith::MulIOp>()) {
+    auto lhs = getKnownIndexRemainder(mul.getLhs(), modulus, depth + 1);
+    auto rhs = getKnownIndexRemainder(mul.getRhs(), modulus, depth + 1);
+    if (lhs && *lhs == 0) {
+      return 0;
+    }
+    if (rhs && *rhs == 0) {
+      return 0;
+    }
+    return lhs && rhs ? std::optional<int64_t>(normalizeRemainder(
+                              *lhs * *rhs, modulus))
+                      : std::nullopt;
+  }
+  return std::nullopt;
+}
+
+static std::optional<int64_t>
+getKnownPointerRemainder(Value pointer, int64_t alignmentBytes,
+                         unsigned depth = 0) {
+  if (alignmentBytes <= 1) {
+    return 0;
+  }
+  if (depth > 8) {
+    return std::nullopt;
+  }
+  if (isa<BlockArgument>(pointer)) {
+    return 0;
+  }
+  if (auto cast = pointer.getDefiningOp<CastPtrOp>()) {
+    Value input = cast.getInput();
+    if (isa<PtrType>(input.getType())) {
+      return getKnownPointerRemainder(input, alignmentBytes, depth + 1);
+    }
+    if (isa<IntegerType>(input.getType())) {
+      return getKnownIndexRemainder(input, alignmentBytes);
+    }
+    return std::nullopt;
+  }
+  if (auto cast = pointer.getDefiningOp<UnrealizedConversionCastOp>()) {
+    bool isSingleCast = cast->getNumOperands() == 1 &&
+                        cast->getNumResults() == 1;
+    if (isSingleCast) {
+      return getKnownPointerRemainder(cast.getOperand(0), alignmentBytes,
+                                      depth + 1);
+    }
+    return std::nullopt;
+  }
+  auto add = pointer.getDefiningOp<AddPtrOp>();
+  if (!add) {
+    return std::nullopt;
+  }
+  auto base = getKnownPointerRemainder(add.getPtr(), alignmentBytes,
+                                       depth + 1);
+  auto pointerType = dyn_cast<PtrType>(add.getPtr().getType());
+  if (!base || !pointerType) {
+    return std::nullopt;
+  }
+  unsigned elementBits = getPTOStorageElemBitWidth(pointerType.getElementType());
+  if (elementBits == 0 || elementBits % 8 != 0) {
+    return std::nullopt;
+  }
+  int64_t elementBytes = static_cast<int64_t>(elementBits / 8);
+  int64_t offsetModulus =
+      alignmentBytes / std::gcd(alignmentBytes, elementBytes);
+  auto offset = getKnownIndexRemainder(add.getOffset(), offsetModulus);
+  if (!offset) {
+    return std::nullopt;
+  }
+  return normalizeRemainder(*base + *offset * elementBytes, alignmentBytes);
+}
+
+struct NormalizedPointer {
+  Value root;
+  PTOTypedExprRef offset;
+  int64_t elementBytes = 0;
+};
+
+static std::optional<NormalizedPointer>
+normalizePointer(Value pointer, PTOValueEvolutionAnalysis &valueEvolution) {
+  auto elementBytes = getElementBytes(pointer);
+  if (!elementBytes) {
+    return std::nullopt;
+  }
+  NormalizedPointer result{pointer,
+                           makePTOConstantExpr(0, pointer.getType()),
+                           *elementBytes};
+  while (true) {
+    if (auto add = result.root.getDefiningOp<AddPtrOp>()) {
+      auto parentBytes = getElementBytes(add.getPtr());
+      if (!parentBytes || *parentBytes != result.elementBytes) {
+        break;
+      }
+      result.offset = makePTOAddExpr(
+          result.offset, valueEvolution.getExpr(add.getOffset()),
+          add.getOffset().getType());
+      result.root = add.getPtr();
+      continue;
+    }
+    if (auto cast = result.root.getDefiningOp<CastPtrOp>()) {
+      auto inputBytes = getElementBytes(cast.getInput());
+      if (!inputBytes || *inputBytes != result.elementBytes) {
+        break;
+      }
+      result.root = cast.getInput();
+      continue;
+    }
+    break;
+  }
+  return result;
+}
+
 } // namespace
+
+std::optional<int64_t>
+mlir::pto::getKnownAddressRemainderBytes(Value pointer, Value elementOffset,
+                                         Type elementType,
+                                         int64_t alignmentBytes) {
+  if (alignmentBytes <= 0) {
+    return std::nullopt;
+  }
+  auto base = getKnownPointerRemainder(pointer, alignmentBytes);
+  unsigned elementBits = getPTOStorageElemBitWidth(elementType);
+  if (!base || elementBits == 0 || elementBits % 8 != 0) {
+    return std::nullopt;
+  }
+  int64_t elementBytes = static_cast<int64_t>(elementBits / 8);
+  int64_t offsetModulus =
+      alignmentBytes / std::gcd(alignmentBytes, elementBytes);
+  auto offset = getKnownIndexRemainder(elementOffset, offsetModulus);
+  if (!offset) {
+    return std::nullopt;
+  }
+  return normalizeRemainder(*base + *offset * elementBytes, alignmentBytes);
+}
+
+bool mlir::pto::isKnownAddressAligned(Value pointer, Value elementOffset,
+                                      Type elementType,
+                                      int64_t alignmentBytes) {
+  std::optional<int64_t> remainder = getKnownAddressRemainderBytes(
+      pointer, elementOffset, elementType, alignmentBytes);
+  return remainder && *remainder == 0;
+}
+
+std::optional<int64_t>
+mlir::pto::getKnownAddressDifferenceBytes(Value from, Value to) {
+  func::FuncOp func = from ? from.getParentRegion()->getParentOfType<func::FuncOp>()
+                           : func::FuncOp();
+  if (!func || !to ||
+      to.getParentRegion()->getParentOfType<func::FuncOp>() != func) {
+    return std::nullopt;
+  }
+  PTOValueEvolutionAnalysis valueEvolution(func);
+  auto fromInfo = normalizePointer(from, valueEvolution);
+  auto toInfo = normalizePointer(to, valueEvolution);
+  if (!fromInfo || !toInfo || fromInfo->root != toInfo->root ||
+      fromInfo->elementBytes != toInfo->elementBytes) {
+    return std::nullopt;
+  }
+  auto fromPoint = valueEvolution.getPointExpression(fromInfo->offset);
+  auto toPoint = valueEvolution.getPointExpression(toInfo->offset);
+  if (!fromPoint || !toPoint) {
+    return std::nullopt;
+  }
+  auto differenceExpr = makePTOSubExpr(*toPoint.value, *fromPoint.value);
+  auto difference = normalizePTOLinearExpr(differenceExpr);
+  if (!difference) {
+    return std::nullopt;
+  }
+  if (!difference->terms.empty()) {
+    return std::nullopt;
+  }
+  int64_t result;
+  if (llvm::MulOverflow(difference->constant, fromInfo->elementBytes, result)) {
+    return std::nullopt;
+  }
+  return result;
+}
 
 PTOAddressAnalysis::PTOAddressAnalysis(func::FuncOp func,
                                        AnalysisManager &analysisManager)

--- a/lib/PTO/IR/CMakeLists.txt
+++ b/lib/PTO/IR/CMakeLists.txt
@@ -18,6 +18,7 @@ add_mlir_dialect_library(PTOIR
   PTO.cpp
   VPTO.cpp
   VPTOAddressSemantics.cpp
+  VPTOMemoryDist.cpp
   VPTOScheduling.cpp
   VMI.cpp
   VPTOUbOps.cpp

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -14,9 +14,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "PTO/Support/CodeConstants.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
+#include "PTO/IR/VPTOMemoryDist.h"
+#include "PTO/Support/CodeConstants.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -1011,11 +1012,19 @@ static scf::IfOp getEnclosingBranchIf(Operation *op) {
 }
 
 static bool isValueOwnedByRegion(Value value, Region *region) {
+  Region *valueRegion = nullptr;
   if (auto blockArg = dyn_cast<BlockArgument>(value)) {
-    return blockArg.getParentRegion() == region;
+    valueRegion = blockArg.getParentRegion();
+  } else if (Operation *def = value.getDefiningOp()) {
+    valueRegion = def->getParentRegion();
   }
-  if (Operation *def = value.getDefiningOp()) {
-    return def->getParentRegion() == region;
+
+  while (valueRegion) {
+    if (valueRegion == region) {
+      return true;
+    }
+    Operation *parentOp = valueRegion->getParentOp();
+    valueRegion = parentOp ? parentOp->getParentRegion() : nullptr;
   }
   return false;
 }
@@ -1924,62 +1933,32 @@ static std::optional<unsigned> getDistElementWidth(Type type) {
   return std::nullopt;
 }
 
-static bool isSupportedVldx2DistToken(StringRef dist) {
-  return dist == "BDINTLV" || dist == "DINTLV_B8" || dist == "DINTLV_B16" ||
-         dist == "DINTLV_B32";
+static bool isSupportedVldx2DistToken(StringRef dist, Type elementType) {
+  return lookupVPTOMemoryDist(VPTOMemoryOpFamily::LoadX2, dist,
+                              getDistElementWidth(elementType));
 }
 
-static bool isSupportedVldsDistToken(StringRef dist) {
-  return dist == "NORM" || dist == "BRC_B8" || dist == "BRC_B16" ||
-         dist == "BRC_B32" || dist == "US_B8" || dist == "US_B16" ||
-         dist == "DS_B8" || dist == "DS_B16" || dist == "UNPK_B8" ||
-         dist == "UNPK_B16" || dist == "UNPK_B32" || dist == "BRC_BLK" ||
-         dist == "E2B_B16" || dist == "E2B_B32" || dist == "UNPK4" ||
-         dist == "SPLT4CHN" || dist == "SPLT2CHN_B8" || dist == "SPLT2CHN_B16";
+static bool isSupportedVldsDistToken(StringRef dist, Type elementType) {
+  return lookupVPTOMemoryDist(VPTOMemoryOpFamily::Load, dist,
+                              getDistElementWidth(elementType));
 }
 
 static bool isSupportedVstsDistToken(StringRef dist) {
-  return dist == "NORM_B8" || dist == "NORM_B16" || dist == "NORM_B32" ||
-         dist == "1PT_B8" || dist == "1PT_B16" || dist == "1PT_B32" ||
-         dist == "PK_B16" || dist == "PK_B32" || dist == "PK_B64" ||
-         dist == "PK4_B32" || dist == "MRG4CHN_B8" || dist == "MRG2CHN_B8" ||
-         dist == "MRG2CHN_B16";
+  return lookupVPTOMemoryDist(VPTOMemoryOpFamily::Store, dist);
 }
 
 static bool isSupportedVstsx2DistToken(StringRef dist) {
-  return dist == "INTLV_B8" || dist == "INTLV_B16" || dist == "INTLV_B32";
+  return lookupVPTOMemoryDist(VPTOMemoryOpFamily::StoreX2, dist);
 }
 
 static std::optional<StringRef>
-getVstsMaskGranularityOverride(StringRef dist, Type elementType) {
-  auto width = getDistElementWidth(elementType);
-  if (!width) {
+getVstsMaskGranularityOverride(StringRef dist) {
+  const auto *contract =
+      lookupVPTOMemoryDist(VPTOMemoryOpFamily::Store, dist);
+  if (!contract || contract->maskGranularity.empty()) {
     return std::nullopt;
   }
-
-  if (dist == "MRG4CHN_B8") {
-    return StringRef("b32");
-  }
-  if (dist == "MRG2CHN_B8") {
-    return StringRef("b16");
-  }
-  if (dist == "MRG2CHN_B16") {
-    return StringRef("b32");
-  }
-  if (dist == "PK_B16") {
-    return StringRef("b16");
-  }
-  if (dist == "PK_B32" || dist == "PK_B64" || dist == "PK4_B32") {
-    return StringRef("b32");
-  }
-  if (dist == "PK_B64") {
-    return StringRef("b32");
-  }
-  if (dist == "PK4_B32") {
-    return StringRef("b32");
-  }
-
-  return std::nullopt;
+  return contract->maskGranularity;
 }
 
 static bool isSupportedPostMode(StringRef mode) {
@@ -5479,7 +5458,9 @@ static LogicalResult verifyVldsCommon(LoadOp op) {
 
   if (op.getDistAttr()) {
     StringRef dist = *op.getDist();
-    if (!isSupportedVldsDistToken(dist)) {
+    Type elementType =
+        cast<VRegType>(op.getResult().getType()).getElementType();
+    if (!isSupportedVldsDistToken(dist, elementType)) {
       return op.emitOpError(
           "supports only NORM, BRC_B8/B16/B32, US_B8/B16, DS_B8/B16, "
           "UNPK_B8/B16/B32, BRC_BLK, E2B_B16/B32, UNPK4, SPLT4CHN, and "
@@ -7375,7 +7356,8 @@ LogicalResult Vldsx2Op::verify() {
   if (getLow().getType() != getHigh().getType()) {
     return emitOpError("requires low/high results to share one vector type");
   }
-  if (!isSupportedVldx2DistToken(getDist())) {
+  Type elementType = cast<VRegType>(getLow().getType()).getElementType();
+  if (!isSupportedVldx2DistToken(getDist(), elementType)) {
     return emitOpError("requires a supported x2 load distribution token");
   }
   if (getUpdatedBase() &&
@@ -7412,8 +7394,8 @@ static LogicalResult verifyVstsCommon(StoreOp op) {
     return op.emitOpError("requires a supported store distribution token");
   }
   if (std::optional<StringRef> dist = op.getDist()) {
-    if (std::optional<StringRef> granularity = getVstsMaskGranularityOverride(
-            *dist, cast<VRegType>(op.getValue().getType()).getElementType())) {
+    if (std::optional<StringRef> granularity =
+            getVstsMaskGranularityOverride(*dist)) {
       if (failed(verifyMaskTypeWithGranularityLike(op, op.getMask().getType(),
                                                    "mask type", *granularity))) {
         return failure();

--- a/lib/PTO/IR/VPTOMemoryDist.cpp
+++ b/lib/PTO/IR/VPTOMemoryDist.cpp
@@ -1,0 +1,515 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- VPTOMemoryDist.cpp - VPTO vector memory dist contracts ------------===//
+
+#include "PTO/IR/VPTOMemoryDist.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/MathExtras.h"
+
+#include <algorithm>
+#include <limits>
+
+using namespace mlir;
+using namespace mlir::pto;
+
+namespace {
+
+using Family = VPTOMemoryOpFamily;
+using Dist = VPTOMemoryDist;
+using Predicate = VPTOPredicatePolicy;
+using Transfer = VPTOMemoryTransferKind;
+using Size = VPTOMemorySizeRule;
+
+static const VPTOMemoryDistContract contracts[] = {
+    {Family::Load,
+     Dist::LoadNorm,
+     "NORM",
+     0,
+     0,
+     1,
+     Predicate::NotPresent,
+     Transfer::Identity,
+     Size::Block,
+     Size::Vector,
+     {}},
+    {Family::Load,
+     Dist::BrcB8,
+     "BRC_B8",
+     8,
+     1,
+     1,
+     Predicate::NotPresent,
+     Transfer::ScalarBroadcast,
+     Size::Element,
+     Size::Element,
+     {}},
+    {Family::Load,
+     Dist::BrcB16,
+     "BRC_B16",
+     16,
+     2,
+     1,
+     Predicate::NotPresent,
+     Transfer::ScalarBroadcast,
+     Size::Element,
+     Size::Element,
+     {}},
+    {Family::Load,
+     Dist::BrcB32,
+     "BRC_B32",
+     32,
+     3,
+     1,
+     Predicate::NotPresent,
+     Transfer::ScalarBroadcast,
+     Size::Element,
+     Size::Element,
+     {}},
+    {Family::Load,
+     Dist::UsB8,
+     "US_B8",
+     8,
+     6,
+     1,
+     Predicate::NotPresent,
+     Transfer::Upsample2,
+     Size::VectorDiv2,
+     Size::VectorDiv2,
+     {}},
+    {Family::Load,
+     Dist::UsB16,
+     "US_B16",
+     16,
+     7,
+     1,
+     Predicate::NotPresent,
+     Transfer::Upsample2,
+     Size::VectorDiv2,
+     Size::VectorDiv2,
+     {}},
+    {Family::Load,
+     Dist::DsB8,
+     "DS_B8",
+     8,
+     8,
+     1,
+     Predicate::NotPresent,
+     Transfer::Downsample2,
+     Size::Block,
+     Size::VectorTimes2,
+     {}},
+    {Family::Load,
+     Dist::DsB16,
+     "DS_B16",
+     16,
+     9,
+     1,
+     Predicate::NotPresent,
+     Transfer::Downsample2,
+     Size::Block,
+     Size::VectorTimes2,
+     {}},
+    {Family::LoadX2,
+     Dist::BlockDeinterleave,
+     "BDINTLV",
+     0,
+     10,
+     2,
+     Predicate::NotPresent,
+     Transfer::BlockDeinterleave2,
+     Size::Block,
+     Size::VectorTimes2,
+     {}},
+    {Family::LoadX2,
+     Dist::DeinterleaveB8,
+     "DINTLV_B8",
+     8,
+     11,
+     2,
+     Predicate::NotPresent,
+     Transfer::ElementDeinterleave2,
+     Size::Block,
+     Size::VectorTimes2,
+     {}},
+    {Family::LoadX2,
+     Dist::DeinterleaveB16,
+     "DINTLV_B16",
+     16,
+     12,
+     2,
+     Predicate::NotPresent,
+     Transfer::ElementDeinterleave2,
+     Size::Block,
+     Size::VectorTimes2,
+     {}},
+    {Family::Load,
+     Dist::UnpackB8,
+     "UNPK_B8",
+     8,
+     13,
+     1,
+     Predicate::NotPresent,
+     Transfer::LaneExpand2,
+     Size::VectorDiv2,
+     Size::VectorDiv2,
+     {}},
+    {Family::Load,
+     Dist::UnpackB16,
+     "UNPK_B16",
+     16,
+     14,
+     1,
+     Predicate::NotPresent,
+     Transfer::LaneExpand2,
+     Size::VectorDiv2,
+     Size::VectorDiv2,
+     {}},
+    {Family::Load,
+     Dist::BroadcastBlock,
+     "BRC_BLK",
+     0,
+     15,
+     1,
+     Predicate::NotPresent,
+     Transfer::BlockBroadcast,
+     Size::Block,
+     Size::Block,
+     {}},
+    {Family::Load,
+     Dist::ElementToBlockB16,
+     "E2B_B16",
+     16,
+     16,
+     1,
+     Predicate::NotPresent,
+     Transfer::ElementToBlock,
+     Size::VectorDiv16,
+     Size::VectorDiv16,
+     {}},
+    {Family::Load,
+     Dist::ElementToBlockB32,
+     "E2B_B32",
+     32,
+     17,
+     1,
+     Predicate::NotPresent,
+     Transfer::ElementToBlock,
+     Size::VectorDiv8,
+     Size::VectorDiv8,
+     {}},
+    {Family::Load,
+     Dist::UnpackB32,
+     "UNPK_B32",
+     32,
+     18,
+     1,
+     Predicate::NotPresent,
+     Transfer::LaneExpand2,
+     Size::VectorDiv2,
+     Size::VectorDiv2,
+     {}},
+    {Family::LoadX2,
+     Dist::DeinterleaveB32,
+     "DINTLV_B32",
+     32,
+     19,
+     2,
+     Predicate::NotPresent,
+     Transfer::ElementDeinterleave2,
+     Size::Block,
+     Size::VectorTimes2,
+     {}},
+    {Family::Load,
+     Dist::Unpack4B8,
+     "UNPK4",
+     8,
+     20,
+     1,
+     Predicate::NotPresent,
+     Transfer::LaneExpand4,
+     Size::VectorDiv4,
+     Size::VectorDiv4,
+     {}},
+    {Family::Load,
+     Dist::Split4ChannelB8,
+     "SPLT4CHN",
+     8,
+     21,
+     1,
+     Predicate::NotPresent,
+     Transfer::SplitChannel,
+     Size::Block,
+     Size::Vector,
+     {}},
+    {Family::Load,
+     Dist::Split2ChannelB8,
+     "SPLT2CHN_B8",
+     8,
+     22,
+     1,
+     Predicate::NotPresent,
+     Transfer::SplitChannel,
+     Size::Block,
+     Size::Vector,
+     {}},
+    {Family::Load,
+     Dist::Split2ChannelB16,
+     "SPLT2CHN_B16",
+     16,
+     23,
+     1,
+     Predicate::NotPresent,
+     Transfer::SplitChannel,
+     Size::Block,
+     Size::Vector,
+     {}},
+    {Family::Store,
+     Dist::StoreNormB8,
+     "NORM_B8",
+     8,
+     0,
+     1,
+     Predicate::Applied,
+     Transfer::Identity,
+     Size::Block,
+     Size::Vector,
+     {}},
+    {Family::Store,
+     Dist::StoreNormB16,
+     "NORM_B16",
+     16,
+     1,
+     1,
+     Predicate::Applied,
+     Transfer::Identity,
+     Size::Block,
+     Size::Vector,
+     {}},
+    {Family::Store,
+     Dist::StoreNormB32,
+     "NORM_B32",
+     32,
+     2,
+     1,
+     Predicate::Applied,
+     Transfer::Identity,
+     Size::Block,
+     Size::Vector,
+     {}},
+    {Family::Store,
+     Dist::OnePointB8,
+     "1PT_B8",
+     8,
+     3,
+     1,
+     Predicate::Ignored,
+     Transfer::Point,
+     Size::Element,
+     Size::Element,
+     {}},
+    {Family::Store,
+     Dist::OnePointB16,
+     "1PT_B16",
+     16,
+     4,
+     1,
+     Predicate::Ignored,
+     Transfer::Point,
+     Size::Element,
+     Size::Element,
+     {}},
+    {Family::Store,
+     Dist::OnePointB32,
+     "1PT_B32",
+     32,
+     5,
+     1,
+     Predicate::Ignored,
+     Transfer::Point,
+     Size::Element,
+     Size::Element,
+     {}},
+    {Family::Store, Dist::PackB16, "PK_B16", 8, 6, 1, Predicate::Applied,
+     Transfer::LaneCompact2, Size::VectorDiv2, Size::VectorDiv2, "b16"},
+    {Family::Store, Dist::PackB32, "PK_B32", 16, 7, 1, Predicate::Applied,
+     Transfer::LaneCompact2, Size::VectorDiv2, Size::VectorDiv2, "b32"},
+    {Family::StoreX2,
+     Dist::InterleaveB8,
+     "INTLV_B8",
+     8,
+     8,
+     2,
+     Predicate::Ignored,
+     Transfer::ElementInterleave2,
+     Size::Block,
+     Size::VectorTimes2,
+     {}},
+    {Family::StoreX2,
+     Dist::InterleaveB16,
+     "INTLV_B16",
+     16,
+     9,
+     2,
+     Predicate::Ignored,
+     Transfer::ElementInterleave2,
+     Size::Block,
+     Size::VectorTimes2,
+     {}},
+    {Family::Store, Dist::PackB64, "PK_B64", 32, 10, 1, Predicate::Applied,
+     Transfer::LaneCompact2, Size::VectorDiv2, Size::VectorDiv2, "b32"},
+    {Family::StoreX2,
+     Dist::InterleaveB32,
+     "INTLV_B32",
+     32,
+     11,
+     2,
+     Predicate::Ignored,
+     Transfer::ElementInterleave2,
+     Size::Block,
+     Size::VectorTimes2,
+     {}},
+    // PK4_B32 is defined over the raw 256-byte register payload. Existing
+    // legal producers use both byte-typed values and b32 carrier values after
+    // explicit lane selection, so the register element type is not fixed.
+    {Family::Store, Dist::Pack4B32, "PK4_B32", 0, 12, 1, Predicate::Applied,
+     Transfer::LaneCompact4, Size::VectorDiv4, Size::VectorDiv4, "b32"},
+    {Family::Store, Dist::Merge4ChannelB8, "MRG4CHN_B8", 8, 13, 1,
+     Predicate::Applied, Transfer::MergeChannel, Size::Block, Size::Vector,
+     "b32"},
+    {Family::Store, Dist::Merge2ChannelB8, "MRG2CHN_B8", 8, 14, 1,
+     Predicate::Applied, Transfer::MergeChannel, Size::Block, Size::Vector,
+     "b16"},
+    {Family::Store, Dist::Merge2ChannelB16, "MRG2CHN_B16", 16, 15, 1,
+     Predicate::Applied, Transfer::MergeChannel, Size::Block, Size::Vector,
+     "b32"},
+};
+
+static std::optional<int64_t> evaluateSizeRule(VPTOMemorySizeRule rule,
+                                               int64_t vectorBytes,
+                                               unsigned elementBits) {
+  if (vectorBytes <= 0) {
+    return std::nullopt;
+  }
+
+  switch (rule) {
+  case Size::Element:
+    if (elementBits == 0 || elementBits % 8 != 0) {
+      return std::nullopt;
+    }
+    return static_cast<int64_t>(elementBits / 8);
+  case Size::Block:
+    return 32;
+  case Size::Vector:
+    return vectorBytes;
+  case Size::VectorTimes2:
+    if (
+        vectorBytes > std::numeric_limits<int64_t>::max() / 2) {
+      return std::nullopt;
+    }
+    return vectorBytes * 2;
+  case Size::VectorDiv2:
+    return vectorBytes % 2 == 0 ? std::optional<int64_t>(vectorBytes / 2)
+                                : std::nullopt;
+  case Size::VectorDiv4:
+    return vectorBytes % 4 == 0 ? std::optional<int64_t>(vectorBytes / 4)
+                                : std::nullopt;
+  case Size::VectorDiv8:
+    return vectorBytes % 8 == 0 ? std::optional<int64_t>(vectorBytes / 8)
+                                : std::nullopt;
+  case Size::VectorDiv16:
+    return vectorBytes % 16 == 0 ? std::optional<int64_t>(vectorBytes / 16)
+                                 : std::nullopt;
+  }
+  return std::nullopt;
+}
+
+static llvm::StringRef getDefaultToken(VPTOMemoryOpFamily family,
+                                       std::optional<unsigned> elementBits) {
+  if (family == Family::Load) {
+    return "NORM";
+  }
+  if (family != Family::Store || !elementBits) {
+    return {};
+  }
+  switch (*elementBits) {
+  case 8:
+    return "NORM_B8";
+  case 16:
+    return "NORM_B16";
+  case 32:
+    return "NORM_B32";
+  default:
+    return {};
+  }
+}
+
+} // namespace
+
+std::optional<int64_t>
+VPTOMemoryDistContract::getRequiredAlignmentBytes(int64_t vectorBytes) const {
+  std::optional<int64_t> alignment =
+      evaluateSizeRule(alignmentRule, vectorBytes, operandElementBits);
+  if (!alignment) {
+    return std::nullopt;
+  }
+  if (alignmentRule == Size::VectorDiv2 || alignmentRule == Size::VectorDiv4) {
+    return std::min<int64_t>(32, *alignment);
+  }
+  return alignment;
+}
+
+std::optional<int64_t>
+VPTOMemoryDistContract::getFullActiveFootprintBytes(int64_t vectorBytes) const {
+  return evaluateSizeRule(footprintRule, vectorBytes, operandElementBits);
+}
+
+int64_t VPTOMemoryDistContract::getDependencyGranularityBytes(
+    int64_t vectorBytes) const {
+  if (transfer == Transfer::ScalarBroadcast) {
+    return 32;
+  }
+  return getFullActiveFootprintBytes(vectorBytes).value_or(0);
+}
+
+bool VPTOMemoryDistContract::isOnePointStore() const {
+  return dist == Dist::OnePointB8 || dist == Dist::OnePointB16 ||
+         dist == Dist::OnePointB32;
+}
+
+const VPTOMemoryDistContract *
+mlir::pto::lookupVPTOMemoryDist(VPTOMemoryOpFamily family,
+                                llvm::StringRef token,
+                                std::optional<unsigned> defaultElementBits) {
+  llvm::StringRef normalizedToken = token;
+  if (normalizedToken.empty()) {
+    normalizedToken = getDefaultToken(family, defaultElementBits);
+  }
+  if (normalizedToken.empty()) {
+    return nullptr;
+  }
+
+  for (const VPTOMemoryDistContract &contract : contracts) {
+    if (contract.family != family || contract.token != normalizedToken) {
+      continue;
+    }
+    return &contract;
+  }
+  return nullptr;
+}
+
+const VPTOMemoryDistContract *
+mlir::pto::getVPTOMemoryDistContract(VPTOMemoryDist dist) {
+  for (const VPTOMemoryDistContract &contract : contracts) {
+    if (contract.dist == dist) {
+      return &contract;
+    }
+  }
+  return nullptr;
+}

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -89,6 +89,7 @@ add_mlir_dialect_library(PTOTransforms
   VMILayoutRematerialize.cpp
   VMILayoutSinkMaterialization.cpp
   VMIToVPTO.cpp
+  VPTOStatefulStreamFusion.cpp
   PTOExpandSoftLib.cpp
   SIMTPersistentFragmentAnalysis.cpp
   PTOAnalyzeSIMTPersistentFragment.cpp

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12,11 +12,14 @@
 // https://discourse.llvm.org/t/matchandrewrite-hiding-virtual-functions/84933/8
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
 
+#include "PTO/Analysis/PTOAddressAnalysis.h"
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/IR/VMIUtils.h"
+#include "PTO/IR/VPTOMemoryDist.h"
 #include "PTO/Transforms/Passes.h"
 #include "PTO/Transforms/VMILayoutSupport.h"
+#include "PTO/Transforms/VPTOLowering.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
@@ -33,12 +36,14 @@
 #include "mlir/Transforms/OneToNTypeConversion.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cassert>
 #include <numeric>
 #include <type_traits>
+#include <variant>
 
 namespace mlir {
 namespace pto {
@@ -57,6 +62,44 @@ std::optional<std::string> getX2MemoryDistToken(Type elementType,
 std::optional<std::string> getDenseLaneStrideLoadDistToken(VMIVRegType type);
 std::optional<std::string> getDenseLaneStrideStoreDistToken(VMIVRegType type);
 std::optional<std::string> getPointStoreDistToken(Type elementType);
+
+static LogicalResult emitStatefulStoreStream(Operation *op, Value base,
+                                              ValueRange values,
+                                              ArrayRef<int64_t> advances,
+                                              OneToNPatternRewriter &rewriter) {
+  bool invalidStreamShape = values.empty() || values.size() != advances.size();
+  if (invalidStreamShape) {
+    return rewriter.notifyMatchFailure(
+        op, "unaligned store stream requires matching non-empty values and "
+            "advances");
+  }
+  if (llvm::any_of(advances, [](int64_t advance) {
+        return advance <= 0 || !llvm::isInt<32>(advance);
+      })) {
+    return rewriter.notifyMatchFailure(
+        op, "unaligned store stream requires positive 32-bit advances");
+  }
+
+  Value align = rewriter
+                    .create<InitAlignOp>(op->getLoc(),
+                                         AlignType::get(rewriter.getContext()))
+                    .getResult();
+  Value currentBase = base;
+  for (auto [value, advance] : llvm::zip_equal(values, advances)) {
+    Value advanceValue =
+        rewriter.create<arith::ConstantIntOp>(op->getLoc(), advance, 32);
+    auto store = rewriter.create<VstusOp>(op->getLoc(), align.getType(),
+                                          currentBase.getType(), align,
+                                          advanceValue, value, currentBase);
+    align = store.getAlignOut();
+    currentBase = store.getBaseOut();
+  }
+
+  Value zero = rewriter.create<arith::ConstantIntOp>(op->getLoc(), 0, 32);
+  rewriter.create<VstasOp>(op->getLoc(), /*updated_base=*/Type{}, align,
+                           currentBase, zero);
+  return success();
+}
 
 bool isVMIType(Type type) { return isa<VMIVRegType, VMIMaskType>(type); }
 
@@ -974,145 +1017,17 @@ std::optional<int64_t> getConstantIndexValue(Value value) {
   return std::nullopt;
 }
 
-static int64_t normalizeRemainder(int64_t value, int64_t modulus) {
-  int64_t remainder = value % modulus;
-  return remainder < 0 ? remainder + modulus : remainder;
-}
-
-std::optional<int64_t> getKnownIndexRemainder(Value value, int64_t modulus,
-                                              int depth = 0) {
-  if (modulus <= 1)
-    return 0;
-  if (depth > 6)
-    return std::nullopt;
-  if (std::optional<int64_t> constant = getConstantIndexValue(value))
-    return normalizeRemainder(*constant, modulus);
-
-  if (auto cast = value.getDefiningOp<arith::IndexCastOp>())
-    return getKnownIndexRemainder(cast.getIn(), modulus, depth + 1);
-  if (auto cast = value.getDefiningOp<arith::ExtSIOp>())
-    return getKnownIndexRemainder(cast.getIn(), modulus, depth + 1);
-  if (auto cast = value.getDefiningOp<arith::ExtUIOp>())
-    return getKnownIndexRemainder(cast.getIn(), modulus, depth + 1);
-  if (auto cast = value.getDefiningOp<UnrealizedConversionCastOp>()) {
-    if (cast->getNumOperands() == 1 && cast->getNumResults() == 1)
-      return getKnownIndexRemainder(cast.getOperand(0), modulus, depth + 1);
-  }
-
-  if (auto add = value.getDefiningOp<arith::AddIOp>()) {
-    std::optional<int64_t> lhs =
-        getKnownIndexRemainder(add.getLhs(), modulus, depth + 1);
-    std::optional<int64_t> rhs =
-        getKnownIndexRemainder(add.getRhs(), modulus, depth + 1);
-    if (lhs && rhs)
-      return normalizeRemainder(*lhs + *rhs, modulus);
-    return std::nullopt;
-  }
-  if (auto sub = value.getDefiningOp<arith::SubIOp>()) {
-    std::optional<int64_t> lhs =
-        getKnownIndexRemainder(sub.getLhs(), modulus, depth + 1);
-    std::optional<int64_t> rhs =
-        getKnownIndexRemainder(sub.getRhs(), modulus, depth + 1);
-    if (lhs && rhs)
-      return normalizeRemainder(*lhs - *rhs, modulus);
-    return std::nullopt;
-  }
-  if (auto mul = value.getDefiningOp<arith::MulIOp>()) {
-    std::optional<int64_t> lhs =
-        getKnownIndexRemainder(mul.getLhs(), modulus, depth + 1);
-    std::optional<int64_t> rhs =
-        getKnownIndexRemainder(mul.getRhs(), modulus, depth + 1);
-    if ((lhs && *lhs == 0) || (rhs && *rhs == 0))
-      return 0;
-    if (lhs && rhs)
-      return normalizeRemainder(*lhs * *rhs, modulus);
-    return std::nullopt;
-  }
-
-  return std::nullopt;
-}
-
-std::optional<int64_t> getKnownPointerByteRemainder(Value pointer,
-                                                    int64_t alignmentBytes,
-                                                    int depth = 0) {
-  if (alignmentBytes <= 1)
-    return 0;
-  if (depth > 6)
-    return std::nullopt;
-
-  // A raw PTO pointer block argument is a base address. Its required
-  // address-space alignment is an ABI precondition; derived pointers must
-  // prove that their element offsets preserve that alignment.
-  if (isa<BlockArgument>(pointer))
-    return 0;
-
-  if (auto cast = pointer.getDefiningOp<CastPtrOp>()) {
-    Value input = cast.getInput();
-    if (isa<PtrType>(input.getType()))
-      return getKnownPointerByteRemainder(input, alignmentBytes, depth + 1);
-    if (isa<IntegerType>(input.getType()))
-      return getKnownIndexRemainder(input, alignmentBytes, depth + 1);
-    return std::nullopt;
-  }
-
-  if (auto cast = pointer.getDefiningOp<UnrealizedConversionCastOp>()) {
-    if (cast->getNumOperands() == 1 && cast->getNumResults() == 1)
-      return getKnownPointerByteRemainder(cast.getOperand(0), alignmentBytes,
-                                          depth + 1);
-    return std::nullopt;
-  }
-
-  if (auto add = pointer.getDefiningOp<AddPtrOp>()) {
-    std::optional<int64_t> base =
-        getKnownPointerByteRemainder(add.getPtr(), alignmentBytes, depth + 1);
-    auto pointerType = dyn_cast<PtrType>(add.getPtr().getType());
-    if (!base || !pointerType)
-      return std::nullopt;
-    unsigned elementBits =
-        pto::getPTOStorageElemBitWidth(pointerType.getElementType());
-    if (elementBits == 0 || elementBits % 8 != 0)
-      return std::nullopt;
-    int64_t elementBytes = elementBits / 8;
-    int64_t offsetModulus =
-        alignmentBytes / std::gcd(alignmentBytes, elementBytes);
-    std::optional<int64_t> offset =
-        getKnownIndexRemainder(add.getOffset(), offsetModulus, depth + 1);
-    if (!offset)
-      return std::nullopt;
-    return normalizeRemainder(*base + *offset * elementBytes, alignmentBytes);
-  }
-
-  return std::nullopt;
-}
-
-bool isKnown32ByteAlignedAddress(Value pointer, Value elementOffset,
-                                 Type elementType) {
-  constexpr int64_t alignmentBytes = 32;
-  std::optional<int64_t> base =
-      getKnownPointerByteRemainder(pointer, alignmentBytes);
-  unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  if (!base || elementBits == 0 || elementBits % 8 != 0)
-    return false;
-
-  int64_t elementBytes = elementBits / 8;
-  int64_t offsetModulus =
-      alignmentBytes / std::gcd(alignmentBytes, elementBytes);
-  std::optional<int64_t> offset =
-      getKnownIndexRemainder(elementOffset, offsetModulus);
-  if (!offset)
-    return false;
-  return normalizeRemainder(*base + *offset * elementBytes, alignmentBytes) ==
-         0;
-}
-
 FailureOr<int64_t> getStaticMemRefElementCount(Type type) {
   auto memrefType = dyn_cast<MemRefType>(type);
   if (!memrefType || !memrefType.hasStaticShape())
     return failure();
 
   int64_t elements = 1;
-  for (int64_t dim : memrefType.getShape())
-    elements *= dim;
+  for (int64_t dim : memrefType.getShape()) {
+    if (llvm::MulOverflow(elements, dim, elements)) {
+      return failure();
+    }
+  }
   return elements;
 }
 
@@ -1121,6 +1036,16 @@ static Type getMemoryElementType(Type type) {
     return ptrType.getElementType();
   if (auto memrefType = dyn_cast<MemRefType>(type))
     return memrefType.getElementType();
+  return {};
+}
+
+static Attribute getMemorySpace(Type type) {
+  if (auto ptrType = dyn_cast<PtrType>(type)) {
+    return ptrType.getMemorySpace();
+  }
+  if (auto memrefType = dyn_cast<MemRefType>(type)) {
+    return memrefType.getMemorySpace();
+  }
   return {};
 }
 
@@ -1134,31 +1059,50 @@ static bool isPackedByteGroupStore(Type destinationType, VRegType valueType) {
          pto::getPTOStorageElemBitWidth(valueIntegerType) == 32;
 }
 
-enum class VMIMemoryValidMaskKind {
-  AllTrue,
-  ExplicitMask,
-};
+enum class VMIMemoryDirection { Read, Write };
 
-enum class VMIMemoryWriteMaskKind {
-  AllTrue,
-  ExplicitMask,
-};
+enum class VMIMemoryCoverageKind { Dense, Prefix, Predicate };
 
-enum class VMIMemoryPermutationKind {
-  Identity,
-};
-
-enum class VMIMemoryFallbackDecisionKind {
-  NotRequired,
-  RequiredUnavailable,
-};
-
-struct VMIMemoryLogicalShape {
+struct VMIMemoryCoverage {
+  VMIMemoryCoverageKind kind = VMIMemoryCoverageKind::Dense;
   int64_t elementCount = 0;
+  Value predicate;
+};
+
+struct VMIIdentityTransfer {};
+struct VMILaneExpandTransfer {
+  int64_t factor = 1;
+};
+struct VMILowBitsCompactTransfer {
+  int64_t factor = 1;
+};
+struct VMIGroupRepeatTransfer {
+  int64_t groups = 1;
+  int64_t lanesPerGroup = 1;
+};
+struct VMIDeinterleaveTransfer {
+  int64_t factor = 2;
+};
+struct VMIInterleaveTransfer {
+  int64_t factor = 2;
+};
+struct VMILaneSelectionTransfer {
+  SmallVector<int64_t> lanes;
+};
+
+using VMIRegisterTransfer =
+    std::variant<VMIIdentityTransfer, VMILaneExpandTransfer,
+                 VMILowBitsCompactTransfer, VMIGroupRepeatTransfer,
+                 VMIDeinterleaveTransfer, VMIInterleaveTransfer,
+                 VMILaneSelectionTransfer>;
+
+struct VMIPlannedAddress {
+  Value base;
+  Value elementOffset;
+  Type elementType;
 };
 
 struct VMIMemoryLaneAddressMap {
-  VMIMemoryPermutationKind permutation = VMIMemoryPermutationKind::Identity;
   int64_t baseElementOffset = 0;
   int64_t elementStride = 1;
   int64_t physicalLaneFootprint = 0;
@@ -1168,18 +1112,12 @@ struct VMIMemoryLaneAddressMap {
   }
 };
 
-struct VMIMemoryFallbackDecision {
-  VMIMemoryFallbackDecisionKind kind =
-      VMIMemoryFallbackDecisionKind::NotRequired;
-  std::string reason = "not required";
+struct VMIByteInterval {
+  int64_t begin = 0;
+  int64_t end = 0;
 
-  static VMIMemoryFallbackDecision notRequired() { return {}; }
-
-  static VMIMemoryFallbackDecision requiredUnavailable(const Twine &reason) {
-    VMIMemoryFallbackDecision decision;
-    decision.kind = VMIMemoryFallbackDecisionKind::RequiredUnavailable;
-    decision.reason = reason.str();
-    return decision;
+  bool contains(const VMIByteInterval &other) const {
+    return begin <= other.begin && end >= other.end;
   }
 };
 
@@ -1190,22 +1128,60 @@ struct VMIMemorySafeReadProof {
   std::optional<int64_t> staticElementCount;
   std::optional<VMIMemoryLaneAddressMap> laneAddressMap;
   int64_t physicalFootprint = 0;
+  std::optional<VMIByteInterval> readableEnvelope;
+  std::optional<VMIByteInterval> candidateReadEnvelope;
+};
+
+struct VMIPhysicalMemorySegment {
+  VMIPlannedAddress address;
+  VMIMemoryCoverage coverage;
+  VMIRegisterTransfer transfer = VMIIdentityTransfer{};
+  VMIMemorySafeReadProof readSafety;
 };
 
 struct VMIMemoryAccessPlan {
-  Type baseType;
+  VMIMemoryDirection direction = VMIMemoryDirection::Read;
+  SmallVector<VMIPhysicalMemorySegment, 1> segments;
   VMIVRegType valueType;
-  std::optional<int64_t> constantOffset;
-  VMIMemoryLogicalShape logicalShape;
-  VMIMemoryValidMaskKind validMask = VMIMemoryValidMaskKind::AllTrue;
-  VMIMemoryPermutationKind permutation = VMIMemoryPermutationKind::Identity;
-  std::optional<VMIMemoryLaneAddressMap> laneAddressMap;
   Attribute paddingValue;
-  VMIMemoryWriteMaskKind writeMask = VMIMemoryWriteMaskKind::AllTrue;
-  VMIMemorySafeReadProof safeReadProof;
   VMISupportResult layoutSupport;
-  VMIMemoryFallbackDecision fallbackDecision;
+
+  VMIPhysicalMemorySegment &front() { return segments.front(); }
+  const VMIPhysicalMemorySegment &front() const { return segments.front(); }
 };
+
+static std::optional<int64_t> getPhysicalVectorBytes(VRegType type) {
+  unsigned elementBits = pto::getPTOStorageElemBitWidth(type.getElementType());
+  int64_t totalBits;
+  if (elementBits == 0 ||
+      llvm::MulOverflow(type.getElementCount(),
+                        static_cast<int64_t>(elementBits), totalBits) ||
+      totalBits <= 0 || totalBits % 8 != 0) {
+    return std::nullopt;
+  }
+  return totalBits / 8;
+}
+
+static bool isDirectMemoryDistAddressLegal(Value base, Value offset,
+                                           Type addressElementType,
+                                           VRegType registerType,
+                                           VPTOMemoryOpFamily family,
+                                           StringRef dist) {
+  unsigned registerElementBits =
+      pto::getPTOStorageElemBitWidth(registerType.getElementType());
+  const VPTOMemoryDistContract *contract = lookupVPTOMemoryDist(
+      family, dist,
+      registerElementBits == 0 ? std::nullopt
+                               : std::optional<unsigned>(registerElementBits));
+  std::optional<int64_t> vectorBytes = getPhysicalVectorBytes(registerType);
+  std::optional<int64_t> requiredAlignment =
+      contract && vectorBytes
+          ? contract->getRequiredAlignmentBytes(*vectorBytes)
+          : std::nullopt;
+  return requiredAlignment &&
+         isKnownAddressAligned(base, offset, addressElementType,
+                               *requiredAlignment);
+}
 
 FailureOr<VMIMemoryLaneAddressMap>
 buildContiguousIdentityLaneAddressMap(int64_t constantOffset,
@@ -1278,93 +1254,299 @@ computeSafeFullReadProof(Type sourceType, std::optional<int64_t> constantOffset,
   proof.laneAddressMap = *addressMap;
 
   proof.physicalFootprint = addressMap->physicalLaneFootprint;
-  if (addressMap->getExclusiveEndElement() > elements)
+  unsigned elementBits =
+      pto::getPTOStorageElemBitWidth(resultType.getElementType());
+  if (elementBits == 0 || elementBits % 8 != 0) {
+    return fail("requires byte-addressable element type");
+  }
+  int64_t elementBytes = static_cast<int64_t>(elementBits / 8);
+  int64_t offsetBytes;
+  int64_t allocationBytes;
+  int64_t footprintBytes;
+  if (
+      llvm::MulOverflow(*constantOffset, elementBytes, offsetBytes) ||
+      llvm::MulOverflow(elements, elementBytes, allocationBytes) ||
+      llvm::MulOverflow(proof.physicalFootprint, elementBytes, footprintBytes)) {
+    return fail("byte read envelope overflows int64");
+  }
+
+  proof.readableEnvelope =
+      VMIByteInterval{-offsetBytes, allocationBytes - offsetBytes};
+  proof.candidateReadEnvelope = VMIByteInterval{0, footprintBytes};
+  if (!proof.readableEnvelope->contains(*proof.candidateReadEnvelope)) {
     return fail(Twine("full physical read footprint [") +
                 Twine(addressMap->baseElementOffset) + ", " +
                 Twine(addressMap->getExclusiveEndElement()) +
                 ") exceeds static memref element count " + Twine(elements));
+  }
 
   proof.proven = true;
   return proof;
 }
 
-VMIMemoryAccessPlan
-buildReadAccessPlan(Value source, Type sourceType, VMIVRegType resultType,
-                    std::optional<int64_t> constantOffset,
-                    VMIMemoryValidMaskKind validMask) {
+static VMIMemorySafeReadProof
+computeSafeStatefulReadProof(Value source, Value offset,
+                             VMIVRegType resultType) {
+  VMIMemorySafeReadProof proof;
+
+  auto fail = [&](const Twine &message) {
+    proof.proven = false;
+    proof.reason = message.str();
+    return proof;
+  };
+
+  FailureOr<int64_t> staticElements =
+      getStaticMemRefElementCount(source.getType());
+  if (failed(staticElements)) {
+    return fail("requires statically shaped memref source");
+  }
+
+  std::optional<int64_t> minOffset = getConstantIndexValue(offset);
+  std::optional<int64_t> maxOffset = minOffset;
+  if (!minOffset) {
+    Operation *anchor = offset.getDefiningOp();
+    if (!anchor) {
+      anchor = offset.getParentBlock()->getParentOp();
+    }
+    scf::ForOp loop = dyn_cast_or_null<scf::ForOp>(anchor);
+    if (!loop && anchor) {
+      loop = anchor->getParentOfType<scf::ForOp>();
+    }
+    func::FuncOp func =
+        anchor ? anchor->getParentOfType<func::FuncOp>() : func::FuncOp();
+    if (loop && func) {
+      PTOValueEvolutionAnalysis valueEvolution(func);
+      PTOAnalysisResult<PTOFiniteRange> range =
+          valueEvolution.getRange(offset, loop);
+      if (range) {
+        auto convertBound =
+            [](const APInt &bound,
+               bool unsignedInterpretation) -> std::optional<int64_t> {
+          if (unsignedInterpretation) {
+            bool exceedsSignedInt64 = bound.getActiveBits() > 63;
+            if (exceedsSignedInt64) {
+              return std::nullopt;
+            }
+            return static_cast<int64_t>(bound.getZExtValue());
+          }
+          if (!bound.isSignedIntN(64)) {
+            return std::nullopt;
+          }
+          return bound.getSExtValue();
+        };
+        minOffset = convertBound(range.value->lowerInclusive,
+                                 range.value->unsignedInterpretation);
+        maxOffset = convertBound(range.value->upperInclusive,
+                                 range.value->unsignedInterpretation);
+      }
+    }
+  }
+  if (!minOffset || !maxOffset) {
+    return fail(
+        "requires a constant offset or proven finite loop offset range");
+  }
+  if (*minOffset < 0 || *maxOffset < *minOffset) {
+    return fail("requires a non-negative valid offset range");
+  }
+
+  unsigned elementBits =
+      pto::getPTOStorageElemBitWidth(resultType.getElementType());
+  if (elementBits == 0 || elementBits % 8 != 0) {
+    return fail("requires byte-addressable element type");
+  }
+  int64_t elementBytes = static_cast<int64_t>(elementBits / 8);
+
+  constexpr int64_t blockBytes = 32;
+  std::optional<int64_t> remainder = getKnownAddressRemainderBytes(
+      source, offset, resultType.getElementType(), blockBytes);
+  if (!remainder) {
+    return fail("requires a proven fixed 32-byte address remainder");
+  }
+
+  FailureOr<int64_t> lanesPerPart =
+      getDataLanesPerPart(resultType.getElementType());
+  FailureOr<int64_t> arity = getVMIPhysicalArity(resultType);
+  bool missingFootprint = failed(lanesPerPart) || failed(arity);
+  if (missingFootprint) {
+    return fail("requires computable physical read footprint");
+  }
+
+  int64_t minOffsetBytes;
+  int64_t maxOffsetBytes;
+  int64_t allocationBytes;
+  int64_t footprintElements;
+  int64_t footprintBytes;
+  bool envelopeOverflows =
+      llvm::MulOverflow(*minOffset, elementBytes, minOffsetBytes) ||
+      llvm::MulOverflow(*maxOffset, elementBytes, maxOffsetBytes) ||
+      llvm::MulOverflow(*staticElements, elementBytes, allocationBytes) ||
+      llvm::MulOverflow(*arity, *lanesPerPart, footprintElements) ||
+      llvm::MulOverflow(footprintElements, elementBytes, footprintBytes);
+  if (envelopeOverflows) {
+    return fail("stateful byte read envelope overflows int64");
+  }
+
+  int64_t roundedInput;
+  int64_t roundedEnd;
+  bool roundedEndOverflows =
+      llvm::AddOverflow(footprintBytes, *remainder, roundedInput) ||
+      llvm::AddOverflow(roundedInput, blockBytes - 1, roundedEnd);
+  if (roundedEndOverflows) {
+    return fail("stateful byte read envelope overflows int64");
+  }
+  roundedEnd = roundedEnd / blockBytes * blockBytes - *remainder;
+
+  int64_t physicalBegin;
+  int64_t physicalEnd;
+  bool physicalEnvelopeOverflows =
+      llvm::SubOverflow(minOffsetBytes, *remainder, physicalBegin) ||
+      llvm::AddOverflow(maxOffsetBytes, roundedEnd, physicalEnd);
+  if (physicalEnvelopeOverflows) {
+    return fail("stateful byte read envelope overflows int64");
+  }
+  proof.readableEnvelope = VMIByteInterval{0, allocationBytes};
+  proof.candidateReadEnvelope = VMIByteInterval{physicalBegin, physicalEnd};
+  proof.proven = proof.readableEnvelope->contains(*proof.candidateReadEnvelope);
+  if (!proof.proven) {
+    proof.reason = (Twine("stateful physical read envelope [") +
+                    Twine(proof.candidateReadEnvelope->begin) + ", " +
+                    Twine(proof.candidateReadEnvelope->end) +
+                    ") exceeds proven allocation envelope [" +
+                    Twine(proof.readableEnvelope->begin) + ", " +
+                    Twine(proof.readableEnvelope->end) + ")")
+                       .str();
+  }
+  return proof;
+}
+
+VMIMemoryAccessPlan buildReadAccessPlan(Value source, Value offset,
+                                        VMIVRegType resultType,
+                                        VMIMemoryCoverageKind coverageKind) {
   VMIMemoryAccessPlan plan;
-  plan.baseType = sourceType;
+  plan.direction = VMIMemoryDirection::Read;
   plan.valueType = resultType;
-  plan.constantOffset = constantOffset;
-  plan.logicalShape.elementCount = resultType.getElementCount();
-  plan.validMask = validMask;
-  plan.permutation = VMIMemoryPermutationKind::Identity;
-  plan.writeMask = VMIMemoryWriteMaskKind::AllTrue;
-  plan.safeReadProof =
+  VMIPhysicalMemorySegment segment;
+  segment.address =
+      VMIPlannedAddress{source, offset, resultType.getElementType()};
+  segment.coverage =
+      VMIMemoryCoverage{coverageKind, resultType.getElementCount(), {}};
+  segment.transfer = VMIIdentityTransfer{};
+  segment.readSafety = computeSafeFullReadProof(
+      source.getType(), getConstantIndexValue(offset), resultType);
+  plan.segments.push_back(std::move(segment));
+  plan.layoutSupport =
+      requireIdentityMemRefLayout(source.getType(), "source", source);
+  return plan;
+}
+
+VMIMemoryAccessPlan buildReadAccessPlan(Value source, Type sourceType,
+                                        VMIVRegType resultType,
+                                        std::optional<int64_t> constantOffset,
+                                        VMIMemoryCoverageKind coverageKind) {
+  VMIMemoryAccessPlan plan;
+  plan.direction = VMIMemoryDirection::Read;
+  plan.valueType = resultType;
+  VMIPhysicalMemorySegment segment;
+  segment.address = VMIPlannedAddress{source, {}, resultType.getElementType()};
+  segment.coverage =
+      VMIMemoryCoverage{coverageKind, resultType.getElementCount(), {}};
+  segment.transfer = VMIIdentityTransfer{};
+  segment.readSafety =
       computeSafeFullReadProof(sourceType, constantOffset, resultType);
-  plan.laneAddressMap = plan.safeReadProof.laneAddressMap;
+  plan.segments.push_back(std::move(segment));
   plan.layoutSupport =
       requireIdentityMemRefLayout(sourceType, "source", source);
   return plan;
 }
 
-VMIMemoryAccessPlan
-buildWriteAccessPlan(Value destination, Type destinationType,
-                     VMIVRegType valueType, VMIMemoryWriteMaskKind writeMask) {
+VMIMemoryAccessPlan buildWriteAccessPlan(Value destination, Value offset,
+                                         VMIVRegType valueType,
+                                         VMIMemoryCoverageKind coverageKind) {
   VMIMemoryAccessPlan plan;
-  plan.baseType = destinationType;
+  plan.direction = VMIMemoryDirection::Write;
   plan.valueType = valueType;
-  plan.logicalShape.elementCount = valueType.getElementCount();
-  plan.validMask = VMIMemoryValidMaskKind::AllTrue;
-  plan.permutation = VMIMemoryPermutationKind::Identity;
-  plan.writeMask = writeMask;
+  VMIPhysicalMemorySegment segment;
+  segment.address =
+      VMIPlannedAddress{destination, offset, valueType.getElementType()};
+  segment.coverage =
+      VMIMemoryCoverage{coverageKind, valueType.getElementCount(), {}};
+  segment.transfer = VMIIdentityTransfer{};
+  plan.segments.push_back(std::move(segment));
+  plan.layoutSupport = requireIdentityMemRefLayout(destination.getType(),
+                                                   "destination", destination);
+  return plan;
+}
+
+VMIMemoryAccessPlan buildWriteAccessPlan(Value destination,
+                                         Type destinationType,
+                                         VMIVRegType valueType,
+                                         VMIMemoryCoverageKind coverageKind) {
+  VMIMemoryAccessPlan plan;
+  plan.direction = VMIMemoryDirection::Write;
+  plan.valueType = valueType;
+  VMIPhysicalMemorySegment segment;
+  segment.address =
+      VMIPlannedAddress{destination, {}, valueType.getElementType()};
+  segment.coverage =
+      VMIMemoryCoverage{coverageKind, valueType.getElementCount(), {}};
+  segment.transfer = VMIIdentityTransfer{};
+  plan.segments.push_back(std::move(segment));
   plan.layoutSupport =
       requireIdentityMemRefLayout(destinationType, "destination", destination);
   return plan;
 }
 
-void requireUnavailableReadFallback(VMIMemoryAccessPlan &plan) {
+static std::string
+getUnavailableReadFallbackReason(VMIMemoryCoverageKind coverageKind) {
   std::string maskedLoadReason;
-  if (plan.validMask == VMIMemoryValidMaskKind::ExplicitMask)
+  if (coverageKind == VMIMemoryCoverageKind::Predicate) {
     maskedLoadReason =
         "; target true masked/non-faulting load is unavailable because the "
         "current VPTO pto.vlds surface has no mask operand";
+  }
   std::string scratchReason =
       "; scratch memory fallback resource allocation is not implemented";
   std::string guardedReason =
       "; guarded memory fallback control-flow lowering is not implemented";
-  plan.fallbackDecision = VMIMemoryFallbackDecision::requiredUnavailable(
-      Twine("partial/tail read needs a scratch, guarded, or true "
-            "masked/non-faulting load fallback, but no such fallback resource "
-            "plan is implemented") +
-      maskedLoadReason + scratchReason + guardedReason);
+  return (Twine("partial/tail read needs a scratch, guarded, or true "
+                "masked/non-faulting load fallback, but no such fallback "
+                "resource plan is implemented") +
+          maskedLoadReason + scratchReason + guardedReason)
+      .str();
 }
 
 FailureOr<int64_t> verifyFullOrSafeReadVRegChunks(Operation *op,
                                                   VMIVRegType type,
-                                                  Type sourceType, Value offset,
+                                                  Value source, Value offset,
                                                   PatternRewriter &rewriter) {
   std::string fullChunkReason;
   FailureOr<int64_t> lanesPerPart =
       checkFullDataPhysicalChunks(type, &fullChunkReason);
-  if (succeeded(lanesPerPart))
+  bool usesAlignedLoad =
+      isKnownAddressAligned(source, offset, type.getElementType(), 32);
+  bool canUseAlignedFullChunk = succeeded(lanesPerPart) && usesAlignedLoad;
+  if (canUseAlignedFullChunk) {
     return *lanesPerPart;
+  }
 
   VMIMemorySafeReadProof safeReadProof =
-      computeSafeFullReadProof(sourceType, getConstantIndexValue(offset), type);
+      usesAlignedLoad
+          ? computeSafeFullReadProof(source.getType(),
+                                     getConstantIndexValue(offset), type)
+          : computeSafeStatefulReadProof(source, offset, type);
   if (safeReadProof.proven) {
     lanesPerPart = getDataLanesPerPart(type.getElementType());
     if (succeeded(lanesPerPart))
       return *lanesPerPart;
   }
 
-  lanesPerPart = getDataLanesPerPart(type.getElementType());
-  if (succeeded(lanesPerPart))
-    return *lanesPerPart;
-
+  std::string legalizationReason =
+      succeeded(lanesPerPart)
+          ? "unaligned load requires a proven stateful physical read envelope"
+          : fullChunkReason;
   (void)rewriter.notifyMatchFailure(
-      op, Twine("memory lowering ") + fullChunkReason +
-              "; safe full-read proof failed: " + safeReadProof.reason);
+      op, Twine("memory lowering ") + legalizationReason +
+              "; safe physical-read proof failed: " + safeReadProof.reason);
   return failure();
 }
 
@@ -1378,9 +1560,8 @@ checkSupportedLoadShape(VMIVRegType type, Value source, Type sourceType,
     return failure();
   };
 
-  VMIMemoryAccessPlan accessPlan =
-      buildReadAccessPlan(source, sourceType, type,
-                          constantOffset, VMIMemoryValidMaskKind::AllTrue);
+  VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(
+      source, sourceType, type, constantOffset, VMIMemoryCoverageKind::Dense);
   if (!accessPlan.layoutSupport.isSupported())
     return fail(accessPlan.layoutSupport.reason);
 
@@ -1414,8 +1595,8 @@ LogicalResult checkSupportedDeinterleaveLoadShape(
   if (!getX2MemoryDistToken(lowType.getElementType(), "DINTLV"))
     return fail("requires 8/16/32-bit element type for vldsx2 DINTLV");
 
-  VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(op.getSource(), op.getSource().getType(), lowType,
-      getConstantIndexValue(op.getOffset()), VMIMemoryValidMaskKind::AllTrue);
+  VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(
+      op.getSource(), op.getOffset(), lowType, VMIMemoryCoverageKind::Dense);
   if (!accessPlan.layoutSupport.isSupported())
     return fail(accessPlan.layoutSupport.reason);
 
@@ -1425,12 +1606,11 @@ LogicalResult checkSupportedDeinterleaveLoadShape(
   return success();
 }
 
-LogicalResult
-checkSupportedStoreShape(VMIVRegType type, Value destination,
-                         Type destinationType, std::string *reason) {
-  VMIMemoryAccessPlan accessPlan =
-      buildWriteAccessPlan(destination, destinationType, type,
-                           VMIMemoryWriteMaskKind::AllTrue);
+LogicalResult checkSupportedStoreShape(VMIVRegType type, Value destination,
+                                       Type destinationType,
+                                       std::string *reason) {
+  VMIMemoryAccessPlan accessPlan = buildWriteAccessPlan(
+      destination, destinationType, type, VMIMemoryCoverageKind::Dense);
   if (!accessPlan.layoutSupport.isSupported()) {
     if (reason)
       *reason = accessPlan.layoutSupport.reason;
@@ -1496,8 +1676,9 @@ LogicalResult checkSupportedInterleaveStoreShape(
   if (!getX2MemoryDistToken(lowType.getElementType(), "INTLV"))
     return fail("requires 8/16/32-bit element type for vstsx2 INTLV");
 
-  VMIMemoryAccessPlan accessPlan = buildWriteAccessPlan(op.getDestination(), op.getDestination().getType(), lowType,
-      VMIMemoryWriteMaskKind::AllTrue);
+  VMIMemoryAccessPlan accessPlan =
+      buildWriteAccessPlan(op.getDestination(), op.getOffset(), lowType,
+                           VMIMemoryCoverageKind::Dense);
   if (!accessPlan.layoutSupport.isSupported())
     return fail(accessPlan.layoutSupport.reason);
   if (failed(checkSupportedMaskableVReg(lowType, reason)))
@@ -1629,8 +1810,9 @@ checkSupportedGroupLoadShape(VMIGroupLoadOp op, std::string *reason) {
     VMILayoutSupport supports;
     if (failed(supports.getGroupLoadLayoutFact(op, reason)))
       return failure();
-    VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(op.getSource(), op.getSource().getType(), resultType,
-        getConstantIndexValue(op.getOffset()), VMIMemoryValidMaskKind::AllTrue);
+    VMIMemoryAccessPlan accessPlan =
+        buildReadAccessPlan(op.getSource(), op.getOffset(), resultType,
+                            VMIMemoryCoverageKind::Dense);
     if (!accessPlan.layoutSupport.isSupported())
       return fail(accessPlan.layoutSupport.reason);
     if (!isa<PtrType>(op.getSource().getType()))
@@ -1671,8 +1853,8 @@ LogicalResult checkSupportedGroupSlotLoadShape(
   if (failed(fact))
     return failure();
 
-  VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(op.getSource(), op.getSource().getType(), resultType,
-      getConstantIndexValue(op.getOffset()), VMIMemoryValidMaskKind::AllTrue);
+  VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(
+      op.getSource(), op.getOffset(), resultType, VMIMemoryCoverageKind::Dense);
   if (!accessPlan.layoutSupport.isSupported())
     return fail(accessPlan.layoutSupport.reason);
   if (!isa<PtrType>(op.getSource().getType()))
@@ -1717,9 +1899,10 @@ LogicalResult checkSupportedGroupBroadcastLoadShape(
   VMILayoutSupport supports;
   if (failed(supports.getGroupBroadcastLoadSupport(op, reason)))
     return failure();
-  VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(op.getSource(), op.getSource().getType(),
-      cast<VMIVRegType>(op.getResult().getType()),
-      getConstantIndexValue(op.getOffset()), VMIMemoryValidMaskKind::AllTrue);
+  VMIMemoryAccessPlan accessPlan =
+      buildReadAccessPlan(op.getSource(), op.getOffset(),
+                          cast<VMIVRegType>(op.getResult().getType()),
+                          VMIMemoryCoverageKind::Dense);
   if (!accessPlan.layoutSupport.isSupported())
     return fail(accessPlan.layoutSupport.reason);
   if (!isa<PtrType>(op.getSource().getType()))
@@ -1802,9 +1985,9 @@ checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
                                op.getNumGroupsAttr().getInt(), rowStride)) {
     if (!isa<PtrType>(op.getDestination().getType()))
       return fail("compact small group_store requires !pto.ptr destination");
-    VMIMemoryAccessPlan accessPlan = buildWriteAccessPlan(
-        op.getDestination(), op.getDestination().getType(), valueType,
-        VMIMemoryWriteMaskKind::AllTrue);
+    VMIMemoryAccessPlan accessPlan =
+        buildWriteAccessPlan(op.getDestination(), op.getOffset(), valueType,
+                             VMIMemoryCoverageKind::Dense);
     if (!accessPlan.layoutSupport.isSupported())
       return fail(accessPlan.layoutSupport.reason);
     return success();
@@ -1816,8 +1999,9 @@ checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
     if (failed(fact))
       return failure();
 
-    VMIMemoryAccessPlan accessPlan = buildWriteAccessPlan(op.getDestination(), op.getDestination().getType(),
-        valueType, VMIMemoryWriteMaskKind::AllTrue);
+    VMIMemoryAccessPlan accessPlan =
+        buildWriteAccessPlan(op.getDestination(), op.getOffset(), valueType,
+                             VMIMemoryCoverageKind::Dense);
     if (!accessPlan.layoutSupport.isSupported())
       return fail(accessPlan.layoutSupport.reason);
 
@@ -1883,9 +2067,9 @@ checkSupportedMaskedLoadShape(VMIMaskedLoadOp op, std::string *reason) {
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
   VMILayoutAttr passthruLayout = passthruType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(op.getSource(), op.getSource().getType(), resultType,
-      getConstantIndexValue(op.getOffset()),
-      VMIMemoryValidMaskKind::ExplicitMask);
+  VMIMemoryAccessPlan accessPlan =
+      buildReadAccessPlan(op.getSource(), op.getOffset(), resultType,
+                          VMIMemoryCoverageKind::Predicate);
   if (!accessPlan.layoutSupport.isSupported())
     return fail(accessPlan.layoutSupport.reason);
   if (!resultLayout || !passthruLayout || !maskLayout)
@@ -1898,14 +2082,16 @@ checkSupportedMaskedLoadShape(VMIMaskedLoadOp op, std::string *reason) {
   if (succeeded(checkFullDataPhysicalChunks(resultType, &fullChunkReason)))
     return success();
 
-  if (accessPlan.safeReadProof.proven)
+  if (accessPlan.front().readSafety.proven) {
     return success();
-  requireUnavailableReadFallback(accessPlan);
+  }
+  std::string fallbackReason =
+      getUnavailableReadFallbackReason(VMIMemoryCoverageKind::Predicate);
   return fail(Twine("partial/tail masked_load requires statically safe "
                     "full-read footprint; value ") +
               fullChunkReason + ", safe-read proof " +
-              accessPlan.safeReadProof.reason +
-              "; fallback decision: " + accessPlan.fallbackDecision.reason);
+              accessPlan.front().readSafety.reason +
+              "; fallback unavailable: " + fallbackReason);
 }
 
 LogicalResult
@@ -2182,9 +2368,9 @@ checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
   VMILayoutAttr passthruLayout = passthruType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(op.getSource(), op.getSource().getType(), resultType,
-      getConstantIndexValue(op.getOffset()),
-      VMIMemoryValidMaskKind::ExplicitMask);
+  VMIMemoryAccessPlan accessPlan =
+      buildReadAccessPlan(op.getSource(), op.getOffset(), resultType,
+                          VMIMemoryCoverageKind::Predicate);
   if (!accessPlan.layoutSupport.isSupported())
     return fail(accessPlan.layoutSupport.reason);
   if (!resultLayout || !passthruLayout || !maskLayout)
@@ -2202,21 +2388,23 @@ checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
       succeeded(checkFullDataPhysicalChunks(resultType, &fullChunkReason)))
     return success();
 
-  if (staticAllActive && accessPlan.safeReadProof.proven)
+  if (staticAllActive && accessPlan.front().readSafety.proven) {
     return success();
+  }
 
   std::string allActivePathReason;
   if (!staticAllActive) {
     allActivePathReason =
         maskReason.empty() ? "requires static all-active mask" : maskReason;
   } else {
-    requireUnavailableReadFallback(accessPlan);
+    std::string fallbackReason =
+        getUnavailableReadFallbackReason(VMIMemoryCoverageKind::Predicate);
     allActivePathReason =
         (Twine("requires full physical chunks or statically safe full-read "
                "footprint; value ") +
          fullChunkReason + ", safe-read proof " +
-         accessPlan.safeReadProof.reason +
-         "; fallback decision: " + accessPlan.fallbackDecision.reason)
+         accessPlan.front().readSafety.reason +
+         "; fallback unavailable: " + fallbackReason)
             .str();
   }
 
@@ -2259,8 +2447,8 @@ checkSupportedMaskedStoreShape(VMIVRegType valueType, VMIMaskType maskType,
                                Value destination, Type destinationType,
                                std::string *reason) {
   VMIMemoryAccessPlan accessPlan =
-      buildWriteAccessPlan(destination, destinationType,
-                           valueType, VMIMemoryWriteMaskKind::ExplicitMask);
+      buildWriteAccessPlan(destination, destinationType, valueType,
+                           VMIMemoryCoverageKind::Predicate);
   if (!accessPlan.layoutSupport.isSupported()) {
     if (reason)
       *reason = accessPlan.layoutSupport.reason;
@@ -6013,8 +6201,16 @@ struct OneToNVMILoadOpPattern : OneToNOpConversionPattern<VMILoadOp> {
       return failure();
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
-    if (std::optional<std::string> dist =
-            getDenseLaneStrideLoadDistToken(resultVMIType)) {
+    std::optional<std::string> laneStrideDist =
+        getDenseLaneStrideLoadDistToken(resultVMIType);
+    auto laneStrideResultType =
+        resultTypes.empty() ? VRegType{} : dyn_cast<VRegType>(resultTypes[0]);
+    bool canUseLaneStrideDist =
+        laneStrideDist && laneStrideResultType &&
+        isDirectMemoryDistAddressLegal(
+            op.getSource(), op.getOffset(), resultVMIType.getElementType(),
+            laneStrideResultType, VPTOMemoryOpFamily::Load, *laneStrideDist);
+    if (canUseLaneStrideDist) {
       SmallVector<Value> results;
       results.reserve(resultTypes.size());
       int64_t semanticOffset = 0;
@@ -6023,12 +6219,12 @@ struct OneToNVMILoadOpPattern : OneToNOpConversionPattern<VMILoadOp> {
           return rewriter.notifyMatchFailure(op, "load result must be vreg");
         Value chunkOffset =
             createChunkOffset(op.getLoc(), *offset, semanticOffset, rewriter);
-        results.push_back(rewriter
-                              .create<VldsOp>(op.getLoc(), resultType,
-                                              /*updated_base=*/Type{}, *source,
-                                              chunkOffset,
-                                              rewriter.getStringAttr(*dist))
-                              .getResult());
+        results.push_back(
+            rewriter
+                .create<VldsOp>(op.getLoc(), resultType,
+                                /*updated_base=*/Type{}, *source, chunkOffset,
+                                rewriter.getStringAttr(*laneStrideDist))
+                .getResult());
         FailureOr<int64_t> activeLanes =
             getActiveDataLanesInPhysicalChunk(resultVMIType, index);
         if (failed(activeLanes))
@@ -6041,7 +6237,7 @@ struct OneToNVMILoadOpPattern : OneToNOpConversionPattern<VMILoadOp> {
     }
 
     FailureOr<int64_t> lanesPerPart = verifyFullOrSafeReadVRegChunks(
-        op, resultVMIType, op.getSource().getType(), *offset, rewriter);
+        op, resultVMIType, op.getSource(), op.getOffset(), rewriter);
     if (failed(lanesPerPart))
       return failure();
 
@@ -6064,7 +6260,16 @@ struct OneToNVMILoadOpPattern : OneToNOpConversionPattern<VMILoadOp> {
         resultLayout.getFactor() == 2 && *noWiderThanContiguous) {
       std::optional<std::string> dist =
           getX2MemoryDistToken(resultVMIType.getElementType(), "DINTLV");
-      if (dist && !resultTypes.empty() && resultTypes.size() % 2 == 0) {
+      auto firstType = resultTypes.empty()
+                           ? VRegType{}
+                           : dyn_cast<VRegType>(resultTypes.front());
+      bool canUseDist =
+          dist && firstType &&
+          isDirectMemoryDistAddressLegal(
+              op.getSource(), op.getOffset(), resultVMIType.getElementType(),
+              firstType, VPTOMemoryOpFamily::LoadX2, *dist);
+      if (canUseDist &&
+          resultTypes.size() % 2 == 0) {
         int64_t groups = resultTypes.size() / 2;
         SmallVector<Value> lows;
         SmallVector<Value> highs;
@@ -6099,7 +6304,16 @@ struct OneToNVMILoadOpPattern : OneToNOpConversionPattern<VMILoadOp> {
         *noWiderThanContiguous) {
       std::optional<std::string> dist =
           getX2MemoryDistToken(resultVMIType.getElementType(), "DINTLV");
-      if (dist && !resultTypes.empty() && resultTypes.size() % 4 == 0) {
+      auto firstType = resultTypes.empty()
+                           ? VRegType{}
+                           : dyn_cast<VRegType>(resultTypes.front());
+      bool canUseDist =
+          dist && firstType &&
+          isDirectMemoryDistAddressLegal(
+              op.getSource(), op.getOffset(), resultVMIType.getElementType(),
+              firstType, VPTOMemoryOpFamily::LoadX2, *dist);
+      if (canUseDist &&
+          resultTypes.size() % 4 == 0) {
         int64_t groups = resultTypes.size() / 4;
         SmallVector<Value> part0;
         SmallVector<Value> part1;
@@ -6158,18 +6372,60 @@ struct OneToNVMILoadOpPattern : OneToNOpConversionPattern<VMILoadOp> {
 
     SmallVector<Value> contiguousParts;
     contiguousParts.reserve(contiguousTypes.size());
+    auto firstContiguousType =
+        contiguousTypes.empty() ? VRegType{}
+                                : dyn_cast<VRegType>(contiguousTypes.front());
+    bool useAlignedAccess =
+        firstContiguousType &&
+        isDirectMemoryDistAddressLegal(
+            op.getSource(), op.getOffset(), resultVMIType.getElementType(),
+            firstContiguousType, VPTOMemoryOpFamily::Load, "NORM");
+    Value unalignedBase;
+    Value unalignedAlign;
+    if (!useAlignedAccess) {
+      unalignedBase = materializeBufferPointer(
+          *source, resultVMIType.getElementType(),
+          getMemorySpace((*source).getType()), rewriter, op.getLoc());
+      if (!unalignedBase) {
+        return rewriter.notifyMatchFailure(
+            op, "continuous unaligned load requires a ptr-compatible source");
+      }
+      unalignedBase =
+          rewriter
+              .create<AddPtrOp>(op.getLoc(), unalignedBase.getType(),
+                                unalignedBase, *offset)
+              .getResult();
+      unalignedAlign =
+          rewriter
+              .create<VldasOp>(op.getLoc(),
+                               AlignType::get(rewriter.getContext()),
+                               unalignedBase)
+              .getResult();
+    }
     for (auto [index, resultType] : llvm::enumerate(contiguousTypes)) {
       auto vregType = dyn_cast<VRegType>(resultType);
       if (!vregType)
         return rewriter.notifyMatchFailure(op, "load result must be vreg");
-      Value chunkOffset = createChunkOffset(op.getLoc(), *offset,
-                                            index * *lanesPerPart, rewriter);
-      contiguousParts.push_back(rewriter
-                                    .create<VldsOp>(op.getLoc(), resultType,
-                                                    /*updated_base=*/Type{},
-                                                    *source, chunkOffset,
-                                                    /*dist=*/nullptr)
-                                    .getResult());
+      if (useAlignedAccess) {
+        Value chunkOffset = createChunkOffset(op.getLoc(), *offset,
+                                              index * *lanesPerPart, rewriter);
+        contiguousParts.push_back(rewriter
+                                      .create<VldsOp>(op.getLoc(), resultType,
+                                                      /*updated_base=*/Type{},
+                                                      *source, chunkOffset,
+                                                      /*dist=*/nullptr)
+                                      .getResult());
+        continue;
+      }
+
+      Value increment = rewriter.create<arith::ConstantIndexOp>(
+          op.getLoc(), *lanesPerPart);
+      auto load = rewriter.create<VldusOp>(
+          op.getLoc(), resultType, unalignedAlign.getType(),
+          unalignedBase.getType(), unalignedBase, unalignedAlign, increment);
+      contiguousParts.push_back(load.getResult());
+      unalignedAlign = load.getUpdatedAlign();
+      unalignedBase = load.getUpdatedBase();
     }
 
     FailureOr<SmallVector<Value>> results = materializeDataLayoutConversion(
@@ -6232,6 +6488,35 @@ struct OneToNVMIDeinterleaveLoadOpPattern
       return rewriter.notifyMatchFailure(
           op, "deinterleave_load requires matching low/high physical arity");
 
+    auto firstType =
+        lowTypes.empty() ? VRegType{} : dyn_cast<VRegType>(lowTypes.front());
+    bool useDirectAccess =
+        firstType &&
+        isDirectMemoryDistAddressLegal(op.getSource(), op.getOffset(),
+                                       lowVMIType.getElementType(), firstType,
+                                       VPTOMemoryOpFamily::LoadX2, *dist);
+    Value streamBase;
+    Value streamAlign;
+    if (!useDirectAccess) {
+      streamBase = materializeBufferPointer(
+          *source, lowVMIType.getElementType(),
+          getMemorySpace((*source).getType()), rewriter, op.getLoc());
+      if (!streamBase) {
+        return rewriter.notifyMatchFailure(
+            op, "unaligned deinterleave_load requires a ptr-compatible "
+                "source");
+      }
+      streamBase = rewriter
+                       .create<AddPtrOp>(op.getLoc(), streamBase.getType(),
+                                         streamBase, *offset)
+                       .getResult();
+      streamAlign = rewriter
+                        .create<VldasOp>(op.getLoc(),
+                                         AlignType::get(rewriter.getContext()),
+                                         streamBase)
+                        .getResult();
+    }
+
     SmallVector<Value> lows;
     SmallVector<Value> highs;
     lows.reserve(lowTypes.size());
@@ -6242,15 +6527,34 @@ struct OneToNVMIDeinterleaveLoadOpPattern
       if (lowType != highType)
         return rewriter.notifyMatchFailure(
             op, "deinterleave_load requires matching low/high physical types");
-      Value chunkOffset = createChunkOffset(
-          op.getLoc(), *offset, static_cast<int64_t>(index) * 2 * *lanesPerPart,
-          rewriter);
-      auto load =
-          rewriter.create<Vldsx2Op>(
-              op.getLoc(), lowType, highType, /*updated_base=*/Type{}, *source,
-              chunkOffset, rewriter.getStringAttr(*dist));
-      lows.push_back(load.getLow());
-      highs.push_back(load.getHigh());
+      if (useDirectAccess) {
+        Value chunkOffset = createChunkOffset(
+            op.getLoc(), *offset,
+            static_cast<int64_t>(index) * 2 * *lanesPerPart, rewriter);
+        auto load = rewriter.create<Vldsx2Op>(
+            op.getLoc(), lowType, highType, /*updated_base=*/Type{}, *source,
+            chunkOffset, rewriter.getStringAttr(*dist));
+        lows.push_back(load.getLow());
+        highs.push_back(load.getHigh());
+        continue;
+      }
+
+      Value increment =
+          rewriter.create<arith::ConstantIndexOp>(op.getLoc(), *lanesPerPart);
+      auto first = rewriter.create<VldusOp>(
+          op.getLoc(), lowType, streamAlign.getType(), streamBase.getType(),
+          streamBase, streamAlign, increment);
+      auto second = rewriter.create<VldusOp>(
+          op.getLoc(), highType, first.getUpdatedAlign().getType(),
+          first.getUpdatedBase().getType(), first.getUpdatedBase(),
+          first.getUpdatedAlign(), increment);
+      auto deinterleaved =
+          rewriter.create<VdintlvOp>(op.getLoc(), lowType, highType,
+                                     first.getResult(), second.getResult());
+      lows.push_back(deinterleaved.getLow());
+      highs.push_back(deinterleaved.getHigh());
+      streamBase = second.getUpdatedBase();
+      streamAlign = second.getUpdatedAlign();
     }
 
     SmallVector<Value> results;
@@ -7015,7 +7319,7 @@ struct OneToNVMIMaskedLoadOpPattern
       return failure();
 
     FailureOr<int64_t> lanesPerPart = verifyFullOrSafeReadVRegChunks(
-        op, resultVMIType, (*source).getType(), *offset, rewriter);
+        op, resultVMIType, op.getSource(), op.getOffset(), rewriter);
     if (failed(lanesPerPart))
       return failure();
 
@@ -7144,7 +7448,7 @@ struct OneToNVMIExpandLoadOpPattern
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (isStaticAllActiveMask(op.getMask(), resultVMIType.getElementCount())) {
       FailureOr<int64_t> lanesPerPart = verifyFullOrSafeReadVRegChunks(
-          op, resultVMIType, (*source).getType(), *offset, rewriter);
+          op, resultVMIType, op.getSource(), op.getOffset(), rewriter);
       if (failed(lanesPerPart))
         return failure();
 
@@ -7247,8 +7551,17 @@ struct OneToNVMIStoreOpPattern : OneToNOpConversionPattern<VMIStoreOp> {
       return failure();
 
     ValueRange valueParts = adaptor.getValue();
-    if (std::optional<std::string> dist =
-            getDenseLaneStrideStoreDistToken(valueVMIType)) {
+    std::optional<std::string> laneStrideDist =
+        getDenseLaneStrideStoreDistToken(valueVMIType);
+    auto laneStrideValueType =
+        valueParts.empty() ? VRegType{}
+                           : dyn_cast<VRegType>(valueParts.front().getType());
+    bool canUseLaneStrideDist =
+        laneStrideDist && laneStrideValueType &&
+        isDirectMemoryDistAddressLegal(
+            op.getDestination(), op.getOffset(), valueVMIType.getElementType(),
+            laneStrideValueType, VPTOMemoryOpFamily::Store, *laneStrideDist);
+    if (canUseLaneStrideDist) {
       std::optional<StringRef> maskGranularity =
           getDenseLaneStrideStoreMaskGranularity(valueVMIType);
       if (!maskGranularity)
@@ -7276,8 +7589,8 @@ struct OneToNVMIStoreOpPattern : OneToNOpConversionPattern<VMIStoreOp> {
             createChunkOffset(op.getLoc(), *offset, semanticOffset, rewriter);
         rewriter.create<VstsOp>(op.getLoc(),
                                 /*updated_base=*/Type{}, value, *destination,
-                                chunkOffset, rewriter.getStringAttr(*dist),
-                                *mask);
+                                chunkOffset,
+                                rewriter.getStringAttr(*laneStrideDist), *mask);
         semanticOffset += *activeLanes;
       }
       rewriter.eraseOp(op);
@@ -7311,7 +7624,16 @@ struct OneToNVMIStoreOpPattern : OneToNOpConversionPattern<VMIStoreOp> {
         *noWiderThanContiguous) {
       std::optional<std::string> dist =
           getX2MemoryDistToken(valueVMIType.getElementType(), "INTLV");
-      if (dist && !valueParts.empty() && valueParts.size() % 2 == 0) {
+      auto firstType = valueParts.empty()
+                           ? VRegType{}
+                           : dyn_cast<VRegType>(valueParts.front().getType());
+      bool canUseDist = dist && firstType &&
+                        isDirectMemoryDistAddressLegal(
+                            op.getDestination(), op.getOffset(),
+                            valueVMIType.getElementType(), firstType,
+                            VPTOMemoryOpFamily::StoreX2, *dist);
+      if (canUseDist &&
+          valueParts.size() % 2 == 0) {
         int64_t groups = valueParts.size() / 2;
         for (int64_t group = 0; group < groups; ++group) {
           Value low = valueParts[group];
@@ -7344,6 +7666,32 @@ struct OneToNVMIStoreOpPattern : OneToNOpConversionPattern<VMIStoreOp> {
     if (failed(storeParts))
       return failure();
 
+    auto firstStoreType =
+        storeParts->empty() ? VRegType{}
+                            : dyn_cast<VRegType>(storeParts->front().getType());
+    bool useAlignedAccess =
+        firstStoreType &&
+        isDirectMemoryDistAddressLegal(
+            op.getDestination(), op.getOffset(), valueVMIType.getElementType(),
+            firstStoreType, VPTOMemoryOpFamily::Store, "");
+    Value storeBase;
+    if (!useAlignedAccess) {
+      storeBase = materializeBufferPointer(
+          *destination, valueVMIType.getElementType(),
+          getMemorySpace((*destination).getType()), rewriter, op.getLoc());
+      if (!storeBase) {
+        return rewriter.notifyMatchFailure(
+            op,
+            "continuous unaligned store requires a ptr-compatible destination");
+      }
+      storeBase = rewriter
+                      .create<AddPtrOp>(op.getLoc(), storeBase.getType(),
+                                        storeBase, *offset)
+                      .getResult();
+    }
+
+    SmallVector<Value> unalignedValues;
+    SmallVector<int64_t> unalignedAdvances;
     for (auto [index, value] : llvm::enumerate(*storeParts)) {
       auto vregType = dyn_cast<VRegType>(value.getType());
       if (!vregType)
@@ -7357,19 +7705,42 @@ struct OneToNVMIStoreOpPattern : OneToNOpConversionPattern<VMIStoreOp> {
         if (*activeLanes == 0)
           continue;
       }
-      FailureOr<Value> mask =
-          fullPhysicalChunks
-              ? createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter)
-              : createContiguousStoreMask(op.getLoc(), valueVMIType, index,
-                                          vregType, rewriter);
-      if (failed(mask))
-        return rewriter.notifyMatchFailure(
-            op, "unsupported element type for store mask");
-      Value chunkOffset = createChunkOffset(op.getLoc(), *offset,
-                                            index * *lanesPerPart, rewriter);
-      rewriter.create<VstsOp>(op.getLoc(),
-                              /*updated_base=*/Type{}, value, *destination,
-                              chunkOffset, /*dist=*/nullptr, *mask);
+      if (useAlignedAccess) {
+        FailureOr<Value> mask =
+            fullPhysicalChunks
+                ? createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter)
+                : createContiguousStoreMask(op.getLoc(), valueVMIType, index,
+                                            vregType, rewriter);
+        if (failed(mask)) {
+          return rewriter.notifyMatchFailure(
+              op, "unsupported element type for store mask");
+        }
+        Value chunkOffset = createChunkOffset(op.getLoc(), *offset,
+                                              index * *lanesPerPart, rewriter);
+        rewriter.create<VstsOp>(op.getLoc(),
+                                /*updated_base=*/Type{}, value, *destination,
+                                chunkOffset, /*dist=*/nullptr, *mask);
+        continue;
+      }
+
+      int64_t activeLanes = *lanesPerPart;
+      if (!fullPhysicalChunks) {
+        FailureOr<int64_t> maybeActiveLanes =
+            getContiguousActiveDataLanes(valueVMIType, index);
+        if (failed(maybeActiveLanes)) {
+          return rewriter.notifyMatchFailure(
+              op, "failed to compute unaligned store active lanes");
+        }
+        activeLanes = *maybeActiveLanes;
+      }
+      unalignedValues.push_back(value);
+      unalignedAdvances.push_back(activeLanes);
+    }
+
+    if (!useAlignedAccess &&
+        failed(emitStatefulStoreStream(op, storeBase, unalignedValues,
+                                        unalignedAdvances, rewriter))) {
+      return failure();
     }
 
     rewriter.eraseOp(op);
@@ -7413,6 +7784,32 @@ struct OneToNVMIInterleaveStoreOpPattern
       return rewriter.notifyMatchFailure(
           op, "interleave_store requires matching low/high physical arity");
 
+    auto firstType = lowParts.empty()
+                         ? VRegType{}
+                         : dyn_cast<VRegType>(lowParts.front().getType());
+    bool useDirectAccess =
+        firstType &&
+        isDirectMemoryDistAddressLegal(op.getDestination(), op.getOffset(),
+                                       lowVMIType.getElementType(), firstType,
+                                       VPTOMemoryOpFamily::StoreX2, *dist);
+    SmallVector<Value> streamValues;
+    SmallVector<int64_t> streamAdvances;
+    Value streamBase;
+    if (!useDirectAccess) {
+      streamBase = materializeBufferPointer(
+          *destination, lowVMIType.getElementType(),
+          getMemorySpace((*destination).getType()), rewriter, op.getLoc());
+      if (!streamBase) {
+        return rewriter.notifyMatchFailure(
+            op, "unaligned interleave_store requires a ptr-compatible "
+                "destination");
+      }
+      streamBase = rewriter
+                       .create<AddPtrOp>(op.getLoc(), streamBase.getType(),
+                                         streamBase, *offset)
+                       .getResult();
+    }
+
     for (size_t index = 0, e = lowParts.size(); index < e; ++index) {
       Value low = lowParts[index];
       Value high = highParts[index];
@@ -7423,17 +7820,34 @@ struct OneToNVMIInterleaveStoreOpPattern
       if (!vregType)
         return rewriter.notifyMatchFailure(
             op, "interleave_store value must be vreg");
-      FailureOr<Value> mask =
-          createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
-      if (failed(mask))
-        return rewriter.notifyMatchFailure(
-            op, "unsupported element type for interleave_store mask");
-      Value chunkOffset = createChunkOffset(
-          op.getLoc(), *offset, static_cast<int64_t>(index) * 2 * *lanesPerPart,
-          rewriter);
-      rewriter.create<Vstsx2Op>(op.getLoc(), low, high, *destination,
-                                chunkOffset, rewriter.getStringAttr(*dist),
-                                *mask);
+      if (useDirectAccess) {
+        FailureOr<Value> mask =
+            createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
+        if (failed(mask)) {
+          return rewriter.notifyMatchFailure(
+              op, "unsupported element type for interleave_store mask");
+        }
+        Value chunkOffset = createChunkOffset(
+            op.getLoc(), *offset,
+            static_cast<int64_t>(index) * 2 * *lanesPerPart, rewriter);
+        rewriter.create<Vstsx2Op>(op.getLoc(), low, high, *destination,
+                                  chunkOffset, rewriter.getStringAttr(*dist),
+                                  *mask);
+        continue;
+      }
+
+      auto packets =
+          rewriter.create<VintlvOp>(op.getLoc(), vregType, vregType, low, high);
+      streamValues.push_back(packets.getLow());
+      streamValues.push_back(packets.getHigh());
+      streamAdvances.push_back(*lanesPerPart);
+      streamAdvances.push_back(*lanesPerPart);
+    }
+
+    if (!useDirectAccess &&
+        failed(emitStatefulStoreStream(op, streamBase, streamValues,
+                                       streamAdvances, rewriter))) {
+      return failure();
     }
 
     rewriter.eraseOp(op);
@@ -7463,8 +7877,6 @@ struct OneToNVMIGroupStoreOpPattern
     if (failed(destination) || failed(offset) || failed(rowStride))
       return failure();
 
-    unsigned elementBits =
-        pto::getPTOStorageElemBitWidth(valueVMIType.getElementType());
     bool compactSmallGroupStore = isCompactSmallGroupStore(
         layout, valueVMIType, op.getNumGroupsAttr().getInt(),
         getConstantIndexValue(op.getRowStride()));
@@ -7510,16 +7922,16 @@ struct OneToNVMIGroupStoreOpPattern
       // The VMI input remains group_slots(num_groups=8, slots=8). Its active
       // group values occupy the leading physical lanes. Materialize the same
       // lane_stride=1 carrier as ensure_layout before selecting either an
-      // aligned NORM store or unaligned 32-bit point stores.
+      // aligned NORM store or an unaligned contiguous store stream.
       ValueRange valueParts = adaptor.getValue();
       if (valueParts.size() != 1)
         return rewriter.notifyMatchFailure(
             op, "compact small group_store requires one physical value part");
       auto valueType = dyn_cast<VRegType>(valueParts.front().getType());
-      auto destinationType = dyn_cast<PtrType>((*destination).getType());
-      if (!valueType || !destinationType)
+      if (!valueType || !isa<PtrType>((*destination).getType())) {
         return rewriter.notifyMatchFailure(
             op, "compact small group_store requires vreg and ptr operands");
+      }
 
       Value compactValue = valueParts.front();
       if (layout.getLaneStride() != 1) {
@@ -7538,8 +7950,8 @@ struct OneToNVMIGroupStoreOpPattern
         compactValue = packed->front();
       }
 
-      if (isKnown32ByteAlignedAddress(*destination, *offset,
-                                      valueVMIType.getElementType())) {
+      if (isKnownAddressAligned(*destination, *offset,
+                                valueVMIType.getElementType(), 32)) {
         auto compactType = dyn_cast<VRegType>(compactValue.getType());
         std::optional<std::string> normalDist =
             getX2MemoryDistToken(valueVMIType.getElementType(), "NORM");
@@ -7564,64 +7976,16 @@ struct OneToNVMIGroupStoreOpPattern
         return success();
       }
 
-      FailureOr<VRegType> wordType =
-          getUnsignedCarrierVRegType(rewriter.getContext(), 32);
-      if (failed(wordType))
-        return rewriter.notifyMatchFailure(
-            op, "failed to derive compact group-store word carrier type");
-      FailureOr<Value> words =
-          bitcastVReg(op.getLoc(), compactValue, *wordType, rewriter);
-      FailureOr<Value> wordMask = createPrefixMask(
-          op.getLoc(), MaskType::get(rewriter.getContext(), "b32"), "PAT_VL1",
-          rewriter);
-      if (failed(words) || failed(wordMask))
-        return rewriter.notifyMatchFailure(
-            op, "failed to materialize compact group-store words");
-
       Value elementBase =
           rewriter
               .create<AddPtrOp>(op.getLoc(), (*destination).getType(),
                                 *destination, *offset)
               .getResult();
-      auto wordPtrType =
-          PtrType::get(rewriter.getContext(), wordType->getElementType(),
-                       destinationType.getMemorySpace());
-      Value wordBase =
-          rewriter.create<CastPtrOp>(op.getLoc(), wordPtrType, elementBase)
-              .getResult();
-      FailureOr<Value> allWordMask =
-          createAllTrueMaskForVReg(op.getLoc(), *wordType, rewriter);
-      if (failed(allWordMask))
-        return rewriter.notifyMatchFailure(
-            op, "failed to materialize compact group-store word selector mask");
-      auto indexType =
-          VRegType::get(rewriter.getContext(), wordType->getElementCount(),
-                        rewriter.getI32Type());
-
-      int64_t wordCount = valueVMIType.getElementCount() *
-                          static_cast<int64_t>(elementBits) / 32;
-      for (int64_t wordIndex = 0; wordIndex < wordCount; ++wordIndex) {
-        Value word = *words;
-        if (wordIndex != 0) {
-          FailureOr<Value> index = createScalarOffsetConstant(
-              op.getLoc(), indexType.getElementType(), wordIndex, rewriter);
-          if (failed(index))
-            return rewriter.notifyMatchFailure(
-                op, "failed to materialize compact group-store word index");
-          Value indices =
-              rewriter
-                  .create<VdupOp>(op.getLoc(), indexType, *index, *allWordMask,
-                                  /*position=*/nullptr)
-                  .getResult();
-          word = rewriter
-                     .create<VselrOp>(op.getLoc(), *wordType, *words, indices)
-                     .getResult();
-        }
-        Value wordOffset =
-            rewriter.create<arith::ConstantIndexOp>(op.getLoc(), wordIndex);
-        rewriter.create<VstsOp>(
-            op.getLoc(), /*updated_base=*/Type{}, word, wordBase, wordOffset,
-            rewriter.getStringAttr("1PT_B32"), *wordMask);
+      SmallVector<Value> streamValues{compactValue};
+      SmallVector<int64_t> streamAdvances{valueVMIType.getElementCount()};
+      if (failed(emitStatefulStoreStream(op, elementBase, streamValues,
+                                          streamAdvances, rewriter))) {
+        return failure();
       }
 
       rewriter.eraseOp(op);
@@ -7644,9 +8008,7 @@ struct OneToNVMIGroupStoreOpPattern
       FailureOr<int64_t> lanesPerPart =
           getDataLanesPerPart(valueVMIType.getElementType());
       if (constantRowStride && *constantRowStride == 1 &&
-          succeeded(lanesPerPart) && layout.getNumGroups() <= *lanesPerPart &&
-          isKnown32ByteAlignedAddress(*destination, *offset,
-                                      valueVMIType.getElementType())) {
+          succeeded(lanesPerPart) && layout.getNumGroups() <= *lanesPerPart) {
         auto firstType = dyn_cast<VRegType>(valueParts.front().getType());
         if (!firstType)
           return rewriter.notifyMatchFailure(op,
@@ -7685,14 +8047,37 @@ struct OneToNVMIGroupStoreOpPattern
                        .getResult();
         }
 
-        FailureOr<Value> storeMask = createPrefixMaskForActiveLanes(
-            op.getLoc(), *maskType, layout.getNumGroups(), rewriter);
-        if (failed(storeMask))
-          return rewriter.notifyMatchFailure(
-              op, "failed to create packed group_store store mask");
-        rewriter.create<VstsOp>(op.getLoc(),
-                                /*updated_base=*/Type{}, packed, *destination,
-                                *offset, /*dist=*/nullptr, *storeMask);
+        if (isKnownAddressAligned(*destination, *offset,
+                                  valueVMIType.getElementType(), 32)) {
+          FailureOr<Value> storeMask = createPrefixMaskForActiveLanes(
+              op.getLoc(), *maskType, layout.getNumGroups(), rewriter);
+          if (failed(storeMask)) {
+            return rewriter.notifyMatchFailure(
+                op, "failed to create packed group_store store mask");
+          }
+          rewriter.create<VstsOp>(op.getLoc(),
+                                  /*updated_base=*/Type{}, packed, *destination,
+                                  *offset, /*dist=*/nullptr, *storeMask);
+        } else {
+          Value storeBase = materializeBufferPointer(
+              *destination, valueVMIType.getElementType(),
+              getMemorySpace((*destination).getType()), rewriter, op.getLoc());
+          if (!storeBase) {
+            return rewriter.notifyMatchFailure(
+                op, "packed unaligned group_store requires a ptr-compatible "
+                    "destination");
+          }
+          storeBase = rewriter
+                          .create<AddPtrOp>(op.getLoc(), storeBase.getType(),
+                                            storeBase, *offset)
+                          .getResult();
+          SmallVector<Value> streamValues{packed};
+          SmallVector<int64_t> streamAdvances{layout.getNumGroups()};
+          if (failed(emitStatefulStoreStream(op, storeBase, streamValues,
+                                              streamAdvances, rewriter))) {
+            return failure();
+          }
+        }
         rewriter.eraseOp(op);
         return success();
       }
@@ -7772,8 +8157,8 @@ struct OneToNVMIGroupStoreOpPattern
                 op, "unsupported element type for packed group_store mask");
           if (!laneStridedPackedByteStore && numGroups == 8 &&
               valueParts.size() == 1 &&
-              isKnown32ByteAlignedAddress(*destination, *offset,
-                                          valueVMIType.getElementType())) {
+              isKnownAddressAligned(*destination, *offset,
+                                    valueVMIType.getElementType(), 32)) {
             MLIRContext *ctx = rewriter.getContext();
             auto ui16 = IntegerType::get(
                 ctx, 16, IntegerType::SignednessSemantics::Unsigned);
@@ -7824,6 +8209,12 @@ struct OneToNVMIGroupStoreOpPattern
             return rewriter.notifyMatchFailure(
                 op, "failed to create packed group_store lane selector");
 
+          SmallVector<Value> statefulValues;
+          SmallVector<int64_t> statefulAdvances;
+          bool useDirectPack4 = isDirectMemoryDistAddressLegal(
+              op.getDestination(), op.getOffset(),
+              getMemoryElementType(op.getDestination().getType()),
+              firstVRegType, VPTOMemoryOpFamily::Store, "PK4_B32");
           for (int64_t blockStart = 0; blockStart < numGroups;
                blockStart += 32) {
             FailureOr<Value> zero =
@@ -7865,11 +8256,54 @@ struct OneToNVMIGroupStoreOpPattern
               return rewriter.notifyMatchFailure(
                   op, "failed to create packed group_store store mask");
             Value groupOffset = createGroupChunkOffset(
-                op.getLoc(), *offset, *rowStride, blockStart / 4,
+                op.getLoc(), *offset, *rowStride, blockStart,
                 /*chunkLaneOffset=*/0, rewriter);
-            rewriter.create<VstsOp>(
-                op.getLoc(), /*updated_base=*/Type{}, merged, *destination,
-                groupOffset, rewriter.getStringAttr("PK4_B32"), *storeMask);
+            if (useDirectPack4) {
+              rewriter.create<VstsOp>(
+                  op.getLoc(), /*updated_base=*/Type{}, merged, *destination,
+                  groupOffset, rewriter.getStringAttr("PK4_B32"), *storeMask);
+              continue;
+            }
+
+            MLIRContext *ctx = rewriter.getContext();
+            auto ui16 = IntegerType::get(
+                ctx, 16, IntegerType::SignednessSemantics::Unsigned);
+            auto ui8 = IntegerType::get(
+                ctx, 8, IntegerType::SignednessSemantics::Unsigned);
+            auto packed16Type = VRegType::get(ctx, 128, ui16);
+            auto packed8Type = VRegType::get(ctx, 256, ui8);
+            Value packed16 =
+                rewriter
+                    .create<VpackOp>(op.getLoc(), packed16Type, merged,
+                                     rewriter.getStringAttr("LOWER"))
+                    .getResult();
+            statefulValues.push_back(
+                rewriter
+                    .create<VpackOp>(op.getLoc(), packed8Type, packed16,
+                                     rewriter.getStringAttr("LOWER"))
+                    .getResult());
+            statefulAdvances.push_back(activeGroups);
+          }
+
+          if (!useDirectPack4) {
+            Type destinationElementType =
+                getMemoryElementType((*destination).getType());
+            Value storeBase = materializeBufferPointer(
+                *destination, destinationElementType,
+                getMemorySpace((*destination).getType()), rewriter,
+                op.getLoc());
+            if (!storeBase) {
+              return rewriter.notifyMatchFailure(
+                  op, "unaligned packed byte group_store requires a "
+                      "ptr-compatible destination");
+            }
+            storeBase = rewriter
+                            .create<AddPtrOp>(op.getLoc(), storeBase.getType(),
+                                              storeBase, *offset)
+                            .getResult();
+            if (failed(emitStatefulStoreStream(op, storeBase, statefulValues,
+                                               statefulAdvances, rewriter)))
+              return failure();
           }
 
           rewriter.eraseOp(op);
@@ -7887,8 +8321,68 @@ struct OneToNVMIGroupStoreOpPattern
           return rewriter.notifyMatchFailure(
               op, "unsupported slots=8 lane_stride group_store packing");
 
-        auto maskType =
-            MaskType::get(rewriter.getContext(), *maskGranularity);
+        auto maskType = MaskType::get(rewriter.getContext(), *maskGranularity);
+        SmallVector<Value> groupOffsets;
+        bool useDirectAccess = true;
+        for (auto [slotBlock, value] : llvm::enumerate(valueParts)) {
+          auto vregType = dyn_cast<VRegType>(value.getType());
+          if (!vregType) {
+            return rewriter.notifyMatchFailure(
+                op, "group_store value must be vreg");
+          }
+          Value groupOffset = createGroupChunkOffset(
+              op.getLoc(), *offset, *rowStride, slotBlock * 8,
+              /*chunkLaneOffset=*/0, rewriter);
+          groupOffsets.push_back(groupOffset);
+          useDirectAccess &= isDirectMemoryDistAddressLegal(
+              op.getDestination(), groupOffset,
+              getMemoryElementType(op.getDestination().getType()), vregType,
+              VPTOMemoryOpFamily::Store, *dist);
+        }
+
+        if (!useDirectAccess) {
+          VMILayoutAttr compactLayout = VMILayoutAttr::getGroupSlots(
+              rewriter.getContext(), layout.getNumGroups(), layout.getSlots());
+          auto compactType = VMIVRegType::get(
+              rewriter.getContext(), valueVMIType.getElementCount(),
+              valueVMIType.getElementType(), compactLayout);
+          FailureOr<SmallVector<Value>> compactValues =
+              materializeEnsureLayoutConversion(
+                  op, valueParts, valueVMIType, compactType,
+                  *this->getTypeConverter(), rewriter);
+          if (
+              failed(compactValues) ||
+              compactValues->size() != valueParts.size()) {
+            return rewriter.notifyMatchFailure(
+                op, "failed to compact unaligned slots=8 group_store");
+          }
+
+          SmallVector<int64_t> advances;
+          for (size_t slotBlock = 0; slotBlock < compactValues->size();
+               ++slotBlock) {
+            advances.push_back(std::min<int64_t>(8, numGroups - slotBlock * 8));
+          }
+          Type destinationElementType =
+              getMemoryElementType((*destination).getType());
+          Value storeBase = materializeBufferPointer(
+              *destination, destinationElementType,
+              getMemorySpace((*destination).getType()), rewriter, op.getLoc());
+          if (!storeBase) {
+            return rewriter.notifyMatchFailure(
+                op, "unaligned slots=8 group_store requires a ptr-compatible "
+                    "destination");
+          }
+          storeBase = rewriter
+                          .create<AddPtrOp>(op.getLoc(), storeBase.getType(),
+                                            storeBase, *offset)
+                          .getResult();
+          if (failed(emitStatefulStoreStream(op, storeBase, *compactValues,
+                                             advances, rewriter)))
+            return failure();
+          rewriter.eraseOp(op);
+          return success();
+        }
+
         for (auto [slotBlock, value] : llvm::enumerate(valueParts)) {
           if (!isa<VRegType>(value.getType()))
             return rewriter.notifyMatchFailure(
@@ -7900,23 +8394,60 @@ struct OneToNVMIGroupStoreOpPattern
           if (failed(mask))
             return rewriter.notifyMatchFailure(
                 op, "failed to create packed slots=8 group_store mask");
-          Value groupOffset = createGroupChunkOffset(
-              op.getLoc(), *offset, *rowStride, slotBlock * 8,
-              /*chunkLaneOffset=*/0, rewriter);
-          rewriter.create<VstsOp>(
-              op.getLoc(), /*updated_base=*/Type{}, value, *destination,
-              groupOffset, rewriter.getStringAttr(*dist), *mask);
+          rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{}, value,
+                                  *destination, groupOffsets[slotBlock],
+                                  rewriter.getStringAttr(*dist), *mask);
         }
 
         rewriter.eraseOp(op);
         return success();
       }
 
+      SmallVector<Value> groupOffsets;
+      bool useDirectAccess = true;
       for (auto [slotBlock, value] : llvm::enumerate(valueParts)) {
         auto vregType = dyn_cast<VRegType>(value.getType());
         if (!vregType)
           return rewriter.notifyMatchFailure(op,
                                              "group_store value must be vreg");
+        Value groupOffset = createGroupChunkOffset(
+            op.getLoc(), *offset, *rowStride, slotBlock * 8,
+            /*chunkLaneOffset=*/0, rewriter);
+        groupOffsets.push_back(groupOffset);
+        useDirectAccess &= isDirectMemoryDistAddressLegal(
+            op.getDestination(), groupOffset,
+            getMemoryElementType(op.getDestination().getType()), vregType,
+            VPTOMemoryOpFamily::Store, "");
+      }
+
+      if (!useDirectAccess) {
+        SmallVector<int64_t> advances;
+        for (size_t slotBlock = 0; slotBlock < valueParts.size(); ++slotBlock) {
+          advances.push_back(std::min<int64_t>(8, numGroups - slotBlock * 8));
+        }
+        Type destinationElementType =
+            getMemoryElementType((*destination).getType());
+        Value storeBase = materializeBufferPointer(
+            *destination, destinationElementType,
+            getMemorySpace((*destination).getType()), rewriter, op.getLoc());
+        if (!storeBase) {
+          return rewriter.notifyMatchFailure(
+              op, "unaligned slots=8 group_store requires a ptr-compatible "
+                  "destination");
+        }
+        storeBase = rewriter
+                        .create<AddPtrOp>(op.getLoc(), storeBase.getType(),
+                                          storeBase, *offset)
+                        .getResult();
+        if (failed(emitStatefulStoreStream(op, storeBase, valueParts, advances,
+                                           rewriter)))
+          return failure();
+        rewriter.eraseOp(op);
+        return success();
+      }
+
+      for (auto [slotBlock, value] : llvm::enumerate(valueParts)) {
+        auto vregType = cast<VRegType>(value.getType());
         FailureOr<MaskType> maskType =
             getMaskTypeForVReg(vregType, rewriter.getContext());
         if (failed(maskType))
@@ -7928,12 +8459,10 @@ struct OneToNVMIGroupStoreOpPattern
         if (failed(mask))
           return rewriter.notifyMatchFailure(
               op, "failed to create slots=8 group_store mask");
-        Value groupOffset = createGroupChunkOffset(
-            op.getLoc(), *offset, *rowStride, slotBlock * 8,
-            /*chunkLaneOffset=*/0, rewriter);
         rewriter.create<VstsOp>(op.getLoc(),
                                 /*updated_base=*/Type{}, value, *destination,
-                                groupOffset, /*dist=*/nullptr, *mask);
+                                groupOffsets[slotBlock], /*dist=*/nullptr,
+                                *mask);
       }
 
       rewriter.eraseOp(op);
@@ -8140,6 +8669,13 @@ struct OneToNVMIMaskedStoreOpPattern
                 op, "failed to compact lane_stride masked_store predicate");
           Value chunkOffset =
               createChunkOffset(op.getLoc(), *offset, semanticOffset, rewriter);
+          if (!isDirectMemoryDistAddressLegal(
+                  *destination, chunkOffset, valueVMIType.getElementType(),
+                  vregType, VPTOMemoryOpFamily::Store, *dist)) {
+            return rewriter.notifyMatchFailure(
+                op, "lane_stride masked_store requires a proven target "
+                    "alignment for every physical store chunk");
+          }
           rewriter.create<VstsOp>(op.getLoc(),
                                   /*updated_base=*/Type{}, value, *destination,
                                   chunkOffset, rewriter.getStringAttr(*dist),
@@ -8198,6 +8734,13 @@ struct OneToNVMIMaskedStoreOpPattern
             op, "failed to materialize masked_store predicate");
       Value chunkOffset = createChunkOffset(op.getLoc(), *offset,
                                             index * *lanesPerPart, rewriter);
+      if (!isDirectMemoryDistAddressLegal(
+              *destination, chunkOffset, valueVMIType.getElementType(),
+              vregType, VPTOMemoryOpFamily::Store, /*dist=*/{})) {
+        return rewriter.notifyMatchFailure(
+            op, "masked_store requires a proven target alignment for every "
+                "physical store chunk");
+      }
       rewriter.create<VstsOp>(op.getLoc(),
                               /*updated_base=*/Type{}, value, *destination,
                               chunkOffset, /*dist=*/nullptr, *storeMask);
@@ -8259,13 +8802,30 @@ struct OneToNVMIGroupBroadcastLoadOpPattern
       return std::nullopt;
     };
 
-    if (succeeded(directFact) &&
-        directFact->kind == VMIGroupBroadcastLoadDirectKind::BRC) {
+    bool canUseDirectBRC = false;
+    if (
+        succeeded(directFact) &&
+        directFact->kind == VMIGroupBroadcastLoadDirectKind::BRC &&
+        !resultTypes.empty()) {
+      std::optional<StringRef> brcDist = getBRCDist();
+      auto firstType = dyn_cast<VRegType>(resultTypes.front());
+      canUseDirectBRC =
+          brcDist && firstType &&
+          isDirectMemoryDistAddressLegal(
+              op.getSource(), op.getOffset(), resultVMIType.getElementType(),
+              firstType, VPTOMemoryOpFamily::Load, *brcDist);
+    }
+
+    if (
+        succeeded(directFact) &&
+        directFact->kind == VMIGroupBroadcastLoadDirectKind::BRC &&
+        canUseDirectBRC) {
       if (numGroups <= 0 ||
-          static_cast<int64_t>(resultTypes.size()) % numGroups != 0)
+          static_cast<int64_t>(resultTypes.size()) % numGroups != 0) {
         return rewriter.notifyMatchFailure(
             op, "group_broadcast_load BRC result arity is not divisible by "
                 "num_groups");
+      }
       // BRC duplicates the scalar independently into every physical result
       // chunk. Derive the chunk count from the assigned result arity so
       // deinterleaved scalar-broadcast layouts (d2/d4) remain valid even
@@ -8309,8 +8869,25 @@ struct OneToNVMIGroupBroadcastLoadOpPattern
       return success();
     }
 
+    bool canUseDirectE2B = false;
+    if (
+        succeeded(directFact) &&
+        directFact->kind == VMIGroupBroadcastLoadDirectKind::E2B &&
+        !resultTypes.empty()) {
+      unsigned elementBits = directFact->layout.elementBits;
+      StringRef e2bDist =
+          elementBits == 16 ? StringRef("E2B_B16") : StringRef("E2B_B32");
+      auto firstType = dyn_cast<VRegType>(resultTypes.front());
+      canUseDirectE2B =
+          (elementBits == 16 || elementBits == 32) && firstType &&
+          isDirectMemoryDistAddressLegal(
+              op.getSource(), op.getOffset(), resultVMIType.getElementType(),
+              firstType, VPTOMemoryOpFamily::Load, e2bDist);
+    }
+
     if (failed(directFact) ||
-        directFact->kind != VMIGroupBroadcastLoadDirectKind::E2B) {
+        directFact->kind != VMIGroupBroadcastLoadDirectKind::E2B ||
+        !canUseDirectE2B) {
       std::optional<int64_t> stride =
           getConstantIndexValue(op.getSourceGroupStride());
       int64_t slots = (stride && *stride == 1) ? 8 : 1;

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitterInternal.h
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitterInternal.h
@@ -11,6 +11,7 @@
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOSyncUtils.h"
 #include "PTO/IR/PTOTypeUtils.h"
+#include "PTO/IR/VPTOMemoryDist.h"
 #include "PTO/Transforms/Passes.h"
 #include "PTO/Transforms/VPTOLLVMEmitter.h"
 #include "PTO/Transforms/VPTOLLVMEmitterHelper.h"

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitterPacking.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitterPacking.cpp
@@ -30,56 +30,24 @@ FailureOr<Value> packShiftedFields(Operation *anchor, Value base, ArrayRef<std::
 }
 
 std::optional<uint64_t> parseLoadX2DistImmediate(StringRef dist, Type elementType) {
-  auto width = getDistElementWidth(elementType);
-  if (dist == "BDINTLV") {
-    return 10;
-  }
-  if (!width) {
-    return std::nullopt;
-  }
-  if (dist == "DINTLV_B8") {
-    return std::optional<uint64_t>(11);
-  }
-  if (dist == "DINTLV_B16") {
-    return std::optional<uint64_t>(12);
-  }
-  if (dist == "DINTLV_B32") {
-    return std::optional<uint64_t>(19);
-  }
-  return std::nullopt;
+  const auto *contract = lookupVPTOMemoryDist(VPTOMemoryOpFamily::LoadX2, dist,
+                                              getDistElementWidth(elementType));
+  return contract ? std::optional<uint64_t>(contract->a5Immediate)
+                  : std::nullopt;
 }
 
 std::optional<uint64_t> parseStoreDistImmediate(StringRef dist, Type elementType) {
-  auto width = getDistElementWidth(elementType);
-  if (dist.empty()) {
-    if (!width) {
-      return std::nullopt;
-    }
-    if (*width == 8) {
-      return 0;
-    }
-    if (*width == 16) {
-      return 1;
-    }
-    if (*width == 32) {
-      return 2;
-    }
-    return std::nullopt;
-  }
-  static constexpr std::pair<StringLiteral, uint64_t> encodings[] = {
-      {"NORM_B8", 0},     {"NORM_B16", 1},    {"NORM_B32", 2},     {"1PT_B8", 3},  {"1PT_B16", 4},
-      {"1PT_B32", 5},     {"PK_B16", 6},      {"PK_B32", 7},       {"PK_B64", 10}, {"PK4_B32", 12},
-      {"MRG4CHN_B8", 13}, {"MRG2CHN_B8", 14}, {"MRG2CHN_B16", 15},
-  };
-  for (const auto &[name, value] : encodings) {
-    if (dist == name) {
-      return value;
-    }
-  }
-  return std::nullopt;
+  const auto *contract = lookupVPTOMemoryDist(
+      VPTOMemoryOpFamily::Store, dist,
+      dist.empty() ? getDistElementWidth(elementType) : std::nullopt);
+  return contract ? std::optional<uint64_t>(contract->a5Immediate)
+                  : std::nullopt;
 }
 
-bool isOnePointStoreDist(StringRef dist) { return dist == "1PT_B8" || dist == "1PT_B16" || dist == "1PT_B32"; }
+bool isOnePointStoreDist(StringRef dist) {
+  const auto *contract = lookupVPTOMemoryDist(VPTOMemoryOpFamily::Store, dist);
+  return contract && contract->isOnePointStore();
+}
 
 bool isMaskOnlyUsedByOnePointStores(Value mask) {
   return !mask.use_empty() && llvm::all_of(mask.getUsers(), [](Operation *user) {
@@ -88,21 +56,11 @@ bool isMaskOnlyUsedByOnePointStores(Value mask) {
   });
 }
 
-std::optional<uint64_t> parseStoreX2DistImmediate(StringRef dist, Type elementType) {
-  auto width = getDistElementWidth(elementType);
-  if (!width) {
-    return std::nullopt;
-  }
-  if (dist == "INTLV_B8") {
-    return std::optional<uint64_t>(8);
-  }
-  if (dist == "INTLV_B16") {
-    return std::optional<uint64_t>(9);
-  }
-  if (dist == "INTLV_B32") {
-    return std::optional<uint64_t>(11);
-  }
-  return std::nullopt;
+std::optional<uint64_t> parseStoreX2DistImmediate(StringRef dist, Type) {
+  const auto *contract =
+      lookupVPTOMemoryDist(VPTOMemoryOpFamily::StoreX2, dist);
+  return contract ? std::optional<uint64_t>(contract->a5Immediate)
+                  : std::nullopt;
 }
 
 Value packBlockRepeatStride(Operation *anchor, Value blockStride, Value repeatStride) {

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitterTypeHelpers.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitterTypeHelpers.cpp
@@ -1346,27 +1346,10 @@ uint64_t determineVsqzStoreHint(pto::VsqzOp vsqz) {
 }
 
 std::optional<uint64_t> parseLoadDistImmediate(StringRef dist, Type elementType) {
-  if (dist.empty() || dist == "NORM") {
-    return 0;
-  }
-  static constexpr std::pair<StringLiteral, uint64_t> kModes[] = {
-      {"BRC_B8", 1},   {"BRC_B16", 2},  {"BRC_B32", 3},  {"US_B8", 6},        {"US_B16", 7},
-      {"DS_B8", 8},    {"DS_B16", 9},   {"UNPK_B8", 13}, {"UNPK_B16", 14},    {"UNPK_B32", 18},
-      {"BRC_BLK", 15}, {"E2B_B16", 16}, {"E2B_B32", 17}, {"SPLT2CHN_B8", 22}, {"SPLT2CHN_B16", 23},
-  };
-  for (const auto &[name, value] : kModes) {
-    if (dist == name) {
-      return value;
-    }
-  }
-  if (dist == "UNPK4" || dist == "SPLT4CHN") {
-    auto width = getDistElementWidth(elementType);
-    if (!width || *width != 8) {
-      return std::nullopt;
-    }
-    return dist == "UNPK4" ? 20 : 21;
-  }
-  return std::nullopt;
+  const auto *contract = lookupVPTOMemoryDist(VPTOMemoryOpFamily::Load, dist,
+                                              getDistElementWidth(elementType));
+  return contract ? std::optional<uint64_t>(contract->a5Immediate)
+                  : std::nullopt;
 }
 
 } // namespace mlir::pto::detail

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -13,8 +13,9 @@
 #include "PTO/Transforms/VPTOLLVMEmitterHelper.h"
 
 #include "PTO/IR/PTO.h"
-#include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/IR/PTOSyncUtils.h"
+#include "PTO/IR/PTOTypeUtils.h"
+#include "PTO/IR/VPTOMemoryDist.h"
 #include "PTO/Transforms/Passes.h"
 
 #include "mlir/Conversion/Passes.h"
@@ -1827,191 +1828,32 @@ static uint64_t determineVsqzStoreHint(pto::VsqzOp vsqz) {
 
 static std::optional<uint64_t> parseLoadDistImmediate(StringRef dist,
                                                       Type elementType) {
-  auto width = getDistElementWidth(elementType);
-  if (dist.empty() || dist == "NORM")
-  {
-    return 0;
-  }
-  if (!width)
-  {
-    return std::nullopt;
-  }
-  if (dist == "BRC_B8")
-  {
-    return std::optional<uint64_t>(1);
-  }
-  if (dist == "BRC_B16")
-  {
-    return std::optional<uint64_t>(2);
-  }
-  if (dist == "BRC_B32")
-  {
-    return std::optional<uint64_t>(3);
-  }
-  if (dist == "US_B8")
-  {
-    return std::optional<uint64_t>(6);
-  }
-  if (dist == "US_B16")
-  {
-    return std::optional<uint64_t>(7);
-  }
-  if (dist == "DS_B8")
-  {
-    return std::optional<uint64_t>(8);
-  }
-  if (dist == "DS_B16")
-  {
-    return std::optional<uint64_t>(9);
-  }
-  if (dist == "UNPK_B8")
-  {
-    return std::optional<uint64_t>(13);
-  }
-  if (dist == "UNPK_B16")
-  {
-    return std::optional<uint64_t>(14);
-  }
-  if (dist == "UNPK_B32")
-  {
-    return std::optional<uint64_t>(18);
-  }
-  if (dist == "BRC_BLK")
-  {
-    return 15;
-  }
-  if (dist == "E2B_B16")
-  {
-    return std::optional<uint64_t>(16);
-  }
-  if (dist == "E2B_B32")
-  {
-    return std::optional<uint64_t>(17);
-  }
-  if (dist == "UNPK4")
-  {
-    return *width == 8 ? std::optional<uint64_t>(20) : std::nullopt;
-  }
-  if (dist == "SPLT4CHN")
-  {
-    return *width == 8 ? std::optional<uint64_t>(21) : std::nullopt;
-  }
-  if (dist == "SPLT2CHN_B8")
-  {
-    return std::optional<uint64_t>(22);
-  }
-  if (dist == "SPLT2CHN_B16")
-  {
-    return std::optional<uint64_t>(23);
-  }
-  return std::nullopt;
+  const auto *contract = lookupVPTOMemoryDist(VPTOMemoryOpFamily::Load, dist,
+                                              getDistElementWidth(elementType));
+  return contract ? std::optional<uint64_t>(contract->a5Immediate)
+                  : std::nullopt;
 }
 
 static std::optional<uint64_t> parseLoadX2DistImmediate(StringRef dist,
                                                         Type elementType) {
-  auto width = getDistElementWidth(elementType);
-  if (dist == "BDINTLV")
-  {
-    return 10;
-  }
-  if (!width)
-  {
-    return std::nullopt;
-  }
-  if (dist == "DINTLV_B8")
-  {
-    return std::optional<uint64_t>(11);
-  }
-  if (dist == "DINTLV_B16")
-  {
-    return std::optional<uint64_t>(12);
-  }
-  if (dist == "DINTLV_B32")
-  {
-    return std::optional<uint64_t>(19);
-  }
-  return std::nullopt;
+  const auto *contract = lookupVPTOMemoryDist(VPTOMemoryOpFamily::LoadX2, dist,
+                                              getDistElementWidth(elementType));
+  return contract ? std::optional<uint64_t>(contract->a5Immediate)
+                  : std::nullopt;
 }
 
 static std::optional<uint64_t> parseStoreDistImmediate(StringRef dist,
                                                        Type elementType) {
-  auto width = getDistElementWidth(elementType);
-  if (dist.empty()) {
-    if (!width)
-    {
-      return std::nullopt;
-    }
-    if (*width == 8)
-    {
-      return 0;
-    }
-    if (*width == 16)
-    {
-      return 1;
-    }
-    if (*width == 32)
-    {
-      return 2;
-    }
-    return std::nullopt;
-  }
-  if (dist == "NORM_B8")
-  {
-    return std::optional<uint64_t>(0);
-  }
-  if (dist == "NORM_B16")
-  {
-    return std::optional<uint64_t>(1);
-  }
-  if (dist == "NORM_B32")
-  {
-    return std::optional<uint64_t>(2);
-  }
-  if (dist == "1PT_B8")
-  {
-    return std::optional<uint64_t>(3);
-  }
-  if (dist == "1PT_B16")
-  {
-    return std::optional<uint64_t>(4);
-  }
-  if (dist == "1PT_B32")
-  {
-    return std::optional<uint64_t>(5);
-  }
-  if (dist == "PK_B16")
-  {
-    return std::optional<uint64_t>(6);
-  }
-  if (dist == "PK_B32")
-  {
-    return std::optional<uint64_t>(7);
-  }
-  if (dist == "PK_B64")
-  {
-    return std::optional<uint64_t>(10);
-  }
-  if (dist == "PK4_B32")
-  {
-    return std::optional<uint64_t>(12);
-  }
-  if (dist == "MRG4CHN_B8")
-  {
-    return std::optional<uint64_t>(13);
-  }
-  if (dist == "MRG2CHN_B8")
-  {
-    return std::optional<uint64_t>(14);
-  }
-  if (dist == "MRG2CHN_B16")
-  {
-    return std::optional<uint64_t>(15);
-  }
-  return std::nullopt;
+  const auto *contract = lookupVPTOMemoryDist(
+      VPTOMemoryOpFamily::Store, dist,
+      dist.empty() ? getDistElementWidth(elementType) : std::nullopt);
+  return contract ? std::optional<uint64_t>(contract->a5Immediate)
+                  : std::nullopt;
 }
 
 static bool isOnePointStoreDist(StringRef dist) {
-  return dist == "1PT_B8" || dist == "1PT_B16" || dist == "1PT_B32";
+  const auto *contract = lookupVPTOMemoryDist(VPTOMemoryOpFamily::Store, dist);
+  return contract && contract->isOnePointStore();
 }
 
 static bool isMaskOnlyUsedByOnePointStores(Value mask) {
@@ -2022,25 +1864,11 @@ static bool isMaskOnlyUsedByOnePointStores(Value mask) {
 }
 
 static std::optional<uint64_t> parseStoreX2DistImmediate(StringRef dist,
-                                                         Type elementType) {
-  auto width = getDistElementWidth(elementType);
-  if (!width)
-  {
-    return std::nullopt;
-  }
-  if (dist == "INTLV_B8")
-  {
-    return std::optional<uint64_t>(8);
-  }
-  if (dist == "INTLV_B16")
-  {
-    return std::optional<uint64_t>(9);
-  }
-  if (dist == "INTLV_B32")
-  {
-    return std::optional<uint64_t>(11);
-  }
-  return std::nullopt;
+                                                         Type) {
+  const auto *contract =
+      lookupVPTOMemoryDist(VPTOMemoryOpFamily::StoreX2, dist);
+  return contract ? std::optional<uint64_t>(contract->a5Immediate)
+                  : std::nullopt;
 }
 
 static Value packBlockRepeatStride(Operation *anchor, Value blockStride,

--- a/lib/PTO/Transforms/VPTOStatefulStreamFusion.cpp
+++ b/lib/PTO/Transforms/VPTOStatefulStreamFusion.cpp
@@ -1,0 +1,723 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/Transforms/VPTOStatefulStreamFusion.h"
+#include "PTO/Analysis/PTOAddressAnalysis.h"
+#include "PTO/IR/PTO.h"
+#include "PTO/IR/PTOTypeUtils.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/Support/MathExtras.h"
+#include <limits>
+#include <optional>
+
+using namespace mlir;
+using namespace mlir::pto;
+
+namespace {
+struct StatefulStoreStream {
+  InitAlignOp init;
+  VstusOp firstStore;
+  VstasOp flush;
+  Value initialBase;
+  Value finalAlign;
+  Value finalBase;
+  int64_t totalAdvance = 0;
+};
+
+static std::optional<int64_t> getConstantInt64(Value value) {
+  APInt constant;
+  bool isConstant = matchPattern(value, m_ConstantInt(&constant)) &&
+                    constant.isSignedIntN(64);
+  if (!isConstant) {
+    return std::nullopt;
+  }
+  return constant.getSExtValue();
+}
+
+static std::optional<StatefulStoreStream>
+parseStatefulStoreStream(InitAlignOp init) {
+  Value initialAlign = init.getResult();
+  if (!initialAlign.hasOneUse()) {
+    return std::nullopt;
+  }
+  auto firstStore = dyn_cast<VstusOp>(*initialAlign.getUsers().begin());
+  bool isFirstStore = firstStore && firstStore.getAlignIn() == initialAlign &&
+                      firstStore->getBlock() == init->getBlock();
+  if (!isFirstStore) {
+    return std::nullopt;
+  }
+
+  StatefulStoreStream stream{init, firstStore, {}, firstStore.getBase(),
+                             {},   {},         0};
+  VstusOp store = firstStore;
+  while (true) {
+    Value baseOut = store.getBaseOut();
+    std::optional<int64_t> advance = getConstantInt64(store.getOffset());
+    if (!baseOut || !advance ||
+        llvm::AddOverflow(stream.totalAdvance, *advance, stream.totalAdvance) ||
+        !store.getAlignOut().hasOneUse() || !baseOut.hasOneUse()) {
+      return std::nullopt;
+    }
+
+    Operation *alignUser = *store.getAlignOut().getUsers().begin();
+    Operation *baseUser = *baseOut.getUsers().begin();
+    if (auto nextStore = dyn_cast<VstusOp>(alignUser)) {
+      if (baseUser != nextStore ||
+          nextStore.getAlignIn() != store.getAlignOut() ||
+          nextStore.getBase() != baseOut ||
+          nextStore->getBlock() != init->getBlock()) {
+        return std::nullopt;
+      }
+      store = nextStore;
+      continue;
+    }
+
+    auto flush = dyn_cast<VstasOp>(alignUser);
+    std::optional<int64_t> flushOffset;
+    if (flush) {
+      flushOffset = getConstantInt64(flush.getOffset());
+    }
+    bool isValidFlush =
+        flush && baseUser == flush && flush.getValue() == store.getAlignOut() &&
+        flush.getDestination() == baseOut && !flush.getUpdatedBase() &&
+        flushOffset && *flushOffset == 0 &&
+        flush->getBlock() == init->getBlock();
+    if (!isValidFlush) {
+      return std::nullopt;
+    }
+
+    stream.flush = flush;
+    stream.finalAlign = store.getAlignOut();
+    stream.finalBase = baseOut;
+    return stream;
+  }
+}
+
+static bool areContiguousStatefulAddresses(Value first, int64_t advanceElements,
+                                           Value second) {
+  auto firstType = dyn_cast<PtrType>(first.getType());
+  if (!firstType || firstType != second.getType()) {
+    return false;
+  }
+  unsigned elementBits = getPTOStorageElemBitWidth(firstType.getElementType());
+  if (elementBits == 0 || elementBits % 8 != 0) {
+    return false;
+  }
+  int64_t elementBytes = static_cast<int64_t>(elementBits / 8);
+  int64_t expectedBytes;
+  if (llvm::MulOverflow(advanceElements, elementBytes, expectedBytes)) {
+    return false;
+  }
+  auto difference = getKnownAddressDifferenceBytes(first, second);
+  return difference && *difference == expectedBytes;
+}
+
+static bool canMoveStatefulStoreFlush(StatefulStoreStream first,
+                                      StatefulStoreStream second) {
+  bool isOrdered = first.flush->getBlock() == second.firstStore->getBlock() &&
+                   first.flush->isBeforeInBlock(second.firstStore);
+  if (!isOrdered) {
+    return false;
+  }
+  bool sawSecondInit = false;
+  for (Operation *op = first.flush->getNextNode(); op != second.firstStore;
+       op = op->getNextNode()) {
+    if (!op) {
+      return false;
+    }
+    if (op == second.init) {
+      sawSecondInit = true;
+      continue;
+    }
+    bool isSafeInterveningOp = isa<InitAlignOp>(op) == false &&
+                               op->getNumRegions() == 0 &&
+                               isMemoryEffectFree(op);
+    if (!isSafeInterveningOp) {
+      return false;
+    }
+  }
+  return sawSecondInit;
+}
+
+static bool tryFuseStatefulStoreStreams(StatefulStoreStream first,
+                                        StatefulStoreStream second) {
+  bool matchingTypes =
+      first.initialBase.getType() == second.initialBase.getType();
+  if (!matchingTypes || !canMoveStatefulStoreFlush(first, second)) {
+    return false;
+  }
+  bool isContiguous = areContiguousStatefulAddresses(
+      first.initialBase, first.totalAdvance, second.initialBase);
+  if (!isContiguous) {
+    return false;
+  }
+
+  second.firstStore.getAlignInMutable().set(first.finalAlign);
+  second.firstStore.getBaseMutable().set(first.finalBase);
+  first.flush.erase();
+  second.init.erase();
+  return true;
+}
+
+static void fuseStatefulStoreStreams(ModuleOp module) {
+  while (true) {
+    SmallVector<InitAlignOp> initializers;
+    module.walk([&](InitAlignOp init) { initializers.push_back(init); });
+    DenseMap<Block *, StatefulStoreStream> previousStreams;
+    bool changed = false;
+    for (InitAlignOp init : initializers) {
+      std::optional<StatefulStoreStream> stream =
+          parseStatefulStoreStream(init);
+      Block *block = init->getBlock();
+      if (!stream) {
+        previousStreams.erase(block);
+        continue;
+      }
+      auto previous = previousStreams.find(block);
+      bool canFuse = previous != previousStreams.end() &&
+                     tryFuseStatefulStoreStreams(previous->second, *stream);
+      if (canFuse) {
+        changed = true;
+        break;
+      }
+      previousStreams[block] = *stream;
+    }
+    if (!changed) {
+      return;
+    }
+  }
+}
+
+struct StatefulLoadStream {
+  VldasOp init;
+  VldusOp firstLoad;
+  VldusOp lastLoad;
+  Value initialSource;
+  Value finalAlign;
+  Value finalBase;
+  int64_t totalElements = 0;
+};
+
+static std::optional<StatefulLoadStream> parseStatefulLoadStream(VldasOp init) {
+  Value initialAlign = init.getResult();
+  if (!initialAlign.hasOneUse()) {
+    return std::nullopt;
+  }
+  auto firstLoad = dyn_cast<VldusOp>(*initialAlign.getUsers().begin());
+  bool isFirstLoad = firstLoad && firstLoad.getAlign() == initialAlign &&
+                     firstLoad->getBlock() == init->getBlock() &&
+                     firstLoad.getIncrement() && firstLoad.getUpdatedBase();
+  if (!isFirstLoad) {
+    return std::nullopt;
+  }
+
+  StatefulLoadStream stream{init, firstLoad, {}, firstLoad.getSource(),
+                            {},   {},        0};
+  VldusOp load = firstLoad;
+  while (true) {
+    auto resultType = dyn_cast<VRegType>(load.getResult().getType());
+    auto increment = getConstantInt64(load.getIncrement());
+    if (!resultType || !increment ||
+        *increment != resultType.getElementCount() ||
+        llvm::AddOverflow(stream.totalElements, *increment,
+                          stream.totalElements)) {
+      return std::nullopt;
+    }
+    Value nextAlign = load.getUpdatedAlign();
+    Value nextBase = load.getUpdatedBase();
+    if (!nextAlign.hasOneUse()) {
+      stream.lastLoad = load;
+      stream.finalAlign = nextAlign;
+      stream.finalBase = nextBase;
+      return stream;
+    }
+    auto nextLoad = dyn_cast<VldusOp>(*nextAlign.getUsers().begin());
+    bool isNextLoad = nextLoad && nextLoad.getAlign() == nextAlign &&
+                      nextBase.hasOneUse() &&
+                      *nextBase.getUsers().begin() == nextLoad &&
+                      nextLoad.getSource() == nextBase &&
+                      nextLoad->getBlock() == init->getBlock() &&
+                      nextLoad.getIncrement() && nextLoad.getUpdatedBase();
+    if (!isNextLoad) {
+      return std::nullopt;
+    }
+    load = nextLoad;
+  }
+}
+
+static bool canMoveLoadStream(StatefulLoadStream first,
+                              StatefulLoadStream second) {
+  bool isOrdered = first.lastLoad->getBlock() == second.firstLoad->getBlock() &&
+                   first.lastLoad->isBeforeInBlock(second.init);
+  if (!isOrdered) {
+    return false;
+  }
+  for (Operation *op = first.lastLoad->getNextNode(); op != second.init;
+       op = op->getNextNode()) {
+    bool isSafeInterveningOp =
+        op && op->getNumRegions() == 0 && isMemoryEffectFree(op);
+    if (!isSafeInterveningOp) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool tryFuseStatefulLoadStreams(StatefulLoadStream first,
+                                       StatefulLoadStream second) {
+  bool matchingTypes =
+      first.initialSource.getType() == second.initialSource.getType();
+  if (!matchingTypes || !canMoveLoadStream(first, second)) {
+    return false;
+  }
+  bool isContiguous = areContiguousStatefulAddresses(
+      first.initialSource, first.totalElements, second.initialSource);
+  if (!isContiguous) {
+    return false;
+  }
+
+  second.firstLoad.getSourceMutable().set(first.finalBase);
+  second.firstLoad.getAlignMutable().set(first.finalAlign);
+  second.init.erase();
+  return true;
+}
+
+static void fuseStatefulLoadStreams(ModuleOp module) {
+  while (true) {
+    SmallVector<VldasOp> initializers;
+    module.walk([&](VldasOp init) { initializers.push_back(init); });
+    DenseMap<Block *, StatefulLoadStream> previousStreams;
+    bool changed = false;
+    for (VldasOp init : initializers) {
+      auto stream = parseStatefulLoadStream(init);
+      Block *block = init->getBlock();
+      if (!stream) {
+        previousStreams.erase(block);
+        continue;
+      }
+      auto previous = previousStreams.find(block);
+      bool canFuse = previous != previousStreams.end() &&
+                     tryFuseStatefulLoadStreams(previous->second, *stream);
+      if (canFuse) {
+        changed = true;
+        break;
+      }
+      previousStreams[block] = *stream;
+    }
+    if (!changed) {
+      return;
+    }
+  }
+}
+
+static std::optional<int64_t> getLoopTripCount(scf::ForOp loop) {
+  auto lower = getConstantInt64(loop.getLowerBound());
+  auto upper = getConstantInt64(loop.getUpperBound());
+  auto step = getConstantInt64(loop.getStep());
+  if (!lower || !upper || !step || *step <= 0 || *lower >= *upper) {
+    return std::nullopt;
+  }
+  __int128 distance = static_cast<__int128>(*upper) - *lower;
+  __int128 count = (distance + static_cast<__int128>(*step) - 1) / *step;
+  if (count > std::numeric_limits<int64_t>::max()) {
+    return std::nullopt;
+  }
+  return static_cast<int64_t>(count);
+}
+
+static std::optional<int64_t>
+getLoopAddressCoefficient(Value value, scf::ForOp loop,
+                          DenseMap<Value, int64_t> &cache,
+                          DenseSet<Value> &failed) {
+  bool isOutside =
+      loop.isDefinedOutsideOfLoop(value) || matchPattern(value, m_Constant());
+  if (isOutside) {
+    return 0;
+  }
+  if (value == loop.getInductionVar()) {
+    return 1;
+  }
+  if (auto it = cache.find(value); it != cache.end()) {
+    return it->second;
+  }
+  bool isFailed = failed.contains(value) || isa<BlockArgument>(value);
+  if (isFailed) {
+    return std::nullopt;
+  }
+
+  Operation *def = value.getDefiningOp();
+  auto coefficient = [&](Value operand) {
+    return getLoopAddressCoefficient(operand, loop, cache, failed);
+  };
+  std::optional<int64_t> result;
+  int64_t combined;
+  if (auto add = dyn_cast_or_null<arith::AddIOp>(def)) {
+    auto lhs = coefficient(add.getLhs());
+    auto rhs = coefficient(add.getRhs());
+    if (lhs && rhs && !llvm::AddOverflow(*lhs, *rhs, combined)) {
+      result = combined;
+    }
+  } else if (auto sub = dyn_cast_or_null<arith::SubIOp>(def)) {
+    auto lhs = coefficient(sub.getLhs());
+    auto rhs = coefficient(sub.getRhs());
+    if (lhs && rhs && !llvm::SubOverflow(*lhs, *rhs, combined)) {
+      result = combined;
+    }
+  } else if (auto mul = dyn_cast_or_null<arith::MulIOp>(def)) {
+    auto lhsConstant = getConstantInt64(mul.getLhs());
+    auto rhsConstant = getConstantInt64(mul.getRhs());
+    Value varying = lhsConstant ? mul.getRhs() : mul.getLhs();
+    std::optional<int64_t> constant = lhsConstant ? lhsConstant : rhsConstant;
+    auto varyingCoefficient = constant ? coefficient(varying) : std::nullopt;
+    if (constant && varyingCoefficient &&
+        !llvm::MulOverflow(*constant, *varyingCoefficient, combined)) {
+      result = combined;
+    }
+  } else if (auto addPtr = dyn_cast_or_null<AddPtrOp>(def)) {
+    auto pointer = coefficient(addPtr.getPtr());
+    auto offset = coefficient(addPtr.getOffset());
+    if (pointer && offset && !llvm::AddOverflow(*pointer, *offset, combined)) {
+      result = combined;
+    }
+  } else if (auto castPtr = dyn_cast_or_null<CastPtrOp>(def)) {
+    result = coefficient(castPtr.getInput());
+  } else if (isa_and_nonnull<arith::IndexCastOp, arith::IndexCastUIOp>(def)) {
+    result = coefficient(def->getOperand(0));
+  }
+
+  if (!result) {
+    failed.insert(value);
+    return std::nullopt;
+  }
+  cache[value] = *result;
+  return result;
+}
+
+static bool isLoopContinuousAddress(Value address, int64_t streamAdvance,
+                                    scf::ForOp loop) {
+  auto tripCount = getLoopTripCount(loop);
+  auto step = getConstantInt64(loop.getStep());
+  if (!tripCount || *tripCount < 2 || !step) {
+    return false;
+  }
+  DenseMap<Value, int64_t> cache;
+  DenseSet<Value> failed;
+  auto coefficient = getLoopAddressCoefficient(address, loop, cache, failed);
+  int64_t iterationAdvance;
+  return coefficient &&
+         !llvm::MulOverflow(*coefficient, *step, iterationAdvance) &&
+         iterationAdvance == streamAdvance;
+}
+
+static Value materializeAtLoopEntry(Value value, scf::ForOp loop,
+                                    IRRewriter &rewriter,
+                                    DenseMap<Value, Value> &cache) {
+  if (loop.isDefinedOutsideOfLoop(value)) {
+    return value;
+  }
+  if (value == loop.getInductionVar()) {
+    return loop.getLowerBound();
+  }
+  if (auto it = cache.find(value); it != cache.end()) {
+    return it->second;
+  }
+  if (isa<BlockArgument>(value)) {
+    return nullptr;
+  }
+
+  Operation *def = value.getDefiningOp();
+  bool canMaterialize = def && def->getParentOp() == loop &&
+                        def->getNumRegions() == 0 && isMemoryEffectFree(def);
+  if (!canMaterialize) {
+    return nullptr;
+  }
+  IRMapping mapping;
+  for (Value operand : def->getOperands()) {
+    Value mapped = materializeAtLoopEntry(operand, loop, rewriter, cache);
+    if (!mapped) {
+      return nullptr;
+    }
+    mapping.map(operand, mapped);
+  }
+  Operation *clone = rewriter.clone(*def, mapping);
+  for (auto [original, materialized] :
+       llvm::zip_equal(def->getResults(), clone->getResults())) {
+    cache[original] = materialized;
+  }
+  return cache.lookup(value);
+}
+
+static DenseSet<Operation *>
+getStoreStreamOperations(StatefulStoreStream stream) {
+  DenseSet<Operation *> operations{stream.init, stream.flush};
+  VstusOp store = stream.firstStore;
+  while (store) {
+    operations.insert(store);
+    bool isFinalStore = store.getAlignOut() == stream.finalAlign;
+    if (isFinalStore) {
+      break;
+    }
+    store = dyn_cast<VstusOp>(*store.getAlignOut().getUsers().begin());
+  }
+  return operations;
+}
+
+static DenseSet<Operation *>
+getLoadStreamOperations(StatefulLoadStream stream) {
+  DenseSet<Operation *> operations{stream.init};
+  VldusOp load = stream.firstLoad;
+  while (load) {
+    operations.insert(load);
+    if (load == stream.lastLoad) {
+      break;
+    }
+    load = dyn_cast<VldusOp>(*load.getUpdatedAlign().getUsers().begin());
+  }
+  return operations;
+}
+
+static bool hasOtherStatefulOperation(scf::ForOp loop,
+                                      const DenseSet<Operation *> &streamOps) {
+  bool found = false;
+  loop.walk([&](Operation *op) {
+    bool isOtherStateful =
+        !streamOps.contains(op) &&
+        isa<InitAlignOp, VldasOp, VldusOp, VstusOp, VstasOp>(op);
+    if (isOtherStateful) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+static Value getPointerRoot(Value pointer) {
+  while (auto addPtr = pointer.getDefiningOp<AddPtrOp>()) {
+    pointer = addPtr.getPtr();
+  }
+  return pointer;
+}
+
+static std::optional<int64_t> getStaticPointerRootAddress(Value pointer) {
+  pointer = getPointerRoot(pointer);
+  auto castPtr = pointer.getDefiningOp<CastPtrOp>();
+  if (!castPtr) {
+    return std::nullopt;
+  }
+  Value address = castPtr.getInput();
+  if (auto cast = address.getDefiningOp<UnrealizedConversionCastOp>()) {
+    bool hasSingleOperand = cast->getNumOperands() == 1;
+    if (!hasSingleOperand) {
+      return std::nullopt;
+    }
+    address = cast->getOperand(0);
+  }
+  return getConstantInt64(address);
+}
+
+static bool mayAliasPointerRoots(Value lhs, Value rhs) {
+  Value lhsRoot = getPointerRoot(lhs);
+  Value rhsRoot = getPointerRoot(rhs);
+  if (lhsRoot == rhsRoot) {
+    return true;
+  }
+  auto lhsAddress = getStaticPointerRootAddress(lhsRoot);
+  auto rhsAddress = getStaticPointerRootAddress(rhsRoot);
+  return !lhsAddress || !rhsAddress || *lhsAddress == *rhsAddress;
+}
+
+static bool
+hasPotentiallyAliasingEffect(scf::ForOp loop, Value streamAddress,
+                             const DenseSet<Operation *> &streamOps) {
+  bool found = false;
+  loop.walk([&](Operation *op) {
+    bool skipOperation =
+        found || op == loop || streamOps.contains(op) || isMemoryEffectFree(op);
+    if (skipOperation) {
+      return;
+    }
+
+    bool hasPointerOperand = false;
+    for (Value operand : op->getOperands()) {
+      if (!isa<PtrType>(operand.getType())) {
+        continue;
+      }
+      hasPointerOperand = true;
+      if (mayAliasPointerRoots(streamAddress, operand)) {
+        found = true;
+        return;
+      }
+    }
+    // Unknown side effects cannot be moved across safely.
+    if (!hasPointerOperand) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+static bool fuseLoopCarriedStoreStream(StatefulStoreStream stream,
+                                       IRRewriter &rewriter) {
+  auto loop = stream.init->getParentOfType<scf::ForOp>();
+  DenseSet<Operation *> streamOps = getStoreStreamOperations(stream);
+  bool canFuse =
+      loop && stream.init->getParentOp() == loop &&
+      isLoopContinuousAddress(stream.initialBase, stream.totalAdvance, loop) &&
+      !hasOtherStatefulOperation(loop, streamOps) &&
+      !hasPotentiallyAliasingEffect(loop, stream.initialBase, streamOps);
+  if (!canFuse) {
+    return false;
+  }
+
+  rewriter.setInsertionPoint(loop);
+  Location loopLoc = loop.getLoc();
+  unsigned originalResults = loop.getNumResults();
+  DenseMap<Value, Value> cache;
+  Value initialBase =
+      materializeAtLoopEntry(stream.initialBase, loop, rewriter, cache);
+  if (!initialBase) {
+    return false;
+  }
+  Value initialAlign =
+      rewriter.create<InitAlignOp>(loopLoc, stream.finalAlign.getType())
+          .getResult();
+  SmallVector<BlockArgument> newArguments;
+  NewYieldValuesFn yields = [&](OpBuilder &, Location,
+                                ArrayRef<BlockArgument> arguments) {
+    newArguments.assign(arguments.begin(), arguments.end());
+    return SmallVector<Value>{stream.finalBase, stream.finalAlign};
+  };
+  auto replacement = loop.replaceWithAdditionalYields(
+      rewriter, ValueRange{initialBase, initialAlign}, false, yields);
+  if (failed(replacement)) {
+    return false;
+  }
+  auto newLoop = cast<scf::ForOp>(replacement->getOperation());
+  stream.firstStore.getBaseMutable().set(newArguments[0]);
+  stream.firstStore.getAlignInMutable().set(newArguments[1]);
+  stream.init.erase();
+  stream.flush.erase();
+
+  rewriter.setInsertionPointAfter(newLoop);
+  Value zero = rewriter.create<arith::ConstantIntOp>(loopLoc, 0, 32);
+  rewriter.create<VstasOp>(loopLoc, /*updated_base=*/Type{},
+                           newLoop.getResult(originalResults + 1),
+                           newLoop.getResult(originalResults), zero);
+  return true;
+}
+
+static bool fuseLoopCarriedLoadStream(StatefulLoadStream stream,
+                                      IRRewriter &rewriter) {
+  auto loop = stream.init->getParentOfType<scf::ForOp>();
+  DenseSet<Operation *> streamOps = getLoadStreamOperations(stream);
+  bool canFuse =
+      loop && stream.init->getParentOp() == loop &&
+      isLoopContinuousAddress(stream.initialSource, stream.totalElements,
+                              loop) &&
+      !hasOtherStatefulOperation(loop, streamOps) &&
+      !hasPotentiallyAliasingEffect(loop, stream.initialSource, streamOps);
+  if (!canFuse) {
+    return false;
+  }
+
+  rewriter.setInsertionPoint(loop);
+  DenseMap<Value, Value> cache;
+  Value initialBase =
+      materializeAtLoopEntry(stream.initialSource, loop, rewriter, cache);
+  if (!initialBase) {
+    return false;
+  }
+  Value initialAlign =
+      rewriter
+          .create<VldasOp>(loop.getLoc(), stream.finalAlign.getType(),
+                           initialBase)
+          .getResult();
+  SmallVector<BlockArgument> newArguments;
+  NewYieldValuesFn yields = [&](OpBuilder &, Location,
+                                ArrayRef<BlockArgument> arguments) {
+    newArguments.assign(arguments.begin(), arguments.end());
+    return SmallVector<Value>{stream.finalBase, stream.finalAlign};
+  };
+  auto replacement = loop.replaceWithAdditionalYields(
+      rewriter, ValueRange{initialBase, initialAlign}, false, yields);
+  if (failed(replacement)) {
+    return false;
+  }
+  stream.firstLoad.getSourceMutable().set(newArguments[0]);
+  stream.firstLoad.getAlignMutable().set(newArguments[1]);
+  stream.init.erase();
+  return true;
+}
+
+static void fuseLoopCarriedStatefulStreams(ModuleOp module) {
+  IRRewriter rewriter(module.getContext());
+  while (true) {
+    bool changed = false;
+    SmallVector<InitAlignOp> storeInitializers;
+    module.walk([&](InitAlignOp init) { storeInitializers.push_back(init); });
+    for (InitAlignOp init : storeInitializers) {
+      auto stream = parseStatefulStoreStream(init);
+      if (stream && fuseLoopCarriedStoreStream(*stream, rewriter)) {
+        changed = true;
+        break;
+      }
+    }
+    if (changed) {
+      continue;
+    }
+
+    SmallVector<VldasOp> loadInitializers;
+    module.walk([&](VldasOp init) { loadInitializers.push_back(init); });
+    for (VldasOp init : loadInitializers) {
+      auto stream = parseStatefulLoadStream(init);
+      if (stream && fuseLoopCarriedLoadStream(*stream, rewriter)) {
+        changed = true;
+        break;
+      }
+    }
+    if (!changed) {
+      return;
+    }
+  }
+}
+
+static void runVPTOStatefulStreamFusionImpl(ModuleOp module) {
+  fuseStatefulStoreStreams(module);
+  fuseStatefulLoadStreams(module);
+  fuseLoopCarriedStatefulStreams(module);
+}
+} // namespace
+
+namespace mlir::pto {
+#define GEN_PASS_DEF_VPTOSTATEFULSTREAMFUSION
+#include "PTO/Transforms/Passes.h.inc"
+
+struct VPTOStatefulStreamFusionPass
+    : public impl::VPTOStatefulStreamFusionBase<
+          VPTOStatefulStreamFusionPass> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(VPTOStatefulStreamFusionPass)
+
+  void runOnOperation() override {
+    runVPTOStatefulStreamFusion(getOperation());
+  }
+};
+
+std::unique_ptr<Pass> createVPTOStatefulStreamFusionPass() {
+  return std::make_unique<VPTOStatefulStreamFusionPass>();
+}
+
+void runVPTOStatefulStreamFusion(ModuleOp module) {
+  runVPTOStatefulStreamFusionImpl(module);
+}
+} // namespace mlir::pto

--- a/test/lit/vmi_new/opt/blockquant_bf16_group4_scale_expand_vmi_opt.pto
+++ b/test/lit/vmi_new/opt/blockquant_bf16_group4_scale_expand_vmi_opt.pto
@@ -22,11 +22,14 @@
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @blockquant_bf16_group4_scale_expand(
-      %src: !pto.ptr<bf16, ub>,
-      %dst: !pto.ptr<bf16, ub>,
-      %off: index) attributes {pto.kernel} {
+      %tile: index) attributes {pto.kernel} {
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %src = pto.castptr %c0_i64 : i64 -> !pto.ptr<bf16, ub>
+    %dst = pto.castptr %c4096_i64 : i64 -> !pto.ptr<bf16, ub>
     %c128 = arith.constant 128 : index
     %c256 = arith.constant 256 : index
+    %off = arith.muli %tile, %c128 : index
     %mask256 = pto.vmi.create_mask %c256
         : index -> !pto.vmi.mask<256xpred>
     %x = pto.vmi.vload %src[%off]

--- a/test/lit/vmi_new/opt/compute_mrope_f16_vmi_opt.pto
+++ b/test/lit/vmi_new/opt/compute_mrope_f16_vmi_opt.pto
@@ -30,7 +30,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
       attributes {pto.kernel} {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
-    %c2_i32 = arith.constant 2 : i32
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
 
     %x_ub = pto.castptr %x_ub_u : !pto.ptr<ui16, ub> -> !pto.ptr<f16, ub>
     %y_ub = pto.castptr %y_ub_u : !pto.ptr<ui16, ub> -> !pto.ptr<f16, ub>
@@ -39,14 +40,15 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %cur_tokens = arith.index_cast %curTokens : i32 to index
     %num_heads_idx = arith.index_cast %num_heads : i32 to index
     %num_heads_max_idx = arith.index_cast %num_heads_max : i32 to index
-    %head_align_idx = arith.index_cast %headAlign_fp16 : i32 to index
-    %rotary_dim_idx = arith.index_cast %rotary_dim : i32 to index
+    %head_align_units = arith.index_cast %headAlign_fp16 : i32 to index
+    %rotary_dim_units = arith.index_cast %rotary_dim : i32 to index
+    %head_align_idx = arith.muli %head_align_units, %c16 : index
+    %rotary_dim_idx = arith.muli %rotary_dim_units, %c32 : index
 
-    %half_rotary_i32 = arith.divui %rotary_dim, %c2_i32 : i32
     %suffix_len_i32 = arith.subi %head_size, %rotary_dim : i32
     %has_suffix = arith.cmpi sgt, %head_size, %rotary_dim : i32
 
-    %half_rotary = arith.index_cast %half_rotary_i32 : i32 to index
+    %half_rotary = arith.muli %rotary_dim_units, %c16 : index
     %suffix_len = arith.index_cast %suffix_len_i32 : i32 to index
     %half_mask = pto.vmi.create_mask %half_rotary : index -> !pto.vmi.mask<64xpred>
     %suffix_mask = pto.vmi.create_mask %suffix_len : index -> !pto.vmi.mask<64xpred>

--- a/test/lit/vmi_new/opt/compute_y1_to_fp8_fp16_vmi_opt.pto
+++ b/test/lit/vmi_new/opt/compute_y1_to_fp8_fp16_vmi_opt.pto
@@ -17,21 +17,19 @@
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @ComputeY1ToFP8_fp16_e4m3_vmi(
-      %dataLen: i16,
-      %blockCount: i16,
-      %xAddr: !pto.ptr<f16, ub>,
-      %mxScale1ReciprocalAddr: !pto.ptr<f16, ub>,
-      %y1Addr: !pto.ptr<f8E4M3FN, ub>,
-      %ubBlockSize: i16,
-      %vlForHalfNumber: i16)
+      %blockCount: i16)
       attributes {pto.kernel} {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
-    %c2 = arith.constant 2 : index
+    %c256 = arith.constant 256 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c16384_i64 = arith.constant 16384 : i64
+    %c20480_i64 = arith.constant 20480 : i64
+    %xAddr = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
+    %mxScale1ReciprocalAddr = pto.castptr %c16384_i64 : i64 -> !pto.ptr<f16, ub>
+    %y1Addr = pto.castptr %c20480_i64 : i64 -> !pto.ptr<f8E4M3FN, ub>
 
     %block_count = arith.index_cast %blockCount : i16 to index
-    %vl_half = arith.index_cast %vlForHalfNumber : i16 to index
-    %load_stride_y8 = arith.muli %vl_half, %c2 : index
 
     pto.vecscope {
       %scale_f16 = pto.vmi.vload %mxScale1ReciprocalAddr[%c0], %c1 {group = 8}
@@ -42,8 +40,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
         : !pto.vmi.vreg<256xf16> -> !pto.vmi.vreg<256xf32>
 
       scf.for %i = %c0 to %block_count step %c1 {
-        %x_off = arith.muli %i, %load_stride_y8 : index
-        %y_off = arith.muli %i, %load_stride_y8 : index
+        %x_off = arith.muli %i, %c256 : index
+        %y_off = arith.muli %i, %c256 : index
 
         %x_f16 = pto.vmi.vload %xAddr[%x_off]
           : !pto.ptr<f16, ub> -> !pto.vmi.vreg<256xf16>
@@ -64,21 +62,19 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
   }
 
   func.func @ComputeY1ToFP8_fp16_e5m2_vmi(
-      %dataLen: i16,
-      %blockCount: i16,
-      %xAddr: !pto.ptr<f16, ub>,
-      %mxScale1ReciprocalAddr: !pto.ptr<f16, ub>,
-      %y1Addr: !pto.ptr<f8E5M2, ub>,
-      %ubBlockSize: i16,
-      %vlForHalfNumber: i16)
+      %blockCount: i16)
       attributes {pto.kernel} {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
-    %c2 = arith.constant 2 : index
+    %c256 = arith.constant 256 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c16384_i64 = arith.constant 16384 : i64
+    %c20480_i64 = arith.constant 20480 : i64
+    %xAddr = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
+    %mxScale1ReciprocalAddr = pto.castptr %c16384_i64 : i64 -> !pto.ptr<f16, ub>
+    %y1Addr = pto.castptr %c20480_i64 : i64 -> !pto.ptr<f8E5M2, ub>
 
     %block_count = arith.index_cast %blockCount : i16 to index
-    %vl_half = arith.index_cast %vlForHalfNumber : i16 to index
-    %load_stride_y8 = arith.muli %vl_half, %c2 : index
 
     pto.vecscope {
       %scale_f16 = pto.vmi.vload %mxScale1ReciprocalAddr[%c0], %c1 {group = 8}
@@ -89,8 +85,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
         : !pto.vmi.vreg<256xf16> -> !pto.vmi.vreg<256xf32>
 
       scf.for %i = %c0 to %block_count step %c1 {
-        %x_off = arith.muli %i, %load_stride_y8 : index
-        %y_off = arith.muli %i, %load_stride_y8 : index
+        %x_off = arith.muli %i, %c256 : index
+        %y_off = arith.muli %i, %c256 : index
 
         %x_f16 = pto.vmi.vload %xAddr[%x_off]
           : !pto.ptr<f16, ub> -> !pto.vmi.vreg<256xf16>

--- a/test/lit/vmi_new/opt/fa4_vsstb_cast_layout_opt.pto
+++ b/test/lit/vmi_new/opt/fa4_vsstb_cast_layout_opt.pto
@@ -7,15 +7,20 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // RUN: pto-test-opt %s -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
-// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s | FileCheck %s --check-prefix=VPTO --implicit-check-not=pto.vmi. --implicit-check-not='!pto.vmi'
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s | FileCheck %s --check-prefix=VPTO --implicit-check-not=pto.vmi. --implicit-check-not='!pto.vmi' --implicit-check-not=pto.vldas --implicit-check-not=pto.vldus
 
 // FA4 narrows four one-chunk f32 streams before block-strided stores. Prefer
 // the one-chunk c -> ls2 cast relation before group_store requests contiguous
 // values, then materialize ls2 -> c on the narrower f16 side.
+// Static UB bases and a 16-element tile stride keep source loads aligned.
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @fa4_vsstb_cast_layout_opt(
-      %src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f16, ub>, %off: index) {
+      %tile: index) {
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %src = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %dst = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f16, ub>
     %c16 = arith.constant 16 : index
     %c64 = arith.constant 64 : index
     %c128 = arith.constant 128 : index
@@ -23,6 +28,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %c1024 = arith.constant 1024 : index
     %c1040 = arith.constant 1040 : index
     %c2064 = arith.constant 2064 : index
+    %off = arith.muli %tile, %c16 : index
 
     %x0 = pto.vmi.load %src[%off]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>

--- a/test/lit/vmi_new/opt/fused_quant_dequant_vmi_opt.pto
+++ b/test/lit/vmi_new/opt/fused_quant_dequant_vmi_opt.pto
@@ -21,17 +21,16 @@
 // - the FP8 roundtrip needs no standalone vector-interleave materialization.
 
 // VPTO-LABEL: func.func @fused_qd_vmi_current
-// VPTO: scf.for
-// VPTO: scf.if
-// VPTO: pto.vecscope
-// VPTO: pto.pset_b16 "PAT_ALL"
+// VPTO-DAG: pto.pset_b16 "PAT_ALL"
+// VPTO-DAG: %[[SCALE_BASE:[^ ]+]] = pto.addptr {{.*}}, %c0 : <ui8, ub> -> <ui8, ub>
+// VPTO-DAG: %[[SCALE_ALIGN:.*]] = pto.init_align
 // VPTO: pto.pset_b16 "PAT_VL8"
-// VPTO: pto.pset_b32 "PAT_VL1"
-// VPTO: scf.for
+// VPTO: %[[SCALE_LOOP:.*]]:{{[0-9]+}} = scf.for
+// VPTO-SAME: iter_args(%[[SCALE_BASE_ARG:.*]] = %[[SCALE_BASE]], %[[SCALE_ALIGN_ARG:.*]] = %[[SCALE_ALIGN]]{{.*}})
 // VPTO: %[[REDUCE_LOW:.*]], %[[REDUCE_HIGH:.*]] = pto.vldsx2 {{.*}}, "DINTLV_B16"
 // VPTO: pto.vcgmax
 // VPTO: pto.vcvt {{.*}} {part = "EVEN", sat = "SAT"}
-// VPTO: pto.vsts {{.*}} {dist = "1PT_B32"}
+// VPTO: %[[SCALE_ALIGN_OUT:.*]], %[[SCALE_BASE_OUT:.*]] = pto.vstus %[[SCALE_ALIGN_ARG]], {{.*}}, {{.*}}, %[[SCALE_BASE_ARG]]
 // VPTO: %[[RECIP_LOW:.*]] = pto.vselr {{.*}} : !pto.vreg<128xbf16>, !pto.vreg<128xui16> -> !pto.vreg<128xbf16>
 // VPTO: %[[RECIP_HIGH:.*]] = pto.vselr {{.*}} : !pto.vreg<128xbf16>, !pto.vreg<128xui16> -> !pto.vreg<128xbf16>
 // VPTO: %[[QUANT_0:[^,]+]], %{{.*}} = pto.vlds {{.*}} {dist = "UNPK_B16"}
@@ -88,6 +87,8 @@
 // VPTO: pto.vsts %[[DEQUANT_BF16_1]], {{.*}} {dist = "PK_B32"}
 // VPTO: pto.vsts %[[DEQUANT_BF16_2]], {{.*}} {dist = "PK_B32"}
 // VPTO: pto.vsts %[[DEQUANT_BF16_3]], {{.*}} {dist = "PK_B32"}
+// VPTO: scf.yield %[[SCALE_BASE_OUT]], %[[SCALE_ALIGN_OUT]]
+// VPTO: pto.vstas %[[SCALE_LOOP]]#1, %[[SCALE_LOOP]]#0,
 
 module attributes {pto.target_arch = "a5"} {
   module attributes {pto.backend = "vpto", pto.kernel_kind = #pto.kernel_kind<vector>, pto.target_arch = "a5"} {

--- a/test/lit/vmi_new/opt/per_block_bf16_group8_quant_vmi_opt.pto
+++ b/test/lit/vmi_new/opt/per_block_bf16_group8_quant_vmi_opt.pto
@@ -21,10 +21,11 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
   func.func @per_block_bf16_group8_quant_vmi_opt(
       %src: !pto.ptr<bf16, ub>,
       %dst: !pto.ptr<f8E4M3FN, ub>,
-      %off: index) attributes {pto.kernel} {
+      %tile: index) attributes {pto.kernel} {
     %c128 = arith.constant 128 : index
     %c256 = arith.constant 256 : index
     %cst = arith.constant 0.000000e+00 : bf16
+    %off = arith.muli %tile, %c128 : index
     %off128 = arith.addi %off, %c128 : index
     %mask = pto.vmi.create_mask %c256
         : index -> !pto.vmi.mask<256xpred>

--- a/test/lit/vmi_new/vmi_compact_load_store_group_alias.pto
+++ b/test/lit/vmi_new/vmi_compact_load_store_group_alias.pto
@@ -124,19 +124,25 @@ module {
 // LOWER-LABEL: func.func @compact_2(
 // LOWER: pto.pset_b32 "PAT_VL2"
 // LOWER: pto.vsldb
-// LOWER: pto.vsts
+// LOWER: pto.init_align
+// LOWER: pto.vstus
+// LOWER: pto.vstas
 // LOWER-NOT: pto.vmi.
 
 // LOWER-LABEL: func.func @compact_4(
 // LOWER: pto.pset_b32 "PAT_VL4"
 // LOWER: pto.vsldb
-// LOWER: pto.vsts
+// LOWER: pto.init_align
+// LOWER: pto.vstus
+// LOWER: pto.vstas
 // LOWER-NOT: pto.vmi.
 
 // LOWER-LABEL: func.func @compact_8(
 // LOWER: pto.pset_b32 "PAT_VL8"
 // LOWER: pto.vsldb
-// LOWER: pto.vsts
+// LOWER: pto.init_align
+// LOWER: pto.vstus
+// LOWER: pto.vstas
 // LOWER-NOT: pto.vmi.
 
 // LOWER-LABEL: func.func @compact_reduce_through_elementwise(

--- a/test/lit/vmi_new/vmi_deinterleave_load_layout_propagation.pto
+++ b/test/lit/vmi_new/vmi_deinterleave_load_layout_propagation.pto
@@ -16,7 +16,9 @@ module {
       %acc: !pto.vmi.vreg<256xui16>,
       %full_mask: !pto.vmi.mask<256xpred>,
       %limit: ui32) -> !pto.vmi.vreg<256xui16> {
-    %low, %high = pto.vmi.vload %src[%offset] {dist_mode = "dintlv"}
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    %low, %high = pto.vmi.vload %src[%aligned_offset] {dist_mode = "dintlv"}
         : !pto.ptr<ui32, ub>
         -> !pto.vmi.vreg<256xui32>, !pto.vmi.vreg<256xui32>
     %valid = pto.vmi.vcmps %low, %limit, %full_mask {cmp = "lt"}
@@ -33,7 +35,9 @@ module {
   func.func @vmi_deinterleave_load_high_cast(
       %src: !pto.ptr<ui32, ub>,
       %offset: index) -> !pto.vmi.vreg<256xui8> {
-    %low, %high = pto.vmi.vload %src[%offset] {dist_mode = "dintlv"}
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    %low, %high = pto.vmi.vload %src[%aligned_offset] {dist_mode = "dintlv"}
         : !pto.ptr<ui32, ub>
         -> !pto.vmi.vreg<256xui32>, !pto.vmi.vreg<256xui32>
     %result = pto.vmi.vcvt %high {saturate = "SAT"}

--- a/test/lit/vmi_new/vmi_interleaved_memory_ops.pto
+++ b/test/lit/vmi_new/vmi_interleaved_memory_ops.pto
@@ -13,7 +13,9 @@ module {
   func.func @vmi_deinterleave_load(
       %src: !pto.ptr<f32, ub>,
       %offset: index) -> (!pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>) {
-    %low, %high = pto.vmi.vload %src[%offset] {dist_mode = "dintlv"}
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    %low, %high = pto.vmi.vload %src[%aligned_offset] {dist_mode = "dintlv"}
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>
     return %low, %high : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>
   }
@@ -23,7 +25,9 @@ module {
       %high: !pto.vmi.vreg<64xf32>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) {
-    pto.vmi.vstore %low, %high, %dst[%offset] {dist_mode = "intlv"}
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    pto.vmi.vstore %low, %high, %dst[%aligned_offset] {dist_mode = "intlv"}
         : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
     return
   }
@@ -36,7 +40,7 @@ module {
 // ASSIGN: return %[[LOW]], %[[HIGH]] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
 
 // LOWER-LABEL: func.func @vmi_deinterleave_load(
-// LOWER: %[[LOW:.*]], %[[HIGH:.*]] = pto.vldsx2 %arg0[%arg1], "DINTLV_B32"
+// LOWER: %[[LOW:.*]], %[[HIGH:.*]] = pto.vldsx2 %arg0[{{.*}}], "DINTLV_B32"
 // LOWER: return %[[LOW]], %[[HIGH]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.
@@ -50,7 +54,7 @@ module {
 
 // LOWER-LABEL: func.func @vmi_interleave_store(
 // LOWER: %[[MASK:.*]] = pto.pset_b32 "PAT_ALL"
-// LOWER: pto.vstsx2 %arg0, %arg1, %arg2[%arg3], "INTLV_B32", %[[MASK]]
+// LOWER: pto.vstsx2 %arg0, %arg1, %arg2[{{.*}}], "INTLV_B32", %[[MASK]]
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.
 // LOWER-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_lane_stride_dense_load_store.pto
+++ b/test/lit/vmi_new/vmi_lane_stride_dense_load_store.pto
@@ -16,7 +16,9 @@ module {
   func.func @vmi_layout_fold_load_lane_stride(
       %src: !pto.ptr<f16, ub>, %off: index)
       -> !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous, lane_stride = 2>> {
-    %load = pto.vmi.vload %src[%off] {dist_mode = "continuous"}
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
+    %load = pto.vmi.vload %src[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f16, ub>
         -> !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous>>
     %strided = pto.vmi.ensure_layout %load
@@ -29,10 +31,12 @@ module {
   func.func @vmi_layout_fold_store_lane_stride(
       %value: !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous, lane_stride = 2>>,
       %dst: !pto.ptr<f16, ub>, %off: index) {
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
     %compact = pto.vmi.ensure_layout %value
         : !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous, lane_stride = 2>>
         -> !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous>>
-    pto.vmi.vstore %compact, %dst[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %compact, %dst[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous>>,
           !pto.ptr<f16, ub>
     return
@@ -59,10 +63,12 @@ module {
   func.func @vmi_layout_fold_store_lane_stride_b32(
       %value: !pto.vmi.vreg<32xf32, #pto.vmi.layout<contiguous, lane_stride = 2>>,
       %dst: !pto.ptr<f32, ub>, %off: index) {
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %compact = pto.vmi.ensure_layout %value
         : !pto.vmi.vreg<32xf32, #pto.vmi.layout<contiguous, lane_stride = 2>>
         -> !pto.vmi.vreg<32xf32, #pto.vmi.layout<contiguous>>
-    pto.vmi.vstore %compact, %dst[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %compact, %dst[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<32xf32, #pto.vmi.layout<contiguous>>,
           !pto.ptr<f32, ub>
     return
@@ -70,13 +76,15 @@ module {
 
   func.func @vmi_layout_fold_load_store_lane_stride4_u8(
       %src: !pto.ptr<ui8, ub>, %dst: !pto.ptr<ui8, ub>, %off: index) {
-    %load = pto.vmi.vload %src[%off] {dist_mode = "continuous"}
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
+    %load = pto.vmi.vload %src[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<ui8, ub>
         -> !pto.vmi.vreg<64xui8, #pto.vmi.layout<contiguous>>
     %strided = pto.vmi.ensure_layout %load
         : !pto.vmi.vreg<64xui8, #pto.vmi.layout<contiguous>>
         -> !pto.vmi.vreg<64xui8, #pto.vmi.layout<contiguous, lane_stride = 4>>
-    pto.vmi.vstore %strided, %dst[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %strided, %dst[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<64xui8, #pto.vmi.layout<contiguous, lane_stride = 4>>,
           !pto.ptr<ui8, ub>
     return
@@ -197,7 +205,9 @@ module {
   func.func @vmi_load_extui_u8_u16_zero_gap(
       %src: !pto.ptr<ui8, ub>, %off: index)
       -> !pto.vmi.vreg<128xui16, #pto.vmi.layout<contiguous>> {
-    %load = pto.vmi.vload %src[%off] {dist_mode = "continuous"}
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
+    %load = pto.vmi.vload %src[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<ui8, ub>
         -> !pto.vmi.vreg<128xui8, #pto.vmi.layout<contiguous, lane_stride = 2>>
     %wide = pto.vmi.vcvt %load
@@ -210,7 +220,9 @@ module {
   func.func @vmi_load_extui_u16_u32_zero_gap(
       %src: !pto.ptr<ui16, ub>, %off: index)
       -> !pto.vmi.vreg<64xui32, #pto.vmi.layout<contiguous>> {
-    %load = pto.vmi.vload %src[%off] {dist_mode = "continuous"}
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
+    %load = pto.vmi.vload %src[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<ui16, ub>
         -> !pto.vmi.vreg<64xui16, #pto.vmi.layout<contiguous, lane_stride = 2>>
     %wide = pto.vmi.vcvt %load
@@ -223,7 +235,9 @@ module {
   func.func @vmi_load_extui_u8_u32_zero_gap(
       %src: !pto.ptr<ui8, ub>, %off: index)
       -> !pto.vmi.vreg<64xui32, #pto.vmi.layout<contiguous>> {
-    %load = pto.vmi.vload %src[%off] {dist_mode = "continuous"}
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
+    %load = pto.vmi.vload %src[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<ui8, ub>
         -> !pto.vmi.vreg<64xui8, #pto.vmi.layout<contiguous, lane_stride = 4>>
     %wide = pto.vmi.vcvt %load

--- a/test/lit/vmi_new/vmi_lane_stride_masked_store.pto
+++ b/test/lit/vmi_new/vmi_lane_stride_masked_store.pto
@@ -16,13 +16,15 @@ module {
       %value: !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous, lane_stride = 2>>,
       %mask: !pto.vmi.mask<64xb16, #pto.vmi.layout<contiguous, lane_stride = 2>>,
       %dst: !pto.ptr<f16, ub>, %offset: index) {
+    %c16 = arith.constant 16 : index
+    %aligned_offset = arith.muli %offset, %c16 : index
     %value_c = pto.vmi.ensure_layout %value
         : !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous, lane_stride = 2>>
         -> !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous>>
     %mask_c = pto.vmi.ensure_mask_layout %mask
         : !pto.vmi.mask<64xb16, #pto.vmi.layout<contiguous, lane_stride = 2>>
         -> !pto.vmi.mask<64xb16, #pto.vmi.layout<contiguous>>
-    pto.vmi.vstore %value_c, %dst[%offset], %mask_c {dist_mode = "continuous"}
+    pto.vmi.vstore %value_c, %dst[%aligned_offset], %mask_c {dist_mode = "continuous"}
         : !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous>>,
           !pto.ptr<f16, ub>,
           !pto.vmi.mask<64xb16, #pto.vmi.layout<contiguous>>
@@ -33,13 +35,15 @@ module {
       %value: !pto.vmi.vreg<64xui8, #pto.vmi.layout<contiguous, lane_stride = 4>>,
       %mask: !pto.vmi.mask<64xb8, #pto.vmi.layout<contiguous, lane_stride = 4>>,
       %dst: !pto.ptr<ui8, ub>, %offset: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_offset = arith.muli %offset, %c32 : index
     %value_c = pto.vmi.ensure_layout %value
         : !pto.vmi.vreg<64xui8, #pto.vmi.layout<contiguous, lane_stride = 4>>
         -> !pto.vmi.vreg<64xui8, #pto.vmi.layout<contiguous>>
     %mask_c = pto.vmi.ensure_mask_layout %mask
         : !pto.vmi.mask<64xb8, #pto.vmi.layout<contiguous, lane_stride = 4>>
         -> !pto.vmi.mask<64xb8, #pto.vmi.layout<contiguous>>
-    pto.vmi.vstore %value_c, %dst[%offset], %mask_c {dist_mode = "continuous"}
+    pto.vmi.vstore %value_c, %dst[%aligned_offset], %mask_c {dist_mode = "continuous"}
         : !pto.vmi.vreg<64xui8, #pto.vmi.layout<contiguous>>,
           !pto.ptr<ui8, ub>,
           !pto.vmi.mask<64xb8, #pto.vmi.layout<contiguous>>

--- a/test/lit/vmi_new/vmi_layout_assignment_broadcast_dense_group_users.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_broadcast_dense_group_users.pto
@@ -17,15 +17,17 @@ module {
       %off: index,
       %scale: f32) {
     %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
     %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %scale_v = pto.vmi.vbrc %scale
         : f32 -> !pto.vmi.vreg<256xf32>
-    %x = pto.vmi.vload %base[%off]
+    %x = pto.vmi.vload %base[%aligned_off]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
     %copy = pto.vmi.vadd %x, %scale_v
         : !pto.vmi.vreg<256xf32>, !pto.vmi.vreg<256xf32>
         -> !pto.vmi.vreg<256xf32>
-    pto.vmi.vstore %copy, %copy_out[%off]
+    pto.vmi.vstore %copy, %copy_out[%aligned_off]
         : !pto.vmi.vreg<256xf32>, !pto.ptr<f32, ub>
     %mask = pto.vmi.create_group_mask %c32
         {num_groups = 8, group_size = 32}
@@ -37,7 +39,7 @@ module {
         {group = 8, reassoc}
         : !pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred>
         -> !pto.vmi.vreg<8xf32>
-    pto.vmi.vstore %sum, %sum_out[%off], %c1 {group = 8}
+    pto.vmi.vstore %sum, %sum_out[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_broadcast_remat.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_broadcast_remat.pto
@@ -15,6 +15,8 @@ module {
       %src: !pto.vmi.vreg<128xf16>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) -> !pto.vmi.vreg<128xf32> {
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
     %broadcast = pto.vmi.vbrc %scalar
         : f32 -> !pto.vmi.vreg<128xf32>
     %wide = pto.vmi.vcvt %src
@@ -22,7 +24,7 @@ module {
     %sum = pto.vmi.vadd %broadcast, %wide
         : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>
         -> !pto.vmi.vreg<128xf32>
-    pto.vmi.vstore %broadcast, %dst[%offset]
+    pto.vmi.vstore %broadcast, %dst[%aligned_offset]
         : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
     return %sum : !pto.vmi.vreg<128xf32>
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_call_argument_boundary.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_call_argument_boundary.pto
@@ -27,13 +27,15 @@ module {
   func.func @caller(%base: !pto.ptr<f32, ub>,
                     %out: !pto.ptr<f32, ub>,
                     %off: index) {
+    %c8 = arith.constant 8 : index
     %c32 = arith.constant 32 : index
-    %x = pto.vmi.vload %base[%off]
+    %aligned_off = arith.muli %off, %c8 : index
+    %x = pto.vmi.vload %base[%aligned_off]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
     %mask = pto.vmi.create_group_mask %c32
         {num_groups = 8, group_size = 32}
         : index -> !pto.vmi.mask<256xpred>
-    call @consume(%x, %mask, %out, %off)
+    call @consume(%x, %mask, %out, %aligned_off)
         : (!pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred>,
            !pto.ptr<f32, ub>, index) -> ()
     return
@@ -65,7 +67,9 @@ module {
 // LOWER: pto.vdintlv
 // LOWER: pto.pdintlv_b32
 // LOWER-COUNT-4: pto.vcgadd
-// LOWER: pto.vsts
+// LOWER: pto.init_align
+// LOWER: pto.vstus
+// LOWER: pto.vstas
 // LOWER-LABEL: func.func @caller(
 // LOWER: call @consume(
 // LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_cmp_mask_granularity.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_cmp_mask_granularity.pto
@@ -15,11 +15,13 @@ module {
       %rhs: !pto.vmi.vreg<64xf32>,
       %dst: !pto.ptr<bf16, ub>,
       %offset: index) {
+    %c16 = arith.constant 16 : index
+    %aligned_offset = arith.muli %offset, %c16 : index
     %mask = pto.vmi.cmpf "olt", %lhs, %rhs
         : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32> -> !pto.vmi.mask<64xpred>
     %value = pto.vmi.truncf %lhs {saturate = "SAT"}
         : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xbf16>
-    pto.vmi.masked_store %value, %dst[%offset], %mask
+    pto.vmi.masked_store %value, %dst[%aligned_offset], %mask
         : !pto.vmi.vreg<64xbf16>, !pto.ptr<bf16, ub>, !pto.vmi.mask<64xpred>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_constant_remat.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_constant_remat.pto
@@ -14,6 +14,8 @@ module {
       %src: !pto.vmi.vreg<128xf16>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) -> !pto.vmi.vreg<128xf32> {
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
     %constant = "pto.vmi.constant"() {
       value = dense<1.000000e+00> : tensor<128xf32>
     } : () -> !pto.vmi.vreg<128xf32>
@@ -22,7 +24,7 @@ module {
     %sum = pto.vmi.vadd %constant, %wide
         : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>
         -> !pto.vmi.vreg<128xf32>
-    pto.vmi.vstore %constant, %dst[%offset]
+    pto.vmi.vstore %constant, %dst[%aligned_offset]
         : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
     return %sum : !pto.vmi.vreg<128xf32>
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_create_group_mask_s32_dynamic.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_create_group_mask_s32_dynamic.pto
@@ -17,12 +17,14 @@ module {
       %active_cols: index) {
     %c0_f32 = arith.constant 0.000000e+00 : f32
     %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %mask = pto.vmi.create_group_mask %active_cols
         {num_groups = 8, group_size = 32}
         : index -> !pto.vmi.mask<256xpred>
     %zero = pto.vmi.vbrc %c0_f32
         : f32 -> !pto.vmi.vreg<256xf32>
-    %loaded = pto.vmi.vload %base[%off]
+    %loaded = pto.vmi.vload %base[%aligned_off]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
     %x = pto.vmi.vsel %mask, %loaded, %zero
         : !pto.vmi.mask<256xpred>, !pto.vmi.vreg<256xf32>,
@@ -30,7 +32,7 @@ module {
     %sum = pto.vmi.vcadd %x, %mask {group = 8, reassoc}
         : !pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred>
         -> !pto.vmi.vreg<8xf32>
-    pto.vmi.vstore %sum, %sum_out[%off], %c1 {group = 8}
+    pto.vmi.vstore %sum, %sum_out[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
     return
   }
@@ -56,6 +58,7 @@ module {
 // LOWER-COUNT-4: pto.pdintlv_b32
 // LOWER-COUNT-4: pto.vcgadd
 // LOWER: pto.vsts
+// LOWER-NOT: pto.vstus
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.
 // LOWER-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_layout_assignment_dense_f16_f32_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_dense_f16_f32_store.pto
@@ -14,11 +14,13 @@ module {
       %src: !pto.ptr<f16, ub>,
       %dst: !pto.ptr<f32, ub>,
       %off: index) {
-    %x16 = pto.vmi.vload %src[%off]
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
+    %x16 = pto.vmi.vload %src[%aligned_off]
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
     %x32 = pto.vmi.vcvt %x16
         : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
-    pto.vmi.vstore %x32, %dst[%off]
+    pto.vmi.vstore %x32, %dst[%aligned_off]
         : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
     return
   }
@@ -27,11 +29,13 @@ module {
       %src: !pto.ptr<f16, ub>,
       %dst: !pto.ptr<f32, ub>,
       %off: index) {
-    %x16 = pto.vmi.vload %src[%off]
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
+    %x16 = pto.vmi.vload %src[%aligned_off]
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<256xf16>
     %x32 = pto.vmi.vcvt %x16
         : !pto.vmi.vreg<256xf16> -> !pto.vmi.vreg<256xf32>
-    pto.vmi.vstore %x32, %dst[%off]
+    pto.vmi.vstore %x32, %dst[%aligned_off]
         : !pto.vmi.vreg<256xf32>, !pto.ptr<f32, ub>
     return
   }
@@ -40,11 +44,13 @@ module {
       %src: !pto.ptr<f16, ub>,
       %dst: !pto.ptr<f32, ub>,
       %off: index) {
-    %x16 = pto.vmi.vload %src[%off]
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
+    %x16 = pto.vmi.vload %src[%aligned_off]
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<64xf16>
     %x32 = pto.vmi.vcvt %x16
         : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xf32>
-    pto.vmi.vstore %x32, %dst[%off]
+    pto.vmi.vstore %x32, %dst[%aligned_off]
         : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
     return
   }
@@ -53,15 +59,17 @@ module {
       %src: !pto.ptr<f16, ub>,
       %dst: !pto.ptr<f16, ub>,
       %off: index) {
+    %c16 = arith.constant 16 : index
     %c64 = arith.constant 64 : index
+    %aligned_off = arith.muli %off, %c16 : index
     %mask = pto.vmi.create_mask %c64 : index -> !pto.vmi.mask<64xpred>
-    %x16 = pto.vmi.vload %src[%off]
+    %x16 = pto.vmi.vload %src[%aligned_off]
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<64xf16>
     %x32 = pto.vmi.vcvt %x16
         : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xf32>
     %y16 = pto.vmi.vcvt %x32 {saturate = "SAT"}
         : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf16>
-    pto.vmi.vstore %y16, %dst[%off], %mask
+    pto.vmi.vstore %y16, %dst[%aligned_off], %mask
         : !pto.vmi.vreg<64xf16>, !pto.ptr<f16, ub>, !pto.vmi.mask<64xpred>
     return
   }
@@ -70,11 +78,13 @@ module {
       %src: !pto.ptr<f32, ub>,
       %dst: !pto.ptr<f16, ub>,
       %off: index) {
-    %x32 = pto.vmi.vload %src[%off]
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
+    %x32 = pto.vmi.vload %src[%aligned_off]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
     %x16 = pto.vmi.vcvt %x32 {saturate = "SAT"}
         : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf16>
-    pto.vmi.vstore %x16, %dst[%off]
+    pto.vmi.vstore %x16, %dst[%aligned_off]
         : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>
     return
   }
@@ -83,11 +93,13 @@ module {
       %src: !pto.ptr<f32, ub>,
       %dst: !pto.ptr<f16, ub>,
       %off: index) {
-    %x32 = pto.vmi.vload %src[%off]
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
+    %x32 = pto.vmi.vload %src[%aligned_off]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
     %x16 = pto.vmi.vcvt %x32 {saturate = "SAT"}
         : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf16>
-    pto.vmi.vstore %x16, %dst[%off]
+    pto.vmi.vstore %x16, %dst[%aligned_off]
         : !pto.vmi.vreg<256xf16>, !pto.ptr<f16, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_dense_group_reduce_multi_consumer.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_dense_group_reduce_multi_consumer.pto
@@ -16,15 +16,17 @@ module {
       %copy_out: !pto.ptr<f32, ub>,
       %off: index) {
     %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
     %c256 = arith.constant 256 : index
-    %x = pto.vmi.vload %src[%off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
+    %aligned_off = arith.muli %off, %c8 : index
+    %x = pto.vmi.vload %src[%aligned_off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
     %mask = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xpred>
     %sum = pto.vmi.vcadd %x, %mask {group = 8, reassoc}
         : !pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred>
         -> !pto.vmi.vreg<8xf32>
-    pto.vmi.vstore %sum, %sum_out[%off], %c1 {group = 8}
+    pto.vmi.vstore %sum, %sum_out[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
-    pto.vmi.vstore %x, %copy_out[%off]
+    pto.vmi.vstore %x, %copy_out[%aligned_off]
         : !pto.vmi.vreg<256xf32>, !pto.ptr<f32, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_dense_store_group_slots.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_dense_store_group_slots.pto
@@ -34,5 +34,7 @@ module {
 
 // LOWER-LABEL: func.func @vmi_layout_assignment_dense_store_group_slots(
 // LOWER: pto.vcgadd
-// LOWER: pto.vsts
+// LOWER: pto.init_align
+// LOWER: pto.vstus
+// LOWER: pto.vstas
 // LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_f32_f8_store_reduce.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_f32_f8_store_reduce.pto
@@ -16,18 +16,20 @@ module {
       %out8: !pto.ptr<f8E4M3FN, ub>,
       %off: index) {
     %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
     %c256 = arith.constant 256 : index
-    %x32 = pto.vmi.vload %src[%off]
+    %aligned_off = arith.muli %off, %c32 : index
+    %x32 = pto.vmi.vload %src[%aligned_off]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
     %mask = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xpred>
     %sumv = pto.vmi.vcadd %x32, %mask {group = 8, reassoc}
         : !pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred>
         -> !pto.vmi.vreg<8xf32>
-    pto.vmi.vstore %sumv, %sum[%off], %c1 {group = 8}
+    pto.vmi.vstore %sumv, %sum[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
     %x8 = pto.vmi.vcvt %x32 {saturate = "SAT"}
         : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
-    pto.vmi.vstore %x8, %out8[%off]
+    pto.vmi.vstore %x8, %out8[%aligned_off]
         : !pto.vmi.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_f8_compute_f8.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_f8_compute_f8.pto
@@ -15,7 +15,9 @@ module {
       %scale: f32,
       %dst: !pto.ptr<f8E4M3FN, ub>,
       %off: index) {
-    %x8 = pto.vmi.vload %src[%off]
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
+    %x8 = pto.vmi.vload %src[%aligned_off]
         : !pto.ptr<f8E4M3FN, ub> -> !pto.vmi.vreg<256xf8E4M3FN>
     %x32 = pto.vmi.vcvt %x8
         : !pto.vmi.vreg<256xf8E4M3FN> -> !pto.vmi.vreg<256xf32>
@@ -26,7 +28,7 @@ module {
         -> !pto.vmi.vreg<256xf32>
     %y8 = pto.vmi.vcvt %y32 {saturate = "SAT"}
         : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
-    pto.vmi.vstore %y8, %dst[%off]
+    pto.vmi.vstore %y8, %dst[%aligned_off]
         : !pto.vmi.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_group_broadcast_load_e2b_b16.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_broadcast_load_e2b_b16.pto
@@ -12,7 +12,9 @@ module {
   func.func @vmi_layout_assignment_group_broadcast_load_e2b_b16(
       %src: !pto.ptr<bf16, ub>, %off: index) -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<contiguous>> {
     %c1 = arith.constant 1 : index
-    %out = pto.vmi.vload %src[%off], %c1 {dist_mode = "brc", group = 8}
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
+    %out = pto.vmi.vload %src[%aligned_off], %c1 {dist_mode = "brc", group = 8}
         : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<contiguous>>
     return %out : !pto.vmi.vreg<256xbf16, #pto.vmi.layout<contiguous>>
   }
@@ -20,7 +22,9 @@ module {
   func.func @vmi_layout_assignment_group_broadcast_load_e2b_b32(
       %src: !pto.ptr<f32, ub>, %off: index) -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>> {
     %c1 = arith.constant 1 : index
-    %out = pto.vmi.vload %src[%off], %c1 {dist_mode = "brc", group = 8}
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
+    %out = pto.vmi.vload %src[%aligned_off], %c1 {dist_mode = "brc", group = 8}
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
     return %out : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
   }
@@ -28,7 +32,9 @@ module {
   func.func @vmi_layout_assignment_group_broadcast_load_e2b_b32_deint4(
       %src: !pto.ptr<f32, ub>, %off: index) -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>> {
     %c1 = arith.constant 1 : index
-    %out = pto.vmi.vload %src[%off], %c1 {dist_mode = "brc", group = 8}
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
+    %out = pto.vmi.vload %src[%aligned_off], %c1 {dist_mode = "brc", group = 8}
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
     return %out : !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
   }
@@ -51,12 +57,12 @@ module {
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_broadcast_load_e2b_b32
 // CHECK-SAME: (%[[SRC32:.*]]: !pto.ptr<f32, ub>, %[[OFF32:.*]]: index)
-// CHECK: %[[E2B32:.*]] = pto.vlds %[[SRC32]][%[[OFF32]]] {dist = "E2B_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK: %[[E2B32:.*]] = pto.vlds %[[SRC32]][{{.*}}] {dist = "E2B_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 // CHECK: return %[[E2B32]] : !pto.vreg<64xf32>
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_broadcast_load_e2b_b32_deint4
 // CHECK-SAME: (%[[SRC32D4:.*]]: !pto.ptr<f32, ub>, %[[OFF32D4:.*]]: index)
-// CHECK: %[[E2B32D4:.*]] = pto.vlds %[[SRC32D4]][%[[OFF32D4]]] {dist = "E2B_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK: %[[E2B32D4:.*]] = pto.vlds %[[SRC32D4]][{{.*}}] {dist = "E2B_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 // CHECK-NOT: pto.vselr
 // CHECK: return %[[E2B32D4]], %[[E2B32D4]], %[[E2B32D4]], %[[E2B32D4]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>
 

--- a/test/lit/vmi_new/vmi_layout_assignment_group_broadcast_multi_consumer.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_broadcast_multi_consumer.pto
@@ -16,8 +16,10 @@ module {
       %dense_out: !pto.ptr<f16, ub>,
       %off: index) {
     %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
     %c128 = arith.constant 128 : index
-    %x = pto.vmi.vload %src[%off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
+    %aligned_off = arith.muli %off, %c16 : index
+    %x = pto.vmi.vload %src[%aligned_off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
     %mask = pto.vmi.create_mask %c128 : index -> !pto.vmi.mask<128xpred>
     %sum = pto.vmi.vcadd %x, %mask {group = 8, reassoc}
         : !pto.vmi.vreg<128xf32>, !pto.vmi.mask<128xpred>
@@ -30,13 +32,13 @@ module {
     %ysum = pto.vmi.vcadd %y, %mask {group = 8, reassoc}
         : !pto.vmi.vreg<128xf32>, !pto.vmi.mask<128xpred>
         -> !pto.vmi.vreg<8xf32>
-    pto.vmi.vstore %ysum, %sum_out[%off], %c1 {group = 8}
+    pto.vmi.vstore %ysum, %sum_out[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
     %b_for_cast = pto.vmi.vbrc %sum {group = 8}
         : !pto.vmi.vreg<8xf32> -> !pto.vmi.vreg<128xf32>
     %h = pto.vmi.vcvt %b_for_cast {saturate = "SAT"}
         : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf16>
-    pto.vmi.vstore %h, %dense_out[%off]
+    pto.vmi.vstore %h, %dense_out[%aligned_off]
         : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_maxf_quant.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_maxf_quant.pto
@@ -16,11 +16,13 @@ module {
       %out8: !pto.ptr<f8E4M3FN, ub>,
       %off: index) {
     %c8 = arith.constant 8 : index
+    %c32 = arith.constant 32 : index
     %c256 = arith.constant 256 : index
     %eps = arith.constant 1.000000e-04 : f32
     %fp8_max = arith.constant 4.480000e+02 : f32
     %mask = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xpred>
-    %x = pto.vmi.vload %src[%off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
+    %aligned_off = arith.muli %off, %c32 : index
+    %x = pto.vmi.vload %src[%aligned_off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
     %abs = pto.vmi.vabs %x : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf32>
     %amax_raw = pto.vmi.vcmax %abs, %mask {group = 2}
         : !pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred>
@@ -33,7 +35,7 @@ module {
     %scale = pto.vmi.vdiv %amax, %fp8_max2
         : !pto.vmi.vreg<2xf32>, !pto.vmi.vreg<2xf32>
         -> !pto.vmi.vreg<2xf32>
-    pto.vmi.vstore %scale, %scale_out[%off], %c8 {group = 2}
+    pto.vmi.vstore %scale, %scale_out[%aligned_off], %c8 {group = 2}
         : !pto.vmi.vreg<2xf32>, !pto.ptr<f32, ub>
     %scale_vec = pto.vmi.vbrc %scale {group = 2}
         : !pto.vmi.vreg<2xf32> -> !pto.vmi.vreg<256xf32>
@@ -42,7 +44,7 @@ module {
         -> !pto.vmi.vreg<256xf32>
     %q8 = pto.vmi.vcvt %q {saturate = "SAT"}
         : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
-    pto.vmi.vstore %q8, %out8[%off]
+    pto.vmi.vstore %q8, %out8[%aligned_off]
         : !pto.vmi.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s16_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s16_store.pto
@@ -45,8 +45,10 @@ module {
 // LOWER: %[[SLO:.*]] = pto.vcgadd %[[LO]], %[[MLO]]
 // LOWER: %[[SHI:.*]] = pto.vcgadd %[[HI]], %[[MHI]]
 // LOWER: %[[SUM:.*]] = pto.vadd %[[SLO]], %[[SHI]], %[[VL8]]
-// LOWER: %[[STORE_MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
-// LOWER: pto.vsts %[[SUM]], %arg4[%arg5], %[[STORE_MASK]]
+// LOWER: %[[BASE:.*]] = pto.addptr %arg4, %arg5
+// LOWER: %[[ALIGN:.*]] = pto.init_align
+// LOWER: %[[NEXT_ALIGN:.*]], %[[NEXT_BASE:.*]] = pto.vstus %[[ALIGN]], %{{.*}}, %[[SUM]], %[[BASE]]
+// LOWER: pto.vstas %[[NEXT_ALIGN]], %[[NEXT_BASE]], %{{.*}}
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.
 // LOWER-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s16_truncf_broadcast_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s16_truncf_broadcast_store.pto
@@ -15,6 +15,8 @@ module {
       %mask: !pto.vmi.mask<128xpred>,
       %dst: !pto.ptr<f16, ub>,
       %off: index) {
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
     %sum32 = pto.vmi.vcadd %source, %mask {group = 8, reassoc}
         : !pto.vmi.vreg<128xf32>, !pto.vmi.mask<128xpred>
         -> !pto.vmi.vreg<8xf32>
@@ -22,7 +24,7 @@ module {
         : !pto.vmi.vreg<8xf32> -> !pto.vmi.vreg<128xf32>
     %rows16 = pto.vmi.vcvt %rows32 {saturate = "SAT"}
         : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf16>
-    pto.vmi.vstore %rows16, %dst[%off]
+    pto.vmi.vstore %rows16, %dst[%aligned_off]
         : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s32_broadcast_reduce.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s32_broadcast_reduce.pto
@@ -56,7 +56,9 @@ module {
 // LOWER-NOT: pto.vsel {{.*}}
 // LOWER-NOT: pto.vdup
 // LOWER-COUNT-4: pto.vmul
-// LOWER: pto.vsts {{.*}}, %arg8[%arg9], {{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// LOWER: pto.init_align
+// LOWER: pto.vstus
+// LOWER: pto.vstas
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.
 // LOWER-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s32_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s32_store.pto
@@ -44,8 +44,9 @@ module {
 // LOWER: %[[VL8:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // LOWER-COUNT-4: pto.vcgadd
 // LOWER-COUNT-3: pto.vadd {{.*}}, {{.*}}, %[[VL8]]
-// LOWER: %[[STORE_MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
-// LOWER: pto.vsts {{.*}}, %arg8[%arg9], %[[STORE_MASK]]
+// LOWER: pto.init_align
+// LOWER: pto.vstus
+// LOWER: pto.vstas
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.
 // LOWER-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s64_tail_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s64_tail_store.pto
@@ -14,12 +14,13 @@ module {
       %src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f32, ub>, %off: index) {
     %c8 = arith.constant 8 : index
     %c384 = arith.constant 384 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %mask = pto.vmi.create_mask %c384 : index -> !pto.vmi.mask<384xpred>
-    %x = pto.vmi.vload %src[%off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<384xf32>
+    %x = pto.vmi.vload %src[%aligned_off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<384xf32>
     %sum = pto.vmi.vcadd %x, %mask {group = 6, reassoc}
         : !pto.vmi.vreg<384xf32>, !pto.vmi.mask<384xpred>
         -> !pto.vmi.vreg<6xf32>
-    pto.vmi.vstore %sum, %dst[%off], %c8 {group = 6}
+    pto.vmi.vstore %sum, %dst[%aligned_off], %c8 {group = 6}
         : !pto.vmi.vreg<6xf32>, !pto.ptr<f32, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_slots8_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_slots8_store.pto
@@ -36,8 +36,9 @@ module {
 
 // LOWER-LABEL: func.func @vmi_layout_assignment_group_reduce_slots8_store(
 // LOWER: %[[SUM:.*]] = pto.vcgadd %arg0, %arg1 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-// LOWER: %[[STORE_MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
-// LOWER: pto.vsts %[[SUM]], %arg2[%arg3], %[[STORE_MASK]] : !pto.vreg<64xf32>, {{(!pto\.ptr)?<f32, ub>}}, !pto.mask<b32>
+// LOWER: %[[ALIGN:.*]] = pto.init_align
+// LOWER: %[[NEXT_ALIGN:.*]], %[[NEXT_BASE:.*]] = pto.vstus %[[ALIGN]], %{{.*}}, %[[SUM]], %{{.*}}
+// LOWER: pto.vstas %[[NEXT_ALIGN]], %[[NEXT_BASE]], %{{.*}}
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.
 // LOWER-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_layout_assignment_group_slot_broadcast_load_e2b_b16.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_slot_broadcast_load_e2b_b16.pto
@@ -12,7 +12,9 @@ module {
   func.func @vmi_layout_assignment_group_slot_broadcast_load_e2b_b16(
       %src: !pto.ptr<f16, ub>, %off: index) -> !pto.vmi.vreg<256xf16> {
     %c1 = arith.constant 1 : index
-    %slots = pto.vmi.vload %src[%off], %c1 {group = 16}
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
+    %slots = pto.vmi.vload %src[%aligned_off], %c1 {group = 16}
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<16xf16>
     %out = pto.vmi.vbrc %slots {group = 16}
         : !pto.vmi.vreg<16xf16> -> !pto.vmi.vreg<256xf16>
@@ -22,7 +24,9 @@ module {
   func.func @vmi_layout_assignment_group_slot_broadcast_load_e2b_b16_deint2(
       %src: !pto.ptr<bf16, ub>, %off: index) -> !pto.vmi.vreg<256xbf16> {
     %c1 = arith.constant 1 : index
-    %slots = pto.vmi.vload %src[%off], %c1 {group = 8}
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
+    %slots = pto.vmi.vload %src[%aligned_off], %c1 {group = 8}
         : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<8xbf16>
     %out = pto.vmi.vbrc %slots {group = 8}
         : !pto.vmi.vreg<8xbf16> -> !pto.vmi.vreg<256xbf16>
@@ -32,7 +36,9 @@ module {
   func.func @vmi_layout_assignment_group_slot_broadcast_load_e2b_b32(
       %src: !pto.ptr<f32, ub>, %off: index) -> !pto.vmi.vreg<64xf32> {
     %c1 = arith.constant 1 : index
-    %slots = pto.vmi.vload %src[%off], %c1 {group = 8}
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
+    %slots = pto.vmi.vload %src[%aligned_off], %c1 {group = 8}
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<8xf32>
     %out = pto.vmi.vbrc %slots {group = 8}
         : !pto.vmi.vreg<8xf32> -> !pto.vmi.vreg<64xf32>
@@ -42,7 +48,9 @@ module {
   func.func @vmi_layout_assignment_group_slot_broadcast_load_e2b_b32_deint2(
       %src: !pto.ptr<f32, ub>, %off: index) -> !pto.vmi.vreg<128xf32> {
     %c1 = arith.constant 1 : index
-    %slots = pto.vmi.vload %src[%off], %c1 {group = 8}
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
+    %slots = pto.vmi.vload %src[%aligned_off], %c1 {group = 8}
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<8xf32>
     %out = pto.vmi.vbrc %slots {group = 8}
         : !pto.vmi.vreg<8xf32> -> !pto.vmi.vreg<128xf32>
@@ -59,15 +67,15 @@ module {
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_slot_broadcast_load_e2b_b16_deint2
 // CHECK-SAME: (%[[SRC2:.*]]: !pto.ptr<bf16, ub>, %[[OFF2:.*]]: index)
-// CHECK: %[[E2B2:.*]] = pto.vlds %[[SRC2]][%[[OFF2]]] {dist = "E2B_B16"} : !pto.ptr<bf16, ub> -> !pto.vreg<128xbf16>
+// CHECK: %[[E2B2:.*]] = pto.vlds %[[SRC2]][{{.*}}] {dist = "E2B_B16"} : !pto.ptr<bf16, ub> -> !pto.vreg<128xbf16>
 // CHECK: return %[[E2B2]], %[[E2B2]] : !pto.vreg<128xbf16>, !pto.vreg<128xbf16>
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_slot_broadcast_load_e2b_b32
 // CHECK-SAME: (%[[SRC3:.*]]: !pto.ptr<f32, ub>, %[[OFF3:.*]]: index)
-// CHECK: %[[E2B3:.*]] = pto.vlds %[[SRC3]][%[[OFF3]]] {dist = "E2B_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK: %[[E2B3:.*]] = pto.vlds %[[SRC3]][{{.*}}] {dist = "E2B_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 // CHECK: return %[[E2B3]] : !pto.vreg<64xf32>
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_slot_broadcast_load_e2b_b32_deint2
 // CHECK-SAME: (%[[SRC4:.*]]: !pto.ptr<f32, ub>, %[[OFF4:.*]]: index)
-// CHECK: %[[E2B4:.*]] = pto.vlds %[[SRC4]][%[[OFF4]]] {dist = "E2B_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK: %[[E2B4:.*]] = pto.vlds %[[SRC4]][{{.*}}] {dist = "E2B_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 // CHECK: return %[[E2B4]], %[[E2B4]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>

--- a/test/lit/vmi_new/vmi_layout_assignment_group_slot_load_dual_layout.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_slot_load_dual_layout.pto
@@ -65,7 +65,9 @@ module {
 // LOWER-LABEL: func.func @vmi_layout_assignment_group_slot_load_dual_layout(
 // LOWER: pto.pset_b32 "PAT_VL8"
 // LOWER: pto.vsldb
-// LOWER: pto.vsts {{.*}}, %arg21[%arg23], {{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// LOWER: pto.init_align
+// LOWER: pto.vstus
+// LOWER: pto.vstas
 // LOWER-COUNT-8: pto.vsldb
 // LOWER-COUNT-8: pto.vsts
 // LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_group_slots_cf_join.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_slots_cf_join.pto
@@ -16,26 +16,28 @@ module {
       %dst: !pto.ptr<f32, ub>,
       %off: index) {
     %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
     %c128 = arith.constant 128 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %mask = pto.vmi.create_mask %c128 : index -> !pto.vmi.mask<128xpred>
     %sum = scf.if %cond -> !pto.vmi.vreg<8xf32> {
-      %x = pto.vmi.vload %src[%off]
+      %x = pto.vmi.vload %src[%aligned_off]
           : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
       %a = pto.vmi.vcadd %x, %mask {group = 8, reassoc}
           : !pto.vmi.vreg<128xf32>, !pto.vmi.mask<128xpred>
           -> !pto.vmi.vreg<8xf32>
       scf.yield %a : !pto.vmi.vreg<8xf32>
     } else {
-      %b = pto.vmi.vload %rhs[%off], %c1 {group = 8}
+      %b = pto.vmi.vload %rhs[%aligned_off], %c1 {group = 8}
           : !pto.ptr<f32, ub> -> !pto.vmi.vreg<8xf32>
       scf.yield %b : !pto.vmi.vreg<8xf32>
     }
-    %bias = pto.vmi.vload %rhs[%off], %c1 {group = 8}
+    %bias = pto.vmi.vload %rhs[%aligned_off], %c1 {group = 8}
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<8xf32>
     %out = pto.vmi.vadd %sum, %bias
         : !pto.vmi.vreg<8xf32>, !pto.vmi.vreg<8xf32>
         -> !pto.vmi.vreg<8xf32>
-    pto.vmi.vstore %out, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %out, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_group_slots_fanout.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_slots_fanout.pto
@@ -53,11 +53,15 @@ module {
 
 // LOWER-LABEL: func.func @vmi_layout_assignment_group_slots_fanout(
 // LOWER: %[[FIRST_SUM:.*]] = pto.vadd {{.*}}, {{.*}}, {{.*}} : !pto.vreg<64xf32>
-// LOWER: pto.vsts %[[FIRST_SUM]], %arg4[%arg6], {{.*}} : !pto.vreg<64xf32>, {{(!pto\.ptr)?<f32, ub>}}, !pto.mask<b32>
+// LOWER: pto.init_align
+// LOWER: pto.vstus {{.*}}, %[[FIRST_SUM]],
+// LOWER: pto.vstas
 // LOWER: pto.vselr %[[FIRST_SUM]]
 // LOWER: pto.vselr %[[FIRST_SUM]]
 // LOWER-COUNT-2: pto.vmul
-// LOWER: pto.vsts {{.*}}, %arg5[%arg6], {{.*}} : !pto.vreg<64xf32>, {{(!pto\.ptr)?<f32, ub>}}, !pto.mask<b32>
+// LOWER: pto.init_align
+// LOWER: pto.vstus
+// LOWER: pto.vstas
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.
 // LOWER-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_layout_assignment_group_store_slots1_unit_stride.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_store_slots1_unit_stride.pto
@@ -15,11 +15,13 @@ module {
       %dst: !pto.ptr<f32, ub>,
       %off: index) {
     %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %sum = pto.vmi.vcadd %source, %mask
         {group = 8, reassoc}
         : !pto.vmi.vreg<512xf32>, !pto.vmi.mask<512xpred>
         -> !pto.vmi.vreg<8xf32>
-    pto.vmi.vstore %sum, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %sum, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
     return
   }
@@ -27,8 +29,10 @@ module {
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_store_slots1_unit_stride(
 // CHECK-COUNT-8: pto.vcadd
-// CHECK: pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
-// CHECK-COUNT-8: pto.vsts {{.*}} {dist = "1PT_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// CHECK-COUNT-8: pto.vdup
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vstus
+// CHECK-NOT: dist = "1PT_B32"
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_layout_assignment_intlv_lane_stride.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_intlv_lane_stride.pto
@@ -15,11 +15,13 @@ module {
   func.func @f16_ls2(
       %src0: !pto.ptr<f16, ub>, %src1: !pto.ptr<f16, ub>,
       %dst0: !pto.ptr<f16, ub>, %dst1: !pto.ptr<f16, ub>, %off: index) {
+    %c16 = arith.constant 16 : index
     %c64 = arith.constant 64 : index
+    %aligned_off = arith.muli %off, %c16 : index
     %mask = pto.vmi.create_mask %c64 : index -> !pto.vmi.mask<64xpred>
-    %a = pto.vmi.vload %src0[%off] {dist_mode = "continuous"}
+    %a = pto.vmi.vload %src0[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<64xf16>
-    %b = pto.vmi.vload %src1[%off] {dist_mode = "continuous"}
+    %b = pto.vmi.vload %src1[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<64xf16>
     %even, %odd = pto.vmi.vdintlv %a, %b, %mask
         : !pto.vmi.vreg<64xf16>, !pto.vmi.vreg<64xf16>,
@@ -29,9 +31,9 @@ module {
         : !pto.vmi.vreg<64xf16>, !pto.vmi.vreg<64xf16>,
           !pto.vmi.mask<64xpred>
         -> !pto.vmi.vreg<64xf16>, !pto.vmi.vreg<64xf16>
-    pto.vmi.vstore %lo, %dst0[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %lo, %dst0[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<64xf16>, !pto.ptr<f16, ub>
-    pto.vmi.vstore %hi, %dst1[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %hi, %dst1[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<64xf16>, !pto.ptr<f16, ub>
     return
   }
@@ -40,11 +42,13 @@ module {
       %src0: !pto.ptr<f8E4M3FN, ub>, %src1: !pto.ptr<f8E4M3FN, ub>,
       %dst0: !pto.ptr<f8E4M3FN, ub>, %dst1: !pto.ptr<f8E4M3FN, ub>,
       %off: index) {
+    %c32 = arith.constant 32 : index
     %c128 = arith.constant 128 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %mask = pto.vmi.create_mask %c128 : index -> !pto.vmi.mask<128xpred>
-    %a = pto.vmi.vload %src0[%off] {dist_mode = "continuous"}
+    %a = pto.vmi.vload %src0[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f8E4M3FN, ub> -> !pto.vmi.vreg<128xf8E4M3FN>
-    %b = pto.vmi.vload %src1[%off] {dist_mode = "continuous"}
+    %b = pto.vmi.vload %src1[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f8E4M3FN, ub> -> !pto.vmi.vreg<128xf8E4M3FN>
     %even, %odd = pto.vmi.vdintlv %a, %b, %mask
         : !pto.vmi.vreg<128xf8E4M3FN>, !pto.vmi.vreg<128xf8E4M3FN>,
@@ -54,9 +58,9 @@ module {
         : !pto.vmi.vreg<128xf8E4M3FN>, !pto.vmi.vreg<128xf8E4M3FN>,
           !pto.vmi.mask<128xpred>
         -> !pto.vmi.vreg<128xf8E4M3FN>, !pto.vmi.vreg<128xf8E4M3FN>
-    pto.vmi.vstore %lo, %dst0[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %lo, %dst0[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<128xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>
-    pto.vmi.vstore %hi, %dst1[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %hi, %dst1[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<128xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>
     return
   }
@@ -64,11 +68,13 @@ module {
   func.func @ui8_ls4(
       %src0: !pto.ptr<ui8, ub>, %src1: !pto.ptr<ui8, ub>,
       %dst0: !pto.ptr<ui8, ub>, %dst1: !pto.ptr<ui8, ub>, %off: index) {
+    %c32 = arith.constant 32 : index
     %c64 = arith.constant 64 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %mask = pto.vmi.create_mask %c64 : index -> !pto.vmi.mask<64xpred>
-    %a = pto.vmi.vload %src0[%off] {dist_mode = "continuous"}
+    %a = pto.vmi.vload %src0[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<64xui8>
-    %b = pto.vmi.vload %src1[%off] {dist_mode = "continuous"}
+    %b = pto.vmi.vload %src1[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<64xui8>
     %even, %odd = pto.vmi.vdintlv %a, %b, %mask
         : !pto.vmi.vreg<64xui8>, !pto.vmi.vreg<64xui8>,
@@ -78,9 +84,9 @@ module {
         : !pto.vmi.vreg<64xui8>, !pto.vmi.vreg<64xui8>,
           !pto.vmi.mask<64xpred>
         -> !pto.vmi.vreg<64xui8>, !pto.vmi.vreg<64xui8>
-    pto.vmi.vstore %lo, %dst0[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %lo, %dst0[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<64xui8>, !pto.ptr<ui8, ub>
-    pto.vmi.vstore %hi, %dst1[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %hi, %dst1[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<64xui8>, !pto.ptr<ui8, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_iota_remat.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_iota_remat.pto
@@ -15,6 +15,8 @@ module {
       %src: !pto.vmi.vreg<128xf16>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) -> !pto.vmi.vreg<128xf32> {
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
     %iota = pto.vmi.vci %base
         : f32 -> !pto.vmi.vreg<128xf32>
     %wide = pto.vmi.vcvt %src
@@ -22,7 +24,7 @@ module {
     %sum = pto.vmi.vadd %iota, %wide
         : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>
         -> !pto.vmi.vreg<128xf32>
-    pto.vmi.vstore %iota, %dst[%offset]
+    pto.vmi.vstore %iota, %dst[%aligned_offset]
         : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
     return %sum : !pto.vmi.vreg<128xf32>
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_load_truncf.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_load_truncf.pto
@@ -13,7 +13,9 @@ module {
   func.func @vmi_layout_assignment_load_truncf(
       %src: !pto.ptr<f32, ub>,
       %offset: index) -> !pto.vmi.vreg<128xf16> {
-    %wide = pto.vmi.vload %src[%offset]
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    %wide = pto.vmi.vload %src[%aligned_offset]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
     %narrow = pto.vmi.vcvt %wide {saturate = "SAT"}
         : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf16>
@@ -24,9 +26,11 @@ module {
       %src: !pto.ptr<f32, ub>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) -> !pto.vmi.vreg<128xf16> {
-    %wide = pto.vmi.vload %src[%offset]
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    %wide = pto.vmi.vload %src[%aligned_offset]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
-    pto.vmi.vstore %wide, %dst[%offset]
+    pto.vmi.vstore %wide, %dst[%aligned_offset]
         : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
     %narrow = pto.vmi.vcvt %wide {saturate = "SAT"}
         : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf16>

--- a/test/lit/vmi_new/vmi_layout_assignment_mask_granularity_f32_f16_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_mask_granularity_f32_f16_store.pto
@@ -15,13 +15,15 @@ module {
       %out32: !pto.ptr<f32, ub>,
       %out16: !pto.ptr<f16, ub>,
       %off: index) {
+    %c16 = arith.constant 16 : index
     %c96 = arith.constant 96 : index
-    %x = pto.vmi.vload %src[%off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
+    %aligned_off = arith.muli %off, %c16 : index
+    %x = pto.vmi.vload %src[%aligned_off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
     %mask = pto.vmi.create_mask %c96 : index -> !pto.vmi.mask<128xpred>
-    pto.vmi.vstore %x, %out32[%off], %mask
+    pto.vmi.vstore %x, %out32[%aligned_off], %mask
         : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<128xpred>
     %h = pto.vmi.vcvt %x {saturate = "SAT"} : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf16>
-    pto.vmi.vstore %h, %out16[%off], %mask
+    pto.vmi.vstore %h, %out16[%aligned_off], %mask
         : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.vmi.mask<128xpred>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_mask_select_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_mask_select_store.pto
@@ -16,9 +16,11 @@ module {
       %dense: !pto.ptr<f32, ub>,
       %masked: !pto.ptr<f32, ub>,
       %off: index) {
+    %c8 = arith.constant 8 : index
     %c48 = arith.constant 48 : index
-    %x = pto.vmi.vload %src[%off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
-    %y = pto.vmi.vload %rhs[%off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+    %aligned_off = arith.muli %off, %c8 : index
+    %x = pto.vmi.vload %src[%aligned_off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+    %y = pto.vmi.vload %rhs[%aligned_off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
     %mask = pto.vmi.create_mask %c48 : index -> !pto.vmi.mask<64xpred>
     %sum = pto.vmi.vadd %x, %y
         : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>
@@ -26,9 +28,9 @@ module {
     %passthrough = pto.vmi.vsel %mask, %sum, %x
         : !pto.vmi.mask<64xpred>, !pto.vmi.vreg<64xf32>,
           !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
-    pto.vmi.vstore %passthrough, %dense[%off]
+    pto.vmi.vstore %passthrough, %dense[%aligned_off]
         : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
-    pto.vmi.vstore %sum, %masked[%off], %mask
+    pto.vmi.vstore %sum, %masked[%aligned_off], %mask
         : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<64xpred>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_masked_load_dense_group_users.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_masked_load_dense_group_users.pto
@@ -17,22 +17,24 @@ module {
       %off: index) {
     %c0_f32 = arith.constant 0.000000e+00 : f32
     %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
     %c256 = arith.constant 256 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %mask = pto.vmi.create_mask %c256
         : index -> !pto.vmi.mask<256xpred>
     %zero = pto.vmi.vbrc %c0_f32
         : f32 -> !pto.vmi.vreg<256xf32>
-    %loaded = pto.vmi.vload %base[%off]
+    %loaded = pto.vmi.vload %base[%aligned_off]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
     %x = pto.vmi.vsel %mask, %loaded, %zero
         : !pto.vmi.mask<256xpred>, !pto.vmi.vreg<256xf32>,
           !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf32>
-    pto.vmi.vstore %x, %copy_out[%off]
+    pto.vmi.vstore %x, %copy_out[%aligned_off]
         : !pto.vmi.vreg<256xf32>, !pto.ptr<f32, ub>
     %sum = pto.vmi.vcadd %x, %mask {group = 8, reassoc}
         : !pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred>
         -> !pto.vmi.vreg<8xf32>
-    pto.vmi.vstore %sum, %sum_out[%off], %c1 {group = 8}
+    pto.vmi.vstore %sum, %sum_out[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_masked_load_group_tail_s32.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_masked_load_group_tail_s32.pto
@@ -16,13 +16,15 @@ module {
       %off: index) {
     %c0_f32 = arith.constant 0.000000e+00 : f32
     %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
     %c25 = arith.constant 25 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %mask = pto.vmi.create_group_mask %c25
         {num_groups = 8, group_size = 32}
         : index -> !pto.vmi.mask<256xpred>
     %zero = pto.vmi.vbrc %c0_f32
         : f32 -> !pto.vmi.vreg<256xf32>
-    %loaded = pto.vmi.vload %base[%off]
+    %loaded = pto.vmi.vload %base[%aligned_off]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
     %x = pto.vmi.vsel %mask, %loaded, %zero
         : !pto.vmi.mask<256xpred>, !pto.vmi.vreg<256xf32>,
@@ -30,7 +32,7 @@ module {
     %sum = pto.vmi.vcadd %x, %mask {group = 8, reassoc}
         : !pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred>
         -> !pto.vmi.vreg<8xf32>
-    pto.vmi.vstore %sum, %sum_out[%off], %c1 {group = 8}
+    pto.vmi.vstore %sum, %sum_out[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
     return
   }
@@ -48,3 +50,4 @@ module {
 // LOWER: pto.vdintlv
 // LOWER: pto.vcgadd
 // LOWER: pto.vsts
+// LOWER-NOT: pto.vstus

--- a/test/lit/vmi_new/vmi_layout_assignment_non_load_s32_reduce.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_non_load_s32_reduce.pto
@@ -16,9 +16,11 @@ module {
       %dst: !pto.ptr<f32, ub>,
       %off: index) {
     %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
     %c256 = arith.constant 256 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %mask = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xpred>
-    %a = pto.vmi.vload %base[%off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
+    %a = pto.vmi.vload %base[%aligned_off] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
     %biasv = pto.vmi.vbrc %bias : f32 -> !pto.vmi.vreg<256xf32>
     %x = pto.vmi.vadd %a, %biasv
         : !pto.vmi.vreg<256xf32>, !pto.vmi.vreg<256xf32>
@@ -27,7 +29,7 @@ module {
         {group = 8, reassoc}
         : !pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred>
         -> !pto.vmi.vreg<8xf32>
-    pto.vmi.vstore %sum, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %sum, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
     return
   }
@@ -53,8 +55,8 @@ module {
 // LOWER-COUNT-4: pto.vdup %arg1
 // LOWER-COUNT-7: pto.vadd {{.*}}, {{.*}}, {{.*}} : !pto.vreg<64xf32>
 // LOWER: pto.vcgadd
-// LOWER: %[[VL8:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
-// LOWER: pto.vsts {{.*}}, %arg2[%arg3], {{.*}} : !pto.vreg<64xf32>, {{(!pto\.ptr)?<f32, ub>}}, !pto.mask<b32>
+// LOWER: pto.vsts
+// LOWER-NOT: pto.vstus
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.
 // LOWER-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_layout_assignment_rematerialize_weak_producers.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_rematerialize_weak_producers.pto
@@ -21,6 +21,8 @@ module {
       %dst0: !pto.ptr<f32, ub>,
       %dst1: !pto.ptr<f32, ub>,
       %off: index) {
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %mask = pto.vmi.create_mask %off : index -> !pto.vmi.mask<128xpred>
     %index = pto.vmi.vci %scale : f32 -> !pto.vmi.vreg<128xf32>
     %score_base = pto.vmi.vadd %index, %index
@@ -29,7 +31,7 @@ module {
     %score = pto.vmi.vmuls %score_base, %scale, %mask
         : !pto.vmi.vreg<128xf32>, f32, !pto.vmi.mask<128xpred>
           -> !pto.vmi.vreg<128xf32>
-    pto.vmi.vstore %score, %dst0[%off]
+    pto.vmi.vstore %score, %dst0[%aligned_off]
         : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
 
     %exp = pto.vmi.vexpdif %x, %max, %mask
@@ -42,7 +44,7 @@ module {
     %sum = pto.vmi.vcadd %with_index, %mask {group = 8, reassoc}
         : !pto.vmi.vreg<128xf32>, !pto.vmi.mask<128xpred>
           -> !pto.vmi.vreg<8xf32>
-    pto.vmi.group_store %sum, %dst1[%off], %one {num_groups = 8}
+    pto.vmi.group_store %sum, %dst1[%aligned_off], %one {num_groups = 8}
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_scalar_brc_vexpdif_group_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_scalar_brc_vexpdif_group_store.pto
@@ -13,11 +13,13 @@ module {
   func.func @scalar_brc_vexpdif_group_store(
       %scores: !pto.ptr<f32, ub>, %row_max: !pto.ptr<f32, ub>,
       %dst: !pto.ptr<bf16, ub>, %off: index) {
+    %c8 = arith.constant 8 : index
     %c128 = arith.constant 128 : index
     %c1024 = arith.constant 1024 : index
-    %x = pto.vmi.vload %scores[%off] {dist_mode = "continuous"}
+    %aligned_off = arith.muli %off, %c8 : index
+    %x = pto.vmi.vload %scores[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
-    %max = pto.vmi.vload %row_max[%off] {dist_mode = "brc"}
+    %max = pto.vmi.vload %row_max[%aligned_off] {dist_mode = "brc"}
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
     %mask = pto.vmi.create_mask %c128
         : index -> !pto.vmi.mask<128xpred>
@@ -26,7 +28,7 @@ module {
           !pto.vmi.mask<128xpred> -> !pto.vmi.vreg<128xf32>
     %narrow = pto.vmi.truncf %exp {saturate = "SAT"}
         : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xbf16>
-    pto.vmi.vstore %narrow, %dst[%off], %c1024 {group = 8}
+    pto.vmi.vstore %narrow, %dst[%aligned_off], %c1024 {group = 8}
         : !pto.vmi.vreg<128xbf16>, !pto.ptr<bf16, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_store_ensure.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_store_ensure.pto
@@ -14,12 +14,14 @@ module {
       %src: !pto.vmi.vreg<128xf16>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) {
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
     %wide = pto.vmi.vcvt %src
         : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
     %sum = pto.vmi.vadd %wide, %wide
         : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>
         -> !pto.vmi.vreg<128xf32>
-    pto.vmi.vstore %sum, %dst[%offset] {dist_mode = "continuous"}
+    pto.vmi.vstore %sum, %dst[%aligned_offset] {dist_mode = "continuous"}
         : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_assignment_store_prefer_lane_stride.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_store_prefer_lane_stride.pto
@@ -15,14 +15,16 @@ module {
   func.func @f16_store_prefers_lane_stride(
       %src0: !pto.ptr<f16, ub>, %src1: !pto.ptr<f16, ub>,
       %dst: !pto.ptr<f16, ub>, %off: index) {
-    %x = pto.vmi.vload %src0[%off] {dist_mode = "continuous"}
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
+    %x = pto.vmi.vload %src0[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<64xf16>
-    %y = pto.vmi.vload %src1[%off] {dist_mode = "continuous"}
+    %y = pto.vmi.vload %src1[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<64xf16>
     %sum = pto.vmi.vadd %x, %y
         : !pto.vmi.vreg<64xf16>, !pto.vmi.vreg<64xf16>
         -> !pto.vmi.vreg<64xf16>
-    pto.vmi.vstore %sum, %dst[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %sum, %dst[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<64xf16>, !pto.ptr<f16, ub>
     return
   }
@@ -30,16 +32,18 @@ module {
   func.func @f16_masked_store_prefers_lane_stride(
       %src0: !pto.ptr<f16, ub>, %src1: !pto.ptr<f16, ub>,
       %dst: !pto.ptr<f16, ub>, %off: index) {
+    %c16 = arith.constant 16 : index
     %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c16 : index
     %mask = pto.vmi.create_mask %c32 : index -> !pto.vmi.mask<64xpred>
-    %x = pto.vmi.vload %src0[%off] {dist_mode = "continuous"}
+    %x = pto.vmi.vload %src0[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<64xf16>
-    %y = pto.vmi.vload %src1[%off] {dist_mode = "continuous"}
+    %y = pto.vmi.vload %src1[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<64xf16>
     %sum = pto.vmi.vadd %x, %y
         : !pto.vmi.vreg<64xf16>, !pto.vmi.vreg<64xf16>
         -> !pto.vmi.vreg<64xf16>
-    pto.vmi.vstore %sum, %dst[%off], %mask
+    pto.vmi.vstore %sum, %dst[%aligned_off], %mask
         : !pto.vmi.vreg<64xf16>, !pto.ptr<f16, ub>,
           !pto.vmi.mask<64xpred>
     return
@@ -48,14 +52,16 @@ module {
   func.func @f16_full_width_store_stays_contiguous(
       %src0: !pto.ptr<f16, ub>, %src1: !pto.ptr<f16, ub>,
       %dst: !pto.ptr<f16, ub>, %off: index) {
-    %x = pto.vmi.vload %src0[%off] {dist_mode = "continuous"}
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
+    %x = pto.vmi.vload %src0[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
-    %y = pto.vmi.vload %src1[%off] {dist_mode = "continuous"}
+    %y = pto.vmi.vload %src1[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
     %sum = pto.vmi.vadd %x, %y
         : !pto.vmi.vreg<128xf16>, !pto.vmi.vreg<128xf16>
         -> !pto.vmi.vreg<128xf16>
-    pto.vmi.vstore %sum, %dst[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %sum, %dst[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>
     return
   }
@@ -63,14 +69,16 @@ module {
   func.func @ui8_half_width_store_prefers_lane_stride2(
       %src0: !pto.ptr<ui8, ub>, %src1: !pto.ptr<ui8, ub>,
       %dst: !pto.ptr<ui8, ub>, %off: index) {
-    %x = pto.vmi.vload %src0[%off] {dist_mode = "continuous"}
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
+    %x = pto.vmi.vload %src0[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<128xui8>
-    %y = pto.vmi.vload %src1[%off] {dist_mode = "continuous"}
+    %y = pto.vmi.vload %src1[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<128xui8>
     %sum = pto.vmi.vadd %x, %y
         : !pto.vmi.vreg<128xui8>, !pto.vmi.vreg<128xui8>
         -> !pto.vmi.vreg<128xui8>
-    pto.vmi.vstore %sum, %dst[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %sum, %dst[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<128xui8>, !pto.ptr<ui8, ub>
     return
   }
@@ -78,31 +86,35 @@ module {
   func.func @ui8_quarter_width_store_prefers_lane_stride4(
       %src0: !pto.ptr<ui8, ub>, %src1: !pto.ptr<ui8, ub>,
       %dst: !pto.ptr<ui8, ub>, %off: index) {
-    %x = pto.vmi.vload %src0[%off] {dist_mode = "continuous"}
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
+    %x = pto.vmi.vload %src0[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<64xui8>
-    %y = pto.vmi.vload %src1[%off] {dist_mode = "continuous"}
+    %y = pto.vmi.vload %src1[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<64xui8>
     %sum = pto.vmi.vadd %x, %y
         : !pto.vmi.vreg<64xui8>, !pto.vmi.vreg<64xui8>
         -> !pto.vmi.vreg<64xui8>
-    pto.vmi.vstore %sum, %dst[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %sum, %dst[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<64xui8>, !pto.ptr<ui8, ub>
     return
   }
 
   func.func @f16_store_does_not_override_channel_merge(
-      %src: !pto.ptr<f16, ub>, %dst: !pto.ptr<f16, ub>, %off: index) {
+      %src: memref<256xf16, #pto.address_space<vec>>,
+      %dst: !pto.ptr<f16, ub>, %off: index) {
+    %c0 = arith.constant 0 : index
     %c64 = arith.constant 64 : index
     %mask = pto.vmi.create_mask %c64 : index -> !pto.vmi.mask<128xpred>
-    %x = pto.vmi.vload %src[%off] {dist_mode = "continuous"}
-        : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
+    %x = pto.vmi.vload %src[%c0] {dist_mode = "continuous"}
+        : memref<256xf16, #pto.address_space<vec>> -> !pto.vmi.vreg<128xf16>
     %lo, %hi = "pto.vmi.channel_split"(%x)
         : (!pto.vmi.vreg<128xf16>)
         -> (!pto.vmi.vreg<64xf16>, !pto.vmi.vreg<64xf16>)
     %merged = "pto.vmi.channel_merge"(%lo, %hi)
         : (!pto.vmi.vreg<64xf16>, !pto.vmi.vreg<64xf16>)
         -> !pto.vmi.vreg<128xf16>
-    pto.vmi.vstore %merged, %dst[%off], %mask
+    pto.vmi.vstore %merged, %dst[%c0], %mask
         : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>,
           !pto.vmi.mask<128xpred>
     return
@@ -194,4 +206,4 @@ module {
 // LOWER: %[[LOAD:.*]] = pto.vlds
 // LOWER: %[[LOW:.*]], %[[HIGH:.*]] = pto.vdintlv %[[LOAD]], %[[LOAD]]
 // LOWER: pto.vintlv
-// LOWER: pto.vsts {{.*}} : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
+// LOWER: pto.vsts

--- a/test/lit/vmi_new/vmi_layout_assignment_trunci_lane_stride.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_trunci_lane_stride.pto
@@ -14,26 +14,32 @@
 module {
   func.func @vmi_layout_assignment_group_slot_trunci_lane_stride(
       %wide: !pto.vmi.vreg<8xi32, #pto.vmi.layout<num_groups = 8, slots = 8>>,
-      %dst: !pto.ptr<ui8, ub>,
       %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<ui8, ub>
     %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %narrow = pto.vmi.vcvt %wide {saturate = "SAT"}
         : !pto.vmi.vreg<8xi32, #pto.vmi.layout<num_groups = 8, slots = 8>>
         -> !pto.vmi.vreg<8xui8>
-    pto.vmi.vstore %narrow, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %narrow, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xui8>, !pto.ptr<ui8, ub>
     return
   }
 
   func.func @vmi_layout_assignment_group_slot_trunci_lane_stride2(
       %wide: !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>,
-      %dst: !pto.ptr<ui8, ub>,
       %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<ui8, ub>
     %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %narrow = pto.vmi.vcvt %wide {saturate = "SAT"}
         : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>
         -> !pto.vmi.vreg<8xui8>
-    pto.vmi.vstore %narrow, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %narrow, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xui8>, !pto.ptr<ui8, ub>
     return
   }
@@ -48,8 +54,9 @@ module {
 // LOWER: pto.vcvt {{.*}} {part = "P0", sat = "SAT"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<256xui8>
 // LOWER: %[[PACK16:.*]] = pto.vpack {{.*}}, "LOWER" : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
 // LOWER: %[[PACK8:.*]] = pto.vpack %[[PACK16]], "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
-// LOWER: %[[WORDS:.*]] = pto.vbitcast %[[PACK8]] : !pto.vreg<256xui8> -> !pto.vreg<64xui32>
-// LOWER-COUNT-2: pto.vsts {{.*}} {dist = "1PT_B32"}
+// LOWER: pto.vsts %[[PACK8]],
+// LOWER-NOT: pto.vstus
+// LOWER-NOT: dist = "1PT_B32"
 // LOWER-NOT: dist = "PK_B16"
 // LOWER-NOT: dist = "PK4_B32"
 // LOWER-NOT: pto.vmi.
@@ -65,8 +72,9 @@ module {
 // LOWER: %[[CVT2:.*]] = pto.vcvt {{.*}} {part = "EVEN", sat = "SAT"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<256xui8>
 // LOWER: %[[CARRIER2:.*]] = pto.vbitcast %[[CVT2]] : !pto.vreg<256xui8> -> !pto.vreg<128xui16>
 // LOWER: %[[PACKEDV2:.*]] = pto.vpack %[[CARRIER2]], "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
-// LOWER: %[[WORDS2:.*]] = pto.vbitcast %[[PACKEDV2]] : !pto.vreg<256xui8> -> !pto.vreg<64xui32>
-// LOWER-COUNT-2: pto.vsts {{.*}} {dist = "1PT_B32"}
+// LOWER: pto.vsts %[[PACKEDV2]],
+// LOWER-NOT: pto.vstus
+// LOWER-NOT: dist = "1PT_B32"
 // LOWER-NOT: dist = "PK_B16"
 // LOWER-NOT: dist = "PK4_B32"
 // LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_widen_dense_reduce_multi_consumer.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_widen_dense_reduce_multi_consumer.pto
@@ -18,11 +18,13 @@ module {
       %off: index) {
     %c128 = arith.constant 128 : index
     %c0 = arith.constant 0 : index
-    %a = pto.vmi.vload %src[%off] {dist_mode = "continuous"}
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
+    %a = pto.vmi.vload %src[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
     %w = pto.vmi.vcvt %a
         : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
-    %k1 = pto.vmi.vload %rhs[%off] {dist_mode = "continuous"}
+    %k1 = pto.vmi.vload %rhs[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
     %t1 = pto.vmi.vmul %w, %k1
         : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>

--- a/test/lit/vmi_new/vmi_layout_assignment_widen_f16_store_reduce.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_widen_f16_store_reduce.pto
@@ -16,16 +16,18 @@ module {
       %dense: !pto.ptr<f32, ub>,
       %off: index) {
     %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
     %c128 = arith.constant 128 : index
-    %x16 = pto.vmi.vload %src[%off] {dist_mode = "continuous"} : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
+    %aligned_off = arith.muli %off, %c16 : index
+    %x16 = pto.vmi.vload %src[%aligned_off] {dist_mode = "continuous"} : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
     %x32 = pto.vmi.vcvt %x16 : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
     %mask = pto.vmi.create_mask %c128 : index -> !pto.vmi.mask<128xpred>
     %sumv = pto.vmi.vcadd %x32, %mask {group = 8, reassoc}
         : !pto.vmi.vreg<128xf32>, !pto.vmi.mask<128xpred>
         -> !pto.vmi.vreg<8xf32>
-    pto.vmi.vstore %sumv, %sum[%off], %c1 {group = 8}
+    pto.vmi.vstore %sumv, %sum[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
-    pto.vmi.vstore %x32, %dense[%off] {dist_mode = "continuous"}
+    pto.vmi.vstore %x32, %dense[%aligned_off] {dist_mode = "continuous"}
         : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_layout_fold_deint4.pto
+++ b/test/lit/vmi_new/vmi_layout_fold_deint4.pto
@@ -14,10 +14,12 @@ module {
       %value: !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) {
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
     %value_c = pto.vmi.ensure_layout %value
         : !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
         -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
-    pto.vmi.vstore %value_c, %dst[%offset] {dist_mode = "continuous"}
+    pto.vmi.vstore %value_c, %dst[%aligned_offset] {dist_mode = "continuous"}
         : !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>,
           !pto.ptr<f32, ub>
     return
@@ -28,13 +30,15 @@ module {
       %mask: !pto.vmi.mask<256xb32, #pto.vmi.layout<deinterleaved = 4>>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) {
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
     %value_c = pto.vmi.ensure_layout %value
         : !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
         -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
     %mask_c = pto.vmi.ensure_mask_layout %mask
         : !pto.vmi.mask<256xb32, #pto.vmi.layout<deinterleaved = 4>>
         -> !pto.vmi.mask<256xb32, #pto.vmi.layout<contiguous>>
-    pto.vmi.vstore %value_c, %dst[%offset], %mask_c
+    pto.vmi.vstore %value_c, %dst[%aligned_offset], %mask_c
         : !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>,
           !pto.ptr<f32, ub>,
           !pto.vmi.mask<256xb32, #pto.vmi.layout<contiguous>>

--- a/test/lit/vmi_new/vmi_layout_fold_load.pto
+++ b/test/lit/vmi_new/vmi_layout_fold_load.pto
@@ -14,7 +14,9 @@ module {
       %src: !pto.ptr<f32, ub>, %off: index)
       -> (!pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>,
           !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>) {
-    %load = pto.vmi.vload %src[%off] {dist_mode = "continuous"}
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
+    %load = pto.vmi.vload %src[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f32, ub>
         -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
     %split0 = pto.vmi.ensure_layout %load
@@ -32,7 +34,9 @@ module {
       %src: !pto.ptr<f32, ub>, %off: index)
       -> (!pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>,
           !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>) {
-    %load = pto.vmi.vload %src[%off] {dist_mode = "continuous"}
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
+    %load = pto.vmi.vload %src[%aligned_off] {dist_mode = "continuous"}
         : !pto.ptr<f32, ub>
         -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
     %split = pto.vmi.ensure_layout %load

--- a/test/lit/vmi_new/vmi_layout_fold_masked_store.pto
+++ b/test/lit/vmi_new/vmi_layout_fold_masked_store.pto
@@ -15,13 +15,15 @@ module {
       %mask: !pto.vmi.mask<128xb32, #pto.vmi.layout<deinterleaved = 2>>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) {
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
     %value_c = pto.vmi.ensure_layout %value
         : !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
         -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
     %mask_c = pto.vmi.ensure_mask_layout %mask
         : !pto.vmi.mask<128xb32, #pto.vmi.layout<deinterleaved = 2>>
         -> !pto.vmi.mask<128xb32, #pto.vmi.layout<contiguous>>
-    pto.vmi.vstore %value_c, %dst[%offset], %mask_c
+    pto.vmi.vstore %value_c, %dst[%aligned_offset], %mask_c
         : !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>,
           !pto.ptr<f32, ub>,
           !pto.vmi.mask<128xb32, #pto.vmi.layout<contiguous>>

--- a/test/lit/vmi_new/vmi_layout_fold_store.pto
+++ b/test/lit/vmi_new/vmi_layout_fold_store.pto
@@ -16,6 +16,8 @@ module {
       %out1: !pto.ptr<f32, ub>,
       %out2: !pto.ptr<f32, ub>,
       %offset: index) {
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
     %scale_v = pto.vmi.vbrc %scale
         : f32 -> !pto.vmi.vreg<128xf32>
     %wide = pto.vmi.vcvt %src
@@ -23,9 +25,9 @@ module {
     %prod = pto.vmi.vmul %wide, %scale_v
         : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>
         -> !pto.vmi.vreg<128xf32>
-    pto.vmi.vstore %prod, %out1[%offset] {dist_mode = "continuous"}
+    pto.vmi.vstore %prod, %out1[%aligned_offset] {dist_mode = "continuous"}
         : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
-    pto.vmi.vstore %wide, %out2[%offset] {dist_mode = "continuous"}
+    pto.vmi.vstore %wide, %out2[%aligned_offset] {dist_mode = "continuous"}
         : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
     return
   }
@@ -61,4 +63,3 @@ module {
 // LOWER: pto.vstsx2 %[[WIDE0]], %[[WIDE1]]
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.
-

--- a/test/lit/vmi_new/vmi_layout_rematerialize_relation.pto
+++ b/test/lit/vmi_new/vmi_layout_rematerialize_relation.pto
@@ -11,10 +11,11 @@
 
 module {
   func.func @vmi_layout_rematerialize_direct_ext(
-      %src: !pto.ptr<f16, ub>, %off: index)
+      %src: memref<512xf16, #pto.address_space<vec>>, %off: index)
       -> !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous>> {
-    %x16 = pto.vmi.vload %src[%off]
-        : !pto.ptr<f16, ub>
+    %c0 = arith.constant 0 : index
+    %x16 = pto.vmi.vload %src[%c0]
+        : memref<512xf16, #pto.address_space<vec>>
         -> !pto.vmi.vreg<256xf16, #pto.vmi.layout<contiguous>>
     %x32_d2 = pto.vmi.vcvt %x16
         : !pto.vmi.vreg<256xf16, #pto.vmi.layout<contiguous>>
@@ -29,13 +30,15 @@ module {
   }
 
   func.func @vmi_layout_rematerialize_mulf_chain(
-      %lhs: !pto.ptr<f16, ub>, %rhs: !pto.ptr<f16, ub>, %off: index)
+      %lhs: memref<512xf16, #pto.address_space<vec>>,
+      %rhs: memref<512xf16, #pto.address_space<vec>>, %off: index)
       -> !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous>> {
-    %lhs16 = pto.vmi.vload %lhs[%off]
-        : !pto.ptr<f16, ub>
+    %c0 = arith.constant 0 : index
+    %lhs16 = pto.vmi.vload %lhs[%c0]
+        : memref<512xf16, #pto.address_space<vec>>
         -> !pto.vmi.vreg<256xf16, #pto.vmi.layout<contiguous>>
-    %rhs16 = pto.vmi.vload %rhs[%off]
-        : !pto.ptr<f16, ub>
+    %rhs16 = pto.vmi.vload %rhs[%c0]
+        : memref<512xf16, #pto.address_space<vec>>
         -> !pto.vmi.vreg<256xf16, #pto.vmi.layout<contiguous>>
     %lhs32_d2 = pto.vmi.vcvt %lhs16
         : !pto.vmi.vreg<256xf16, #pto.vmi.layout<contiguous>>
@@ -57,11 +60,12 @@ module {
   }
 
   func.func @vmi_layout_rematerialize_ext_multi_consumer(
-      %src: !pto.ptr<f16, ub>, %off: index)
+      %src: memref<512xf16, #pto.address_space<vec>>, %off: index)
       -> (!pto.vmi.vreg<256xf16, #pto.vmi.layout<contiguous>>,
           !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous>>) {
-    %x16 = pto.vmi.vload %src[%off]
-        : !pto.ptr<f16, ub>
+    %c0 = arith.constant 0 : index
+    %x16 = pto.vmi.vload %src[%c0]
+        : memref<512xf16, #pto.address_space<vec>>
         -> !pto.vmi.vreg<256xf16, #pto.vmi.layout<contiguous>>
     %x32_d2 = pto.vmi.vcvt %x16
         : !pto.vmi.vreg<256xf16, #pto.vmi.layout<contiguous>>
@@ -81,10 +85,11 @@ module {
   }
 
   func.func @vmi_layout_rematerialize_keeps_wider_source(
-      %src: !pto.ptr<f16, ub>, %off: index)
+      %src: memref<256xf16, #pto.address_space<vec>>, %off: index)
       -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>> {
-    %x16 = pto.vmi.vload %src[%off]
-        : !pto.ptr<f16, ub>
+    %c0 = arith.constant 0 : index
+    %x16 = pto.vmi.vload %src[%c0]
+        : memref<256xf16, #pto.address_space<vec>>
         -> !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
     %x32_d2 = pto.vmi.vcvt %x16
         : !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>

--- a/test/lit/vmi_new/vmi_pre_assignment_combine_contiguous_group_load.pto
+++ b/test/lit/vmi_new/vmi_pre_assignment_combine_contiguous_group_load.pto
@@ -21,7 +21,8 @@ module {
     %exp_mask = pto.vmi.vbrc %c32640_ui16
         : ui16 -> !pto.vmi.vreg<256xui16>
     %c32 = arith.constant 32 : index
-    %x = pto.vmi.vload %src[%off], %c32 {group = 8}
+    %aligned_off = arith.muli %off, %c32 : index
+    %x = pto.vmi.vload %src[%aligned_off], %c32 {group = 8}
         : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
     %bits = pto.vmi.vinterpret_cast %x
         : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xui16>
@@ -35,11 +36,12 @@ module {
   }
 
   func.func @contiguous_ui8_group_load(
-      %src: !pto.ptr<ui8, ub>,
+      %src: memref<256xui8, #pto.address_space<vec>>,
       %off: index) -> !pto.vmi.vreg<64xui8> {
+    %c0 = arith.constant 0 : index
     %c16 = arith.constant 16 : index
-    %value = pto.vmi.vload %src[%off], %c16 {group = 4}
-        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<64xui8>
+    %value = pto.vmi.vload %src[%c0], %c16 {group = 4}
+        : memref<256xui8, #pto.address_space<vec>> -> !pto.vmi.vreg<64xui8>
     return %value : !pto.vmi.vreg<64xui8>
   }
 
@@ -47,7 +49,8 @@ module {
       %src: !pto.ptr<f32, ub>,
       %off: index) -> !pto.vmi.vreg<128xf32> {
     %c8 = arith.constant 8 : index
-    %value = pto.vmi.vload %src[%off], %c8 {group = 16}
+    %aligned_off = arith.muli %off, %c8 : index
+    %value = pto.vmi.vload %src[%aligned_off], %c8 {group = 16}
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
     return %value : !pto.vmi.vreg<128xf32>
   }
@@ -56,7 +59,8 @@ module {
       %src: !pto.ptr<si16, ub>,
       %off: index) -> !pto.vmi.vreg<128xsi16> {
     %c16 = arith.constant 16 : index
-    %value = pto.vmi.vload %src[%off], %c16 {group = 8}
+    %aligned_off = arith.muli %off, %c16 : index
+    %value = pto.vmi.vload %src[%aligned_off], %c16 {group = 8}
         : !pto.ptr<si16, ub> -> !pto.vmi.vreg<128xsi16>
     return %value : !pto.vmi.vreg<128xsi16>
   }

--- a/test/lit/vmi_new/vmi_pre_assignment_combine_group_slot_broadcast_load.pto
+++ b/test/lit/vmi_new/vmi_pre_assignment_combine_group_slot_broadcast_load.pto
@@ -13,7 +13,9 @@ module {
   func.func @not_e2b_num_groups_16(%src: !pto.ptr<f16, ub>, %off: index)
       -> !pto.vmi.vreg<256xf16> {
     %c1 = arith.constant 1 : index
-    %slots = pto.vmi.group_slot_load %src[%off], %c1 {num_groups = 16}
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
+    %slots = pto.vmi.group_slot_load %src[%aligned_off], %c1 {num_groups = 16}
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<16xf16>
     %out = pto.vmi.vbrc %slots {group = 16}
         : !pto.vmi.vreg<16xf16> -> !pto.vmi.vreg<256xf16>
@@ -23,7 +25,9 @@ module {
   func.func @e2b_deint4_candidate(%src: !pto.ptr<f32, ub>, %off: index)
       -> !pto.vmi.vreg<256xf32> {
     %c1 = arith.constant 1 : index
-    %slots = pto.vmi.group_slot_load %src[%off], %c1 {num_groups = 8}
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
+    %slots = pto.vmi.group_slot_load %src[%aligned_off], %c1 {num_groups = 8}
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<8xf32>
     %out = pto.vmi.vbrc %slots {group = 8}
         : !pto.vmi.vreg<8xf32> -> !pto.vmi.vreg<256xf32>
@@ -34,7 +38,9 @@ module {
                                      %x: !pto.vmi.vreg<256xf16>, %off: index)
       -> !pto.vmi.vreg<256xf32> {
     %c1 = arith.constant 1 : index
-    %slots = pto.vmi.group_slot_load %scale[%off], %c1 {num_groups = 8}
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
+    %slots = pto.vmi.group_slot_load %scale[%aligned_off], %c1 {num_groups = 8}
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<8xf32>
     %sf = pto.vmi.vbrc %slots {group = 8}
         : !pto.vmi.vreg<8xf32> -> !pto.vmi.vreg<256xf32>

--- a/test/lit/vmi_new/vmi_prefer_lane_stride_narrowing.pto
+++ b/test/lit/vmi_new/vmi_prefer_lane_stride_narrowing.pto
@@ -17,11 +17,13 @@ module attributes {pto.target_arch = "a5"} {
     func.func @truncf_dense_store(
         %src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f8E4M3FN, ub>,
         %offset: index) {
-      %value = pto.vmi.vload %src[%offset] {dist_mode = "continuous"}
+      %c32 = arith.constant 32 : index
+      %aligned_offset = arith.muli %offset, %c32 : index
+      %value = pto.vmi.vload %src[%aligned_offset] {dist_mode = "continuous"}
           : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
       %narrow = pto.vmi.vcvt %value {rounding = "R", saturate = "SAT"}
           : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
-      pto.vmi.vstore %narrow, %dst[%offset] {dist_mode = "continuous"}
+      pto.vmi.vstore %narrow, %dst[%aligned_offset] {dist_mode = "continuous"}
           : !pto.vmi.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>
       return
     }
@@ -29,12 +31,14 @@ module attributes {pto.target_arch = "a5"} {
     func.func @trunci_dense_masked_store(
         %src: !pto.ptr<ui32, ub>, %dst: !pto.ptr<ui8, ub>,
         %offset: index, %active: index) {
+      %c32 = arith.constant 32 : index
+      %aligned_offset = arith.muli %offset, %c32 : index
       %mask = pto.vmi.create_mask %active : index -> !pto.vmi.mask<256xpred>
-      %value = pto.vmi.vload %src[%offset] {dist_mode = "continuous"}
+      %value = pto.vmi.vload %src[%aligned_offset] {dist_mode = "continuous"}
           : !pto.ptr<ui32, ub> -> !pto.vmi.vreg<256xui32>
       %narrow = pto.vmi.vcvt %value {saturate = "SAT"}
           : !pto.vmi.vreg<256xui32> -> !pto.vmi.vreg<256xui8>
-      pto.vmi.vstore %narrow, %dst[%offset], %mask {dist_mode = "continuous"}
+      pto.vmi.vstore %narrow, %dst[%aligned_offset], %mask {dist_mode = "continuous"}
           : !pto.vmi.vreg<256xui8>, !pto.ptr<ui8, ub>,
             !pto.vmi.mask<256xpred>
       return

--- a/test/lit/vmi_new/vmi_ptoas_cli_control_flow.pto
+++ b/test/lit/vmi_new/vmi_ptoas_cli_control_flow.pto
@@ -16,6 +16,8 @@ module attributes {pto.target_arch = "a5"} {
         %rhs: f32,
         %dst: !pto.ptr<f32, ub>,
         %offset: index) {
+      %c8 = arith.constant 8 : index
+      %aligned_offset = arith.muli %offset, %c8 : index
       %lhs_v = pto.vmi.vbrc %lhs
           : f32 -> !pto.vmi.vreg<128xf32>
       %rhs_v = pto.vmi.vbrc %rhs
@@ -25,7 +27,7 @@ module attributes {pto.target_arch = "a5"} {
       } else {
         scf.yield %rhs_v : !pto.vmi.vreg<128xf32>
       }
-      pto.vmi.vstore %chosen, %dst[%offset]
+      pto.vmi.vstore %chosen, %dst[%aligned_offset]
           : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
       return
     }

--- a/test/lit/vmi_new/vmi_ptoas_cli_licm.pto
+++ b/test/lit/vmi_new/vmi_ptoas_cli_licm.pto
@@ -16,13 +16,15 @@ module attributes {pto.target_arch = "a5"} {
         %count: index) {
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
+      %c16 = arith.constant 16 : index
       pto.vecscope {
         scf.for %i = %c0 to %count step %c1 {
-          %x16 = pto.vmi.vload %src[%i] {dist_mode = "continuous"}
+          %aligned_i = arith.muli %i, %c16 : index
+          %x16 = pto.vmi.vload %src[%aligned_i] {dist_mode = "continuous"}
               : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
           %x32 = pto.vmi.vcvt %x16
               : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
-          pto.vmi.vstore %x32, %dst[%i]
+          pto.vmi.vstore %x32, %dst[%aligned_i]
               : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
         }
       }

--- a/test/lit/vmi_new/vmi_ptoas_cli_pipeline.pto
+++ b/test/lit/vmi_new/vmi_ptoas_cli_pipeline.pto
@@ -15,9 +15,11 @@ module attributes {pto.target_arch = "a5"} {
         %scalar: f32,
         %dst: !pto.ptr<f32, ub>,
         %offset: index) {
+      %c8 = arith.constant 8 : index
+      %aligned_offset = arith.muli %offset, %c8 : index
       %value = pto.vmi.vbrc %scalar
           : f32 -> !pto.vmi.vreg<128xf32>
-      pto.vmi.vstore %value, %dst[%offset]
+      pto.vmi.vstore %value, %dst[%aligned_offset]
           : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
       return
     }
@@ -26,11 +28,13 @@ module attributes {pto.target_arch = "a5"} {
         %src: !pto.ptr<f16, ub>,
         %dst: !pto.ptr<f32, ub>,
         %offset: index) {
-      %x16 = pto.vmi.vload %src[%offset] {dist_mode = "continuous"}
+      %c16 = arith.constant 16 : index
+      %aligned_offset = arith.muli %offset, %c16 : index
+      %x16 = pto.vmi.vload %src[%aligned_offset] {dist_mode = "continuous"}
           : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
       %x32 = pto.vmi.vcvt %x16
           : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
-      pto.vmi.vstore %x32, %dst[%offset]
+      pto.vmi.vstore %x32, %dst[%aligned_offset]
           : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
       return
     }
@@ -39,9 +43,9 @@ module attributes {pto.target_arch = "a5"} {
 
 // CHECK-LABEL: func.func @vmi_ptoas_cli_pipeline
 // CHECK: pto.vecscope
-// CHECK: pto.vdup
-// CHECK: pto.vsts
-// CHECK: pto.vsts
+// CHECK: %[[VALUE:.*]] = pto.vdup
+// CHECK: pto.vsts %[[VALUE]]
+// CHECK: pto.vsts %[[VALUE]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_continuous_reduce_store.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_continuous_reduce_store.pto
@@ -14,11 +14,13 @@ module {
       %source: !pto.vmi.vreg<64xf32>,
       %reduce_mask: !pto.vmi.mask<64xpred>,
       %dst: !pto.ptr<f32, ub>, %off: index) {
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %store_mask = pto.vmi.pset "PAT_ALL" : !pto.vmi.mask<1xpred>
     %sum = pto.vmi.vcadd %source, %reduce_mask {reassoc}
         : !pto.vmi.vreg<64xf32>, !pto.vmi.mask<64xpred>
         -> !pto.vmi.vreg<1xf32>
-    pto.vmi.vstore %sum, %dst[%off], %store_mask
+    pto.vmi.vstore %sum, %dst[%aligned_off], %store_mask
         : !pto.vmi.vreg<1xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<1xpred>
     return
   }
@@ -51,10 +53,12 @@ module {
       %source: !pto.vmi.vreg<512xf32>,
       %mask: !pto.vmi.mask<512xpred>,
       %dst: !pto.ptr<f32, ub>, %off: index) {
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %sum = pto.vmi.vcadd %source, %mask {group = 8, reassoc}
         : !pto.vmi.vreg<512xf32>, !pto.vmi.mask<512xpred>
         -> !pto.vmi.vreg<8xf32>
-    pto.vmi.vstore %sum, %dst[%off]
+    pto.vmi.vstore %sum, %dst[%aligned_off]
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
     return
   }
@@ -64,10 +68,12 @@ module {
       %reduce_mask: !pto.vmi.mask<64xpred>,
       %store_mask: !pto.vmi.mask<1xpred>,
       %dst: !pto.ptr<f32, ub>, %off: index) {
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %sum = pto.vmi.vcadd %source, %reduce_mask {reassoc}
         : !pto.vmi.vreg<64xf32>, !pto.vmi.mask<64xpred>
         -> !pto.vmi.vreg<1xf32>
-    pto.vmi.vstore %sum, %dst[%off], %store_mask
+    pto.vmi.vstore %sum, %dst[%aligned_off], %store_mask
         : !pto.vmi.vreg<1xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<1xpred>
     return
   }
@@ -106,14 +112,21 @@ module {
 // LOWER: pto.vsts {{.*}} {dist = "1PT_B32"}
 
 // LOWER-LABEL: func.func @continuous_reduce_store_2(
-// LOWER: pto.vsts {{.*}} {dist = "1PT_B32"}
-// LOWER: pto.vsts {{.*}} {dist = "1PT_B32"}
+// LOWER: pto.init_align
+// LOWER: pto.vstus
+// LOWER: pto.vstas
+// LOWER-NOT: dist = "1PT_B32"
 
 // LOWER-LABEL: func.func @continuous_reduce_store_4(
-// LOWER-COUNT-4: pto.vsts {{.*}} {dist = "1PT_B32"}
+// LOWER: pto.init_align
+// LOWER: pto.vstus
+// LOWER: pto.vstas
+// LOWER-NOT: dist = "1PT_B32"
 
 // LOWER-LABEL: func.func @continuous_reduce_store_8(
-// LOWER-COUNT-8: pto.vsts {{.*}} {dist = "1PT_B32"}
+// LOWER: pto.vsts
+// LOWER-NOT: pto.vstus
+// LOWER-NOT: dist = "1PT_B32"
 
 // LOWER-LABEL: func.func @dynamic_mask_keeps_masked_store(
 // LOWER: pto.vsts

--- a/test/lit/vmi_new/vmi_to_vpto_e2e_widen_add_store.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_e2e_widen_add_store.pto
@@ -11,7 +11,9 @@
 module {
   func.func @vmi_to_vpto_f16_widen_add_store(
       %src: !pto.ptr<f16, ub>, %dst: !pto.ptr<f32, ub>, %offset: index) {
-    %narrow = pto.vmi.vload %src[%offset]
+    %c16 = arith.constant 16 : index
+    %aligned_offset = arith.muli %offset, %c16 : index
+    %narrow = pto.vmi.vload %src[%aligned_offset]
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
     %wide = pto.vmi.vcvt %narrow
         : !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
@@ -20,14 +22,16 @@ module {
         : !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>,
           !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
         -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
-    pto.vmi.vstore %sum, %dst[%offset]
+    pto.vmi.vstore %sum, %dst[%aligned_offset]
         : !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>, !pto.ptr<f32, ub>
     return
   }
 
   func.func @vmi_to_vpto_f8_widen_add_store(
       %src: !pto.ptr<f8E4M3FN, ub>, %dst: !pto.ptr<f32, ub>, %offset: index) {
-    %narrow = pto.vmi.vload %src[%offset]
+    %c32 = arith.constant 32 : index
+    %aligned_offset = arith.muli %offset, %c32 : index
+    %narrow = pto.vmi.vload %src[%aligned_offset]
         : !pto.ptr<f8E4M3FN, ub> -> !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous>>
     %wide = pto.vmi.vcvt %narrow
         : !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous>>
@@ -36,14 +40,14 @@ module {
         : !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>,
           !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
         -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
-    pto.vmi.vstore %sum, %dst[%offset]
+    pto.vmi.vstore %sum, %dst[%aligned_offset]
         : !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>, !pto.ptr<f32, ub>
     return
   }
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_f16_widen_add_store(
-// CHECK: %[[NARROW:.*]] = pto.vlds %arg0[%arg2] : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+// CHECK: %[[NARROW:.*]] = pto.vlds
 // CHECK: %[[CVT_MASK:.*]] = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
 // CHECK: %[[EVEN:.*]] = pto.vcvt %[[NARROW]], %[[CVT_MASK]] {part = "EVEN"}
 // CHECK: %[[ODD:.*]] = pto.vcvt %[[NARROW]], %[[CVT_MASK]] {part = "ODD"}
@@ -52,13 +56,13 @@ module {
 // CHECK: %[[ADD_MASK1:.*]] = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
 // CHECK: %[[SUM1:.*]] = pto.vadd %[[ODD]], %[[ODD]], %[[ADD_MASK1]]
 // CHECK: %[[STORE_MASK:.*]] = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
-// CHECK: pto.vstsx2 %[[SUM0]], %[[SUM1]], %arg1[%arg2], "INTLV_B32", %[[STORE_MASK]]
+// CHECK: pto.vstsx2 %[[SUM0]], %[[SUM1]], %arg1[%{{.*}}], "INTLV_B32", %[[STORE_MASK]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_f8_widen_add_store(
-// CHECK: %[[NARROW8:.*]] = pto.vlds %arg0[%arg2] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+// CHECK: %[[NARROW8:.*]] = pto.vlds
 // CHECK: pto.vcvt %[[NARROW8]], {{.*}} {part = "P0"}
 // CHECK: pto.vcvt %[[NARROW8]], {{.*}} {part = "P1"}
 // CHECK: pto.vcvt %[[NARROW8]], {{.*}} {part = "P2"}

--- a/test/lit/vmi_new/vmi_to_vpto_ensure_group_slot_layout.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_ensure_group_slot_layout.pto
@@ -165,56 +165,64 @@ module {
 // CHECK-LABEL: func.func @gs8_to_gs8_ls2_ui8(
 // CHECK: %[[U:.*]] = pto.vzunpack %arg0, %{{.*}} : !pto.vreg<256xui8> -> !pto.vreg<128xui16>
 // CHECK: %[[R:.*]] = pto.vbitcast %[[U]] : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
-// CHECK-COUNT-2: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: pto.vstus
+// CHECK-NOT: dist = "1PT_B32"
 
 // CHECK-LABEL: func.func @gs8_ls2_to_gs8_ui8(
 // CHECK: %[[C:.*]] = pto.vbitcast %arg0 : !pto.vreg<256xui8> -> !pto.vreg<128xui16>
 // CHECK: %[[R:.*]] = pto.vpack %[[C]], "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
-// CHECK: %[[WORDS:.*]] = pto.vbitcast %[[R]] : !pto.vreg<256xui8> -> !pto.vreg<64xui32>
-// CHECK-COUNT-2: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: pto.vstus {{.*}}, %[[R]],
+// CHECK-NOT: dist = "1PT_B32"
 
 // CHECK-LABEL: func.func @gs8_to_gs8_ls4_ui8(
 // CHECK: %[[U2:.*]] = pto.vzunpack %arg0, %{{.*}} : !pto.vreg<256xui8> -> !pto.vreg<128xui16>
 // CHECK: %[[U4:.*]] = pto.vzunpack %[[U2]], %{{.*}} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
 // CHECK: %[[R:.*]] = pto.vbitcast %[[U4]] : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
-// CHECK-COUNT-2: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: pto.vstus
+// CHECK-NOT: dist = "1PT_B32"
 
 // CHECK-LABEL: func.func @gs8_ls4_to_gs8_ui8(
 // CHECK: %[[C:.*]] = pto.vbitcast %arg0 : !pto.vreg<256xui8> -> !pto.vreg<64xui32>
 // CHECK: %[[P2:.*]] = pto.vpack %[[C]], "LOWER" : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
 // CHECK: %[[R:.*]] = pto.vpack %[[P2]], "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
-// CHECK: %[[WORDS:.*]] = pto.vbitcast %[[R]] : !pto.vreg<256xui8> -> !pto.vreg<64xui32>
-// CHECK-COUNT-2: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: pto.vstus {{.*}}, %[[R]],
+// CHECK-NOT: dist = "1PT_B32"
 
 // CHECK-LABEL: func.func @gs8_ls2_to_gs8_ls4_ui8(
 // CHECK: %[[C:.*]] = pto.vbitcast %arg0 : !pto.vreg<256xui8> -> !pto.vreg<128xui16>
 // CHECK: %[[U4:.*]] = pto.vzunpack %[[C]], %{{.*}} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
 // CHECK: %[[R:.*]] = pto.vbitcast %[[U4]] : !pto.vreg<64xui32> -> !pto.vreg<256xui8>
-// CHECK-COUNT-2: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: pto.vstus
+// CHECK-NOT: dist = "1PT_B32"
 
 // CHECK-LABEL: func.func @gs8_ls4_to_gs8_ls2_ui8(
 // CHECK: %[[C:.*]] = pto.vbitcast %arg0 : !pto.vreg<256xui8> -> !pto.vreg<64xui32>
 // CHECK: %[[P:.*]] = pto.vpack %[[C]], "LOWER" : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
 // CHECK: %[[R:.*]] = pto.vbitcast %[[P]] : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
-// CHECK-COUNT-2: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: pto.vstus
+// CHECK-NOT: dist = "1PT_B32"
 
 // CHECK-LABEL: func.func @gs8_to_gs8_ls2_ui16(
 // CHECK: %[[U:.*]] = pto.vzunpack %arg0, %{{.*}} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
 // CHECK: %[[R:.*]] = pto.vbitcast %[[U]] : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
-// CHECK-COUNT-4: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: pto.vstus
+// CHECK-NOT: dist = "1PT_B32"
 
 // CHECK-LABEL: func.func @gs8_ls2_to_gs8_ui16(
 // CHECK: %[[C:.*]] = pto.vbitcast %arg0 : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
 // CHECK: %[[R:.*]] = pto.vpack %[[C]], "LOWER" : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
-// CHECK: %[[WORDS:.*]] = pto.vbitcast %[[R]] : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
-// CHECK-COUNT-4: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: pto.vstus {{.*}}, %[[R]],
+// CHECK-NOT: dist = "1PT_B32"
 
 // CHECK-LABEL: func.func @gs8_to_gs8_ls2_ui8_multichunk(
 // CHECK: pto.vzunpack
 // CHECK: pto.vbitcast
 // CHECK: pto.vzunpack
 // CHECK: pto.vbitcast
-// CHECK-COUNT-2: pto.vsts
+// CHECK: %[[ALIGN:.*]] = pto.init_align
+// CHECK: %[[NEXT_ALIGN:.*]], %[[NEXT_BASE:.*]] = pto.vstus %[[ALIGN]],
+// CHECK: %[[FINAL_ALIGN:.*]], %[[FINAL_BASE:.*]] = pto.vstus %[[NEXT_ALIGN]],
+// CHECK: pto.vstas %[[FINAL_ALIGN]], %[[FINAL_BASE]],
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_expand_load_all_active.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_expand_load_all_active.pto
@@ -31,8 +31,11 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_expand_load_all_active(
-// CHECK: %[[LOAD:.*]] = pto.vlds %arg0[%arg1] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-// CHECK: return %[[LOAD]]
+// CHECK-NOT: pto.vlds
+// CHECK: %[[BASE:.*]] = pto.addptr %arg0, %arg1
+// CHECK: %[[LOAD:.*]] = pto.vgather2_bc %[[BASE]]
+// CHECK: %[[OUT:.*]] = pto.vsel %[[LOAD]], %arg2
+// CHECK: return %[[OUT]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_extf_f4x2_to_bf16x2_variants.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_extf_f4x2_to_bf16x2_variants.pto
@@ -21,9 +21,11 @@ module {
       %src: !pto.vmi.vreg<256x!pto.f4E1M2x2>,
       %dst: !pto.ptr<!pto.bf16x2, ub>,
       %off: index) {
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %r = pto.vmi.vcvt %src
         : !pto.vmi.vreg<256x!pto.f4E1M2x2> -> !pto.vmi.vreg<256x!pto.bf16x2>
-    pto.vmi.vstore %r, %dst[%off]
+    pto.vmi.vstore %r, %dst[%aligned_off]
         : !pto.vmi.vreg<256x!pto.bf16x2>, !pto.ptr<!pto.bf16x2, ub>
     return
   }
@@ -33,9 +35,11 @@ module {
       %src: !pto.vmi.vreg<256x!pto.f4E2M1x2>,
       %dst: !pto.ptr<!pto.bf16x2, ub>,
       %off: index) {
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %r = pto.vmi.vcvt %src
         : !pto.vmi.vreg<256x!pto.f4E2M1x2> -> !pto.vmi.vreg<256x!pto.bf16x2>
-    pto.vmi.vstore %r, %dst[%off]
+    pto.vmi.vstore %r, %dst[%aligned_off]
         : !pto.vmi.vreg<256x!pto.bf16x2>, !pto.ptr<!pto.bf16x2, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_to_vpto_group_reduce_partial_slots8.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_reduce_partial_slots8.pto
@@ -12,14 +12,18 @@ module {
   func.func @vmi_to_vpto_group_reduce_f16_s64_g4(
       %source: !pto.vmi.vreg<256xf16, #pto.vmi.layout<deinterleaved = 4>>,
       %mask: !pto.vmi.mask<256xb16, #pto.vmi.layout<deinterleaved = 4>>,
-      %dst: !pto.ptr<f16, ub>, %off: index) {
+      %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<f16, ub>
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
     %c1 = arith.constant 1 : index
     %out = pto.vmi.vcadd %source, %mask
         {group = 4, reassoc}
         : !pto.vmi.vreg<256xf16, #pto.vmi.layout<deinterleaved = 4>>,
           !pto.vmi.mask<256xb16, #pto.vmi.layout<deinterleaved = 4>>
         -> !pto.vmi.vreg<4xf16, #pto.vmi.layout<num_groups = 4, slots = 8>>
-    pto.vmi.vstore %out, %dst[%off], %c1 {group = 4}
+    pto.vmi.vstore %out, %dst[%aligned_off], %c1 {group = 4}
         : !pto.vmi.vreg<4xf16, #pto.vmi.layout<num_groups = 4, slots = 8>>,
           !pto.ptr<f16, ub>
     return
@@ -28,14 +32,18 @@ module {
   func.func @vmi_to_vpto_group_reduce_f16_s64_g8(
       %source: !pto.vmi.vreg<512xf16, #pto.vmi.layout<deinterleaved = 4>>,
       %mask: !pto.vmi.mask<512xb16, #pto.vmi.layout<deinterleaved = 4>>,
-      %dst: !pto.ptr<f16, ub>, %off: index) {
+      %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<f16, ub>
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
     %c1 = arith.constant 1 : index
     %out = pto.vmi.vcadd %source, %mask
         {group = 8, reassoc}
         : !pto.vmi.vreg<512xf16, #pto.vmi.layout<deinterleaved = 4>>,
           !pto.vmi.mask<512xb16, #pto.vmi.layout<deinterleaved = 4>>
         -> !pto.vmi.vreg<8xf16, #pto.vmi.layout<num_groups = 8, slots = 8>>
-    pto.vmi.vstore %out, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %out, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf16, #pto.vmi.layout<num_groups = 8, slots = 8>>,
           !pto.ptr<f16, ub>
     return
@@ -44,14 +52,18 @@ module {
   func.func @vmi_to_vpto_group_reduce_f16_s64_g12(
       %source: !pto.vmi.vreg<768xf16, #pto.vmi.layout<deinterleaved = 4>>,
       %mask: !pto.vmi.mask<768xb16, #pto.vmi.layout<deinterleaved = 4>>,
-      %dst: !pto.ptr<f16, ub>, %off: index) {
+      %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<f16, ub>
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
     %c1 = arith.constant 1 : index
     %out = pto.vmi.vcadd %source, %mask
         {group = 12, reassoc}
         : !pto.vmi.vreg<768xf16, #pto.vmi.layout<deinterleaved = 4>>,
           !pto.vmi.mask<768xb16, #pto.vmi.layout<deinterleaved = 4>>
         -> !pto.vmi.vreg<12xf16, #pto.vmi.layout<num_groups = 12, slots = 8>>
-    pto.vmi.vstore %out, %dst[%off], %c1 {group = 12}
+    pto.vmi.vstore %out, %dst[%aligned_off], %c1 {group = 12}
         : !pto.vmi.vreg<12xf16, #pto.vmi.layout<num_groups = 12, slots = 8>>,
           !pto.ptr<f16, ub>
     return
@@ -62,8 +74,9 @@ module {
 // CHECK-DAG: %[[SLOT4:.*]] = pto.pset_b16 "PAT_VL4" : !pto.mask<b16>
 // CHECK-COUNT-4: pto.vcgadd
 // CHECK-COUNT-3: pto.vadd {{.*}}, {{.*}}, %[[SLOT4]]
-// CHECK: %[[WORDS4:.*]] = pto.vbitcast {{.*}} : !pto.vreg<128xf16> -> !pto.vreg<64xui32>
-// CHECK-COUNT-2: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vstus
+// CHECK-NOT: dist = "1PT_B32"
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
@@ -72,8 +85,9 @@ module {
 // CHECK-DAG: %[[SLOT8:.*]] = pto.pset_b16 "PAT_VL8" : !pto.mask<b16>
 // CHECK-COUNT-4: pto.vcgadd
 // CHECK-COUNT-3: pto.vadd {{.*}}, {{.*}}, %[[SLOT8]]
-// CHECK: %[[WORDS8:.*]] = pto.vbitcast {{.*}} : !pto.vreg<128xf16> -> !pto.vreg<64xui32>
-// CHECK-COUNT-4: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vstus
+// CHECK-NOT: dist = "1PT_B32"
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
@@ -85,10 +99,10 @@ module {
 // CHECK: %[[SLOT4_12:.*]] = pto.pset_b16 "PAT_VL4" : !pto.mask<b16>
 // CHECK-COUNT-4: pto.vcgadd
 // CHECK-COUNT-3: pto.vadd {{.*}}, {{.*}}, %[[SLOT4_12]]
-// CHECK: %[[STORE8_12:.*]] = pto.pset_b16 "PAT_VL8" : !pto.mask<b16>
-// CHECK: pto.vsts {{.*}}, {{.*}}, %[[STORE8_12]]
-// CHECK: %[[STORE4_12:.*]] = pto.pset_b16 "PAT_VL4" : !pto.mask<b16>
-// CHECK: pto.vsts {{.*}}, {{.*}}, %[[STORE4_12]]
+// CHECK: %[[ALIGN:.*]] = pto.init_align
+// CHECK: %[[NEXT_ALIGN:.*]], %[[NEXT_BASE:.*]] = pto.vstus %[[ALIGN]], %{{.*}}, {{.*}}, {{.*}}
+// CHECK: %[[FINAL_ALIGN:.*]], %[[FINAL_BASE:.*]] = pto.vstus %[[NEXT_ALIGN]], %{{.*}}, {{.*}}, %[[NEXT_BASE]]
+// CHECK: pto.vstas %[[FINAL_ALIGN]], %[[FINAL_BASE]], %{{.*}}
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_group_slot_load.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_slot_load.pto
@@ -155,8 +155,9 @@ module {
 // CHECK: %[[LOAD_MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
 // CHECK: %[[BASE:.*]] = pto.addptr %arg0, %arg2 : <f32, ub> -> <f32, ub>
 // CHECK: %[[OUT:.*]] = pto.vsldb %[[BASE]], {{.*}}, {{.*}}, %[[LOAD_MASK]]
-// CHECK: %[[STORE_MASK:.*]] = pto.pset_b32 "PAT_VL8" : !pto.mask<b32>
-// CHECK: pto.vsts %[[OUT]], %arg1[%arg2], %[[STORE_MASK]] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// CHECK: pto.init_align
+// CHECK: pto.vstus
+// CHECK: pto.vstas
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
@@ -171,7 +172,7 @@ module {
 // CHECK: pto.vcvt {{.*}} {part = "P0"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
 // CHECK: pto.vshl
 // CHECK: pto.vselr
-// CHECK: pto.vsts {{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// CHECK: pto.vstus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
@@ -183,7 +184,7 @@ module {
 // CHECK: pto.vbitcast %[[U32]] : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
 // CHECK: pto.pset_b16 "PAT_VL16" : !pto.mask<b16>
 // CHECK: pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
-// CHECK: pto.vsts {{.*}} : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
+// CHECK: pto.vstus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
@@ -192,7 +193,10 @@ module {
 // CHECK: %[[LOAD:.*]] = pto.vsldb {{.*}} : !pto.ptr<ui8, ub>, i16, i16, !pto.mask<b8> -> !pto.vreg<256xui8>
 // CHECK: %[[UNPACK:.*]] = pto.vzunpack %[[LOAD]]
 // CHECK: %[[WIDE:.*]] = pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<128xui16>
-// CHECK: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: pto.init_align
+// CHECK: pto.vstus {{.*}}, %[[WIDE]],
+// CHECK: pto.vstas
+// CHECK-NOT: dist = "1PT_B32"
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 

--- a/test/lit/vmi_new/vmi_to_vpto_group_store_compact_small.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_store_compact_small.pto
@@ -88,6 +88,16 @@ module {
     return
   }
 
+  func.func @unaligned_compact_group_store_ui8_ls4(
+      %value: !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>,
+      %dst: !pto.ptr<ui8, ub>, %off: index) {
+    %c1 = arith.constant 1 : index
+    pto.vmi.vstore %value, %dst[%off], %c1 {group = 8}
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>,
+          !pto.ptr<ui8, ub>
+    return
+  }
+
   func.func @aligned_compact_group_store_ui8_ls2(
       %value: !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>) {
     %c102400_i64 = arith.constant 102400 : i64
@@ -126,8 +136,12 @@ module {
 
   func.func @regular_group_store_ui32(
       %value: !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>,
-      %dst: !pto.ptr<ui32, ub>, %off: index) {
+      %tile: index) {
+    %base_addr = arith.constant 102400 : i64
+    %dst = pto.castptr %base_addr : i64 -> !pto.ptr<ui32, ub>
     %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %off = arith.muli %tile, %c8 : index
     pto.vmi.vstore %value, %dst[%off], %c1 {group = 8}
         : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>,
           !pto.ptr<ui32, ub>
@@ -146,8 +160,12 @@ module {
 
   func.func @regular_group_store_f32(
       %value: !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8>>,
-      %dst: !pto.ptr<f32, ub>, %off: index) {
+      %tile: index) {
+    %base_addr = arith.constant 102400 : i64
+    %dst = pto.castptr %base_addr : i64 -> !pto.ptr<f32, ub>
     %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %off = arith.muli %tile, %c8 : index
     pto.vmi.vstore %value, %dst[%off], %c1 {group = 8}
         : !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8>>,
           !pto.ptr<f32, ub>
@@ -166,8 +184,11 @@ module {
 // ASSIGN: pto.vmi.group_store %arg0
 
 // LOWER-LABEL: func.func @compact_group_store_ui16(
-// LOWER: %[[WORDS:.*]] = pto.vbitcast %arg0 : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
-// LOWER-COUNT-4: pto.vsts {{.*}} {dist = "1PT_B32"} : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
+// LOWER: %[[UI16_BASE:.*]] = pto.addptr %arg1, %arg2
+// LOWER: %[[UI16_ALIGN:.*]] = pto.init_align
+// LOWER: %[[UI16_NEXT_ALIGN:.*]], %[[UI16_NEXT_BASE:.*]] = pto.vstus %[[UI16_ALIGN]], %{{.*}}, %arg0, %[[UI16_BASE]]
+// LOWER: pto.vstas %[[UI16_NEXT_ALIGN]], %[[UI16_NEXT_BASE]], %{{.*}}
+// LOWER-NOT: dist = "1PT_B32"
 // LOWER-NOT: dist = "NORM_B16"
 // LOWER-NOT: dist = "PK_B16"
 // LOWER-NOT: dist = "PK4_B32"
@@ -179,15 +200,28 @@ module {
 // LOWER: pto.vsts %arg0, %{{.*}}[%{{.*}}], %{{.*}} {dist = "NORM_B16"} : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.mask<b16>
 // LOWER-NOT: dist = "1PT_B32"
 // LOWER-LABEL: func.func @partially_aligned_compact_group_store_bf16(
-// LOWER-COUNT-4: pto.vsts {{.*}} {dist = "1PT_B32"} : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
+// LOWER: %[[PARTIAL_ALIGN:.*]] = pto.init_align
+// LOWER: %[[PARTIAL_NEXT_ALIGN:.*]], %[[PARTIAL_NEXT_BASE:.*]] = pto.vstus %[[PARTIAL_ALIGN]], %{{.*}}, %arg0, %{{.*}}
+// LOWER: pto.vstas %[[PARTIAL_NEXT_ALIGN]], %[[PARTIAL_NEXT_BASE]], %{{.*}}
+// LOWER-NOT: dist = "1PT_B32"
 // LOWER-NOT: dist = "NORM_B16"
 // LOWER-LABEL: func.func @unaligned_base_compact_group_store_bf16(
-// LOWER-COUNT-4: pto.vsts {{.*}} {dist = "1PT_B32"} : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
+// LOWER: %[[UNALIGNED_ALIGN:.*]] = pto.init_align
+// LOWER: %[[UNALIGNED_NEXT_ALIGN:.*]], %[[UNALIGNED_NEXT_BASE:.*]] = pto.vstus %[[UNALIGNED_ALIGN]], %{{.*}}, %arg0, %{{.*}}
+// LOWER: pto.vstas %[[UNALIGNED_NEXT_ALIGN]], %[[UNALIGNED_NEXT_BASE]], %{{.*}}
+// LOWER-NOT: dist = "1PT_B32"
 // LOWER-NOT: dist = "NORM_B16"
 // LOWER-LABEL: func.func @aligned_compact_group_store_ui8_ls4(
 // LOWER: %[[PACK16:.*]] = pto.vpack {{.*}}, "LOWER" : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
 // LOWER: %[[PACK8:.*]] = pto.vpack %[[PACK16]], "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
 // LOWER: pto.vsts %[[PACK8]], %{{.*}}[%{{.*}}], %{{.*}} {dist = "NORM_B8"} : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b8>
+// LOWER-NOT: dist = "1PT_B32"
+// LOWER-LABEL: func.func @unaligned_compact_group_store_ui8_ls4(
+// LOWER: %[[UNALIGNED_PACK16:.*]] = pto.vpack {{.*}}, "LOWER" : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
+// LOWER: %[[UNALIGNED_PACK8:.*]] = pto.vpack %[[UNALIGNED_PACK16]], "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
+// LOWER: %[[UNALIGNED_UI8_ALIGN:.*]] = pto.init_align
+// LOWER: %[[UNALIGNED_UI8_NEXT_ALIGN:.*]], %[[UNALIGNED_UI8_NEXT_BASE:.*]] = pto.vstus %[[UNALIGNED_UI8_ALIGN]], %{{.*}}, %[[UNALIGNED_PACK8]], %{{.*}}
+// LOWER: pto.vstas %[[UNALIGNED_UI8_NEXT_ALIGN]], %[[UNALIGNED_UI8_NEXT_BASE]], %{{.*}}
 // LOWER-NOT: dist = "1PT_B32"
 // LOWER-LABEL: func.func @aligned_compact_group_store_ui8_ls2(
 // LOWER: %[[PACKED8:.*]] = pto.vpack {{.*}}, "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
@@ -206,8 +240,10 @@ module {
 // LOWER-NOT: dist = "1PT_B32"
 // LOWER-COUNT-1: pto.vsts {{.*}} : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
 // LOWER-LABEL: func.func @compact_group_store_f32(
-// LOWER: %[[F32WORDS:.*]] = pto.vbitcast %arg0 : !pto.vreg<64xf32> -> !pto.vreg<64xui32>
-// LOWER-COUNT-4: pto.vsts {{.*}} {dist = "1PT_B32"} : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
+// LOWER: %[[F32_ALIGN:.*]] = pto.init_align
+// LOWER: %[[F32_NEXT_ALIGN:.*]], %[[F32_NEXT_BASE:.*]] = pto.vstus %[[F32_ALIGN]], %{{.*}}, %arg0, %{{.*}}
+// LOWER: pto.vstas %[[F32_NEXT_ALIGN]], %[[F32_NEXT_BASE]], %{{.*}}
+// LOWER-NOT: dist = "1PT_B32"
 // LOWER-LABEL: func.func @regular_group_store_f32(
 // LOWER-NOT: dist = "1PT_B32"
 // LOWER-COUNT-1: pto.vsts {{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>

--- a/test/lit/vmi_new/vmi_to_vpto_group_store_lane_stride.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_store_lane_stride.pto
@@ -13,9 +13,13 @@
 module {
   func.func @group_store_ui8_slots8_lane_stride2(
       %value: !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>,
-      %dst: !pto.ptr<ui8, ub>, %off: index) {
+      %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<ui8, ub>
     %c1 = arith.constant 1 : index
-    pto.vmi.vstore %value, %dst[%off], %c1 {group = 8}
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
+    pto.vmi.vstore %value, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>,
           !pto.ptr<ui8, ub>
     return
@@ -23,9 +27,10 @@ module {
 }
 
 // CHECK-LABEL: func.func @group_store_ui8_slots8_lane_stride2(
-// CHECK: pto.vpack {{.*}}, "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
-// CHECK: pto.vbitcast {{.*}} : !pto.vreg<256xui8> -> !pto.vreg<64xui32>
-// CHECK-COUNT-2: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: %[[PACKED:.*]] = pto.vpack {{.*}}, "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
+// CHECK: pto.vsts %[[PACKED]],
+// CHECK-NOT: pto.vstus
+// CHECK-NOT: dist = "1PT_B32"
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_group_store_slots1_unit_stride_alignment.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_store_slots1_unit_stride_alignment.pto
@@ -40,8 +40,11 @@ module {
 // CHECK-NOT: dist = "1PT_B32"
 
 // CHECK-LABEL: func.func @unaligned_unit_stride_group_store(
-// CHECK-NOT: pto.vdup
-// CHECK-COUNT-8: pto.vsts {{.*}} {dist = "1PT_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// CHECK-COUNT-8: pto.vdup
+// CHECK: %[[ALIGN:.*]] = pto.init_align
+// CHECK: %[[NEXT_ALIGN:.*]], %[[NEXT_BASE:.*]] = pto.vstus %[[ALIGN]], %{{.*}}, %{{.*}}, %{{.*}}
+// CHECK: pto.vstas %[[NEXT_ALIGN]], %[[NEXT_BASE]], %{{.*}}
+// CHECK-NOT: dist = "1PT_B32"
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_group_store_slots8_packed_byte.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_store_slots8_packed_byte.pto
@@ -11,8 +11,21 @@
 module {
   func.func @vmi_to_vpto_group_store_slots8_i32_to_u8(
       %value: !pto.vmi.vreg<32xi32, #pto.vmi.layout<num_groups = 32, slots = 8>>,
-      %dst: !pto.ptr<ui8, ub>,
-      %off: index) {
+      %tile: index) {
+    %base_addr = arith.constant 102400 : i64
+    %dst = pto.castptr %base_addr : i64 -> !pto.ptr<ui8, ub>
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %off = arith.muli %tile, %c32 : index
+    pto.vmi.vstore %value, %dst[%off], %c1 {group = 32}
+        : !pto.vmi.vreg<32xi32, #pto.vmi.layout<num_groups = 32, slots = 8>>,
+          !pto.ptr<ui8, ub>
+    return
+  }
+
+  func.func @vmi_to_vpto_group_store_slots8_i32_to_u8_unaligned(
+      %value: !pto.vmi.vreg<32xi32, #pto.vmi.layout<num_groups = 32, slots = 8>>,
+      %dst: !pto.ptr<ui8, ub>, %off: index) {
     %c1 = arith.constant 1 : index
     pto.vmi.vstore %value, %dst[%off], %c1 {group = 32}
         : !pto.vmi.vreg<32xi32, #pto.vmi.layout<num_groups = 32, slots = 8>>,
@@ -34,6 +47,12 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_store_slots8_i32_to_u8(
 // CHECK-COUNT-1: pto.vsts {{.*}} {dist = "PK4_B32"} : !pto.vreg<64xi32>, !pto.ptr<ui8, ub>, !pto.mask<b32>
+// CHECK-LABEL: func.func @vmi_to_vpto_group_store_slots8_i32_to_u8_unaligned(
+// CHECK: %[[PACK16:.*]] = pto.vpack {{.*}}, "LOWER" : !pto.vreg<64xi32> -> !pto.vreg<128xui16>
+// CHECK: %[[PACK8:.*]] = pto.vpack %[[PACK16]], "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
+// CHECK: %[[ALIGN:.*]] = pto.init_align
+// CHECK: %[[NEXT_ALIGN:.*]], %[[NEXT_BASE:.*]] = pto.vstus %[[ALIGN]], %{{.*}}, %[[PACK8]], %{{.*}}
+// CHECK: pto.vstas %[[NEXT_ALIGN]], %[[NEXT_BASE]], %{{.*}}
 // CHECK-LABEL: func.func @vmi_to_vpto_group_store_slots8_i32_to_u8_padded(
 // CHECK: pto.vpack {{.*}} "LOWER" : !pto.vreg<64xi32> -> !pto.vreg<128xui16>
 // CHECK: pto.vpack {{.*}} "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>

--- a/test/lit/vmi_new/vmi_to_vpto_integer_casts.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_integer_casts.pto
@@ -96,13 +96,16 @@ module {
 
   func.func @vmi_to_vpto_group_slot_trunci_i32_to_ui8(
       %wide: !pto.vmi.vreg<8xi32, #pto.vmi.layout<num_groups = 8, slots = 1>>,
-      %dst: !pto.ptr<ui8, ub>,
       %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<ui8, ub>
     %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %narrow = pto.vmi.vcvt %wide {saturate = "SAT"}
         : !pto.vmi.vreg<8xi32, #pto.vmi.layout<num_groups = 8, slots = 1>>
         -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 1>>
-    pto.vmi.vstore %narrow, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %narrow, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 1>>,
           !pto.ptr<ui8, ub>
     return
@@ -110,13 +113,16 @@ module {
 
   func.func @vmi_to_vpto_group_slot_trunci_slots8_i32_to_ui8(
       %wide: !pto.vmi.vreg<8xi32, #pto.vmi.layout<num_groups = 8, slots = 8>>,
-      %dst: !pto.ptr<ui8, ub>,
       %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<ui8, ub>
     %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %narrow = pto.vmi.vcvt %wide {saturate = "SAT"}
         : !pto.vmi.vreg<8xi32, #pto.vmi.layout<num_groups = 8, slots = 8>>
         -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>
-    pto.vmi.vstore %narrow, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %narrow, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>,
           !pto.ptr<ui8, ub>
     return
@@ -146,12 +152,16 @@ module {
 
   func.func @vmi_to_vpto_group_slot_extui_slots1_ui8_to_ui32(
       %input: !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 1>>,
-      %dst: !pto.ptr<ui32, ub>, %off: index) {
+      %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<ui32, ub>
     %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %wide = pto.vmi.vcvt %input
         : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 1>>
         -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 1>>
-    pto.vmi.vstore %wide, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %wide, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 1>>,
           !pto.ptr<ui32, ub>
     return
@@ -159,12 +169,16 @@ module {
 
   func.func @vmi_to_vpto_group_slot_extui_slots1_ui16_to_ui32(
       %input: !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>,
-      %dst: !pto.ptr<ui32, ub>, %off: index) {
+      %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<ui32, ub>
     %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %aligned_off = arith.muli %off, %c8 : index
     %wide = pto.vmi.vcvt %input
         : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>
         -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 1>>
-    pto.vmi.vstore %wide, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %wide, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 1>>,
           !pto.ptr<ui32, ub>
     return
@@ -230,12 +244,16 @@ module {
 
   func.func @vmi_to_vpto_group_slot_trunci_slots1_ui32_to_ui16(
       %input: !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 1>>,
-      %dst: !pto.ptr<ui16, ub>, %off: index) {
+      %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<ui16, ub>
     %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
     %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
         : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 1>>
         -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>
-    pto.vmi.vstore %narrow, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %narrow, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 1>>,
           !pto.ptr<ui16, ub>
     return
@@ -243,12 +261,16 @@ module {
 
   func.func @vmi_to_vpto_group_slot_trunci_slots8_ui32_to_ui16(
       %input: !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>,
-      %dst: !pto.ptr<ui16, ub>, %off: index) {
+      %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<ui16, ub>
     %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %aligned_off = arith.muli %off, %c16 : index
     %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
         : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
         -> !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
-    pto.vmi.vstore %narrow, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %narrow, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>,
           !pto.ptr<ui16, ub>
     return
@@ -256,13 +278,16 @@ module {
 
   func.func @vmi_to_vpto_group_slot_trunci_slots8_i32_to_ui8_lane_stride(
       %wide: !pto.vmi.vreg<8xi32, #pto.vmi.layout<num_groups = 8, slots = 8>>,
-      %dst: !pto.ptr<ui8, ub>,
       %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<ui8, ub>
     %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %narrow = pto.vmi.vcvt %wide {saturate = "SAT"}
         : !pto.vmi.vreg<8xi32, #pto.vmi.layout<num_groups = 8, slots = 8>>
         -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>
-    pto.vmi.vstore %narrow, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %narrow, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 4>>,
           !pto.ptr<ui8, ub>
     return
@@ -270,13 +295,16 @@ module {
 
   func.func @vmi_to_vpto_group_slot_trunci_slots8_ui16_to_ui8_lane_stride(
       %wide: !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>,
-      %dst: !pto.ptr<ui8, ub>,
       %off: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<ui8, ub>
     %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %narrow = pto.vmi.vcvt %wide {saturate = "SAT"}
         : !pto.vmi.vreg<8xui16, #pto.vmi.layout<num_groups = 8, slots = 8>>
         -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
-    pto.vmi.vstore %narrow, %dst[%off], %c1 {group = 8}
+    pto.vmi.vstore %narrow, %dst[%aligned_off], %c1 {group = 8}
         : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>,
           !pto.ptr<ui8, ub>
     return
@@ -351,6 +379,7 @@ module {
 // CHECK: pto.vcvt {{.*}} {part = "P0", sat = "SAT"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<256xui8>
 // CHECK: pto.vcvt {{.*}} {part = "P0", sat = "SAT"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<256xui8>
 // CHECK: pto.vsts
+// CHECK-NOT: pto.vstus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
@@ -359,6 +388,7 @@ module {
 // CHECK: pto.pset_b32 "PAT_VL8"
 // CHECK: pto.vcvt {{.*}} {part = "P0", sat = "SAT"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<256xui8>
 // CHECK: pto.vsts
+// CHECK-NOT: pto.vstus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
@@ -372,12 +402,16 @@ module {
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extui_slots1_ui8_to_ui32(
 // CHECK: %[[VL1U8:.*]] = pto.pset_b8 "PAT_VL1" : !pto.mask<b8>
 // CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1U8]] {part = "P0"} : !pto.vreg<256xui8>, !pto.mask<b8> -> !pto.vreg<64xui32>
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vstus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_extui_slots1_ui16_to_ui32(
 // CHECK: %[[VL1U16EXT:.*]] = pto.pset_b16 "PAT_VL1" : !pto.mask<b16>
 // CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1U16EXT]] {part = "EVEN"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<64xui32>
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vstus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 
@@ -408,29 +442,36 @@ module {
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_trunci_slots1_ui32_to_ui16(
 // CHECK: %[[VL1U32:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK-COUNT-8: pto.vcvt {{.*}}, %[[VL1U32]] {part = "EVEN", sat = "SAT"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<128xui16>
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vstus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_trunci_slots8_ui32_to_ui16(
 // CHECK: pto.vcvt {{.*}} {part = "EVEN", sat = "SAT"} : !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<128xui16>
 // CHECK: pto.vbitcast {{.*}} : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vstus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_trunci_slots8_i32_to_ui8_lane_stride(
 // CHECK: pto.vcvt {{.*}} {part = "P0", sat = "SAT"} : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<256xui8>
 // CHECK: pto.vpack {{.*}} "LOWER" : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
-// CHECK: pto.vpack {{.*}} "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
-// CHECK-COUNT-2: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: %[[PACKED_I32_UI8:.*]] = pto.vpack {{.*}} "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
+// CHECK: pto.vsts %[[PACKED_I32_UI8]],
+// CHECK-NOT: pto.vstus
+// CHECK-NOT: dist = "1PT_B32"
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_slot_trunci_slots8_ui16_to_ui8_lane_stride(
 // CHECK: pto.vcvt {{.*}} {part = "EVEN", sat = "SAT"} : !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<256xui8>
-// CHECK: pto.vpack {{.*}} "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
-// CHECK: pto.vbitcast {{.*}} : !pto.vreg<256xui8> -> !pto.vreg<64xui32>
-// CHECK-COUNT-2: pto.vsts {{.*}} {dist = "1PT_B32"}
+// CHECK: %[[PACKED_UI16_UI8:.*]] = pto.vpack {{.*}} "LOWER" : !pto.vreg<128xui16> -> !pto.vreg<256xui8>
+// CHECK: pto.vsts %[[PACKED_UI16_UI8]],
+// CHECK-NOT: pto.vstus
+// CHECK-NOT: dist = "1PT_B32"
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_load_deint.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_load_deint.pto
@@ -11,7 +11,9 @@
 module {
   func.func @vmi_to_vpto_load_deint2(%src: !pto.ptr<f32, ub>, %offset: index)
       -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>) {
-    %lo, %hi = pto.vmi.vload %src[%offset] {dist_mode = "dintlv"}
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    %lo, %hi = pto.vmi.vload %src[%aligned_offset] {dist_mode = "dintlv"}
         : !pto.ptr<f32, ub>
         -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
     %p0 = "pto.vmi.unpack"(%lo)
@@ -23,7 +25,9 @@ module {
 
   func.func @vmi_to_vpto_load_deint4(%src: !pto.ptr<f32, ub>, %offset: index)
       -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>) {
-    %lo, %hi = pto.vmi.vload %src[%offset] {dist_mode = "dintlv"}
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    %lo, %hi = pto.vmi.vload %src[%aligned_offset] {dist_mode = "dintlv"}
         : !pto.ptr<f32, ub>
         -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>, !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
     %p0, %p1 = "pto.vmi.unpack"(%lo)
@@ -38,14 +42,14 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_load_deint2(
-// CHECK: %[[P0:.*]], %[[P1:.*]] = pto.vldsx2 %arg0[%arg1], "DINTLV_B32"
+// CHECK: %[[P0:.*]], %[[P1:.*]] = pto.vldsx2 %arg0[{{.*}}], "DINTLV_B32"
 // CHECK: return %[[P0]], %[[P1]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_load_deint4(
-// CHECK: %[[P0:.*]], %[[P2:.*]] = pto.vldsx2 %arg0[%arg1], "DINTLV_B32"
+// CHECK: %[[P0:.*]], %[[P2:.*]] = pto.vldsx2 %arg0[{{.*}}], "DINTLV_B32"
 // CHECK: %[[P1:.*]], %[[P3:.*]] = pto.vldsx2 %arg0[{{.*}}], "DINTLV_B32"
 // CHECK: return %[[P0]], %[[P1]], %[[P2]], %[[P3]]
 // CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_load_deint_multichunk.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_load_deint_multichunk.pto
@@ -12,7 +12,9 @@ module {
   func.func @vmi_to_vpto_load_deint2_multichunk(
       %src: !pto.ptr<f32, ub>, %offset: index)
       -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>) {
-    %lo, %hi = pto.vmi.vload %src[%offset] {dist_mode = "dintlv"}
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    %lo, %hi = pto.vmi.vload %src[%aligned_offset] {dist_mode = "dintlv"}
         : !pto.ptr<f32, ub>
         -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>, !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
     %p0, %p1 = "pto.vmi.unpack"(%lo)
@@ -31,7 +33,9 @@ module {
           !pto.vreg<64xf32>, !pto.vreg<64xf32>,
           !pto.vreg<64xf32>, !pto.vreg<64xf32>,
           !pto.vreg<64xf32>, !pto.vreg<64xf32>) {
-    %lo, %hi = pto.vmi.vload %src[%offset] {dist_mode = "dintlv"}
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    %lo, %hi = pto.vmi.vload %src[%aligned_offset] {dist_mode = "dintlv"}
         : !pto.ptr<f32, ub>
         -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>, !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
     %p0_0, %p0_1, %p1_0, %p1_1 = "pto.vmi.unpack"(%lo)
@@ -49,7 +53,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_load_deint2_multichunk(
-// CHECK: %[[P0_0:.*]], %[[P1_0:.*]] = pto.vldsx2 %arg0[%arg1], "DINTLV_B32"
+// CHECK: %[[P0_0:.*]], %[[P1_0:.*]] = pto.vldsx2 %arg0[{{.*}}], "DINTLV_B32"
 // CHECK: %[[P0_1:.*]], %[[P1_1:.*]] = pto.vldsx2 %arg0[{{.*}}], "DINTLV_B32"
 // CHECK: return %[[P0_0]], %[[P0_1]], %[[P1_0]], %[[P1_1]]
 // CHECK-NOT: pto.vmi.
@@ -57,7 +61,7 @@ module {
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_load_deint4_multichunk(
-// CHECK: %[[P0_0:.*]], %[[P2_0:.*]] = pto.vldsx2 %arg0[%arg1], "DINTLV_B32"
+// CHECK: %[[P0_0:.*]], %[[P2_0:.*]] = pto.vldsx2 %arg0[{{.*}}], "DINTLV_B32"
 // CHECK: %[[P0_1:.*]], %[[P2_1:.*]] = pto.vldsx2 %arg0[{{.*}}], "DINTLV_B32"
 // CHECK: %[[P1_0:.*]], %[[P3_0:.*]] = pto.vldsx2 %arg0[{{.*}}], "DINTLV_B32"
 // CHECK: %[[P1_1:.*]], %[[P3_1:.*]] = pto.vldsx2 %arg0[{{.*}}], "DINTLV_B32"

--- a/test/lit/vmi_new/vmi_to_vpto_load_nonfull.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_load_nonfull.pto
@@ -10,10 +10,12 @@
 
 module {
   func.func @vmi_to_vpto_load_nonfull(
-      %src: !pto.ptr<f32, ub>, %offset: index)
+      %src: memref<64xf32, #pto.address_space<vec>>)
       -> (!pto.vreg<64xf32>) {
-    %value = pto.vmi.vload %src[%offset]
-        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<3xf32, #pto.vmi.layout<contiguous>>
+    %c0 = arith.constant 0 : index
+    %value = pto.vmi.vload %src[%c0]
+        : memref<64xf32, #pto.address_space<vec>>
+        -> !pto.vmi.vreg<3xf32, #pto.vmi.layout<contiguous>>
     %part = "pto.vmi.unpack"(%value)
         : (!pto.vmi.vreg<3xf32, #pto.vmi.layout<contiguous>>) -> !pto.vreg<64xf32>
     return %part : !pto.vreg<64xf32>
@@ -21,7 +23,8 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_load_nonfull(
-// CHECK: pto.vlds %arg0[%arg1] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK: pto.vlds
+// CHECK-NOT: pto.vldus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_load_nonfull_memref.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_load_nonfull_memref.pto
@@ -9,11 +9,13 @@
 // RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
 
 module {
-  func.func @vmi_to_vpto_load_nonfull_memref(%src: !pto.ptr<f32, ub>)
+  func.func @vmi_to_vpto_load_nonfull_memref(
+      %src: memref<128xf32, #pto.address_space<vec>>)
       -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>) {
     %c0 = arith.constant 0 : index
     %value = pto.vmi.vload %src[%c0]
-        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>
+        : memref<128xf32, #pto.address_space<vec>>
+        -> !pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>
     %p0, %p1 = "pto.vmi.unpack"(%value)
         : (!pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>)
         -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>)
@@ -24,8 +26,8 @@ module {
 // CHECK-LABEL: func.func @vmi_to_vpto_load_nonfull_memref(
 // CHECK: %[[C64:.*]] = arith.constant 64 : index
 // CHECK: %[[C0:.*]] = arith.constant 0 : index
-// CHECK: pto.vlds %arg0[%[[C0]]] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-// CHECK: pto.vlds %arg0[%[[C64]]] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK: pto.vlds %arg0[%[[C0]]]
+// CHECK: pto.vlds %arg0[%[[C64]]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_load_safe_tail_memref.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_load_safe_tail_memref.pto
@@ -9,22 +9,26 @@
 // RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
 
 module {
-  func.func @vmi_to_vpto_load_safe_tail_memref(%src: !pto.ptr<f32, ub>)
+  func.func @vmi_to_vpto_load_safe_tail_memref(
+      %src: memref<128xf32, #pto.address_space<vec>>)
       -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>) {
     %c0 = arith.constant 0 : index
     %value = pto.vmi.vload %src[%c0]
-        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>
+        : memref<128xf32, #pto.address_space<vec>>
+        -> !pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>
     %p0, %p1 = "pto.vmi.unpack"(%value)
         : (!pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>)
         -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>)
     return %p0, %p1 : !pto.vreg<64xf32>, !pto.vreg<64xf32>
   }
 
-  func.func @vmi_to_vpto_load_safe_tail_memref_nonzero_offset(%src: !pto.ptr<f32, ub>)
+  func.func @vmi_to_vpto_load_safe_tail_memref_nonzero_offset(
+      %src: memref<136xf32, #pto.address_space<vec>>)
       -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>) {
     %c4 = arith.constant 4 : index
     %value = pto.vmi.vload %src[%c4]
-        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>
+        : memref<136xf32, #pto.address_space<vec>>
+        -> !pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>
     %p0, %p1 = "pto.vmi.unpack"(%value)
         : (!pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>)
         -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>)
@@ -36,18 +40,18 @@ module {
 // CHECK-LABEL: func.func @vmi_to_vpto_load_safe_tail_memref(
 // CHECK: %[[C64:.*]] = arith.constant 64 : index
 // CHECK: %[[C0:.*]] = arith.constant 0 : index
-// CHECK: %[[P0:.*]] = pto.vlds %arg0[%[[C0]]] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-// CHECK: %[[P1:.*]] = pto.vlds %arg0[%[[C64]]] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK: %[[P0:.*]] = pto.vlds
+// CHECK: %[[P1:.*]] = pto.vlds
 // CHECK: return %[[P0]], %[[P1]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_load_safe_tail_memref_nonzero_offset(
-// CHECK: %[[C68:.*]] = arith.constant 68 : index
+// CHECK: %[[C64:.*]] = arith.constant 64 : index
 // CHECK: %[[C4:.*]] = arith.constant 4 : index
-// CHECK: %[[P0:.*]] = pto.vlds %arg0[%[[C4]]] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-// CHECK: %[[P1:.*]] = pto.vlds %arg0[%[[C68]]] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK: %[[P0:[^,]+]], %{{[^,]+}}, %{{[^ ]+}} = pto.vldus
+// CHECK: %[[P1:[^,]+]], %{{[^,]+}}, %{{[^ ]+}} = pto.vldus
 // CHECK: return %[[P0]], %[[P1]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_load_safe_tail_memref_negative_offset.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_load_safe_tail_memref_negative_offset.pto
@@ -6,7 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+// RUN: not pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto 2>&1 | FileCheck %s
 
 module {
   func.func @vmi_to_vpto_load_safe_tail_memref_negative_offset(%src: !pto.ptr<f32, ub>)
@@ -21,9 +21,4 @@ module {
   }
 }
 
-// CHECK-LABEL: func.func @vmi_to_vpto_load_safe_tail_memref_negative_offset(
-// CHECK: pto.vlds
-// CHECK: pto.vlds
-// CHECK-NOT: pto.vmi.
-// CHECK-NOT: !pto.vmi.
-// CHECK-NOT: unrealized_conversion_cast
+// CHECK: VMI-RESIDUAL-OP: failed to convert all VMI ops/types to VPTO

--- a/test/lit/vmi_new/vmi_to_vpto_load_store_contiguous.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_load_store_contiguous.pto
@@ -9,25 +9,125 @@
 // RUN: pto-test-opt %s -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
 
 module {
-  func.func @vmi_to_vpto_load_store_contiguous(
+  func.func @dynamic_unaligned_store_f32(
       %src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f32, ub>, %offset: index) {
-    %value = pto.vmi.vload %src[%offset]
+    %c0 = arith.constant 0 : index
+    %value = pto.vmi.vload %src[%c0]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
     pto.vmi.vstore %value, %dst[%offset]
         : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
     return
   }
+
+  func.func @constant_unaligned_full_chunk_load_f32(
+      %src: memref<136xf32, #pto.address_space<vec>>,
+      %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %value = pto.vmi.vload %src[%c4]
+        : memref<136xf32, #pto.address_space<vec>>
+        -> !pto.vmi.vreg<128xf32>
+    pto.vmi.vstore %value, %dst[%c0]
+        : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
+    return
+  }
+
+  func.func @known_aligned_f32(
+      %src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %value = pto.vmi.vload %src[%c0]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+    pto.vmi.vstore %value, %dst[%c0]
+        : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
+    return
+  }
+
+  func.func @known_aligned_loop_iv_f32(
+      %src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c8 = arith.constant 8 : index
+    %c64 = arith.constant 64 : index
+    scf.for %offset = %c0 to %c64 step %c8 {
+      %value = pto.vmi.vload %src[%offset]
+          : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+      pto.vmi.vstore %value, %dst[%offset]
+          : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
+    }
+    return
+  }
+
+  func.func @constant_unaligned_f16_tail(
+      %src: memref<272xf16, #pto.address_space<vec>>,
+      %dst: memref<272xf16, #pto.address_space<vec>>) {
+    %c1 = arith.constant 1 : index
+    %value = pto.vmi.vload %src[%c1]
+        : memref<272xf16, #pto.address_space<vec>> -> !pto.vmi.vreg<130xf16>
+    pto.vmi.vstore %value, %dst[%c1]
+        : !pto.vmi.vreg<130xf16>,
+          memref<272xf16, #pto.address_space<vec>>
+    return
+  }
+
+  func.func @dynamic_unaligned_memref(
+      %src: memref<256xui8, #pto.address_space<vec>>,
+      %dst: memref<256xui8, #pto.address_space<vec>>, %offset: index) {
+    %c0 = arith.constant 0 : index
+    %value = "pto.vmi.load"(%src, %c0)
+        : (memref<256xui8, #pto.address_space<vec>>, index)
+        -> !pto.vmi.vreg<256xui8>
+    "pto.vmi.store"(%value, %dst, %offset)
+        : (!pto.vmi.vreg<256xui8>,
+           memref<256xui8, #pto.address_space<vec>>, index) -> ()
+    return
+  }
 }
 
-// CHECK-LABEL: func.func @vmi_to_vpto_load_store_contiguous(
-// CHECK: %[[C64_LOAD:.*]] = arith.constant 64 : index
-// CHECK: %[[L0:.*]] = pto.vlds %arg0[%arg2] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-// CHECK: %[[OFF1_LOAD:.*]] = arith.addi %arg2, %[[C64_LOAD]] : index
-// CHECK: %[[L1:.*]] = pto.vlds %arg0[%[[OFF1_LOAD]]] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-// CHECK: %[[M0:.*]] = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
-// CHECK: pto.vsts %[[L0]], %arg1[%arg2], %[[M0]] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
-// CHECK: %[[M1:.*]] = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
-// CHECK: pto.vsts %[[L1]], %arg1[{{.*}}], %[[M1]] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// CHECK-LABEL: func.func @dynamic_unaligned_store_f32(
+// CHECK: %[[L0:.*]] = pto.vlds
+// CHECK: %[[L1:.*]] = pto.vlds
+// CHECK: %[[DST_BASE:.*]] = pto.addptr %arg1, %arg2
+// CHECK: %[[SA0:.*]] = pto.init_align : !pto.align
+// CHECK: %[[SA1:.*]], %[[DST1:.*]] = pto.vstus %[[SA0]], %{{.*}}, %[[L0]], %[[DST_BASE]]
+// CHECK: %[[SA2:.*]], %[[DST2:.*]] = pto.vstus %[[SA1]], %{{.*}}, %[[L1]], %[[DST1]]
+// CHECK: pto.vstas %[[SA2]], %[[DST2]], %{{.*}}
+
+// CHECK-LABEL: func.func @constant_unaligned_full_chunk_load_f32(
+// CHECK: %[[SRC_PTR:.*]] = pto.castptr %arg0 : memref<136xf32, #pto.address_space<vec>> -> !pto.ptr<f32, ub>
+// CHECK: %[[SRC_BASE:.*]] = pto.addptr %[[SRC_PTR]], %{{.*}}
+// CHECK: %[[LA0:.*]] = pto.vldas %[[SRC_BASE]]
+// CHECK: %[[L0:.*]], %[[LA1:.*]], %[[SRC1:.*]] = pto.vldus %[[SRC_BASE]], %[[LA0]], %{{.*}}
+// CHECK: %[[L1:.*]], %{{.*}}, %{{.*}} = pto.vldus %[[SRC1]], %[[LA1]], %{{.*}}
+// CHECK: pto.vsts %[[L0]]
+// CHECK: pto.vsts %[[L1]]
+
+// CHECK-LABEL: func.func @known_aligned_f32(
+// CHECK: %[[ALIGNED_LOAD:.*]] = pto.vlds %arg0[%{{.*}}]
+// CHECK: pto.vsts %[[ALIGNED_LOAD]], %arg1[%{{.*}}], %{{.*}}
+// CHECK-NOT: pto.vldas
+// CHECK-NOT: pto.vstus
+
+// CHECK-LABEL: func.func @known_aligned_loop_iv_f32(
+// CHECK: scf.for
+// CHECK: %[[LOOP_LOAD:.*]] = pto.vlds %arg0[%{{.*}}]
+// CHECK: pto.vsts %[[LOOP_LOAD]], %arg1[%{{.*}}], %{{.*}}
+// CHECK-NOT: pto.vldas
+// CHECK-NOT: pto.vstus
+
+// CHECK-LABEL: func.func @constant_unaligned_f16_tail(
+// CHECK: %[[C2:.*]] = arith.constant 2 : i32
+// CHECK: %[[C128:.*]] = arith.constant 128 : i32
+// CHECK-COUNT-1: pto.vldas
+// CHECK: %[[F16_SA0:.*]] = pto.init_align : !pto.align
+// CHECK: %[[F16_SA1:.*]], %[[F16_DST1:.*]] = pto.vstus %[[F16_SA0]], %[[C128]],
+// CHECK: %[[F16_SA2:.*]], %[[F16_DST2:.*]] = pto.vstus %[[F16_SA1]], %[[C2]],
+// CHECK: pto.vstas %[[F16_SA2]], %[[F16_DST2]], %{{.*}}
+
+// CHECK-LABEL: func.func @dynamic_unaligned_memref(
+// CHECK: %[[U8_LOAD:.*]] = pto.vlds %arg0
+// CHECK: %[[DST_PTR:.*]] = pto.castptr %arg1 : memref<256xui8, #pto.address_space<vec>> -> !pto.ptr<ui8, ub>
+// CHECK: %[[U8_DST:.*]] = pto.addptr %[[DST_PTR]], %arg2
+// CHECK: pto.vstus {{.*}}, %[[U8_DST]]
+// CHECK: pto.vstas
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_masked_load.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_masked_load.pto
@@ -10,13 +10,14 @@
 
 module {
   func.func @vmi_to_vpto_masked_load(
-      %src: !pto.ptr<f32, ub>,
+      %src: memref<72xf32, #pto.address_space<vec>>,
       %offset: index,
       %mask: !pto.vmi.mask<64xb32, #pto.vmi.layout<contiguous>>,
       %passthru: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>)
       -> !pto.vreg<64xf32> {
-    %loaded = pto.vmi.vload %src[%offset]
-        : !pto.ptr<f32, ub>
+    %c4 = arith.constant 4 : index
+    %loaded = pto.vmi.vload %src[%c4]
+        : memref<72xf32, #pto.address_space<vec>>
         -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
     %out = pto.vmi.vsel %mask, %loaded, %passthru
         : !pto.vmi.mask<64xb32, #pto.vmi.layout<contiguous>>,
@@ -31,7 +32,7 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_masked_load(
-// CHECK: %[[LOAD:.*]] = pto.vlds %arg0[%arg1] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK: %[[LOAD:[^,]+]], %{{[^,]+}}, %{{[^ ]+}} = pto.vldus
 // CHECK: %[[OUT:.*]] = pto.vsel %[[LOAD]], %arg3, %arg2 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: return %[[OUT]]
 // CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_masked_load_nonfull.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_masked_load_nonfull.pto
@@ -10,13 +10,13 @@
 
 module {
   func.func @vmi_to_vpto_masked_load_nonfull(
-      %src: !pto.ptr<f32, ub>,
-      %offset: index,
+      %src: memref<72xf32, #pto.address_space<vec>>,
       %mask: !pto.vmi.mask<3xb32, #pto.vmi.layout<contiguous>>,
       %passthru: !pto.vmi.vreg<3xf32, #pto.vmi.layout<contiguous>>)
       -> !pto.vreg<64xf32> {
-    %loaded = pto.vmi.vload %src[%offset]
-        : !pto.ptr<f32, ub>
+    %c4 = arith.constant 4 : index
+    %loaded = pto.vmi.vload %src[%c4]
+        : memref<72xf32, #pto.address_space<vec>>
         -> !pto.vmi.vreg<3xf32, #pto.vmi.layout<contiguous>>
     %out = pto.vmi.vsel %mask, %loaded, %passthru
         : !pto.vmi.mask<3xb32, #pto.vmi.layout<contiguous>>,
@@ -31,8 +31,8 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_masked_load_nonfull(
-// CHECK: %[[LOAD:.*]] = pto.vlds %arg0[%arg1] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-// CHECK: %[[OUT:.*]] = pto.vsel %[[LOAD]], %arg3, %arg2
+// CHECK: %[[LOAD:[^,]+]], %{{[^,]+}}, %{{[^ ]+}} = pto.vldus
+// CHECK: %[[OUT:.*]] = pto.vsel %[[LOAD]], %arg2, %arg1
 // CHECK: return %[[OUT]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_masked_load_safe_tail_memref.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_masked_load_safe_tail_memref.pto
@@ -10,13 +10,13 @@
 
 module {
   func.func @vmi_to_vpto_masked_load_safe_tail_memref(
-      %src: !pto.ptr<f32, ub>,
+      %src: memref<128xf32, #pto.address_space<vec>>,
       %mask: !pto.vmi.mask<100xb32, #pto.vmi.layout<contiguous>>,
       %passthru: !pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>)
       -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>) {
     %c0 = arith.constant 0 : index
     %loaded = pto.vmi.vload %src[%c0]
-        : !pto.ptr<f32, ub>
+        : memref<128xf32, #pto.address_space<vec>>
         -> !pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>
     %out = pto.vmi.vsel %mask, %loaded, %passthru
         : !pto.vmi.mask<100xb32, #pto.vmi.layout<contiguous>>,
@@ -30,13 +30,13 @@ module {
   }
 
   func.func @vmi_to_vpto_masked_load_safe_tail_memref_nonzero_offset(
-      %src: !pto.ptr<f32, ub>,
+      %src: memref<136xf32, #pto.address_space<vec>>,
       %mask: !pto.vmi.mask<100xb32, #pto.vmi.layout<contiguous>>,
       %passthru: !pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>)
       -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>) {
     %c4 = arith.constant 4 : index
     %loaded = pto.vmi.vload %src[%c4]
-        : !pto.ptr<f32, ub>
+        : memref<136xf32, #pto.address_space<vec>>
         -> !pto.vmi.vreg<100xf32, #pto.vmi.layout<contiguous>>
     %out = pto.vmi.vsel %mask, %loaded, %passthru
         : !pto.vmi.mask<100xb32, #pto.vmi.layout<contiguous>>,
@@ -53,8 +53,8 @@ module {
 // CHECK-LABEL: func.func @vmi_to_vpto_masked_load_safe_tail_memref(
 // CHECK: %[[C64:.*]] = arith.constant 64 : index
 // CHECK: %[[C0:.*]] = arith.constant 0 : index
-// CHECK: %[[L0:.*]] = pto.vlds %arg0[%[[C0]]] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-// CHECK: %[[L1:.*]] = pto.vlds %arg0[%[[C64]]] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK: %[[L0:.*]] = pto.vlds
+// CHECK: %[[L1:.*]] = pto.vlds
 // CHECK: %[[O0:.*]] = pto.vsel %[[L0]], %arg3, %arg1 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: %[[O1:.*]] = pto.vsel %[[L1]], %arg4, %arg2 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: return %[[O0]], %[[O1]]
@@ -63,10 +63,10 @@ module {
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_masked_load_safe_tail_memref_nonzero_offset(
-// CHECK: %[[C68:.*]] = arith.constant 68 : index
+// CHECK: %[[C64:.*]] = arith.constant 64 : index
 // CHECK: %[[C4:.*]] = arith.constant 4 : index
-// CHECK: %[[L0:.*]] = pto.vlds %arg0[%[[C4]]] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-// CHECK: %[[L1:.*]] = pto.vlds %arg0[%[[C68]]] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK: %[[L0:[^,]+]], %{{[^,]+}}, %{{[^ ]+}} = pto.vldus
+// CHECK: %[[L1:[^,]+]], %{{[^,]+}}, %{{[^ ]+}} = pto.vldus
 // CHECK: %[[O0:.*]] = pto.vsel %[[L0]], %arg3, %arg1 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: %[[O1:.*]] = pto.vsel %[[L1]], %arg4, %arg2 : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: return %[[O0]], %[[O1]]

--- a/test/lit/vmi_new/vmi_to_vpto_masked_load_safe_tail_memref_negative_offset.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_masked_load_safe_tail_memref_negative_offset.pto
@@ -6,7 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+// RUN: not pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto 2>&1 | FileCheck %s
 
 module {
   func.func @vmi_to_vpto_masked_load_safe_tail_memref_negative_offset(
@@ -30,8 +30,4 @@ module {
   }
 }
 
-// CHECK-LABEL: func.func @vmi_to_vpto_masked_load_safe_tail_memref_negative_offset(
-// CHECK-COUNT-2: pto.vlds
-// CHECK-COUNT-2: pto.vsel
-// CHECK-NOT: pto.vmi.
-// CHECK-NOT: !pto.vmi.
+// CHECK: VMI-RESIDUAL-OP: failed to convert all VMI ops/types to VPTO

--- a/test/lit/vmi_new/vmi_to_vpto_masked_store.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_masked_store.pto
@@ -14,7 +14,9 @@ module {
       %mask: !pto.vmi.mask<128xb32>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) {
-    pto.vmi.vstore %value, %dst[%offset], %mask
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    pto.vmi.vstore %value, %dst[%aligned_offset], %mask
         : !pto.vmi.vreg<128xf32>,
           !pto.ptr<f32, ub>,
           !pto.vmi.mask<128xb32>
@@ -30,8 +32,10 @@ module {
 // CHECK-SAME: %[[DST:[^,]+]]: !pto.ptr<f32, ub>
 // CHECK-SAME: %[[OFF:[^)]+]]: index
 // CHECK: %[[C64:.*]] = arith.constant 64 : index
-// CHECK: pto.vsts %[[V0]], %[[DST]][%[[OFF]]], %[[M0]] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
-// CHECK: %[[OFF1:.*]] = arith.addi %[[OFF]], %[[C64]] : index
+// CHECK: %[[C8:.*]] = arith.constant 8 : index
+// CHECK: %[[ALIGNED_OFF:.*]] = arith.muli %[[OFF]], %[[C8]] : index
+// CHECK: pto.vsts %[[V0]], %[[DST]][%[[ALIGNED_OFF]]], %[[M0]] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// CHECK: %[[OFF1:.*]] = arith.addi %[[ALIGNED_OFF]], %[[C64]] : index
 // CHECK: pto.vsts %[[V1]], %[[DST]][%[[OFF1]]], %[[M1]] : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_masked_store_deint_tail.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_masked_store_deint_tail.pto
@@ -14,7 +14,9 @@ module {
       %mask: !pto.vmi.mask<4xb32, #pto.vmi.layout<deinterleaved = 2>>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) {
-    pto.vmi.vstore %value, %dst[%offset], %mask
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    pto.vmi.vstore %value, %dst[%aligned_offset], %mask
         : !pto.vmi.vreg<4xf32, #pto.vmi.layout<deinterleaved = 2>>,
           !pto.ptr<f32, ub>,
           !pto.vmi.mask<4xb32, #pto.vmi.layout<deinterleaved = 2>>
@@ -30,12 +32,14 @@ module {
 // CHECK-SAME: %[[DST:[^,]+]]: !pto.ptr<f32, ub>
 // CHECK-SAME: %[[OFF:[^)]+]]: index
 // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+// CHECK: %[[C8:.*]] = arith.constant 8 : index
+// CHECK: %[[ALIGNED_OFF:.*]] = arith.muli %[[OFF]], %[[C8]] : index
 // CHECK: %[[LOW:.*]], %[[HIGH:.*]] = pto.vintlv %[[V0]], %[[V1]]
 // CHECK: %[[USER:.*]], %{{.*}} = pto.pintlv_b32 %[[M0]], %[[M1]]
 // CHECK: %[[TAIL:.*]], %{{.*}} = pto.plt_b32 %[[C4]] : i32 -> !pto.mask<b32>, i32
 // CHECK: %[[ALL:.*]] = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
 // CHECK: %[[MASK:.*]] = pto.pand %[[USER]], %[[TAIL]], %[[ALL]]
-// CHECK: pto.vsts %[[LOW]], %[[DST]][%[[OFF]]], %[[MASK]]
+// CHECK: pto.vsts %[[LOW]], %[[DST]][%[[ALIGNED_OFF]]], %[[MASK]]
 // CHECK-NOT: pto.vsts %[[HIGH]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_masked_store_tail.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_masked_store_tail.pto
@@ -14,7 +14,9 @@ module {
       %mask: !pto.vmi.mask<100xb32>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) {
-    pto.vmi.vstore %value, %dst[%offset], %mask
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    pto.vmi.vstore %value, %dst[%aligned_offset], %mask
         : !pto.vmi.vreg<100xf32>,
           !pto.ptr<f32, ub>,
           !pto.vmi.mask<100xb32>
@@ -29,8 +31,11 @@ module {
 // CHECK-SAME: %[[M1:[^,]+]]: !pto.mask<b32>
 // CHECK-SAME: %[[DST:[^,]+]]: !pto.ptr<f32, ub>
 // CHECK-SAME: %[[OFF:[^)]+]]: index
+// CHECK: %[[C64:.*]] = arith.constant 64 : index
 // CHECK: %[[C36:.*]] = arith.constant 36 : i32
-// CHECK: pto.vsts %[[V0]], %[[DST]][%[[OFF]]], %[[M0]]
+// CHECK: %[[C8:.*]] = arith.constant 8 : index
+// CHECK: %[[ALIGNED_OFF:.*]] = arith.muli %[[OFF]], %[[C8]] : index
+// CHECK: pto.vsts %[[V0]], %[[DST]][%[[ALIGNED_OFF]]], %[[M0]]
 // CHECK: %[[TAIL:.*]], %{{.*}} = pto.plt_b32 %[[C36]] : i32 -> !pto.mask<b32>, i32
 // CHECK: %[[ALL:.*]] = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
 // CHECK: %[[COMBINED:.*]] = pto.pand %[[M1]], %[[TAIL]], %[[ALL]] : !pto.mask<b32>, !pto.mask<b32>, !pto.mask<b32> -> !pto.mask<b32>

--- a/test/lit/vmi_new/vmi_to_vpto_memory_alignment_safety_invalid.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_memory_alignment_safety_invalid.pto
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -split-input-file -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-lower-unified-to-legacy -vmi-to-vpto 2>&1 | FileCheck %s
+
+module {
+  func.func @full_chunk_unaligned_load_without_read_envelope(
+      %src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f32, ub>, %offset: index) {
+    %c0 = arith.constant 0 : index
+    %value = pto.vmi.vload %src[%offset]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+    pto.vmi.vstore %value, %dst[%c0]
+        : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @full_chunk_unaligned_load_exceeds_static_read_envelope(
+      %src: memref<65xf32, #pto.address_space<vec>>,
+      %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %value = pto.vmi.vload %src[%c1]
+        : memref<65xf32, #pto.address_space<vec>> -> !pto.vmi.vreg<64xf32>
+    pto.vmi.vstore %value, %dst[%c0]
+        : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @unaligned_masked_store(
+      %value: !pto.vmi.vreg<64xf32>,
+      %mask: !pto.vmi.mask<64xb32>,
+      %dst: !pto.ptr<f32, ub>, %offset: index) {
+    pto.vmi.vstore %value, %dst[%offset], %mask
+        : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<64xb32>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @unaligned_lane_stride_masked_store(
+      %value: !pto.vmi.vreg<64xf16,
+          #pto.vmi.layout<contiguous, lane_stride = 2>>,
+      %mask: !pto.vmi.mask<64xb16,
+          #pto.vmi.layout<contiguous, lane_stride = 2>>,
+      %dst: !pto.ptr<f16, ub>, %offset: index) {
+    pto.vmi.masked_store %value, %dst[%offset], %mask
+        : !pto.vmi.vreg<64xf16,
+              #pto.vmi.layout<contiguous, lane_stride = 2>>,
+          !pto.ptr<f16, ub>,
+          !pto.vmi.mask<64xb16,
+              #pto.vmi.layout<contiguous, lane_stride = 2>>
+    return
+  }
+}
+
+// CHECK-COUNT-4: VMI-RESIDUAL-OP: failed to convert all VMI ops/types to VPTO

--- a/test/lit/vmi_new/vmi_to_vpto_memory_footprint.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_memory_footprint.pto
@@ -10,11 +10,12 @@
 
 module {
   func.func @vmi_to_vpto_load_deint2_f16_no_widen(
-      %src: !pto.ptr<f16, ub>, %offset: index)
+      %src: memref<144xf16, #pto.address_space<vec>>)
       -> (!pto.vreg<128xf16>, !pto.vreg<128xf16>) {
+    %c8 = arith.constant 8 : index
     %c64 = arith.constant 64 : index
-    %value = pto.vmi.vload %src[%offset]
-        : !pto.ptr<f16, ub>
+    %value = pto.vmi.vload %src[%c8]
+        : memref<144xf16, #pto.address_space<vec>>
         -> !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
     %mask = pto.vmi.create_mask %c64
         : index -> !pto.vmi.mask<128xb16, #pto.vmi.layout<contiguous>>
@@ -67,7 +68,7 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_load_deint2_f16_no_widen(
 // CHECK-NOT: pto.vldsx2
-// CHECK: %[[LOAD:.*]] = pto.vlds %arg0[%arg1]
+// CHECK: %[[LOAD:[^,]+]], %{{[^,]+}}, %{{[^ ]+}} = pto.vldus
 // CHECK: %[[LOW:.*]], %[[HIGH:.*]] = pto.vdintlv %[[LOAD]], %[[LOAD]]
 // CHECK: return %[[LOW]], %[[HIGH]]
 // CHECK-NOT: pto.vmi.
@@ -77,9 +78,9 @@ module {
 // CHECK-LABEL: func.func @vmi_to_vpto_store_deint2_f16_no_widen(
 // CHECK-NOT: pto.vstsx2
 // CHECK: %[[LOW:.*]], %[[HIGH:.*]] = pto.vintlv %arg0, %arg1
-// CHECK: %[[MASK:.*]] = pto.pset_b16 "PAT_ALL"
-// CHECK: pto.vsts %[[LOW]], %arg2[%arg3], %[[MASK]]
-// CHECK-NOT: pto.vsts %[[HIGH]]
+// CHECK: pto.init_align
+// CHECK: pto.vstus
+// CHECK-NOT: pto.vstus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_memory_x2_widths.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_memory_x2_widths.pto
@@ -12,7 +12,9 @@ module {
   func.func @vmi_to_vpto_load_deint2_f16(
       %src: !pto.ptr<f16, ub>, %offset: index)
       -> (!pto.vreg<128xf16>, !pto.vreg<128xf16>) {
-    %lo, %hi = pto.vmi.vload %src[%offset] {dist_mode = "dintlv"}
+    %c16 = arith.constant 16 : index
+    %aligned_offset = arith.muli %offset, %c16 : index
+    %lo, %hi = pto.vmi.vload %src[%aligned_offset] {dist_mode = "dintlv"}
         : !pto.ptr<f16, ub>
         -> !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>, !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
     %p0 = "pto.vmi.unpack"(%lo)
@@ -26,14 +28,16 @@ module {
       %lo: !pto.vmi.vreg<256xi8, #pto.vmi.layout<contiguous>>,
       %hi: !pto.vmi.vreg<256xi8, #pto.vmi.layout<contiguous>>,
       %dst: !pto.ptr<i8, ub>, %offset: index) {
-    pto.vmi.vstore %lo, %hi, %dst[%offset] {dist_mode = "intlv"}
+    %c32 = arith.constant 32 : index
+    %aligned_offset = arith.muli %offset, %c32 : index
+    pto.vmi.vstore %lo, %hi, %dst[%aligned_offset] {dist_mode = "intlv"}
         : !pto.vmi.vreg<256xi8, #pto.vmi.layout<contiguous>>, !pto.vmi.vreg<256xi8, #pto.vmi.layout<contiguous>>, !pto.ptr<i8, ub>
     return
   }
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_load_deint2_f16(
-// CHECK: %[[P0:.*]], %[[P1:.*]] = pto.vldsx2 %arg0[%arg1], "DINTLV_B16"
+// CHECK: %[[P0:.*]], %[[P1:.*]] = pto.vldsx2 %arg0[{{.*}}], "DINTLV_B16"
 // CHECK: return %[[P0]], %[[P1]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
@@ -41,7 +45,7 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_store_deint2_i8(
 // CHECK: %[[MASK:.*]] = pto.pset_b8 "PAT_ALL"
-// CHECK: pto.vstsx2 %arg0, %arg1, %arg2[%arg3], "INTLV_B8", %[[MASK]]
+// CHECK: pto.vstsx2 %arg0, %arg1, %arg2[{{.*}}], "INTLV_B8", %[[MASK]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_quant_dequant.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_quant_dequant.pto
@@ -16,11 +16,13 @@ module {
       %rows: index,
       %full_blocks: index,
       %tail: index,
-      %src_stride: index,
-      %dst_stride: index) {
+      %src_stride_tiles: index,
+      %dst_stride_tiles: index) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c128 = arith.constant 128 : index
+    %src_stride = arith.muli %src_stride_tiles, %c128 : index
+    %dst_stride = arith.muli %dst_stride_tiles, %c128 : index
     %has_tail = arith.cmpi ne, %tail, %c0 : index
     scf.for %row = %c0 to %rows step %c1 {
       %src_row = arith.muli %row, %src_stride : index
@@ -71,11 +73,13 @@ module {
       %rows: index,
       %full_blocks: index,
       %tail: index,
-      %src_stride: index,
-      %dst_stride: index) {
+      %src_stride_tiles: index,
+      %dst_stride_tiles: index) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c128 = arith.constant 128 : index
+    %src_stride = arith.muli %src_stride_tiles, %c128 : index
+    %dst_stride = arith.muli %dst_stride_tiles, %c128 : index
     %has_tail = arith.cmpi ne, %tail, %c0 : index
     scf.for %row = %c0 to %rows step %c1 {
       %src_row = arith.muli %row, %src_stride : index
@@ -126,11 +130,13 @@ module {
       %rows: index,
       %full_blocks: index,
       %tail: index,
-      %src_stride: index,
-      %dst_stride: index) {
+      %src_stride_tiles: index,
+      %dst_stride_tiles: index) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c256 = arith.constant 256 : index
+    %src_stride = arith.muli %src_stride_tiles, %c256 : index
+    %dst_stride = arith.muli %dst_stride_tiles, %c256 : index
     %has_tail = arith.cmpi ne, %tail, %c0 : index
     scf.for %row = %c0 to %rows step %c1 {
       %src_row = arith.muli %row, %src_stride : index
@@ -181,11 +187,13 @@ module {
       %rows: index,
       %full_blocks: index,
       %tail: index,
-      %src_stride: index,
-      %dst_stride: index) {
+      %src_stride_tiles: index,
+      %dst_stride_tiles: index) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c256 = arith.constant 256 : index
+    %src_stride = arith.muli %src_stride_tiles, %c256 : index
+    %dst_stride = arith.muli %dst_stride_tiles, %c256 : index
     %has_tail = arith.cmpi ne, %tail, %c0 : index
     scf.for %row = %c0 to %rows step %c1 {
       %src_row = arith.muli %row, %src_stride : index
@@ -236,14 +244,14 @@ module {
 // CHECK-SAME: %[[DDST:[^,]+]]: !pto.ptr<f32, ub>
 // CHECK: scf.for
 // CHECK: scf.for
-// CHECK: pto.vlds {{.*}} : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+// CHECK: pto.vlds
 // CHECK: pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
 // CHECK: pto.vcvt {{.*}} {part = "ODD"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
 // CHECK: pto.vmul {{.*}} : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: pto.vstsx2 {{.*}} "INTLV_B32"{{.*}} : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.ptr<f32, ub>, index, !pto.mask<b32>
 // CHECK: scf.if
 // CHECK: pto.plt_b32 {{.*}} : i32 -> !pto.mask<b32>, i32
-// CHECK: pto.vsts {{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// CHECK: pto.vsts
 
 // CHECK-LABEL: func.func @vmi_to_vpto_quant_matrix_f32_to_f16(
 // CHECK-SAME: %[[QSRC:[^,]+]]: !pto.ptr<f32, ub>
@@ -251,7 +259,7 @@ module {
 // CHECK-SAME: %[[QDST:[^,]+]]: !pto.ptr<f16, ub>
 // CHECK: scf.for
 // CHECK: scf.for
-// CHECK-COUNT-2: pto.vlds {{.*}} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK-COUNT-2: pto.vlds
 // CHECK-COUNT-2: pto.vmul {{.*}} : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
 // CHECK: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
@@ -259,7 +267,7 @@ module {
 // CHECK-NOT: pto.vor
 // CHECK-COUNT-2: pto.vsts {{.*}} {dist = "PK_B32"} : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b32>
 // CHECK: scf.if
-// CHECK-COUNT-2: pto.vlds {{.*}} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK-COUNT-2: pto.vlds
 // CHECK-COUNT-2: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
 // CHECK-NOT: part = "ODD"
 // CHECK-NOT: pto.vor
@@ -272,17 +280,17 @@ module {
 // CHECK-SAME: %[[FDST:[^,]+]]: !pto.ptr<f32, ub>
 // CHECK: scf.for
 // CHECK: scf.for
-// CHECK: pto.vlds {{.*}} : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+// CHECK: pto.vlds
 // CHECK: pto.vcvt {{.*}} {part = "P0"} : !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<64xf32>
 // CHECK: pto.vcvt {{.*}} {part = "P1"} : !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<64xf32>
 // CHECK: pto.vcvt {{.*}} {part = "P2"} : !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<64xf32>
 // CHECK: pto.vcvt {{.*}} {part = "P3"} : !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<64xf32>
 // CHECK: pto.vmul {{.*}} : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK: pto.vintlv
-// CHECK: pto.vsts {{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// CHECK: pto.vsts
 // CHECK: scf.if
 // CHECK: pto.plt_b32 {{.*}} : i32 -> !pto.mask<b32>, i32
-// CHECK: pto.vsts {{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// CHECK: pto.vsts
 
 // CHECK-LABEL: func.func @vmi_to_vpto_quant_matrix_f32_to_fp8(
 // CHECK-SAME: %[[FQSRC:[^,]+]]: !pto.ptr<f32, ub>
@@ -290,7 +298,7 @@ module {
 // CHECK-SAME: %[[FQDST:[^,]+]]: !pto.ptr<f8E4M3FN, ub>
 // CHECK: scf.for
 // CHECK: scf.for
-// CHECK-COUNT-4: pto.vlds {{.*}} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK-COUNT-4: pto.vlds
 // CHECK: pto.vmul {{.*}} : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK-COUNT-4: pto.vcvt {{.*}} {part = "P0", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<256xf8E4M3FN>
 // CHECK-NOT: part = "P1"
@@ -299,7 +307,7 @@ module {
 // CHECK-NOT: pto.vor
 // CHECK-COUNT-4: pto.vsts {{.*}} {dist = "PK4_B32"} : !pto.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, !pto.mask<b32>
 // CHECK: scf.if
-// CHECK-COUNT-4: pto.vlds {{.*}} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK-COUNT-4: pto.vlds
 // CHECK-COUNT-4: pto.vcvt {{.*}} {part = "P0", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<256xf8E4M3FN>
 // CHECK-NOT: part = "P1"
 // CHECK-NOT: part = "P2"

--- a/test/lit/vmi_new/vmi_to_vpto_quant_fp8.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_quant_fp8.pto
@@ -14,7 +14,9 @@ module {
       %inv_scale: f32,
       %dst: !pto.ptr<f8E4M3FN, ub>,
       %offset: index) {
-    %wide = pto.vmi.vload %src[%offset]
+    %c32 = arith.constant 32 : index
+    %aligned_offset = arith.muli %offset, %c32 : index
+    %wide = pto.vmi.vload %src[%aligned_offset]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
     %scale_vec = pto.vmi.vbrc %inv_scale
         : f32 -> !pto.vmi.vreg<256xf32>
@@ -23,14 +25,14 @@ module {
         -> !pto.vmi.vreg<256xf32>
     %packed = pto.vmi.vcvt %scaled {saturate = "SAT"}
         : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
-    pto.vmi.vstore %packed, %dst[%offset]
+    pto.vmi.vstore %packed, %dst[%aligned_offset]
         : !pto.vmi.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>
     return
   }
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_quant_matrix_f32_to_fp8(
-// CHECK-COUNT-4: pto.vlds {{.*}} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK-COUNT-4: pto.vlds
 // CHECK-COUNT-4: pto.vcvt {{.*}} {part = "P0", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<256xf8E4M3FN>
 // CHECK-NOT: part = "P1"
 // CHECK-NOT: part = "P2"

--- a/test/lit/vmi_new/vmi_to_vpto_quant_fp8_attrs.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_quant_fp8_attrs.pto
@@ -15,7 +15,9 @@ module {
       %inv_scale: f32,
       %dst: !pto.ptr<f8E4M3FN, ub>,
       %offset: index) {
-    %wide = pto.vmi.vload %src[%offset]
+    %c32 = arith.constant 32 : index
+    %aligned_offset = arith.muli %offset, %c32 : index
+    %wide = pto.vmi.vload %src[%aligned_offset]
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
     %scale_vec = pto.vmi.vbrc %inv_scale
         : f32 -> !pto.vmi.vreg<256xf32>
@@ -24,7 +26,7 @@ module {
         -> !pto.vmi.vreg<256xf32>
     %packed = pto.vmi.vcvt %scaled {rounding = "H", saturate = "SAT"}
         : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
-    pto.vmi.vstore %packed, %dst[%offset]
+    pto.vmi.vstore %packed, %dst[%aligned_offset]
         : !pto.vmi.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addf_store.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addf_store.pto
@@ -16,8 +16,10 @@ module {
       %dst_bf16: !pto.ptr<bf16, ub>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) {
+    %c16 = arith.constant 16 : index
     %c64 = arith.constant 64 : index
     %c1 = arith.constant 1 : index
+    %aligned_offset = arith.muli %offset, %c16 : index
     %mask64 = pto.vmi.create_mask %c64 : index -> !pto.vmi.mask<64xpred>
     %mask1 = pto.vmi.create_mask %c1 : index -> !pto.vmi.mask<1xpred>
     %sum = pto.vmi.vadd %source, %rhs, %mask64
@@ -25,12 +27,12 @@ module {
           !pto.vmi.mask<64xpred> -> !pto.vmi.vreg<64xf32>
     %narrow = pto.vmi.vcvt %sum {saturate = "SAT"}
         : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xbf16>
-    pto.vmi.vstore %narrow, %dst_bf16[%offset], %mask64
+    pto.vmi.vstore %narrow, %dst_bf16[%aligned_offset], %mask64
         : !pto.vmi.vreg<64xbf16>, !pto.ptr<bf16, ub>, !pto.vmi.mask<64xpred>
     %reduce = pto.vmi.vcadd %sum, %mask64 {reassoc}
         : !pto.vmi.vreg<64xf32>, !pto.vmi.mask<64xpred>
         -> !pto.vmi.vreg<1xf32>
-    pto.vmi.vstore %reduce, %dst[%offset], %mask1
+    pto.vmi.vstore %reduce, %dst[%aligned_offset], %mask1
         : !pto.vmi.vreg<1xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<1xpred>
     return
   }
@@ -60,10 +62,12 @@ module {
 // LOWER-SAME: %[[DST_BF16:[^,]+]]: !pto.ptr<bf16, ub>
 // LOWER-SAME: %[[DST:[^,]+]]: !pto.ptr<f32, ub>
 // LOWER-SAME: %[[OFF:[^)]+]]: index
+// LOWER: %[[C16:.*]] = arith.constant 16 : index
+// LOWER: %[[ALIGNED_OFF:.*]] = arith.muli %[[OFF]], %[[C16]] : index
 // LOWER: %[[REDUCE_MASK:.*]] = pto.pset_b32 "PAT_ALL"
 // LOWER: %[[ALL:.*]] = pto.pset_b32 "PAT_ALL"
 // LOWER: %[[SUM:.*]] = pto.vadd %[[SRC]], %[[RHS]], %[[ALL]]
-// LOWER: pto.vsts {{.*}}, %[[DST_BF16]][%[[OFF]]], {{.*}} {dist = "PK_B32"}
+// LOWER: pto.vsts {{.*}}, %[[DST_BF16]][%[[ALIGNED_OFF]]], {{.*}} {dist = "PK_B32"}
 // LOWER: %[[REDUCED:.*]] = pto.vcadd %[[SUM]], %[[REDUCE_MASK]]
 // LOWER: %[[STORE_MASK:.*]] = pto.pset_b32 "PAT_VL1"
-// LOWER: pto.vsts %[[REDUCED]], %[[DST]][%[[OFF]]], {{.*}} {dist = "1PT_B32"}
+// LOWER: pto.vsts %[[REDUCED]], %[[DST]][%[[ALIGNED_OFF]]], {{.*}} {dist = "1PT_B32"}

--- a/test/lit/vmi_new/vmi_to_vpto_stateful_stream_fusion.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_stateful_stream_fusion.pto
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto -vpto-stateful-stream-fusion | FileCheck %s
+
+module {
+  func.func private @side_effect()
+  func.func @fuse_three_streams(%v0: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %v1: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %v2: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %dst: !pto.ptr<f32, ub>) {
+    %c1 = arith.constant 1 : index
+    %c65 = arith.constant 65 : index
+    %c129 = arith.constant 129 : index
+    pto.vmi.vstore %v0, %dst[%c1] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    pto.vmi.vstore %v1, %dst[%c65] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    pto.vmi.vstore %v2, %dst[%c129] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    return
+  }
+  func.func @keep_non_contiguous_streams(%v0: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %v1: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %dst: !pto.ptr<f32, ub>) {
+    %c1 = arith.constant 1 : index
+    %c66 = arith.constant 66 : index
+    pto.vmi.vstore %v0, %dst[%c1] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    pto.vmi.vstore %v1, %dst[%c66] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    return
+  }
+  func.func @keep_streams_across_side_effect(%v0: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %v1: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %dst: !pto.ptr<f32, ub>) {
+    %c1 = arith.constant 1 : index
+    %c65 = arith.constant 65 : index
+    pto.vmi.vstore %v0, %dst[%c1] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    func.call @side_effect() : () -> ()
+    pto.vmi.vstore %v1, %dst[%c65] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    return
+  }
+  func.func @keep_streams_for_different_roots(%v0: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %v1: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %dst0: !pto.ptr<f32, ub>, %dst1: !pto.ptr<f32, ub>) {
+    %c1 = arith.constant 1 : index
+    %c65 = arith.constant 65 : index
+    pto.vmi.vstore %v0, %dst0[%c1] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    pto.vmi.vstore %v1, %dst1[%c65] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    return
+  }
+  func.func @fuse_contiguous_and_group_store(%v0: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %v1: !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 1>>, %dst: !pto.ptr<f32, ub>) {
+    %c1 = arith.constant 1 : index
+    %c65 = arith.constant 65 : index
+    pto.vmi.vstore %v0, %dst[%c1] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    pto.vmi.vstore %v1, %dst[%c65], %c1 {group = 8} : !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 1>>, !pto.ptr<f32, ub>
+    return
+  }
+  func.func @fuse_load_streams(
+      %src: memref<136xf32, #pto.address_space<vec>>)
+      -> (!pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>) {
+    %c1 = arith.constant 1 : index
+    %c65 = arith.constant 65 : index
+    %v0 = pto.vmi.vload %src[%c1]
+        : memref<136xf32, #pto.address_space<vec>>
+        -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+    %v1 = pto.vmi.vload %src[%c65]
+        : memref<136xf32, #pto.address_space<vec>>
+        -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+    return %v0, %v1 : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+  }
+  func.func @fuse_store_loop(%value: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c64 = arith.constant 64 : index
+    scf.for %i = %c0 to %c4 step %c1 {
+      %iteration_offset = arith.muli %i, %c64 : index
+      %offset = arith.addi %iteration_offset, %c1 : index
+      pto.vmi.vstore %value, %dst[%offset] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    }
+    return
+  }
+  func.func @fuse_load_loop(
+      %src: memref<328xf32, #pto.address_space<vec>>,
+      %initial: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>)
+      -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c64 = arith.constant 64 : index
+    %result = scf.for %i = %c0 to %c4 step %c1 iter_args(%current = %initial) -> (!pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>) {
+      %iteration_offset = arith.muli %i, %c64 : index
+      %offset = arith.addi %iteration_offset, %c1 : index
+      %value = pto.vmi.vload %src[%offset]
+          : memref<328xf32, #pto.address_space<vec>>
+          -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+      scf.yield %value : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+    }
+    return %result : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+  }
+  func.func @keep_dynamic_trip_loop(%value: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %dst: !pto.ptr<f32, ub>, %upper: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    scf.for %i = %c0 to %upper step %c1 {
+      %iteration_offset = arith.muli %i, %c64 : index
+      %offset = arith.addi %iteration_offset, %c1 : index
+      pto.vmi.vstore %value, %dst[%offset] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    }
+    return
+  }
+  func.func @keep_non_contiguous_loop(%value: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c65 = arith.constant 65 : index
+    scf.for %i = %c0 to %c4 step %c1 {
+      %iteration_offset = arith.muli %i, %c65 : index
+      %offset = arith.addi %iteration_offset, %c1 : index
+      pto.vmi.vstore %value, %dst[%offset] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    }
+    return
+  }
+  func.func @keep_single_iteration_loop(%value: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    scf.for %i = %c0 to %c1 step %c1 {
+      %offset = arith.addi %i, %c1 : index
+      pto.vmi.vstore %value, %dst[%offset] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+    }
+    return
+  }
+  func.func @keep_store_loop_with_aliasing_load(%value: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, %dst: !pto.ptr<f32, ub>) -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c64 = arith.constant 64 : index
+    %result = scf.for %i = %c0 to %c4 step %c1 iter_args(%current = %value) -> (!pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>) {
+      %iteration_offset = arith.muli %i, %c64 : index
+      %offset = arith.addi %iteration_offset, %c1 : index
+      pto.vmi.vstore %value, %dst[%offset] : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>, !pto.ptr<f32, ub>
+      %loaded = pto.vmi.vload %dst[%iteration_offset] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+      scf.yield %loaded : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+    }
+    return %result : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+  }
+}
+
+// CHECK-LABEL: func.func @fuse_three_streams(
+// CHECK: %[[ALIGN0:.*]] = pto.init_align
+// CHECK: %[[ALIGN1:.*]], %[[BASE1:.*]] = pto.vstus %[[ALIGN0]],
+// CHECK-NOT: pto.init_align
+// CHECK-NOT: pto.vstas
+// CHECK: %[[ALIGN2:.*]], %[[BASE2:.*]] = pto.vstus %[[ALIGN1]], {{.*}}, {{.*}}, %[[BASE1]]
+// CHECK-NOT: pto.init_align
+// CHECK-NOT: pto.vstas
+// CHECK: %[[ALIGN3:.*]], %[[BASE3:.*]] = pto.vstus %[[ALIGN2]], {{.*}}, {{.*}}, %[[BASE2]]
+// CHECK: pto.vstas %[[ALIGN3]], %[[BASE3]],
+// CHECK: return
+// CHECK-LABEL: func.func @keep_non_contiguous_streams(
+// CHECK: pto.init_align
+// CHECK: pto.vstus
+// CHECK: pto.vstas
+// CHECK: pto.init_align
+// CHECK: pto.vstus
+// CHECK: pto.vstas
+// CHECK: return
+// CHECK-LABEL: func.func @keep_streams_across_side_effect(
+// CHECK: pto.init_align
+// CHECK: pto.vstas
+// CHECK: call @side_effect()
+// CHECK: pto.init_align
+// CHECK: pto.vstas
+// CHECK: return
+// CHECK-LABEL: func.func @keep_streams_for_different_roots(
+// CHECK: pto.init_align
+// CHECK: pto.vstus
+// CHECK: pto.vstas
+// CHECK: pto.init_align
+// CHECK: pto.vstus
+// CHECK: pto.vstas
+// CHECK: return
+// CHECK-LABEL: func.func @fuse_contiguous_and_group_store(
+// CHECK: %[[GROUP_ALIGN0:.*]] = pto.init_align
+// CHECK: %[[GROUP_ALIGN1:.*]], %[[GROUP_BASE1:.*]] = pto.vstus %[[GROUP_ALIGN0]],
+// CHECK-NOT: pto.init_align
+// CHECK-NOT: pto.vstas
+// CHECK: %[[GROUP_ALIGN2:.*]], %[[GROUP_BASE2:.*]] = pto.vstus %[[GROUP_ALIGN1]], {{.*}}, {{.*}}, %[[GROUP_BASE1]]
+// CHECK: pto.vstas %[[GROUP_ALIGN2]], %[[GROUP_BASE2]],
+// CHECK: return
+// CHECK-LABEL: func.func @fuse_load_streams(
+// CHECK: %[[LOAD_ALIGN0:.*]] = pto.vldas
+// CHECK: %{{.*}}, %[[LOAD_ALIGN1:.*]], %[[LOAD_BASE1:.*]] = pto.vldus {{.*}}, %[[LOAD_ALIGN0]], %{{.*}}
+// CHECK-NOT: pto.vldas
+// CHECK: %{{.*}}, %[[LOAD_ALIGN2:.*]], %[[LOAD_BASE2:.*]] = pto.vldus %[[LOAD_BASE1]], %[[LOAD_ALIGN1]], %{{.*}}
+// CHECK: return
+// CHECK-LABEL: func.func @fuse_store_loop(
+// CHECK: %[[STORE_BASE0:.*]] = pto.addptr
+// CHECK: %[[STORE_ALIGN0:.*]] = pto.init_align
+// CHECK: %[[STORE_LOOP:.*]]:2 = scf.for
+// CHECK-SAME: iter_args(%[[STORE_BASE_ARG:.*]] = %[[STORE_BASE0]], %[[STORE_ALIGN_ARG:.*]] = %[[STORE_ALIGN0]])
+// CHECK-NOT: pto.init_align
+// CHECK: %[[STORE_ALIGN1:.*]], %[[STORE_BASE1:.*]] = pto.vstus %[[STORE_ALIGN_ARG]], {{.*}}, {{.*}}, %[[STORE_BASE_ARG]]
+// CHECK-NOT: pto.vstas
+// CHECK: scf.yield %[[STORE_BASE1]], %[[STORE_ALIGN1]]
+// CHECK: pto.vstas %[[STORE_LOOP]]#1, %[[STORE_LOOP]]#0,
+// CHECK: return
+// CHECK-LABEL: func.func @fuse_load_loop(
+// CHECK: %[[LOAD_BASE0:.*]] = pto.addptr
+// CHECK: %[[LOAD_ALIGN0:.*]] = pto.vldas %[[LOAD_BASE0]]
+// CHECK: %[[LOAD_LOOP:.*]]:3 = scf.for
+// CHECK-SAME: iter_args({{.*}}, %[[LOAD_BASE_ARG:.*]] = %[[LOAD_BASE0]], %[[LOAD_ALIGN_ARG:.*]] = %[[LOAD_ALIGN0]])
+// CHECK-NOT: pto.vldas
+// CHECK: %{{.*}}, %[[LOAD_ALIGN1:.*]], %[[LOAD_BASE1:.*]] = pto.vldus %[[LOAD_BASE_ARG]], %[[LOAD_ALIGN_ARG]],
+// CHECK: scf.yield {{.*}}, %[[LOAD_BASE1]], %[[LOAD_ALIGN1]]
+// CHECK: return %[[LOAD_LOOP]]#0
+// CHECK-LABEL: func.func @keep_dynamic_trip_loop(
+// CHECK: scf.for
+// CHECK: pto.init_align
+// CHECK: pto.vstus
+// CHECK: pto.vstas
+// CHECK: return
+// CHECK-LABEL: func.func @keep_non_contiguous_loop(
+// CHECK: scf.for
+// CHECK: pto.init_align
+// CHECK: pto.vstus
+// CHECK: pto.vstas
+// CHECK: return
+// CHECK-LABEL: func.func @keep_single_iteration_loop(
+// CHECK: scf.for
+// CHECK: pto.init_align
+// CHECK: pto.vstus
+// CHECK: pto.vstas
+// CHECK: return
+// CHECK-LABEL: func.func @keep_store_loop_with_aliasing_load(
+// CHECK: scf.for
+// CHECK: pto.init_align
+// CHECK: pto.vstus
+// CHECK: pto.vstas
+// CHECK: pto.vlds
+// CHECK: return

--- a/test/lit/vmi_new/vmi_to_vpto_store_deint.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_store_deint.pto
@@ -12,7 +12,9 @@ module {
   func.func @vmi_to_vpto_store_deint2(
       %value: !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>,
       %dst: !pto.ptr<f32, ub>, %offset: index) {
-    pto.vmi.vstore %value, %dst[%offset]
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    pto.vmi.vstore %value, %dst[%aligned_offset]
         : !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>, !pto.ptr<f32, ub>
     return
   }
@@ -20,7 +22,9 @@ module {
   func.func @vmi_to_vpto_store_deint4(
       %value: !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>,
       %dst: !pto.ptr<f32, ub>, %offset: index) {
-    pto.vmi.vstore %value, %dst[%offset]
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    pto.vmi.vstore %value, %dst[%aligned_offset]
         : !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>, !pto.ptr<f32, ub>
     return
   }
@@ -28,7 +32,9 @@ module {
   func.func @vmi_to_vpto_store_deint2_multichunk(
       %value: !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 2>>,
       %dst: !pto.ptr<f32, ub>, %offset: index) {
-    pto.vmi.vstore %value, %dst[%offset]
+    %c8 = arith.constant 8 : index
+    %aligned_offset = arith.muli %offset, %c8 : index
+    pto.vmi.vstore %value, %dst[%aligned_offset]
         : !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 2>>, !pto.ptr<f32, ub>
     return
   }
@@ -36,7 +42,7 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_store_deint2(
 // CHECK: %[[MASK:.*]] = pto.pset_b32 "PAT_ALL"
-// CHECK: pto.vstsx2 %arg0, %arg1, %arg2[%arg3], "INTLV_B32", %[[MASK]]
+// CHECK: pto.vstsx2 %arg0, %arg1, %arg2[{{.*}}], "INTLV_B32", %[[MASK]]
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
@@ -46,17 +52,15 @@ module {
 // CHECK: %[[B0:.*]], %[[B1:.*]] = pto.vintlv %arg1, %arg3
 // CHECK: %[[D0:.*]], %[[D1:.*]] = pto.vintlv %[[A0]], %[[B0]]
 // CHECK: %[[D2:.*]], %[[D3:.*]] = pto.vintlv %[[A1]], %[[B1]]
-// CHECK: pto.vsts %[[D0]], %arg4[%arg5]
-// CHECK: pto.vsts %[[D1]], %arg4[{{.*}}]
-// CHECK: pto.vsts %[[D2]], %arg4[{{.*}}]
-// CHECK: pto.vsts %[[D3]], %arg4[{{.*}}]
+// CHECK-COUNT-4: pto.vsts
+// CHECK-NOT: pto.vstus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_store_deint2_multichunk(
 // CHECK: %[[MASK0:.*]] = pto.pset_b32 "PAT_ALL"
-// CHECK: pto.vstsx2 %arg0, %arg2, %arg4[%arg5], "INTLV_B32", %[[MASK0]]
+// CHECK: pto.vstsx2 %arg0, %arg2, %arg4[{{.*}}], "INTLV_B32", %[[MASK0]]
 // CHECK: %[[MASK1:.*]] = pto.pset_b32 "PAT_ALL"
 // CHECK: pto.vstsx2 %arg1, %arg3, %arg4[{{.*}}], "INTLV_B32", %[[MASK1]]
 // CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_store_deint_tail.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_store_deint_tail.pto
@@ -11,9 +11,12 @@
 module {
   func.func @vmi_to_vpto_store_deint_tail(
       %value: !pto.vmi.vreg<6xf32, #pto.vmi.layout<deinterleaved = 2>>,
-      %dst: !pto.ptr<f32, ub>,
       %offset: index) {
-    pto.vmi.vstore %value, %dst[%offset]
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<f32, ub>
+    %c32 = arith.constant 32 : index
+    %aligned_offset = arith.muli %offset, %c32 : index
+    pto.vmi.vstore %value, %dst[%aligned_offset]
         : !pto.vmi.vreg<6xf32, #pto.vmi.layout<deinterleaved = 2>>,
           !pto.ptr<f32, ub>
     return
@@ -23,13 +26,10 @@ module {
 // CHECK-LABEL: func.func @vmi_to_vpto_store_deint_tail(
 // CHECK-SAME: %[[P0:[^,]+]]: !pto.vreg<64xf32>
 // CHECK-SAME: %[[P1:[^,]+]]: !pto.vreg<64xf32>
-// CHECK-SAME: %[[DST:[^,]+]]: !pto.ptr<f32, ub>
-// CHECK-SAME: %[[OFF:[^)]+]]: index
 // CHECK: %[[C6:.*]] = arith.constant 6 : i32
 // CHECK: %[[LOW:.*]], %[[HIGH:.*]] = pto.vintlv %[[P0]], %[[P1]]
-// CHECK: %[[MASK:.*]], %{{.*}} = pto.plt_b32 %[[C6]] : i32 -> !pto.mask<b32>, i32
-// CHECK: pto.vsts %[[LOW]], %[[DST]][%[[OFF]]], %[[MASK]]
-// CHECK-NOT: pto.vsts %[[HIGH]]
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vstus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_store_tail.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_store_tail.pto
@@ -11,19 +11,23 @@
 module {
   func.func @vmi_to_vpto_store_tail(
       %value: !pto.vmi.vreg<100xf32>,
-      %dst: !pto.ptr<f32, ub>, %offset: index) {
-    pto.vmi.vstore %value, %dst[%offset]
+      %offset: index) {
+    %c102400_i64 = arith.constant 102400 : i64
+    %dst = pto.castptr %c102400_i64 : i64 -> !pto.ptr<f32, ub>
+    %c32 = arith.constant 32 : index
+    %aligned_offset = arith.muli %offset, %c32 : index
+    pto.vmi.vstore %value, %dst[%aligned_offset]
         : !pto.vmi.vreg<100xf32>, !pto.ptr<f32, ub>
     return
   }
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_store_tail(
+// CHECK: %[[C64:.*]] = arith.constant 64 : index
 // CHECK: %[[C36:.*]] = arith.constant 36 : i32
-// CHECK: %[[FULL_MASK:.*]] = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
-// CHECK: pto.vsts %arg0, %arg2[%arg3], %[[FULL_MASK]]
-// CHECK: %[[TAIL_MASK:.*]], %{{.*}} = pto.plt_b32 %[[C36]] : i32 -> !pto.mask<b32>, i32
-// CHECK: pto.vsts %arg1, %arg2[{{.*}}], %[[TAIL_MASK]]
+// CHECK: pto.vsts
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vstus
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_truncf_bf16x2_d2_dynamic_mask.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_truncf_bf16x2_d2_dynamic_mask.pto
@@ -21,13 +21,15 @@ module {
       %dst: !pto.ptr<!pto.f4E1M2x2, ub>,
       %off: index,
       %active: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %mask = pto.vmi.create_mask %active
         : index -> !pto.vmi.mask<128xpred>
     %packed = pto.vmi.vcvt %src {rounding = "Z"}
         : !pto.vmi.vreg<128x!pto.bf16x2,
                         #pto.vmi.layout<deinterleaved = 2>>
        -> !pto.vmi.vreg<128x!pto.f4E1M2x2>
-    pto.vmi.vstore %packed, %dst[%off], %mask
+    pto.vmi.vstore %packed, %dst[%aligned_off], %mask
         : !pto.vmi.vreg<128x!pto.f4E1M2x2>,
           !pto.ptr<!pto.f4E1M2x2, ub>,
           !pto.vmi.mask<128xpred>
@@ -52,6 +54,8 @@ module {
 // LOWER-SAME: %[[DST:[^,]+]]: !pto.ptr<!pto.f4E1M2x2, ub>
 // LOWER-SAME: %[[OFF:[^,]+]]: index
 // LOWER-SAME: %[[ACTIVE:[^)]+]]: index)
+// LOWER: %[[C32:.*]] = arith.constant 32 : index
+// LOWER: %[[ALIGNED_OFF:.*]] = arith.muli %[[OFF]], %[[C32]] : index
 // LOWER-DAG: %[[VCVT_MASK:.*]] = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
 // LOWER-DAG: %[[MERGE_MASK:.*]] = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
 // LOWER: %[[P0_BF16:.*]] = pto.vbitcast %[[P0]] : !pto.vreg<64x!pto.bf16x2> -> !pto.vreg<128xbf16>
@@ -63,4 +67,4 @@ module {
 // LOWER: %[[STORE_NONNEG:.*]] = arith.maxsi %[[STORE_ACTIVE_I32]], {{.*}} : i32
 // LOWER: %[[STORE_CLAMPED:.*]] = arith.minui %[[STORE_NONNEG]], {{.*}} : i32
 // LOWER: %[[STORE_M:.*]], %{{.*}} = pto.plt_b16 %[[STORE_CLAMPED]] : i32 -> !pto.mask<b16>, i32
-// LOWER: pto.vsts %[[PACKED]], %[[DST]][%[[OFF]]], %[[STORE_M]] {dist = "PK_B16"} : !pto.vreg<256x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>, !pto.mask<b16>
+// LOWER: pto.vsts %[[PACKED]], %[[DST]][%[[ALIGNED_OFF]]], %[[STORE_M]] {dist = "PK_B16"} : !pto.vreg<256x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>, !pto.mask<b16>

--- a/test/lit/vmi_new/vmi_to_vpto_truncf_bf16x2_d2_lane_stride2.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_truncf_bf16x2_d2_lane_stride2.pto
@@ -16,10 +16,12 @@ module {
       %src: !pto.vmi.vreg<128x!pto.bf16x2, #pto.vmi.layout<deinterleaved = 2>>,
       %dst: !pto.ptr<!pto.f4E1M2x2, ub>,
       %off: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %r = pto.vmi.vcvt %src {rounding = "A"}
         : !pto.vmi.vreg<128x!pto.bf16x2, #pto.vmi.layout<deinterleaved = 2>>
        -> !pto.vmi.vreg<128x!pto.f4E1M2x2>
-    pto.vmi.vstore %r, %dst[%off]
+    pto.vmi.vstore %r, %dst[%aligned_off]
         : !pto.vmi.vreg<128x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>
     return
   }
@@ -39,4 +41,4 @@ module {
 // LOWER: %[[P2_BF16:.*]] = pto.vbitcast %[[P2]] : !pto.vreg<64x!pto.bf16x2> -> !pto.vreg<128xbf16>
 // LOWER: %[[R2:.*]] = pto.vcvt %[[P2_BF16]], {{.*}} {part = "P2", rnd = "A"} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<256x!pto.f4E1M2x2>
 // LOWER: %[[PACKED:.*]] = pto.vor %[[R0]], %[[R2]]
-// LOWER: pto.vsts %[[PACKED]], %[[DST]][%[[OFF]]], {{.*}} {dist = "PK_B16"} : !pto.vreg<256x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>, !pto.mask<b16>
+// LOWER: pto.vsts %[[PACKED]], %[[DST]][{{.*}}], {{.*}} {dist = "PK_B16"} : !pto.vreg<256x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>, !pto.mask<b16>

--- a/test/lit/vmi_new/vmi_to_vpto_truncf_bf16x2_d2_multichunk.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_truncf_bf16x2_d2_multichunk.pto
@@ -19,11 +19,13 @@ module {
                            #pto.vmi.layout<deinterleaved = 2>>,
       %dst: !pto.ptr<!pto.f4E2M1x2, ub>,
       %off: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %packed = pto.vmi.vcvt %src {rounding = "C"}
         : !pto.vmi.vreg<256x!pto.bf16x2,
                         #pto.vmi.layout<deinterleaved = 2>>
        -> !pto.vmi.vreg<256x!pto.f4E2M1x2>
-    pto.vmi.vstore %packed, %dst[%off]
+    pto.vmi.vstore %packed, %dst[%aligned_off]
         : !pto.vmi.vreg<256x!pto.f4E2M1x2>,
           !pto.ptr<!pto.f4E2M1x2, ub>
     return
@@ -51,6 +53,6 @@ module {
 // LOWER: %[[P2C1_BF16:.*]] = pto.vbitcast %[[P2C1]]
 // LOWER: %[[C1P2:.*]] = pto.vcvt %[[P2C1_BF16]], {{.*}} {part = "P2", rnd = "C"}
 // LOWER: %[[C1:.*]] = pto.vor %[[C1P0]], %[[C1P2]]
-// LOWER: pto.vsts %[[C0]], %[[DST]][%[[OFF]]], {{.*}} {dist = "PK_B16"}
-// LOWER: %[[OFF128:.*]] = arith.addi %[[OFF]], %{{.*}} : index
+// LOWER: pto.vsts %[[C0]], %[[DST]][{{.*}}], {{.*}} {dist = "PK_B16"}
+// LOWER: %[[OFF128:.*]] = arith.addi {{.*}}, %{{.*}} : index
 // LOWER: pto.vsts %[[C1]], %[[DST]][%[[OFF128]]], {{.*}} {dist = "PK_B16"}

--- a/test/lit/vmi_new/vmi_to_vpto_truncf_bf16x2_d4_dynamic_mask.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_truncf_bf16x2_d4_dynamic_mask.pto
@@ -21,13 +21,15 @@ module {
       %dst: !pto.ptr<!pto.f4E1M2x2, ub>,
       %off: index,
       %active: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %mask = pto.vmi.create_mask %active
         : index -> !pto.vmi.mask<256xpred>
     %packed = pto.vmi.vcvt %src {rounding = "R"}
         : !pto.vmi.vreg<256x!pto.bf16x2,
                         #pto.vmi.layout<deinterleaved = 4>>
        -> !pto.vmi.vreg<256x!pto.f4E1M2x2>
-    pto.vmi.vstore %packed, %dst[%off], %mask
+    pto.vmi.vstore %packed, %dst[%aligned_off], %mask
         : !pto.vmi.vreg<256x!pto.f4E1M2x2>,
           !pto.ptr<!pto.f4E1M2x2, ub>,
           !pto.vmi.mask<256xpred>
@@ -54,6 +56,8 @@ module {
 // LOWER-SAME: %[[DST:[^,]+]]: !pto.ptr<!pto.f4E1M2x2, ub>
 // LOWER-SAME: %[[OFF:[^,]+]]: index
 // LOWER-SAME: %[[ACTIVE:[^)]+]]: index)
+// LOWER: %[[C32:.*]] = arith.constant 32 : index
+// LOWER: %[[ALIGNED_OFF:.*]] = arith.muli %[[OFF]], %[[C32]] : index
 // LOWER-DAG: %[[VCVT_MASK:.*]] = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
 // LOWER-DAG: %[[MERGE_MASK:.*]] = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
 // LOWER: %[[P0_BF16:.*]] = pto.vbitcast %[[P0]] : !pto.vreg<64x!pto.bf16x2> -> !pto.vreg<128xbf16>
@@ -71,4 +75,4 @@ module {
 // LOWER: %[[STORE_NONNEG:.*]] = arith.maxsi %[[STORE_ACTIVE_I32]], {{.*}} : i32
 // LOWER: %[[STORE_CLAMPED:.*]] = arith.minui %[[STORE_NONNEG]], {{.*}} : i32
 // LOWER: %[[STORE_M:.*]], %{{.*}} = pto.plt_b8 %[[STORE_CLAMPED]] : i32 -> !pto.mask<b8>, i32
-// LOWER: pto.vsts %[[PACKED]], %[[DST]][%[[OFF]]], %[[STORE_M]] : !pto.vreg<256x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>, !pto.mask<b8>
+// LOWER: pto.vsts %[[PACKED]], %[[DST]][%[[ALIGNED_OFF]]], %[[STORE_M]] : !pto.vreg<256x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>, !pto.mask<b8>

--- a/test/lit/vmi_new/vmi_to_vpto_truncf_bf16x2_dynamic_tail.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_truncf_bf16x2_dynamic_tail.pto
@@ -20,6 +20,8 @@ module {
       %dst: !pto.ptr<!pto.f4E1M2x2, ub>,
       %off: index,
       %active: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %mask = pto.vmi.create_mask %active
         : index -> !pto.vmi.mask<128xpred>
     %pair = pto.vmi.vinterpret_cast %src
@@ -27,7 +29,7 @@ module {
     %packed = pto.vmi.vcvt %pair {rounding = "R"}
         : !pto.vmi.vreg<128x!pto.bf16x2>
        -> !pto.vmi.vreg<128x!pto.f4E1M2x2>
-    pto.vmi.vstore %packed, %dst[%off], %mask
+    pto.vmi.vstore %packed, %dst[%aligned_off], %mask
         : !pto.vmi.vreg<128x!pto.f4E1M2x2>,
           !pto.ptr<!pto.f4E1M2x2, ub>,
           !pto.vmi.mask<128xpred>
@@ -54,6 +56,8 @@ module {
 // LOWER-SAME: %[[DST:[^,]+]]: !pto.ptr<!pto.f4E1M2x2, ub>
 // LOWER-SAME: %[[OFF:[^,]+]]: index
 // LOWER-SAME: %[[ACTIVE:[^)]+]]: index)
+// LOWER: %[[C32:.*]] = arith.constant 32 : index
+// LOWER: %[[ALIGNED_OFF:.*]] = arith.muli %[[OFF]], %[[C32]] : index
 // LOWER: %[[SRC0_PAIR:.*]] = pto.vbitcast %[[SRC0]] : !pto.vreg<128xbf16> -> !pto.vreg<64x!pto.bf16x2>
 // LOWER: %[[SRC1_PAIR:.*]] = pto.vbitcast %[[SRC1]] : !pto.vreg<128xbf16> -> !pto.vreg<64x!pto.bf16x2>
 // LOWER-DAG: %[[VCVT_MASK:.*]] = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
@@ -66,6 +70,6 @@ module {
 // LOWER: %[[STORE_CLAMPED:.*]] = arith.minui %[[STORE_NONNEG]], {{.*}} : i32
 // LOWER: %[[STORE_M0:.*]], %[[STORE_REM:.*]] = pto.plt_b32 %[[STORE_CLAMPED]] : i32 -> !pto.mask<b32>, i32
 // LOWER: %[[STORE_M1:.*]], %{{.*}} = pto.plt_b32 %[[STORE_REM]] : i32 -> !pto.mask<b32>, i32
-// LOWER: pto.vsts %[[R0]], %[[DST]][%[[OFF]]], %[[STORE_M0]] {dist = "PK4_B32"} : !pto.vreg<256x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>, !pto.mask<b32>
-// LOWER: %[[OFF64:.*]] = arith.addi %[[OFF]], %{{.*}} : index
+// LOWER: pto.vsts %[[R0]], %[[DST]][%[[ALIGNED_OFF]]], %[[STORE_M0]] {dist = "PK4_B32"} : !pto.vreg<256x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>, !pto.mask<b32>
+// LOWER: %[[OFF64:.*]] = arith.addi %[[ALIGNED_OFF]], %{{.*}} : index
 // LOWER: pto.vsts %[[R1]], %[[DST]][%[[OFF64]]], %[[STORE_M1]] {dist = "PK4_B32"} : !pto.vreg<256x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>, !pto.mask<b32>

--- a/test/lit/vmi_new/vmi_to_vpto_truncf_bf16x2_to_f4x2_variants.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_truncf_bf16x2_to_f4x2_variants.pto
@@ -18,11 +18,13 @@ module {
       %src: !pto.vmi.vreg<128xbf16>,
       %dst: !pto.ptr<!pto.f4E1M2x2, ub>,
       %off: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %pair = pto.vmi.vinterpret_cast %src
         : !pto.vmi.vreg<128xbf16> -> !pto.vmi.vreg<64x!pto.bf16x2>
     %r = pto.vmi.vcvt %pair {rounding = "R"}
         : !pto.vmi.vreg<64x!pto.bf16x2> -> !pto.vmi.vreg<64x!pto.f4E1M2x2>
-    pto.vmi.vstore %r, %dst[%off]
+    pto.vmi.vstore %r, %dst[%aligned_off]
         : !pto.vmi.vreg<64x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>
     return
   }
@@ -32,11 +34,13 @@ module {
       %src: !pto.vmi.vreg<256xbf16>,
       %dst: !pto.ptr<!pto.f4E2M1x2, ub>,
       %off: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %pair = pto.vmi.vinterpret_cast %src
         : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<128x!pto.bf16x2>
     %r = pto.vmi.vcvt %pair {rounding = "A"}
         : !pto.vmi.vreg<128x!pto.bf16x2> -> !pto.vmi.vreg<128x!pto.f4E2M1x2>
-    pto.vmi.vstore %r, %dst[%off]
+    pto.vmi.vstore %r, %dst[%aligned_off]
         : !pto.vmi.vreg<128x!pto.f4E2M1x2>, !pto.ptr<!pto.f4E2M1x2, ub>
     return
   }
@@ -46,11 +50,13 @@ module {
       %src: !pto.vmi.vreg<128xbf16>,
       %dst: !pto.ptr<!pto.f4E1M2x2, ub>,
       %off: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %pair = pto.vmi.vinterpret_cast %src
         : !pto.vmi.vreg<128xbf16> -> !pto.vmi.vreg<64x!pto.bf16x2>
     %r = pto.vmi.vcvt %pair {rounding = "Z"}
         : !pto.vmi.vreg<64x!pto.bf16x2> -> !pto.vmi.vreg<64x!pto.f4E1M2x2>
-    pto.vmi.vstore %r, %dst[%off]
+    pto.vmi.vstore %r, %dst[%aligned_off]
         : !pto.vmi.vreg<64x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>
     return
   }
@@ -60,11 +66,13 @@ module {
       %src: !pto.vmi.vreg<128xbf16>,
       %dst: !pto.ptr<!pto.f4E1M2x2, ub>,
       %off: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %pair = pto.vmi.vinterpret_cast %src
         : !pto.vmi.vreg<128xbf16> -> !pto.vmi.vreg<64x!pto.bf16x2>
     %r = pto.vmi.vcvt %pair {rounding = "F"}
         : !pto.vmi.vreg<64x!pto.bf16x2> -> !pto.vmi.vreg<64x!pto.f4E1M2x2>
-    pto.vmi.vstore %r, %dst[%off]
+    pto.vmi.vstore %r, %dst[%aligned_off]
         : !pto.vmi.vreg<64x!pto.f4E1M2x2>, !pto.ptr<!pto.f4E1M2x2, ub>
     return
   }
@@ -74,11 +82,13 @@ module {
       %src: !pto.vmi.vreg<128xbf16>,
       %dst: !pto.ptr<!pto.f4E2M1x2, ub>,
       %off: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %pair = pto.vmi.vinterpret_cast %src
         : !pto.vmi.vreg<128xbf16> -> !pto.vmi.vreg<64x!pto.bf16x2>
     %r = pto.vmi.vcvt %pair {rounding = "C"}
         : !pto.vmi.vreg<64x!pto.bf16x2> -> !pto.vmi.vreg<64x!pto.f4E2M1x2>
-    pto.vmi.vstore %r, %dst[%off]
+    pto.vmi.vstore %r, %dst[%aligned_off]
         : !pto.vmi.vreg<64x!pto.f4E2M1x2>, !pto.ptr<!pto.f4E2M1x2, ub>
     return
   }
@@ -88,11 +98,13 @@ module {
       %src: !pto.vmi.vreg<128xbf16>,
       %dst: !pto.ptr<!pto.f4E2M1x2, ub>,
       %off: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %pair = pto.vmi.vinterpret_cast %src
         : !pto.vmi.vreg<128xbf16> -> !pto.vmi.vreg<64x!pto.bf16x2>
     %r = pto.vmi.vcvt %pair
         : !pto.vmi.vreg<64x!pto.bf16x2> -> !pto.vmi.vreg<64x!pto.f4E2M1x2>
-    pto.vmi.vstore %r, %dst[%off]
+    pto.vmi.vstore %r, %dst[%aligned_off]
         : !pto.vmi.vreg<64x!pto.f4E2M1x2>, !pto.ptr<!pto.f4E2M1x2, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_to_vpto_truncf_fp8_128_lane_stride.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_truncf_fp8_128_lane_stride.pto
@@ -14,9 +14,11 @@ module {
       %input: !pto.vmi.vreg<128xf32>,
       %dst: !pto.ptr<f8E4M3FN, ub>,
       %off: index) {
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
     %packed = pto.vmi.vcvt %input {saturate = "SAT"}
         : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf8E4M3FN>
-    pto.vmi.vstore %packed, %dst[%off]
+    pto.vmi.vstore %packed, %dst[%aligned_off]
         : !pto.vmi.vreg<128xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_zero_gap_extui_load.pto
+++ b/test/lit/vmi_new/vmi_zero_gap_extui_load.pto
@@ -15,25 +15,27 @@ module {
       %src8: !pto.ptr<ui8, ub>, %src16: !pto.ptr<ui16, ub>,
       %dst16: !pto.ptr<ui16, ub>, %dst32a: !pto.ptr<ui32, ub>,
       %dst32b: !pto.ptr<ui32, ub>, %off: index) {
-    %a = pto.vmi.load %src8[%off]
+    %c32 = arith.constant 32 : index
+    %aligned_off = arith.muli %off, %c32 : index
+    %a = pto.vmi.load %src8[%aligned_off]
         : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<128xui8>
     %aw = pto.vmi.extui %a
         : !pto.vmi.vreg<128xui8> -> !pto.vmi.vreg<128xui16>
-    pto.vmi.store %aw, %dst16[%off]
+    pto.vmi.store %aw, %dst16[%aligned_off]
         : !pto.vmi.vreg<128xui16>, !pto.ptr<ui16, ub>
 
-    %b = pto.vmi.load %src8[%off]
+    %b = pto.vmi.load %src8[%aligned_off]
         : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<64xui8>
     %bw = pto.vmi.extui %b
         : !pto.vmi.vreg<64xui8> -> !pto.vmi.vreg<64xui32>
-    pto.vmi.store %bw, %dst32a[%off]
+    pto.vmi.store %bw, %dst32a[%aligned_off]
         : !pto.vmi.vreg<64xui32>, !pto.ptr<ui32, ub>
 
-    %c = pto.vmi.load %src16[%off]
+    %c = pto.vmi.load %src16[%aligned_off]
         : !pto.ptr<ui16, ub> -> !pto.vmi.vreg<64xui16>
     %cw = pto.vmi.extui %c
         : !pto.vmi.vreg<64xui16> -> !pto.vmi.vreg<64xui32>
-    pto.vmi.store %cw, %dst32b[%off]
+    pto.vmi.store %cw, %dst32b[%aligned_off]
         : !pto.vmi.vreg<64xui32>, !pto.ptr<ui32, ub>
     return
   }
@@ -42,12 +44,12 @@ module {
 // CHECK-LABEL: func.func @vmi_surface_load_extui_zero_gap(
 // CHECK: %[[U8U16:.*]] = pto.vlds {{.*}} {dist = "UNPK_B8"}
 // CHECK-NEXT: %[[U16:.*]] = pto.vbitcast %[[U8U16]] : !pto.vreg<256xui8> -> !pto.vreg<128xui16>
-// CHECK: pto.vsts %[[U16]],
+// CHECK: pto.vsts
 // CHECK: %[[U8U32:.*]] = pto.vlds {{.*}} {dist = "UNPK4"}
 // CHECK-NEXT: %[[U32A:.*]] = pto.vbitcast %[[U8U32]] : !pto.vreg<256xui8> -> !pto.vreg<64xui32>
-// CHECK: pto.vsts %[[U32A]],
+// CHECK: pto.vsts
 // CHECK: %[[U16U32:.*]] = pto.vlds {{.*}} {dist = "UNPK_B16"}
 // CHECK-NEXT: %[[U32B:.*]] = pto.vbitcast %[[U16U32]] : !pto.vreg<128xui16> -> !pto.vreg<64xui32>
-// CHECK: pto.vsts %[[U32B]],
+// CHECK: pto.vsts
 // CHECK-NOT: pto.vcvt
 // CHECK-NOT: pto.vzunpack

--- a/test/lit/vpto/align_local_chain_in_loop_verify.pto
+++ b/test/lit/vpto/align_local_chain_in_loop_verify.pto
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s | FileCheck %s
+
+module {
+  func.func @align_local_chain_in_loop(
+      %src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    scf.for %iv = %c0 to %c1 step %c1 {
+      pto.vecscope {
+        %load_align = pto.vldas %src : !pto.ptr<f32, ub> -> !pto.align
+        %value, %unused_load_align = pto.vldus %src, %load_align
+            : !pto.ptr<f32, ub>, !pto.align
+            -> !pto.vreg<64xf32>, !pto.align
+        %store_align = pto.init_align : !pto.align
+        %next_store_align, %next_dst = pto.vstus
+            %store_align, %c64_i32, %value, %dst
+            : !pto.align, i32, !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+            -> !pto.align, !pto.ptr<f32, ub>
+        pto.vstas %next_store_align, %next_dst, %c0_i32
+            : !pto.align, !pto.ptr<f32, ub>, i32
+      }
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @align_local_chain_in_loop(
+// CHECK: scf.for
+// CHECK: pto.vecscope
+// CHECK: pto.vldas
+// CHECK: pto.vldus
+// CHECK: pto.init_align
+// CHECK: pto.vstus
+// CHECK: pto.vstas

--- a/test/lit/vpto/memory_dist_carrier_width.pto
+++ b/test/lit/vpto/memory_dist_carrier_width.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -split-input-file | FileCheck %s
+
+// Explicit dist tokens describe the physical access width independently of
+// the vreg carrier element type. The carrier still preserves one 256-byte
+// register payload.
+
+module {
+  func.func @load_dist_cross_width_carrier(%src: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %value = pto.vlds %src[%c0] {dist = "E2B_B16"}
+        : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @load_dist_cross_width_carrier
+// CHECK: pto.vlds {{.*}} {dist = "E2B_B16"}
+
+// -----
+
+module {
+  func.func @load_x2_dist_cross_width_carrier(%src: !pto.ptr<f16, ub>) {
+    %c0 = arith.constant 0 : index
+    %low, %high = pto.vldsx2 %src[%c0], "DINTLV_B32"
+        : !pto.ptr<f16, ub>, index
+        -> !pto.vreg<128xf16>, !pto.vreg<128xf16>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @load_x2_dist_cross_width_carrier
+// CHECK: pto.vldsx2 {{.*}}, "DINTLV_B32"

--- a/tools/ptoas/ptoas_pipeline.cpp
+++ b/tools/ptoas/ptoas_pipeline.cpp
@@ -1007,6 +1007,7 @@ static void appendVMISemanticPipeline(OpPassManager &pm) {
   pm.addPass(pto::createVMILegalizeArithSelectPass());
   pm.addPass(pto::createPTOValidateVMILayoutIRPass());
   pm.addPass(pto::createVMIToVPTOPass());
+  pm.addPass(pto::createVPTOStatefulStreamFusionPass());
 }
 
 /// Reject statically invalid scf.for steps at the PTOAS input boundary.


### PR DESCRIPTION
## 背景

VMI memory lowering 过去在多个分支中分别选择 dist、判断地址并管理 align state。地址对齐无法证明时，一部分路径会生成非法的 aligned dist，一部分连续 group payload 会退化为多条 `1PT_B32`，相邻或循环内 stateful 访问也会重复初始化和收尾。

本 PR 将决策拆成物理访问规划和 VPTO 合法化两个阶段，并在合法化后统一融合 stateful stream。

## 修改内容

- 扩展 `PTOAddressAnalysis` 的 typed address 查询，统一证明 byte alignment、同 root 地址差和 loop iteration delta。
- 新增共享 `VPTOMemoryDist` contract，集中维护 load/store dist 的 family、访问宽度、对齐、footprint、predicate、transfer mapping 和 A5 immediate；VPTO verifier 与两个 LLVM emitter 共用同一份事实。
- 在 `VMIToVPTO` 中建立 direction、coverage、register transfer 和 read-safety 物理访问模型：
  - 对 NORM、UNPK/PK、BRC/E2B、DINTLV/INTLV 使用 mode-specific alignment；
  - 对齐可证明时保留 direct dist；
  - 对齐未知且 footprint/coverage 合法时，使用显式 pack/unpack/interleave 变换和一条 `vldas/vldus*` 或 `init_align/vstus*/vstas` chain；
  - arbitrary predicate 和无法证明安全的扩大读取不会转换成无 mask stateful 访问。
- 优化 group store：连续 payload 在 carrier lane mapping 仍可见时完成拼接/压缩，生成精确长度 stateful store；真正稀疏的访问保留自然对齐 point store。
- 完整实现独立 `VPTOStatefulStreamFusion` pass：
  - 融合 basic block 内地址连续的 load/store streams；
  - 对静态 trip count、迭代步幅等于 stream advance 且无潜在别名 effect 的 `scf.for`，将 base/align 变为 loop-carried state；
  - store 在 loop 外初始化、loop 内连续 `vstus`、loop 后只执行一次 `vstas`；load 同理复用 `vldas` state。
- 清理 lit 输入中的伪 unknown-alignment：与非对齐无关的能力测试改为静态 UB base 或带对齐单位的 offset stride，同时保留专门的 unknown/unaligned fallback 测试。
- 增加完整设计文档，记录 planner/legalizer/fusion 边界、ISA contract、read envelope 和正确性不变量。

## 正确性边界

- dist 后缀描述物理访问/重排语义，不被错误当作 `vreg` carrier type；省略 store dist 时才按 carrier width 选择默认 NORM。
- `BRC_B32` 使用 4B 地址合法性，同时保留 containing 32B dependency granularity。
- `1PT_B32` 表示一个 32-bit point，不是 32-byte store。
- `vstus` 只用于 Dense/Prefix 连续 payload；任意 masked store 不会丢失 predicate。
- stateful load 选择受 full-read/read-envelope 证明约束。

## 性能验证

A5 `dav_3510` CA model，4 次迭代、每轮相同的 1 条 `vlds` 和 16B store payload，三组 output 均通过 golden compare：

| 方案 | store 形态 | kernel ticks | RVEC busy |
|---|---|---:|---:|
| 1PT baseline | 16 × `RV_VST` | 2037 | 108 |
| 独立 stream | 4 × `RV_VSTUI` + 4 × `RV_VSTAI` | 2021 | 92 |
| 迭代间融合 | 4 × `RV_VSTUI` + 1 × `RV_VSTAI` | 2014 | 85 |

相对 1PT，独立 stream 的 RVEC busy 减少 14.8%，迭代间融合减少 21.3%。完整输入约束、指令计数和 `fused_quant_dequant` 端到端结果见 PR 评论。

## 验证

- `ninja -C build pto-test-opt PTOASCompilerImplementation PTOASPythonCore`
- `llvm-lit -sv -j 8 build/test/lit/vpto`：549/549
- `llvm-lit -sv -j 8 build/test/lit/vmi_new`：528/528
- `check_changed_code.py --repo . --base origin/main`：0 errors，0 warnings
- `git diff --check`
