### PR TITLE
add sync.set <PIPE_MTE1> / sync.set <PIPE_V>

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -4052,9 +4052,9 @@ LogicalResult mlir::pto::SyncSetOp::verify() {
   auto verifyA5 = [&]() -> LogicalResult {
     if (IntegerAttr eventIdAttr = getEventIdAttr()) {
       int64_t eventId = eventIdAttr.getInt();
-      if (eventId < 0 || eventId > 15) {
+      if (eventId < 0 || eventId > 31) {
         return emitOpError()
-               << "A5 sync.set expects static FFTS event_id in [0, 15], but got "
+               << "A5 sync.set expects static event_id in [0, 31], but got "
                << eventId;
       }
     }
@@ -4209,9 +4209,9 @@ LogicalResult mlir::pto::SyncWaitOp::verify() {
   auto verifyA5 = [&]() -> LogicalResult {
     if (IntegerAttr eventIdAttr = getEventIdAttr()) {
       int64_t eventId = eventIdAttr.getInt();
-      if (eventId < 0 || eventId > 15) {
+      if (eventId < 0 || eventId > 31) {
         return emitOpError()
-               << "A5 sync.wait expects static FFTS event_id in [0, 15], but got "
+               << "A5 sync.wait expects static physical event_id in [0, 31], but got "
                << eventId;
       }
     }

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -6811,6 +6811,54 @@ def wait_intra_block(pipe, event_id):
     _pto.wait_intra_block(_pipe_attr(pipe), event_operand)
 
 
+def set_cross_flag(pipe, event_id):
+    """``pto.set_cross_flag(pipe, event_id)`` – cross-core sync facade for ``pto.sync.set``."""
+    _validate_sync_pipe(pipe, context="set_cross_flag(pipe, event_id)", allowed=("PIPE_FIX",))
+    event_operand = _sync_event_id_operand(event_id, context="set_cross_flag(..., event_id=...)")
+    _pto.sync_set(_pipe_attr(pipe), event_operand)
+
+
+def wait_cross_flag(pipe, event_id):
+    """``pto.wait_cross_flag(pipe, event_id)`` – cross-core sync facade for ``pto.sync.wait``."""
+    _validate_sync_pipe(pipe, context="wait_cross_flag(pipe, event_id)", allowed=("PIPE_FIX",))
+    event_operand = _sync_event_id_operand(event_id, context="wait_cross_flag(..., event_id=...)")
+    _pto.sync_wait(_pipe_attr(pipe), event_operand)
+
+
+def set_intra_flag(pipe, event_id):
+    """``pto.set_intra_flag(pipe, event_id)`` – intra-block sync facade for ``pto.sync.set``."""
+    _validate_sync_pipe(
+        pipe,
+        context="set_intra_flag(pipe, event_id)",
+        allowed=("PIPE_FIX", "PIPE_MTE1", "PIPE_MTE2", "PIPE_MTE3", "PIPE_V"),
+    )
+    event_operand = _sync_event_id_operand_in_range(
+        event_id,
+        context="set_intra_flag(..., event_id=...)",
+        lo=0,
+        hi=31,
+        meaning="physical event_id",
+    )
+    _pto.sync_set(_pipe_attr(pipe), event_operand)
+
+
+def wait_intra_flag(pipe, event_id):
+    """``pto.wait_intra_flag(pipe, event_id)`` – intra-block sync facade for ``pto.sync.wait``."""
+    _validate_sync_pipe(
+        pipe,
+        context="wait_intra_flag(pipe, event_id)",
+        allowed=("PIPE_FIX", "PIPE_MTE1", "PIPE_MTE2", "PIPE_MTE3", "PIPE_V"),
+    )
+    event_operand = _sync_event_id_operand_in_range(
+        event_id,
+        context="wait_intra_flag(..., event_id=...)",
+        lo=0,
+        hi=31,
+        meaning="physical event_id",
+    )
+    _pto.sync_wait(_pipe_attr(pipe), event_operand)
+
+
 def set_flag(src: str, dst: str, *, event_id: int = 0):
     """``pto.set_flag[src, dst, event_id]``.
 
@@ -6958,6 +7006,7 @@ __all__ = [
     "syncthreads", "threadfence", "threadfence_block", "trap", "keep", "resume",
     "pipe_barrier", "get_buf", "rls_buf",
     "set_cross_block", "wait_cross_block", "set_intra_block", "wait_intra_block",
+    "set_cross_flag", "wait_cross_flag", "set_intra_flag", "wait_intra_flag",
     "set_flag", "wait_flag",
     "reserve_buffer", "import_reserved_buffer",
 ]

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -152,6 +152,7 @@ from ._ops import (             # noqa: F401
     pipe_barrier,
     get_buf, rls_buf,
     set_cross_block, wait_cross_block, set_intra_block, wait_intra_block,
+    set_cross_flag, wait_cross_flag, set_intra_flag, wait_intra_flag,
     set_flag, wait_flag,
     reserve_buffer, import_reserved_buffer,
 )

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -388,10 +388,12 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         preferred_names = [
             "set_cross_block", "wait_cross_block",
             "set_intra_block", "wait_intra_block",
-        ]
-        legacy_names = [
             "set_cross_flag", "wait_cross_flag",
             "set_intra_flag", "wait_intra_flag",
+        ]
+        legacy_names = [
+            "set_cross_core", "wait_flag_dev",
+            "wait_intra_core",
         ]
 
         for name in preferred_names:


### PR DESCRIPTION
Summary
Add PTODSL sync facades that lower directly to the unified pto.sync.set / pto.sync.wait ops, and widen the A5 static event-id range for those ops from [0, 15] to [0, 31].

Problem
A5 mixed kernels need intra-block cross-pipe synchronization between the Cube side and the Vector side. In many schedules the natural signal is emitted directly by a producer pipe such as PIPE_MTE1 or PIPE_V, and the consumer waits on that same signal. The previous state made this difficult for two reasons:

The PTODSL surface exposed only set_intra_block / wait_intra_block style facades, which lower to the named block-sync ops. There was no public PTODSL facade for the unified pto.sync.set / pto.sync.wait ops, even though the lower-level VPTO dialect already supported them.
The A5 verifier restricted static sync.set / sync.wait event ids to [0, 15], while physical intra-block event ids in [16, 31] are valid.
As a result, kernels that wanted to signal directly from a non-FIX/non-MTE3 pipe were forced to insert bridge signals through an intermediate pipe. Those bridges introduce extra set_flag / wait_flag pairs and extra sync.wait events, which can amplify the wait count on a single pipe and serialize work that should otherwise overlap. This is a common issue for mixed kernels, not specific to any particular workload.

Fixes: https://github.com/mouliangyu/PTOAS/issues/576