### PR TITLE
fix: keep shared scalar helpers core-neutral

### DIFF
--- a/lib/PTO/Transforms/PTONormalizeUncoveredTileSections.cpp
+++ b/lib/PTO/Transforms/PTONormalizeUncoveredTileSections.cpp
@@ -545,6 +545,23 @@ static std::optional<InferredSectionKind> classifyTileOp(Operation *op) {
   return classifyTileOpByPipe(op);
 }
 
+static std::optional<InferredSectionKind>
+classifyWholeFunctionPipeOp(Operation *op) {
+  if (isTileLikeOp(op)) {
+    return classifyTileOp(op);
+  }
+
+  auto pipeOp = dyn_cast_or_null<OpPipeInterface>(op);
+  if (!pipeOp) {
+    return std::nullopt;
+  }
+
+  // Ordinary PIPE_S and PIPE_MTE2 operations do not determine physical core
+  // ownership because both Cube and Vector cores provide those pipelines.
+  // TileOps retain their dedicated semantic classification above.
+  return classifySyncPipe(pipeOp.getPipe());
+}
+
 struct ModuleKindSummary {
   unsigned vectorCount = 0;
   unsigned cubeCount = 0;
@@ -582,7 +599,8 @@ static void inspectModuleKindOperation(Operation *op,
       summary.ambiguousOps.push_back(op);
     }
   } else if (isPipeLikeOp(op)) {
-    if (std::optional<InferredSectionKind> kind = classifyTileOp(op)) {
+    if (std::optional<InferredSectionKind> kind =
+            classifyWholeFunctionPipeOp(op)) {
       if (*kind == InferredSectionKind::Vector) {
         ++summary.vectorCount;
       } else {

--- a/test/lit/pto/issue1218_shared_scalar_helper_emitc.pto
+++ b/test/lit/pto/issue1218_shared_scalar_helper_emitc.pto
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guard: PIPE_S is shared by Cube and Vector cores, so scalar-only helpers must
+// remain callable from a Cube kernel instead of being guarded by __DAV_VEC__.
+// RUN: pto-test-opt --pto-normalize-uncovered-tile-sections %s -o - | FileCheck %s --check-prefix=IR
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 %s -o - 2>&1 | FileCheck %s --check-prefix=EMITC
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @cube_kernel(%ctx: !pto.ptr<i64>, %peer: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %offset = func.call @CommRemoteOffset_i32(%ctx, %peer)
+        : (!pto.ptr<i64>, index) -> index
+    return
+  }
+
+  func.func private @CommRemoteOffset_i32(
+      %ctx: !pto.ptr<i64>, %peer: index) -> index {
+    %c_r = arith.constant 2 : index
+    %c_w = arith.constant 4 : index
+    %rank_pair = pto.load_scalar %ctx[%c_r] : !pto.ptr<i64> -> i64
+    %rank_i32 = arith.trunci %rank_pair : i64 to i32
+    %rank = arith.index_cast %rank_i32 : i32 to index
+    %local_offset = arith.addi %c_w, %rank : index
+    %local_base = pto.load_scalar %ctx[%local_offset]
+        : !pto.ptr<i64> -> i64
+    %peer_offset = arith.addi %c_w, %peer : index
+    %peer_base = pto.load_scalar %ctx[%peer_offset]
+        : !pto.ptr<i64> -> i64
+    %byte_offset = arith.subi %peer_base, %local_base : i64
+    %element_size = arith.constant 4 : i64
+    %element_offset_i64 = arith.divsi %byte_offset, %element_size : i64
+    %element_offset = arith.index_cast %element_offset_i64 : i64 to index
+    return %element_offset : index
+  }
+}
+
+// IR-LABEL: func.func private @CommRemoteOffset_i32(
+// IR-NOT: pto.kernel_kind
+// IR: pto.load_scalar
+
+// EMITC-LABEL: static AICORE int64_t CommRemoteOffset_i32(
+// EMITC-NOT: __DAV_VEC__
+// EMITC: return
+// EMITC-LABEL: AICORE void cube_kernel(
+// EMITC: #if defined(__DAV_CUBE__)


### PR DESCRIPTION
## Summary

- keep ordinary shared-pipe operations core-neutral during whole-function kernel-kind inference
- preserve the existing TileOp-specific classification path
- add an IR and EmitC regression for a scalar-only helper called from a Cube kernel

## Root cause addressed by this PR

`pto.load_scalar` runs on `PIPE_S`. Whole-function inference reused the TileOp pipe classifier, which treated `PIPE_S` as Vector and attached `pto.kernel_kind<vector>` to `CommRemoteOffset_i32`. EmitC then guarded its local declarations with `__DAV_VEC__`, while the Cube caller and return expression remained active.

This PR fixes that incorrect `PIPE_S -> Vector` inference, which is the path that triggered #1218.

## Known limitation / follow-up

This PR does not change the function-level core-guard placement in `FuncToEmitC`. Independently of inference, an explicitly annotated value-returning `pto.kernel_kind` function can still emit a return after `#endif` while the returned value is declared inside the guard. That separate EmitC defect is intentionally outside the scope of this PR and should be tracked and fixed separately.

## Validation

- issue #1218 full PTO IR compiled successfully with PTOAS level3
- generated `CommRemoteOffset_i32` contains no `__DAV_VEC__` guard
- Bisheng Cube compilation for `dav-c220-cube` succeeded with zero errors
- focused lit regression passed: 1/1
- `check-pto`: 1811 passed, 1 unsupported
- `check-dsl`: 40/40 passed

Closes #1218
