### PR TITLE
[codex] Make CSE VecScope-aware

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -42,6 +42,7 @@ std::unique_ptr<Pass> createPTOResolveReservedBuffersPass();
 std::unique_ptr<Pass> createPTOWrapFunctionsInSectionsPass();
 std::unique_ptr<Pass> createPTONormalizeUncoveredTileSectionsPass();
 std::unique_ptr<Pass> createPTOValidatePhysicalSectionBoundariesPass();
+std::unique_ptr<Pass> createPTOResourceAwareCSEPass();
 std::unique_ptr<Pass> createPTOMaterializeTileOpSectionsPass();
 std::unique_ptr<Pass> createVPTOSplitCVModulePass();
 std::unique_ptr<Pass> createVPTONormalizeContainerPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -23,6 +23,11 @@
 
 include "mlir/Pass/PassBase.td"
 
+def PTOResourceAwareCSE : Pass<"pto-resource-aware-cse"> {
+  let summary = "Eliminate common subexpressions using PTO resource boundaries";
+  let constructor = "mlir::pto::createPTOResourceAwareCSEPass()";
+}
+
 // Define PTOInsertSync Pass
 def PTOInsertSync : Pass<"pto-insert-sync", "func::FuncOp"> {
   let summary = "Insert synchronization flags for PTO dialect";

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -81,6 +81,7 @@ add_mlir_dialect_library(PTOTransforms
   PTOMaterializeSIMTPersistentFragment.cpp
   PTOOutlineSIMTSections.cpp
   PTOInferVPTOVecScope.cpp
+  PTOResourceAwareCSE.cpp
 
   InsertSync/PTOInsertSync.cpp
   PTOInjectBarrierAllSync.cpp

--- a/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
+++ b/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
@@ -99,7 +99,9 @@ static bool isForbiddenInsideInferredVectorScope(Operation *op) {
 }
 
 static bool isVectorScopeBoundaryOperation(Operation *op) {
-  return isa<pto::BarrierOp, pto::BarrierSyncOp>(op);
+  return isa<pto::SetFlagOp, pto::WaitFlagOp, pto::SetFlagDynOp,
+             pto::WaitFlagDynOp, pto::BarrierOp, pto::BarrierSyncOp,
+             pto::MteOpInterface>(op);
 }
 
 static bool hasVecScopeTypedOperandOrResult(Operation *op) {

--- a/lib/PTO/Transforms/PTOResourceAwareCSE.cpp
+++ b/lib/PTO/Transforms/PTOResourceAwareCSE.cpp
@@ -1,0 +1,411 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- PTOResourceAwareCSE.cpp - Resource-aware CSE -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This transformation pass performs a simple common sub-expression elimination
+// algorithm on operations within a region.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/ScopedHashTable.h"
+#include "llvm/Support/Allocator.h"
+#include "llvm/Support/RecyclingAllocator.h"
+#include <deque>
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTORESOURCEAWARECSE
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+static bool isVecScopeRead(Operation *op) {
+  if (!isMemoryEffectFree(op))
+    return false;
+  return llvm::any_of(op->getResultTypes(),
+                      [](Type type) { return isa<pto::MaskType>(type); });
+}
+
+static bool isVecScopeWrite(Operation *op) {
+  return isa<pto::SetFlagOp, pto::WaitFlagOp, pto::SetFlagDynOp,
+             pto::WaitFlagDynOp, pto::BarrierOp, pto::BarrierSyncOp,
+             pto::MteOpInterface>(op);
+}
+
+static bool isReadOnlyCSECandidate(Operation *op) {
+  if (isVecScopeRead(op))
+    return true;
+  auto memEffects = dyn_cast<MemoryEffectOpInterface>(op);
+  return memEffects && memEffects.onlyHasEffect<MemoryEffects::Read>();
+}
+
+struct SimpleOperationInfo : public llvm::DenseMapInfo<Operation *> {
+  static unsigned getHashValue(const Operation *opC) {
+    return OperationEquivalence::computeHash(
+        const_cast<Operation *>(opC),
+        /*hashOperands=*/OperationEquivalence::directHashValue,
+        /*hashResults=*/OperationEquivalence::ignoreHashValue,
+        OperationEquivalence::IgnoreLocations);
+  }
+  static bool isEqual(const Operation *lhsC, const Operation *rhsC) {
+    auto *lhs = const_cast<Operation *>(lhsC);
+    auto *rhs = const_cast<Operation *>(rhsC);
+    if (lhs == rhs)
+      return true;
+    if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
+        rhs == getTombstoneKey() || rhs == getEmptyKey())
+      return false;
+    return OperationEquivalence::isEquivalentTo(
+        const_cast<Operation *>(lhsC), const_cast<Operation *>(rhsC),
+        OperationEquivalence::IgnoreLocations);
+  }
+};
+} // namespace
+
+namespace {
+/// Simple common sub-expression elimination.
+class ResourceAwareCSEDriver {
+public:
+  ResourceAwareCSEDriver(RewriterBase &rewriter, DominanceInfo *domInfo)
+      : rewriter(rewriter), domInfo(domInfo) {}
+
+  /// Simplify all operations within the given op.
+  void simplify(Operation *op, bool *changed = nullptr);
+
+  int64_t getNumCSE() const { return numCSE; }
+  int64_t getNumDCE() const { return numDCE; }
+
+private:
+  /// Shared implementation of operation elimination and scoped map definitions.
+  using AllocatorTy = llvm::RecyclingAllocator<
+      llvm::BumpPtrAllocator,
+      llvm::ScopedHashTableVal<Operation *, Operation *>>;
+  using ScopedMapTy = llvm::ScopedHashTable<Operation *, Operation *,
+                                            SimpleOperationInfo, AllocatorTy>;
+
+  /// Cache holding MemoryEffects information between two operations. The first
+  /// operation is stored has the key. The second operation is stored inside a
+  /// pair in the value. The pair also hold the MemoryEffects between those
+  /// two operations. If the MemoryEffects is nullptr then we assume there is
+  /// no operation with MemoryEffects::Write between the two operations.
+  using MemEffectsCache =
+      DenseMap<Operation *, std::pair<Operation *, MemoryEffects::Effect *>>;
+
+  /// Represents a single entry in the depth first traversal of a CFG.
+  struct CFGStackNode {
+    CFGStackNode(ScopedMapTy &knownValues, DominanceInfoNode *node)
+        : scope(knownValues), node(node), childIterator(node->begin()) {}
+
+    /// Scope for the known values.
+    ScopedMapTy::ScopeTy scope;
+
+    DominanceInfoNode *node;
+    DominanceInfoNode::const_iterator childIterator;
+
+    /// If this node has been fully processed yet or not.
+    bool processed = false;
+  };
+
+  /// Attempt to eliminate a redundant operation. Returns success if the
+  /// operation was marked for removal, failure otherwise.
+  LogicalResult simplifyOperation(ScopedMapTy &knownValues, Operation *op,
+                                  bool hasSSADominance);
+  void simplifyBlock(ScopedMapTy &knownValues, Block *bb, bool hasSSADominance);
+  void simplifyRegion(ScopedMapTy &knownValues, Region &region);
+
+  void replaceUsesAndDelete(ScopedMapTy &knownValues, Operation *op,
+                            Operation *existing, bool hasSSADominance);
+
+  /// Check if there is side-effecting operations other than the given effect
+  /// between the two operations.
+  bool hasOtherSideEffectingOpInBetween(Operation *fromOp, Operation *toOp);
+
+  /// A rewriter for modifying the IR.
+  RewriterBase &rewriter;
+
+  /// Operations marked as dead and to be erased.
+  std::vector<Operation *> opsToErase;
+  DominanceInfo *domInfo = nullptr;
+  // Various statistics.
+  int64_t numCSE = 0;
+  int64_t numDCE = 0;
+};
+} // namespace
+
+void ResourceAwareCSEDriver::replaceUsesAndDelete(ScopedMapTy &knownValues, Operation *op,
+                                     Operation *existing,
+                                     bool hasSSADominance) {
+  // If we find one then replace all uses of the current operation with the
+  // existing one and mark it for deletion. We can only replace an operand in
+  // an operation if it has not been visited yet.
+  if (hasSSADominance) {
+    // If the region has SSA dominance, then we are guaranteed to have not
+    // visited any use of the current operation.
+    if (auto *rewriteListener =
+            dyn_cast_if_present<RewriterBase::Listener>(rewriter.getListener()))
+      rewriteListener->notifyOperationReplaced(op, existing);
+    // Replace all uses, but do not remote the operation yet. This does not
+    // notify the listener because the original op is not erased.
+    rewriter.replaceAllUsesWith(op->getResults(), existing->getResults());
+    opsToErase.push_back(op);
+  } else {
+    // When the region does not have SSA dominance, we need to check if we
+    // have visited a use before replacing any use.
+    auto wasVisited = [&](OpOperand &operand) {
+      return !knownValues.count(operand.getOwner());
+    };
+    if (auto *rewriteListener =
+            dyn_cast_if_present<RewriterBase::Listener>(rewriter.getListener()))
+      for (Value v : op->getResults())
+        if (all_of(v.getUses(), wasVisited))
+          rewriteListener->notifyOperationReplaced(op, existing);
+
+    // Replace all uses, but do not remote the operation yet. This does not
+    // notify the listener because the original op is not erased.
+    rewriter.replaceUsesWithIf(op->getResults(), existing->getResults(),
+                               wasVisited);
+
+    // There may be some remaining uses of the operation.
+    if (op->use_empty())
+      opsToErase.push_back(op);
+  }
+
+  // If the existing operation has an unknown location and the current
+  // operation doesn't, then set the existing op's location to that of the
+  // current op.
+  if (isa<UnknownLoc>(existing->getLoc()) && !isa<UnknownLoc>(op->getLoc()))
+    existing->setLoc(op->getLoc());
+
+  ++numCSE;
+}
+
+bool ResourceAwareCSEDriver::hasOtherSideEffectingOpInBetween(Operation *fromOp,
+                                                 Operation *toOp) {
+  assert(fromOp->getBlock() == toOp->getBlock());
+  assert(isReadOnlyCSECandidate(fromOp) && isReadOnlyCSECandidate(toOp));
+  Operation *nextOp = fromOp->getNextNode();
+  while (nextOp && nextOp != toOp) {
+    if (isVecScopeRead(fromOp) && isVecScopeWrite(nextOp))
+      return true;
+    std::optional<SmallVector<MemoryEffects::EffectInstance>> effects =
+        getEffectsRecursively(nextOp);
+    if (!effects) {
+      // TODO: Do we need to handle other effects generically?
+      // If the operation does not implement the MemoryEffectOpInterface we
+      // conservatively assume it writes.
+      return true;
+    }
+
+    for (const MemoryEffects::EffectInstance &effect : *effects) {
+      if (!isVecScopeRead(fromOp) &&
+          isa<MemoryEffects::Write>(effect.getEffect())) {
+        return true;
+      }
+    }
+    nextOp = nextOp->getNextNode();
+  }
+  return false;
+}
+
+/// Attempt to eliminate a redundant operation.
+LogicalResult ResourceAwareCSEDriver::simplifyOperation(ScopedMapTy &knownValues,
+                                           Operation *op,
+                                           bool hasSSADominance) {
+  // Don't simplify terminator operations.
+  if (op->hasTrait<OpTrait::IsTerminator>())
+    return failure();
+
+  // If the operation is already trivially dead just add it to the erase list.
+  if (isOpTriviallyDead(op)) {
+    opsToErase.push_back(op);
+    ++numDCE;
+    return success();
+  }
+
+  // Don't simplify operations with regions that have multiple blocks.
+  // TODO: We need additional tests to verify that we handle such IR correctly.
+  if (!llvm::all_of(op->getRegions(), [](Region &r) {
+        return r.getBlocks().empty() || llvm::hasSingleElement(r.getBlocks());
+      }))
+    return failure();
+
+  // Some simple use case of operation with memory side-effect are dealt with
+  // here. Operations with no side-effect are done after.
+  if (isVecScopeRead(op) || !isMemoryEffectFree(op)) {
+    // TODO: Only basic use case for operations with MemoryEffects::Read can be
+    // eleminated now. More work needs to be done for more complicated patterns
+    // and other side-effects.
+    if (!isReadOnlyCSECandidate(op))
+      return failure();
+
+    // Look for an existing definition for the operation.
+    if (auto *existing = knownValues.lookup(op)) {
+      if (existing->getBlock() == op->getBlock() &&
+          !hasOtherSideEffectingOpInBetween(existing, op)) {
+        // The operation that can be deleted has been reach with no
+        // side-effecting operations in between the existing operation and
+        // this one so we can remove the duplicate.
+        replaceUsesAndDelete(knownValues, op, existing, hasSSADominance);
+        return success();
+      }
+    }
+    knownValues.insert(op, op);
+    return failure();
+  }
+
+  // Look for an existing definition for the operation.
+  if (auto *existing = knownValues.lookup(op)) {
+    replaceUsesAndDelete(knownValues, op, existing, hasSSADominance);
+    ++numCSE;
+    return success();
+  }
+
+  // Otherwise, we add this operation to the known values map.
+  knownValues.insert(op, op);
+  return failure();
+}
+
+void ResourceAwareCSEDriver::simplifyBlock(ScopedMapTy &knownValues, Block *bb,
+                              bool hasSSADominance) {
+  for (auto &op : *bb) {
+    // Most operations don't have regions, so fast path that case.
+    if (op.getNumRegions() != 0) {
+      // If this operation is isolated above, we can't process nested regions
+      // with the given 'knownValues' map. This would cause the insertion of
+      // implicit captures in explicit capture only regions.
+      if (op.mightHaveTrait<OpTrait::IsIsolatedFromAbove>()) {
+        ScopedMapTy nestedKnownValues;
+        for (auto &region : op.getRegions())
+          simplifyRegion(nestedKnownValues, region);
+      } else {
+        // Otherwise, process nested regions normally.
+        for (auto &region : op.getRegions())
+          simplifyRegion(knownValues, region);
+      }
+    }
+
+    // If the operation is simplified, we don't process any held regions.
+    if (succeeded(simplifyOperation(knownValues, &op, hasSSADominance)))
+      continue;
+  }
+}
+
+void ResourceAwareCSEDriver::simplifyRegion(ScopedMapTy &knownValues, Region &region) {
+  // If the region is empty there is nothing to do.
+  if (region.empty())
+    return;
+
+  bool hasSSADominance = domInfo->hasSSADominance(&region);
+
+  // If the region only contains one block, then simplify it directly.
+  if (region.hasOneBlock()) {
+    ScopedMapTy::ScopeTy scope(knownValues);
+    simplifyBlock(knownValues, &region.front(), hasSSADominance);
+    return;
+  }
+
+  // If the region does not have dominanceInfo, then skip it.
+  // TODO: Regions without SSA dominance should define a different
+  // traversal order which is appropriate and can be used here.
+  if (!hasSSADominance)
+    return;
+
+  // Note, deque is being used here because there was significant performance
+  // gains over vector when the container becomes very large due to the
+  // specific access patterns. If/when these performance issues are no
+  // longer a problem we can change this to vector. For more information see
+  // the llvm mailing list discussion on this:
+  // http://lists.llvm.org/pipermail/llvm-commits/Week-of-Mon-20120116/135228.html
+  std::deque<std::unique_ptr<CFGStackNode>> stack;
+
+  // Process the nodes of the dom tree for this region.
+  stack.emplace_back(std::make_unique<CFGStackNode>(
+      knownValues, domInfo->getRootNode(&region)));
+
+  while (!stack.empty()) {
+    auto &currentNode = stack.back();
+
+    // Check to see if we need to process this node.
+    if (!currentNode->processed) {
+      currentNode->processed = true;
+      simplifyBlock(knownValues, currentNode->node->getBlock(),
+                    hasSSADominance);
+    }
+
+    // Otherwise, check to see if we need to process a child node.
+    if (currentNode->childIterator != currentNode->node->end()) {
+      auto *childNode = *(currentNode->childIterator++);
+      stack.emplace_back(
+          std::make_unique<CFGStackNode>(knownValues, childNode));
+    } else {
+      // Finally, if the node and all of its children have been processed
+      // then we delete the node.
+      stack.pop_back();
+    }
+  }
+}
+
+void ResourceAwareCSEDriver::simplify(Operation *op, bool *changed) {
+  /// Simplify all regions.
+  ScopedMapTy knownValues;
+  for (auto &region : op->getRegions())
+    simplifyRegion(knownValues, region);
+
+  /// Erase any operations that were marked as dead during simplification.
+  for (auto *op : opsToErase)
+    rewriter.eraseOp(op);
+  if (changed)
+    *changed = !opsToErase.empty();
+
+  // Note: CSE does currently not remove ops with regions, so DominanceInfo
+  // does not have to be invalidated.
+}
+
+namespace {
+/// CSE pass.
+class ResourceAwareCSEPass
+    : public pto::impl::PTOResourceAwareCSEBase<ResourceAwareCSEPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void ResourceAwareCSEPass::runOnOperation() {
+  // Simplify the IR.
+  IRRewriter rewriter(&getContext());
+  ResourceAwareCSEDriver driver(rewriter, &getAnalysis<DominanceInfo>());
+  bool changed = false;
+  driver.simplify(getOperation(), &changed);
+
+  // If there was no change to the IR, we mark all analyses as preserved.
+  if (!changed)
+    return markAllAnalysesPreserved();
+
+  // We currently don't remove region operations, so mark dominance as
+  // preserved.
+  markAnalysesPreserved<DominanceInfo, PostDominanceInfo>();
+}
+
+std::unique_ptr<Pass> mlir::pto::createPTOResourceAwareCSEPass() { return std::make_unique<ResourceAwareCSEPass>(); }

--- a/test/lit/vpto/auto_vecscope_infer_flag_boundary.pto
+++ b/test/lit/vpto/auto_vecscope_infer_flag_boundary.pto
@@ -1,0 +1,37 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s
+// Synchronization flags must split inferred PipeV vecscope segments.
+
+module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @auto_vecscope_infer_flag_boundary() {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 1.000000e+00 : f32
+    %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+
+    %mask0 = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %vec0 = pto.vlds %ub[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+    %sum0 = pto.vadds %vec0, %cst, %mask0 : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+    pto.vsts %sum0, %ub[%c0], %mask0 : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    %mask1 = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %vec1 = pto.vlds %ub[%c64] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+    %sum1 = pto.vadds %vec1, %cst, %mask1 : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+    pto.vsts %sum1, %ub[%c64], %mask1 : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+    return
+  }
+  }
+}
+
+// CHECK-LABEL: func.func @auto_vecscope_infer_flag_boundary
+// CHECK: pto.vecscope {
+// CHECK: pto.pset_b32
+// CHECK: pto.vsts
+// CHECK: }
+// CHECK: pto.set_flag
+// CHECK: pto.wait_flag
+// CHECK: pto.vecscope {
+// CHECK: pto.pset_b32
+// CHECK: pto.vsts

--- a/test/lit/vpto/resource_aware_cse.pto
+++ b/test/lit/vpto/resource_aware_cse.pto
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt --pto-resource-aware-cse %s | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  // CHECK-LABEL: func.func @vecscope_read_crosses_memory_write
+  // CHECK-COUNT-1: pto.plt_b32
+  // CHECK: memref.store
+  func.func @vecscope_read_crosses_memory_write(%dst: memref<1xi32>) -> (!pto.mask<b32>, !pto.mask<b32>) {
+    %c0 = arith.constant 0 : index
+    %c7 = arith.constant 7 : i32
+    %mask0, %next0 = pto.plt_b32 %c7 : i32 -> !pto.mask<b32>, i32
+    memref.store %c7, %dst[%c0] : memref<1xi32>
+    %mask1, %next1 = pto.plt_b32 %c7 : i32 -> !pto.mask<b32>, i32
+    return %mask0, %mask1 : !pto.mask<b32>, !pto.mask<b32>
+  }
+
+  // CHECK-LABEL: func.func @vecscope_write_blocks
+  // CHECK-COUNT-2: pto.plt_b32
+  func.func @vecscope_write_blocks() -> (!pto.mask<b32>, !pto.mask<b32>) {
+    %c7 = arith.constant 7 : i32
+    %mask0, %next0 = pto.plt_b32 %c7 : i32 -> !pto.mask<b32>, i32
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    %mask1, %next1 = pto.plt_b32 %c7 : i32 -> !pto.mask<b32>, i32
+    return %mask0, %mask1 : !pto.mask<b32>, !pto.mask<b32>
+  }
+
+  // CHECK-LABEL: func.func @ordinary_memory_write_still_blocks
+  // CHECK-COUNT-2: memref.load
+  func.func @ordinary_memory_write_still_blocks(%src: memref<1xi32>, %dst: memref<1xi32>) -> (i32, i32) {
+    %c0 = arith.constant 0 : index
+    %value0 = memref.load %src[%c0] : memref<1xi32>
+    memref.store %value0, %dst[%c0] : memref<1xi32>
+    %value1 = memref.load %src[%c0] : memref<1xi32>
+    return %value0, %value1 : i32, i32
+  }
+}

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -3074,7 +3074,7 @@ static void prepareVPTOForEmission(PassManager &pm) {
       pto::createPTOUnrollSIMTForPass());
   kernelModulePM.addPass(createSCCPPass());
   kernelModulePM.addPass(createCanonicalizerPass());
-  kernelModulePM.addPass(createCSEPass());
+  kernelModulePM.addPass(pto::createPTOResourceAwareCSEPass());
   kernelModulePM.addNestedPass<func::FuncOp>(
       pto::createPTOAnalyzeSIMTPersistentFragmentPass());
   kernelModulePM.addNestedPass<func::FuncOp>(
@@ -3096,14 +3096,14 @@ static void prepareVPTOForEmission(PassManager &pm) {
   kernelModulePM.addNestedPass<func::FuncOp>(
       pto::createPTONarrowVPTOLoopCountersPass());
   kernelModulePM.addPass(createCanonicalizerPass());
-  kernelModulePM.addPass(createCSEPass());
+  kernelModulePM.addPass(pto::createPTOResourceAwareCSEPass());
   // SoftOps are materialized only after all VPTO optimization and layout
   // decisions.  The materializer creates a temporary func.call; inline it
   // immediately so the final legality check sees the actual VPTO sequence.
   kernelModulePM.addPass(pto::createPTOExpandSoftLibPass());
   kernelModulePM.addPass(pto::createPTOInlineLibCallPass());
   kernelModulePM.addPass(createCanonicalizerPass());
-  kernelModulePM.addPass(createCSEPass());
+  kernelModulePM.addPass(pto::createPTOResourceAwareCSEPass());
   if (vptoSchedulerMode != VPTOSchedulerCLIMode::Off) {
     pto::VPTOSchedulerOptions schedulerOptions;
     schedulerOptions.mode = vptoSchedulerMode == VPTOSchedulerCLIMode::Analyze
@@ -3112,7 +3112,7 @@ static void prepareVPTOForEmission(PassManager &pm) {
     kernelModulePM.addPass(pto::createVPTOSchedulerPass(schedulerOptions));
   }
   kernelModulePM.addPass(pto::createVPTOCombineReductionsPass());
-  kernelModulePM.addPass(createCSEPass());
+  kernelModulePM.addPass(pto::createPTOResourceAwareCSEPass());
   kernelModulePM.addPass(pto::createPTOValidateVPTOEmissionIRPass());
 }
 
@@ -3141,7 +3141,7 @@ static void lowerPTOToVPTOBackend(PassManager &pm, ModuleOp module) {
   if (enableA5VPTOPostLoweringFusionLifecycle) {
     kernelModulePM.addPass(pto::createPTOLowLevelLoopFusionPass());
     kernelModulePM.addPass(mlir::createCanonicalizerPass());
-    kernelModulePM.addPass(mlir::createCSEPass());
+    kernelModulePM.addPass(pto::createPTOResourceAwareCSEPass());
     kernelModulePM.addNestedPass<mlir::func::FuncOp>(
         pto::createPTOFusionPredicateElisionPass());
     kernelModulePM.addNestedPass<mlir::func::FuncOp>(
@@ -3150,13 +3150,13 @@ static void lowerPTOToVPTOBackend(PassManager &pm, ModuleOp module) {
       kernelModulePM.addNestedPass<mlir::func::FuncOp>(
           pto::createPTOUnrollAfterLoopFusionPass());
       kernelModulePM.addPass(mlir::createCanonicalizerPass());
-      kernelModulePM.addPass(mlir::createCSEPass());
+      kernelModulePM.addPass(pto::createPTOResourceAwareCSEPass());
       kernelModulePM.addNestedPass<mlir::func::FuncOp>(
           pto::createPTOFusionLoadStoreElisionPass());
     }
     kernelModulePM.addNestedPass<mlir::func::FuncOp>(
         pto::createPTOFlattenFusionRegionPass());
-    kernelModulePM.addPass(mlir::createCSEPass());
+    kernelModulePM.addPass(pto::createPTOResourceAwareCSEPass());
   }
   kernelModulePM.addNestedPass<mlir::func::FuncOp>(
       pto::createFoldTileBufIntrinsicsPass("addr-only"));
@@ -3273,24 +3273,24 @@ static void appendVMISemanticPipeline(OpPassManager &pm) {
   pm.addPass(pto::createVMILegalizeArithSelectPass());
   pm.addPass(pto::createPTOValidateVMIIRPass());
   pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
+  pm.addPass(pto::createPTOResourceAwareCSEPass());
   pm.addPass(pto::createVMIPreAssignmentCombinePass());
   pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
+  pm.addPass(pto::createPTOResourceAwareCSEPass());
   pm.addPass(pto::createVMILegalizeArithSelectPass());
   pm.addPass(pto::createVMIMaskGranularityAssignmentPass());
   pm.addPass(pto::createVMILayoutAssignmentPass());
   pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
+  pm.addPass(pto::createPTOResourceAwareCSEPass());
   pm.addPass(pto::createVMILayoutRematerializePass());
   pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
+  pm.addPass(pto::createPTOResourceAwareCSEPass());
   pm.addPass(pto::createVMILayoutFoldPass());
   pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
+  pm.addPass(pto::createPTOResourceAwareCSEPass());
   pm.addPass(pto::createVMILayoutSinkMaterializationPass());
   pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
+  pm.addPass(pto::createPTOResourceAwareCSEPass());
   pm.addPass(pto::createVMILegalizeArithSelectPass());
   pm.addPass(pto::createPTOValidateVMILayoutIRPass());
   pm.addPass(pto::createVMIToVPTOPass());
@@ -3719,14 +3719,14 @@ int mlir::pto::compilePTOASModule(
     return 0;
   }
 
-  pm.addPass(createCSEPass());
+  pm.addPass(pto::createPTOResourceAwareCSEPass());
   // PTODSL backend helpers already use the tile-native ABI.
   pm.addPass(pto::createPTOInlineBackendHelpersPass());
   if (effectiveBackend == PTOBackend::EmitC) {
     pm.addPass(createNarrowUnusedMultiResultProvenancePass());
   }
   pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
+  pm.addPass(pto::createPTOResourceAwareCSEPass());
   if (failed(applyConfiguredPassManagerCLOptions(pm, "main PTOAS pipeline"))) {
     return 1;
   }


### PR DESCRIPTION
Fixes #1263

## Summary
- Add a PTOAS-private resource-aware CSE pass based on LLVM 19 CSE.
- Treat VecScope mask-producing operations as readable and set/wait flag, barrier, and MTE operations as VecScope boundaries.
- Replace relevant VPTO, VMI, fusion, and final pipeline generic CSE invocations.
- Extend VecScope boundary inference for flag, barrier, and MTE operations.
- Keep rematerialization unchanged.

## Validation
- LLVM 19 native build targets: PTOTransforms, pto-test-opt, PTOASCompiler
- Resource-aware CSE lit regression
- Issue #1263 reproductions: mtp_projection_norm.pto and prefill_c4_state_update.pto