### PR TITLE
docs: align remaining references with LLVM 19

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -8,7 +8,7 @@
 - PTOAS 首次发布
 
 ## 概述
-PTOAS（PTO Assembler & Optimizer）是面向 PTO Bytecode 的编译器工具链，基于 LLVM/MLIR LLVM21 VPTO 分支 `vpto-dev/llvm-project:feature-vpto-llvm21` 构建。它提供 PTO Dialect 的定义、解析、验证、优化与代码生成能力，并输出可调用 `pto-isa` 的 C++ 代码。
+PTOAS（PTO Assembler & Optimizer）是面向 PTO Bytecode 的编译器工具链，基于 LLVM/MLIR LLVM19 VPTO 分支 `vpto-dev/llvm-project:feature-vpto` 构建。它提供 PTO Dialect 的定义、解析、验证、优化与代码生成能力，并输出可调用 `pto-isa` 的 C++ 代码。
 
 PTOAS很快将集成到以下框架中，敬请期待
 - PyPTO

--- a/docs/designs/ptoas-compiler-dso-wheel-linking.md
+++ b/docs/designs/ptoas-compiler-dso-wheel-linking.md
@@ -240,7 +240,7 @@ mode switch:
 -DMLIR_INSTALL_AGGREGATE_OBJECTS=ON
 ```
 
-The pinned LLVM 21 tree defines these options; `LLVM_ENABLE_PIC` and
+The pinned LLVM 19 tree defines these options; `LLVM_ENABLE_PIC` and
 `MLIR_INSTALL_AGGREGATE_OBJECTS` already default to `ON`, but wheel workflows
 set them explicitly because they are part of the distribution contract. The
 required contract is: LLVM/MLIR component targets are static and
@@ -256,7 +256,7 @@ dependencies on the external LLVM build tree.
 
 Static and shared LLVM SDKs must use separate build directories and cache keys.
 Before enabling the profile, both wheel workflows must bump
-`LLVM_CACHE_FLAVOR`, for example to `llvm21-vpto-wheel-static-v1`. Reusing a
+`LLVM_CACHE_FLAVOR`, for example to `llvm19-vpto-wheel-static-v1`. Reusing a
 cache produced with `BUILD_SHARED_LIBS=ON` is invalid even when the source SHA
 is identical.
 

--- a/docs/designs/ptoas-largest-first-fit-four-gates-memplan-design.md
+++ b/docs/designs/ptoas-largest-first-fit-four-gates-memplan-design.md
@@ -857,8 +857,9 @@ struct ConflictFacts {
 ```bash
 cmake --build build --target ptoas -j8
 
-PATH=/Users/fangrui/workspace/huawei/llvm21-workspace/llvm-project/llvm/build-assert/bin:$PATH \
-  /Users/fangrui/workspace/huawei/llvm21-workspace/llvm-project/llvm/build-assert/bin/llvm-lit \
+export LLVM_BUILD_DIR=/path/to/llvm19/build-assert
+PATH="$LLVM_BUILD_DIR/bin:$PATH" \
+  "$LLVM_BUILD_DIR/bin/llvm-lit" \
   -sv build/test/lit \
   --filter 'plan_memory'
 

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -14060,8 +14060,8 @@ static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
 
       // IndexType is lowered to int64_t for EmitC. SCF structural conversion
       // can still materialize temporary index<->int64_t bridges; keeping them
-      // as emitc.cast leaves illegal index-typed EmitC IR for LLVM 21's C++
-      // emitter, so fold the bridge back to the lowered value.
+      // as emitc.cast leaves illegal index-typed EmitC IR for the C++ emitter,
+      // so fold the bridge back to the lowered value.
       if ((isa<IndexType>(inTy) && isLoweredIndexType(outTy)) ||
           (isLoweredIndexType(inTy) && isa<IndexType>(outTy))) {
         output.replaceAllUsesWith(input);

--- a/lib/PTO/Transforms/VPTOLLVMEmitterDispatcher.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitterDispatcher.cpp
@@ -92,8 +92,9 @@ LogicalResult lowerVPTOModuleToLLVMIRText(
     os << "\n";
   }
   os.flush();
-  // LLVM 21 prints arg-memory effects with memory(...), while the Bisheng
-  // LLVM 15 parser accepts only the equivalent legacy argmemonly spelling.
+  // The LLVM dialect prints arg-memory effects with memory(...), while the
+  // Bisheng LLVM 15 parser accepts only the equivalent legacy argmemonly
+  // spelling.
   constexpr StringLiteral modernArgMemOnly = "memory(argmem: readwrite)";
   size_t offset = 0;
   while ((offset = output.find(modernArgMemOnly.str(), offset)) !=

--- a/ptodsl/docs/developer_guide/tilelib-debugging-playbook.md
+++ b/ptodsl/docs/developer_guide/tilelib-debugging-playbook.md
@@ -12,13 +12,13 @@ usually live in different layers.
 Build PTOAS after C++ or TableGen changes:
 
 ```bash
-cmake --build build-llvm21 --target PTOASPythonCore
+cmake --build build --target PTOASPythonCore
 ```
 
 Stage PTODSL after Python package changes:
 
 ```bash
-ninja -C build-llvm21 PTODSLPackage
+ninja -C build PTODSLPackage
 ```
 
 Run one smoke ST:
@@ -26,7 +26,7 @@ Run one smoke ST:
 ```bash
 python3 test/tilelang_st/script/run_all_st.py \
   -r sim -v a5 \
-  -p build-llvm21/tools/ptoas/ptoas \
+  -p build/tools/ptoas/ptoas \
   -t <tileop> --smoke -j 1
 ```
 
@@ -35,7 +35,7 @@ Run one non-smoke ST:
 ```bash
 python3 test/tilelang_st/script/run_all_st.py \
   -r sim -v a5 \
-  -p build-llvm21/tools/ptoas/ptoas \
+  -p build/tools/ptoas/ptoas \
   -t <tileop> -j 1
 ```
 
@@ -44,7 +44,7 @@ Run one named ST case when supported by `run_st.py`:
 ```bash
 python3 test/tilelang_st/script/run_st.py \
   -r sim -v a5 \
-  -p build-llvm21/tools/ptoas/ptoas \
+  -p build/tools/ptoas/ptoas \
   -t <tileop> \
   -c <case_name>
 ```
@@ -96,7 +96,7 @@ If legality appears correct but `ExpandTileOp` cannot expand:
 Useful compiler-only command:
 
 ```bash
-build-llvm21/tools/ptoas/ptoas \
+build/tools/ptoas/ptoas \
   --pto-arch=a5 --pto-backend=vpto --emit-vpto \
   --enable-insert-sync \
   --mlir-print-ir-after=pto-expand-tile-op \
@@ -127,7 +127,7 @@ Recommended sequence:
 Compiler-only dump:
 
 ```bash
-build-llvm21/tools/ptoas/ptoas \
+build/tools/ptoas/ptoas \
   --pto-arch=a5 --pto-backend=vpto --emit-vpto \
   --enable-insert-sync \
   test/tilelang_st/npu/a5/src/st/testcase/<tileop>/<tileop>.pto \

--- a/test/tilelang_st/script/run_ptodsl_st_parallel.py
+++ b/test/tilelang_st/script/run_ptodsl_st_parallel.py
@@ -32,7 +32,7 @@ def _timestamp():
 
 
 def _default_ptoas_bin(repo_root):
-    candidate = repo_root / "build-llvm21" / "tools" / "ptoas" / "ptoas"
+    candidate = repo_root / "build" / "tools" / "ptoas" / "ptoas"
     if candidate.is_file():
         return candidate
     found = run_st.find_ptoas_bin()
@@ -55,7 +55,7 @@ def _target_dir_from_testcase_root(testcase_root):
 def _log_dir(repo_root, requested):
     if requested:
         return Path(requested).resolve()
-    return repo_root / "build-llvm21" / "tilelang_st_ptodsl_logs" / _timestamp()
+    return repo_root / "build" / "tilelang_st_ptodsl_logs" / _timestamp()
 
 
 def _write_json(path, payload):

--- a/test/tilelib-st/README.md
+++ b/test/tilelib-st/README.md
@@ -211,8 +211,8 @@ Prerequisites:
   Python used to launch the ST cases.
 
 Use the LLVM/MLIR version documented in the repository root `README.md`. At the
-time of writing that is LLVM 21 from the VPTO branch
-`vpto-dev/llvm-project:feature-vpto-llvm21`. If unsure, check
+time of writing that is LLVM 19 from the VPTO branch
+`vpto-dev/llvm-project:feature-vpto`. If unsure, check
 `.github/workflows/ci_sim.yml` and use its current `LLVM_REPO` / `LLVM_REF`.
 PTOAS CMake also verifies the LLVM major version and will reject an
 incompatible LLVM build.

--- a/tools/ptobc/src/ptobc_decode_print.cpp
+++ b/tools/ptobc/src/ptobc_decode_print.cpp
@@ -785,9 +785,9 @@ static mlir::Operation *buildKnownOpFromReader(BuildCtx &bc, Reader &r,
   }
 
   mlir::Operation *op = mlir::Operation::create(state);
-  // In MLIR 21, AttrSizedOperandSegments is stored as an inherent property.
+  // AttrSizedOperandSegments uses generated inherent property storage.
   // OperationState's generic attribute list does not initialize it, so update
-  // the generated property storage directly after creating the registered op.
+  // that storage directly after creating the registered op.
   if (unifiedOperandSegments) {
     setUnifiedOperandSegmentProperty(op, opcode, *unifiedOperandSegments);
   }


### PR DESCRIPTION
## 概述

PTOAS 主线已经降级到 LLVM/MLIR 19，但部分发布说明、调试文档、测试脚本默认路径和实现注释仍沿用 LLVM 21 的叙述。本 PR 将现行使用路径统一到 LLVM 19，避免用户继续使用旧分支或 `build-llvm21` 目录。

## 变更

- 将发布说明和 TileLib simulator runbook 更新为 LLVM 19 VPTO 分支 `feature-vpto`。
- 将 PTODSL TileLib 调试手册和并行 ST 脚本的默认目录从 `build-llvm21` 统一为标准 `build` 目录。
- 更新 wheel linking 设计中的 LLVM 版本和 cache flavor 示例。
- 将 memplan 验证命令中的个人 LLVM 21 绝对路径改为通用 LLVM 19 构建目录示例。
- 去除三处实现注释中已经失效的 LLVM/MLIR 21 版本归因，不改变代码行为。
- 保留 LLVM 19 降级设计、兼容 pass 和带日期历史验证记录中的 LLVM 21 对比说明。

## 验证

- `python3 -m py_compile test/tilelang_st/script/run_ptodsl_st_parallel.py`
- `python3 test/tilelang_st/script/run_ptodsl_st_parallel.py --help`
- 验证并行 ST 脚本默认 PTOAS 和日志路径均位于 `build/`
- `python3 .codex/skills/enforce-ptoas-code-compliance/scripts/check_changed_code.py --repo . --base main`：0 errors，0 warnings
- `git diff --check`
- 检索确认现行内容中不再包含 `build-llvm21`、`feature-vpto-llvm21`、旧 wheel cache 名或个人 LLVM 21 workspace 路径