### PR TITLE
fix(ptoas): reject non-positive scf.for steps

### DIFF
--- a/test/lit/pto/scf_for_non_positive_step_invalid.pto
+++ b/test/lit/pto/scf_for_non_positive_step_invalid.pto
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: split-file %s %t
+// RUN: not ptoas --emit-pto-ir %t/negative.pto 2>&1 | FileCheck %s --check-prefix=NEGATIVE
+// RUN: not ptoas --emit-pto-ir %t/zero.pto 2>&1 | FileCheck %s --check-prefix=ZERO
+// RUN: ptoas --emit-pto-ir %t/positive.pto | FileCheck %s --check-prefix=POSITIVE
+
+//--- negative.pto
+module {
+  func.func @negative_step() {
+    %c8 = arith.constant 8 : index
+    %c0 = arith.constant 0 : index
+    %cn1 = arith.constant -1 : index
+    scf.for %i = %c8 to %c0 step %cn1 {
+    }
+    return
+  }
+}
+
+// NEGATIVE: error: 'scf.for' op constant step operand must be positive
+
+//--- zero.pto
+module {
+  func.func @zero_step() {
+    %c0 = arith.constant 0 : index
+    %c8 = arith.constant 8 : index
+    scf.for %i = %c0 to %c8 step %c0 {
+    }
+    return
+  }
+}
+
+// ZERO: error: 'scf.for' op constant step operand must be positive
+
+//--- positive.pto
+module {
+  func.func private @consume(index)
+
+  func.func @positive_step() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    scf.for %i = %c0 to %c8 step %c1 {
+      func.call @consume(%i) : (index) -> ()
+    }
+    return
+  }
+}
+
+// POSITIVE-LABEL: func.func @positive_step
+// POSITIVE: scf.for

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -34,6 +34,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include <cctype>
 #include <cstdlib>
 #include <cstring>
@@ -3296,11 +3297,30 @@ static void appendVMISemanticPipeline(OpPassManager &pm) {
   pm.addPass(pto::createVMIToVPTOPass());
 }
 
+/// Reject statically invalid scf.for steps at the PTOAS input boundary.
+/// LLVM 19 intentionally does not follow SSA values from scf.for verifiers,
+/// so the generic MLIR verifier cannot enforce this semantic constraint.
+static LogicalResult validateSCFForConstantSteps(ModuleOp module) {
+  WalkResult result = module.walk([](scf::ForOp forOp) -> WalkResult {
+    std::optional<int64_t> step = getConstantIntValue(forOp.getStep());
+    if (!step || *step > 0)
+      return WalkResult::advance();
+
+    forOp.emitOpError("constant step operand must be positive");
+    return WalkResult::interrupt();
+  });
+  return result.wasInterrupted() ? failure() : success();
+}
+
 int mlir::pto::compilePTOASModule(
     OwningOpRef<ModuleOp> &module, PTOASContext &context,
     PTOBackend effectiveBackend, PTOASCompileResult &result,
     bool emitVPTOHostStub) {
   result.reset();
+  if (failed(validateSCFForConstantSteps(*module))) {
+    return 1;
+  }
+
   // Validate stack-local struct provenance before every output path. In
   // particular, --emit-pto-ir returns before the EmitC validation pass and
   // VPTO does not use that pass.


### PR DESCRIPTION
## Summary

- reject statically known non-positive `scf.for` steps at the PTOAS input boundary
- diagnose both negative and zero constant steps before lowering can silently drop a loop or emit a non-terminating loop
- add lit coverage for negative, zero, and positive constant steps

## Validation

- focused lit test: 1/1 passed
- full PTO lit suite: 1810 passed, 1 unsupported
- PTODSL CTest suite: 40/40 passed
- original issue reproducer: negative and zero steps both exit with status 1 and report `constant step operand must be positive`

Closes #1288
