### PR TITLE
chore(release): bump VMI version to v0.1.5

### DIFF
--- a/.github/scripts/update_vmi_version.py
+++ b/.github/scripts/update_vmi_version.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Update the next VMI package version after a VMI release."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+VERSION_RE = re.compile(r'^(\+version = ")([0-9]+\.[0-9]+\.[0-9]+)(")$', re.M)
+TAG_RE = re.compile(r"^vmi-v([0-9]+)\.([0-9]+)\.([0-9]+)$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--patch-file", default="packaging/ptoas-vmi/pyproject.toml.patch")
+    parser.add_argument("--version", required=True, help="Released VMI tag, for example vmi-v0.1.5.")
+    parser.add_argument("--next", action="store_true", help="Advance the released patch version by one.")
+    return parser.parse_args()
+
+
+def normalize_tag(tag: str) -> str:
+    match = TAG_RE.fullmatch(tag.strip())
+    if not match:
+        raise ValueError(f"invalid VMI release tag '{tag}'")
+    return ".".join(match.groups())
+
+
+def read_version(patch_file: pathlib.Path) -> tuple[str, re.Match[str]]:
+    content = patch_file.read_text(encoding="utf-8")
+    matches = list(VERSION_RE.finditer(content))
+    if len(matches) != 1:
+        raise ValueError(f"VMI metadata patch must contain exactly one +version line: {patch_file}")
+    return matches[0].group(2), matches[0]
+
+
+def bump_version(version: str) -> str:
+    major, minor, patch = (int(part) for part in version.split("."))
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def update_version(patch_file: pathlib.Path, released_version: str, advance: bool) -> str:
+    content = patch_file.read_text(encoding="utf-8")
+    current_version, match = read_version(patch_file)
+    if current_version != released_version:
+        raise ValueError(f"metadata version {current_version} does not match released version {released_version}")
+    next_version = bump_version(released_version) if advance else released_version
+    updated = content[: match.start(2)] + next_version + content[match.end(2) :]
+    if updated != content:
+        patch_file.write_text(updated, encoding="utf-8")
+    return next_version
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        released_version = normalize_tag(args.version)
+        next_version = update_version(pathlib.Path(args.patch_file), released_version, args.next)
+    except (OSError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    print(next_version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/update_vmi_version.py
+++ b/.github/scripts/update_vmi_version.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
 """Update the next VMI package version after a VMI release."""
 
 from __future__ import annotations

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -508,3 +508,38 @@ jobs:
           git add CMakeLists.txt
           git commit -m "chore(release): bump base version to v${{ steps.bump.outputs.next_base_version }}"
           git push origin HEAD:${{ github.event.repository.default_branch }}
+
+  bump_vmi_version:
+    name: Bump VMI version after release
+    if: github.event_name == 'release' && github.event.action == 'released' && startsWith(github.ref_name, 'vmi-v')
+    needs: upload_release_assets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Update VMI package version
+        id: bump
+        run: |
+          next_vmi_version="$(python3 .github/scripts/update_vmi_version.py \
+            --version "${GITHUB_REF_NAME}" \
+            --next)"
+          echo "next_vmi_version=${next_vmi_version}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit version bump
+        run: |
+          if git diff --quiet -- packaging/ptoas-vmi/pyproject.toml.patch; then
+            echo "VMI metadata already matches the next version."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packaging/ptoas-vmi/pyproject.toml.patch
+          git commit -m "chore(release): bump VMI version to v${{ steps.bump.outputs.next_vmi_version }}"
+          git push origin HEAD:${{ github.event.repository.default_branch }}

--- a/packaging/ptoas-vmi/pyproject.toml.patch
+++ b/packaging/ptoas-vmi/pyproject.toml.patch
@@ -7,7 +7,7 @@ diff --git a/pyproject.toml b/pyproject.toml
 -dynamic = ["version"]
 -description = "PTO Assembler & Optimizer"
 +name = "ptoas-vmi"
-+version = "0.1.4"
++version = "0.1.5"
 +description = "PTO Assembler & Optimizer with VMI support"
  readme = "README.md"
  requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump the VMI package version from `0.1.4` to `0.1.5`.
- Keep the VMI release workflow version check aligned with the planned `vmi-v0.1.5` tag.

## Scope

This PR only changes the VMI packaging metadata version.