### PR TITLE
ci: add nightly A5 board validation

### DIFF
--- a/.github/scripts/report_a5_board_results.py
+++ b/.github/scripts/report_a5_board_results.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class BoardSummary:
+    results_found: bool
+    counts: Counter[str]
+    failed_cases: tuple[str, ...]
+
+    @property
+    def total(self) -> int:
+        return sum(self.counts.values())
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.results_found
+            and self.total > 0
+            and self.counts.get("FAIL", 0) == 0
+            and set(self.counts).issubset({"OK", "SKIP"})
+        )
+
+
+def load_results(path: Path) -> BoardSummary:
+    if not path.is_file():
+        return BoardSummary(False, Counter(), ())
+
+    counts: Counter[str] = Counter()
+    failed_cases: list[str] = []
+    with path.open(encoding="utf-8", errors="replace", newline="") as stream:
+        reader = csv.DictReader(stream, delimiter="\t")
+        for row in reader:
+            status = (row.get("status") or "UNKNOWN").strip() or "UNKNOWN"
+            testcase = (row.get("testcase") or "<unknown>").strip() or "<unknown>"
+            counts[status] += 1
+            if status == "FAIL":
+                failed_cases.append(testcase)
+    return BoardSummary(True, counts, tuple(failed_cases))
+
+
+def render_markdown(
+    summary: BoardSummary,
+    *,
+    conclusion: str,
+    run_url: str,
+    sha: str,
+) -> str:
+    succeeded = conclusion == "success" and summary.passed
+    lines = [
+        "## A5 nightly board validation",
+        "",
+        f"- Status: **{'PASS' if succeeded else 'FAIL'}**",
+        f"- Commit: `{sha[:12] or 'unknown'}`",
+        f"- Results: OK `{summary.counts.get('OK', 0)}` / "
+        f"FAIL `{summary.counts.get('FAIL', 0)}` / "
+        f"SKIP `{summary.counts.get('SKIP', 0)}` / TOTAL `{summary.total}`",
+    ]
+    if run_url:
+        lines.append(f"- Run: {run_url}")
+    if not summary.results_found:
+        lines.extend(["", "No board result TSV was produced. Inspect the workflow log."])
+    elif summary.failed_cases:
+        lines.extend(["", "### Failed cases", ""])
+        lines.extend(f"- `{case}`" for case in summary.failed_cases[:50])
+        if len(summary.failed_cases) > 50:
+            lines.append(f"- ... and {len(summary.failed_cases) - 50} more")
+    return "\n".join(lines) + "\n"
+
+
+def build_feishu_payload(
+    summary: BoardSummary,
+    *,
+    conclusion: str,
+    run_url: str,
+    sha: str,
+) -> dict[str, object]:
+    succeeded = conclusion == "success" and summary.passed
+    status = "PASS" if succeeded else "FAIL"
+    detail_lines = [
+        f"**Status**: {status}",
+        f"**Commit**: `{sha[:12] or 'unknown'}`",
+        f"**Results**: OK `{summary.counts.get('OK', 0)}` / "
+        f"FAIL `{summary.counts.get('FAIL', 0)}` / "
+        f"SKIP `{summary.counts.get('SKIP', 0)}` / TOTAL `{summary.total}`",
+    ]
+    if not summary.results_found:
+        detail_lines.append("**Error**: result TSV was not produced")
+    elif summary.failed_cases:
+        failed = ", ".join(summary.failed_cases[:20])
+        if len(summary.failed_cases) > 20:
+            failed += f", ... (+{len(summary.failed_cases) - 20})"
+        detail_lines.append(f"**Failed cases**: {failed}")
+
+    elements: list[dict[str, object]] = [
+        {
+            "tag": "div",
+            "text": {"tag": "lark_md", "content": "\n".join(detail_lines)},
+        }
+    ]
+    if run_url:
+        elements.append(
+            {
+                "tag": "action",
+                "actions": [
+                    {
+                        "tag": "button",
+                        "text": {"tag": "plain_text", "content": "Open GitHub run"},
+                        "url": run_url,
+                        "type": "primary",
+                    }
+                ],
+            }
+        )
+    return {
+        "msg_type": "interactive",
+        "card": {
+            "header": {
+                "template": "green" if succeeded else "red",
+                "title": {
+                    "tag": "plain_text",
+                    "content": f"PTOAS A5 nightly board validation: {status}",
+                },
+            },
+            "elements": elements,
+        },
+    }
+
+
+def append_file(path_text: str, content: str) -> None:
+    if not path_text:
+        return
+    with Path(path_text).open("a", encoding="utf-8") as stream:
+        stream.write(content)
+
+
+def send_feishu(webhook_url: str, payload: dict[str, object]) -> None:
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    request = urllib.request.Request(
+        webhook_url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=20) as response:
+        response.read()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Summarize an A5 board result TSV and optionally notify Feishu."
+    )
+    parser.add_argument("--results", type=Path, required=True)
+    parser.add_argument("--conclusion", default="failure")
+    parser.add_argument("--run-url", default="")
+    parser.add_argument("--sha", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    summary = load_results(args.results)
+    markdown = render_markdown(
+        summary,
+        conclusion=args.conclusion,
+        run_url=args.run_url,
+        sha=args.sha,
+    )
+    print(markdown, end="")
+    append_file(os.environ.get("GITHUB_STEP_SUMMARY", ""), markdown)
+    append_file(
+        os.environ.get("GITHUB_OUTPUT", ""),
+        "\n".join(
+            [
+                f"ok={summary.counts.get('OK', 0)}",
+                f"fail={summary.counts.get('FAIL', 0)}",
+                f"skip={summary.counts.get('SKIP', 0)}",
+                f"total={summary.total}",
+            ]
+        )
+        + "\n",
+    )
+
+    webhook_url = os.environ.get("A5_FEISHU_WEBHOOK_URL", "").strip()
+    if webhook_url:
+        payload = build_feishu_payload(
+            summary,
+            conclusion=args.conclusion,
+            run_url=args.run_url,
+            sha=args.sha,
+        )
+        try:
+            send_feishu(webhook_url, payload)
+        except (OSError, urllib.error.URLError) as exc:
+            print(
+                "WARNING: failed to send Feishu notification "
+                f"({type(exc).__name__})",
+                file=sys.stderr,
+            )
+    return 0 if args.conclusion == "success" and summary.passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/report_a5_board_results_test.py
+++ b/.github/scripts/report_a5_board_results_test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import importlib.util
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).with_name("report_a5_board_results.py")
+SPEC = importlib.util.spec_from_file_location("report_a5_board_results", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+REPORT = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = REPORT
+SPEC.loader.exec_module(REPORT)
+
+
+class BoardResultReportTest(unittest.TestCase):
+    def test_load_and_render_results(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="a5-board-report-") as temp_dir:
+            results = pathlib.Path(temp_dir) / "results.tsv"
+            results.write_text(
+                "testcase\tstatus\tstage\tinfo\n"
+                "Abs/abs\tOK\trun\tvalidation=independent-golden\n"
+                "Add/add\tFAIL\trun\texit=1\n"
+                "Print/print\tSKIP\trun\tin SKIP_CASES\n",
+                encoding="utf-8",
+            )
+
+            summary = REPORT.load_results(results)
+            self.assertTrue(summary.results_found)
+            self.assertEqual(summary.total, 3)
+            self.assertEqual(summary.counts["OK"], 1)
+            self.assertEqual(summary.counts["FAIL"], 1)
+            self.assertEqual(summary.failed_cases, ("Add/add",))
+
+            markdown = REPORT.render_markdown(
+                summary,
+                conclusion="failure",
+                run_url="https://github.example/actions/runs/1",
+                sha="0123456789abcdef",
+            )
+            self.assertIn("Status: **FAIL**", markdown)
+            self.assertIn("`Add/add`", markdown)
+            self.assertIn("`0123456789ab`", markdown)
+
+    def test_missing_results_are_reported_as_failure(self) -> None:
+        summary = REPORT.load_results(pathlib.Path("/path/that/does/not/exist"))
+        self.assertFalse(summary.results_found)
+        self.assertFalse(summary.passed)
+        payload = REPORT.build_feishu_payload(
+            summary,
+            conclusion="failure",
+            run_url="",
+            sha="",
+        )
+        self.assertEqual(payload["card"]["header"]["template"], "red")
+
+    def test_successful_results_are_reported_as_pass(self) -> None:
+        summary = REPORT.BoardSummary(
+            True,
+            REPORT.Counter({"OK": 2, "SKIP": 1}),
+            (),
+        )
+        self.assertTrue(summary.passed)
+        payload = REPORT.build_feishu_payload(
+            summary,
+            conclusion="success",
+            run_url="https://github.example/actions/runs/2",
+            sha="abcdef0123456789",
+        )
+        self.assertEqual(payload["card"]["header"]["template"], "green")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci_a5.yml
+++ b/.github/workflows/ci_a5.yml
@@ -270,7 +270,8 @@ jobs:
           export PYTHONPATH="${PTO_INSTALL_DIR}:${MLIR_PYTHON_ROOT}:${PYTHONPATH:-}"
           export LD_LIBRARY_PATH="${LLVM_BUILD_DIR}/lib:${PTO_INSTALL_DIR}/lib:${LD_LIBRARY_PATH:-}"
 
-          bash test/samples/runop.sh --enablebc all 2>&1 | tee "${SAMPLE_BUILD_LOG}"
+          PTOAS_SKIP_CASES="${A3_ONLY_CASES}" \
+            bash test/samples/runop.sh --enablebc all 2>&1 | tee "${SAMPLE_BUILD_LOG}"
           cp test/npu_validation/scripts/generate_testcase.py \
             "${PAYLOAD_DIR}/test/npu_validation/scripts/"
           cp test/npu_validation/scripts/run_remote_npu_validation.sh \
@@ -360,7 +361,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          report_python="${BOARD_PYTHON:-python3}"
+          if [[ -n "${BOARD_PYTHON:-}" && -x "${BOARD_PYTHON}" ]]; then
+            report_python="${BOARD_PYTHON}"
+          elif report_python="$(command -v python3 2>/dev/null)" && [[ -x "${report_python}" ]]; then
+            echo "BOARD_PYTHON is unavailable; using ${report_python} for failure reporting"
+          else
+            echo "ERROR: no executable Python is available for failure reporting" >&2
+            exit 1
+          fi
           results_tsv="${RESULTS_TSV:-${RUNNER_TEMP}/a5-board-results-missing.tsv}"
           "${report_python}" .github/scripts/report_a5_board_results.py \
             --results "${results_tsv}" \

--- a/.github/workflows/ci_a5.yml
+++ b/.github/workflows/ci_a5.yml
@@ -1,0 +1,404 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+name: A5 Nightly Board
+
+on:
+  # GitHub cron is UTC. 19:00 UTC is 03:00 the next day in Beijing (UTC+8).
+  schedule:
+    - cron: "0 19 * * *"
+  workflow_dispatch:
+    inputs:
+      device_id:
+        description: "A5 device requested from task-submit"
+        type: string
+        default: "1"
+      skip_cases:
+        description: "Comma/space separated testcase names to skip"
+        type: string
+        default: "mix_kernel,vadd_validshape,vadd_validshape_dynamic,print,storefp"
+      run_only_cases:
+        description: "Comma/space separated testcase names to run (empty = all A5 cases)"
+        type: string
+        default: ""
+      ptoas_extra_flags:
+        description: "Additional ptoas flags used while generating the payload"
+        type: string
+        default: ""
+      pto_isa_repo:
+        description: "pto-isa repository URL"
+        type: string
+        default: https://gitcode.com/cann/pto-isa.git
+      pto_isa_commit:
+        description: "pto-isa ref (empty = repository CI pin)"
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: a5-nightly-board
+  cancel-in-progress: false
+
+jobs:
+  board-validation:
+    if: github.repository == 'hw-native-sys/PTOAS'
+    runs-on: [self-hosted, Linux, ARM64, ptoas-a5]
+    timeout-minutes: 480
+    env:
+      SOC_VERSION: Ascend950
+      RUN_MODE: npu
+      GOLDEN_MODE: npu
+      DEFAULT_SKIP_CASES: mix_kernel,vadd_validshape,vadd_validshape_dynamic,print,storefp
+      A3_ONLY_CASES: partition5d,partition5d_dynamic,mrgsort,tmatmulk_autosync,movfp_fixpipe_reuse_a3
+      LLVM_BUILD_DIR: ${{ vars.PTOAS_A5_LLVM_BUILD_DIR || '/home/ptoas-board-monitor-a5/llvm-project-vpto-feature/build-shared' }}
+      BOARD_PYTHON: ${{ vars.PTOAS_A5_PYTHON || '/home/anaconda3/bin/python3' }}
+      PTOAS_BUILD_JOBS: ${{ vars.PTOAS_A5_BUILD_JOBS || '4' }}
+      INPUT_DEVICE_ID: ${{ inputs.device_id || vars.PTOAS_A5_DEVICE_ID || '1' }}
+      INPUT_SKIP_CASES: ${{ inputs.skip_cases || '' }}
+      RUN_ONLY_CASES: ${{ inputs.run_only_cases || '' }}
+      PTOAS_EXTRA_FLAGS: ${{ inputs.ptoas_extra_flags || '' }}
+      PTO_ISA_REPO: ${{ inputs.pto_isa_repo || 'https://gitcode.com/cann/pto-isa.git' }}
+      INPUT_PTO_ISA_COMMIT: ${{ inputs.pto_isa_commit || '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve validation parameters
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${INPUT_PTO_ISA_COMMIT}" ]]; then
+            pto_isa_commit="${INPUT_PTO_ISA_COMMIT}"
+          else
+            pto_isa_commit="$("${BOARD_PYTHON}" - <<'PY'
+          import pathlib
+          import re
+
+          text = pathlib.Path(
+              "test/npu_validation/scripts/run_remote_npu_validation.sh"
+          ).read_text(encoding="utf-8")
+          match = re.search(
+              r'^PTO_ISA_COMMIT="\$\{PTO_ISA_COMMIT:-([0-9a-f]{40})\}"$',
+              text,
+              re.MULTILINE,
+          )
+          if match is None:
+              raise SystemExit("failed to resolve the repository pto-isa pin")
+          print(match.group(1))
+          PY
+            )"
+          fi
+
+          skip_cases="${INPUT_SKIP_CASES:-${DEFAULT_SKIP_CASES}}"
+          skip_cases="${skip_cases:+${skip_cases},}${A3_ONLY_CASES}"
+          ptoas_flags="--pto-arch a5 --enable-insert-sync"
+          if [[ -n "${PTOAS_EXTRA_FLAGS}" ]]; then
+            ptoas_flags+=" ${PTOAS_EXTRA_FLAGS}"
+          fi
+
+          {
+            echo "DEVICE_ID=${INPUT_DEVICE_ID}"
+            echo "SKIP_CASES=${skip_cases}"
+            echo "PTOAS_FLAGS=${ptoas_flags}"
+            echo "PTO_ISA_COMMIT=${pto_isa_commit}"
+          } >> "${GITHUB_ENV}"
+
+          echo "SOC_VERSION=${SOC_VERSION}"
+          echo "DEVICE_ID=${INPUT_DEVICE_ID}"
+          echo "SKIP_CASES=${skip_cases}"
+          echo "RUN_ONLY_CASES=${RUN_ONLY_CASES:-<all>}"
+          echo "PTOAS_FLAGS=${ptoas_flags}"
+          echo "PTO_ISA_REPO=${PTO_ISA_REPO}"
+          echo "PTO_ISA_COMMIT=${pto_isa_commit}"
+
+      - name: Check A5 runner environment
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          [[ "$(uname -m)" == "aarch64" ]] || {
+            echo "ERROR: A5 runner must be aarch64" >&2
+            exit 1
+          }
+          for command in cmake git ninja task-submit; do
+            command -v "${command}" >/dev/null || {
+              echo "ERROR: required command is missing: ${command}" >&2
+              exit 1
+            }
+          done
+          [[ -x "${BOARD_PYTHON}" ]] || {
+            echo "ERROR: BOARD_PYTHON is not executable: ${BOARD_PYTHON}" >&2
+            exit 1
+          }
+          for path in \
+            "${LLVM_BUILD_DIR}/bin/llvm-config" \
+            "${LLVM_BUILD_DIR}/lib/cmake/llvm/LLVMConfig.cmake" \
+            "${LLVM_BUILD_DIR}/lib/cmake/mlir/MLIRConfig.cmake"; do
+            [[ -e "${path}" ]] || {
+              echo "ERROR: prebuilt LLVM is missing: ${path}" >&2
+              exit 1
+            }
+          done
+
+          mlir_python_root="${LLVM_BUILD_DIR}/tools/mlir/python_packages/mlir_core"
+          PYTHONPATH="${mlir_python_root}:${PYTHONPATH:-}" \
+          LD_LIBRARY_PATH="${LLVM_BUILD_DIR}/lib:${LD_LIBRARY_PATH:-}" \
+            "${BOARD_PYTHON}" - <<'PY'
+          import numpy
+          import pybind11
+          from mlir.ir import Context
+
+          Context()
+          print("numpy", numpy.__version__)
+          print("pybind11", pybind11.__version__)
+          print("mlir_python_ok")
+          PY
+
+      - name: Prepare isolated work directories
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "${RUNNER_TEMP:-}" ]] || {
+            echo "ERROR: RUNNER_TEMP is empty" >&2
+            exit 1
+          }
+          work_root="${RUNNER_TEMP}/ptoas-a5-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          case "${work_root}" in
+            "${RUNNER_TEMP}"/ptoas-a5-*) ;;
+            *) echo "ERROR: unsafe work root: ${work_root}" >&2; exit 1 ;;
+          esac
+          rm -rf -- "${work_root}"
+          mkdir -p \
+            "${work_root}/payload/test/samples" \
+            "${work_root}/payload/test/npu_validation/scripts" \
+            "${work_root}/payload/test/npu_validation/templates"
+
+          {
+            echo "WORK_ROOT=${work_root}"
+            echo "PTO_BUILD_DIR=${work_root}/build"
+            echo "PTO_INSTALL_DIR=${work_root}/install"
+            echo "PAYLOAD_DIR=${work_root}/payload"
+            echo "PTO_ISA_SOURCE_DIR=${work_root}/pto-isa-source"
+            echo "OUTPUT_ROOT=${work_root}/npu-validation"
+            echo "RESULTS_TSV=${work_root}/remote_npu_validation_results.tsv"
+            echo "SAMPLE_BUILD_LOG=${work_root}/sample-build.log"
+            echo "BOARD_LOG=${work_root}/board-validation.log"
+            echo "MLIR_PYTHON_ROOT=${LLVM_BUILD_DIR}/tools/mlir/python_packages/mlir_core"
+          } >> "${GITHUB_ENV}"
+
+      - name: Configure ccache
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v ccache >/dev/null 2>&1; then
+            echo "ccache is unavailable; continuing without a compiler cache"
+            exit 0
+          fi
+          cache_root="${RUNNER_TOOL_CACHE:-${RUNNER_TEMP}}/ptoas-a5-ccache"
+          mkdir -p "${cache_root}"
+          {
+            echo "CCACHE_DIR=${cache_root}"
+            echo "CCACHE_BASEDIR=${GITHUB_WORKSPACE}"
+            echo "CCACHE_COMPILERCHECK=content"
+            echo "CCACHE_NOHASHDIR=true"
+            echo "CMAKE_C_COMPILER_LAUNCHER=ccache"
+            echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache"
+          } >> "${GITHUB_ENV}"
+          CCACHE_DIR="${cache_root}" ccache --max-size=2G
+          CCACHE_DIR="${cache_root}" ccache --zero-stats
+
+      - name: Build and install PTOAS
+        shell: bash
+        run: |
+          set -euo pipefail
+          python_dir="$(dirname "${BOARD_PYTHON}")"
+          export PATH="${python_dir}:${PATH}"
+          export PYTHONPATH="${MLIR_PYTHON_ROOT}:${PYTHONPATH:-}"
+          export LD_LIBRARY_PATH="${LLVM_BUILD_DIR}/lib:${LD_LIBRARY_PATH:-}"
+
+          cmake_args=(
+            -G Ninja
+            -S "${GITHUB_WORKSPACE}"
+            -B "${PTO_BUILD_DIR}"
+            -DLLVM_DIR="${LLVM_BUILD_DIR}/lib/cmake/llvm"
+            -DMLIR_DIR="${LLVM_BUILD_DIR}/lib/cmake/mlir"
+            -DPython3_EXECUTABLE="${BOARD_PYTHON}"
+            -DPython3_FIND_STRATEGY=LOCATION
+            -DPython_EXECUTABLE="${BOARD_PYTHON}"
+            -DPython_FIND_STRATEGY=LOCATION
+            -Dpybind11_DIR="$(${BOARD_PYTHON} -m pybind11 --cmakedir)"
+            -DMLIR_ENABLE_BINDINGS_PYTHON=ON
+            -DMLIR_PYTHON_PACKAGE_DIR="${PTO_INSTALL_DIR}"
+            -DCMAKE_INSTALL_PREFIX="${PTO_INSTALL_DIR}"
+            -DCMAKE_BUILD_TYPE=Release
+          )
+          if command -v ccache >/dev/null 2>&1; then
+            cmake_args+=(
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            )
+          fi
+          cmake "${cmake_args[@]}"
+          cmake --build "${PTO_BUILD_DIR}" \
+            --target install --parallel "${PTOAS_BUILD_JOBS}"
+          test -x "${PTO_BUILD_DIR}/tools/ptoas/ptoas"
+          test -x "${PTO_BUILD_DIR}/tools/ptobc/ptobc"
+
+      - name: Generate A5 board payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          python_dir="$(dirname "${BOARD_PYTHON}")"
+          export PATH="${python_dir}:${PATH}"
+          export PTOAS_BIN="${PTO_BUILD_DIR}/tools/ptoas/ptoas"
+          export PTOBC_BIN="${PTO_BUILD_DIR}/tools/ptobc/ptobc"
+          export PYTHON_BIN="${BOARD_PYTHON}"
+          export PTO_PYTHON_ROOT="${PTO_INSTALL_DIR}/"
+          export PTOAS_OUT_DIR="${PAYLOAD_DIR}/test/samples"
+          export PYTHONPATH="${PTO_INSTALL_DIR}:${MLIR_PYTHON_ROOT}:${PYTHONPATH:-}"
+          export LD_LIBRARY_PATH="${LLVM_BUILD_DIR}/lib:${PTO_INSTALL_DIR}/lib:${LD_LIBRARY_PATH:-}"
+
+          bash test/samples/runop.sh --enablebc all 2>&1 | tee "${SAMPLE_BUILD_LOG}"
+          cp test/npu_validation/scripts/generate_testcase.py \
+            "${PAYLOAD_DIR}/test/npu_validation/scripts/"
+          cp test/npu_validation/scripts/run_remote_npu_validation.sh \
+            "${PAYLOAD_DIR}/test/npu_validation/scripts/"
+          cp test/npu_validation/templates/* \
+            "${PAYLOAD_DIR}/test/npu_validation/templates/"
+          chmod +x "${PAYLOAD_DIR}/test/npu_validation/scripts/run_remote_npu_validation.sh"
+
+      - name: Vendor pinned pto-isa
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone "${PTO_ISA_REPO}" "${PTO_ISA_SOURCE_DIR}"
+          git -C "${PTO_ISA_SOURCE_DIR}" checkout -f "${PTO_ISA_COMMIT}"
+          mkdir -p "${PAYLOAD_DIR}/pto-isa"
+          cp -a "${PTO_ISA_SOURCE_DIR}/." "${PAYLOAD_DIR}/pto-isa/"
+          rm -rf -- "${PAYLOAD_DIR}/pto-isa/.git"
+          echo "Vendored pto-isa $(git -C "${PTO_ISA_SOURCE_DIR}" rev-parse HEAD)"
+
+      - name: Run A5 board validation through TaskQueue
+        id: board
+        shell: bash
+        run: |
+          set -euo pipefail
+          env_file="${WORK_ROOT}/board-validation.env"
+          printf '%s\n' \
+            "STAGE=run" \
+            "RUN_MODE=${RUN_MODE}" \
+            "SOC_VERSION=${SOC_VERSION}" \
+            "GOLDEN_MODE=${GOLDEN_MODE}" \
+            "SKIP_CASES=${SKIP_CASES}" \
+            "RUN_ONLY_CASES=${RUN_ONLY_CASES}" \
+            "EXPECTED_CASES_FILTER=${RUN_ONLY_CASES}" \
+            "PTO_ISA_REPO=${PTO_ISA_REPO}" \
+            "PTO_ISA_COMMIT=${PTO_ISA_COMMIT}" \
+            "OUTPUT_ROOT=${OUTPUT_ROOT}" \
+            "RESULTS_TSV=${RESULTS_TSV}" \
+            > "${env_file}"
+
+          # shellcheck disable=SC2016 # TASK_DEVICE expands inside TaskQueue.
+          printf -v board_command \
+            'cd %q && export DEVICE_ID="${TASK_DEVICE:-%s}" && bash ./test/npu_validation/scripts/run_remote_npu_validation.sh' \
+            "${PAYLOAD_DIR}" "${DEVICE_ID}"
+          submit_output="$(task-submit \
+            --device "${DEVICE_ID}" \
+            --max-time 0 \
+            --env-file "${env_file}" \
+            "${board_command}")"
+          printf '%s\n' "${submit_output}" | tee "${BOARD_LOG}"
+          task_id="$(printf '%s\n' "${submit_output}" | awk '/^task_[0-9]{8}_[0-9]{6}_[0-9]+$/ { id=$0 } END { print id }')"
+          [[ -n "${task_id}" ]] || {
+            echo "ERROR: task-submit did not return a task id" | tee -a "${BOARD_LOG}" >&2
+            exit 1
+          }
+
+          # shellcheck disable=SC2329 # Invoked by the signal trap below.
+          cancel_task() {
+            echo "Cancelling TaskQueue task ${task_id}" | tee -a "${BOARD_LOG}"
+            task-submit --kill "${task_id}" >/dev/null 2>&1 || true
+          }
+          trap cancel_task INT TERM
+
+          set +e
+          task-submit --timeout 0 --wait "${task_id}" 2>&1 | tee -a "${BOARD_LOG}"
+          wait_rc="${PIPESTATUS[0]}"
+          set -e
+          trap - INT TERM
+
+          status_output="$(task-submit --status "${task_id}" 2>&1)"
+          printf '%s\n' "${status_output}" | tee -a "${BOARD_LOG}"
+          if [[ "${status_output}" =~ exit=([0-9]+) ]]; then
+            task_rc="${BASH_REMATCH[1]}"
+          else
+            echo "ERROR: TaskQueue status has no exit code (wait rc=${wait_rc})" | tee -a "${BOARD_LOG}" >&2
+            exit 1
+          fi
+          if [[ "${wait_rc}" -ne "${task_rc}" ]]; then
+            echo "WARNING: task wait rc=${wait_rc}, recorded task rc=${task_rc}" | tee -a "${BOARD_LOG}" >&2
+          fi
+          exit "${task_rc}"
+
+      - name: Publish board summary and notify Feishu
+        if: always()
+        env:
+          A5_FEISHU_WEBHOOK_URL: ${{ secrets.A5_FEISHU_WEBHOOK_URL }}
+          BOARD_CONCLUSION: ${{ steps.board.outcome || 'failure' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          report_python="${BOARD_PYTHON:-python3}"
+          results_tsv="${RESULTS_TSV:-${RUNNER_TEMP}/a5-board-results-missing.tsv}"
+          "${report_python}" .github/scripts/report_a5_board_results.py \
+            --results "${results_tsv}" \
+            --conclusion "${BOARD_CONCLUSION}" \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --sha "${GITHUB_SHA}"
+
+      - name: Upload A5 board artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a5-nightly-board-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ env.RESULTS_TSV }}
+            ${{ env.SAMPLE_BUILD_LOG }}
+            ${{ env.BOARD_LOG }}
+            ${{ env.PAYLOAD_DIR }}/test/samples/expected_npu_validation_cases.txt
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Show ccache statistics
+        if: always()
+        shell: bash
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            ccache --show-stats || true
+          fi
+
+      - name: Clean isolated work directories
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${WORK_ROOT:-}" || -z "${RUNNER_TEMP:-}" ]]; then
+            echo "Work directory was not initialized; nothing to clean."
+            exit 0
+          fi
+          case "${WORK_ROOT}" in
+            "${RUNNER_TEMP}"/ptoas-a5-*) rm -rf -- "${WORK_ROOT}" ;;
+            *) echo "ERROR: refusing to clean unsafe path: ${WORK_ROOT}" >&2; exit 1 ;;
+          esac

--- a/docs/designs/ci-board-validation-guide.md
+++ b/docs/designs/ci-board-validation-guide.md
@@ -2,11 +2,12 @@
 
 ## 1. 文档目的
 
-本文说明 PTOAS 当前与开发者最相关的 3 条验证链路：
+本文说明 PTOAS 当前与开发者最相关的 4 条验证链路：
 
 1. 本地最小复现：`build -> runop -> 生成 pto/cpp`
 2. GitHub Actions：`Build Wheel` 与 `CI`
-3. PR 评论触发的 A3/A5 手动板测
+3. A5 self-hosted runner 每日板测
+4. PR 评论触发的 A3/A5 手动板测
 
 本文只描述当前仓库已经存在、并且日常开发会直接用到的流程，不展开板测机器人内部实现。
 
@@ -52,7 +53,20 @@
 - `push` / `pull_request`：只跑 GitHub runner 上的构建和样例生成
 - `workflow_dispatch` / `schedule`：除上述步骤外，还会跑远端板测 job `remote-npu-validation`
 
-### 2.3 评论触发板测
+### 2.3 `A5 Nightly Board`
+
+对应 workflow：`.github/workflows/ci_a5.yml`
+
+用途：
+
+- 每天北京时间 `03:00` 在 A5 self-hosted runner 上构建 `main`
+- 生成全量 A5 payload，并通过 `task-submit` 排队执行 NPU 板测
+- 在 GitHub Actions Summary 中展示 `OK / FAIL / SKIP` 汇总并上传结果 artifact
+- 配置 `A5_FEISHU_WEBHOOK_URL` secret 后，同步发送飞书结果卡片
+
+该 workflow 直接在 A5 主机运行，不使用 SSH secret，也不依赖板测监测器的私有脚本。runner 尚未在线时，定时任务会保持排队状态。
+
+### 2.4 评论触发板测
 
 这部分不在本仓库内实现，但当前开发流程依赖它。
 
@@ -252,6 +266,45 @@ gh workflow run ci.yml \
 - `pto_isa_repo` / `pto_isa_commit`：指定板测使用的 `pto-isa`
 - `remote_host` / `remote_user` / `remote_port`：指定远端板机
 
+### 4.4 配置和触发 A5 每日板测
+
+A5 runner 需要注册到 `hw-native-sys/PTOAS`，并具有以下标签：
+
+- `self-hosted`
+- `Linux`
+- `ARM64`
+- `ptoas-a5`
+
+runner 用户需要能够执行 `task-submit`，并能读取预编译 LLVM、CANN 和 Python 环境。建议把 runner service 放入现有 `ptoasboard.slice`，让 runner 侧构建继续受 `35 CPU / 48 GiB` 资源上限约束。`task-submit` 会复用板机任务队列，因此它能和评论板测机器人共享设备而不直接抢卡。
+
+workflow 支持以下 repository variables；未设置时使用 A5 板机当前默认值：
+
+- `PTOAS_A5_LLVM_BUILD_DIR`：预编译 LLVM/MLIR build 目录
+- `PTOAS_A5_PYTHON`：能导入 `numpy`、`pybind11` 和该 LLVM Python binding 的 Python
+- `PTOAS_A5_BUILD_JOBS`：PTOAS 并行编译数，默认 `4`
+- `PTOAS_A5_DEVICE_ID`：传给 `task-submit --device` 的设备号，默认 `1`
+
+飞书通知是可选能力。需要时新增 repository secret `A5_FEISHU_WEBHOOK_URL`；不配置不会影响板测和 GitHub Summary。
+
+手动触发全量 A5 板测：
+
+```bash
+gh workflow run ci_a5.yml \
+  --repo hw-native-sys/PTOAS \
+  --ref main
+```
+
+只跑指定 case：
+
+```bash
+gh workflow run ci_a5.yml \
+  --repo hw-native-sys/PTOAS \
+  --ref main \
+  -f run_only_cases='qwen3_decode_layer_incore_0,qwen3_decode_layer_incore_1'
+```
+
+定时任务固定使用默认分支；GitHub cron 使用 UTC，因此配置为 `0 19 * * *`，对应北京时间次日 `03:00`。同一时间只允许一个 A5 nightly job，新的运行会排队且不会取消正在进行的板测。
+
 ## 5. PR 评论触发板测
 
 ### 5.1 触发前检查
@@ -343,7 +396,7 @@ A5 多 case：
 
 ### 6.3 A3 / A5 分流
 
-如果 case 只适用于某个架构，需要同步更新 `.github/workflows/ci.yml` 中的分流列表：
+如果 case 只适用于某个架构，需要同步更新 `.github/workflows/ci.yml` 和 `.github/workflows/ci_a5.yml` 中的分流列表：
 
 - `A3_ONLY_CASES`
 - `A5_ONLY_CASES`
@@ -385,6 +438,8 @@ A5 多 case：
 
 - `.github/workflows/build_wheel.yml`
 - `.github/workflows/ci.yml`
+- `.github/workflows/ci_a5.yml`
+- `.github/scripts/report_a5_board_results.py`
 - `test/samples/runop.sh`
 - `test/npu_validation/scripts/run_remote_npu_validation.sh`
 - `test/npu_validation/scripts/generate_testcase.py`

--- a/test/lit/npu_validation/runop_generation_skip_cases.test
+++ b/test/lit/npu_validation/runop_generation_skip_cases.test
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# RUN: rm -rf %t
+# RUN: env PTOAS_BIN=/usr/bin/true PYTHON_BIN=/usr/bin/true PTOAS_OUT_DIR=%t/out PTOAS_FLAGS='--pto-arch a5' PTOAS_SKIP_CASES=partition5d,partition5d_dynamic bash %S/../../samples/runop.sh -t Partition5D | FileCheck %s
+
+# CHECK-NOT: FAIL
+# CHECK-DAG: Partition5D(partition5d.py) SKIP listed in PTOAS_SKIP_CASES
+# CHECK-DAG: Partition5D(partition5d_dynamic.py) SKIP listed in PTOAS_SKIP_CASES
+# CHECK-DAG: Partition5D(partition5d_a5.py) OK generated: partition5d_a5-pto.cpp
+# CHECK-DAG: Partition5D(partition5d_dynamic_a5.py) OK generated: partition5d_dynamic_a5-pto.cpp
+# CHECK-NOT: FAIL

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -20,6 +20,8 @@ PTOAS_OUT_DIR="${PTOAS_OUT_DIR:-}"
 PTO_BUILD_DIR="${PTO_BUILD_DIR:-}"
 PTOAS_ENABLE_INSERT_SYNC="${PTOAS_ENABLE_INSERT_SYNC:-1}"
 PTOAS_FLAGS="${PTOAS_FLAGS:-}"
+PTOAS_SKIP_CASES="${PTOAS_SKIP_CASES:-}"
+PTOAS_SKIP_CASES_NORM="$(printf '%s\n' "${PTOAS_SKIP_CASES}" | tr ',[:space:]' '\n' | awk 'NF')"
 MODEL_PTO_DIRS=""
 for model_path in "${BASE_DIR}"/Qwen* "${BASE_DIR}"/Deepseek*; do
   [[ -d "${model_path}" ]] || continue
@@ -50,6 +52,7 @@ Env:
   PTO_BUILD_DIR  # build directory root that contains tools/ptobc (optional)
   PTOAS_FLAGS  # extra flags passed to ptoas (e.g. --enable-insert-sync)
   PTOAS_ENABLE_INSERT_SYNC  # 1 to append --enable-insert-sync to PTOAS_FLAGS (default: 1)
+  PTOAS_SKIP_CASES  # comma/space-separated testcase basenames to skip while generating outputs
   PTO_PTO_DIRS  # space-separated dirs to run .pto directly (default: Sync, every Qwen*/Deepseek* A3/A5 model dir, and the legacy direct-PTO dirs)
 
 Flags:
@@ -78,6 +81,16 @@ sample_dir_arch() {
     Qwen*A3|Deepseek*A3) printf 'a3\n' ;;
     Qwen*A5|Deepseek*A5|TquantMx|TquantMxDn) printf 'a5\n' ;;
   esac
+}
+
+generation_case_is_skipped() {
+  local testcase="${1%-pto}"
+  local item
+
+  while IFS= read -r item; do
+    [[ -n "${item}" && "${item}" == "${testcase}" ]] && return 0
+  done <<< "${PTOAS_SKIP_CASES_NORM}"
+  return 1
 }
 
 resolve_ptoas_bin() {
@@ -315,6 +328,10 @@ process_one_dir() {
         ;;
     esac
     base="$(basename "$f" .py)"
+    if generation_case_is_skipped "${base}"; then
+      echo -e "${A}(${base}.py)\tSKIP\tlisted in PTOAS_SKIP_CASES"
+      continue
+    fi
     if [[ -f "${dir}/${base}-pto.pto" ]]; then
       echo -e "${A}(${base}.py)\tSKIP\tprefer checked-in direct PTO sample: ${base}-pto.pto"
       continue
@@ -1311,6 +1328,10 @@ PY
   if [[ $allow_pto -eq 1 ]]; then
     while IFS= read -r -d '' f; do
       base="$(basename "$f" .pto)"
+      if generation_case_is_skipped "${base}"; then
+        echo -e "${A}(${base}.pto)\tSKIP\tlisted in PTOAS_SKIP_CASES"
+        continue
+      fi
       local expect_fail=0
       local case_target_arch_lc="${target_arch_lc}"
       local -a case_ptoas_cmd_base=("${ptoas_cmd_base[@]}")


### PR DESCRIPTION
## Summary

- add a dedicated A5 self-hosted workflow scheduled for 03:00 Beijing time
- build PTOAS against the existing A5 LLVM cache, generate the A5 payload, and run it through task-submit
- publish result artifacts and an Actions summary, with optional Feishu notification
- document runner labels, repository variables, secret setup, and manual dispatch

## Validation

- actionlint .github/workflows/ci_a5.yml (custom ptoas-a5 label excluded until runner registration)
- python3 .github/scripts/report_a5_board_results_test.py
- PR386 license header check
- live read-only A5 runner preflight for LLVM, Python/MLIR, and task-submit

## Rollout

This is a draft because the PTOAS runner with the ptoas-a5 label still needs to be registered. Scheduled runs will queue until that runner is online. The A5_FEISHU_WEBHOOK_URL secret is optional.
