### PR TITLE
fix(bufid_sync): make optimizeSamePipeMerge deterministic

### DIFF
--- a/lib/PTO/Transforms/BufidSync/BufidSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncAnalysis.cpp
@@ -525,8 +525,50 @@ void BufidSyncAnalysis::insertSyncOperations() {
 }
 
 void BufidSyncAnalysis::optimizeSamePipeMerge() {
+  // DETERMINISTIC ITERATION ORDER, and it is load-bearing rather than tidiness.
+  //
+  // `op2BufSync_` is a `DenseMap<Operation *, ...>`, so its iteration order
+  // follows the POINTER VALUES of the ops, which differ between runs of the same
+  // binary on the same input. The survivor below is
+  // `*std::min_element(ids)` over whichever ids the first-visited op happens to
+  // group, and it is recorded first-writer-wins, so a different visit order picks
+  // a different survivor and emits different code.
+  //
+  // MEASURED before this fix: `Qwen3DecodeA5/rope_kv_cache` compiled six times,
+  // each run pinned with `taskset -c 0`, emitted 24/24/24/23/23/23 `get_buf`.
+  // `mergeMap` size was stable at 4 every run while the TARGETS drifted
+  // (9->2/6/8, 10->3/2/6); only 3->0 and 8->3 were stable. Pinning rules out a
+  // thread race -- it is bucket order. This violates the determinism
+  // `docs/bufid_sync_a5_design.md:300` requires, breaks reproducible builds, and
+  // silently adds run-to-run variance to any A/B measurement taken through this
+  // pass.
+  //
+  // Ordering by the op's earliest bracket position (then by its smallest logic id
+  // as a tie-break) is stable across runs because both come from the SyncIR, not
+  // from the heap. The unified allocator never calls this pass, so it was already
+  // deterministic and is unaffected either way.
+  llvm::SmallVector<Operation *> orderedOps;
+  orderedOps.reserve(op2BufSync_.size());
+  for (auto &entry : op2BufSync_)
+    orderedOps.push_back(entry.first);
+  auto sortKeyOf = [&](Operation *op) {
+    const BufSyncPipeBuild &b = op2BufSync_[op];
+    int idx = std::numeric_limits<int>::max();
+    int lid = std::numeric_limits<int>::max();
+    for (const auto &list : {b.pipeBefore, b.pipeAfter})
+      for (const auto &s : list) {
+        idx = std::min(idx, static_cast<int>(s.syncIRIndex));
+        lid = std::min(lid, s.logicId);
+      }
+    return std::make_pair(idx, lid);
+  };
+  llvm::sort(orderedOps, [&](Operation *a, Operation *b) {
+    return sortKeyOf(a) < sortKeyOf(b);
+  });
+
   DenseMap<int, DenseSet<int>> logicIdToPipeInts;
-  for (auto &[op, build] : op2BufSync_) {
+  for (Operation *op : orderedOps) {
+    auto &build = op2BufSync_[op];
     DenseSet<std::pair<int, int>> seen;
     for (auto &s : build.pipeBefore) {
       auto key = std::make_pair(static_cast<int>(s.pipe), s.logicId);
@@ -544,7 +586,8 @@ void BufidSyncAnalysis::optimizeSamePipeMerge() {
 
   DenseMap<int, int> mergeMap;
 
-  for (auto &[op, build] : op2BufSync_) {
+  for (Operation *op : orderedOps) {
+    auto &build = op2BufSync_[op];
     DenseMap<int, SmallVector<int>> pipeIntToLogicIds;
     DenseSet<std::pair<int, int>> seen;
     for (auto &s : build.pipeBefore) {


### PR DESCRIPTION
`--enable-bufid_sync` emitted different code on repeated runs of the same binary
over the same input.

### Cause
`optimizeSamePipeMerge` iterated `op2BufSync_`, a `DenseMap<Operation *, ...>`, so
visit order followed pointer values. The merge survivor is `*std::min_element(ids)`
over whichever ids the first-visited op groups, recorded first-writer-wins — so a
different visit order picks a different survivor and emits different code.

### Evidence
Eight runs of the same command, each pinned with `taskset -c 0` to rule out a
thread race:

| | `get_buf` | distinct emissions |
|---|---|---|
| before | 24 24 24 24 23 24 24 24 | **3 of 8** |
| after | stable | **1 of 8** |

`mergeMap` size was stable while its targets drifted (9→2 / 9→6 / 9→8, 10→3 /
10→2 / 10→6). Pinning rules out concurrency: it is bucket order.

The exact sequence is deliberately not presented as reproducible — it cannot be,
since that is the defect. What reproduces is the variance, not the pattern.

### Fix
Order ops by earliest bracket `syncIRIndex`, tie-broken by smallest `logicId` —
both come from the SyncIR rather than the heap, so the order is stable across
runs. Only the two loops reading `op2BufSync_` needed it: the int-keyed maps
inside were already deterministic given a deterministic outer order, and the
final rewrite loop is order-independent because it writes a fresh map.

### Why it matters beyond reproducible builds
Every A/B measurement previously taken through this pass carried roughly one
`get_buf` per kernel of unattributed run-to-run variance. Any buffer-id
comparison predating this fix should be treated as carrying that noise.

This also restores what `docs/bufid_sync_a5_design.md:300` already requires:
*"The traversal order should be deterministic so generated IDs are stable."*

### Verification
- 40 pinned runs across three kernels post-fix: **zero variance**
- lit **1664 passed / 0 failed**; ctest **50/50**
- The unified allocator never calls this pass (`BufidSyncPass.cpp:78` is the only
  caller), so that path was already deterministic and is unaffected
