### PR TITLE
fix(ptodsl): exclude loop-local temporaries from runtime while carries (#1256)

### DIFF
--- a/ptodsl/docs/user_guide/05-control-flow.md
+++ b/ptodsl/docs/user_guide/05-control-flow.md
@@ -402,8 +402,10 @@ This lowers to an `scf.for` with `iter_args`.
 The loop-carried state of a native runtime `while` is inferred from values that
 are assigned in the loop and used by the condition, by later iterations, or
 after the loop. Each such value must have a stable type and a well-defined
-initial value before the loop. If you need a more complex loop state pattern,
-use the explicit API:
+initial value before the loop. Loop-local temporaries that are written before
+they are read inside every iteration (e.g. `col = base + index`) are not
+loop-carried and need no initial value outside the loop. If you need a more
+complex loop state pattern, use the explicit API:
 
 ```python
 loop = pto.for_(0, rows, step=1).carry(acc=acc)

--- a/ptodsl/docs/user_guide/05-control-flow.md
+++ b/ptodsl/docs/user_guide/05-control-flow.md
@@ -404,8 +404,14 @@ are assigned in the loop and used by the condition, by later iterations, or
 after the loop. Each such value must have a stable type and a well-defined
 initial value before the loop. Loop-local temporaries that are written before
 they are read inside every iteration (e.g. `col = base + index`) are not
-loop-carried and need no initial value outside the loop. If you need a more
-complex loop state pattern, use the explicit API:
+loop-carried and need no initial value outside the loop.
+
+Because loop-local temporaries stay iteration-local, an `else:` clause of a
+runtime `while` must not read them: the clause runs after the rewrite's
+single traced execution, so it would observe the trace-time value instead of
+the value of the final iteration. Read only genuinely loop-carried names
+(or values that are live after the loop) from an `else:` clause. If you need
+a more complex loop state pattern, use the explicit API:
 
 ```python
 loop = pto.for_(0, rows, step=1).carry(acc=acc)

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -2115,6 +2115,16 @@ class _ControlFlowRewriter:
                                       ctx=ast.Load()), node)
                 return node
 
+        class _ConditionLiteralRewriter(ast.NodeTransformer):
+            # A literal test condition (``while True:`` / ``while False:``)
+            # must be materialized as an i1 constant, not a Python bool: the
+            # controlled condition is combined with ``and``, whose runtime
+            # scalar operator would otherwise reject the bool literal.
+            def visit_Constant(inner, node):
+                if isinstance(node.value, bool):
+                    return ast.copy_location(_flag_const(node.value), node)
+                return node
+
         condition = _ConditionStateRewriter().visit(copy.deepcopy(stmt.test))
         if controlled:
             condition = ast.BinOp(
@@ -2126,6 +2136,7 @@ class _ControlFlowRewriter:
                 ),
             )
             condition = _ConditionStateRewriter().visit(condition)
+        condition = _ConditionLiteralRewriter().visit(condition)
         ast.fix_missing_locations(condition)
         condition_fn = ast.Lambda(
             args=ast.arguments(

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -2073,16 +2073,29 @@ class _ControlFlowRewriter:
             )
         test_info = _name_info(stmt.test)
         control = _loop_control_flags(stmt.body)
-        if (control["break"] or control["continue"] or stmt.orelse) and not (
-            body_info.stores & (test_info.loads | body_info.loads | set(live_after))
-        ):
+        # A loop-carried name must be one whose pre-iteration value is needed:
+        # it is read by the test before each iteration, it is read before any
+        # assignment inside the body (so it depends on the previous iteration's
+        # value), or it stays live after the loop.  ``body_info.loads`` is
+        # deliberately not used here: it includes loop-local temporaries that
+        # are written before they are read each iteration (e.g.
+        # ``col = base + index``), which are not live across iterations and
+        # would be read while still unbound at the pto._while(...) setup.
+        # This mirrors the loop_carried criterion used by ``_rewrite_for``.
+        reads_before = _read_before_assignment_names(stmt.body)
+        required_carries = test_info.loads | reads_before | set(live_after)
+        # A controlled loop (break/continue/else) may legitimately need no
+        # user-level carry: its test reads only loop-invariant names and every
+        # body store is a loop-local temporary.  The active/did_break control
+        # flags then provide the loop-carried state themselves.  Only a
+        # completely store-less body is rejected, since it cannot carry the
+        # control transfer at all.
+        if (control["break"] or control["continue"] or stmt.orelse) and not body_info.stores:
             raise PTODSLAstRewriteError(
                 "ast_rewrite=True runtime while break/continue requires explicit control-state lowering"
             )
-        carry_names = tuple(sorted(
-            body_info.stores & (test_info.loads | body_info.loads | set(live_after))
-        ))
-        if not carry_names:
+        carry_names = tuple(sorted(body_info.stores & required_carries))
+        if not carry_names and not (control["break"] or control["continue"] or stmt.orelse):
             raise PTODSLAstRewriteError(
                 "ast_rewrite=True runtime while requires at least one loop-carried value"
             )

--- a/ptodsl/tests/test_scf_while_ast.py
+++ b/ptodsl/tests/test_scf_while_ast.py
@@ -7,7 +7,16 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
+import re
+
 from ptodsl import pto
+
+
+def _while_iter_arg_count(mlir_text: str) -> int:
+    """Count the loop-carried state slots of the top-level scf.while op."""
+    match = re.search(r"scf\.while\s*\([^)]*\)\s*:\s*\(([^)]*)\)", mlir_text)
+    assert match is not None, "scf.while signature not found in MLIR"
+    return len([part for part in match.group(1).split(",") if part.strip()])
 
 
 @pto.jit(target="a5")
@@ -219,19 +228,29 @@ def main():
 
     # Issue #1256 regressions: loop-local temporaries must not be carried.
     # issue_1256_while_local_temp / break_flag / branch_temp all used to raise
-    # UnboundLocalError at the pto._while(...) setup; the conditional-carry
-    # case must keep value loop-carried and still compile.  The flags-only
-    # case must compile through the control-state flags even with no
-    # user-level carry.
-    for fn in (issue_1256_while_local_temp, issue_1256_while_break_flag,
-               issue_1256_while_branch_temp, issue_1256_while_conditional_carry,
-               issue_1256_while_break_flags_only,
-               issue_1256_while_continue_else_flags_only,
-               issue_1256_exact_while_local_temp, issue_1256_exact_while_true_break,
-               issue_1256_exact_while_branch_cond):
+    # UnboundLocalError at the pto._while(...) setup.  Besides compiling, each
+    # case also locks the exact number of loop-carried slots of the emitted
+    # scf.while, so a future regression that re-adds a loop-local temporary to
+    # the carry state (the #1256 defect) fails this contract.
+    carry_contract = {
+        issue_1256_while_local_temp: 2,               # index, total
+        issue_1256_while_break_flag: 3,               # value + control flags
+        issue_1256_while_branch_temp: 2,              # low, high
+        issue_1256_while_conditional_carry: 1,        # value
+        issue_1256_while_break_flags_only: 2,         # active, did_break
+        issue_1256_while_continue_else_flags_only: 2, # active, did_break
+        issue_1256_exact_while_local_temp: 2,         # index, total
+        issue_1256_exact_while_true_break: 3,         # value + control flags
+        issue_1256_exact_while_branch_cond: 2,        # low, high
+    }
+    for fn, expected_carries in carry_contract.items():
         loop_text = fn.compile().mlir_text()
         assert "scf.while" in loop_text
         assert "scf.condition" in loop_text
+        actual = _while_iter_arg_count(loop_text)
+        assert actual == expected_carries, (
+            f"{fn.__name__}: expected {expected_carries} loop-carried slots, got {actual}; "
+            "loop-local temporaries must not enter the carry state")
 
     def unsupported_break(limit: pto.i32):
         value = pto.const(0, dtype=pto.i32)

--- a/ptodsl/tests/test_scf_while_ast.py
+++ b/ptodsl/tests/test_scf_while_ast.py
@@ -153,6 +153,49 @@ def issue_1256_while_continue_else_flags_only(
     _ = running
 
 
+# Issue #1256 exact repros (https://github.com/hw-native-sys/PTOAS/issues/1256).
+# Case 2 uses a literal ``while True:`` test; the generated condition must
+# materialize the literal as an i1 constant so the break/continue guard
+# (``active/did_break``) can combine with it through the runtime ``and`` op.
+
+
+@pto.jit(target="a5")
+def issue_1256_exact_while_local_temp(limit: pto.i32, base: pto.i32):
+    index = pto.const(0, dtype=pto.i32)
+    total = pto.const(0, dtype=pto.i32)
+    while index < limit:
+        col = base + index
+        total = total + col
+        index = index + pto.const(1, dtype=pto.i32)
+    _ = total
+
+
+@pto.jit(target="a5")
+def issue_1256_exact_while_true_break(limit: pto.i32):
+    value = pto.const(0, dtype=pto.i32)
+    while True:
+        should_break = value >= limit
+        if should_break:
+            break
+        value = value + pto.const(1, dtype=pto.i32)
+    _ = value
+
+
+@pto.jit(target="a5")
+def issue_1256_exact_while_branch_cond(limit: pto.i32, pivot: pto.i32):
+    low = pto.const(0, dtype=pto.i32)
+    high = limit
+    mid = pto.const(0, dtype=pto.i32)
+    while low < high:
+        mid = (low + high) // pto.const(2, dtype=pto.i32)
+        take_upper = mid < pivot
+        if take_upper:
+            low = mid + pto.const(1, dtype=pto.i32)
+        else:
+            high = mid
+    _ = low
+
+
 def unsupported_while_subscript(limit: pto.i32):
     values = [0]
     value = pto.const(0, dtype=pto.i32)
@@ -183,7 +226,9 @@ def main():
     for fn in (issue_1256_while_local_temp, issue_1256_while_break_flag,
                issue_1256_while_branch_temp, issue_1256_while_conditional_carry,
                issue_1256_while_break_flags_only,
-               issue_1256_while_continue_else_flags_only):
+               issue_1256_while_continue_else_flags_only,
+               issue_1256_exact_while_local_temp, issue_1256_exact_while_true_break,
+               issue_1256_exact_while_branch_cond):
         loop_text = fn.compile().mlir_text()
         assert "scf.while" in loop_text
         assert "scf.condition" in loop_text

--- a/ptodsl/tests/test_scf_while_ast.py
+++ b/ptodsl/tests/test_scf_while_ast.py
@@ -67,6 +67,92 @@ def runtime_while_static_break(limit: pto.i32):
     _ = value + pto.const(1, dtype=pto.i32)
 
 
+# ---------------------------------------------------------------------------
+# Issue #1256: _rewrite_while must not carry loop-local temporaries.
+#
+# Before: every body load was treated as loop-carried state, so a temporary
+# written before being read each iteration (e.g. ``col = base + index``) was
+# read while still unbound at the pto._while(...) setup, raising
+# UnboundLocalError during compile.  After: only names read by the test, read
+# before assignment inside the body, or live after the loop are carried.
+# ---------------------------------------------------------------------------
+
+
+@pto.jit(target="a5")
+def issue_1256_while_local_temp(limit: pto.i32):
+    base = pto.const(2, dtype=pto.i32)
+    index = pto.const(0, dtype=pto.i32)
+    total = pto.const(0, dtype=pto.i32)
+    while index < limit:
+        col = base + index
+        total = total + col
+        index = index + 1
+    _ = total
+
+
+@pto.jit(target="a5")
+def issue_1256_while_break_flag(limit: pto.i32):
+    value = pto.const(0, dtype=pto.i32)
+    while value < limit:
+        value = value + pto.const(1, dtype=pto.i32)
+        should_break = value == pto.const(3, dtype=pto.i32)
+        if should_break:
+            break
+    _ = value
+
+
+@pto.jit(target="a5")
+def issue_1256_while_branch_temp(limit: pto.i32):
+    low = pto.const(0, dtype=pto.i32)
+    high = limit
+    while low < high:
+        mid = low + pto.const(2, dtype=pto.i32)
+        take_upper = mid < pto.const(4, dtype=pto.i32)
+        if take_upper:
+            low = mid + pto.const(1, dtype=pto.i32)
+        else:
+            high = mid + pto.const(0, dtype=pto.i32)
+    _ = low
+    _ = high
+
+
+@pto.jit(target="a5")
+def issue_1256_while_conditional_carry(limit: pto.i32):
+    value = pto.const(0, dtype=pto.i32)
+    while value < limit:
+        if value < pto.const(2, dtype=pto.i32):
+            value = value + pto.const(1, dtype=pto.i32)
+    _ = value
+
+
+@pto.jit(target="a5")
+def issue_1256_while_break_flags_only(limit: pto.i32, running: pto.i32, probe: pto.i32):
+    # Controlled loop with no user-level carry: the test only reads
+    # loop-invariant names and the body store is a loop-local temporary,
+    # so the active/did_break control flags provide the loop-carried state.
+    while running < limit:
+        t = probe
+        if t < pto.const(3, dtype=pto.i32):
+            break
+    _ = running
+
+
+@pto.jit(target="a5")
+def issue_1256_while_continue_else_flags_only(
+    limit: pto.i32, running: pto.i32, probe: pto.i32
+):
+    # The loop test is invariant and all authored stores are loop-local.
+    # continue and else therefore rely exclusively on the generated control
+    # flags for their loop-carried state.
+    while running < limit:
+        t = probe
+        if t < pto.const(3, dtype=pto.i32):
+            continue
+    else:
+        t = probe + pto.const(1, dtype=pto.i32)
+    _ = running
+
+
 def unsupported_while_subscript(limit: pto.i32):
     values = [0]
     value = pto.const(0, dtype=pto.i32)
@@ -88,6 +174,20 @@ def main():
         assert "scf.condition" in loop_text
         assert "scf.yield" in loop_text
 
+    # Issue #1256 regressions: loop-local temporaries must not be carried.
+    # issue_1256_while_local_temp / break_flag / branch_temp all used to raise
+    # UnboundLocalError at the pto._while(...) setup; the conditional-carry
+    # case must keep value loop-carried and still compile.  The flags-only
+    # case must compile through the control-state flags even with no
+    # user-level carry.
+    for fn in (issue_1256_while_local_temp, issue_1256_while_break_flag,
+               issue_1256_while_branch_temp, issue_1256_while_conditional_carry,
+               issue_1256_while_break_flags_only,
+               issue_1256_while_continue_else_flags_only):
+        loop_text = fn.compile().mlir_text()
+        assert "scf.while" in loop_text
+        assert "scf.condition" in loop_text
+
     def unsupported_break(limit: pto.i32):
         value = pto.const(0, dtype=pto.i32)
         while value < limit:
@@ -106,6 +206,23 @@ def main():
         assert "static subscript carries" in str(exc)
     else:
         raise AssertionError("while subscript carry must be diagnosed")
+
+    # Issue #1256 reverse regression: a loop-local name used after the loop
+    # without an outer initialization must still fail to trace (no
+    # over-exclusion).  Native Python would report the same unbound name.
+    def issue_1256_unbound_live_after(limit: pto.i32):
+        value = pto.const(0, dtype=pto.i32)
+        while value < limit:
+            col = value + pto.const(1, dtype=pto.i32)
+            value = col
+        _ = col
+
+    try:
+        pto.jit(target="a5")(issue_1256_unbound_live_after).compile()
+    except UnboundLocalError:
+        pass
+    else:
+        raise AssertionError("unbound loop-local used after while must not compile")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes issue #1256:  treated every body load as loop-carried state for , so a loop-local temporary that is written before being read each iteration (e.g. ) was read while still unbound at the  setup, raising  during compile.

The carry criterion now mirrors : a name is carried only when it is read by the loop test, read before assignment inside the body (upward-exposed read via ), or live after the loop.

## Changes

- :  uses  + corrected gate set for //; the two existing diagnostics (control-state lowering, static subscript carries) are unchanged.
- : add issue repros (loop-local temp, break flag, branch temp) asserting  passes with , plus reverse regressions (conditional carry must stay carried; unbound live-after name must still fail).

## Validation

- Machine:  (fresh scratch checkout of latest , Usage

  cmake [options] <path-to-source>
  cmake [options] <path-to-existing-build>
  cmake [options] -S <path-to-source> -B <path-to-build>

Specify a source directory to (re-)generate a build system for it in the
current working directory.  Specify an existing build directory to
re-generate its build system.

Run 'cmake --help' for more information./ build of , ).
-  — PASS
-  — PASS
-  — PASS
- Test project /Users/jimmychou/work/ptoas/PTOAS-ptodsl-main (full suite) — 39/39 passed