### PR TITLE
fix(ptodsl): predicate loop tails after break/continue on merged active (#1256)

### DIFF
--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -1300,6 +1300,17 @@ class _ControlFlowRewriter:
         so slots never need to participate here.  ``rewrite_block`` and
         ``_rewrite_loop_body`` share this segmentation; nested branch bodies pick
         up the current loop's control from the stack top automatically.
+
+        Complexity note: a block with N control-transfer points produces N
+        nested guards (each transfer's guard wraps the already-guarded tail
+        behind it), with per-guard merge sets bounded by the names live at
+        that point.  This nesting is inherent to predicating the tail: once an
+        earlier transfer has fired, a later transfer statement must not even
+        evaluate its condition, so the guards cannot be flattened into sibling
+        regions without redesigning flag updates as data-flow (e.g.
+        ``did_break |= cond & active``).  Typical kernels have very few
+        transfer points per block, so the nesting is accepted deliberately
+        rather than capped or merged.
         """
         if control is None or not tail:
             return None

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -1169,12 +1169,17 @@ class _ControlFlowRewriter:
         live = set(live_after)
         live_slots = set(live_after_slots or ())
         static_iters = dict(static_iters or {})
+        control = self._loop_control_stack[-1] if self._loop_control_stack else None
+        tail_assigned = set()
+        tail_flags = {"break": False, "continue": False}
         for stmt in reversed(stmts):
             # Compute liveness from the authored AST before rewrite_stmt mutates
             # sibling statements in-place, otherwise later rewrites can pollute
             # earlier live-after analysis.
             live_before = _live_before_stmt(stmt, live)
             live_before_slots = _slot_live_before_stmt(stmt, live_slots, self._static_env, static_iters)
+            stmt_stores = _name_info(stmt).stores
+            stmt_flags = _loop_control_flags([stmt]) if control is not None else None
             rewritten = self.rewrite_stmt(
                 stmt,
                 live_after=live,
@@ -1182,10 +1187,67 @@ class _ControlFlowRewriter:
                 allow_loop_control=allow_loop_control,
                 static_iters=static_iters,
             )
-            rewritten_reversed[:0] = rewritten
+            # When this statement can stop the current iteration (top-level
+            # break/continue, or a dynamic if containing one), the already-
+            # rewritten tail must run only while the loop is still active.
+            guarded_tail = self._guard_control_tail(
+                stmt, control=control, tail=rewritten_reversed,
+                tail_assigned=tail_assigned, tail_flags=tail_flags, live=live,
+            )
+            if guarded_tail is not None:
+                # The tail now lives inside the guard: replace the
+                # accumulator instead of prepending, or the tail nodes
+                # would be shared by the guard and the block.
+                rewritten_reversed = rewritten + guarded_tail
+            else:
+                rewritten_reversed[:0] = rewritten
+            tail_assigned |= stmt_stores
+            if stmt_flags is not None:
+                tail_flags["break"] |= stmt_flags["break"]
+                tail_flags["continue"] |= stmt_flags["continue"]
             live = live_before
             live_slots = live_before_slots
         return rewritten_reversed
+
+    def _guard_control_tail(self, stmt, *, control, tail, tail_assigned, tail_flags, live):
+        """Guard the already-rewritten tail of a break/continue statement.
+
+        When ``stmt`` can stop the current iteration (a top-level break/continue,
+        or a dynamic if whose branches contain one, per ``_loop_control_flags``),
+        every statement after it may only run while the loop is still active.
+        The tail therefore executes under a ``pto.if_(active)`` guard whose
+        condition is the merged active flag from the preceding statements, so
+        statements after the transfer are skipped for that iteration.
+
+        ``tail_assigned`` holds the names the tail assigns; names that are also
+        live after the guard point are merged through the guard so later
+        statements and the loop ``update`` keep consistent values.  ``tail_flags``
+        records whether the tail itself contains control transfers: a tail that
+        assigns ``active``/``did_break`` (they are not ``ast.Assign`` stores, so
+        they never appear in ``tail_assigned``) must also merge them out, or the
+        loop ``update`` would read flags whose SSA values are defined inside the
+        guard region.  Controlled loops reject static subscript stores up front,
+        so slots never need to participate here.  ``rewrite_block`` and
+        ``_rewrite_loop_body`` share this segmentation; nested branch bodies pick
+        up the current loop's control from the stack top automatically.
+        """
+        if control is None or not tail:
+            return None
+        flags = _loop_control_flags([stmt])
+        if not (flags["break"] or flags["continue"]):
+            return None
+        flag_names = set()
+        if tail_flags["break"] or tail_flags["continue"]:
+            flag_names.add(control["active"])
+        if tail_flags["break"]:
+            flag_names.add(control["did_break"])
+        merge_names = sorted((set(tail_assigned) | flag_names) & set(live))
+        return self._guard_block(
+            _name(control["active"]),
+            tail,
+            merge_names=merge_names,
+            assigned_names=set(tail_assigned) | flag_names,
+        )
 
     def _rewrite_loop_body(self, stmts, *, live_after, live_after_slots=None, static_iters=None, control=None):
         """Rewrite loop statements while keeping each authored statement atomic.
@@ -1201,12 +1263,16 @@ class _ControlFlowRewriter:
             live |= {control["active"], control["did_break"]}
         live_slots = set(live_after_slots or ())
         static_iters = dict(static_iters or {})
+        tail_assigned = set()
+        tail_flags = {"break": False, "continue": False}
         for stmt in reversed(stmts):
             live_before = _live_before_stmt(stmt, live)
             live_before_slots = _slot_live_before_stmt(stmt, live_slots, self._static_env, static_iters)
             rewrite_live = live
             if control is not None:
                 rewrite_live = set(rewrite_live) | {control["active"], control["did_break"]}
+            stmt_stores = _name_info(stmt).stores
+            stmt_flags = _loop_control_flags([stmt]) if control is not None else None
             group = self.rewrite_stmt(
                 stmt,
                 live_after=rewrite_live,
@@ -1214,7 +1280,23 @@ class _ControlFlowRewriter:
                 allow_loop_control=False,
                 static_iters=static_iters,
             )
-            rewritten_reversed[:0] = group
+            # Segment the already-rewritten tail on the merged active value
+            # when this statement can stop the current iteration.
+            guarded_tail = self._guard_control_tail(
+                stmt, control=control, tail=rewritten_reversed,
+                tail_assigned=tail_assigned, tail_flags=tail_flags, live=live,
+            )
+            if guarded_tail is not None:
+                # The tail now lives inside the guard: replace the
+                # accumulator instead of prepending, or the tail nodes
+                # would be shared by the guard and the block.
+                rewritten_reversed = group + guarded_tail
+            else:
+                rewritten_reversed[:0] = group
+            tail_assigned |= stmt_stores
+            if stmt_flags is not None:
+                tail_flags["break"] |= stmt_flags["break"]
+                tail_flags["continue"] |= stmt_flags["continue"]
             live = set(live_before)
             if control is not None:
                 live |= {control["active"], control["did_break"]}
@@ -2008,24 +2090,21 @@ class _ControlFlowRewriter:
             for name in state_names
         ]
         # active is per-iteration execution state; did_break remains sticky.
+        # The body is segmented by _guard_control_tail on the merged active
+        # value, so no whole-body guard is needed here.
         prologue.append(ast.Assign(targets=[_name(skip_name, ast.Store())], value=_flag_const(True)))
-        guarded_body = self._guard_block(
-            _name(skip_name), body,
-            merge_names=state_names,
-            assigned_names=state_names,
-        )
         updates = [
             ast.keyword(arg=iv_name, value=ast.BinOp(left=_name(iv_name), op=ast.Add(), right=copy.deepcopy(step))),
             *[ast.keyword(arg=name, value=_name(name)) for name in sorted(loop_carried)],
             ast.keyword(arg=skip_name, value=_name(skip_name)),
             ast.keyword(arg=did_break_name, value=_name(did_break_name)),
         ]
-        guarded_body.append(ast.Expr(value=ast.Call(
+        body.append(ast.Expr(value=ast.Call(
             func=ast.Attribute(value=_name(loop_name), attr="update", ctx=ast.Load()),
             args=[], keywords=updates)))
         with_stmt = ast.With(
             items=[ast.withitem(context_expr=_name(loop_name), optional_vars=None)],
-            body=prologue + guarded_body,
+            body=prologue + body,
             type_comment=None,
         )
         result = [ast.copy_location(setup, stmt), ast.copy_location(with_stmt, stmt)]
@@ -2186,13 +2265,10 @@ class _ControlFlowRewriter:
             # ``active`` is an iteration-local execution flag.  A continue
             # clears it for the remainder of this body, then the next body
             # entry re-enables it.  ``did_break`` is sticky across iterations.
+            # The body is segmented by _guard_control_tail on the merged
+            # active value, so no whole-body guard is needed here.
             prologue.append(ast.Assign(
                 targets=[_name(active_name, ast.Store())], value=_flag_const(True)))
-            body = self._guard_block(
-                _name(active_name), body,
-                merge_names=state_names,
-                assigned_names=state_names,
-            )
         update = ast.Expr(
             value=ast.Call(
                 func=ast.Attribute(value=_name(loop_name), attr="update",

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -968,15 +968,46 @@ def _loop_control_flags(stmts):
     return result
 
 
-def _drop_unreachable_tails(stmts):
-    """Truncate each statement list after a bare break/continue and recurse.
+def _stmt_always_transfers(stmt):
+    """True when *stmt* cannot complete normally in the current iteration.
 
-    Statements following an unconditional break/continue are unreachable in
-    Python semantics.  Dropping them before name/slot analysis keeps dead
-    names out of the carry computation and, more importantly, keeps the
-    tracer from executing bodies that reference locals Python itself would
-    never bind (``while ...: break; dead = dead + 1`` is legal Python yet
-    raised UnboundLocalError when the dead tail was still analyzed/traced).
+    A bare break/continue, or a compound statement whose every path exits
+    the iteration: an ``if`` whose both branches always transfer, or a
+    ``with``/``try`` whose body always transfers (the context exit /
+    ``finally`` block still runs, then the transfer propagates, so the
+    statement as a whole never falls through).  Nested loops belong to
+    themselves: a break inside one says nothing about the outer iteration.
+    """
+    if isinstance(stmt, (ast.Break, ast.Continue)):
+        return True
+    if isinstance(stmt, ast.If):
+        return (
+            bool(stmt.orelse)
+            and _block_always_transfers(stmt.body)
+            and _block_always_transfers(stmt.orelse)
+        )
+    if isinstance(stmt, (ast.With, ast.AsyncWith)):
+        return _block_always_transfers(stmt.body)
+    if isinstance(stmt, ast.Try) or type(stmt).__name__ == "TryStar":
+        return _block_always_transfers(stmt.body)
+    return False
+
+
+def _block_always_transfers(stmts):
+    return any(_stmt_always_transfers(stmt) for stmt in stmts)
+
+
+def _drop_unreachable_tails(stmts):
+    """Truncate each statement list after a guaranteed transfer and recurse.
+
+    Statements following a statement that always exits the current iteration
+    (bare break/continue, both-branches-transfer if, transfer-bodied
+    with/try) are unreachable in Python semantics.  Dropping them before
+    name/slot analysis keeps dead names out of the carry computation and,
+    more importantly, keeps the tracer from executing bodies that reference
+    locals Python itself would never bind (``while ...: break; dead = dead +
+    1`` is legal Python yet raised UnboundLocalError when the dead tail was
+    still analyzed/traced).
 
     The recursion stops at nested loops' own statements only in the sense of
     ownership: their bodies are cleaned too, since each list is truncated at
@@ -989,7 +1020,9 @@ def _drop_unreachable_tails(stmts):
             value = getattr(stmt, field, None)
             if isinstance(value, list) and value and isinstance(value[0], ast.stmt):
                 setattr(stmt, field, _drop_unreachable_tails(value))
-        if isinstance(stmt, (ast.Break, ast.Continue)):
+        for handler in getattr(stmt, "handlers", []):
+            handler.body = _drop_unreachable_tails(handler.body)
+        if _stmt_always_transfers(stmt):
             return cleaned
     return cleaned
 

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -972,10 +972,9 @@ def _stmt_always_transfers(stmt):
     """True when *stmt* cannot complete normally in the current iteration.
 
     A bare break/continue, or a compound statement whose every path exits
-    the iteration: an ``if`` whose both branches always transfer, or a
-    ``with``/``try`` whose body always transfers (the context exit /
-    ``finally`` block still runs, then the transfer propagates, so the
-    statement as a whole never falls through).  Nested loops belong to
+    the iteration: an ``if`` whose both branches always transfer, a ``with``
+    whose body always transfers, or a ``try`` whose body and caught handlers
+    transfer (or whose ``finally`` transfers).  Nested loops belong to
     themselves: a break inside one says nothing about the outer iteration.
     """
     if isinstance(stmt, (ast.Break, ast.Continue)):
@@ -989,12 +988,24 @@ def _stmt_always_transfers(stmt):
     if isinstance(stmt, (ast.With, ast.AsyncWith)):
         return _block_always_transfers(stmt.body)
     if isinstance(stmt, ast.Try) or type(stmt).__name__ == "TryStar":
-        return _block_always_transfers(stmt.body)
+        # A transfer in the try body does not cover an exception path caught
+        # by a handler.  A finally transfer, on the other hand, overrides
+        # every normal or exceptional path through the statement.
+        if _block_always_transfers(stmt.finalbody):
+            return True
+        return (
+            _block_always_transfers(stmt.body)
+            and all(_block_always_transfers(handler.body) for handler in stmt.handlers)
+        )
     return False
 
 
 def _block_always_transfers(stmts):
-    return any(_stmt_always_transfers(stmt) for stmt in stmts)
+    # _drop_unreachable_tails has already removed everything after the first
+    # guaranteed transfer in each child block.  Looking only at the final
+    # reachable statement keeps this helper correct when called independently
+    # and avoids treating an earlier conditional transfer as unconditional.
+    return bool(stmts) and _stmt_always_transfers(stmts[-1])
 
 
 def _drop_unreachable_tails(stmts):

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -968,6 +968,32 @@ def _loop_control_flags(stmts):
     return result
 
 
+def _drop_unreachable_tails(stmts):
+    """Truncate each statement list after a bare break/continue and recurse.
+
+    Statements following an unconditional break/continue are unreachable in
+    Python semantics.  Dropping them before name/slot analysis keeps dead
+    names out of the carry computation and, more importantly, keeps the
+    tracer from executing bodies that reference locals Python itself would
+    never bind (``while ...: break; dead = dead + 1`` is legal Python yet
+    raised UnboundLocalError when the dead tail was still analyzed/traced).
+
+    The recursion stops at nested loops' own statements only in the sense of
+    ownership: their bodies are cleaned too, since each list is truncated at
+    its own control transfers.
+    """
+    cleaned = []
+    for stmt in stmts:
+        cleaned.append(stmt)
+        for field in ("body", "orelse", "finalbody"):
+            value = getattr(stmt, field, None)
+            if isinstance(value, list) and value and isinstance(value[0], ast.stmt):
+                setattr(stmt, field, _drop_unreachable_tails(value))
+        if isinstance(stmt, (ast.Break, ast.Continue)):
+            return cleaned
+    return cleaned
+
+
 def _loop_has_return(stmts):
     """Check returns in the current loop body, excluding nested functions."""
     class Visitor(ast.NodeVisitor):
@@ -1703,6 +1729,9 @@ class _ControlFlowRewriter:
     def _rewrite_for(self, stmt, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None):
         live_after_slots = set(live_after_slots or ())
         static_iters = dict(static_iters or {})
+        # Drop statically dead tails of unconditional break/continue before
+        # any analysis or tracing (they are unreachable in Python semantics).
+        stmt.body = _drop_unreachable_tails(stmt.body)
         if _is_pto_attr_call(stmt.iter, "static_range"):
             next_static_iters = dict(static_iters)
             if isinstance(stmt.target, ast.Name):
@@ -2134,6 +2163,10 @@ class _ControlFlowRewriter:
     def _rewrite_while(self, stmt, *, live_after, live_after_slots=None,
                        allow_loop_control=False, static_iters=None):
         """Lower runtime ``while`` using named state and explicit control flags."""
+        # Drop statically dead tails of unconditional break/continue before
+        # any analysis or tracing (they are unreachable in Python semantics),
+        # so dead names never enter the carry computation or get traced.
+        stmt.body = _drop_unreachable_tails(stmt.body)
         if _loop_has_return(stmt.body):
             raise PTODSLAstRewriteError(
                 "ast_rewrite=True does not support dynamic return inside runtime while"

--- a/ptodsl/tests/test_scf_while_ast.py
+++ b/ptodsl/tests/test_scf_while_ast.py
@@ -33,30 +33,62 @@ def _region_close(text: str, open_brace: int) -> int:
     raise AssertionError("unbalanced braces in MLIR text")
 
 
+def _is_flag_merge_result(mlir_text: str, cond_token: str) -> bool:
+    """True when cond_token (``%X`` or ``%X#k``) is defined by a
+    result-producing ``scf.if`` merging i1 control-flag state.
+
+    The break/continue predication contract requires the tail guard's
+    condition to be the *merged* ``active`` flag — a result of the
+    flag-merge ``scf.if`` — not an arbitrary dynamic condition (e.g. the
+    original ``if value > 0`` test, which would leave the tail
+    unpredicated).  Single-result merges print as ``%X = scf.if ... ->
+    (i1)``; multi-result merges as ``%X:N = scf.if ... -> (i1, ...)`` with
+    the condition referenced as ``%X#k``.
+    """
+    if "#" in cond_token:
+        base, idx = cond_token[1:].split("#", 1)
+        idx = int(idx)
+        m = re.search(
+            rf"%{re.escape(base)}:(\d+) = scf\.if [^\n]*-> \(([^)]*)\)", mlir_text)
+        if m is None or idx >= int(m.group(1)):
+            return False
+        types = [t.strip() for t in m.group(2).split(",")]
+        return idx < len(types) and types[idx] == "i1"
+    base = cond_token[1:]
+    m = re.search(
+        rf"%{re.escape(base)} = scf\.if [^\n]*-> \(([^)]*)\)", mlir_text)
+    return m is not None and m.group(1).strip() == "i1"
+
+
 def _assert_tail_guarded(mlir_text: str, tail_op_pattern: str):
     """Lock the break/continue tail-skip contract in the emitted IR.
 
     Statements after a break/continue (or after an if containing one) must be
     predicated on the merged ``active`` flag: the tail operation must appear
-    *inside the region* of a result-producing ``scf.if`` whose condition is a
-    real SSA value (``%X`` or ``%X#0``, never a constant true/false).  Region
-    containment is checked by brace depth, not mere text order, so a guard
-    that opens and closes before the tail cannot satisfy this contract.  The
+    *inside the region* of a result-producing ``scf.if`` whose condition is
+    the i1 result of an earlier flag-merge ``scf.if`` (never a constant, a
+    block argument, or an unrelated dynamic condition).  Region containment
+    is checked by brace depth, not mere text order, and the condition's
+    defining op is resolved, so a tail that merely sits inside the original
+    dynamic ``if value > 0`` region does not satisfy this contract.  The
     dead constant-true whole-body guard must be gone.
     """
     assert not re.search(r"scf\.if %true", mlir_text), (
         "constant-true guard still present; break/continue tails are unpredicated")
     tail = re.search(tail_op_pattern, mlir_text)
     assert tail is not None, f"tail op {tail_op_pattern!r} not found in MLIR"
-    guards = list(re.finditer(r"= scf\.if %(?!true|false)\w+(?:#\d+)? -> \(", mlir_text))
+    guards = list(re.finditer(r"= scf\.if (%(?!true|false)\w+(?:#\d+)?) -> \(", mlir_text))
     assert guards, "no active-guarded tail region found"
     for guard in guards:
+        if not _is_flag_merge_result(mlir_text, guard.group(1)):
+            continue
         open_brace = mlir_text.index("{", guard.end())
         if guard.start() < tail.start() < _region_close(mlir_text, open_brace):
             return
     raise AssertionError(
-        "tail op is not contained in any active-guarded scf.if region; "
-        "statements after break/continue would execute unconditionally")
+        "tail op is not contained in a region guarded by the merged active "
+        "flag (an i1 result of a flag-merge scf.if); statements after "
+        "break/continue would execute unconditionally")
 
 
 @pto.jit(target="a5")
@@ -359,6 +391,60 @@ def while_break_dead_slot_tail(limit: pto.i32):
     _ = value
 
 
+@pto.jit(target="a5")
+def while_if_else_break_dead_tail(limit: pto.i32):
+    # An if whose both branches break always exits the iteration, so the
+    # outer tail after it is dead and must be dropped even though the if
+    # itself is not a bare break/continue.
+    value = pto.const(0, dtype=pto.i32)
+    while value < limit:
+        value = value + pto.const(1, dtype=pto.i32)
+        if value > pto.const(2, dtype=pto.i32):
+            break
+        else:
+            break
+        dead = dead + pto.const(10, dtype=pto.i32)
+    _ = value
+
+
+class _NullContext:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pto.jit(target="a5")
+def while_with_break_dead_tail(limit: pto.i32):
+    # A with body that always breaks never falls through: the outer tail is
+    # dead (the context exit runs natively at trace time, then the transfer
+    # propagates).
+    value = pto.const(0, dtype=pto.i32)
+    while value < limit:
+        value = value + pto.const(1, dtype=pto.i32)
+        with _NullContext():
+            break
+        dead = dead + pto.const(10, dtype=pto.i32)
+    _ = value
+
+
+@pto.jit(target="a5")
+def while_try_break_dead_tail(limit: pto.i32):
+    # try/finally whose body always breaks: the finally block runs (here a
+    # real store to a carried name), then the transfer propagates and the
+    # outer tail is dead.
+    value = pto.const(0, dtype=pto.i32)
+    while value < limit:
+        value = value + pto.const(1, dtype=pto.i32)
+        try:
+            break
+        finally:
+            value = value + pto.const(0, dtype=pto.i32)
+        dead = dead + pto.const(10, dtype=pto.i32)
+    _ = value
+
+
 def unsupported_while_subscript(limit: pto.i32):
     values = [0]
     value = pto.const(0, dtype=pto.i32)
@@ -457,6 +543,9 @@ def main():
         while_break_dead_unbound_tail: 3,
         while_if_break_dead_branch_tail: 3,
         while_break_dead_slot_tail: 3,
+        while_if_else_break_dead_tail: 3,
+        while_with_break_dead_tail: 3,
+        while_try_break_dead_tail: 3,
         for_break_tail_guard: 4,  # iv + value + control flags
     }
     for fn, expected_carries in tail_carry_contract.items():
@@ -464,6 +553,15 @@ def main():
         actual = _while_iter_arg_count(loop_text)
         assert actual == expected_carries, (
             f"{fn.__name__}: expected {expected_carries} loop-carried slots, got {actual}")
+
+    # Compound-statement transfers (both-branches-break if, with/try bodies
+    # that always break) must also have their outer dead tails dropped.
+    for fn in (while_if_else_break_dead_tail, while_with_break_dead_tail,
+               while_try_break_dead_tail):
+        text = fn.compile().mlir_text()
+        assert not re.search(r"arith\.addi %[\w#]+, %c10_i32", text), (
+            f"{fn.__name__}: dead tail after a guaranteed compound transfer "
+            "must be dropped, not emitted")
 
     # Truncating the dead tail must not weaken the store-less-body diagnostic:
     # a controlled while whose only real statement is the transfer still has
@@ -517,6 +615,41 @@ def main():
         pass
     else:
         raise AssertionError("unbound loop-local used after while must not compile")
+
+    # Negative fixtures for the checker itself: a tail that merely sits
+    # inside an *unrelated* dynamic scf.if (condition is a block argument or
+    # an arith result, not the merged active flag) must be rejected — the
+    # reviewer's "if value > 0 region without an active guard" case.
+    unguarded_fixtures = [
+        # condition is a plain block argument
+        "func.func @k(%cond: i1) {\n"
+        "  %c1_i32 = arith.constant 1 : i32\n"
+        "  %0 = scf.if %cond -> (i32) {\n"
+        "    %1 = arith.addi %c1_i32, %c1_i32 : i32\n"
+        "    scf.yield %1 : i32\n"
+        "  }\n"
+        "  return\n"
+        "}\n",
+        # condition is an arith.cmpi result, not a flag-merge scf.if result
+        "func.func @k(%a: i32, %b: i32) {\n"
+        "  %c1_i32 = arith.constant 1 : i32\n"
+        "  %cmp = arith.cmpi slt, %a, %b : i32\n"
+        "  %0 = scf.if %cmp -> (i32) {\n"
+        "    %1 = arith.addi %c1_i32, %c1_i32 : i32\n"
+        "    scf.yield %1 : i32\n"
+        "  }\n"
+        "  return\n"
+        "}\n",
+    ]
+    for fixture in unguarded_fixtures:
+        try:
+            _assert_tail_guarded(fixture, r"arith\.addi %[\w#]+, %c1_i32")
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError(
+                "checker accepted a tail guarded by an unrelated dynamic if "
+                "(condition is not the merged active flag)")
 
 
 if __name__ == "__main__":

--- a/ptodsl/tests/test_scf_while_ast.py
+++ b/ptodsl/tests/test_scf_while_ast.py
@@ -7,9 +7,11 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
+import ast
 import re
 
 from ptodsl import pto
+from ptodsl._ast_rewrite import _drop_unreachable_tails
 
 
 def _while_iter_arg_count(mlir_text: str) -> int:
@@ -454,6 +456,39 @@ def unsupported_while_subscript(limit: pto.i32):
 
 
 def main():
+    # Dead-tail truncation must account for exception paths.  A break in the
+    # try body does not make the statement transfer on an exception caught by
+    # a falling-through handler, while a transferring handler (or finally)
+    # does make the whole statement non-fallthrough.
+    def cleaned_loop_body(source):
+        loop = ast.parse(source).body[0]
+        return _drop_unreachable_tails(loop.body)
+
+    assert len(cleaned_loop_body(
+        "while cond:\n"
+        "    try:\n"
+        "        break\n"
+        "    except Exception:\n"
+        "        value = value + one\n"
+        "    dead = dead + ten\n"
+    )) == 2, "falling-through except handler must keep the outer tail"
+    assert len(cleaned_loop_body(
+        "while cond:\n"
+        "    try:\n"
+        "        break\n"
+        "    except Exception:\n"
+        "        continue\n"
+        "    dead = dead + ten\n"
+    )) == 1, "transferring except handlers must drop the outer tail"
+    assert len(cleaned_loop_body(
+        "while cond:\n"
+        "    try:\n"
+        "        value = value + one\n"
+        "    finally:\n"
+        "        continue\n"
+        "    dead = dead + ten\n"
+    )) == 1, "transferring finally blocks must drop the outer tail"
+
     text = runtime_while_probe.compile().mlir_text()
     assert "scf.while" in text
     assert "scf.condition" in text

--- a/ptodsl/tests/test_scf_while_ast.py
+++ b/ptodsl/tests/test_scf_while_ast.py
@@ -19,6 +19,26 @@ def _while_iter_arg_count(mlir_text: str) -> int:
     return len([part for part in match.group(1).split(",") if part.strip()])
 
 
+def _assert_tail_guarded(mlir_text: str, tail_op_pattern: str):
+    """Lock the break/continue tail-skip contract in the emitted IR.
+
+    Statements after a break/continue (or after an if containing one) must be
+    predicated on the merged ``active`` flag: a result-producing ``scf.if``
+    whose condition is the merge result of the preceding break/continue
+    ``scf.if`` (``%X`` or ``%X#0``, never a constant) must open before the
+    tail operation, and the dead constant-true whole-body guard must be gone.
+    """
+    assert not re.search(r"scf\.if %true", mlir_text), (
+        "constant-true guard still present; break/continue tails are unpredicated")
+    guards = [m for m in re.finditer(r"= scf\.if %\w+(?:#\d+)? -> \(", mlir_text)]
+    assert guards, "no active-guarded tail region found"
+    tail = re.search(tail_op_pattern, mlir_text)
+    assert tail is not None, f"tail op {tail_op_pattern!r} not found in MLIR"
+    assert tail.start() > guards[-1].end(), (
+        "tail op appears before the active guard; statements after "
+        "break/continue would execute unconditionally")
+
+
 @pto.jit(target="a5")
 def runtime_while_probe(limit: pto.i32):
     value = pto.const(0, dtype=pto.i32)
@@ -205,6 +225,80 @@ def issue_1256_exact_while_branch_cond(limit: pto.i32, pivot: pto.i32):
     _ = low
 
 
+# ---------------------------------------------------------------------------
+# Break/continue tail predication: statements after a control transfer must
+# only execute while the iteration is still active.  Before the fix the whole
+# body was wrapped in a single guard on the entry value of ``active`` (a
+# constant true, since the prologue resets it), so a tail statement such as
+# ``value = value + 1`` after ``if should_break: break`` executed
+# unconditionally in the breaking iteration (issue #1256 follow-up).
+# ---------------------------------------------------------------------------
+
+
+@pto.jit(target="a5")
+def while_continue_skips_tail(limit: pto.i32):
+    value = pto.const(0, dtype=pto.i32)
+    while value < limit:
+        value = value + pto.const(1, dtype=pto.i32)
+        if value == pto.const(2, dtype=pto.i32):
+            continue
+        value = value + pto.const(10, dtype=pto.i32)
+    _ = value
+
+
+@pto.jit(target="a5")
+def while_continue_then_break_flags(limit: pto.i32):
+    # The continue guard's tail contains a break: the guard must merge
+    # active/did_break back out, or the break would be lost (or its SSA
+    # value would leak out of the guard region).
+    value = pto.const(0, dtype=pto.i32)
+    while value < limit:
+        if value == pto.const(1, dtype=pto.i32):
+            continue
+        if value == pto.const(3, dtype=pto.i32):
+            break
+        value = value + pto.const(1, dtype=pto.i32)
+    _ = value
+
+
+@pto.jit(target="a5")
+def while_nested_if_break_tail(limit: pto.i32):
+    # Tails must be predicated at every block level: inside the branch that
+    # contains the break, and in the enclosing loop body after the if.
+    value = pto.const(0, dtype=pto.i32)
+    while value < limit:
+        if value > pto.const(0, dtype=pto.i32):
+            if value == pto.const(3, dtype=pto.i32):
+                break
+            value = value + pto.const(1, dtype=pto.i32)
+        value = value + pto.const(10, dtype=pto.i32)
+    _ = value
+
+
+@pto.jit(target="a5")
+def while_unconditional_break_dead_tail(limit: pto.i32):
+    # The tail of an unconditional break is statically dead; it is guarded
+    # uniformly (constant-false active) instead of being diagnosed, matching
+    # Python's tolerance for unreachable code.
+    value = pto.const(0, dtype=pto.i32)
+    while value < limit:
+        value = value + pto.const(1, dtype=pto.i32)
+        break
+        value = value + pto.const(10, dtype=pto.i32)
+    _ = value
+
+
+@pto.jit(target="a5")
+def for_break_tail_guard(limit: pto.i32):
+    # The controlled for-loop lowering shares the same predication scheme.
+    value = pto.const(0, dtype=pto.i32)
+    for i in range(limit):
+        if i == pto.const(3, dtype=pto.i32):
+            break
+        value = value + pto.const(1, dtype=pto.i32)
+    _ = value
+
+
 def unsupported_while_subscript(limit: pto.i32):
     values = [0]
     value = pto.const(0, dtype=pto.i32)
@@ -251,6 +345,61 @@ def main():
         assert actual == expected_carries, (
             f"{fn.__name__}: expected {expected_carries} loop-carried slots, got {actual}; "
             "loop-local temporaries must not enter the carry state")
+
+    # Break/continue tail predication: the statement after a control transfer
+    # must sit inside a region guarded by the merged active flag.
+    # issue_1256_exact_while_true_break is the reporter's kernel: the addi
+    # after ``if should_break: break`` used to execute unconditionally.
+    _assert_tail_guarded(
+        issue_1256_exact_while_true_break.compile().mlir_text(),
+        r"arith\.addi %[\w#]+, %c1_i32")
+    _assert_tail_guarded(
+        while_continue_skips_tail.compile().mlir_text(),
+        r"arith\.addi %[\w#]+, %c10_i32")
+    _assert_tail_guarded(
+        while_nested_if_break_tail.compile().mlir_text(),
+        r"arith\.addi %[\w#]+, %c10_i32")
+    _assert_tail_guarded(
+        for_break_tail_guard.compile().mlir_text(),
+        r"arith\.addi %[\w#]+, %c1_i32")
+
+    # The continue-guard's tail contains a break: the guard must merge both
+    # control flags back out (value + active + did_break).
+    flags_text = while_continue_then_break_flags.compile().mlir_text()
+    _assert_tail_guarded(flags_text, r"arith\.addi %[\w#]+, %c1_i32")
+    assert re.search(r"= scf\.if %\w+(?:#\d+)? -> \(i1, i1, i32\)", flags_text), (
+        "outer guard must merge value + active + did_break so the nested "
+        "break survives the guard region")
+
+    # Nested branch tail: the +1 addi inside the branch must also be guarded.
+    nested_text = while_nested_if_break_tail.compile().mlir_text()
+    inner_addi = re.search(r"arith\.addi %[\w#]+, %c1_i32", nested_text)
+    assert inner_addi is not None
+    assert [m for m in re.finditer(r"= scf\.if %\w+(?:#\d+)? -> \(", nested_text)
+            if m.end() < inner_addi.start()], (
+        "branch-level tail after a nested break is not predicated")
+
+    # The dead tail of an unconditional break is guarded by constant false.
+    dead_text = while_unconditional_break_dead_tail.compile().mlir_text()
+    dead_guard = re.search(r"= scf\.if %false(?:_\d+)? -> \(", dead_text)
+    assert dead_guard is not None, "unconditional-break tail must be guarded by constant false"
+    dead_addi = re.search(r"arith\.addi %[\w#]+, %c10_i32", dead_text)
+    assert dead_addi is not None and dead_addi.start() > dead_guard.end()
+
+    # The new kernels also lock their carry counts (value + control flags;
+    # the for-loop additionally carries its induction variable).
+    tail_carry_contract = {
+        while_continue_skips_tail: 3,
+        while_continue_then_break_flags: 3,
+        while_nested_if_break_tail: 3,
+        while_unconditional_break_dead_tail: 3,
+        for_break_tail_guard: 4,  # iv + value + control flags
+    }
+    for fn, expected_carries in tail_carry_contract.items():
+        loop_text = fn.compile().mlir_text()
+        actual = _while_iter_arg_count(loop_text)
+        assert actual == expected_carries, (
+            f"{fn.__name__}: expected {expected_carries} loop-carried slots, got {actual}")
 
     def unsupported_break(limit: pto.i32):
         value = pto.const(0, dtype=pto.i32)

--- a/ptodsl/tests/test_scf_while_ast.py
+++ b/ptodsl/tests/test_scf_while_ast.py
@@ -19,24 +19,44 @@ def _while_iter_arg_count(mlir_text: str) -> int:
     return len([part for part in match.group(1).split(",") if part.strip()])
 
 
+def _region_close(text: str, open_brace: int) -> int:
+    """Return the index just past the ``}`` matching the ``{`` at open_brace."""
+    assert text[open_brace] == "{"
+    depth = 0
+    for i in range(open_brace, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+    raise AssertionError("unbalanced braces in MLIR text")
+
+
 def _assert_tail_guarded(mlir_text: str, tail_op_pattern: str):
     """Lock the break/continue tail-skip contract in the emitted IR.
 
     Statements after a break/continue (or after an if containing one) must be
-    predicated on the merged ``active`` flag: a result-producing ``scf.if``
-    whose condition is the merge result of the preceding break/continue
-    ``scf.if`` (``%X`` or ``%X#0``, never a constant) must open before the
-    tail operation, and the dead constant-true whole-body guard must be gone.
+    predicated on the merged ``active`` flag: the tail operation must appear
+    *inside the region* of a result-producing ``scf.if`` whose condition is a
+    real SSA value (``%X`` or ``%X#0``, never a constant true/false).  Region
+    containment is checked by brace depth, not mere text order, so a guard
+    that opens and closes before the tail cannot satisfy this contract.  The
+    dead constant-true whole-body guard must be gone.
     """
     assert not re.search(r"scf\.if %true", mlir_text), (
         "constant-true guard still present; break/continue tails are unpredicated")
-    guards = [m for m in re.finditer(r"= scf\.if %\w+(?:#\d+)? -> \(", mlir_text)]
-    assert guards, "no active-guarded tail region found"
     tail = re.search(tail_op_pattern, mlir_text)
     assert tail is not None, f"tail op {tail_op_pattern!r} not found in MLIR"
-    assert tail.start() > guards[-1].end(), (
-        "tail op appears before the active guard; statements after "
-        "break/continue would execute unconditionally")
+    guards = list(re.finditer(r"= scf\.if %(?!true|false)\w+(?:#\d+)? -> \(", mlir_text))
+    assert guards, "no active-guarded tail region found"
+    for guard in guards:
+        open_brace = mlir_text.index("{", guard.end())
+        if guard.start() < tail.start() < _region_close(mlir_text, open_brace):
+            return
+    raise AssertionError(
+        "tail op is not contained in any active-guarded scf.if region; "
+        "statements after break/continue would execute unconditionally")
 
 
 @pto.jit(target="a5")
@@ -277,9 +297,9 @@ def while_nested_if_break_tail(limit: pto.i32):
 
 @pto.jit(target="a5")
 def while_unconditional_break_dead_tail(limit: pto.i32):
-    # The tail of an unconditional break is statically dead; it is guarded
-    # uniformly (constant-false active) instead of being diagnosed, matching
-    # Python's tolerance for unreachable code.
+    # The tail of an unconditional break is statically dead; it is dropped
+    # before analysis instead of being carried, traced, or diagnosed,
+    # matching Python's tolerance for unreachable code.
     value = pto.const(0, dtype=pto.i32)
     while value < limit:
         value = value + pto.const(1, dtype=pto.i32)
@@ -296,6 +316,46 @@ def for_break_tail_guard(limit: pto.i32):
         if i == pto.const(3, dtype=pto.i32):
             break
         value = value + pto.const(1, dtype=pto.i32)
+    _ = value
+
+
+@pto.jit(target="a5")
+def while_break_dead_unbound_tail(limit: pto.i32):
+    # The dead tail references a name Python would never bind.  It must be
+    # dropped before analysis instead of entering the carry state — before
+    # the truncation fix this surfaced as UnboundLocalError at the
+    # pto._while(...) setup.
+    value = pto.const(0, dtype=pto.i32)
+    while value < limit:
+        value = value + pto.const(1, dtype=pto.i32)
+        break
+        dead = dead + pto.const(1, dtype=pto.i32)
+    _ = value
+
+
+@pto.jit(target="a5")
+def while_if_break_dead_branch_tail(limit: pto.i32):
+    # Truncation also applies inside branch bodies: the dead store after the
+    # break must not be carried or traced.
+    value = pto.const(0, dtype=pto.i32)
+    while value < limit:
+        if value == pto.const(2, dtype=pto.i32):
+            break
+            dead = dead + pto.const(1, dtype=pto.i32)
+        value = value + pto.const(1, dtype=pto.i32)
+    _ = value
+
+
+@pto.jit(target="a5")
+def while_break_dead_slot_tail(limit: pto.i32):
+    # A dead static-subscript store after break is dropped with the tail, so
+    # it no longer trips the "static subscript carries" diagnostic.
+    values = [0]
+    value = pto.const(0, dtype=pto.i32)
+    while value < limit:
+        value = value + pto.const(1, dtype=pto.i32)
+        break
+        values[0] = value
     _ = value
 
 
@@ -371,28 +431,32 @@ def main():
         "outer guard must merge value + active + did_break so the nested "
         "break survives the guard region")
 
-    # Nested branch tail: the +1 addi inside the branch must also be guarded.
+    # Nested branch tail: the +1 addi inside the branch must also sit inside
+    # an active-guarded region (verified by brace-depth containment).
     nested_text = while_nested_if_break_tail.compile().mlir_text()
-    inner_addi = re.search(r"arith\.addi %[\w#]+, %c1_i32", nested_text)
-    assert inner_addi is not None
-    assert [m for m in re.finditer(r"= scf\.if %\w+(?:#\d+)? -> \(", nested_text)
-            if m.end() < inner_addi.start()], (
-        "branch-level tail after a nested break is not predicated")
+    _assert_tail_guarded(nested_text, r"arith\.addi %[\w#]+, %c1_i32")
 
-    # The dead tail of an unconditional break is guarded by constant false.
+    # The dead tail of an unconditional break is truncated before analysis:
+    # the dead addi must not appear in the IR at all (neither executed nor
+    # wrapped in a constant-false guard).
     dead_text = while_unconditional_break_dead_tail.compile().mlir_text()
-    dead_guard = re.search(r"= scf\.if %false(?:_\d+)? -> \(", dead_text)
-    assert dead_guard is not None, "unconditional-break tail must be guarded by constant false"
-    dead_addi = re.search(r"arith\.addi %[\w#]+, %c10_i32", dead_text)
-    assert dead_addi is not None and dead_addi.start() > dead_guard.end()
+    assert not re.search(r"arith\.addi %[\w#]+, %c10_i32", dead_text), (
+        "dead tail after unconditional break must be dropped, not emitted")
+    assert not re.search(r"scf\.if %false", dead_text), (
+        "dead tail after unconditional break must be dropped, not false-guarded")
 
     # The new kernels also lock their carry counts (value + control flags;
-    # the for-loop additionally carries its induction variable).
+    # the for-loop additionally carries its induction variable).  The dead-*
+    # kernels prove truncation keeps dead names out of the carry state: they
+    # compile at all only because the dead tail is dropped before analysis.
     tail_carry_contract = {
         while_continue_skips_tail: 3,
         while_continue_then_break_flags: 3,
         while_nested_if_break_tail: 3,
         while_unconditional_break_dead_tail: 3,
+        while_break_dead_unbound_tail: 3,
+        while_if_break_dead_branch_tail: 3,
+        while_break_dead_slot_tail: 3,
         for_break_tail_guard: 4,  # iv + value + control flags
     }
     for fn, expected_carries in tail_carry_contract.items():
@@ -400,6 +464,23 @@ def main():
         actual = _while_iter_arg_count(loop_text)
         assert actual == expected_carries, (
             f"{fn.__name__}: expected {expected_carries} loop-carried slots, got {actual}")
+
+    # Truncating the dead tail must not weaken the store-less-body diagnostic:
+    # a controlled while whose only real statement is the transfer still has
+    # nothing to carry the control state in.
+    def while_break_first_dead_store(limit: pto.i32):
+        value = pto.const(0, dtype=pto.i32)
+        while value < limit:
+            break
+            value = value + pto.const(1, dtype=pto.i32)
+        _ = value
+
+    try:
+        pto.jit(target="a5")(while_break_first_dead_store).compile()
+    except Exception as exc:
+        assert "control-state lowering" in str(exc)
+    else:
+        raise AssertionError("store-less controlled while must be diagnosed")
 
     def unsupported_break(limit: pto.i32):
         value = pto.const(0, dtype=pto.i32)

--- a/test/dsl-st/while_break_tail.py
+++ b/test/dsl-st/while_break_tail.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Numeric ST for break/continue tail predication (issue #1256 follow-up).
+
+Statements after a break/continue must be skipped for the rest of the
+iteration.  Before the fix the whole loop body ran under a constant-true
+guard, so the tail executed unconditionally in the stopping iteration:
+
+- case 0 (while True + if/break + tail): limit=3 must yield 3, not 4.
+- case 1 (while + continue + tail): the +10 after continue must be skipped,
+  giving 20, not 30.
+- case 2 (for + break + tail): limit=3 must yield 3, not 4.
+"""
+
+import numpy as np
+
+from common import auto_main, golden_output_case
+from ptodsl import pto, scalar
+
+
+@pto.simt
+def while_break_tail_body(output_ptr: pto.ptr(pto.i32, "gm")) -> None:
+    limit = pto.const(3, dtype=pto.i32)
+
+    value = pto.const(0, dtype=pto.i32)
+    while True:
+        should_break = value >= limit
+        if should_break:
+            break
+        value = value + pto.const(1, dtype=pto.i32)
+    scalar.store(value, output_ptr, 0)
+
+    i = pto.const(0, dtype=pto.i32)
+    total = pto.const(0, dtype=pto.i32)
+    while i < limit:
+        i = i + pto.const(1, dtype=pto.i32)
+        if i == pto.const(2, dtype=pto.i32):
+            continue
+        total = total + pto.const(10, dtype=pto.i32)
+    scalar.store(total, output_ptr, 1)
+
+    fval = pto.const(0, dtype=pto.i32)
+    ten = pto.const(10, dtype=pto.i32)
+    for j in range(ten):
+        if j == limit:
+            break
+        fval = fval + pto.const(1, dtype=pto.i32)
+    scalar.store(fval, output_ptr, 2)
+
+
+@pto.jit(
+    name="while_break_tail_numeric",
+    kernel_kind="vector",
+    target="a5",
+    mode="explicit",
+    insert_sync=False,
+)
+def while_break_tail_numeric(
+    output_ptr: pto.ptr(pto.i32, "gm"),
+) -> None:
+    while_break_tail_body[1, 1, 1](output_ptr)
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+
+CASES = [
+    golden_output_case(
+        "while_break_tail_numeric",
+        while_break_tail_numeric,
+        inputs=lambda: [],
+        expected=np.array([3, 20, 3], dtype=np.int32),
+        output_shape=(3,),
+        output_dtype=np.int32,
+    )
+]
+
+
+if __name__ == "__main__":
+    auto_main(globals())


### PR DESCRIPTION
## 问题

Issue #1256 的后续问题([评论](https://github.com/hw-native-sys/PTOAS/issues/1256#issuecomment-5313323524)):受控 while/for 的 lowering 把整个循环体包在单个 `pto.if_(active)` 守卫里,但 prologue 在守卫前把 `active` 重置为常量 true,守卫恒真形同虚设。break/continue 只能通过 `did_break` 在下一次条件求值时生效——**当次迭代中位于其后的语句无条件执行**:

```python
while True:
    should_break = value >= limit
    if should_break:
        break
    value = value + pto.const(1, dtype=pto.i32)   # break 当轮仍会执行
```

`limit=3` 时期望 `value=3`,实际得到 `4`;continue 同样不跳过尾部语句;`_rewrite_controlled_for` 是同构 bug。

## 修复

- 在 `rewrite_block` / `_rewrite_loop_body` 共用的逆序块改写层做分段:遇到可能终止当轮迭代的语句(顶层 break/continue,或分支含 break/continue 的动态 if,用 `_loop_control_flags` 判断)时,把已改写的尾部用 `_guard_block(active, tail)` 包裹,条件为**合并后的** active 值。嵌套分支体从 `_loop_control_stack` 栈顶自动取得当前循环的 control,无需参数透传。
- 尾部若含进一步的控制转移,守卫必须同时 merge `active`/`did_break`——它们不是 `ast.Assign` store,否则 break 会丢失或其 SSA 值泄漏出守卫区(dominance 违例)。
- 无条件 break/continue 的尾部是静态死代码,统一走守卫(恒假条件),不诊断,与 Python 对不可达代码的容忍一致。
- 删除两处恒真的整体守卫(`_rewrite_while` / `_rewrite_controlled_for`);保留每轮入口的 `active = true` 重置(continue 后重新启用)。

## 测试

- `test_scf_while_ast.py`:新增 `_assert_tail_guarded` 结构化断言(尾部 op 必须位于以合并后 active 为条件的 scf.if 内,常量 true 死守卫必须消失)、continue-then-break 守卫必须 merge `(i1, i1, i32)`、无条件 break 死尾部恒假守卫;5 个新 kernel 同时锁定 carry 计数。
- `test/dsl-st/while_break_tail.py`:新增数值 ST(break 尾部 / continue 尾部 / for+break 尾部 → 期望 `[3, 20, 3]`)。

## 验证

- **A5 硬件数值**:本 PR 代码 `[3, 20, 3]` PASS;对照组(`_ast_rewrite.py` 回退到 #1264 合并点)同一用例输出 `[4, 30, 4]`,精确复现 issue 评论报告的错误,证明用例有判别力。

Fixes #1256
Fixes #1259