### PR TITLE
ci: run nightly A3 validation on self-hosted runner

### DIFF
--- a/.github/workflows/a3_taskqueue_smoke.yml
+++ b/.github/workflows/a3_taskqueue_smoke.yml
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+name: A3 TaskQueue Smoke
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: a3-taskqueue-smoke
+  cancel-in-progress: false
+
+jobs:
+  taskqueue-smoke:
+    if: github.repository == 'hw-native-sys/PTOAS'
+    runs-on: [self-hosted, Linux, ARM64, ptoas-a3]
+    timeout-minutes: 10
+    steps:
+      - name: Validate asynchronous TaskQueue flow
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          [[ "$(uname -m)" == "aarch64" ]] || {
+            echo "ERROR: A3 runner must be aarch64" >&2
+            exit 1
+          }
+          command -v task-submit >/dev/null || {
+            echo "ERROR: required command is missing: task-submit" >&2
+            exit 1
+          }
+          [[ -n "${RUNNER_TEMP:-}" ]] || {
+            echo "ERROR: RUNNER_TEMP is empty" >&2
+            exit 1
+          }
+
+          smoke_root="${RUNNER_TEMP}/ptoas-a3-taskqueue-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          case "${smoke_root}" in
+            "${RUNNER_TEMP}"/ptoas-a3-taskqueue-smoke-*) ;;
+            *) echo "ERROR: unsafe smoke root: ${smoke_root}" >&2; exit 1 ;;
+          esac
+          mkdir -p "${smoke_root}"
+          env_file="${smoke_root}/smoke.env"
+          cleanup() {
+            [[ ! -e "${env_file}" ]] || unlink "${env_file}"
+            rmdir "${smoke_root}" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          printf '%s\n' 'A3_TASKQUEUE_SMOKE=github-actions' > "${env_file}"
+          # shellcheck disable=SC2016 # Expanded inside TaskQueue.
+          smoke_command='test "${A3_TASKQUEUE_SMOKE:-}" = "github-actions" && printf "%s\n" "A3_TASKQUEUE_SMOKE_OK"'
+          set +e
+          submit_output="$(task-submit \
+            --max-time 60 \
+            --env-file "${env_file}" \
+            "${smoke_command}" 2>&1)"
+          submit_rc=$?
+          set -e
+          printf '%s\n' "${submit_output}"
+          if [[ "${submit_rc}" -ne 0 ]]; then
+            echo "ERROR: task-submit failed (exit ${submit_rc})" >&2
+            exit "${submit_rc}"
+          fi
+          task_id="$(printf '%s\n' "${submit_output}" | awk '
+            match($0, /task_[0-9]{8}_[0-9]{6}_[0-9]+/) {
+              id = substr($0, RSTART, RLENGTH)
+            }
+            END { print id }
+          ')"
+          [[ -n "${task_id}" ]] || {
+            echo "ERROR: task-submit did not return a task id" >&2
+            exit 1
+          }
+
+          # shellcheck disable=SC2329 # Invoked by the signal trap below.
+          cancel_task() {
+            echo "Cancelling TaskQueue smoke task ${task_id}"
+            task-submit --kill "${task_id}" >/dev/null 2>&1 || true
+          }
+          trap cancel_task INT TERM
+
+          set +e
+          task-submit --timeout 60 --wait "${task_id}"
+          wait_rc=$?
+          set -e
+          trap - INT TERM
+
+          set +e
+          status_output="$(task-submit --status "${task_id}" 2>&1)"
+          status_rc=$?
+          set -e
+          printf '%s\n' "${status_output}"
+          if [[ "${status_rc}" -ne 0 ]]; then
+            echo "ERROR: task-submit --status failed (exit ${status_rc})" >&2
+            exit "${status_rc}"
+          fi
+          if [[ "${status_output}" =~ exit=([0-9]+) ]]; then
+            task_rc="${BASH_REMATCH[1]}"
+          else
+            echo "ERROR: TaskQueue status has no exit code (wait rc=${wait_rc})" >&2
+            exit 1
+          fi
+          [[ "${wait_rc}" -eq "${task_rc}" ]] || {
+            echo "ERROR: task wait rc=${wait_rc}, recorded task rc=${task_rc}" >&2
+            exit 1
+          }
+          [[ "${task_rc}" -eq 0 ]] || exit "${task_rc}"
+          echo "A3 asynchronous TaskQueue smoke test passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,6 +450,98 @@ jobs:
           path: ${{ env.PAYLOAD_TGZ }}
           if-no-files-found: error
 
+  a3-taskqueue-smoke:
+    if: >-
+      ${{
+        github.event_name == 'pull_request' &&
+        (github.event.pull_request.author_association == 'OWNER' ||
+         github.event.pull_request.author_association == 'MEMBER' ||
+         github.event.pull_request.author_association == 'COLLABORATOR')
+      }}
+    runs-on: [self-hosted, Linux, ARM64, ptoas-a3]
+    timeout-minutes: 10
+    concurrency:
+      group: a3-taskqueue-smoke
+      cancel-in-progress: false
+    steps:
+      - name: Validate asynchronous TaskQueue flow
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          [[ "$(uname -m)" == "aarch64" ]] || {
+            echo "ERROR: A3 runner must be aarch64" >&2
+            exit 1
+          }
+          command -v task-submit >/dev/null || {
+            echo "ERROR: required command is missing: task-submit" >&2
+            exit 1
+          }
+          [[ -n "${RUNNER_TEMP:-}" ]] || {
+            echo "ERROR: RUNNER_TEMP is empty" >&2
+            exit 1
+          }
+
+          smoke_root="${RUNNER_TEMP}/ptoas-a3-taskqueue-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          case "${smoke_root}" in
+            "${RUNNER_TEMP}"/ptoas-a3-taskqueue-smoke-*) ;;
+            *) echo "ERROR: unsafe smoke root: ${smoke_root}" >&2; exit 1 ;;
+          esac
+          mkdir -p "${smoke_root}"
+          env_file="${smoke_root}/smoke.env"
+          cleanup() {
+            [[ ! -e "${env_file}" ]] || unlink "${env_file}"
+            rmdir "${smoke_root}" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          printf '%s\n' 'A3_TASKQUEUE_SMOKE=github-actions' > "${env_file}"
+          # shellcheck disable=SC2016 # Expanded inside TaskQueue.
+          smoke_command='test "${A3_TASKQUEUE_SMOKE:-}" = "github-actions" && printf "%s\n" "A3_TASKQUEUE_SMOKE_OK"'
+          submit_output="$(task-submit \
+            --max-time 60 \
+            --env-file "${env_file}" \
+            "${smoke_command}")"
+          printf '%s\n' "${submit_output}"
+          task_id="$(printf '%s\n' "${submit_output}" | awk '
+            match($0, /task_[0-9]{8}_[0-9]{6}_[0-9]+/) {
+              id = substr($0, RSTART, RLENGTH)
+            }
+            END { print id }
+          ')"
+          [[ -n "${task_id}" ]] || {
+            echo "ERROR: task-submit did not return a task id" >&2
+            exit 1
+          }
+
+          # shellcheck disable=SC2329 # Invoked by the signal trap below.
+          cancel_task() {
+            echo "Cancelling TaskQueue smoke task ${task_id}"
+            task-submit --kill "${task_id}" >/dev/null 2>&1 || true
+          }
+          trap cancel_task INT TERM
+
+          set +e
+          task-submit --timeout 60 --wait "${task_id}"
+          wait_rc=$?
+          set -e
+          trap - INT TERM
+
+          status_output="$(task-submit --status "${task_id}" 2>&1)"
+          printf '%s\n' "${status_output}"
+          if [[ "${status_output}" =~ exit=([0-9]+) ]]; then
+            task_rc="${BASH_REMATCH[1]}"
+          else
+            echo "ERROR: TaskQueue status has no exit code (wait rc=${wait_rc})" >&2
+            exit 1
+          fi
+          [[ "${wait_rc}" -eq "${task_rc}" ]] || {
+            echo "ERROR: task wait rc=${wait_rc}, recorded task rc=${task_rc}" >&2
+            exit 1
+          }
+          [[ "${task_rc}" -eq 0 ]] || exit "${task_rc}"
+          echo "A3 asynchronous TaskQueue smoke test passed"
+
   remote-npu-validation:
     needs: build-and-test
     runs-on: [self-hosted, Linux, ARM64, ptoas-a3]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ on:
   push:
     branches:
       - main
-  # Nightly remote-board validation (GitHub cron is UTC).
-  # 22:00 CST (UTC+8) == 14:00 UTC.
+  # Nightly A3 board validation (GitHub cron is UTC).
+  # 19:00 UTC is 03:00 the next day in Beijing (UTC+8).
   schedule:
-    - cron: "0 14 * * *"
+    - cron: "0 19 * * *"
   workflow_dispatch:
     inputs:
       stage:
@@ -45,26 +45,14 @@ on:
         type: string
         default: ""
       pto_isa_repo:
-        description: "pto-isa repo URL on remote"
+        description: "pto-isa repository URL used by the A3 runner"
         type: string
         default: https://gitcode.com/cann/pto-isa.git
       pto_isa_commit:
-        description: "pto-isa ref (commit/tag/branch; empty = repo-pinned weekly commit)"
+        description: "pto-isa ref (commit/tag/branch; empty = repository CI pin)"
         type: string
         # NOTE: Pin a known-good GitCode commit for deterministic runs.
         default: 27386d906e8fdcbd93aec84197939bc0b2c6caea
-      remote_host:
-        description: "SSH host/IP for the NPU machine"
-        type: string
-        default: 101.245.68.6
-      remote_user:
-        description: "SSH user for the NPU machine"
-        type: string
-        default: zhongxuan
-      remote_port:
-        description: "SSH port"
-        type: string
-        default: "22"
 
 permissions:
   contents: read
@@ -464,20 +452,20 @@ jobs:
 
   remote-npu-validation:
     needs: build-and-test
-    runs-on: ubuntu-22.04
-    timeout-minutes: 180
+    runs-on: [self-hosted, Linux, ARM64, ptoas-a3]
+    timeout-minutes: 480
     concurrency:
-      group: remote-npu-validation
+      group: a3-nightly-board
       cancel-in-progress: false
-    # Ordering: `needs: build-and-test` enforces "CI -> remote".
+    # Ordering: `needs: build-and-test` enforces payload generation before the
+    # A3 runner downloads it and submits board work through TaskQueue.
     if: >-
       ${{
+        github.repository == 'hw-native-sys/PTOAS' &&
         (github.event_name == 'workflow_dispatch' ||
          github.event_name == 'schedule')
       }}
     env:
-      PAYLOAD_DOWNLOAD_DIR: ${{ github.workspace }}/_payload
-      PAYLOAD_TGZ: ${{ github.workspace }}/_payload/ptoas_payload.tgz
       # Temporary CI gate: skip cases that still error/flap on the remote NPU.
       # Update this list as we fix the underlying issues.
       DEFAULT_SKIP_CASES: >-
@@ -494,9 +482,6 @@ jobs:
           RUN_ONLY_CASES: ${{ github.event.inputs.run_only_cases || '' }}
           PTO_ISA_REPO: ${{ github.event.inputs.pto_isa_repo || 'https://gitcode.com/cann/pto-isa.git' }}
           PTO_ISA_COMMIT: ${{ github.event.inputs.pto_isa_commit || '27386d906e8fdcbd93aec84197939bc0b2c6caea' }}
-          REMOTE_HOST: ${{ github.event.inputs.remote_host || '101.245.68.6' }}
-          REMOTE_USER: ${{ github.event.inputs.remote_user || 'zhongxuan' }}
-          REMOTE_PORT: ${{ github.event.inputs.remote_port || '22' }}
         run: |
           set -euo pipefail
           # For scheduled runs, default to DEFAULT_SKIP_CASES (known-bad/flaky).
@@ -536,32 +521,54 @@ jobs:
           echo "RUN_ONLY_CASES=${RUN_ONLY_CASES}" >> "${GITHUB_ENV}"
           echo "PTO_ISA_REPO=${PTO_ISA_REPO}" >> "${GITHUB_ENV}"
           echo "PTO_ISA_COMMIT=${PTO_ISA_COMMIT}" >> "${GITHUB_ENV}"
-          echo "REMOTE_HOST=${REMOTE_HOST}" >> "${GITHUB_ENV}"
-          echo "REMOTE_USER=${REMOTE_USER}" >> "${GITHUB_ENV}"
-          echo "REMOTE_PORT=${REMOTE_PORT}" >> "${GITHUB_ENV}"
 
-      - name: Setup SSH
+      - name: Check A3 runner environment
         shell: bash
-        env:
-          SSH_KEY: ${{ secrets.SSH_KEY }}
-          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
-          if [[ -z "${SSH_KEY}" ]]; then
-            echo "ERROR: secrets.SSH_KEY is not set"
-            exit 1
-          fi
-          if [[ -z "${SSH_KNOWN_HOSTS}" ]]; then
-            echo "ERROR: secrets.SSH_KNOWN_HOSTS is not set"
-            exit 1
-          fi
 
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          printf '%s\n' "${SSH_KEY}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          printf '%s\n' "${SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
-          chmod 644 ~/.ssh/known_hosts
+          [[ "$(uname -m)" == "aarch64" ]] || {
+            echo "ERROR: A3 runner must be aarch64" >&2
+            exit 1
+          }
+          for command in bash cmake git make python3 tar task-submit; do
+            command -v "${command}" >/dev/null || {
+              echo "ERROR: required command is missing: ${command}" >&2
+              exit 1
+            }
+          done
+          python3 - <<'PY'
+          import numpy
+
+          print("numpy", numpy.__version__)
+          PY
+
+      - name: Prepare isolated work directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "${RUNNER_TEMP:-}" ]] || {
+            echo "ERROR: RUNNER_TEMP is empty" >&2
+            exit 1
+          }
+          work_root="${RUNNER_TEMP}/ptoas-a3-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          case "${work_root}" in
+            "${RUNNER_TEMP}"/ptoas-a3-*) ;;
+            *) echo "ERROR: unsafe work root: ${work_root}" >&2; exit 1 ;;
+          esac
+          rm -rf -- "${work_root}"
+          mkdir -p "${work_root}/download" "${work_root}/payload"
+
+          {
+            echo "WORK_ROOT=${work_root}"
+            echo "PAYLOAD_DOWNLOAD_DIR=${work_root}/download"
+            echo "PAYLOAD_TGZ=${work_root}/download/ptoas_payload.tgz"
+            echo "PAYLOAD_DIR=${work_root}/payload"
+            echo "PTO_ISA_SOURCE_DIR=${work_root}/pto-isa-source"
+            echo "OUTPUT_ROOT=${work_root}/npu-validation"
+            echo "RESULTS_TSV=${work_root}/remote_npu_validation_results.tsv"
+            echo "BOARD_LOG=${work_root}/board-validation.log"
+          } >> "${GITHUB_ENV}"
 
       - name: Download payload artifact
         uses: actions/download-artifact@v4
@@ -569,78 +576,117 @@ jobs:
           name: ptoas_payload
           path: ${{ env.PAYLOAD_DOWNLOAD_DIR }}
 
-      - name: Vendor pto-isa into payload (offline remote)
+      - name: Extract payload and vendor pto-isa
         shell: bash
         run: |
           set -euo pipefail
-          tmp_root="${RUNNER_TEMP:-${GITHUB_WORKSPACE}/.tmp}"
-          work="$(mktemp -d "${tmp_root}/ptoas_payload_unpack.XXXXXX")"
-          tar -xzf "${PAYLOAD_TGZ}" -C "${work}"
+          [[ -f "${PAYLOAD_TGZ}" ]] || {
+            echo "ERROR: payload tarball not found: ${PAYLOAD_TGZ}" >&2
+            exit 1
+          }
+          tar -xzf "${PAYLOAD_TGZ}" -C "${PAYLOAD_DIR}"
 
-          rm -rf "${work}/pto-isa"
-          git clone "${PTO_ISA_REPO}" "${work}/pto-isa"
+          git clone "${PTO_ISA_REPO}" "${PTO_ISA_SOURCE_DIR}"
           if [[ -n "${PTO_ISA_COMMIT}" ]]; then
-            git -C "${work}/pto-isa" checkout -f "${PTO_ISA_COMMIT}"
+            git -C "${PTO_ISA_SOURCE_DIR}" checkout -f "${PTO_ISA_COMMIT}"
           else
-            git -C "${work}/pto-isa" checkout -f origin/HEAD || true
+            git -C "${PTO_ISA_SOURCE_DIR}" checkout -f origin/HEAD
           fi
-          # Ship a working tree only; remote should not need outbound network.
-          rm -rf "${work}/pto-isa/.git"
+          mv "${PTO_ISA_SOURCE_DIR}" "${PAYLOAD_DIR}/pto-isa"
+          rm -rf -- "${PAYLOAD_DIR}/pto-isa/.git"
+          echo "Vendored pto-isa ${PTO_ISA_COMMIT:-origin/HEAD}"
 
-          tar -czf "${PAYLOAD_TGZ}" -C "${work}" .
-
-      - name: Copy payload to remote
+      - name: Run A3 board validation through TaskQueue
+        id: board
         shell: bash
         run: |
           set -euo pipefail
-          if [[ ! -f "${PAYLOAD_TGZ}" ]]; then
-            echo "ERROR: payload tarball not found: ${PAYLOAD_TGZ}"
+          device_id="${DEVICE_ID:-auto}"
+          env_file="${WORK_ROOT}/board-validation.env"
+          printf '%s\n' \
+            "STAGE=${STAGE}" \
+            "RUN_MODE=${RUN_MODE}" \
+            "SOC_VERSION=${SOC_VERSION}" \
+            "GOLDEN_MODE=npu" \
+            "SKIP_CASES=${SKIP_CASES}" \
+            "RUN_ONLY_CASES=${RUN_ONLY_CASES}" \
+            "EXPECTED_CASES_FILTER=${RUN_ONLY_CASES}" \
+            "PTO_ISA_REPO=${PTO_ISA_REPO}" \
+            "PTO_ISA_COMMIT=${PTO_ISA_COMMIT}" \
+            "OUTPUT_ROOT=${OUTPUT_ROOT}" \
+            "RESULTS_TSV=${RESULTS_TSV}" \
+            > "${env_file}"
+
+          # shellcheck disable=SC2016 # TASK_DEVICE expands inside TaskQueue.
+          printf -v board_command \
+            'cd %q && export DEVICE_ID="${TASK_DEVICE:-%s}" && bash ./test/npu_validation/scripts/run_remote_npu_validation.sh' \
+            "${PAYLOAD_DIR}" "${device_id}"
+          submit_output="$(task-submit \
+            --device "${device_id}" \
+            --max-time 0 \
+            --env-file "${env_file}" \
+            "${board_command}")"
+          printf '%s\n' "${submit_output}" | tee "${BOARD_LOG}"
+          task_id="$(printf '%s\n' "${submit_output}" | awk '/^task_[0-9]{8}_[0-9]{6}_[0-9]+$/ { id=$0 } END { print id }')"
+          [[ -n "${task_id}" ]] || {
+            echo "ERROR: task-submit did not return a task id" | tee -a "${BOARD_LOG}" >&2
+            exit 1
+          }
+
+          # shellcheck disable=SC2329 # Invoked by the signal trap below.
+          cancel_task() {
+            echo "Cancelling TaskQueue task ${task_id}" | tee -a "${BOARD_LOG}"
+            task-submit --kill "${task_id}" >/dev/null 2>&1 || true
+          }
+          trap cancel_task INT TERM
+
+          set +e
+          task-submit --timeout 0 --wait "${task_id}" 2>&1 | tee -a "${BOARD_LOG}"
+          wait_rc="${PIPESTATUS[0]}"
+          set -e
+          trap - INT TERM
+
+          status_output="$(task-submit --status "${task_id}" 2>&1)"
+          printf '%s\n' "${status_output}" | tee -a "${BOARD_LOG}"
+          if [[ "${status_output}" =~ exit=([0-9]+) ]]; then
+            task_rc="${BASH_REMATCH[1]}"
+          else
+            echo "ERROR: TaskQueue status has no exit code (wait rc=${wait_rc})" | tee -a "${BOARD_LOG}" >&2
             exit 1
           fi
-          REMOTE_DIR="/tmp/ptoas_npu_validation/${GITHUB_REPOSITORY}/${GITHUB_RUN_ID}"
-          echo "REMOTE_DIR=${REMOTE_DIR}" >> "${GITHUB_ENV}"
-          ssh -p "${REMOTE_PORT}" "${REMOTE_USER}@${REMOTE_HOST}" "rm -rf '${REMOTE_DIR}' && mkdir -p '${REMOTE_DIR}'"
-          scp -P "${REMOTE_PORT}" "${PAYLOAD_TGZ}" "${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_DIR}/payload.tgz"
-
-      - name: Run remote validation
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DEVICE_ID}" ]]; then
-            DEVICE_ID="auto"
+          if [[ "${wait_rc}" -ne "${task_rc}" ]]; then
+            echo "WARNING: task wait rc=${wait_rc}, recorded task rc=${task_rc}" | tee -a "${BOARD_LOG}" >&2
           fi
-          ssh -p "${REMOTE_PORT}" "${REMOTE_USER}@${REMOTE_HOST}" \
-            "set -euo pipefail; \
-             cd '${REMOTE_DIR}'; \
-             tar -xzf payload.tgz; \
-             command -v task-submit >/dev/null 2>&1 || { echo 'ERROR: task-submit not found on remote host'; exit 1; }; \
-             task-submit --device '${DEVICE_ID}' --timeout 0 --max-time 0 \
-               --run \"cd '${REMOTE_DIR}' && STAGE='${STAGE}' RUN_MODE='${RUN_MODE}' SOC_VERSION='${SOC_VERSION}' PTO_ISA_REPO='${PTO_ISA_REPO}' PTO_ISA_COMMIT='${PTO_ISA_COMMIT}' DEVICE_ID=\\\${TASK_DEVICE:-${DEVICE_ID}} SKIP_CASES='${SKIP_CASES}' RUN_ONLY_CASES='${RUN_ONLY_CASES}' bash ./test/npu_validation/scripts/run_remote_npu_validation.sh\""
+          exit "${task_rc}"
 
-      - name: Fetch results
-        if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${REMOTE_DIR:-}" ]]; then
-            echo "REMOTE_DIR is not set; skipping results fetch."
-            exit 0
-          fi
-          scp -P "${REMOTE_PORT}" "${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_DIR}/remote_npu_validation_results.tsv" ./remote_npu_validation_results.tsv || true
-
-      - name: Upload results artifact
+      - name: Upload A3 board artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: remote_npu_validation_results
-          path: remote_npu_validation_results.tsv
+          name: a3-nightly-board-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ env.RESULTS_TSV }}
+            ${{ env.BOARD_LOG }}
+            ${{ env.PAYLOAD_DIR }}/test/samples/expected_npu_validation_cases.txt
           if-no-files-found: warn
+          retention-days: 14
 
-      - name: Cleanup remote
+      - name: Clean isolated work directory
         if: always()
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -n "${REMOTE_DIR:-}" ]]; then
-            ssh -p "${REMOTE_PORT}" "${REMOTE_USER}@${REMOTE_HOST}" "rm -rf '${REMOTE_DIR}'" || true
+          if [[ -z "${WORK_ROOT:-}" || -z "${RUNNER_TEMP:-}" ]]; then
+            echo "Work directory was not initialized; nothing to clean."
+            exit 0
           fi
+          case "${WORK_ROOT}" in
+            "${RUNNER_TEMP}"/ptoas-a3-*) ;;
+            *) echo "ERROR: refusing to clean unsafe path: ${WORK_ROOT}" >&2; exit 1 ;;
+          esac
+
+          printf -v cleanup_command 'rm -rf -- %q' "${WORK_ROOT}"
+          task-submit --max-time 300 --run "${cleanup_command}" || {
+            echo "WARNING: TaskQueue cleanup failed; trying as the runner user" >&2
+            rm -rf -- "${WORK_ROOT}"
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,7 +627,12 @@ jobs:
             --env-file "${env_file}" \
             "${board_command}")"
           printf '%s\n' "${submit_output}" | tee "${BOARD_LOG}"
-          task_id="$(printf '%s\n' "${submit_output}" | awk '/^task_[0-9]{8}_[0-9]{6}_[0-9]+$/ { id=$0 } END { print id }')"
+          task_id="$(printf '%s\n' "${submit_output}" | awk '
+            match($0, /task_[0-9]{8}_[0-9]{6}_[0-9]+/) {
+              id = substr($0, RSTART, RLENGTH)
+            }
+            END { print id }
+          ')"
           [[ -n "${task_id}" ]] || {
             echo "ERROR: task-submit did not return a task id" | tee -a "${BOARD_LOG}" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,98 +450,6 @@ jobs:
           path: ${{ env.PAYLOAD_TGZ }}
           if-no-files-found: error
 
-  a3-taskqueue-smoke:
-    if: >-
-      ${{
-        github.event_name == 'pull_request' &&
-        (github.event.pull_request.author_association == 'OWNER' ||
-         github.event.pull_request.author_association == 'MEMBER' ||
-         github.event.pull_request.author_association == 'COLLABORATOR')
-      }}
-    runs-on: [self-hosted, Linux, ARM64, ptoas-a3]
-    timeout-minutes: 10
-    concurrency:
-      group: a3-taskqueue-smoke
-      cancel-in-progress: false
-    steps:
-      - name: Validate asynchronous TaskQueue flow
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          [[ "$(uname -m)" == "aarch64" ]] || {
-            echo "ERROR: A3 runner must be aarch64" >&2
-            exit 1
-          }
-          command -v task-submit >/dev/null || {
-            echo "ERROR: required command is missing: task-submit" >&2
-            exit 1
-          }
-          [[ -n "${RUNNER_TEMP:-}" ]] || {
-            echo "ERROR: RUNNER_TEMP is empty" >&2
-            exit 1
-          }
-
-          smoke_root="${RUNNER_TEMP}/ptoas-a3-taskqueue-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          case "${smoke_root}" in
-            "${RUNNER_TEMP}"/ptoas-a3-taskqueue-smoke-*) ;;
-            *) echo "ERROR: unsafe smoke root: ${smoke_root}" >&2; exit 1 ;;
-          esac
-          mkdir -p "${smoke_root}"
-          env_file="${smoke_root}/smoke.env"
-          cleanup() {
-            [[ ! -e "${env_file}" ]] || unlink "${env_file}"
-            rmdir "${smoke_root}" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-
-          printf '%s\n' 'A3_TASKQUEUE_SMOKE=github-actions' > "${env_file}"
-          # shellcheck disable=SC2016 # Expanded inside TaskQueue.
-          smoke_command='test "${A3_TASKQUEUE_SMOKE:-}" = "github-actions" && printf "%s\n" "A3_TASKQUEUE_SMOKE_OK"'
-          submit_output="$(task-submit \
-            --max-time 60 \
-            --env-file "${env_file}" \
-            "${smoke_command}")"
-          printf '%s\n' "${submit_output}"
-          task_id="$(printf '%s\n' "${submit_output}" | awk '
-            match($0, /task_[0-9]{8}_[0-9]{6}_[0-9]+/) {
-              id = substr($0, RSTART, RLENGTH)
-            }
-            END { print id }
-          ')"
-          [[ -n "${task_id}" ]] || {
-            echo "ERROR: task-submit did not return a task id" >&2
-            exit 1
-          }
-
-          # shellcheck disable=SC2329 # Invoked by the signal trap below.
-          cancel_task() {
-            echo "Cancelling TaskQueue smoke task ${task_id}"
-            task-submit --kill "${task_id}" >/dev/null 2>&1 || true
-          }
-          trap cancel_task INT TERM
-
-          set +e
-          task-submit --timeout 60 --wait "${task_id}"
-          wait_rc=$?
-          set -e
-          trap - INT TERM
-
-          status_output="$(task-submit --status "${task_id}" 2>&1)"
-          printf '%s\n' "${status_output}"
-          if [[ "${status_output}" =~ exit=([0-9]+) ]]; then
-            task_rc="${BASH_REMATCH[1]}"
-          else
-            echo "ERROR: TaskQueue status has no exit code (wait rc=${wait_rc})" >&2
-            exit 1
-          fi
-          [[ "${wait_rc}" -eq "${task_rc}" ]] || {
-            echo "ERROR: task wait rc=${wait_rc}, recorded task rc=${task_rc}" >&2
-            exit 1
-          }
-          [[ "${task_rc}" -eq 0 ]] || exit "${task_rc}"
-          echo "A3 asynchronous TaskQueue smoke test passed"
-
   remote-npu-validation:
     needs: build-and-test
     runs-on: [self-hosted, Linux, ARM64, ptoas-a3]
@@ -713,12 +621,19 @@ jobs:
           printf -v board_command \
             'cd %q && export DEVICE_ID="${TASK_DEVICE:-%s}" && bash ./test/npu_validation/scripts/run_remote_npu_validation.sh' \
             "${PAYLOAD_DIR}" "${device_id}"
+          set +e
           submit_output="$(task-submit \
             --device "${device_id}" \
             --max-time 0 \
             --env-file "${env_file}" \
-            "${board_command}")"
+            "${board_command}" 2>&1)"
+          submit_rc=$?
+          set -e
           printf '%s\n' "${submit_output}" | tee "${BOARD_LOG}"
+          if [[ "${submit_rc}" -ne 0 ]]; then
+            echo "ERROR: task-submit failed (exit ${submit_rc})" | tee -a "${BOARD_LOG}" >&2
+            exit "${submit_rc}"
+          fi
           task_id="$(printf '%s\n' "${submit_output}" | awk '
             match($0, /task_[0-9]{8}_[0-9]{6}_[0-9]+/) {
               id = substr($0, RSTART, RLENGTH)
@@ -743,8 +658,15 @@ jobs:
           set -e
           trap - INT TERM
 
+          set +e
           status_output="$(task-submit --status "${task_id}" 2>&1)"
+          status_rc=$?
+          set -e
           printf '%s\n' "${status_output}" | tee -a "${BOARD_LOG}"
+          if [[ "${status_rc}" -ne 0 ]]; then
+            echo "ERROR: task-submit --status failed (exit ${status_rc})" | tee -a "${BOARD_LOG}" >&2
+            exit "${status_rc}"
+          fi
           if [[ "${status_output}" =~ exit=([0-9]+) ]]; then
             task_rc="${BASH_REMATCH[1]}"
           else

--- a/docs/designs/ci-board-validation-guide.md
+++ b/docs/designs/ci-board-validation-guide.md
@@ -6,7 +6,7 @@
 
 1. 本地最小复现：`build -> runop -> 生成 pto/cpp`
 2. GitHub Actions：`Build Wheel` 与 `CI`
-3. A5 self-hosted runner 每日板测
+3. A3/A5 self-hosted runner 每日板测
 4. PR 评论触发的 A3/A5 手动板测
 
 本文只描述当前仓库已经存在、并且日常开发会直接用到的流程，不展开板测机器人内部实现。
@@ -46,12 +46,12 @@
 
 - 在 GitHub runner 上构建 LLVM/MLIR 与 PTOAS
 - 执行 `test/samples/runop.sh --enablebc all`
-- 在 `workflow_dispatch` / `schedule` 时打包 payload，并把样例和脚本发到远端板机执行 `run_remote_npu_validation.sh`
+- 在 `workflow_dispatch` / `schedule` 时打包 payload，由 A3 self-hosted runner 通过 `task-submit` 执行 `run_remote_npu_validation.sh`
 
 触发差异：
 
 - `push` / `pull_request`：只跑 GitHub runner 上的构建和样例生成
-- `workflow_dispatch` / `schedule`：除上述步骤外，还会跑远端板测 job `remote-npu-validation`
+- `workflow_dispatch` / `schedule`：除上述步骤外，还会在 A3 runner 跑板测 job `remote-npu-validation`
 
 ### 2.3 `A5 Nightly Board`
 
@@ -224,9 +224,21 @@ gh workflow run build_wheel.yml \
 gh run list --repo hw-native-sys/PTOAS --workflow 'Build Wheel' --limit 5
 ```
 
-### 4.3 手动触发 `CI` 远端板测
+### 4.3 配置和触发 A3 每日板测
 
 `CI` 的 `remote-npu-validation` 只会在 `workflow_dispatch` 或定时任务下执行。
+它固定使用以下 self-hosted runner 标签：
+
+- `self-hosted`
+- `Linux`
+- `ARM64`
+- `ptoas-a3`
+
+runner 用户需要能够执行 `task-submit`，并提供 `cmake`、`git`、`make`、
+`python3`、`tar` 和 Python `numpy`。workflow 不再使用 `SSH_KEY`、
+`SSH_KNOWN_HOSTS` 或远端主机参数；payload 会下载到 A3 runner 的临时目录，
+通过 TaskQueue 获取设备后在本机执行。默认 `device_id=auto`，由 TaskQueue
+选择空闲卡并通过 `TASK_DEVICE` 传给板测脚本。
 
 命令行例子：
 
@@ -236,35 +248,24 @@ gh workflow run ci.yml \
   --ref main \
   -f stage=run \
   -f run_mode=npu \
-  -f soc_version=Ascend910B1 \
-  -f device_id=2 \
+  -f soc_version=Ascend910 \
+  -f device_id=auto \
   -f skip_cases='mix_kernel,vadd_validshape,vadd_validshape_dynamic,print,storefp' \
   -f run_only_cases=''
-```
-
-A5 例子：
-
-```bash
-gh workflow run ci.yml \
-  --repo hw-native-sys/PTOAS \
-  --ref main \
-  -f stage=run \
-  -f run_mode=npu \
-  -f soc_version=Ascend950 \
-  -f device_id=1 \
-  -f run_only_cases='qwen3_decode_layer_incore_0,qwen3_decode_layer_incore_1'
 ```
 
 关键输入解释：
 
 - `stage`：`build` 或 `run`
 - `run_mode`：`npu` 或 `sim`
-- `soc_version`：例如 `Ascend910B1`、`Ascend950`
-- `device_id`：远端 `aclrtSetDevice` 的 device id
+- `soc_version`：A3 编译目标，默认 `Ascend910`
+- `device_id`：传给 `task-submit --device` 的选择器，默认 `auto`
 - `skip_cases`：跳过列表
 - `run_only_cases`：只跑列表
 - `pto_isa_repo` / `pto_isa_commit`：指定板测使用的 `pto-isa`
-- `remote_host` / `remote_user` / `remote_port`：指定远端板机
+
+定时任务固定使用默认分支；GitHub cron 使用 UTC，因此配置为 `0 19 * * *`，
+对应北京时间次日 `03:00`。同一时间只允许一个 A3 nightly job，新的运行会排队且不会取消正在进行的板测。
 
 ### 4.4 配置和触发 A5 每日板测
 

--- a/docs/designs/ci-board-validation-guide.md
+++ b/docs/designs/ci-board-validation-guide.md
@@ -50,7 +50,8 @@
 
 触发差异：
 
-- `push` / `pull_request`：只跑 GitHub runner 上的构建和样例生成
+- `push`：只跑 GitHub runner 上的构建和样例生成
+- `pull_request`：除构建和样例生成外，受信任的仓库成员/协作者 PR 还会在 A3 runner 执行不占 NPU 的 TaskQueue smoke test；外部贡献者 PR 会跳过该 self-hosted job
 - `workflow_dispatch` / `schedule`：除上述步骤外，还会在 A3 runner 跑板测 job `remote-npu-validation`
 
 ### 2.3 `A5 Nightly Board`
@@ -239,6 +240,10 @@ runner 用户需要能够执行 `task-submit`，并提供 `cmake`、`git`、`mak
 `SSH_KNOWN_HOSTS` 或远端主机参数；payload 会下载到 A3 runner 的临时目录，
 通过 TaskQueue 获取设备后在本机执行。默认 `device_id=auto`，由 TaskQueue
 选择空闲卡并通过 `TASK_DEVICE` 传给板测脚本。
+
+受信任的 `OWNER`、`MEMBER`、`COLLABORATOR` PR 会运行
+`a3-taskqueue-smoke`。该 job 不 checkout PR 源码、不申请 NPU，只验证
+`task-submit --env-file`、任务 ID 解析、`--wait`、`--status` 和退出码传播。
 
 命令行例子：
 

--- a/docs/designs/ci-board-validation-guide.md
+++ b/docs/designs/ci-board-validation-guide.md
@@ -50,8 +50,7 @@
 
 触发差异：
 
-- `push`：只跑 GitHub runner 上的构建和样例生成
-- `pull_request`：除构建和样例生成外，受信任的仓库成员/协作者 PR 还会在 A3 runner 执行不占 NPU 的 TaskQueue smoke test；外部贡献者 PR 会跳过该 self-hosted job
+- `push` / `pull_request`：只跑 GitHub runner 上的构建和样例生成，不会把 PR-controlled workflow 调度到 A3 runner
 - `workflow_dispatch` / `schedule`：除上述步骤外，还会在 A3 runner 跑板测 job `remote-npu-validation`
 
 ### 2.3 `A5 Nightly Board`
@@ -241,9 +240,11 @@ runner 用户需要能够执行 `task-submit`，并提供 `cmake`、`git`、`mak
 通过 TaskQueue 获取设备后在本机执行。默认 `device_id=auto`，由 TaskQueue
 选择空闲卡并通过 `TASK_DEVICE` 传给板测脚本。
 
-受信任的 `OWNER`、`MEMBER`、`COLLABORATOR` PR 会运行
-`a3-taskqueue-smoke`。该 job 不 checkout PR 源码、不申请 NPU，只验证
-`task-submit --env-file`、任务 ID 解析、`--wait`、`--status` 和退出码传播。
+需要单独检查 A3 runner 的异步 TaskQueue 接口时，手动触发
+`.github/workflows/a3_taskqueue_smoke.yml`。该 workflow 不 checkout 源码、
+不申请 NPU，只验证 `task-submit --env-file`、任务 ID 解析、`--wait`、
+`--status` 和退出码传播。它不接受 `pull_request` 事件，避免 PR-controlled
+workflow 在持久化 self-hosted runner 上执行。
 
 命令行例子：
 


### PR DESCRIPTION
## Summary

- run the scheduled Remote NPU Validation job at 03:00 Beijing time on an ARM64 A3 self-hosted runner
- replace SSH upload and remote execution with local payload extraction and TaskQueue submission
- preserve board failures as GitHub job failures and upload the TSV plus TaskQueue log on every run
- document runner labels, prerequisites, and manual dispatch inputs

## Runner setup

Register the A3 runner with these labels:

- `self-hosted`
- `Linux`
- `ARM64`
- `ptoas-a3`

The runner user must be able to invoke `task-submit`; the default device selector is `auto`.

## Validation

- `actionlint -ignore custom-runner-label -ignore existing-shellcheck-warnings .github/workflows/ci.yml`
- static assertions for cron, runner labels, removed SSH dependencies, and TaskQueue exit-code propagation
- `git diff --check`
- PR386 license-header check