### PR TITLE
fix(vmi): preserve scalar broadcast layout flexibility

### DIFF
--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -414,13 +414,6 @@ struct LayoutSolver {
     return fact->layout.resultLayout;
   }
 
-  bool hasDirectGroupBroadcastLoadCandidate(VMIGroupBroadcastLoadOp op) {
-    VMILayoutSupport supports;
-    return succeeded(supports.getGroupBroadcastLoadDirectFact(
-        cast<VMIVRegType>(op.getResult().getType()), op.getSource().getType(),
-        op.getSourceGroupStride(), op.getNumGroupsAttr().getInt()));
-  }
-
   VMILayoutAttr getPreferredGroupBroadcastSourceLayout(Value value,
                                                        int64_t numGroups) {
     auto type = dyn_cast<VMIVRegType>(value.getType());
@@ -1514,8 +1507,18 @@ struct LayoutSolver {
         return WalkResult::advance();
       }
       if (auto load = dyn_cast<VMIGroupBroadcastLoadOp>(op)) {
+        FailureOr<VMIGroupBroadcastLoadDirectFact> directFact =
+            VMILayoutSupport().getGroupBroadcastLoadDirectFact(load);
+        // A no-group BRC load is a scalar broadcast. Let downstream users
+        // choose its physical layout; unresolved values fall back to dense.
+        bool scalarBroadcast =
+            succeeded(directFact) &&
+            directFact->kind == VMIGroupBroadcastLoadDirectKind::BRC &&
+            load.getNumGroupsAttr().getInt() == 1;
+        if (scalarBroadcast)
+          return WalkResult::advance();
         DataLayoutSeedPhase phase =
-            hasDirectGroupBroadcastLoadCandidate(load)
+            succeeded(directFact)
                 ? DataLayoutSeedPhase::GroupBroadcastLoad
                 : DataLayoutSeedPhase::Other;
         if (failed(setNaturalLayout(load.getResult(),

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -746,6 +746,7 @@ struct GroupBroadcastLoadLayoutPattern {
   ElementBitsPattern elementBits;
   GroupMemoryPattern memory = memContiguous();
   LayoutPattern resultLayout;
+  ElementCountPattern numGroups = anyG();
 };
 
 static constexpr GroupBroadcastLoadLayoutPattern
@@ -758,6 +759,10 @@ static constexpr GroupBroadcastLoadLayoutPattern
         {gb(4), bits<8, 16, 32>(), memContiguous(), c()},
         {gb(4), bits<8, 16, 32>(), memContiguous(), d(4)},
         {gbFull(), bits<8, 16, 32>(), memAny(), c()},
+        // A single-group BRC is a scalar broadcast. Its equal-valued result
+        // may use a deinterleaved physical layout without data rearrangement.
+        {gbFull(), bits<8, 16, 32>(), memAny(), d(2), G<1>()},
+        {gbFull(), bits<8, 16, 32>(), memAny(), d(4), G<1>()},
 };
 
 struct GroupBroadcastLoadDirectPattern {
@@ -779,6 +784,12 @@ static constexpr GroupBroadcastLoadDirectPattern
          memContiguous(), d(4)},
         {VMIGroupBroadcastLoadDirectKind::BRC, anyG(), gbFull(),
          bits<8, 16, 32>(), memAny(), c()},
+        // Scalar BRC can be emitted once per physical result chunk, so its
+        // equal-valued result is also directly available as d2/d4.
+        {VMIGroupBroadcastLoadDirectKind::BRC, G<1>(), gbFull(),
+         bits<8, 16, 32>(), memAny(), d(2)},
+        {VMIGroupBroadcastLoadDirectKind::BRC, G<1>(), gbFull(),
+         bits<8, 16, 32>(), memAny(), d(4)},
 };
 
 struct GroupBroadcastLayoutPattern {
@@ -1563,6 +1574,8 @@ VMILayoutSupport::getGroupBroadcastLoadLayoutFact(VMIVRegType resultType,
     if (!matchesGroupBlockPattern(pattern.block, *key)) {
       continue;
     }
+    if (!matchesElementCountPattern(pattern.numGroups, numGroups))
+      continue;
     if (!matchesElementBitsPattern(pattern.elementBits, elementBits)) {
       continue;
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8225,8 +8225,17 @@ struct OneToNVMIGroupBroadcastLoadOpPattern
 
     if (succeeded(directFact) &&
         directFact->kind == VMIGroupBroadcastLoadDirectKind::BRC) {
+      if (numGroups <= 0 ||
+          static_cast<int64_t>(resultTypes.size()) % numGroups != 0)
+        return rewriter.notifyMatchFailure(
+            op, "group_broadcast_load BRC result arity is not divisible by "
+                "num_groups");
+      // BRC duplicates the scalar independently into every physical result
+      // chunk. Derive the chunk count from the assigned result arity so
+      // deinterleaved scalar-broadcast layouts (d2/d4) remain valid even
+      // when their logical group size is only one full part.
       int64_t chunksPerGroup =
-          directFact->layout.groupSize / directFact->layout.lanesPerPart;
+          static_cast<int64_t>(resultTypes.size()) / numGroups;
       std::optional<StringRef> brcDist = getBRCDist();
       if (!brcDist)
         return rewriter.notifyMatchFailure(

--- a/test/lit/vmi_new/vmi_layout_assignment_group_broadcast_load_e2b_b16.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_broadcast_load_e2b_b16.pto
@@ -32,6 +32,14 @@ module {
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
     return %out : !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
   }
+
+  func.func @vmi_layout_assignment_scalar_broadcast_load_deint2(
+      %src: !pto.ptr<f32, ub>, %off: index)
+      -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>> {
+    %out = pto.vmi.vload %src[%off] {dist_mode = "brc"}
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+    return %out : !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+  }
 }
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_broadcast_load_e2b_b16
@@ -51,3 +59,9 @@ module {
 // CHECK: %[[E2B32D4:.*]] = pto.vlds %[[SRC32D4]][%[[OFF32D4]]] {dist = "E2B_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 // CHECK-NOT: pto.vselr
 // CHECK: return %[[E2B32D4]], %[[E2B32D4]], %[[E2B32D4]], %[[E2B32D4]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>
+
+// CHECK-LABEL: func.func @vmi_layout_assignment_scalar_broadcast_load_deint2
+// CHECK: %[[SCALAR_BRC0:.*]] = pto.vlds %{{.*}}[%{{.*}}] {dist = "BRC_B32"}
+// CHECK: %[[SCALAR_BRC1:.*]] = pto.vlds %{{.*}}[%{{.*}}] {dist = "BRC_B32"}
+// CHECK-NOT: pto.vmi.ensure_layout
+// CHECK: return %[[SCALAR_BRC0]], %[[SCALAR_BRC1]]

--- a/test/lit/vmi_new/vmi_layout_assignment_scalar_brc_vexpdif_group_store.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_scalar_brc_vexpdif_group_store.pto
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER
+
+module {
+  func.func @scalar_brc_vexpdif_group_store(
+      %scores: !pto.ptr<f32, ub>, %row_max: !pto.ptr<f32, ub>,
+      %dst: !pto.ptr<bf16, ub>, %off: index) {
+    %c128 = arith.constant 128 : index
+    %c1024 = arith.constant 1024 : index
+    %x = pto.vmi.vload %scores[%off] {dist_mode = "continuous"}
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
+    %max = pto.vmi.vload %row_max[%off] {dist_mode = "brc"}
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
+    %mask = pto.vmi.create_mask %c128
+        : index -> !pto.vmi.mask<128xpred>
+    %exp = pto.vmi.vexpdif %x, %max, %mask
+        : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>,
+          !pto.vmi.mask<128xpred> -> !pto.vmi.vreg<128xf32>
+    %narrow = pto.vmi.truncf %exp {saturate = "SAT"}
+        : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xbf16>
+    pto.vmi.vstore %narrow, %dst[%off], %c1024 {group = 8}
+        : !pto.vmi.vreg<128xbf16>, !pto.ptr<bf16, ub>
+    return
+  }
+}
+
+// ASSIGN-LABEL: func.func @scalar_brc_vexpdif_group_store
+// ASSIGN: %[[X:.*]] = pto.vmi.load
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[MAX:.*]] = pto.vmi.group_broadcast_load
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[EXP:.*]] = pto.vmi.vexpdif %[[X]], %[[MAX]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[NARROW:.*]] = pto.vmi.truncf %[[EXP]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>
+// ASSIGN-NOT: pto.vmi.ensure_layout
+// ASSIGN: pto.vmi.group_store %[[NARROW]]
+
+// LOWER-LABEL: func.func @scalar_brc_vexpdif_group_store
+// LOWER: %[[X0:.*]], %[[X1:.*]] = pto.vldsx2 {{.*}}, "DINTLV_B32"
+// LOWER: %[[MAX0:.*]] = pto.vlds {{.*}} {dist = "BRC_B32"}
+// LOWER: %[[MAX1:.*]] = pto.vlds {{.*}} {dist = "BRC_B32"}
+// LOWER: pto.vexpdif %[[X0]], %[[MAX0]]
+// LOWER: pto.vexpdif %[[X1]], %[[MAX1]]
+// LOWER-NOT: pto.vpack
+// LOWER: pto.vsstb
+// LOWER-NOT: pto.vmi.


### PR DESCRIPTION
## Summary

- Treat `num_groups=1` BRC loads as scalar broadcasts whose result layout is chosen by downstream consumers.
- Add direct scalar-BRC support for deinterleaved physical result layouts without inserting `ensure_layout`.
- Derive BRC physical chunk count from assigned result arity and add regression coverage for the `vexpdif` plus BF16 group-store path.

## Validation

- Incremental build: `cmake --build build-llvm21 --target pto-test-opt -j4`
- FileCheck: scalar BRC layout assignment and lowering regression
- FileCheck: existing group broadcast load assignment/lowering regression

The validated lowering uses `vldsx2 DINTLV_B32` for scores, independent `BRC_B32` loads for the scalar max, and independent `vsstb` output without `ensure_layout`.

Closes #1271
