### PR TITLE
ci: 统一 ci-sim 的 Python 与 PTOAS 环境

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -344,7 +344,7 @@ jobs:
           "${CI_SIM_VENV}/bin/python" -m pip install --upgrade pip
           "${CI_SIM_VENV}/bin/pip" install \
             setuptools wheel 'scikit-build-core>=0.12.2,<2' 'pybind11<3' \
-            nanobind 'numpy>=2' ml-dtypes ninja pytest pytest-xdist PyYAML cloudpickle
+            nanobind numpy ml-dtypes ninja pytest pytest-xdist PyYAML cloudpickle
 
           TORCH_DEVICE_BACKEND_AUTOLOAD=0 "${CI_SIM_VENV}/bin/python" - <<'PY'
           import sys
@@ -533,7 +533,9 @@ jobs:
       - name: Run PyPTO PTOAS end-to-end simulator smoke
         shell: bash
         env:
-          PTOAS_ROOT: ${{ env.CI_SIM_VENV }}/bin
+          # PyPTO expects PTOAS_ROOT to be the complete PTOAS build output
+          # directory, not merely the venv console-script directory.
+          PTOAS_ROOT: ${{ github.workspace }}/build/tools/ptoas
           PTO_ISA_ROOT: ${{ env.PTO_ISA_ROOT }}
           TORCH_DEVICE_BACKEND_AUTOLOAD: "0"
         run: |

--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -110,7 +110,7 @@ jobs:
     env:
       LLVM_REPO: https://github.com/vpto-dev/llvm-project.git
       LLVM_REF: feature-vpto
-      PTOAS_VENV: ${{ github.workspace }}/.work/ptoas-sim-venv
+      CI_SIM_VENV: ${{ github.workspace }}/.work/ci-sim-venv
       VPTO_SIM_WORKSPACE: ${{ github.workspace }}/.work/vpto-sim-ci
       TILELIB_ST_WORKSPACE: ${{ github.workspace }}/.work/tilelib-st-ci
       PYPTO_REF: ef6ce7cd8bd33b4c93b58dc34830a20b145736ac
@@ -154,7 +154,7 @@ jobs:
           fi
 
           echo "ASCEND_HOME_PATH=${ASCEND_HOME_PATH_DETECTED}" >> "${GITHUB_ENV}"
-          echo "PTOAS_BIN=${PTOAS_VENV}/bin/ptoas" >> "${GITHUB_ENV}"
+          echo "PTOAS_BIN=${CI_SIM_VENV}/bin/ptoas" >> "${GITHUB_ENV}"
 
       - name: Ensure runner dependencies
         shell: bash
@@ -206,18 +206,95 @@ jobs:
           echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "${GITHUB_ENV}"
           echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "${GITHUB_ENV}"
 
+      - name: Resolve shared simulator Python
+        shell: bash
+        run: |
+          set -euo pipefail
+          source "${ASCEND_HOME_PATH}/bin/setenv.bash"
+
+          add_python_candidate() {
+            local candidate="$1"
+            local resolved
+            [[ -n "${candidate}" ]] || return 0
+            if [[ "${candidate}" != */* ]]; then
+              resolved="$(command -v "${candidate}" 2>/dev/null || true)"
+            else
+              resolved="${candidate}"
+            fi
+            [[ -n "${resolved}" && -x "${resolved}" ]] || return 0
+            resolved="$(readlink -f "${resolved}")"
+            case ":${PYTHON_CANDIDATES[*]}:" in
+              *":${resolved}:"*) return 0 ;;
+            esac
+            PYTHON_CANDIDATES+=("${resolved}")
+          }
+
+          has_torch_npu_packages() {
+            "$1" - <<'PY'
+          import importlib.util
+
+          missing = [
+              name for name in ("torch", "torch_npu")
+              if importlib.util.find_spec(name) is None
+          ]
+          raise SystemExit(1 if missing else 0)
+          PY
+          }
+
+          PYTHON_CANDIDATES=()
+          if [[ -n "${CI_SIM_PYTHON_BIN:-}" ]]; then
+            add_python_candidate "${CI_SIM_PYTHON_BIN}"
+          elif [[ -n "${PTO_DSL_ST_PYTHON_BIN:-}" ]]; then
+            # Preserve the existing self-hosted runner override while the
+            # shared environment migrates to the ci-sim-wide variable name.
+            add_python_candidate "${PTO_DSL_ST_PYTHON_BIN}"
+          else
+            add_python_candidate python3
+            shopt -s nullglob
+            for candidate in \
+              /home/*/miniconda3/bin/python3 \
+              /home/*/miniconda3/bin/python \
+              /home/*/anaconda3/bin/python3 \
+              /home/*/anaconda3/bin/python \
+              /home/*/miniconda3/envs/*/bin/python \
+              /home/*/anaconda3/envs/*/bin/python \
+              /opt/conda/envs/*/bin/python
+            do
+              add_python_candidate "${candidate}"
+            done
+            shopt -u nullglob
+          fi
+
+          SELECTED_BASE_PYTHON=""
+          for candidate in "${PYTHON_CANDIDATES[@]}"; do
+            echo "Probing shared simulator Python package presence: ${candidate}"
+            if has_torch_npu_packages "${candidate}"; then
+              SELECTED_BASE_PYTHON="${candidate}"
+              break
+            fi
+          done
+
+          if [[ -z "${SELECTED_BASE_PYTHON}" ]]; then
+            echo "ERROR: ci-sim requires an existing Python runtime with torch and torch_npu." >&2
+            echo "ERROR: set CI_SIM_PYTHON_BIN to a compatible pre-installed interpreter." >&2
+            exit 1
+          fi
+
+          PYTHON_ABI_TAG="$("${SELECTED_BASE_PYTHON}" - <<'PY'
+          import sys
+          print(f"py{sys.version_info.major}{sys.version_info.minor}")
+          PY
+          )"
+          BASE_HASH="$(printf '%s' "${SELECTED_BASE_PYTHON}" | sha256sum | cut -c1-12)"
+          echo "CI_SIM_BASE_PYTHON=${SELECTED_BASE_PYTHON}" >> "${GITHUB_ENV}"
+          echo "CI_SIM_PYTHON_TAG=${PYTHON_ABI_TAG}-${BASE_HASH}" >> "${GITHUB_ENV}"
+
       - name: Resolve LLVM directories
         shell: bash
         run: |
           set -euo pipefail
           echo "LLVM_ROOT=${RUNNER_TOOL_CACHE}/llvm-project" >> "${GITHUB_ENV}"
-          echo "LLVM_DIR=${RUNNER_TOOL_CACHE}/llvm-project/llvm/build-assert-llvm19" >> "${GITHUB_ENV}"
-
-      - name: Resolve PTODSL build directories
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "PTO_DSL_ST_BUILD_DIR=${GITHUB_WORKSPACE}/build-ptodsl" >> "${GITHUB_ENV}"
+          echo "LLVM_DIR=${RUNNER_TOOL_CACHE}/llvm-project/llvm/build-assert-llvm19-${CI_SIM_PYTHON_TAG}" >> "${GITHUB_ENV}"
 
       - name: Resolve LLVM cache key
         id: llvm-cache-key
@@ -233,7 +310,7 @@ jobs:
             exit 1
           fi
           echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
-          echo "key=llvm-build-${sha}-llvm19-assert-shared-mlirpy-v3" >> "${GITHUB_OUTPUT}"
+          echo "key=llvm-build-${sha}-llvm19-assert-shared-mlirpy-${CI_SIM_PYTHON_TAG}-v4" >> "${GITHUB_OUTPUT}"
 
       - name: Restore LLVM build cache
         id: llvm-cache
@@ -248,8 +325,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf "${GITHUB_WORKSPACE}/build"
-          rm -rf "${GITHUB_WORKSPACE}/build-ptodsl"
-          rm -rf "${PTOAS_VENV}"
+          rm -rf "${CI_SIM_VENV}"
           rm -rf "${VPTO_SIM_WORKSPACE}"
           rm -rf "${TILELIB_ST_WORKSPACE}"
           rm -rf "${PYPTO_WORKSPACE}"
@@ -257,15 +333,41 @@ jobs:
           rm -rf "${PTO_ISA_ROOT}"
           rm -rf "${GITHUB_WORKSPACE}/.work/camodel"
 
-      - name: Create PTOAS simulator environment
+      - name: Create shared simulator environment
         shell: bash
         run: |
           set -euo pipefail
-          python3 -m venv "${PTOAS_VENV}"
-          "${PTOAS_VENV}/bin/python" -m pip install --upgrade pip
-          "${PTOAS_VENV}/bin/pip" install \
-            'scikit-build-core>=0.12.2,<2' 'pybind11<3' \
-            numpy ml-dtypes
+          "${CI_SIM_BASE_PYTHON}" -m venv --system-site-packages "${CI_SIM_VENV}"
+          if ! "${CI_SIM_VENV}/bin/python" -m pip --version >/dev/null 2>&1; then
+            "${CI_SIM_VENV}/bin/python" -m ensurepip --upgrade
+          fi
+          "${CI_SIM_VENV}/bin/python" -m pip install --upgrade pip
+          "${CI_SIM_VENV}/bin/pip" install \
+            setuptools wheel 'scikit-build-core>=0.12.2,<2' 'pybind11<3' \
+            nanobind 'numpy>=2' ml-dtypes ninja pytest pytest-xdist PyYAML cloudpickle
+
+          TORCH_DEVICE_BACKEND_AUTOLOAD=0 "${CI_SIM_VENV}/bin/python" - <<'PY'
+          import sys
+          import cloudpickle
+          import nanobind
+          import numpy
+          import pybind11
+          import pytest
+          import torch
+          import torch_npu  # noqa: F401
+          import xdist
+          import yaml
+
+          print(sys.executable)
+          print(f"python {sys.version_info.major}.{sys.version_info.minor}")
+          print("torch", torch.__version__)
+          print("torch_npu", getattr(torch_npu, "__version__", "unknown"))
+          print("numpy", numpy.__version__)
+          PY
+
+          echo "${CI_SIM_VENV}/bin" >> "${GITHUB_PATH}"
+          echo "CI_SIM_PYTHON=${CI_SIM_VENV}/bin/python" >> "${GITHUB_ENV}"
+          echo "CI_SIM_BIN_DIR=${CI_SIM_VENV}/bin" >> "${GITHUB_ENV}"
 
       - name: Prepare LLVM source
         shell: bash
@@ -304,9 +406,9 @@ jobs:
             -DBUILD_SHARED_LIBS=ON \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-            -DPython3_EXECUTABLE="${PTOAS_VENV}/bin/python" \
-            -DPython_EXECUTABLE="${PTOAS_VENV}/bin/python" \
-            -Dpybind11_DIR="$("${PTOAS_VENV}/bin/python" -m pybind11 --cmakedir)" \
+            -DPython3_EXECUTABLE="${CI_SIM_PYTHON}" \
+            -DPython_EXECUTABLE="${CI_SIM_PYTHON}" \
+            -Dpybind11_DIR="$("${CI_SIM_PYTHON}" -m pybind11 --cmakedir)" \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_TARGETS_TO_BUILD="host"
 
@@ -328,11 +430,11 @@ jobs:
           export CC=gcc
           export CXX=g++
           LLVM_BUILD_DIR="${LLVM_DIR}" \
-            "${PTOAS_VENV}/bin/python" -m pip install --editable . \
+            "${CI_SIM_PYTHON}" -m pip install --editable . \
               --no-build-isolation --no-deps \
               --config-settings="build-dir=${GITHUB_WORKSPACE}/build"
-          PATH="${PTOAS_VENV}/bin:${PATH}" \
-          PYTHON="${PTOAS_VENV}/bin/python" \
+          PATH="${CI_SIM_BIN_DIR}:${PATH}" \
+          PYTHON="${CI_SIM_PYTHON}" \
             bash docker/test_wheel_imports.sh
 
       - name: Checkout PyPTO
@@ -391,15 +493,6 @@ jobs:
           ln -sf "$(command -v x86_64-conda-linux-gnu-gcc)" "${PYPTO_WORKSPACE}/.work/bin/gcc-15"
           echo "${PYPTO_WORKSPACE}/.work/bin" >> "${GITHUB_PATH}"
 
-      - name: Prepare PyPTO Python dependencies
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --index-url https://download.pytorch.org/whl/cpu torch
-          python3 -m pip install scikit-build-core nanobind ninja pytest cloudpickle
-
       - name: Install PyPTO frontend and runtime
         shell: bash
         env:
@@ -407,12 +500,14 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf "${PYPTO_WORKSPACE}/build" "${PYPTO_WORKSPACE}/_skbuild" "${PYPTO_WORKSPACE}/runtime/build"
-          python3 -m pip install --no-build-isolation --no-deps "${PYPTO_WORKSPACE}"
+          "${CI_SIM_PYTHON}" -m pip install --no-build-isolation --no-deps "${PYPTO_WORKSPACE}"
           # ci_sim only runs PyPTO simulator tests. Keep the runtime install from
           # auto-detecting onboard platforms from the runner's CANN environment.
-          env -u ASCEND_HOME_PATH python3 -m pip install --no-build-isolation --no-deps "${PYPTO_WORKSPACE}/runtime"
+          env -u ASCEND_HOME_PATH \
+            "${CI_SIM_PYTHON}" -m pip install --no-build-isolation --no-deps \
+              "${PYPTO_WORKSPACE}/runtime"
 
-          python3 - <<'PY'
+          "${CI_SIM_PYTHON}" - <<'PY'
           from pathlib import Path
 
           from simpler_setup.environment import PROJECT_ROOT
@@ -438,7 +533,7 @@ jobs:
       - name: Run PyPTO PTOAS end-to-end simulator smoke
         shell: bash
         env:
-          PTOAS_ROOT: ${{ github.workspace }}/build/tools/ptoas
+          PTOAS_ROOT: ${{ env.CI_SIM_VENV }}/bin
           PTO_ISA_ROOT: ${{ env.PTO_ISA_ROOT }}
           TORCH_DEVICE_BACKEND_AUTOLOAD: "0"
         run: |
@@ -453,7 +548,7 @@ jobs:
             local log_file="${PYPTO_RUN_WORKSPACE}/${suite_name}_${platform}.log"
             shift 2
 
-            python3 -m pytest "$@" \
+            "${CI_SIM_PYTHON}" -m pytest "$@" \
               -v \
               --platform="${platform}" \
               --save-kernels \
@@ -525,172 +620,11 @@ jobs:
             echo "ERROR: cannot find dav_3510 camodel lib under ${ASCEND_HOME_PATH}" >&2
             exit 1
           fi
-          SIM_LIB_DIR="$(python3 scripts/prepare_quiet_camodel.py \
+          SIM_LIB_DIR="$("${CI_SIM_PYTHON}" scripts/prepare_quiet_camodel.py \
             --source-dir "${camodel_candidates[0]}" \
             --output-dir "${GITHUB_WORKSPACE}/.work/camodel")"
           echo "SIM_LIB_DIR=${SIM_LIB_DIR}" >> "${GITHUB_ENV}"
           echo "SIM_LIB_DIR=${SIM_LIB_DIR}"
-
-      - name: Resolve PTODSL Python
-        shell: bash
-        run: |
-          set -euo pipefail
-          source "${ASCEND_HOME_PATH}/bin/setenv.bash"
-
-          add_python_candidate() {
-            local candidate="$1"
-            local resolved
-            [[ -n "${candidate}" ]] || return 0
-            if [[ "${candidate}" != */* ]]; then
-              resolved="$(command -v "${candidate}" 2>/dev/null || true)"
-            else
-              resolved="${candidate}"
-            fi
-            [[ -n "${resolved}" && -x "${resolved}" ]] || return 0
-            resolved="$(readlink -f "${resolved}")"
-            case ":${PYTHON_CANDIDATES[*]}:" in
-              *":${resolved}:"*) return 0 ;;
-            esac
-            PYTHON_CANDIDATES+=("${resolved}")
-          }
-
-          has_torch_npu_packages() {
-            "$1" - <<'PY'
-          import importlib.util
-
-          missing = [
-              name for name in ("torch", "torch_npu")
-              if importlib.util.find_spec(name) is None
-          ]
-          raise SystemExit(1 if missing else 0)
-          PY
-          }
-
-          probe_ptodsl_runtime_python() {
-            TORCH_DEVICE_BACKEND_AUTOLOAD=0 "$1" - <<'PY'
-          import sys
-          import nanobind
-          import numpy
-          import pybind11
-          import pytest
-          import xdist
-          import yaml
-          import torch
-          import torch_npu  # noqa: F401
-
-          print(sys.executable)
-          print(f"python {sys.version_info.major}.{sys.version_info.minor}")
-          print("torch", torch.__version__)
-          print("torch_npu", getattr(torch_npu, "__version__", "unknown"))
-          print("numpy", numpy.__version__)
-          print("nanobind", getattr(nanobind, "__version__", "unknown"))
-          print("pybind11", pybind11.__version__)
-          print("pytest", pytest.__version__)
-          print("pytest-xdist", xdist.__version__)
-          PY
-          }
-
-          missing_ptodsl_python_deps() {
-            "$1" - <<'PY'
-          import importlib.util
-
-          deps = [
-              ("setuptools", "setuptools"),
-              ("wheel", "wheel"),
-              ("scikit_build_core", "scikit-build-core>=0.12.2,<2"),
-              ("nanobind", "nanobind"),
-              ("numpy", "numpy"),
-              ("ml_dtypes", "ml-dtypes"),
-              ("pytest", "pytest"),
-              ("xdist", "pytest-xdist"),
-              ("yaml", "PyYAML"),
-          ]
-
-          missing = [
-              requirement for module_name, requirement in deps
-              if importlib.util.find_spec(module_name) is None
-          ]
-
-          try:
-              import pybind11
-              version = tuple(int(part) for part in pybind11.__version__.split(".")[:1])
-              if version >= (3,):
-                  missing.append("pybind11<3")
-          except Exception:
-              missing.append("pybind11<3")
-
-          print(" ".join(missing))
-          PY
-          }
-
-          PYTHON_CANDIDATES=()
-          if [[ -n "${PTO_DSL_ST_PYTHON_BIN:-}" ]]; then
-            add_python_candidate "${PTO_DSL_ST_PYTHON_BIN}"
-          else
-            add_python_candidate python3
-            shopt -s nullglob
-            for candidate in \
-              /home/*/miniconda3/bin/python3 \
-              /home/*/miniconda3/bin/python \
-              /home/*/anaconda3/bin/python3 \
-              /home/*/anaconda3/bin/python \
-              /home/*/miniconda3/envs/*/bin/python \
-              /home/*/anaconda3/envs/*/bin/python \
-              /opt/conda/envs/*/bin/python
-            do
-              add_python_candidate "${candidate}"
-            done
-            shopt -u nullglob
-          fi
-
-          SELECTED_BASE_PYTHON=""
-          for candidate in "${PYTHON_CANDIDATES[@]}"; do
-            echo "Probing PTODSL base Python package presence: ${candidate}"
-            if has_torch_npu_packages "${candidate}"; then
-              SELECTED_BASE_PYTHON="${candidate}"
-              break
-            fi
-          done
-
-          if [[ -z "${SELECTED_BASE_PYTHON}" ]]; then
-            echo "ERROR: PTODSL DSL ST requires an existing Python runtime with torch and torch_npu." >&2
-            echo "ERROR: this workflow intentionally does not install torch or torch_npu on every run." >&2
-            echo "ERROR: set PTO_DSL_ST_PYTHON_BIN to a compatible pre-installed interpreter." >&2
-            exit 1
-          fi
-
-          PYTHON_ABI_TAG="$("${SELECTED_BASE_PYTHON}" - <<'PY'
-          import sys
-          print(f"py{sys.version_info.major}{sys.version_info.minor}")
-          PY
-          )"
-          BASE_HASH="$(printf '%s' "${SELECTED_BASE_PYTHON}" | sha256sum | cut -c1-12)"
-          PYTHON_TAG="${PYTHON_ABI_TAG}-${BASE_HASH}"
-          PTODSL_PYTHON_ROOT="${RUNNER_TOOL_CACHE}/ptodsl-python/${PYTHON_TAG}"
-          if [[ ! -x "${PTODSL_PYTHON_ROOT}/bin/python" ]]; then
-            rm -rf "${PTODSL_PYTHON_ROOT}"
-            "${SELECTED_BASE_PYTHON}" -m venv --system-site-packages "${PTODSL_PYTHON_ROOT}"
-          fi
-
-          PTODSL_PYTHON="${PTODSL_PYTHON_ROOT}/bin/python"
-          if ! "${PTODSL_PYTHON}" -m pip --version >/dev/null 2>&1; then
-            "${PTODSL_PYTHON}" -m ensurepip --upgrade
-          fi
-          missing_deps="$(missing_ptodsl_python_deps "${PTODSL_PYTHON}")"
-          if [[ -n "${missing_deps}" ]]; then
-            "${PTODSL_PYTHON}" -m pip install ${missing_deps}
-          fi
-
-          probe_ptodsl_runtime_python "${PTODSL_PYTHON}"
-
-          PTO_DSL_ST_LLVM_DIR="${RUNNER_TOOL_CACHE}/llvm-project/llvm/build-assert-llvm19-${PYTHON_TAG}"
-          PTO_DSL_ST_BIN_DIR="$(dirname "${PTODSL_PYTHON}")"
-          echo "PTO_DSL_ST_BASE_PYTHON=${SELECTED_BASE_PYTHON}" >> "${GITHUB_ENV}"
-          echo "PTO_DSL_ST_PYTHON_BIN=${PTODSL_PYTHON}" >> "${GITHUB_ENV}"
-          echo "PTO_DSL_ST_BIN_DIR=${PTO_DSL_ST_BIN_DIR}" >> "${GITHUB_ENV}"
-          echo "PTO_DSL_ST_PTOAS_BIN=${PTO_DSL_ST_BIN_DIR}/ptoas" >> "${GITHUB_ENV}"
-          echo "PTO_DSL_ST_PYTHON_TAG=${PYTHON_TAG}" >> "${GITHUB_ENV}"
-          echo "PTO_DSL_ST_LLVM_DIR=${PTO_DSL_ST_LLVM_DIR}" >> "${GITHUB_ENV}"
 
       - name: Run TileOp ST CI
         # Temporarily keep the legacy-named TileOp ST harness in smoke mode for every trigger.
@@ -700,91 +634,11 @@ jobs:
           mkdir -p "${TILELIB_ST_WORKSPACE}"
           export LLVM_BUILD_DIR="${LLVM_DIR}"
           ASCEND_HOME_PATH="${ASCEND_HOME_PATH}" \
+          PYTHON_BIN="${CI_SIM_PYTHON}" \
           PTOAS_BIN="${PTOAS_BIN}" \
           bash test/tilelang_st/script/run_ci.sh -r sim -v a5 \
             --build-jobs 32 --jobs 64 --smoke \
             2>&1 | tee "${TILELIB_ST_WORKSPACE}/run_ci.log"
-
-      - name: Restore PTODSL LLVM build cache
-        id: ptodsl-llvm-cache
-        continue-on-error: true
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.PTO_DSL_ST_LLVM_DIR }}
-          key: llvm-build-${{ steps.llvm-cache-key.outputs.sha }}-llvm19-assert-shared-mlirpy-${{ env.PTO_DSL_ST_PYTHON_TAG }}-v3
-
-      - name: Build PTODSL LLVM/MLIR
-        if: steps.ptodsl-llvm-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd "${LLVM_ROOT}"
-          export CC=gcc
-          export CXX=g++
-          PTODSL_PYTHON_PREFIX="$(dirname "$(dirname "${PTO_DSL_ST_PYTHON_BIN}")")"
-          export VIRTUAL_ENV="${PTODSL_PYTHON_PREFIX}"
-          export PATH="${PTODSL_PYTHON_PREFIX}/bin:${PATH}"
-          PYBIND11_CMAKE_DIR="$("${PTO_DSL_ST_PYTHON_BIN}" -m pybind11 --cmakedir)"
-          NANOBIND_CMAKE_DIR="$("${PTO_DSL_ST_PYTHON_BIN}" -m nanobind --cmake_dir)"
-          PYTHON_INCLUDE_DIR="$("${PTO_DSL_ST_PYTHON_BIN}" - <<'PY'
-          import sysconfig
-          print(sysconfig.get_path("include"))
-          PY
-          )"
-          PYTHON_LIBRARY="$("${PTO_DSL_ST_PYTHON_BIN}" - <<'PY'
-          import sysconfig
-          print(sysconfig.get_config_var("LIBDIR") + "/" + sysconfig.get_config_var("LDLIBRARY"))
-          PY
-          )"
-          rm -rf "${PTO_DSL_ST_LLVM_DIR}"
-          cmake -G Ninja -S llvm -B "${PTO_DSL_ST_LLVM_DIR}" \
-            -DLLVM_ENABLE_PROJECTS="mlir;clang" \
-            -DBUILD_SHARED_LIBS=ON \
-            -DLLVM_ENABLE_ASSERTIONS=ON \
-            -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-            -DPython3_EXECUTABLE="${PTO_DSL_ST_PYTHON_BIN}" \
-            -DPython_EXECUTABLE="${PTO_DSL_ST_PYTHON_BIN}" \
-            -DPython3_ROOT_DIR="${PTODSL_PYTHON_PREFIX}" \
-            -DPython_ROOT_DIR="${PTODSL_PYTHON_PREFIX}" \
-            -DPython3_INCLUDE_DIR="${PYTHON_INCLUDE_DIR}" \
-            -DPython_INCLUDE_DIR="${PYTHON_INCLUDE_DIR}" \
-            -DPython3_LIBRARY="${PYTHON_LIBRARY}" \
-            -DPython_LIBRARY="${PYTHON_LIBRARY}" \
-            -DPython3_FIND_STRATEGY=LOCATION \
-            -DPython_FIND_STRATEGY=LOCATION \
-            -DPython3_FIND_VIRTUALENV=ONLY \
-            -DPython_FIND_VIRTUALENV=ONLY \
-            -DPython3_FIND_REGISTRY=NEVER \
-            -DPython_FIND_REGISTRY=NEVER \
-            -DPython3_FIND_FRAMEWORK=NEVER \
-            -DPython_FIND_FRAMEWORK=NEVER \
-            -Dpybind11_DIR="${PYBIND11_CMAKE_DIR}" \
-            -Dnanobind_DIR="${NANOBIND_CMAKE_DIR}" \
-            -DCMAKE_PREFIX_PATH="${PYBIND11_CMAKE_DIR};${NANOBIND_CMAKE_DIR};${PTODSL_PYTHON_PREFIX}" \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DLLVM_TARGETS_TO_BUILD="host"
-
-          ninja -C "${PTO_DSL_ST_LLVM_DIR}"
-
-      - name: Save PTODSL LLVM build cache
-        if: steps.ptodsl-llvm-cache.outputs.cache-hit != 'true'
-        continue-on-error: true
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ env.PTO_DSL_ST_LLVM_DIR }}
-          key: llvm-build-${{ steps.llvm-cache-key.outputs.sha }}-llvm19-assert-shared-mlirpy-${{ env.PTO_DSL_ST_PYTHON_TAG }}-v3
-
-      - name: Install PTODSL PTOAS editable
-        shell: bash
-        run: |
-          set -euo pipefail
-          rm -rf "${PTO_DSL_ST_BUILD_DIR}"
-          export CC=gcc
-          export CXX=g++
-          LLVM_BUILD_DIR="${PTO_DSL_ST_LLVM_DIR}" \
-            "${PTO_DSL_ST_PYTHON_BIN}" -m pip install --editable . \
-              --no-build-isolation --no-deps \
-              --config-settings="build-dir=${PTO_DSL_ST_BUILD_DIR}"
 
       - name: Probe PTODSL runtime Python
         shell: bash
@@ -795,7 +649,7 @@ jobs:
           source "${ASCEND_HOME_PATH}/bin/setenv.bash"
 
           probe_ptodsl_python() {
-            "${PTO_DSL_ST_PYTHON_BIN}" - <<'PY'
+            "${CI_SIM_PYTHON}" - <<'PY'
           import sys
           import ptoas.mlir.ir  # noqa: F401
           from ptodsl import pto  # noqa: F401
@@ -807,7 +661,7 @@ jobs:
           }
 
           probe_torch_npu_python() {
-            "${PTO_DSL_ST_PYTHON_BIN}" - <<'PY'
+            "${CI_SIM_PYTHON}" - <<'PY'
           import numpy
           import torch
           import torch_npu  # noqa: F401
@@ -820,10 +674,14 @@ jobs:
 
           PROBE_LOG="${TILELIB_ST_WORKSPACE}/ptodsl-python-probe.log"
           : > "${PROBE_LOG}"
-          echo "Probing PTODSL DSL ST Python: ${PTO_DSL_ST_PYTHON_BIN}" | tee -a "${PROBE_LOG}"
-          echo "Probing PTODSL DSL ST ptoas: ${PTO_DSL_ST_PTOAS_BIN}" | tee -a "${PROBE_LOG}"
-          if [[ ! -x "${PTO_DSL_ST_PTOAS_BIN}" ]]; then
-            echo "ERROR: installed PTODSL ptoas entry is missing: ${PTO_DSL_ST_PTOAS_BIN}" | tee -a "${PROBE_LOG}" >&2
+          echo "Probing shared ci-sim Python: ${CI_SIM_PYTHON}" | tee -a "${PROBE_LOG}"
+          echo "Probing shared ci-sim ptoas: ${PTOAS_BIN}" | tee -a "${PROBE_LOG}"
+          if [[ ! -x "${PTOAS_BIN}" ]]; then
+            echo "ERROR: installed shared ptoas entry is missing: ${PTOAS_BIN}" | tee -a "${PROBE_LOG}" >&2
+            exit 1
+          fi
+          if [[ "$(head -n 1 "${PTOAS_BIN}")" != "#!${CI_SIM_PYTHON}" ]]; then
+            echo "ERROR: ptoas does not use the shared ci-sim Python: ${PTOAS_BIN}" | tee -a "${PROBE_LOG}" >&2
             exit 1
           fi
           if ! probe_ptodsl_python >> "${PROBE_LOG}" 2>&1; then
@@ -836,7 +694,7 @@ jobs:
             echo "ERROR: selected PTODSL Python cannot import torch, torch_npu, and numpy." >&2
             exit 1
           fi
-          "${PTO_DSL_ST_PTOAS_BIN}" --version >> "${PROBE_LOG}" 2>&1
+          "${PTOAS_BIN}" --version >> "${PROBE_LOG}" 2>&1
 
           cat "${PROBE_LOG}"
 
@@ -846,15 +704,15 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${VPTO_SIM_WORKSPACE}"
-          export PYTHON_BIN="${PTO_DSL_ST_PYTHON_BIN}"
-          export PTO_PYTHON_BIN="${PTO_DSL_ST_PYTHON_BIN}"
-          export PATH="${PTO_DSL_ST_BIN_DIR}:${PATH}"
+          export PYTHON_BIN="${CI_SIM_PYTHON}"
+          export PTO_PYTHON_BIN="${CI_SIM_PYTHON}"
+          export PATH="${CI_SIM_BIN_DIR}:${PATH}"
           export TORCH_DEVICE_BACKEND_AUTOLOAD=0
           source "${ASCEND_HOME_PATH}/bin/setenv.bash"
 
           WORK_SPACE="${VPTO_SIM_WORKSPACE}" \
           ASCEND_HOME_PATH="${ASCEND_HOME_PATH}" \
-          PTOAS_BIN="${PTO_DSL_ST_PTOAS_BIN}" \
+          PTOAS_BIN="${PTOAS_BIN}" \
           DEVICE=SIM \
           JOBS="${JOBS:-32}" \
           bash test/vpto/scripts/run_host_vpto_validation_parallel.sh
@@ -864,16 +722,16 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${TILELIB_ST_WORKSPACE}"
-          export PYTHON_BIN="${PTO_DSL_ST_PYTHON_BIN}"
-          export PTO_PYTHON_BIN="${PTO_DSL_ST_PYTHON_BIN}"
-          export PATH="${PTO_DSL_ST_BIN_DIR}:${PATH}"
+          export PYTHON_BIN="${CI_SIM_PYTHON}"
+          export PTO_PYTHON_BIN="${CI_SIM_PYTHON}"
+          export PATH="${CI_SIM_BIN_DIR}:${PATH}"
           export TORCH_DEVICE_BACKEND_AUTOLOAD=0
           source "${ASCEND_HOME_PATH}/bin/setenv.bash"
 
           TILELIB_ST_OUTPUT_ROOT="${TILELIB_ST_WORKSPACE}/tilelib-st-a5" \
           ASCEND_HOME_PATH="${ASCEND_HOME_PATH}" \
-          PTOAS_BIN="${PTO_DSL_ST_PTOAS_BIN}" \
-          "${PTO_DSL_ST_PYTHON_BIN}" -m pytest \
+          PTOAS_BIN="${PTOAS_BIN}" \
+          "${CI_SIM_PYTHON}" -m pytest \
             -n "${TILELIB_ST_JOBS:-16}" --dist=worksteal -v \
             test/tilelib-st/test_tilelib_st.py \
             2>&1 | tee "${TILELIB_ST_WORKSPACE}/tilelib-st-a5.log"
@@ -883,14 +741,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${TILELIB_ST_WORKSPACE}"
-          export PYTHON_BIN="${PTO_DSL_ST_PYTHON_BIN}"
-          export PTO_PYTHON_BIN="${PTO_DSL_ST_PYTHON_BIN}"
-          export PATH="${PTO_DSL_ST_BIN_DIR}:${PATH}"
+          export PYTHON_BIN="${CI_SIM_PYTHON}"
+          export PTO_PYTHON_BIN="${CI_SIM_PYTHON}"
+          export PATH="${CI_SIM_BIN_DIR}:${PATH}"
           export TORCH_DEVICE_BACKEND_AUTOLOAD=0
           source "${ASCEND_HOME_PATH}/bin/setenv.bash"
 
           ASCEND_HOME_PATH="${ASCEND_HOME_PATH}" \
-          PTOAS_BIN="${PTO_DSL_ST_PTOAS_BIN}" \
+          PTOAS_BIN="${PTOAS_BIN}" \
           scripts/sim_dsl.sh test/dsl-st \
             2>&1 | tee "${TILELIB_ST_WORKSPACE}/ptodsl-dsl-st.log"
 

--- a/test/tilelang_st/script/run_ci.sh
+++ b/test/tilelang_st/script/run_ci.sh
@@ -13,4 +13,5 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 export PYTHONUNBUFFERED=1
 
-exec python3 "${SCRIPT_DIR}/run_all_st.py" "$@"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+exec "${PYTHON_BIN}" "${SCRIPT_DIR}/run_all_st.py" "$@"


### PR DESCRIPTION
## 背景

当前 `ci-sim` 在同一个 job 内维护多套 Python/PTOAS 环境：基础 PTOAS 使用独立 venv，PyPTO 使用 runner 的 `python3` 和 CPU PyTorch，PTODSL 又基于预装 `torch/torch_npu` 创建另一套 venv，并为它重复构建 LLVM 和 PTOAS。这既存在 Python ABI/依赖不一致风险，也增加了 simulator CI 的构建时间。

Related to #818.

## 修改内容

- 在 LLVM 配置前选择一个同时提供 `torch` 和 `torch_npu` 的 runner Python，并基于它创建唯一的 `CI_SIM_VENV`。
- 将 Python ABI 和基础解释器路径纳入 LLVM build 目录与 cache key，避免不同解释器复用不兼容的 MLIR Python 构建。
- 在共享 venv 中统一安装 PTOAS、PyPTO frontend/runtime 及 simulator 测试依赖。
- 让 PyPTO、TileOp、VPTO、TileLib 和 PTODSL 测试全部显式使用 `CI_SIM_PYTHON`；PyPTO 继续使用完整的 `build/tools/ptoas` 输出目录，其他测试使用共享 venv 中的 `ptoas`，两者来自同一次 PTOAS 构建。
- 删除 PTODSL 专用的第二套 LLVM cache/build 和 PTOAS editable install。
- 保留旧的 `PTO_DSL_ST_PYTHON_BIN` runner 配置作为兼容回退，新配置统一使用 `CI_SIM_PYTHON_BIN`。
- 让 `test/tilelang_st/script/run_ci.sh` 遵循显式传入的 `PYTHON_BIN`，避免脚本内部回退到 runner 的 `python3`。
- 增加运行时探测，校验共享 Python 可导入 PTOAS/PTODSL、`torch` 和 `torch_npu`，并确认 `ptoas` console script 的 shebang 指向共享解释器。

## 预期效果

- `ci-sim` 只构建一次 LLVM/MLIR 和 PTOAS。
- 所有 simulator 测试使用同一个 Python ABI、Python package environment 和 PTOAS 安装。
- 不再向 runner 默认 Python 安装 CPU PyTorch，避免与预装 `torch_npu` 环境交叉污染；共享 venv 不强制升级 base 环境的 numpy。

## 验证

- 使用 PyYAML 解析 `.github/workflows/ci_sim.yml`。
- 检查 workflow 只保留一个 LLVM build step 和一个 PTOAS editable install step。
- 检查共享环境创建后不存在裸 `python3 -m pip` 或 `python3 -m pytest` 调用。
- `bash -n test/tilelang_st/script/run_ci.sh`。
- 使用 `/bin/echo` 作为 `PYTHON_BIN` 验证 TileOp 入口的解释器透传。
- `git diff --check`。

完整 simulator/CANN 验证需要在 self-hosted `ci-sim` runner 上完成，因此先以 draft PR 提交。
