### PR TITLE
fix(ptodsl): allow section-local loop carries

### DIFF
--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -1156,8 +1156,8 @@ class _ControlFlowRewriter:
         self._counter += 1
         return value
 
-    def _current_value(self, name):
-        if name in self._section_uninitialized_aliases:
+    def _current_value(self, name, *, requires_pre_if_value=False):
+        if requires_pre_if_value and name in self._section_uninitialized_aliases:
             raise PTODSLAstRewriteError(
                 "ast_rewrite=True runtime if reads a section-local value before it is initialized; "
                 f"initialize {name!r} before the conditional"
@@ -1548,7 +1548,7 @@ class _ControlFlowRewriter:
         result.extend(
             ast.Assign(
                 targets=[_name(old_name, ast.Store())],
-                value=self._current_value(name),
+                value=self._current_value(name, requires_pre_if_value=True),
             )
             for name, old_name in old_value_names.items()
         )

--- a/ptodsl/tests/test_section.py
+++ b/ptodsl/tests/test_section.py
@@ -239,6 +239,27 @@ def lexical_section_uninitialized_conditional_probe():
 
 
 @pto.jit(target="a5", mode="explicit")
+def lexical_section_conditional_loop_carry_probe():
+    base = pto.const(0, dtype=pto.ui64)
+    one = pto.const(1, dtype=pto.i32)
+    with pto.section("vector"):
+        if pto.get_block_idx() < one:
+            with pto.vecscope():
+                dst_ptr = pto.castptr(base, pto.ptr(pto.f32, "ub"))
+                mask = pto.pset_b32(pto.MaskPattern.ALL)
+                value = pto.vlds(dst_ptr, pto.const(0))
+                for _ in range(2):
+                    dst_ptr = pto.vsstb(
+                        value,
+                        dst_ptr,
+                        pto.i16(32),
+                        pto.i16(0),
+                        mask,
+                        post_update=pto.PostUpdate.ON,
+                    )
+
+
+@pto.jit(target="a5", mode="explicit")
 def lexical_section_nested_conditional_rebinding_probe():
     one = pto.const(1, dtype=pto.i32)
     value = pto.const(0, dtype=pto.i32)
@@ -411,6 +432,10 @@ def main() -> None:
         lambda: lexical_section_uninitialized_conditional_probe.compile(),
         "reads a section-local value before it is initialized",
     )
+
+    conditional_loop_carry_text = lexical_section_conditional_loop_carry_probe.compile().mlir_text()
+    assert conditional_loop_carry_text.count("pto.section.vector {") == 1
+    assert "scf.for" in conditional_loop_carry_text
 
     loop_carry_text = lexical_section_loop_carry_probe.compile().mlir_text()
     assert loop_carry_text.count("pto.section.cube {") == 1


### PR DESCRIPTION
## Summary
- allow a section-local value initialized inside a runtime `if` to seed a native `range` loop carry within that branch
- retain the diagnostic when an `if` merge needs an uninitialized pre-branch value
- add a focused PTODSL section regression test

## Validation
- `python ptodsl/tests/test_section.py`
- `python ptodsl/tests/test_ast_rewrite_example_ir.py`
- `python -m pytest -q --ignore=e2e` from `ptodsl/tests` (225 passed, 1407 subtests passed)
- issue #1267 minimal reproduction compiles and emits `scf.for`

NPU E2E coverage was not runnable in this environment because `aclInit` failed with error 507008.

Closes #1267