### PR TITLE
fix(ptodsl): preserve entering SSA values for nested partial assignments

### DIFF
--- a/ptodsl/docs/user_guide/05-control-flow.md
+++ b/ptodsl/docs/user_guide/05-control-flow.md
@@ -454,8 +454,10 @@ def ast_rewrite_static_loop_kernel():
         pto.pipe_barrier(pto.Pipe.ALL)
 ```
 
-`pto.static_range(...)` keeps Python `for` semantics. The loop target remains
-available after the loop:
+`pto.static_range(...)` keeps Python `for` semantics. Bindings created or
+deleted by the unrolled body and `else` clause remain in effect after tracing.
+The loop target remains available after a non-empty loop unless the body
+deletes it:
 
 <!-- ptodsl-doc-test: {"mode":"compile","symbol":"ast_rewrite_static_loop_target_kernel","compile":{}} -->
 ```python

--- a/ptodsl/docs/user_guide/05-control-flow.md
+++ b/ptodsl/docs/user_guide/05-control-flow.md
@@ -406,6 +406,12 @@ initial value before the loop. Loop-local temporaries that are written before
 they are read inside every iteration (e.g. `col = base + index`) are not
 loop-carried and need no initial value outside the loop.
 
+For a value assigned only on some iterations but used after the loop, the
+default path preserves the entering value and therefore requires that value to
+be definitely bound before the `while`. Otherwise AST rewrite reports the
+value as `last-iteration-only`; initialize it before the loop or use explicit
+loop state.
+
 Because loop-local temporaries stay iteration-local, an `else:` clause of a
 runtime `while` must not read them: the clause runs after the rewrite's
 single traced execution, so it would observe the trace-time value instead of

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -2484,7 +2484,7 @@ class _ControlFlowRewriter:
         if unsupported_last_values:
             raise PTODSLAstRewriteError(
                 "ast_rewrite=True runtime while cannot expose last-iteration-only values yet; "
-                f"use explicit pto.while_(...).carry(...) for {unsupported_last_values}"
+                f"use explicit pto.while_(...) state for {unsupported_last_values}"
             )
         if not carry_names and not (control["break"] or control["continue"] or stmt.orelse):
             raise PTODSLAstRewriteError(

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -1759,6 +1759,16 @@ class _ControlFlowRewriter:
                     next_static_iters[stmt.target.id] = values
             saved_control_stack = self._loop_control_stack
             self._loop_control_stack = []
+            name_target = stmt.target.id if isinstance(stmt.target, ast.Name) else None
+            entry_with_iv = set(bound_before or ())
+            if name_target is not None:
+                entry_with_iv.add(name_target)
+            orelse_with_iv = set(bound_before or ())
+            # The induction target is only definitely bound in the else clause
+            # when the static range is known non-empty; an empty static range
+            # jumps straight to the else clause with the target unbound.
+            if name_target is not None and values is not None and len(values) > 0:
+                orelse_with_iv.add(name_target)
             try:
                 stmt.body = self.rewrite_block(
                     stmt.body,
@@ -1766,7 +1776,7 @@ class _ControlFlowRewriter:
                     live_after_slots=live_after_slots,
                     allow_loop_control=True,
                     static_iters=next_static_iters,
-                    bound_on_entry=set(bound_before or ()) | {stmt.target.id},
+                    bound_on_entry=entry_with_iv,
                 )
                 stmt.orelse = self.rewrite_block(
                     stmt.orelse,
@@ -1774,7 +1784,7 @@ class _ControlFlowRewriter:
                     live_after_slots=live_after_slots,
                     allow_loop_control=True,
                     static_iters=static_iters,
-                    bound_on_entry=set(bound_before or ()) | {stmt.target.id},
+                    bound_on_entry=orelse_with_iv,
                 )
             finally:
                 self._loop_control_stack = saved_control_stack
@@ -1824,7 +1834,14 @@ class _ControlFlowRewriter:
         safe_reads = reads_before_raw | {
             name for name in implicit_reads if name in (bound_before or set())
         }
-        loop_carried = tuple(sorted(body_info.stores & safe_reads))
+        # The induction variable is re-bound at the top of every iteration and
+        # must never be inferred as a carried name, otherwise the carry init
+        # would read it before the loop (unbound) or shadow the fresh binding.
+        loop_carried = tuple(
+            name
+            for name in sorted(body_info.stores & safe_reads)
+            if name != stmt.target.id
+        )
         slot_reads_raw = _read_before_assignment_slots(stmt.body, self._static_env, static_iters)
         slot_reads = _read_before_assignment_slots(
             stmt.body, self._static_env, static_iters, live_after=assigned_slots_live_after

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -696,6 +696,36 @@ def _definite_stores(stmt) -> set[str]:
     return set()
 
 
+def _deleted_names(node) -> set[str]:
+    """Names whose local bindings may be deleted while executing node."""
+    deleted = set()
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Delete(self, delete):
+            for target in delete.targets:
+                deleted.update(_simple_name_targets(target))
+
+        def visit_FunctionDef(self, function):
+            return
+
+        def visit_AsyncFunctionDef(self, function):
+            return
+
+        def visit_Lambda(self, function):
+            return
+
+        def visit_ClassDef(self, class_def):
+            return
+
+    visitor = Visitor()
+    if isinstance(node, list):
+        for item in node:
+            visitor.visit(item)
+    else:
+        visitor.visit(node)
+    return deleted
+
+
 def _definite_out_stmt(stmt, bound_in, static_env=None, static_iters=None) -> set[str]:
     """Definite-assignment dataflow through one statement (not a block)."""
     if isinstance(stmt, ast.Assign) or (isinstance(stmt, ast.AnnAssign) and stmt.value is not None):
@@ -716,15 +746,52 @@ def _definite_out_stmt(stmt, bound_in, static_env=None, static_iters=None) -> se
                 out |= _simple_name_targets(item.optional_vars)
         return _definite_out_block(stmt.body, out, static_env, static_iters)
     if isinstance(stmt, ast.For):
-        # Runtime loop bodies or targets are not definite (the loop may not
-        # run), but a known non-empty static_range definitely binds a simple
-        # Name target after the loop.
-        out = set(bound_in)
-        if isinstance(stmt.target, ast.Name) and _is_pto_attr_call(stmt.iter, "static_range"):
+        # Runtime loop bodies or targets are not definite because the loop may
+        # not run. A known static_range, however, executes at trace time, so its
+        # body and normal-completion else clause update bindings exactly like a
+        # Python for-loop.
+        if _is_pto_attr_call(stmt.iter, "static_range"):
             values = _try_eval_static_range(stmt.iter, static_env or {}, static_iters or {})
-            if values is not None and len(values) > 0:
-                out.add(stmt.target.id)
-        return out
+            if values is not None:
+                out = set(bound_in)
+                if not values:
+                    return _definite_out_block(
+                        stmt.orelse, out, static_env, static_iters
+                    )
+
+                target_names = _simple_name_targets(stmt.target)
+                control = _loop_control_flags(stmt.body)
+                if control["break"] or control["continue"]:
+                    # Do not credit body assignments that a transfer may skip.
+                    # The target is rebound before every entered iteration, but
+                    # a body deletion can still leave it (or another incoming
+                    # name) unbound on the final/breaking path.
+                    out |= target_names
+                    out -= _deleted_names(stmt.body)
+                    if control["break"]:
+                        # The else clause is optional when a break is possible:
+                        # keep no additions from it, and remove bindings it may
+                        # delete on the normal-completion path.
+                        return out - _deleted_names(stmt.orelse)
+                    return _definite_out_block(
+                        stmt.orelse, out, static_env, static_iters
+                    )
+
+                loop_static_iters = dict(static_iters or {})
+                for value in values:
+                    iteration_static_iters = dict(loop_static_iters)
+                    if isinstance(stmt.target, ast.Name):
+                        iteration_static_iters[stmt.target.id] = (value,)
+                    out |= target_names
+                    out = _definite_out_block(
+                        stmt.body, out, static_env, iteration_static_iters
+                    )
+                if isinstance(stmt.target, ast.Name):
+                    loop_static_iters[stmt.target.id] = (values[-1],)
+                return _definite_out_block(
+                    stmt.orelse, out, static_env, loop_static_iters
+                )
+        return set(bound_in)
     # Everything else does not definitely bind names: loop bodies may not run
     # and the loop variable is unbound for empty ranges.
     return set(bound_in)

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -71,7 +71,16 @@ def rewrite_jit_function(
             section_uninitialized_aliases=section_rewriter.section_uninitialized_aliases,
             reject_bare_returns=reject_bare_returns,
         )
-        function_def.body = rewriter.rewrite_block(function_def.body, live_after=set())
+        entry_params = set()
+        for _arg in (
+            list(function_def.args.posonlyargs)
+            + list(function_def.args.args)
+            + list(function_def.args.kwonlyargs)
+        ):
+            entry_params.add(_arg.arg)
+        function_def.body = rewriter.rewrite_block(
+            function_def.body, live_after=set(), bound_on_entry=entry_params
+        )
     tree = ast.Module(body=[function_def], type_ignores=[])
     ast.fix_missing_locations(tree)
 
@@ -616,8 +625,8 @@ def _slot_live_before_stmt(stmt, live_after, static_env, static_iters) -> set[_S
     return (set(live) - info.stores) | info.loads
 
 
-def _read_before_assignment_slots(stmts, static_env, static_iters=None) -> set[_SubscriptSlot]:
-    return _slot_live_before_block(stmts, set(), static_env, static_iters)
+def _read_before_assignment_slots(stmts, static_env, static_iters=None, live_after=None) -> set[_SubscriptSlot]:
+    return _slot_live_before_block(stmts, set(live_after or ()), static_env, static_iters)
 
 
 def _kill_slots_for_assigned_bases(slots, stmt) -> set[_SubscriptSlot]:
@@ -676,6 +685,30 @@ def _definite_stores(stmt) -> set[str]:
     if isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
         return _simple_name_targets(stmt.target)
     return set()
+
+
+def _definite_out_stmt(stmt, bound_in) -> set[str]:
+    """Definite-assignment dataflow through one statement (not a block)."""
+    if isinstance(stmt, ast.Assign) or (isinstance(stmt, ast.AnnAssign) and stmt.value is not None):
+        return set(bound_in) | _definite_stores(stmt)
+    if isinstance(stmt, ast.If):
+        return _definite_out_block(stmt.body, bound_in) & _definite_out_block(stmt.orelse, bound_in)
+    if isinstance(stmt, ast.With):
+        out = set(bound_in)
+        for item in stmt.items:
+            if item.optional_vars is not None:
+                out |= _simple_name_targets(item.optional_vars)
+        return out
+    # Loops (and everything else) do not definitely bind names: a loop body or
+    # branch may never execute, and the loop variable is unbound for empty ranges.
+    return set(bound_in)
+
+
+def _definite_out_block(stmts, bound_in) -> set[str]:
+    out = set(bound_in)
+    for stmt in stmts:
+        out = _definite_out_stmt(stmt, out)
+    return out
 
 
 def _resolve_subscript_slots(node, static_env, static_iters, *, require_static) -> set[_SubscriptSlot]:
@@ -1187,18 +1220,20 @@ class _ControlFlowRewriter:
             )
         return _name(name)
 
-    def rewrite_block(self, stmts, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None):
+    def rewrite_block(self, stmts, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None, bound_on_entry=None):
         rewritten_reversed = []
         live = set(live_after)
         live_slots = set(live_after_slots or ())
         static_iters = dict(static_iters or {})
-        # Names definitely bound by earlier sibling statements, per position.
-        # Used to avoid turning unbound partial live-outs into loop carries.
+        # Names definitely bound on entry to this block, plus the per-position
+        # definite-in used to avoid turning unbound partial live-outs into loop
+        # carries. Nested blocks inherit the definite-in of their enclosing
+        # statement; the root block starts from the function parameters.
+        definite_in = set(bound_on_entry or ())
         bound_before_by_stmt = {}
-        bound_so_far = set()
         for preceding in stmts:
-            bound_before_by_stmt[id(preceding)] = set(bound_so_far)
-            bound_so_far |= _definite_stores(preceding)
+            bound_before_by_stmt[id(preceding)] = set(definite_in)
+            definite_in = _definite_out_stmt(preceding, definite_in)
         for stmt in reversed(stmts):
             # Compute liveness from the authored AST before rewrite_stmt mutates
             # sibling statements in-place, otherwise later rewrites can pollute
@@ -1218,7 +1253,7 @@ class _ControlFlowRewriter:
             live_slots = live_before_slots
         return rewritten_reversed
 
-    def _rewrite_loop_body(self, stmts, *, live_after, live_after_slots=None, static_iters=None, control=None):
+    def _rewrite_loop_body(self, stmts, *, live_after, live_after_slots=None, static_iters=None, control=None, bound_on_entry=None):
         """Rewrite loop statements while keeping each authored statement atomic.
 
         A rewritten dynamic ``if`` may contain several setup/branch/merge
@@ -1232,6 +1267,11 @@ class _ControlFlowRewriter:
             live |= {control["active"], control["did_break"]}
         live_slots = set(live_after_slots or ())
         static_iters = dict(static_iters or {})
+        definite_in = set(bound_on_entry or ())
+        bound_before_by_stmt = {}
+        for preceding in stmts:
+            bound_before_by_stmt[id(preceding)] = set(definite_in)
+            definite_in = _definite_out_stmt(preceding, definite_in)
         for stmt in reversed(stmts):
             live_before = _live_before_stmt(stmt, live)
             live_before_slots = _slot_live_before_stmt(stmt, live_slots, self._static_env, static_iters)
@@ -1244,6 +1284,7 @@ class _ControlFlowRewriter:
                 live_after_slots=live_slots,
                 allow_loop_control=False,
                 static_iters=static_iters,
+                bound_before=bound_before_by_stmt.get(id(stmt), set()),
             )
             rewritten_reversed[:0] = group
             live = set(live_before)
@@ -1262,6 +1303,7 @@ class _ControlFlowRewriter:
                 live_after_slots=live_after_slots,
                 allow_loop_control=allow_loop_control,
                 static_iters=static_iters,
+                bound_before=bound_before,
             )
         if isinstance(stmt, ast.For):
             return self._rewrite_for(
@@ -1279,6 +1321,7 @@ class _ControlFlowRewriter:
                 live_after_slots=live_after_slots,
                 allow_loop_control=allow_loop_control,
                 static_iters=static_iters,
+                bound_before=bound_before,
             )
         if isinstance(stmt, (ast.Break, ast.Continue)):
             if self._loop_control_stack:
@@ -1307,16 +1350,20 @@ class _ControlFlowRewriter:
             )
         ]
 
-    def _rewrite_nested(self, stmt, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None):
+    def _rewrite_nested(self, stmt, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None, bound_before=None):
         live_after_slots = set(live_after_slots or ())
         static_iters = dict(static_iters or {})
         if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            inner_params = set()
+            for arg in stmt.args.posonlyargs + stmt.args.args + stmt.args.kwonlyargs:
+                inner_params.add(arg.arg)
             stmt.body = self.rewrite_block(
                 stmt.body,
                 live_after=set(),
                 live_after_slots=set(),
                 allow_loop_control=False,
                 static_iters={},
+                bound_on_entry=inner_params,
             )
             return stmt
         if isinstance(stmt, (ast.Lambda, ast.ClassDef)):
@@ -1332,6 +1379,7 @@ class _ControlFlowRewriter:
                         live_after_slots=live_after_slots,
                         allow_loop_control=allow_loop_control,
                         static_iters=static_iters,
+                        bound_on_entry=bound_before,
                     ),
                 )
             elif isinstance(value, ast.AST):
@@ -1354,7 +1402,7 @@ class _ControlFlowRewriter:
                         )
         return stmt
 
-    def _rewrite_if(self, stmt, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None):
+    def _rewrite_if(self, stmt, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None, bound_before=None):
         live_after_slots = set(live_after_slots or ())
         static_iters = dict(static_iters or {})
         if _is_pto_attr_call(stmt.test, "const_expr"):
@@ -1364,6 +1412,7 @@ class _ControlFlowRewriter:
                 live_after_slots=live_after_slots,
                 allow_loop_control=allow_loop_control,
                 static_iters=static_iters,
+                bound_on_entry=bound_before,
             )
             stmt.orelse = self.rewrite_block(
                 stmt.orelse,
@@ -1371,6 +1420,7 @@ class _ControlFlowRewriter:
                 live_after_slots=live_after_slots,
                 allow_loop_control=allow_loop_control,
                 static_iters=static_iters,
+                bound_on_entry=bound_before,
             )
             return [stmt]
 
@@ -1434,6 +1484,7 @@ class _ControlFlowRewriter:
             live_after_slots=branch_live_after_slots,
             allow_loop_control=False,
             static_iters=static_iters,
+            bound_on_entry=bound_before,
         )
         else_body = self.rewrite_block(
             stmt.orelse,
@@ -1441,6 +1492,7 @@ class _ControlFlowRewriter:
             live_after_slots=branch_live_after_slots,
             allow_loop_control=False,
             static_iters=static_iters,
+            bound_on_entry=bound_before,
         )
         trace_time_if = ast.If(
             test=_name(cond_name),
@@ -1705,6 +1757,7 @@ class _ControlFlowRewriter:
                     live_after_slots=live_after_slots,
                     allow_loop_control=True,
                     static_iters=next_static_iters,
+                    bound_on_entry=bound_before,
                 )
                 stmt.orelse = self.rewrite_block(
                     stmt.orelse,
@@ -1712,6 +1765,7 @@ class _ControlFlowRewriter:
                     live_after_slots=live_after_slots,
                     allow_loop_control=True,
                     static_iters=static_iters,
+                    bound_on_entry=bound_before,
                 )
             finally:
                 self._loop_control_stack = saved_control_stack
@@ -1724,6 +1778,7 @@ class _ControlFlowRewriter:
                 live_after=live_after,
                 live_after_slots=live_after_slots,
                 static_iters=static_iters,
+                bound_before=bound_before,
             )
         if not isinstance(stmt.target, ast.Name):
             raise PTODSLAstRewriteError("ast_rewrite=True runtime for-loops require a simple name target")
@@ -1752,7 +1807,8 @@ class _ControlFlowRewriter:
         # Only the implicit (default-path) reads are additionally gated on a
         # definite binding before the loop: carrying an unbound name would read
         # an unbound Python local when the loop is entered, instead of the clear
-        # last-iteration-only diagnostics below.
+        # last-iteration-only diagnostics below. The same gate applies to static
+        # subscript slots, keyed on the definite binding of the slot base list.
         reads_before_raw = _read_before_assignment_names(stmt.body)
         reads_before = _read_before_assignment_names(stmt.body, live_after=assigned_live_after)
         implicit_reads = reads_before - reads_before_raw
@@ -1760,7 +1816,15 @@ class _ControlFlowRewriter:
             name for name in implicit_reads if name in (bound_before or set())
         }
         loop_carried = tuple(sorted(body_info.stores & safe_reads))
-        loop_carried_slots = tuple(sorted(body_slot_info.stores & slot_reads_before))
+        slot_reads_raw = _read_before_assignment_slots(stmt.body, self._static_env, static_iters)
+        slot_reads = _read_before_assignment_slots(
+            stmt.body, self._static_env, static_iters, live_after=assigned_slots_live_after
+        )
+        slot_implicit = slot_reads - slot_reads_raw
+        safe_slots = slot_reads_raw | {
+            slot for slot in slot_implicit if slot.base in (bound_before or set())
+        }
+        loop_carried_slots = tuple(sorted(body_slot_info.stores & safe_slots))
         unsupported_last_values = sorted(assigned_live_after - set(loop_carried))
         if unsupported_last_values:
             raise PTODSLAstRewriteError(
@@ -1783,6 +1847,7 @@ class _ControlFlowRewriter:
             live_after=loop_live_after,
             live_after_slots=loop_live_after_slots,
             static_iters=static_iters,
+            bound_on_entry=set(bound_before or ()) | set(loop_carried) | {slot.base for slot in loop_carried_slots},
         )
 
         slot_carry_names = {
@@ -1979,7 +2044,7 @@ class _ControlFlowRewriter:
             ) for name in merge_names)
         return result
 
-    def _rewrite_controlled_for(self, stmt, *, live_after, live_after_slots=None, static_iters=None):
+    def _rewrite_controlled_for(self, stmt, *, live_after, live_after_slots=None, static_iters=None, bound_before=None):
         """Lower range-for with transfers or else clauses through scf.while."""
         if not isinstance(stmt.target, ast.Name):
             raise PTODSLAstRewriteError(
@@ -1998,9 +2063,14 @@ class _ControlFlowRewriter:
             raise PTODSLAstRewriteError(
                 "ast_rewrite=True runtime for break/continue does not support static subscript carries yet"
             )
-        reads_before = _read_before_assignment_names(stmt.body)
-        loop_carried = set(body_info.stores & reads_before)
-        loop_carried |= set(body_info.stores & set(live_after))
+        reads_before_raw = _read_before_assignment_names(stmt.body)
+        assigned_live_after = body_info.stores & set(live_after)
+        reads_before = _read_before_assignment_names(stmt.body, live_after=assigned_live_after)
+        implicit_reads = (reads_before - reads_before_raw) | assigned_live_after
+        safe_reads = reads_before_raw | {
+            name for name in implicit_reads if name in (bound_before or set())
+        }
+        loop_carried = set(body_info.stores & safe_reads)
         loop_carried.discard(stmt.target.id)
         unsupported_last = sorted((body_info.stores & set(live_after)) - loop_carried)
         if unsupported_last:
@@ -2080,6 +2150,7 @@ class _ControlFlowRewriter:
                 live_after_slots=set(),
                 control={"active": skip_name, "did_break": did_break_name},
                 static_iters=static_iters,
+                bound_on_entry=set(bound_before or ()) | set(loop_carried) | {iv_name},
             )
         finally:
             self._loop_control_stack.pop()
@@ -2122,6 +2193,7 @@ class _ControlFlowRewriter:
                 live_after_slots=live_after_slots,
                 allow_loop_control=False,
                 static_iters=static_iters,
+                bound_on_entry=bound_before,
             )
             else_info = _name_info(stmt.orelse)
             else_merge_names = tuple(sorted(else_info.stores & set(live_after)))
@@ -2134,7 +2206,7 @@ class _ControlFlowRewriter:
         return result
 
     def _rewrite_while(self, stmt, *, live_after, live_after_slots=None,
-                       allow_loop_control=False, static_iters=None):
+                       allow_loop_control=False, static_iters=None, bound_before=None):
         """Lower runtime ``while`` using named state and explicit control flags."""
         if _loop_has_return(stmt.body):
             raise PTODSLAstRewriteError(
@@ -2228,6 +2300,7 @@ class _ControlFlowRewriter:
                     if controlled else None
                 ),
                 static_iters=static_iters,
+                bound_on_entry=set(bound_before or ()) | set(carry_names),
             )
         finally:
             if controlled:
@@ -2292,6 +2365,7 @@ class _ControlFlowRewriter:
                 live_after_slots=live_after_slots,
                 allow_loop_control=False,
                 static_iters=static_iters,
+                bound_on_entry=bound_before,
             )
             else_info = _name_info(stmt.orelse)
             else_merge_names = tuple(sorted(else_info.stores & set(live_after)))

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -661,6 +661,23 @@ def _simple_name_targets(target) -> set[str]:
     return set()
 
 
+def _definite_stores(stmt) -> set[str]:
+    """Names definitely (unconditionally) bound by one statement.
+
+    Conservative on purpose: names assigned inside conditionals or loop bodies
+    are not treated as definite, so implicit loop carries are only inferred for
+    names that are provably bound before the loop statement.
+    """
+    if isinstance(stmt, ast.Assign):
+        names = set()
+        for target in stmt.targets:
+            names.update(_simple_name_targets(target))
+        return names
+    if isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+        return _simple_name_targets(stmt.target)
+    return set()
+
+
 def _resolve_subscript_slots(node, static_env, static_iters, *, require_static) -> set[_SubscriptSlot]:
     if not isinstance(node.value, ast.Name):
         return set()
@@ -1175,6 +1192,13 @@ class _ControlFlowRewriter:
         live = set(live_after)
         live_slots = set(live_after_slots or ())
         static_iters = dict(static_iters or {})
+        # Names definitely bound by earlier sibling statements, per position.
+        # Used to avoid turning unbound partial live-outs into loop carries.
+        bound_before_by_stmt = {}
+        bound_so_far = set()
+        for preceding in stmts:
+            bound_before_by_stmt[id(preceding)] = set(bound_so_far)
+            bound_so_far |= _definite_stores(preceding)
         for stmt in reversed(stmts):
             # Compute liveness from the authored AST before rewrite_stmt mutates
             # sibling statements in-place, otherwise later rewrites can pollute
@@ -1187,6 +1211,7 @@ class _ControlFlowRewriter:
                 live_after_slots=live_slots,
                 allow_loop_control=allow_loop_control,
                 static_iters=static_iters,
+                bound_before=bound_before_by_stmt.get(id(stmt), set()),
             )
             rewritten_reversed[:0] = rewritten
             live = live_before
@@ -1227,7 +1252,7 @@ class _ControlFlowRewriter:
             live_slots = live_before_slots
         return rewritten_reversed
 
-    def rewrite_stmt(self, stmt, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None):
+    def rewrite_stmt(self, stmt, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None, bound_before=None):
         live_after_slots = set(live_after_slots or ())
         static_iters = dict(static_iters or {})
         if isinstance(stmt, ast.If):
@@ -1245,6 +1270,7 @@ class _ControlFlowRewriter:
                 live_after_slots=live_after_slots,
                 allow_loop_control=allow_loop_control,
                 static_iters=static_iters,
+                bound_before=bound_before,
             )
         if isinstance(stmt, ast.While):
             return self._rewrite_while(
@@ -1443,16 +1469,25 @@ class _ControlFlowRewriter:
         }
         dynamic_then_body = copy.deepcopy(then_body)
         dynamic_else_body = copy.deepcopy(else_body)
-        if if_entry_names:
+        if if_entry_names or old_slot_value_names:
             # The restore assignments below emit no IR: they only reset the
-            # trace-time Python binding so every dynamic branch starts from the
-            # same entering SSA environment.
+            # trace-time Python bindings so every dynamic branch starts from the
+            # same entering SSA environment. Slot temporaries are shared between
+            # sibling branches as well, so restore them from their entry copies
+            # too; otherwise a nested conditional inside one branch captures the
+            # other branch's slot value.
             entry_restores = [
                 ast.Assign(
                     targets=[_name(name, ast.Store())],
                     value=_name(if_entry_names[name]),
                 )
                 for name in sorted(if_entry_names)
+            ] + [
+                ast.Assign(
+                    targets=[_name(slot_value_names[slot], ast.Store())],
+                    value=_name(old_slot_value_names[slot]),
+                )
+                for slot in sorted(merge_slots)
             ]
             dynamic_then_body = copy.deepcopy(entry_restores) + dynamic_then_body
             dynamic_else_body = copy.deepcopy(entry_restores) + dynamic_else_body
@@ -1652,7 +1687,7 @@ class _ControlFlowRewriter:
             )
         )
 
-    def _rewrite_for(self, stmt, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None):
+    def _rewrite_for(self, stmt, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None, bound_before=None):
         live_after_slots = set(live_after_slots or ())
         static_iters = dict(static_iters or {})
         if _is_pto_attr_call(stmt.iter, "static_range"):
@@ -1714,8 +1749,17 @@ class _ControlFlowRewriter:
         # Seed backward liveness with the body stores that are live after the
         # loop so that a partial assignment whose default path keeps the previous
         # value is recognized as a live-in and therefore a loop-carried iter_arg.
+        # Only the implicit (default-path) reads are additionally gated on a
+        # definite binding before the loop: carrying an unbound name would read
+        # an unbound Python local when the loop is entered, instead of the clear
+        # last-iteration-only diagnostics below.
+        reads_before_raw = _read_before_assignment_names(stmt.body)
         reads_before = _read_before_assignment_names(stmt.body, live_after=assigned_live_after)
-        loop_carried = tuple(sorted(body_info.stores & reads_before))
+        implicit_reads = reads_before - reads_before_raw
+        safe_reads = reads_before_raw | {
+            name for name in implicit_reads if name in (bound_before or set())
+        }
+        loop_carried = tuple(sorted(body_info.stores & safe_reads))
         loop_carried_slots = tuple(sorted(body_slot_info.stores & slot_reads_before))
         unsupported_last_values = sorted(assigned_live_after - set(loop_carried))
         if unsupported_last_values:

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -904,8 +904,14 @@ def _live_before_stmt(stmt, live_after) -> set[str]:
     return (set(live_after) - info.stores) | info.loads
 
 
-def _read_before_assignment_names(stmts):
-    return _live_before_block(stmts, set())
+def _read_before_assignment_names(stmts, live_after=None):
+    """Return the names read (or implicitly relied on) before assignment.
+
+    live_after seeds backward liveness. Without a seed only explicit reads are
+    visible; with a seed, the partial-assignment default paths of nested
+    conditionals surface their implicit reads of the entering value.
+    """
+    return _live_before_block(stmts, set(live_after or ()))
 
 
 def _is_pto_attr_call(node, name: str) -> bool:
@@ -1381,6 +1387,21 @@ class _ControlFlowRewriter:
 
         branch_live_after = set(live_after) | set(merge_names)
         branch_live_after_slots = set(live_after_slots) | set(merge_slots)
+        # Variables not assigned on one side need their entering value at branch
+        # merge time, and variables read inside a branch need a clean entering
+        # environment. Snapshot the entering SSA value of exactly those names and
+        # restore the Python binding at the top of each dynamic branch so sibling
+        # branch tracing never observes the other branch's rebindings.
+        branch_entry_names = set(old_value_names) | (
+            assigned_any
+            & (
+                _live_before_block(stmt.body, branch_live_after)
+                | _live_before_block(stmt.orelse, branch_live_after)
+            )
+        )
+        if_entry_names = {
+            name: self._fresh(f'if_entry_{name}') for name in sorted(branch_entry_names)
+        }
         then_body = self.rewrite_block(
             stmt.body,
             live_after=branch_live_after,
@@ -1422,6 +1443,19 @@ class _ControlFlowRewriter:
         }
         dynamic_then_body = copy.deepcopy(then_body)
         dynamic_else_body = copy.deepcopy(else_body)
+        if if_entry_names:
+            # The restore assignments below emit no IR: they only reset the
+            # trace-time Python binding so every dynamic branch starts from the
+            # same entering SSA environment.
+            entry_restores = [
+                ast.Assign(
+                    targets=[_name(name, ast.Store())],
+                    value=_name(if_entry_names[name]),
+                )
+                for name in sorted(if_entry_names)
+            ]
+            dynamic_then_body = copy.deepcopy(entry_restores) + dynamic_then_body
+            dynamic_else_body = copy.deepcopy(entry_restores) + dynamic_else_body
         if slot_value_names:
             dynamic_then_body = [
                 _SlotValueRewriter(slot_value_names, self._static_env, static_iters).visit(stmt)
@@ -1447,7 +1481,7 @@ class _ControlFlowRewriter:
                 self._branch_assign(
                     branch_name,
                     merge_names,
-                    old_value_names=old_value_names,
+                    entry_names=if_entry_names,
                     assigned_names=then_assigned,
                     slot_value_names=slot_value_names,
                     old_slot_value_names=old_slot_value_names,
@@ -1458,7 +1492,7 @@ class _ControlFlowRewriter:
                 self._branch_assign(
                     branch_name,
                     merge_names,
-                    old_value_names=old_value_names,
+                    entry_names=if_entry_names,
                     assigned_names=else_assigned,
                     slot_value_names=slot_value_names,
                     old_slot_value_names=old_slot_value_names,
@@ -1511,7 +1545,14 @@ class _ControlFlowRewriter:
                     type_comment=None,
                 )
             )
-        dynamic_body = [with_stmt]
+        dynamic_body = [
+            ast.Assign(
+                targets=[_name(if_entry_names[name], ast.Store())],
+                value=self._current_value(name),
+            )
+            for name in sorted(if_entry_names)
+        ]
+        dynamic_body.append(with_stmt)
         dynamic_body.extend(
             ast.Assign(
                 targets=[_name(name, ast.Store())],
@@ -1547,13 +1588,6 @@ class _ControlFlowRewriter:
         ]
         result.extend(
             ast.Assign(
-                targets=[_name(old_name, ast.Store())],
-                value=self._current_value(name),
-            )
-            for name, old_name in old_value_names.items()
-        )
-        result.extend(
-            ast.Assign(
                 targets=[_name(value_name, ast.Store())],
                 value=_slot_subscript(slot),
             )
@@ -1587,7 +1621,7 @@ class _ControlFlowRewriter:
         branch_name,
         names,
         *,
-        old_value_names,
+        entry_names,
         assigned_names,
         slot_value_names=None,
         old_slot_value_names=None,
@@ -1599,7 +1633,7 @@ class _ControlFlowRewriter:
         keywords = [
             ast.keyword(
                 arg=name,
-                value=_name(name if name in assigned_names else old_value_names[name]),
+                value=_name(name if name in assigned_names else entry_names[name]),
             )
             for name in names
         ]
@@ -1674,10 +1708,13 @@ class _ControlFlowRewriter:
         body_slot_info = _slot_info(stmt.body, self._static_env, static_iters)
         if body_slot_info.invalid_stores:
             raise PTODSLAstRewriteError(body_slot_info.invalid_stores[0])
-        reads_before = _read_before_assignment_names(stmt.body)
         slot_reads_before = _read_before_assignment_slots(stmt.body, self._static_env, static_iters)
         assigned_live_after = body_info.stores & set(live_after)
         assigned_slots_live_after = body_slot_info.stores & set(live_after_slots)
+        # Seed backward liveness with the body stores that are live after the
+        # loop so that a partial assignment whose default path keeps the previous
+        # value is recognized as a live-in and therefore a loop-carried iter_arg.
+        reads_before = _read_before_assignment_names(stmt.body, live_after=assigned_live_after)
         loop_carried = tuple(sorted(body_info.stores & reads_before))
         loop_carried_slots = tuple(sorted(body_slot_info.stores & slot_reads_before))
         unsupported_last_values = sorted(assigned_live_after - set(loop_carried))
@@ -1862,10 +1899,10 @@ class _ControlFlowRewriter:
             targets=[_name(old_names[name], ast.Store())], value=_name(name))
             for name in merge_names]
         then_body = list(body) + [self._branch_assign(
-            branch_name, merge_names, old_value_names=old_names,
+            branch_name, merge_names, entry_names=old_names,
             assigned_names=assigned_names)] if merge_names else list(body)
         else_body = [self._branch_assign(
-            branch_name, merge_names, old_value_names=old_names,
+            branch_name, merge_names, entry_names=old_names,
             assigned_names=set())] if merge_names else [ast.Pass()]
         result = prefix + [ast.With(
             items=[ast.withitem(

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -698,7 +698,7 @@ def _definite_out_stmt(stmt, bound_in) -> set[str]:
         for item in stmt.items:
             if item.optional_vars is not None:
                 out |= _simple_name_targets(item.optional_vars)
-        return out
+        return _definite_out_block(stmt.body, out)
     # Loops (and everything else) do not definitely bind names: a loop body or
     # branch may never execute, and the loop variable is unbound for empty ranges.
     return set(bound_in)
@@ -1347,6 +1347,7 @@ class _ControlFlowRewriter:
                 live_after_slots=live_after_slots,
                 allow_loop_control=allow_loop_control,
                 static_iters=static_iters,
+                bound_before=bound_before,
             )
         ]
 
@@ -1389,6 +1390,7 @@ class _ControlFlowRewriter:
                     live_after_slots=live_after_slots,
                     allow_loop_control=allow_loop_control,
                     static_iters=static_iters,
+                    bound_before=bound_before,
                 )
             elif isinstance(value, list):
                 for item in value:
@@ -1399,6 +1401,7 @@ class _ControlFlowRewriter:
                             live_after_slots=live_after_slots,
                             allow_loop_control=allow_loop_control,
                             static_iters=static_iters,
+                            bound_before=bound_before,
                         )
         return stmt
 

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -1371,6 +1371,12 @@ class _ControlFlowRewriter:
             return stmt
         for field, value in ast.iter_fields(stmt):
             if field in {"body", "orelse", "finalbody"} and isinstance(value, list):
+                entry_bindings = set(bound_before or ())
+                if field == "body" and isinstance(stmt, ast.With):
+                    # The with-as targets are definitely bound inside the body.
+                    for item in stmt.items:
+                        if item.optional_vars is not None:
+                            entry_bindings |= _simple_name_targets(item.optional_vars)
                 setattr(
                     stmt,
                     field,
@@ -1380,7 +1386,7 @@ class _ControlFlowRewriter:
                         live_after_slots=live_after_slots,
                         allow_loop_control=allow_loop_control,
                         static_iters=static_iters,
-                        bound_on_entry=bound_before,
+                        bound_on_entry=entry_bindings,
                     ),
                 )
             elif isinstance(value, ast.AST):
@@ -1760,7 +1766,7 @@ class _ControlFlowRewriter:
                     live_after_slots=live_after_slots,
                     allow_loop_control=True,
                     static_iters=next_static_iters,
-                    bound_on_entry=bound_before,
+                    bound_on_entry=set(bound_before or ()) | {stmt.target.id},
                 )
                 stmt.orelse = self.rewrite_block(
                     stmt.orelse,
@@ -1768,7 +1774,7 @@ class _ControlFlowRewriter:
                     live_after_slots=live_after_slots,
                     allow_loop_control=True,
                     static_iters=static_iters,
-                    bound_on_entry=bound_before,
+                    bound_on_entry=set(bound_before or ()) | {stmt.target.id},
                 )
             finally:
                 self._loop_control_stack = saved_control_stack
@@ -1850,7 +1856,12 @@ class _ControlFlowRewriter:
             live_after=loop_live_after,
             live_after_slots=loop_live_after_slots,
             static_iters=static_iters,
-            bound_on_entry=set(bound_before or ()) | set(loop_carried) | {slot.base for slot in loop_carried_slots},
+            bound_on_entry=(
+                set(bound_before or ())
+                | {stmt.target.id}
+                | set(loop_carried)
+                | {slot.base for slot in loop_carried_slots}
+            ),
         )
 
         slot_carry_names = {

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -687,27 +687,44 @@ def _definite_stores(stmt) -> set[str]:
     return set()
 
 
-def _definite_out_stmt(stmt, bound_in) -> set[str]:
+def _definite_out_stmt(stmt, bound_in, static_env=None, static_iters=None) -> set[str]:
     """Definite-assignment dataflow through one statement (not a block)."""
     if isinstance(stmt, ast.Assign) or (isinstance(stmt, ast.AnnAssign) and stmt.value is not None):
         return set(bound_in) | _definite_stores(stmt)
+    if isinstance(stmt, ast.Delete):
+        out = set(bound_in)
+        for target in stmt.targets:
+            out -= _simple_name_targets(target)
+        return out
     if isinstance(stmt, ast.If):
-        return _definite_out_block(stmt.body, bound_in) & _definite_out_block(stmt.orelse, bound_in)
+        return _definite_out_block(stmt.body, bound_in, static_env, static_iters) & _definite_out_block(
+            stmt.orelse, bound_in, static_env, static_iters
+        )
     if isinstance(stmt, ast.With):
         out = set(bound_in)
         for item in stmt.items:
             if item.optional_vars is not None:
                 out |= _simple_name_targets(item.optional_vars)
-        return _definite_out_block(stmt.body, out)
-    # Loops (and everything else) do not definitely bind names: a loop body or
-    # branch may never execute, and the loop variable is unbound for empty ranges.
+        return _definite_out_block(stmt.body, out, static_env, static_iters)
+    if isinstance(stmt, ast.For):
+        # Runtime loop bodies or targets are not definite (the loop may not
+        # run), but a known non-empty static_range definitely binds a simple
+        # Name target after the loop.
+        out = set(bound_in)
+        if isinstance(stmt.target, ast.Name) and _is_pto_attr_call(stmt.iter, "static_range"):
+            values = _try_eval_static_range(stmt.iter, static_env or {}, static_iters or {})
+            if values is not None and len(values) > 0:
+                out.add(stmt.target.id)
+        return out
+    # Everything else does not definitely bind names: loop bodies may not run
+    # and the loop variable is unbound for empty ranges.
     return set(bound_in)
 
 
-def _definite_out_block(stmts, bound_in) -> set[str]:
+def _definite_out_block(stmts, bound_in, static_env=None, static_iters=None) -> set[str]:
     out = set(bound_in)
     for stmt in stmts:
-        out = _definite_out_stmt(stmt, out)
+        out = _definite_out_stmt(stmt, out, static_env, static_iters)
     return out
 
 
@@ -1233,7 +1250,7 @@ class _ControlFlowRewriter:
         bound_before_by_stmt = {}
         for preceding in stmts:
             bound_before_by_stmt[id(preceding)] = set(definite_in)
-            definite_in = _definite_out_stmt(preceding, definite_in)
+            definite_in = _definite_out_stmt(preceding, definite_in, self._static_env, static_iters)
         for stmt in reversed(stmts):
             # Compute liveness from the authored AST before rewrite_stmt mutates
             # sibling statements in-place, otherwise later rewrites can pollute
@@ -1271,7 +1288,7 @@ class _ControlFlowRewriter:
         bound_before_by_stmt = {}
         for preceding in stmts:
             bound_before_by_stmt[id(preceding)] = set(definite_in)
-            definite_in = _definite_out_stmt(preceding, definite_in)
+            definite_in = _definite_out_stmt(preceding, definite_in, self._static_env, static_iters)
         for stmt in reversed(stmts):
             live_before = _live_before_stmt(stmt, live)
             live_before_slots = _slot_live_before_stmt(stmt, live_slots, self._static_env, static_iters)

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -2453,14 +2453,22 @@ class _ControlFlowRewriter:
         # A loop-carried name must be one whose pre-iteration value is needed:
         # it is read by the test before each iteration, it is read before any
         # assignment inside the body (so it depends on the previous iteration's
-        # value), or it stays live after the loop.  ``body_info.loads`` is
-        # deliberately not used here: it includes loop-local temporaries that
-        # are written before they are read each iteration (e.g.
-        # ``col = base + index``), which are not live across iterations and
-        # would be read while still unbound at the pto._while(...) setup.
-        # This mirrors the loop_carried criterion used by ``_rewrite_for``.
-        reads_before = _read_before_assignment_names(stmt.body)
-        required_carries = test_info.loads | reads_before | set(live_after)
+        # value), or it is an assigned live-out whose partial-assignment default
+        # path keeps the entering value.  Seed backward liveness with assigned
+        # live-outs so nested conditionals expose that implicit read, then gate
+        # only those implicit reads on a definite binding before the loop.  An
+        # unbound implicit read must take the same last-iteration-only diagnostic
+        # as runtime for-loops instead of being evaluated by pto._while(...)
+        # setup.  This mirrors _rewrite_for while retaining explicit reads from
+        # the authored body and test.
+        assigned_live_after = body_info.stores & set(live_after)
+        reads_before_raw = _read_before_assignment_names(stmt.body)
+        reads_before = _read_before_assignment_names(stmt.body, live_after=assigned_live_after)
+        implicit_reads = reads_before - reads_before_raw
+        safe_reads = reads_before_raw | {
+            name for name in implicit_reads if name in (bound_before or set())
+        }
+        required_carries = test_info.loads | safe_reads
         # A controlled loop (break/continue/else) may legitimately need no
         # user-level carry: its test reads only loop-invariant names and every
         # body store is a loop-local temporary.  The active/did_break control
@@ -2472,6 +2480,12 @@ class _ControlFlowRewriter:
                 "ast_rewrite=True runtime while break/continue requires explicit control-state lowering"
             )
         carry_names = tuple(sorted(body_info.stores & required_carries))
+        unsupported_last_values = sorted(assigned_live_after - set(carry_names))
+        if unsupported_last_values:
+            raise PTODSLAstRewriteError(
+                "ast_rewrite=True runtime while cannot expose last-iteration-only values yet; "
+                f"use explicit pto.while_(...).carry(...) for {unsupported_last_values}"
+            )
         if not carry_names and not (control["break"] or control["continue"] or stmt.orelse):
             raise PTODSLAstRewriteError(
                 "ast_rewrite=True runtime while requires at least one loop-carried value"

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -279,6 +279,48 @@ def ast_static_range_nonempty_definite_gate_fn(rows, cond):
     _ = value
 
 
+def ast_static_range_body_init_definite_gate_fn(rows, cond, seed):
+    for _ in pto.static_range(1):
+        value = seed
+    for replacement in range(rows):
+        if cond:
+            value = replacement
+    _ = value
+
+
+def ast_static_range_delete_target_gate_fn(rows, cond, seed):
+    value = seed
+    for value in pto.static_range(1):
+        del value
+    for replacement in range(rows):
+        if cond:
+            value = replacement
+    _ = value
+
+
+def ast_static_range_empty_orelse_init_gate_fn(rows, cond, seed):
+    for _ in pto.static_range(0):
+        pass
+    else:
+        value = seed
+    for replacement in range(rows):
+        if cond:
+            value = replacement
+    _ = value
+
+
+def ast_static_range_orelse_delete_gate_fn(rows, cond, seed):
+    value = seed
+    for _ in pto.static_range(1):
+        pass
+    else:
+        del value
+    for replacement in range(rows):
+        if cond:
+            value = replacement
+    _ = value
+
+
 @pto.jit(target='a5', backend='vpto', mode='explicit')
 def ast_del_then_partial_liveout_probe(rows: pto.i32, cond: pto.i1):
     zero = pto.const(0, dtype=pto.i32)
@@ -493,21 +535,48 @@ def _assert_ast_rewrite_nested_partial_assign_ssa_identity():
     import inspect as _inspect
     import textwrap as _textwrap
     from ptodsl._ast_rewrite import _ControlFlowRewriter as _CFR
-    gate_src = _textwrap.dedent(_inspect.getsource(ast_static_range_nonempty_definite_gate_fn))
-    gate_tree = _ast.parse(gate_src)
-    gate_fn = next(
-        n
-        for n in _ast.walk(gate_tree)
-        if isinstance(n, _ast.FunctionDef) and n.name == 'ast_static_range_nonempty_definite_gate_fn'
-    )
-    gate_rewriter = _CFR(static_env={})
-    gate_body = gate_rewriter.rewrite_block(gate_fn.body, live_after={'value'})
-    gate_module = _ast.Module(body=gate_body, type_ignores=[])
-    _ast.fix_missing_locations(gate_module)
-    gate_text = _ast.unparse(gate_module)
+    def rewrite_gate(fn):
+        gate_src = _textwrap.dedent(_inspect.getsource(fn))
+        gate_tree = _ast.parse(gate_src)
+        gate_fn = next(
+            n
+            for n in _ast.walk(gate_tree)
+            if isinstance(n, _ast.FunctionDef) and n.name == fn.__name__
+        )
+        gate_rewriter = _CFR(static_env={})
+        gate_body = gate_rewriter.rewrite_block(
+            gate_fn.body,
+            live_after={'value'},
+            bound_on_entry={arg.arg for arg in gate_fn.args.args},
+        )
+        gate_module = _ast.Module(body=gate_body, type_ignores=[])
+        _ast.fix_missing_locations(gate_module)
+        return _ast.unparse(gate_module)
+
+    gate_text = rewrite_gate(ast_static_range_nonempty_definite_gate_fn)
     expect(
         'carry(value=value)' in gate_text,
         'known non-empty static_range target should be credited as bound for an implicit carry',
+    )
+    body_init_text = rewrite_gate(ast_static_range_body_init_definite_gate_fn)
+    expect(
+        'carry(value=value)' in body_init_text,
+        'known non-empty static_range body initialization should make an implicit carry safe',
+    )
+    empty_orelse_text = rewrite_gate(ast_static_range_empty_orelse_init_gate_fn)
+    expect(
+        'carry(value=value)' in empty_orelse_text,
+        'known empty static_range else initialization should make an implicit carry safe',
+    )
+    expect_raises(
+        PTODSLAstRewriteError,
+        lambda: rewrite_gate(ast_static_range_delete_target_gate_fn),
+        'last-iteration-only',
+    )
+    expect_raises(
+        PTODSLAstRewriteError,
+        lambda: rewrite_gate(ast_static_range_orelse_delete_gate_fn),
+        'last-iteration-only',
     )
     del _ast, _inspect, _textwrap, _CFR
 

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -211,6 +211,28 @@ def ast_with_body_bound_partial_liveout_probe(rows: pto.i32, cond: pto.i1):
     _ = value
 
 
+@pto.jit(target='a5', backend='vpto', mode='explicit')
+def ast_with_as_bound_partial_liveout_probe(rows: pto.i32, cols: pto.i32, cond: pto.i1):
+    # The with-as target is definitely bound inside the body; an inner runtime
+    # loop that partially rebinds it must see it as a valid partial carry.
+    with pto.for_(0, rows, step=1) as value:
+        for replacement in range(cols):
+            if cond:
+                value = replacement
+        pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=value)
+
+
+@pto.jit(target='a5', backend='vpto', mode='explicit')
+def ast_for_iv_bound_partial_liveout_probe(rows: pto.i32, cols: pto.i32, cond: pto.i1):
+    # The runtime for induction variable is bound at the top of its own body;
+    # an inner loop that partially rebinds it must see it as a valid carry.
+    for value in range(rows):
+        for replacement in range(cols):
+            if cond:
+                value = replacement
+        pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=value)
+
+
 def _all_operations(operation):
     yield operation
     for region in operation.regions:
@@ -415,6 +437,8 @@ def _assert_ast_rewrite_nested_partial_assign_ssa_identity():
         (ast_slot_partial_assign_loop_carry_probe.compile().mlir_text(), 'loop static-subscript partial assignment'),
         (ast_with_entry_bound_partial_liveout_probe.compile().mlir_text(), 'with-entry-bound partial live-out'),
         (ast_with_body_bound_partial_liveout_probe.compile().mlir_text(), 'with-body-bound partial live-out'),
+        (ast_with_as_bound_partial_liveout_probe.compile().mlir_text(), 'with-as-bound partial live-out'),
+        (ast_for_iv_bound_partial_liveout_probe.compile().mlir_text(), 'for-induction-variable-bound partial live-out'),
     ):
         expect_parse_roundtrip_and_verify(probe_text, 'AST-rewritten ' + label)
         expect('iter_args(' in probe_text, label + ' should lower through scf.for iter_args')

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -39,6 +39,215 @@ from ptodsl._tracing import current_session
 from ptoas.mlir.ir import InsertionPoint, Location, Module
 
 
+@pto.jit(target='a5')
+def ast_nested_partial_assign_entry_isolated_probe(cond3: pto.i1, cond1: pto.i1):
+    # Sibling branch isolation: the outer then-branch rebinds lo_bits before the
+    # inner conditional is traced, so the inner else (which never assigns lo_bits)
+    # must still fall back to the value captured before the outer if.
+    lo_bits = pto.const(0, dtype=pto.ui32)
+    hi_bits = pto.const(0x40000000, dtype=pto.ui32)
+
+    q1_bits = pto.const(0x10000000, dtype=pto.ui32)
+    q2_bits = pto.const(0x20000000, dtype=pto.ui32)
+
+    if cond3:
+        lo_bits = q2_bits
+    else:
+        if cond1:
+            lo_bits = q1_bits
+            hi_bits = q2_bits
+        # else: lo_bits/hi_bits must remain at their pre-if values.
+
+    _ = hi_bits
+    _ = lo_bits
+
+
+@pto.jit(target='a5')
+def ast_nested_partial_assign_loop_carry_probe(
+    rows: pto.i32,
+    cond3: pto.i1,
+    cond2: pto.i1,
+    cond1: pto.i1,
+):
+    # Issue 1252 structure: three nested conditionals inside a runtime loop,
+    # where the innermost else only assigns hi_bits. On that path lo_bits must
+    # remain the loop-carried value from the previous iteration.
+    lo_bits = pto.const(0, dtype=pto.ui32)
+    hi_bits = pto.const(0x40000000, dtype=pto.ui32)
+
+    q1_bits = pto.const(0x10000000, dtype=pto.ui32)
+    q2_bits = pto.const(0x20000000, dtype=pto.ui32)
+    q3_bits = pto.const(0x30000000, dtype=pto.ui32)
+
+    for _ in range(rows):
+        if cond3:
+            lo_bits = q3_bits
+        else:
+            if cond2:
+                lo_bits = q2_bits
+                hi_bits = q3_bits
+            else:
+                if cond1:
+                    lo_bits = q1_bits
+                    hi_bits = q2_bits
+                else:
+                    hi_bits = q1_bits  # lo_bits must remain unchanged
+
+    _ = hi_bits
+    _ = lo_bits
+
+
+def _all_operations(operation):
+    yield operation
+    for region in operation.regions:
+        for block in region.blocks:
+            for nested in block.operations:
+                yield from _all_operations(nested)
+
+
+def _ui32_const_results(operation, value):
+    # The frontend materializes ui32 scalars as i32 constants wrapped in
+    # builtin.unrealized_conversion_cast ops, so match constants by value only.
+    results = []
+    for op in _all_operations(operation):
+        if op.operation.name == 'arith.constant':
+            attr = op.attributes['value']
+            if attr.value == value:
+                results.append(op.results[0])
+    return results
+
+
+def _cast_result_of_const(const_result):
+    # Resolve the ui32 value of a constant through its feeding conversion cast.
+    for use in const_result.uses:
+        user = getattr(use, 'owner', None)
+        if user is not None and user.operation.name == 'builtin.unrealized_conversion_cast':
+            return user.results[0]
+    return const_result
+
+
+def _same_ssa(a, b):
+    try:
+        return a == b
+    except Exception:
+        return str(a) == str(b)
+
+
+def _scf_if_count(block):
+    if_ops = [op for op in block.operations if op.operation.name == 'scf.if']
+    if not if_ops:
+        return 0
+    return 1 + _scf_if_count(if_ops[0].regions[1].blocks[0])
+
+
+def _innermost_else_yield_operands(block):
+    if_ops = [op for op in block.operations if op.operation.name == 'scf.if']
+    if not if_ops:
+        for op in block.operations:
+            if op.operation.name == 'scf.yield':
+                return list(op.operands)
+        return []
+    return _innermost_else_yield_operands(if_ops[0].regions[1].blocks[0])
+
+
+def _find_op(region, name):
+    for block in region.blocks:
+        for op in block.operations:
+            if op.operation.name == name:
+                return op
+    return None
+
+
+def _find_op_anywhere(operation, name):
+    for op in _all_operations(operation):
+        if op.operation.name == name:
+            return op
+    return None
+
+
+def _assert_ast_rewrite_nested_partial_assign_ssa_identity():
+    # Focused probe 1: sibling-tracing isolation without a loop.
+    isolated_text = ast_nested_partial_assign_entry_isolated_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        isolated_text,
+        'AST-rewritten nested partial assignment entry isolation',
+    )
+    with make_context() as ctx:
+        isolated_module = Module.parse(isolated_text, ctx)
+        isolated_func = _find_op_anywhere(isolated_module.operation, 'func.func')
+        expect(isolated_func is not None, 'entry isolation probe should contain a func.func op')
+        func_block = isolated_func.regions[0].blocks[0]
+        zero_consts = _ui32_const_results(isolated_module.operation, 0)
+        expect(len(zero_consts) >= 1, 'entry isolation probe should materialize the pre-if 0 constant')
+        zero_value = _cast_result_of_const(zero_consts[0])
+        q2_consts = _ui32_const_results(isolated_module.operation, 0x20000000)
+        expect(len(q2_consts) >= 1, 'entry isolation probe should materialize the q2 constant')
+        expect(
+            _scf_if_count(func_block) == 2,
+            'entry isolation probe should contain two nested scf.if ops',
+        )
+        yield_operands = _innermost_else_yield_operands(func_block)
+        expect(len(yield_operands) == 2, 'innermost else should yield two values')
+        expect(
+            _same_ssa(yield_operands[1], zero_value),
+            'innermost else must yield the pre-if lo_bits value, not the sibling branch rebinding',
+        )
+        expect(
+            not any(_same_ssa(yield_operands[1], q) for q in q2_consts),
+            'innermost else must not yield the sibling branch q2 value',
+        )
+
+    # Focused probe 2: the issue-1252 runtime loop structure.
+    loop_text = ast_nested_partial_assign_loop_carry_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        loop_text,
+        'AST-rewritten issue-1252 nested partial assignment loop',
+    )
+    with make_context() as ctx:
+        loop_module = Module.parse(loop_text, ctx)
+        loop_func = _find_op_anywhere(loop_module.operation, 'func.func')
+        expect(loop_func is not None, 'issue-1252 probe should contain a func.func op')
+        for_op = _find_op(loop_func.regions[0], 'scf.for')
+        expect(for_op is not None, 'issue-1252 probe should lower to a runtime scf.for')
+        loop_body = for_op.regions[0].blocks[0]
+        arguments = list(loop_body.arguments)
+        expect(
+            len(arguments) == 3,
+            'scf.for should carry the induction variable plus two ui32 iter_args',
+        )
+        expect(
+            str(arguments[1].type) == 'ui32' and str(arguments[2].type) == 'ui32',
+            'both loop iter_args should be ui32',
+        )
+        expect(
+            _scf_if_count(loop_body) == 3,
+            'issue-1252 probe should contain three nested scf.if ops',
+        )
+        yield_operands = _innermost_else_yield_operands(loop_body)
+        expect(len(yield_operands) == 2, 'innermost else should yield two values')
+        expect(
+            _same_ssa(yield_operands[1], arguments[2]),
+            'innermost else must yield the lo_bits loop-carried block argument',
+        )
+        q2_consts = _ui32_const_results(loop_module.operation, 0x20000000)
+        expect(
+            not any(_same_ssa(yield_operands[1], q) for q in q2_consts),
+            'innermost else must not yield the sibling branch q2 constant',
+        )
+        init_operands = list(for_op.operands)[3:]
+        expect(len(init_operands) == 2, 'scf.for should have exactly two iter_arg init operands')
+        hi_consts = _ui32_const_results(loop_module.operation, 0x40000000)
+        lo_consts = _ui32_const_results(loop_module.operation, 0)
+        expect(
+            hi_consts and _same_ssa(init_operands[0], _cast_result_of_const(hi_consts[0])),
+            'first iter_arg should be hi_bits initialized to 0x40000000',
+        )
+        expect(
+            lo_consts and _same_ssa(init_operands[1], _cast_result_of_const(lo_consts[0])),
+            'second iter_arg should be lo_bits initialized to 0',
+        )
+
+
 def expect(condition: bool, message: str) -> None:
     if not condition:
         raise AssertionError(message)
@@ -7931,6 +8140,9 @@ def main() -> None:
 
     print("ptodsl_jit_compile: PASS")
     os._exit(0)
+
+
+_assert_ast_rewrite_nested_partial_assign_ssa_identity()
 
 
 if __name__ == "__main__":

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -128,6 +128,64 @@ def ast_unbound_partial_liveout_loop_probe(rows: pto.i32, cond: pto.i1):
     _ = value
 
 
+@pto.jit(target='a5')
+def ast_unbound_partial_liveout_controlled_loop_probe(rows: pto.i32, cond: pto.i1, stop: pto.i1):
+    # break/continue/for-else loops must apply the same definite-binding gate.
+    one = pto.const(1, dtype=pto.i32)
+    for _ in range(rows):
+        if cond:
+            value = one
+        if stop:
+            break
+    _ = value
+
+
+@pto.jit(target='a5')
+def ast_param_bound_partial_liveout_loop_probe(rows: pto.i32, cond: pto.i1, value: pto.i32):
+    one = pto.const(1, dtype=pto.i32)
+    for _ in range(rows):
+        if cond:
+            value = one
+    _ = value
+
+
+@pto.jit(target='a5')
+def ast_outer_bound_partial_liveout_loop_probe(rows: pto.i32, cond: pto.i1, outer: pto.i1):
+    one = pto.const(1, dtype=pto.i32)
+    zero = pto.const(0, dtype=pto.i32)
+    value = zero
+    if outer:
+        for _ in range(rows):
+            if cond:
+                value = one
+    _ = value
+
+
+@pto.jit(target='a5')
+def ast_both_branch_bound_partial_liveout_loop_probe(rows: pto.i32, cond: pto.i1, choose: pto.i1):
+    one = pto.const(1, dtype=pto.i32)
+    zero = pto.const(0, dtype=pto.i32)
+    if choose:
+        value = zero
+    else:
+        value = one
+    for _ in range(rows):
+        if cond:
+            value = one
+    _ = value
+
+
+@pto.jit(target='a5')
+def ast_slot_partial_assign_loop_carry_probe(rows: pto.i32, cond: pto.i1):
+    zero = pto.const(0, dtype=pto.ui32)
+    one = pto.const(1, dtype=pto.ui32)
+    values = [zero]
+    for _ in range(rows):
+        if cond:
+            values[0] = one
+    _ = values[0]
+
+
 def _all_operations(operation):
     yield operation
     for region in operation.regions:
@@ -317,6 +375,22 @@ def _assert_ast_rewrite_nested_partial_assign_ssa_identity():
         lambda: ast_unbound_partial_liveout_loop_probe.compile(),
         'last-iteration-only',
     )
+    expect_raises(
+        PTODSLAstRewriteError,
+        lambda: ast_unbound_partial_liveout_controlled_loop_probe.compile(),
+        'last-iteration-only',
+    )
+
+    # Definitely-bound partial live-outs (parameters, outer blocks, both branches
+    # of a prior conditional, and static subscript slots) are loop carries.
+    for probe_text, label in (
+        (ast_param_bound_partial_liveout_loop_probe.compile().mlir_text(), 'parameter-bound partial live-out'),
+        (ast_outer_bound_partial_liveout_loop_probe.compile().mlir_text(), 'outer-block-bound partial live-out'),
+        (ast_both_branch_bound_partial_liveout_loop_probe.compile().mlir_text(), 'both-branches-bound partial live-out'),
+        (ast_slot_partial_assign_loop_carry_probe.compile().mlir_text(), 'loop static-subscript partial assignment'),
+    ):
+        expect_parse_roundtrip_and_verify(probe_text, 'AST-rewritten ' + label)
+        expect('iter_args(' in probe_text, label + ' should lower through scf.for iter_args')
 
 
 def expect(condition: bool, message: str) -> None:

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -233,6 +233,40 @@ def ast_for_iv_bound_partial_liveout_probe(rows: pto.i32, cols: pto.i32, cond: p
         pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=value)
 
 
+@pto.jit(target='a5', backend='vpto', mode='explicit')
+def ast_for_iv_augassign_probe(rows: pto.i32):
+    # Augmenting the induction variable must not infer it as a loop carry (it
+    # is re-bound at the top of every iteration) and must not read it before
+    # the loop is entered.
+    for value in range(rows):
+        value += 1
+        pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=value)
+
+
+@pto.jit(target='a5', backend='vpto', mode='explicit')
+def ast_static_range_empty_orelse_partial_probe(rows: pto.i32, cond: pto.i1):
+    # An empty static range jumps straight to the else clause with the target
+    # unbound; the inner partial live-out must keep the explicit diagnostics.
+    for value in pto.static_range(0):
+        pass
+    else:
+        for replacement in range(rows):
+            if cond:
+                value = replacement
+        pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=value)
+
+
+@pto.jit(target='a5', backend='vpto', mode='explicit')
+def ast_static_range_subscript_target_probe(rows: pto.i32):
+    # Non-Name static_range targets keep their trace-time semantics and must
+    # not crash the rewrite with an AttributeError.
+    zero = pto.const(0, dtype=pto.i32)
+    values = [zero]
+    for values[0] in pto.static_range(1):
+        pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=values[0])
+    _ = values[0]
+
+
 def _all_operations(operation):
     yield operation
     for region in operation.regions:
@@ -416,6 +450,18 @@ def _assert_ast_rewrite_nested_partial_assign_ssa_identity():
             'innermost else of the slot probe must not yield the sibling branch q2 value',
         )
 
+    # Augmenting the induction variable must not invent a carry for it.
+    iv_augassign_text = ast_for_iv_augassign_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(iv_augassign_text, 'AST-rewritten induction-variable augment-assignment')
+    expect(
+        'iter_args(' not in iv_augassign_text,
+        'augmenting the induction variable should not infer a spurious loop carry',
+    )
+
+    # Non-Name static_range targets keep trace-time semantics (no scf.for).
+    subscript_target_text = ast_static_range_subscript_target_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(subscript_target_text, 'AST-rewritten static-range subscript target')
+
     # Unbound partial live-outs must stay on the explicit diagnostics path.
     expect_raises(
         PTODSLAstRewriteError,
@@ -425,6 +471,11 @@ def _assert_ast_rewrite_nested_partial_assign_ssa_identity():
     expect_raises(
         PTODSLAstRewriteError,
         lambda: ast_unbound_partial_liveout_controlled_loop_probe.compile(),
+        'last-iteration-only',
+    )
+    expect_raises(
+        PTODSLAstRewriteError,
+        lambda: ast_static_range_empty_orelse_partial_probe.compile(),
         'last-iteration-only',
     )
 

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -97,6 +97,37 @@ def ast_nested_partial_assign_loop_carry_probe(
     _ = lo_bits
 
 
+@pto.jit(target='a5')
+def ast_nested_partial_assign_slot_entry_isolated_probe(cond3: pto.i1, cond1: pto.i1):
+    # Static-subscript analogue of the entry isolation probe: the slot value is
+    # rewritten into a shared Python temporary, so the same sibling pollution
+    # would leak unless the temporary is restored at each branch entry.
+    zero = pto.const(0, dtype=pto.ui32)
+    q1_bits = pto.const(0x10000000, dtype=pto.ui32)
+    q2_bits = pto.const(0x20000000, dtype=pto.ui32)
+
+    values = [zero]
+    if cond3:
+        values[0] = q2_bits
+    else:
+        if cond1:
+            values[0] = q1_bits
+        # else: values[0] must remain at its pre-if value.
+
+    out = values[0]
+    _ = out
+
+
+@pto.jit(target='a5')
+def ast_unbound_partial_liveout_loop_probe(rows: pto.i32, cond: pto.i1):
+    # value is never bound before the loop, so it must stay on the
+    # last-iteration-only diagnostics path instead of becoming an implicit carry.
+    for _ in range(rows):
+        if cond:
+            value = 0
+    _ = value
+
+
 def _all_operations(operation):
     yield operation
     for region in operation.regions:
@@ -192,8 +223,9 @@ def _assert_ast_rewrite_nested_partial_assign_ssa_identity():
             _same_ssa(yield_operands[1], zero_value),
             'innermost else must yield the pre-if lo_bits value, not the sibling branch rebinding',
         )
+        q2_cast = [_cast_result_of_const(q) for q in q2_consts]
         expect(
-            not any(_same_ssa(yield_operands[1], q) for q in q2_consts),
+            not any(_same_ssa(yield_operands[1], q) for q in q2_cast),
             'innermost else must not yield the sibling branch q2 value',
         )
 
@@ -230,8 +262,9 @@ def _assert_ast_rewrite_nested_partial_assign_ssa_identity():
             'innermost else must yield the lo_bits loop-carried block argument',
         )
         q2_consts = _ui32_const_results(loop_module.operation, 0x20000000)
+        q2_cast = [_cast_result_of_const(q) for q in q2_consts]
         expect(
-            not any(_same_ssa(yield_operands[1], q) for q in q2_consts),
+            not any(_same_ssa(yield_operands[1], q) for q in q2_cast),
             'innermost else must not yield the sibling branch q2 constant',
         )
         init_operands = list(for_op.operands)[3:]
@@ -246,6 +279,44 @@ def _assert_ast_rewrite_nested_partial_assign_ssa_identity():
             lo_consts and _same_ssa(init_operands[1], _cast_result_of_const(lo_consts[0])),
             'second iter_arg should be lo_bits initialized to 0',
         )
+
+    # Focused probe 3: static-subscript partial assignment keeps the entry slot.
+    slot_text = ast_nested_partial_assign_slot_entry_isolated_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        slot_text,
+        'AST-rewritten nested static-subscript partial assignment isolation',
+    )
+    with make_context() as ctx:
+        slot_module = Module.parse(slot_text, ctx)
+        slot_func = _find_op_anywhere(slot_module.operation, 'func.func')
+        expect(slot_func is not None, 'slot isolation probe should contain a func.func op')
+        slot_block = slot_func.regions[0].blocks[0]
+        zero_consts = _ui32_const_results(slot_module.operation, 0)
+        expect(len(zero_consts) >= 1, 'slot isolation probe should materialize the entry 0 constant')
+        zero_value = _cast_result_of_const(zero_consts[0])
+        q2_consts = _ui32_const_results(slot_module.operation, 0x20000000)
+        q2_cast = [_cast_result_of_const(q) for q in q2_consts]
+        expect(
+            _scf_if_count(slot_block) == 2,
+            'slot isolation probe should contain two nested scf.if ops',
+        )
+        slot_yield = _innermost_else_yield_operands(slot_block)
+        expect(len(slot_yield) == 1, 'innermost else of the slot probe should yield one value')
+        expect(
+            _same_ssa(slot_yield[0], zero_value),
+            'innermost else of the slot probe must yield the entry slot value',
+        )
+        expect(
+            not any(_same_ssa(slot_yield[0], q) for q in q2_cast),
+            'innermost else of the slot probe must not yield the sibling branch q2 value',
+        )
+
+    # Unbound partial live-outs must stay on the explicit diagnostics path.
+    expect_raises(
+        PTODSLAstRewriteError,
+        lambda: ast_unbound_partial_liveout_loop_probe.compile(),
+        'last-iteration-only',
+    )
 
 
 def expect(condition: bool, message: str) -> None:

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -267,6 +267,30 @@ def ast_static_range_subscript_target_probe(rows: pto.i32):
     _ = values[0]
 
 
+def ast_static_range_nonempty_definite_gate_fn(rows, cond):
+    # Source-only helper for the rewrite-level gate assertion: the static_range
+    # target must be credited as definitely bound once it has run, so the later
+    # partial loop can carry the value without being rejected.
+    for value in pto.static_range(1):
+        pass
+    for replacement in range(rows):
+        if cond:
+            value = replacement
+    _ = value
+
+
+@pto.jit(target='a5', backend='vpto', mode='explicit')
+def ast_del_then_partial_liveout_probe(rows: pto.i32, cond: pto.i1):
+    zero = pto.const(0, dtype=pto.i32)
+    one = pto.const(1, dtype=pto.i32)
+    value = zero
+    del value
+    for _ in range(rows):
+        if cond:
+            value = one
+    _ = value
+
+
 def _all_operations(operation):
     yield operation
     for region in operation.regions:
@@ -462,6 +486,31 @@ def _assert_ast_rewrite_nested_partial_assign_ssa_identity():
     subscript_target_text = ast_static_range_subscript_target_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(subscript_target_text, 'AST-rewritten static-range subscript target')
 
+    # A known non-empty static_range definitely binds its target afterwards, so
+    # the rewrite gate must credit it for a later implicit loop carry instead of
+    # rejecting it as last-iteration-only (verified at the rewrite level).
+    import ast as _ast
+    import inspect as _inspect
+    import textwrap as _textwrap
+    from ptodsl._ast_rewrite import _ControlFlowRewriter as _CFR
+    gate_src = _textwrap.dedent(_inspect.getsource(ast_static_range_nonempty_definite_gate_fn))
+    gate_tree = _ast.parse(gate_src)
+    gate_fn = next(
+        n
+        for n in _ast.walk(gate_tree)
+        if isinstance(n, _ast.FunctionDef) and n.name == 'ast_static_range_nonempty_definite_gate_fn'
+    )
+    gate_rewriter = _CFR(static_env={})
+    gate_body = gate_rewriter.rewrite_block(gate_fn.body, live_after={'value'})
+    gate_module = _ast.Module(body=gate_body, type_ignores=[])
+    _ast.fix_missing_locations(gate_module)
+    gate_text = _ast.unparse(gate_module)
+    expect(
+        'carry(value=value)' in gate_text,
+        'known non-empty static_range target should be credited as bound for an implicit carry',
+    )
+    del _ast, _inspect, _textwrap, _CFR
+
     # Unbound partial live-outs must stay on the explicit diagnostics path.
     expect_raises(
         PTODSLAstRewriteError,
@@ -476,6 +525,11 @@ def _assert_ast_rewrite_nested_partial_assign_ssa_identity():
     expect_raises(
         PTODSLAstRewriteError,
         lambda: ast_static_range_empty_orelse_partial_probe.compile(),
+        'last-iteration-only',
+    )
+    expect_raises(
+        PTODSLAstRewriteError,
+        lambda: ast_del_then_partial_liveout_probe.compile(),
         'last-iteration-only',
     )
 

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -186,6 +186,31 @@ def ast_slot_partial_assign_loop_carry_probe(rows: pto.i32, cond: pto.i1):
     _ = values[0]
 
 
+@pto.jit(target='a5', backend='vpto', mode='explicit')
+def ast_with_entry_bound_partial_liveout_probe(rows: pto.i32, cond: pto.i1, value: pto.i32):
+    # A function parameter must remain definitely bound inside a vecscope body.
+    one = pto.const(1, dtype=pto.i32)
+    with pto.vecscope():
+        for _ in range(rows):
+            if cond:
+                value = one
+        _ = value
+    _ = value
+
+
+@pto.jit(target='a5', backend='vpto', mode='explicit')
+def ast_with_body_bound_partial_liveout_probe(rows: pto.i32, cond: pto.i1):
+    # A name bound inside the with body is definite after the with statement.
+    one = pto.const(1, dtype=pto.i32)
+    zero = pto.const(0, dtype=pto.i32)
+    with pto.vecscope():
+        value = zero
+    for _ in range(rows):
+        if cond:
+            value = one
+    _ = value
+
+
 def _all_operations(operation):
     yield operation
     for region in operation.regions:
@@ -388,6 +413,8 @@ def _assert_ast_rewrite_nested_partial_assign_ssa_identity():
         (ast_outer_bound_partial_liveout_loop_probe.compile().mlir_text(), 'outer-block-bound partial live-out'),
         (ast_both_branch_bound_partial_liveout_loop_probe.compile().mlir_text(), 'both-branches-bound partial live-out'),
         (ast_slot_partial_assign_loop_carry_probe.compile().mlir_text(), 'loop static-subscript partial assignment'),
+        (ast_with_entry_bound_partial_liveout_probe.compile().mlir_text(), 'with-entry-bound partial live-out'),
+        (ast_with_body_bound_partial_liveout_probe.compile().mlir_text(), 'with-body-bound partial live-out'),
     ):
         expect_parse_roundtrip_and_verify(probe_text, 'AST-rewritten ' + label)
         expect('iter_args(' in probe_text, label + ' should lower through scf.for iter_args')

--- a/ptodsl/tests/test_scf_while_ast.py
+++ b/ptodsl/tests/test_scf_while_ast.py
@@ -209,6 +209,29 @@ def issue_1256_while_conditional_carry(limit: pto.i32):
 
 
 @pto.jit(target="a5")
+def while_unbound_partial_liveout(limit: pto.i32, cond: pto.i1):
+    index = pto.const(0, dtype=pto.i32)
+    one = pto.const(1, dtype=pto.i32)
+    while index < limit:
+        if cond:
+            value = one
+        index = index + one
+    _ = value
+
+
+@pto.jit(target="a5")
+def while_bound_partial_liveout(limit: pto.i32, cond: pto.i1):
+    index = pto.const(0, dtype=pto.i32)
+    value = pto.const(0, dtype=pto.i32)
+    one = pto.const(1, dtype=pto.i32)
+    while index < limit:
+        if cond:
+            value = one
+        index = index + one
+    _ = value
+
+
+@pto.jit(target="a5")
 def issue_1256_while_break_flags_only(limit: pto.i32, running: pto.i32, probe: pto.i32):
     # Controlled loop with no user-level carry: the test only reads
     # loop-invariant names and the body store is a loop-local temporary,
@@ -527,6 +550,19 @@ def main():
             f"{fn.__name__}: expected {expected_carries} loop-carried slots, got {actual}; "
             "loop-local temporaries must not enter the carry state")
 
+    # While-loop partial live-outs use the same definite-binding rule as
+    # runtime for-loops: an unbound default path is diagnosed explicitly,
+    # while a value initialized before the loop becomes an ordinary carry.
+    try:
+        while_unbound_partial_liveout.compile()
+    except Exception as exc:
+        assert "last-iteration-only" in str(exc), str(exc)
+    else:
+        raise AssertionError("unbound partial while live-out must be diagnosed")
+    bound_text = while_bound_partial_liveout.compile().mlir_text()
+    assert "scf.while" in bound_text
+    assert _while_iter_arg_count(bound_text) == 2
+
     # Break/continue tail predication: the statement after a control transfer
     # must sit inside a region guarded by the merged active flag.
     # issue_1256_exact_while_true_break is the reporter's kernel: the addi
@@ -634,9 +670,9 @@ def main():
     else:
         raise AssertionError("while subscript carry must be diagnosed")
 
-    # Issue #1256 reverse regression: a loop-local name used after the loop
-    # without an outer initialization must still fail to trace (no
-    # over-exclusion).  Native Python would report the same unbound name.
+    # A loop-local name used after the loop without an outer initialization
+    # must stay on the explicit last-iteration-only diagnostics path rather
+    # than being evaluated as an unbound carry at while setup.
     def issue_1256_unbound_live_after(limit: pto.i32):
         value = pto.const(0, dtype=pto.i32)
         while value < limit:
@@ -646,10 +682,10 @@ def main():
 
     try:
         pto.jit(target="a5")(issue_1256_unbound_live_after).compile()
-    except UnboundLocalError:
-        pass
+    except Exception as exc:
+        assert "last-iteration-only" in str(exc), str(exc)
     else:
-        raise AssertionError("unbound loop-local used after while must not compile")
+        raise AssertionError("unbound loop-local used after while must be diagnosed")
 
     # Negative fixtures for the checker itself: a tail that merely sits
     # inside an *unrelated* dynamic scf.if (condition is a block argument or


### PR DESCRIPTION
Fixes #1252

## Problem

PTODSL rewrites nested Python conditionals into scf.if structures while
tracing. Both dynamic sibling branches share the same Python variable
environment: the branch traced first rebinds a Python variable, and the
later branch observes that rebinding. For a variable a branch does not
assign (partial assignment), the rewritten fallback captured the current
Python value instead of the entering value, silently substituting the
sibling branch value in the merged yields:

    scf.yield %q1_bits, %arg15 : ui32, ui32   (expected)
    scf.yield %q1_bits, %q2_bits : ui32, ui32 (actual, wrong lo_bits)

The generated MLIR passes the verifier and the backend, so it surfaced as
a silent numerical error at runtime (reported from a real TileLang top-p
kernel). A second gap blocked the minimal reproducer: a plain runtime for
loop only recognized explicitly-read loop carries, so the variable kept
only via the partial-assignment default path was rejected as
last-iteration-only before the wrong yield could ever be produced.

## Changes (PTODSL AST rewrite only)

- _ControlFlowRewriter._rewrite_if: compute the names that need their
  entering value (fallbacks plus names live-in to a branch), snapshot those
  values once on the runtime path right before pto.if_, and restore the
  Python binding at the start of both dynamic branch bodies. The restore
  assignments emit no IR; they only isolate sibling branch tracing
  environments. _branch_assign now reuses the entry snapshot for unassigned
  names. The native Python bool path is unchanged.
- _read_before_assignment_names: accept an optional live_after seed;
  _rewrite_for seeds it with the body stores that are live after the loop so
  partial-assignment default paths are recognized as loop carries.
  Accumulator loops keep working and last-iteration-only diagnostics are
  preserved.

## Tests

Two focused probes in ptodsl/tests/test_jit_compile.py with MLIR op-tree
SSA identity assertions:

- no-loop nested partial assignment: the inner else must yield the pre-if
  value, not the sibling branch rebinding;
- the #1252 runtime loop structure: three nested scf.if inside an scf.for
  carrying hi_bits/lo_bits, asserting the innermost else yields the lo_bits
  loop-carried block argument (and not the q2 constant).

Both modules pass parse round-trip and the verifier.

## Verification (LLVM 19 toolchain)

    cmake --build build --target PTODSLPackage PTOAS_Python
    ctest --test-dir build --output-on-failure -R '^(ptodsl_jit_compile|ptodsl_section|ptodsl_jit_diagnostics)$'
    cmake --build build --target check-dsl

All 39 PTODSL ctest targets pass, including the new probes (RED verified on
the unfixed baseline: the innermost-else yield carried the sibling branch
value).
