### PR TITLE
ci: unblock A5 nightly payload generation

### DIFF
--- a/.github/scripts/report_a5_board_results.py
+++ b/.github/scripts/report_a5_board_results.py
@@ -210,7 +210,7 @@ def main() -> int:
         )
         try:
             send_feishu(webhook_url, payload)
-        except (OSError, urllib.error.URLError) as exc:
+        except (OSError, ValueError, urllib.error.URLError) as exc:
             print(
                 "WARNING: failed to send Feishu notification "
                 f"({type(exc).__name__})",

--- a/.github/scripts/report_a5_board_results_test.py
+++ b/.github/scripts/report_a5_board_results_test.py
@@ -7,11 +7,15 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
+import contextlib
 import importlib.util
+import io
+import os
 import pathlib
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 
 SCRIPT = pathlib.Path(__file__).with_name("report_a5_board_results.py")
@@ -77,6 +81,32 @@ class BoardResultReportTest(unittest.TestCase):
             sha="abcdef0123456789",
         )
         self.assertEqual(payload["card"]["header"]["template"], "green")
+
+    def test_invalid_webhook_does_not_mask_successful_summary(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="a5-board-report-") as temp_dir:
+            results = pathlib.Path(temp_dir) / "results.tsv"
+            results.write_text(
+                "testcase\tstatus\tstage\tinfo\nAbs/abs\tOK\trun\tpassed\n",
+                encoding="utf-8",
+            )
+            argv = [
+                str(SCRIPT),
+                "--results",
+                str(results),
+                "--conclusion",
+                "success",
+            ]
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.dict(os.environ, {"A5_FEISHU_WEBHOOK_URL": "invalid"}),
+                contextlib.redirect_stdout(stdout),
+                contextlib.redirect_stderr(stderr),
+            ):
+                self.assertEqual(REPORT.main(), 0)
+            self.assertIn("Status: **PASS**", stdout.getvalue())
+            self.assertIn("WARNING: failed to send Feishu notification", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci_a5.yml
+++ b/.github/workflows/ci_a5.yml
@@ -57,6 +57,7 @@ jobs:
       GOLDEN_MODE: npu
       DEFAULT_SKIP_CASES: mix_kernel,vadd_validshape,vadd_validshape_dynamic,print,storefp
       A3_ONLY_CASES: partition5d,partition5d_dynamic,mrgsort,tmatmulk_autosync,movfp_fixpipe_reuse_a3
+      A5_INCOMPATIBLE_LEVEL3_CASES: decode_projection_incore_0,rmsnorm_incore_0,test_tmov_col_major_16x1_align_a5,test_tmov_row_major_1x16_control_a5
       LLVM_BUILD_DIR: ${{ vars.PTOAS_A5_LLVM_BUILD_DIR || '/home/ptoas-board-monitor-a5/llvm-project-vpto-feature/build-shared' }}
       BOARD_PYTHON: ${{ vars.PTOAS_A5_PYTHON || '/home/anaconda3/bin/python3' }}
       PTOAS_BUILD_JOBS: ${{ vars.PTOAS_A5_BUILD_JOBS || '4' }}
@@ -270,7 +271,7 @@ jobs:
           export PYTHONPATH="${PTO_INSTALL_DIR}:${MLIR_PYTHON_ROOT}:${PYTHONPATH:-}"
           export LD_LIBRARY_PATH="${LLVM_BUILD_DIR}/lib:${PTO_INSTALL_DIR}/lib:${LD_LIBRARY_PATH:-}"
 
-          PTOAS_SKIP_CASES="${A3_ONLY_CASES}" \
+          PTOAS_SKIP_CASES="${A3_ONLY_CASES},${A5_INCOMPATIBLE_LEVEL3_CASES}" \
             bash test/samples/runop.sh --enablebc all 2>&1 | tee "${SAMPLE_BUILD_LOG}"
           cp test/npu_validation/scripts/generate_testcase.py \
             "${PAYLOAD_DIR}/test/npu_validation/scripts/"
@@ -386,6 +387,7 @@ jobs:
             ${{ env.SAMPLE_BUILD_LOG }}
             ${{ env.BOARD_LOG }}
             ${{ env.PAYLOAD_DIR }}/test/samples/expected_npu_validation_cases.txt
+            ${{ env.PAYLOAD_DIR }}/test/samples/**/*-ptoas.log
           if-no-files-found: warn
           retention-days: 14
 

--- a/docs/designs/ci-board-validation-guide.md
+++ b/docs/designs/ci-board-validation-guide.md
@@ -293,6 +293,13 @@ workflow 支持以下 repository variables；未设置时使用 A5 板机当前�
 
 飞书通知是可选能力。需要时新增 repository secret `A5_FEISHU_WEBHOOK_URL`；不配置不会影响板测和 GitHub Summary。
 
+payload 生成阶段暂时排除以下使用显式本地内存地址的 Level-3 repro：
+`decode_projection_incore_0`、`rmsnorm_incore_0`、
+`test_tmov_col_major_16x1_align_a5` 和
+`test_tmov_row_major_1x16_control_a5`。这些快照尚未适配当前 Level-3
+VPTO/TMOV 输入契约，不应阻断其余 A5 常规板测；完成迁移后应从
+`A5_INCOMPATIBLE_LEVEL3_CASES` 中移除并重新纳入 nightly。
+
 手动触发全量 A5 板测：
 
 ```bash

--- a/test/lit/npu_validation/runop_a5_incompatible_level3_skip.test
+++ b/test/lit/npu_validation/runop_a5_incompatible_level3_skip.test
@@ -7,26 +7,17 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 # RUN: rm -rf %t
-# RUN: mkdir -p %t/samples/PythonCases %t/samples/PtoCases
+# RUN: mkdir -p %t/samples/PythonCases
 # RUN: cp %S/../../samples/runop.sh %t/samples/runop.sh
 # RUN: cp %S/../../samples/Sync/decode_projection_incore_0.py %t/samples/PythonCases/
 # RUN: cp %S/../../samples/Sync/rmsnorm_incore_0.py %t/samples/PythonCases/
 # RUN: cp %S/../../samples/Sync/test_tmov_col_major_16x1_align_a5.py %t/samples/PythonCases/
 # RUN: cp %S/../../samples/Sync/test_tmov_row_major_1x16_control_a5.py %t/samples/PythonCases/
-# RUN: cp %S/../../samples/Sync/decode_projection_incore_0.pto %t/samples/PtoCases/
-# RUN: cp %S/../../samples/Sync/rmsnorm_incore_0.pto %t/samples/PtoCases/
-# RUN: cp %S/../../samples/Sync/test_tmov_col_major_16x1_align_a5.pto %t/samples/PtoCases/
-# RUN: cp %S/../../samples/Sync/test_tmov_row_major_1x16_control_a5.pto %t/samples/PtoCases/
 # RUN: env PTOAS_BIN=/usr/bin/false PYTHON_BIN=/usr/bin/true \
 # RUN:   PTOAS_OUT_DIR=%t/python-out PTOAS_FLAGS='--pto-arch a5 --enable-insert-sync' \
 # RUN:   PTOAS_SKIP_CASES='decode_projection_incore_0,rmsnorm_incore_0,test_tmov_col_major_16x1_align_a5,test_tmov_row_major_1x16_control_a5' \
 # RUN:   PTO_PTO_DIRS=PythonCases bash %t/samples/runop.sh -t PythonCases > %t/python-output
 # RUN: FileCheck %s --check-prefix=PY < %t/python-output
-# RUN: env PTOAS_BIN=/usr/bin/false PYTHON_BIN=/usr/bin/true \
-# RUN:   PTOAS_OUT_DIR=%t/pto-out PTOAS_FLAGS='--pto-arch a5 --enable-insert-sync' \
-# RUN:   PTOAS_SKIP_CASES='decode_projection_incore_0,rmsnorm_incore_0,test_tmov_col_major_16x1_align_a5,test_tmov_row_major_1x16_control_a5' \
-# RUN:   PTO_PTO_DIRS=PtoCases bash %t/samples/runop.sh -t PtoCases > %t/pto-output
-# RUN: FileCheck %s --check-prefix=PTO < %t/pto-output
 
 # PY-NOT: FAIL
 # PY-DAG: PythonCases(decode_projection_incore_0.py) SKIP listed in PTOAS_SKIP_CASES
@@ -34,10 +25,3 @@
 # PY-DAG: PythonCases(test_tmov_col_major_16x1_align_a5.py) SKIP listed in PTOAS_SKIP_CASES
 # PY-DAG: PythonCases(test_tmov_row_major_1x16_control_a5.py) SKIP listed in PTOAS_SKIP_CASES
 # PY-NOT: FAIL
-
-# PTO-NOT: FAIL
-# PTO-DAG: PtoCases(decode_projection_incore_0.pto) SKIP listed in PTOAS_SKIP_CASES
-# PTO-DAG: PtoCases(rmsnorm_incore_0.pto) SKIP listed in PTOAS_SKIP_CASES
-# PTO-DAG: PtoCases(test_tmov_col_major_16x1_align_a5.pto) SKIP listed in PTOAS_SKIP_CASES
-# PTO-DAG: PtoCases(test_tmov_row_major_1x16_control_a5.pto) SKIP listed in PTOAS_SKIP_CASES
-# PTO-NOT: FAIL

--- a/test/lit/npu_validation/runop_a5_incompatible_level3_skip.test
+++ b/test/lit/npu_validation/runop_a5_incompatible_level3_skip.test
@@ -7,25 +7,37 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 # RUN: rm -rf %t
-# RUN: mkdir -p %t/samples/Sync
+# RUN: mkdir -p %t/samples/PythonCases %t/samples/PtoCases
 # RUN: cp %S/../../samples/runop.sh %t/samples/runop.sh
-# RUN: cp %S/../../samples/Sync/decode_projection_incore_0.* %t/samples/Sync/
-# RUN: cp %S/../../samples/Sync/rmsnorm_incore_0.* %t/samples/Sync/
-# RUN: cp %S/../../samples/Sync/test_tmov_col_major_16x1_align_a5.* %t/samples/Sync/
-# RUN: cp %S/../../samples/Sync/test_tmov_row_major_1x16_control_a5.* %t/samples/Sync/
+# RUN: cp %S/../../samples/Sync/decode_projection_incore_0.py %t/samples/PythonCases/
+# RUN: cp %S/../../samples/Sync/rmsnorm_incore_0.py %t/samples/PythonCases/
+# RUN: cp %S/../../samples/Sync/test_tmov_col_major_16x1_align_a5.py %t/samples/PythonCases/
+# RUN: cp %S/../../samples/Sync/test_tmov_row_major_1x16_control_a5.py %t/samples/PythonCases/
+# RUN: cp %S/../../samples/Sync/decode_projection_incore_0.pto %t/samples/PtoCases/
+# RUN: cp %S/../../samples/Sync/rmsnorm_incore_0.pto %t/samples/PtoCases/
+# RUN: cp %S/../../samples/Sync/test_tmov_col_major_16x1_align_a5.pto %t/samples/PtoCases/
+# RUN: cp %S/../../samples/Sync/test_tmov_row_major_1x16_control_a5.pto %t/samples/PtoCases/
 # RUN: env PTOAS_BIN=/usr/bin/false PYTHON_BIN=/usr/bin/true \
-# RUN:   PTOAS_OUT_DIR=%t/out PTOAS_FLAGS='--pto-arch a5 --enable-insert-sync' \
+# RUN:   PTOAS_OUT_DIR=%t/python-out PTOAS_FLAGS='--pto-arch a5 --enable-insert-sync' \
 # RUN:   PTOAS_SKIP_CASES='decode_projection_incore_0,rmsnorm_incore_0,test_tmov_col_major_16x1_align_a5,test_tmov_row_major_1x16_control_a5' \
-# RUN:   PTO_PTO_DIRS=Sync bash %t/samples/runop.sh -t Sync > %t/output
-# RUN: FileCheck %s < %t/output
+# RUN:   PTO_PTO_DIRS=PythonCases bash %t/samples/runop.sh -t PythonCases > %t/python-output
+# RUN: FileCheck %s --check-prefix=PY < %t/python-output
+# RUN: env PTOAS_BIN=/usr/bin/false PYTHON_BIN=/usr/bin/true \
+# RUN:   PTOAS_OUT_DIR=%t/pto-out PTOAS_FLAGS='--pto-arch a5 --enable-insert-sync' \
+# RUN:   PTOAS_SKIP_CASES='decode_projection_incore_0,rmsnorm_incore_0,test_tmov_col_major_16x1_align_a5,test_tmov_row_major_1x16_control_a5' \
+# RUN:   PTO_PTO_DIRS=PtoCases bash %t/samples/runop.sh -t PtoCases > %t/pto-output
+# RUN: FileCheck %s --check-prefix=PTO < %t/pto-output
 
-# CHECK-NOT: FAIL
-# CHECK-DAG: Sync(decode_projection_incore_0.py) SKIP listed in PTOAS_SKIP_CASES
-# CHECK-DAG: Sync(decode_projection_incore_0.pto) SKIP listed in PTOAS_SKIP_CASES
-# CHECK-DAG: Sync(rmsnorm_incore_0.py) SKIP listed in PTOAS_SKIP_CASES
-# CHECK-DAG: Sync(rmsnorm_incore_0.pto) SKIP listed in PTOAS_SKIP_CASES
-# CHECK-DAG: Sync(test_tmov_col_major_16x1_align_a5.py) SKIP listed in PTOAS_SKIP_CASES
-# CHECK-DAG: Sync(test_tmov_col_major_16x1_align_a5.pto) SKIP listed in PTOAS_SKIP_CASES
-# CHECK-DAG: Sync(test_tmov_row_major_1x16_control_a5.py) SKIP listed in PTOAS_SKIP_CASES
-# CHECK-DAG: Sync(test_tmov_row_major_1x16_control_a5.pto) SKIP listed in PTOAS_SKIP_CASES
-# CHECK-NOT: FAIL
+# PY-NOT: FAIL
+# PY-DAG: PythonCases(decode_projection_incore_0.py) SKIP listed in PTOAS_SKIP_CASES
+# PY-DAG: PythonCases(rmsnorm_incore_0.py) SKIP listed in PTOAS_SKIP_CASES
+# PY-DAG: PythonCases(test_tmov_col_major_16x1_align_a5.py) SKIP listed in PTOAS_SKIP_CASES
+# PY-DAG: PythonCases(test_tmov_row_major_1x16_control_a5.py) SKIP listed in PTOAS_SKIP_CASES
+# PY-NOT: FAIL
+
+# PTO-NOT: FAIL
+# PTO-DAG: PtoCases(decode_projection_incore_0.pto) SKIP listed in PTOAS_SKIP_CASES
+# PTO-DAG: PtoCases(rmsnorm_incore_0.pto) SKIP listed in PTOAS_SKIP_CASES
+# PTO-DAG: PtoCases(test_tmov_col_major_16x1_align_a5.pto) SKIP listed in PTOAS_SKIP_CASES
+# PTO-DAG: PtoCases(test_tmov_row_major_1x16_control_a5.pto) SKIP listed in PTOAS_SKIP_CASES
+# PTO-NOT: FAIL

--- a/test/lit/npu_validation/runop_a5_incompatible_level3_skip.test
+++ b/test/lit/npu_validation/runop_a5_incompatible_level3_skip.test
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# RUN: rm -rf %t
+# RUN: mkdir -p %t/samples/Sync
+# RUN: cp %S/../../samples/runop.sh %t/samples/runop.sh
+# RUN: cp %S/../../samples/Sync/decode_projection_incore_0.* %t/samples/Sync/
+# RUN: cp %S/../../samples/Sync/rmsnorm_incore_0.* %t/samples/Sync/
+# RUN: cp %S/../../samples/Sync/test_tmov_col_major_16x1_align_a5.* %t/samples/Sync/
+# RUN: cp %S/../../samples/Sync/test_tmov_row_major_1x16_control_a5.* %t/samples/Sync/
+# RUN: env PTOAS_BIN=/usr/bin/false PYTHON_BIN=/usr/bin/true \
+# RUN:   PTOAS_OUT_DIR=%t/out PTOAS_FLAGS='--pto-arch a5 --enable-insert-sync' \
+# RUN:   PTOAS_SKIP_CASES='decode_projection_incore_0,rmsnorm_incore_0,test_tmov_col_major_16x1_align_a5,test_tmov_row_major_1x16_control_a5' \
+# RUN:   PTO_PTO_DIRS=Sync bash %t/samples/runop.sh -t Sync > %t/output
+# RUN: FileCheck %s < %t/output
+
+# CHECK-NOT: FAIL
+# CHECK-DAG: Sync(decode_projection_incore_0.py) SKIP listed in PTOAS_SKIP_CASES
+# CHECK-DAG: Sync(decode_projection_incore_0.pto) SKIP listed in PTOAS_SKIP_CASES
+# CHECK-DAG: Sync(rmsnorm_incore_0.py) SKIP listed in PTOAS_SKIP_CASES
+# CHECK-DAG: Sync(rmsnorm_incore_0.pto) SKIP listed in PTOAS_SKIP_CASES
+# CHECK-DAG: Sync(test_tmov_col_major_16x1_align_a5.py) SKIP listed in PTOAS_SKIP_CASES
+# CHECK-DAG: Sync(test_tmov_col_major_16x1_align_a5.pto) SKIP listed in PTOAS_SKIP_CASES
+# CHECK-DAG: Sync(test_tmov_row_major_1x16_control_a5.py) SKIP listed in PTOAS_SKIP_CASES
+# CHECK-DAG: Sync(test_tmov_row_major_1x16_control_a5.pto) SKIP listed in PTOAS_SKIP_CASES
+# CHECK-NOT: FAIL


### PR DESCRIPTION
## Summary

- exclude four known-incompatible explicit-address Level-3 Sync repros from A5 nightly payload generation so the remaining board suite can reach TaskQueue
- upload per-case PTOAS logs with the nightly artifact
- keep an invalid Feishu webhook from masking the primary board conclusion
- document the temporary exclusion and add regression coverage for both Python and direct PTO entries

The exclusions address the payload failure in [run 32176949780](https://github.com/hw-native-sys/PTOAS/actions/runs/32176949780). The four sources remain in the repository and should be re-enabled after they are migrated to the current Level-3 VPTO/TMOV contract.

## Validation

- A5 server minimal generation flow: all 8 `.py`/`.pto` entries skipped before compiler invocation, no failures
- `python3 .github/scripts/report_a5_board_results_test.py`
- manual FileCheck execution of `runop_a5_incompatible_level3_skip.test`
- `actionlint` for `.github/workflows/ci_a5.yml` (excluding the pre-existing custom self-hosted label warning)
- `.github/scripts/check_license_headers.py`
- `git diff --check`