### PR TITLE
fix(vmi): isolate weak layout producer fanout

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -130,6 +130,7 @@ std::unique_ptr<Pass> createPTOValidateVMIIRPass();
 std::unique_ptr<Pass> createPTOValidateVMILayoutIRPass();
 std::unique_ptr<Pass> createVMIPreAssignmentCombinePass();
 std::unique_ptr<Pass> createVMIMaskGranularityAssignmentPass();
+std::unique_ptr<Pass> createVMILayoutRematerializeWeakProducersPass();
 std::unique_ptr<Pass> createVMILayoutAssignmentPass();
 std::unique_ptr<Pass> createVMILayoutFoldPass();
 std::unique_ptr<Pass> createVMILayoutRematerializePass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -1008,6 +1008,23 @@ def VMILayoutAssignment : Pass<"vmi-layout-assignment", "ModuleOp"> {
                            "mlir::scf::SCFDialect"];
 }
 
+def VMILayoutRematerializeWeakProducers
+    : Pass<"vmi-layout-rematerialize-weak-producers", "ModuleOp"> {
+  let summary = "Rematerialize weak layout producers before layout assignment";
+  let description = [{
+    Clones pure layout-polymorphic producers at their multiple uses before
+    layout assignment. This keeps independent consumer dataflows from being
+    connected only by a shared rematerializable SSA value. Strong dataflow
+    layout propagation remains the responsibility of vmi-layout-assignment.
+  }];
+  let constructor = "mlir::pto::createVMILayoutRematerializeWeakProducersPass()";
+  let dependentDialects = ["mlir::cf::ControlFlowDialect",
+                           "mlir::func::FuncDialect",
+                           "mlir::pto::PTODialect",
+                           "mlir::memref::MemRefDialect",
+                           "mlir::scf::SCFDialect"];
+}
+
 def VMIMaskGranularityAssignment
     : Pass<"vmi-mask-granularity-assignment", "ModuleOp"> {
   let summary = "Assign concrete VMI mask granularities";

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -68,6 +68,7 @@ add_mlir_dialect_library(PTOTransforms
   VMIMaskGranularityAssignment.cpp
   VMILowerUnifiedToLegacy.cpp
   VMINormalizeSignlessIntToUnsigned.cpp
+  VMILayoutRematerializeWeakProducers.cpp
   VMILayoutAssignment.cpp
   VMILayoutFold.cpp
   VMILayoutPropagation.cpp

--- a/lib/PTO/Transforms/VMILayoutPropagation.cpp
+++ b/lib/PTO/Transforms/VMILayoutPropagation.cpp
@@ -1351,6 +1351,7 @@ LogicalResult VMILayoutPropagator::propagateFact(Value value,
     if (failed(propagateThrough(result.getDefiningOp(), value, layout))) {
       return failure();
     }
+
   }
 
   SmallVector<OpOperand *, mlir::pto::kValue8> uses;

--- a/lib/PTO/Transforms/VMILayoutRematerializeWeakProducers.cpp
+++ b/lib/PTO/Transforms/VMILayoutRematerializeWeakProducers.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- VMILayoutRematerializeWeakProducers.cpp - Rematerialize weak producers ===//
+//===----------------------------------------------------------------------===//
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_VMILAYOUTREMATERIALIZEWEAKPRODUCERS
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::pto;
+
+namespace {
+
+static bool isLayoutPolymorphicProducer(Operation *op) {
+  return isa<VMIConstantOp, VMIBroadcastOp, VMIIotaOp, VMICreateMaskOp,
+             VMICreateGroupMaskOp, VMIConstantMaskOp>(op);
+}
+
+struct VMILayoutRematerializeWeakProducersPass
+    : public mlir::pto::impl::VMILayoutRematerializeWeakProducersBase<
+          VMILayoutRematerializeWeakProducersPass> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(
+      VMILayoutRematerializeWeakProducersPass)
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    SmallVector<Operation *, 16> producers;
+    module.walk([&](Operation *op) {
+      if (isLayoutPolymorphicProducer(op)) {
+        producers.push_back(op);
+      }
+    });
+
+    for (Operation *producer : producers) {
+      const unsigned resultCount = producer->getNumResults();
+      if (resultCount != 1) {
+        continue;
+      }
+      Value result = producer->getResult(0);
+      SmallVector<OpOperand *, 4> uses;
+      for (OpOperand &use : result.getUses()) {
+        uses.push_back(&use);
+      }
+      const size_t useCount = uses.size();
+      if (useCount < 2) {
+        continue;
+      }
+
+      DenseMap<Operation *, SmallVector<OpOperand *, 4>> usesByOwner;
+      SmallVector<Operation *, 4> owners;
+      for (OpOperand *use : uses) {
+        Operation *owner = use->getOwner();
+        const bool isNewOwner = usesByOwner.find(owner) == usesByOwner.end();
+        if (isNewOwner) {
+          owners.push_back(owner);
+        }
+        usesByOwner[owner].push_back(use);
+      }
+
+      for (size_t ownerIndex = 1; ownerIndex < owners.size(); ++ownerIndex) {
+        Operation *owner = owners[ownerIndex];
+        OpBuilder builder(owner);
+        Operation *clone = builder.clone(*producer);
+        for (OpOperand *use : usesByOwner[owner]) {
+          use->set(clone->getResult(0));
+        }
+      }
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass>
+mlir::pto::createVMILayoutRematerializeWeakProducersPass() {
+  return std::make_unique<VMILayoutRematerializeWeakProducersPass>();
+}

--- a/test/lit/vmi_new/vmi_layout_assignment_rematerialize_weak_producers.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_rematerialize_weak_producers.pto
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0.
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-rematerialize-weak-producers -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-rematerialize-weak-producers -vmi-layout-assignment -vmi-layout-rematerialize | FileCheck %s --check-prefix=REMAT
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-rematerialize-weak-producers -vmi-layout-assignment -vmi-layout-rematerialize -vmi-to-vpto | FileCheck %s --check-prefix=LOWER
+
+// A mask and a VCI result are shared by two independent dataflows. The group
+// reduction dataflow needs deinterleaved=2, while the dense score store is
+// naturally contiguous. Weak producer fanout must not connect these layouts.
+module {
+  func.func @vmi_layout_assignment_rematerialize_weak_producers(
+      %x: !pto.vmi.vreg<128xf32>,
+      %max: !pto.vmi.vreg<128xf32>,
+      %scale: f32,
+      %dst0: !pto.ptr<f32, ub>,
+      %dst1: !pto.ptr<f32, ub>,
+      %off: index) {
+    %mask = pto.vmi.create_mask %off : index -> !pto.vmi.mask<128xpred>
+    %index = pto.vmi.vci %scale : f32 -> !pto.vmi.vreg<128xf32>
+    %score_base = pto.vmi.vadd %index, %index
+        : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>
+          -> !pto.vmi.vreg<128xf32>
+    %score = pto.vmi.vmuls %score_base, %scale, %mask
+        : !pto.vmi.vreg<128xf32>, f32, !pto.vmi.mask<128xpred>
+          -> !pto.vmi.vreg<128xf32>
+    pto.vmi.vstore %score, %dst0[%off]
+        : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
+
+    %exp = pto.vmi.vexpdif %x, %max, %mask
+        : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>,
+          !pto.vmi.mask<128xpred> -> !pto.vmi.vreg<128xf32>
+    %with_index = pto.vmi.vadd %exp, %index
+        : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>
+          -> !pto.vmi.vreg<128xf32>
+    %one = arith.constant 1 : index
+    %sum = pto.vmi.vcadd %with_index, %mask {group = 8, reassoc}
+        : !pto.vmi.vreg<128xf32>, !pto.vmi.mask<128xpred>
+          -> !pto.vmi.vreg<8xf32>
+    pto.vmi.group_store %sum, %dst1[%off], %one {num_groups = 8}
+        : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
+    return
+  }
+}
+
+// ASSIGN-LABEL: func.func @vmi_layout_assignment_rematerialize_weak_producers(
+// ASSIGN: %[[MASK:.*]] = pto.vmi.create_mask %{{.*}} : index -> !pto.vmi.mask<128xb32, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[INDEX:.*]] = pto.vmi.iota %{{.*}} : f32 -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[INDEX_C:.*]] = pto.vmi.iota %{{.*}} : f32 -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
+// ASSIGN: %[[SCORE_BASE:.*]] = pto.vmi.addf %{{.*}}, %[[INDEX_C]]
+// ASSIGN-SAME: !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>, !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>> -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
+// ASSIGN: %[[MASK_C:.*]] = pto.vmi.create_mask %{{.*}} : index -> !pto.vmi.mask<128xb32, #pto.vmi.layout<contiguous>>
+// ASSIGN: pto.vmi.vmuls %[[SCORE_BASE]], {{.*}}, %[[MASK_C]]
+// ASSIGN-SAME: !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>, f32, !pto.vmi.mask<128xb32, #pto.vmi.layout<contiguous>> -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
+// ASSIGN: pto.vmi.vexpdif {{.*}} !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: pto.vmi.group_reduce_addf {{.*}} !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+
+// REMAT-LABEL: func.func @vmi_layout_assignment_rematerialize_weak_producers(
+// REMAT: %[[INDEX_D2:.*]] = pto.vmi.iota %{{.*}} : f32 -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+// REMAT: %[[INDEX_C:.*]] = pto.vmi.iota %{{.*}} : f32 -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
+// REMAT: %[[MASK_C:.*]] = pto.vmi.create_mask %{{.*}} : index -> !pto.vmi.mask<128xb32, #pto.vmi.layout<contiguous>>
+// REMAT-NOT: pto.vmi.ensure_mask_layout
+
+// LOWER-LABEL: func.func @vmi_layout_assignment_rematerialize_weak_producers(
+// LOWER-NOT: pto.vintlv
+// LOWER-NOT: pto.pintlv_b32
+// LOWER: pto.vdintlv
+// LOWER: pto.vexpdif
+// LOWER: pto.vcgadd
+// LOWER-NOT: pto.vmi.

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -3279,6 +3279,7 @@ static void appendVMISemanticPipeline(OpPassManager &pm) {
   pm.addPass(createCSEPass());
   pm.addPass(pto::createVMILegalizeArithSelectPass());
   pm.addPass(pto::createVMIMaskGranularityAssignmentPass());
+  pm.addPass(pto::createVMILayoutRematerializeWeakProducersPass());
   pm.addPass(pto::createVMILayoutAssignmentPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());


### PR DESCRIPTION
## Summary
- Add a standalone `vmi-layout-rematerialize-weak-producers` pass before `vmi-layout-assignment`.
- Rematerialize pure layout-polymorphic producers (mask, constant, broadcast, iota/VCI) at multiple uses so independent consumer dataflows can select their natural layouts.
- Keep strong VReg propagation and layout-assignment priorities unchanged; no weak-fanout special case remains in `VMILayoutPropagation`.
- Add a regression test with two weak connection points (shared mask and iota/VCI) feeding contiguous and deinterleaved-2 flows.

## Validation
- Targeted rematerialization/assignment/VMI-to-VPTO lit test: passed.
- Real `.work/fa-vmi-current-q8192-k8192.pto`:
  - before: `vldsx2=2`, `vintlv=1`, `pintlv_b32=1`
  - after: `vldsx2=1`, `vintlv=0`, `pintlv_b32=0`
- Changed-code compliance checker: 0 errors, 0 warnings.

Fixes #1271
