### PR TITLE
vgather support i8/ui8 -> i16/ui16

### DIFF
--- a/docs/isa/vmi-isa/07-sfu.md
+++ b/docs/isa/vmi-isa/07-sfu.md
@@ -413,7 +413,7 @@
 
 ### `pto.vmi.vgather`
 
-- **semantics:** Indexed gather from UB at B32 granularity. For each active
+- **semantics:** Indexed gather from UB at B32/B16 granularity. For each active
   lane `i`, load `src[offsets[i]]`.
 
   ```c
@@ -423,7 +423,17 @@
 
 - **syntax:**
   ```mlir
-  %g = pto.vmi.vgather %src, %offsets, %mask : !pto.ptr<T, ub>, !pto.vmi.vreg<L×i32>, !pto.vmi.mask<L> -> !pto.vmi.vreg<L×T>
+  // B32 path
+  %g = pto.vmi.vgather %src, %offsets, %mask
+      : !pto.ptr<T, ub>, !pto.vmi.vreg<L×i32>, !pto.vmi.mask<L×b32> -> !pto.vmi.vreg<L×T>   // T in {i32,ui32,f32}
+
+  // B16 path
+  %g = pto.vmi.vgather %src, %offsets, %mask
+      : !pto.ptr<T, ub>, !pto.vmi.vreg<L×ui16>, !pto.vmi.mask<L×b16> -> !pto.vmi.vreg<L×T>   // T in {i16,ui16,f16,bf16}
+  %g = pto.vmi.vgather %src, %offsets, %mask
+      : !pto.ptr<i8, ub>, !pto.vmi.vreg<L×ui16>, !pto.vmi.mask<L×b16> -> !pto.vmi.vreg<L×i16>
+  %g = pto.vmi.vgather %src, %offsets, %mask
+      : !pto.ptr<ui8, ub>, !pto.vmi.vreg<L×ui16>, !pto.vmi.mask<L×b16> -> !pto.vmi.vreg<L×ui16>
   ```
 - **operands:**
 
@@ -435,12 +445,10 @@
 
 - **results:** `!pto.vmi.vreg<L×T>`
 - **attributes:** `pmode`
-- **datatypes:** `i8`–`i32`, `f16`, `bf16`, `f32`
-- **lowering to `pto.mi`:**
-  ```
-  K × pto.vgather2
-  ```
-  `#mi = K`, `dep = 1`, util data-dependent.
+- **datatypes:** B32 -- `i32`/`ui32`/`f32`; B16 -- `i16`/`ui16`/`f16`/`bf16`,
+  plus `i8`/`ui8` -> `i16`/`ui16` zero-extension.
+- **lowering:** B16 -> `K × pto.vgather2`; B32 -> `K × pto.vgather2_bc`.
+  A statically all-active mask omits the trailing `vsel`.
 
 ### `pto.vmi.vgatherb`
 

--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -710,6 +710,13 @@ def VMIMaskedLoadOp : VMI_Op<"masked_load", [DeclareOpInterfaceMethods<MemoryEff
 
 def VMIGatherOp : VMI_Op<"gather", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "VMI logical masked indexed gather with passthrough lanes";
+  let description = [{
+    Gathers elements from UB memory using an index vector.
+    i8/ui8 sources may be gathered into matching i16/ui16 results. The
+    8-to-16 promotion is a zero-extension: one byte is read per lane and the
+    upper 8 bits are zero-filled, regardless of whether the source element
+    type is signed (i8) or unsigned (ui8). Sign-extension is not supported.
+  }];
   let arguments = (ins PtrOrMemRef:$source,
                        VMI_VRegTypeConstraint:$indices,
                        VMI_MaskTypeConstraint:$mask,
@@ -1584,9 +1591,13 @@ def VMIVdintlvOp : VMI_Op<"vdintlv"> {
 }
 
 def VMIVgatherOp : VMI_Op<"vgather", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-  let summary = "VMI logical masked indexed gather (B32 granularity)";
+  let summary = "VMI logical masked indexed gather";
   let description = [{
     Gathers elements from UB memory using an index vector.
+    i8/ui8 sources may be gathered into matching i16/ui16 results. The
+    8-to-16 promotion is a zero-extension: one byte is read per lane and the
+    upper 8 bits are zero-filled, regardless of whether the source element
+    type is signed (i8) or unsigned (ui8). Sign-extension is not supported.
     Inactive lanes are controlled by pmode (no explicit passthru operand).
 
     pmode controls inactive-lane behavior:

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -2717,6 +2717,12 @@ def PTO_Vmrgsort4Op : PTO_VectorMicroOp<"vmrgsort4"> {
 def PTO_Vgather2Op : PTO_VectorMicroOp<"vgather2", [
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   ]> {
+  let description = [{
+    Masked indexed gather from a UB-backed source. For 8-bit integer sources
+    the result is a 16-bit integer (i8/ui8 -> i16/ui16) produced by
+    zero-extension (one byte per lane, upper 8 bits zero-filled).
+    Sign-extension is not performed.
+  }];
   let arguments = (ins
     PTO_BufferType:$source,
     PTO_VectorType:$offsets,

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -562,6 +562,72 @@ static LogicalResult verifyMemoryElementMatches(Operation *op, Type memoryType,
   return success();
 }
 
+// 8->16 gather promotion is a zero-extension (unsigned) operation. signless
+// i8/i16 are accepted and treated as unsigned bytes; sign-extension is not
+// supported (see VMIVgatherOp / Vgather2Op description).
+static bool isVMI8To16GatherPair(Type sourceElemType, Type resultElemType) {
+  auto srcInt = dyn_cast<IntegerType>(sourceElemType);
+  auto resInt = dyn_cast<IntegerType>(resultElemType);
+  if (!srcInt || !resInt ||
+      srcInt.getWidth() != mlir::pto::kValue8 ||
+      resInt.getWidth() != mlir::pto::kValue16) {
+    return false;
+  }
+  if (srcInt.isUnsigned()) {
+    return resInt.isUnsigned();
+  }
+  return !resInt.isUnsigned();
+}
+
+static LogicalResult verifyGatherMemoryElementMatches(
+    Operation *op, Type memoryType, VMIVRegType dataType, StringRef role) {
+  Type memoryElementType = getMemoryElementType(memoryType);
+  if (!memoryElementType) {
+    return success();
+  }
+  if (memoryElementType == dataType.getElementType()) {
+    return success();
+  }
+  if (isVMI8To16GatherPair(memoryElementType, dataType.getElementType())) {
+    return success();
+  }
+  return op->emitOpError()
+         << "requires memory " << role
+         << " element type to match VMI data element type"
+            " or be an 8-bit integer promoted to a matching 16-bit integer";
+}
+
+static bool isSameWidth16BitGatherPair(Type sourceElemType,
+                                       Type resultElemType) {
+  // Existing VMI f16/bf16 path: same-width 16-bit float gather.
+  if (sourceElemType == resultElemType &&
+      (sourceElemType.isF16() || sourceElemType.isBF16())) {
+    return true;
+  }
+  auto srcInt = dyn_cast<IntegerType>(sourceElemType);
+  auto resInt = dyn_cast<IntegerType>(resultElemType);
+  // Existing VMI ui16/i16 path: same-width 16-bit integer gather with matching
+  // integer semantics (signless i16 / i16 is accepted as the non-unsigned side).
+  if (!srcInt || !resInt ||
+      srcInt.getWidth() != mlir::pto::kValue16 ||
+      resInt.getWidth() != mlir::pto::kValue16) {
+    return false;
+  }
+  if (srcInt.isUnsigned()) {
+    return resInt.isUnsigned();
+  }
+  return !resInt.isUnsigned();
+}
+
+static bool isSupported16BitGatherResult(Type sourceElemType,
+                                         Type resultElemType) {
+  // New 8 -> 16 path: i8/ui8 -> i16/ui16 with matching integer semantics.
+  if (isVMI8To16GatherPair(sourceElemType, resultElemType)) {
+    return true;
+  }
+  return isSameWidth16BitGatherPair(sourceElemType, resultElemType);
+}
+
 static LogicalResult verifyContiguousIfLayoutAssigned(Operation *op,
                                                       VMIVRegType type,
                                                       StringRef role) {
@@ -2582,7 +2648,7 @@ LogicalResult VMIGatherOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto passthruType = cast<VMIVRegType>(getPassthru().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
+  if (failed(verifyGatherMemoryElementMatches(getOperation(), getSource().getType(),
                                         resultType, "source"))) {
     return failure();
   }
@@ -2609,13 +2675,13 @@ LogicalResult VMIGatherOp::verify() {
     return failure();
   }
 
-  auto resultIntegerType = dyn_cast<IntegerType>(resultType.getElementType());
   if (indexElementType.getWidth() == mlir::pto::kValue16 &&
-      (!resultIntegerType || !resultIntegerType.isUnsigned() ||
-       resultIntegerType.getWidth() != mlir::pto::kValue16)) {
+      !isSupported16BitGatherResult(
+          getMemoryElementType(getSource().getType()),
+          resultType.getElementType())) {
     return emitOpError(
-        "requires ui16 result and passthru element type when using ui16 "
-        "indices");
+        "requires i16/ui16/f16/bf16 result and passthru element type when "
+        "using ui16 indices, or i8/ui8 -> i16/ui16 integer promotion");
   }
   return verifyMaskMatchesData(getOperation(), maskType, resultType);
 }
@@ -4022,7 +4088,7 @@ LogicalResult VMIVgatherOp::verify() {
     return failure();
   }
 
-  if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
+  if (failed(verifyGatherMemoryElementMatches(getOperation(), getSource().getType(),
                                         resultType, "source"))) {
     return failure();
   }
@@ -4044,16 +4110,15 @@ LogicalResult VMIVgatherOp::verify() {
     return failure();
   }
 
-  // 16-bit offsets only address the ui16 gather path (pto.vgather2 / b16 mask),
-  // which requires a ui16 result element type. Reject other 16-bit-offset
-  // results here so the error surfaces at the vgather op rather than later in
-  // the legacy gather it lowers to.
-  auto resultIntegerType = dyn_cast<IntegerType>(resultType.getElementType());
+  // 16-bit offsets address the pto.vgather2 / b16 mask path.  It supports
+  // i16/ui16/f16/bf16 same-width gather and i8/ui8 -> i16/ui16 promotion.
   if (indexElementType.getWidth() == mlir::pto::kValue16 &&
-      (!resultIntegerType || !resultIntegerType.isUnsigned() ||
-       resultIntegerType.getWidth() != mlir::pto::kValue16)) {
+      !isSupported16BitGatherResult(
+          getMemoryElementType(getSource().getType()),
+          resultType.getElementType())) {
     return emitOpError(
-        "requires ui16 result element type when using ui16 offsets");
+        "requires i16/ui16/f16/bf16 result element type when using ui16 "
+        "offsets, or i8/ui8 -> i16/ui16 integer promotion");
   }
 
   if (auto pmode = getPmode()) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -1941,14 +1941,37 @@ checkSupportedGatherShape(VMIGatherOp op, std::string *reason) {
   auto indexElementType = dyn_cast<IntegerType>(indicesType.getElementType());
   if (!indexElementType || indexElementType.isSigned())
     return fail("requires signless or unsigned integer indices");
-  bool isU16Gather = resultBits == 16 && indexElementType.isUnsigned() &&
-                     indexElementType.getWidth() == 16 &&
-                     maskType.getGranularity() == "b16";
+  Type sourceElemType = getMemoryElementType(op.getSource().getType());
+  auto sourceInt = dyn_cast<IntegerType>(sourceElemType);
+  auto resultInt = dyn_cast<IntegerType>(resultType.getElementType());
+  bool isB8To16Gather =
+      resultBits == 16 && sourceInt && resultInt &&
+      sourceInt.getWidth() == mlir::pto::kValue8 &&
+      resultInt.getWidth() == mlir::pto::kValue16 &&
+      indexElementType.isUnsigned() &&
+      indexElementType.getWidth() == 16 &&
+      maskType.getGranularity() == "b16" &&
+      ((sourceInt.isUnsigned() && resultInt.isUnsigned()) ||
+       (!sourceInt.isUnsigned() && !resultInt.isUnsigned()));
+  bool isSameWidth16Gather =
+      resultBits == 16 && indexElementType.isUnsigned() &&
+      indexElementType.getWidth() == 16 &&
+      maskType.getGranularity() == "b16" &&
+      ((sourceInt && resultInt &&
+        sourceInt.getWidth() == mlir::pto::kValue16 &&
+        resultInt.getWidth() == mlir::pto::kValue16 &&
+        ((sourceInt.isUnsigned() && resultInt.isUnsigned()) ||
+         (!sourceInt.isUnsigned() && !resultInt.isUnsigned()))) ||
+       (sourceElemType == resultType.getElementType() &&
+        (sourceElemType.isF16() || sourceElemType.isBF16())));
+  bool isB16Gather = isSameWidth16Gather || isB8To16Gather;
   bool isB32Gather = resultBits == 32 && indexElementType.getWidth() == 32 &&
                      maskType.getGranularity() == "b32";
-  if (!isU16Gather && !isB32Gather)
+  if (!isB16Gather && !isB32Gather) {
     return fail("requires either 32-bit results with 32-bit indices and b32 "
-                "mask, or ui16 results with ui16 indices and b16 mask");
+                "mask, or ui16/i16/f16/bf16 results with ui16 indices and "
+                "b16 mask (including i8/ui8 -> i16/ui16 promotion)");
+  }
 
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
   FailureOr<int64_t> indicesArity = getVMIPhysicalArity(indicesType);
@@ -1962,7 +1985,16 @@ checkSupportedGatherShape(VMIGatherOp op, std::string *reason) {
     return fail("requires result, indices, passthru, and mask to have the "
                 "same physical arity");
 
-  if (isB32Gather) {
+  // Each pto.vgather2/pto.vgather2_bc emits one physical vector register per
+  // result part. The ISA has a hard limit of four physical registers per
+  // pto.vmi instruction, so reject anything above that instead of silently
+  // lowering to five or more physical gathers.
+  if (*resultArity > mlir::pto::kValue4) {
+    return fail("gather exceeds the 4 physical register limit per VMI "
+                "instruction");
+  }
+
+  if (isB32Gather || (isB16Gather && *resultArity != 1)) {
     std::string resultReason;
     std::string indicesReason;
     std::string passthruReason;
@@ -1978,8 +2010,6 @@ checkSupportedGatherShape(VMIGatherOp op, std::string *reason) {
                   passthruReason);
     if (failed(checkFullVMIPhysicalChunks(maskType, &maskReason)))
       return fail(Twine("mask requires full physical chunks; ") + maskReason);
-  } else if (*resultArity != 1) {
-    return fail("ui16 gather currently supports one physical chunk");
   }
 
   return success();
@@ -7048,6 +7078,13 @@ struct OneToNVMIGatherOpPattern : OneToNOpConversionPattern<VMIGatherOp> {
         indicesParts.size() != passthruParts.size() ||
         indicesParts.size() != resultTypes.size())
       return rewriter.notifyMatchFailure(op, "gather physical arity mismatch");
+    // Static all-active masks select gathered[0] for every lane, so the
+    // trailing vsel is a semantic no-op. Skip it and keep gathered directly.
+    // Non-static masks still take the original gather + vsel path.
+    auto resultVMIType = cast<VMIVRegType>(op.getResult().getType());
+    bool allActive = isStaticAllActiveMask(op.getMask(),
+                                           resultVMIType.getElementCount());
+
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
@@ -7069,10 +7106,14 @@ struct OneToNVMIGatherOpPattern : OneToNOpConversionPattern<VMIGatherOp> {
                                  .create<Vgather2BcOp>(op.getLoc(), resultType,
                                                        *source, indices, mask)
                                  .getResult();
-      results.push_back(
-          rewriter
-              .create<VselOp>(op.getLoc(), resultType, gathered, passthru, mask)
-              .getResult());
+      if (allActive) {
+        results.push_back(gathered);
+      } else {
+        results.push_back(
+            rewriter
+                .create<VselOp>(op.getLoc(), resultType, gathered, passthru, mask)
+                .getResult());
+      }
     }
 
     replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
@@ -13394,9 +13435,10 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
         return WalkResult::advance();
       gather.emitError()
           << kVMIDiagUnsupportedPrefix
-          << "pto.vmi.gather lowers through pto.vgather2_bc + pto.vsel only "
+          << "pto.vmi.gather lowers through pto.vgather2/pto.vgather2_bc + pto.vsel only "
              "for UB pointer sources, contiguous full physical chunks, "
-             "32-bit result elements, i32 indices, and b32 masks ("
+             "ui16/i16/f16/bf16 results with ui16 indices and b16 masks, "
+             "or 32-bit results with i32 indices and b32 masks ("
           << reason << ")";
       return WalkResult::interrupt();
     }

--- a/lib/PTO/Transforms/VPTOMaskSimplify.cpp
+++ b/lib/PTO/Transforms/VPTOMaskSimplify.cpp
@@ -52,11 +52,27 @@ struct SimplifyAllTruePredicateReorder : public OpRewritePattern<OpTy> {
   }
 };
 
+struct SimplifyVselAllTrueMask : public OpRewritePattern<VselOp> {
+  using OpRewritePattern<VselOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(VselOp op,
+                                PatternRewriter &rewriter) const override {
+    // vsel(src0, src1, mask) selects src0 for all-true masks.
+    if (!isAllTrueMask(op.getMask())) {
+      return failure();
+    }
+
+    rewriter.replaceOp(op, op.getSrc0());
+    return success();
+  }
+};
+
 struct VPTOMaskSimplifyPass
     : public pto::impl::VPTOMaskSimplifyBase<VPTOMaskSimplifyPass> {
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
-    patterns.add<SimplifyAllTruePredicateReorder<PintlvB8Op>,
+    patterns.add<SimplifyVselAllTrueMask,
+                 SimplifyAllTruePredicateReorder<PintlvB8Op>,
                  SimplifyAllTruePredicateReorder<PintlvB16Op>,
                  SimplifyAllTruePredicateReorder<PintlvB32Op>,
                  SimplifyAllTruePredicateReorder<PdintlvB8Op>,

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -432,10 +432,21 @@ def _derive_hist_result_type(acc, *, context: str):
 
 def _derive_vgather_result_type(source, offsets, *, context: str):
     offsets_type = _as_vmi_vreg_type(_type_of(offsets), context=context)
-    result_type = _pointer_element_type(_type_of(source), context=context)
+    result_elem_type = _pointer_element_type(_type_of(source), context=context)
+    # 8-bit integer sources use the B16 gather promotion path (i8 -> i16,
+    # ui8 -> ui16, si8 -> si16).
+    if IntegerType.isinstance(result_elem_type):
+        source_int_type = IntegerType(result_elem_type)
+        if source_int_type.width == 8:
+            if source_int_type.is_unsigned:
+                result_elem_type = IntegerType.get_unsigned(16)
+            elif source_int_type.is_signed:
+                result_elem_type = IntegerType.get_signed(16)
+            else:
+                result_elem_type = IntegerType.get_signless(16)
     return _pto.VMIVRegType.get(
         offsets_type.element_count,
-        result_type,
+        result_elem_type,
         layout=offsets_type.layout,
     )
 

--- a/test/lit/vmi_new/vmi_to_vpto_gather_all_active_mask.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_all_active_mask.pto
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s
+
+// A statically all-active mask selects gathered[0] for every lane, so
+// collect_gather must lower to a bare vgather2 without the trailing vsel.
+
+module {
+  func.func @gather_all_active_mask_u16(
+      %src: !pto.ptr<ui16, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>)
+      -> !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>> {
+    %c32 = arith.constant 32 : index
+    %mask = pto.vmi.create_mask %c32 : index -> !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui16, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>
+    return %out : !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>
+  }
+}
+
+// CHECK-LABEL: func.func @gather_all_active_mask_u16(
+// CHECK: %[[GATHER:.*]] = pto.vgather2
+// CHECK-SAME: !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+// CHECK-NOT: pto.vsel
+// CHECK: return %[[GATHER]]
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_gather_all_active_mask_multi_chunk.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_all_active_mask_multi_chunk.pto
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// A statically all-active 512-lane mask selects gathered[0] for every part.
+// The all-active shortcut must apply per part in the multi-chunk loop and
+// therefore must emit four bare vgather2 ops without trailing vsel.
+
+module {
+  func.func @gather_all_active_mask_i8_to_i16_512(
+      %src: !pto.ptr<i8, ub>,
+      %indices: !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>) {
+    %c512 = arith.constant 512 : index
+    %mask = pto.vmi.create_mask %c512 : index -> !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i8, ub>,
+          !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<512xi16, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<512xi16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>)
+    return %p0, %p1, %p2, %p3
+        : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>
+  }
+}
+
+// CHECK-LABEL: func.func @gather_all_active_mask_i8_to_i16_512(
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK-NOT: pto.vsel
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_gather_chunk_sweep_i32_i32.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_chunk_sweep_i32_i32.pto
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Chunk sweep for physical block counts {1,2,4} x {static all-active, dynamic mask}.
+// C=4 is the ISA limit of four physical registers per VMI instruction.
+
+module {
+  func.func @gather_i32_i32_2chunk_allactive(
+      %src: !pto.ptr<i32, ub>,
+      %indices: !pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<64xi32>, !pto.vreg<64xi32>) {
+    %c128 = arith.constant 128 : index
+    %mask = pto.vmi.create_mask %c128 : index -> !pto.vmi.mask<128xb32, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i32, ub>,
+          !pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<128xb32, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>
+    %p0, %p1 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<64xi32>, !pto.vreg<64xi32>)
+    return %p0, %p1 : !pto.vreg<64xi32>, !pto.vreg<64xi32>
+  }
+
+  func.func @gather_i32_i32_2chunk_dynamic(
+      %src: !pto.ptr<i32, ub>,
+      %indices: !pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<128xb32, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<64xi32>, !pto.vreg<64xi32>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i32, ub>,
+          !pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<128xb32, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>
+    %p0, %p1 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<64xi32>, !pto.vreg<64xi32>)
+    return %p0, %p1 : !pto.vreg<64xi32>, !pto.vreg<64xi32>
+  }
+
+  func.func @gather_i32_i32_4chunk_allactive(
+      %src: !pto.ptr<i32, ub>,
+      %indices: !pto.vmi.vreg<256xi32, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.vreg<64xi32>) {
+    %c256 = arith.constant 256 : index
+    %mask = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xb32, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i32, ub>,
+          !pto.vmi.vreg<256xi32, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<256xb32, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<256xi32, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<256xi32, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.vreg<64xi32>)
+    return %p0, %p1, %p2, %p3 : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.vreg<64xi32>
+  }
+
+  func.func @gather_i32_i32_4chunk_dynamic(
+      %src: !pto.ptr<i32, ub>,
+      %indices: !pto.vmi.vreg<256xi32, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<256xb32, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.vreg<64xi32>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i32, ub>,
+          !pto.vmi.vreg<256xi32, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<256xb32, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<256xi32, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<256xi32, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.vreg<64xi32>)
+    return %p0, %p1, %p2, %p3 : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.vreg<64xi32>
+  }
+}
+
+// CHECK-LABEL: func.func @gather_i32_i32_2chunk_allactive(
+// CHECK: pto.vgather2_bc
+// CHECK: pto.vgather2_bc
+// CHECK-NOT: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_i32_i32_2chunk_dynamic(
+// CHECK: pto.vgather2_bc
+// CHECK: pto.vsel
+// CHECK: pto.vgather2_bc
+// CHECK: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_i32_i32_4chunk_allactive(
+// CHECK: pto.vgather2_bc
+// CHECK: pto.vgather2_bc
+// CHECK: pto.vgather2_bc
+// CHECK: pto.vgather2_bc
+// CHECK-NOT: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_i32_i32_4chunk_dynamic(
+// CHECK: pto.vgather2_bc
+// CHECK: pto.vsel
+// CHECK: pto.vgather2_bc
+// CHECK: pto.vsel
+// CHECK: pto.vgather2_bc
+// CHECK: pto.vsel
+// CHECK: pto.vgather2_bc
+// CHECK: pto.vsel
+// CHECK: return
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_gather_chunk_sweep_i8_i16.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_chunk_sweep_i8_i16.pto
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Chunk sweep for physical block counts {1,2,4} x {static all-active, dynamic mask}.
+// C=4 is the ISA limit of four physical registers per VMI instruction.
+
+module {
+  func.func @gather_i8_i16_1chunk_allactive(
+      %src: !pto.ptr<i8, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xi16>) {
+    %c32 = arith.constant 32 : index
+    %mask = pto.vmi.create_mask %c32 : index -> !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i8, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xi16, #pto.vmi.layout<contiguous>>
+    %p0 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<32xi16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xi16>)
+    return %p0 : !pto.vreg<128xi16>
+  }
+
+  func.func @gather_i8_i16_1chunk_dynamic(
+      %src: !pto.ptr<i8, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xi16>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i8, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xi16, #pto.vmi.layout<contiguous>>
+    %p0 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<32xi16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xi16>)
+    return %p0 : !pto.vreg<128xi16>
+  }
+
+  func.func @gather_i8_i16_2chunk_allactive(
+      %src: !pto.ptr<i8, ub>,
+      %indices: !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xi16>, !pto.vreg<128xi16>) {
+    %c256 = arith.constant 256 : index
+    %mask = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i8, ub>,
+          !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<256xi16, #pto.vmi.layout<contiguous>>
+    %p0, %p1 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<256xi16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xi16>, !pto.vreg<128xi16>)
+    return %p0, %p1 : !pto.vreg<128xi16>, !pto.vreg<128xi16>
+  }
+
+  func.func @gather_i8_i16_2chunk_dynamic(
+      %src: !pto.ptr<i8, ub>,
+      %indices: !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xi16>, !pto.vreg<128xi16>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i8, ub>,
+          !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<256xi16, #pto.vmi.layout<contiguous>>
+    %p0, %p1 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<256xi16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xi16>, !pto.vreg<128xi16>)
+    return %p0, %p1 : !pto.vreg<128xi16>, !pto.vreg<128xi16>
+  }
+
+  func.func @gather_i8_i16_4chunk_allactive(
+      %src: !pto.ptr<i8, ub>,
+      %indices: !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>) {
+    %c512 = arith.constant 512 : index
+    %mask = pto.vmi.create_mask %c512 : index -> !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i8, ub>,
+          !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<512xi16, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<512xi16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>)
+    return %p0, %p1, %p2, %p3 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>
+  }
+
+  func.func @gather_i8_i16_4chunk_dynamic(
+      %src: !pto.ptr<i8, ub>,
+      %indices: !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i8, ub>,
+          !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<512xi16, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<512xi16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>)
+    return %p0, %p1, %p2, %p3 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.vreg<128xi16>
+  }
+}
+
+// CHECK-LABEL: func.func @gather_i8_i16_1chunk_allactive(
+// CHECK: pto.vgather2
+// CHECK-NOT: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_i8_i16_1chunk_dynamic(
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_i8_i16_2chunk_allactive(
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK-NOT: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_i8_i16_2chunk_dynamic(
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_i8_i16_4chunk_allactive(
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK-NOT: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_i8_i16_4chunk_dynamic(
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: return
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_gather_chunk_sweep_u16_u16.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_chunk_sweep_u16_u16.pto
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Chunk sweep for physical block counts {1,2,4} x {static all-active, dynamic mask}.
+// C=4 is the ISA limit of four physical registers per VMI instruction.
+
+module {
+  func.func @gather_u16_u16_1chunk_allactive(
+      %src: !pto.ptr<ui16, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>) {
+    %c32 = arith.constant 32 : index
+    %mask = pto.vmi.create_mask %c32 : index -> !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui16, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>
+    %p0 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>)
+    return %p0 : !pto.vreg<128xui16>
+  }
+
+  func.func @gather_u16_u16_1chunk_dynamic(
+      %src: !pto.ptr<ui16, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui16, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>
+    %p0 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>)
+    return %p0 : !pto.vreg<128xui16>
+  }
+
+  func.func @gather_u16_u16_2chunk_allactive(
+      %src: !pto.ptr<ui16, ub>,
+      %indices: !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>) {
+    %c256 = arith.constant 256 : index
+    %mask = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui16, ub>,
+          !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>
+    %p0, %p1 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>)
+    return %p0, %p1 : !pto.vreg<128xui16>, !pto.vreg<128xui16>
+  }
+
+  func.func @gather_u16_u16_2chunk_dynamic(
+      %src: !pto.ptr<ui16, ub>,
+      %indices: !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui16, ub>,
+          !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>
+    %p0, %p1 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>)
+    return %p0, %p1 : !pto.vreg<128xui16>, !pto.vreg<128xui16>
+  }
+
+  func.func @gather_u16_u16_4chunk_allactive(
+      %src: !pto.ptr<ui16, ub>,
+      %indices: !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>) {
+    %c512 = arith.constant 512 : index
+    %mask = pto.vmi.create_mask %c512 : index -> !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui16, ub>,
+          !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>)
+    return %p0, %p1, %p2, %p3 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>
+  }
+
+  func.func @gather_u16_u16_4chunk_dynamic(
+      %src: !pto.ptr<ui16, ub>,
+      %indices: !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui16, ub>,
+          !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>)
+    return %p0, %p1, %p2, %p3 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>
+  }
+}
+
+// CHECK-LABEL: func.func @gather_u16_u16_1chunk_allactive(
+// CHECK: pto.vgather2
+// CHECK-NOT: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_u16_u16_1chunk_dynamic(
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_u16_u16_2chunk_allactive(
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK-NOT: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_u16_u16_2chunk_dynamic(
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_u16_u16_4chunk_allactive(
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK-NOT: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_u16_u16_4chunk_dynamic(
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: return
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_gather_chunk_sweep_ui8_ui16.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_chunk_sweep_ui8_ui16.pto
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Chunk sweep for physical block counts {1,2,4} x {static all-active, dynamic mask}.
+// C=4 is the ISA limit of four physical registers per VMI instruction.
+
+module {
+  func.func @gather_ui8_ui16_1chunk_allactive(
+      %src: !pto.ptr<ui8, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>) {
+    %c32 = arith.constant 32 : index
+    %mask = pto.vmi.create_mask %c32 : index -> !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui8, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>
+    %p0 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>)
+    return %p0 : !pto.vreg<128xui16>
+  }
+
+  func.func @gather_ui8_ui16_1chunk_dynamic(
+      %src: !pto.ptr<ui8, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui8, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>
+    %p0 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>)
+    return %p0 : !pto.vreg<128xui16>
+  }
+
+  func.func @gather_ui8_ui16_2chunk_allactive(
+      %src: !pto.ptr<ui8, ub>,
+      %indices: !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>) {
+    %c256 = arith.constant 256 : index
+    %mask = pto.vmi.create_mask %c256 : index -> !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui8, ub>,
+          !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>
+    %p0, %p1 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>)
+    return %p0, %p1 : !pto.vreg<128xui16>, !pto.vreg<128xui16>
+  }
+
+  func.func @gather_ui8_ui16_2chunk_dynamic(
+      %src: !pto.ptr<ui8, ub>,
+      %indices: !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui8, ub>,
+          !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>
+    %p0, %p1 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>)
+    return %p0, %p1 : !pto.vreg<128xui16>, !pto.vreg<128xui16>
+  }
+
+  func.func @gather_ui8_ui16_4chunk_allactive(
+      %src: !pto.ptr<ui8, ub>,
+      %indices: !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>) {
+    %c512 = arith.constant 512 : index
+    %mask = pto.vmi.create_mask %c512 : index -> !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui8, ub>,
+          !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>)
+    return %p0, %p1, %p2, %p3 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>
+  }
+
+  func.func @gather_ui8_ui16_4chunk_dynamic(
+      %src: !pto.ptr<ui8, ub>,
+      %indices: !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui8, ub>,
+          !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>)
+    return %p0, %p1, %p2, %p3 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>
+  }
+}
+
+// CHECK-LABEL: func.func @gather_ui8_ui16_1chunk_allactive(
+// CHECK: pto.vgather2
+// CHECK-NOT: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_ui8_ui16_1chunk_dynamic(
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_ui8_ui16_2chunk_allactive(
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK-NOT: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_ui8_ui16_2chunk_dynamic(
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_ui8_ui16_4chunk_allactive(
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK: pto.vgather2
+// CHECK-NOT: pto.vsel
+// CHECK: return
+
+// CHECK-LABEL: func.func @gather_ui8_ui16_4chunk_dynamic(
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: return
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_gather_f16_bf16.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_f16_bf16.pto
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+module {
+  func.func @vmi_to_vpto_gather_f16(
+      %src: !pto.ptr<f16, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>)
+      -> !pto.vreg<128xf16> {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<f16, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xf16, #pto.vmi.layout<contiguous>>
+    %part = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<32xf16, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<128xf16>
+    return %part : !pto.vreg<128xf16>
+  }
+
+  func.func @vmi_to_vpto_gather_bf16(
+      %src: !pto.ptr<bf16, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>)
+      -> !pto.vreg<128xbf16> {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<bf16, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xbf16, #pto.vmi.layout<contiguous>>
+    %part = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<32xbf16, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<128xbf16>
+    return %part : !pto.vreg<128xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @vmi_to_vpto_gather_f16(
+// CHECK: %[[GATHER_F16:.*]] = pto.vgather2 %arg0, %arg1, %arg2 : !pto.ptr<f16, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+// CHECK: %[[OUT_F16:.*]] = pto.vsel %[[GATHER_F16]], %{{.*}}, %arg2 : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+// CHECK: return %[[OUT_F16]]
+
+// CHECK-LABEL: func.func @vmi_to_vpto_gather_bf16(
+// CHECK: %[[GATHER_BF16:.*]] = pto.vgather2 %arg0, %arg1, %arg2 : !pto.ptr<bf16, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xbf16>
+// CHECK: %[[OUT_BF16:.*]] = pto.vsel %[[GATHER_BF16]], %{{.*}}, %arg2 : !pto.vreg<128xbf16>, !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<128xbf16>
+// CHECK: return %[[OUT_BF16]]
+
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_gather_granularity_conflict.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_granularity_conflict.pto
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=GRAN
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=VPTO
+
+module {
+  func.func @gather_pred_conflict_ui16_i32(
+      %src16: !pto.ptr<ui16, ub>,
+      %idx16: !pto.vmi.vreg<128xui16>,
+      %src32: !pto.ptr<i32, ub>,
+      %idx32: !pto.vmi.vreg<128xi32>,
+      %mask: !pto.vmi.mask<128xpred>)
+      -> (!pto.vmi.vreg<128xui16>, !pto.vmi.vreg<128xi32>) {
+    %g16 = pto.vmi.vgather %src16, %idx16, %mask
+        : !pto.ptr<ui16, ub>, !pto.vmi.vreg<128xui16>, !pto.vmi.mask<128xpred>
+        -> !pto.vmi.vreg<128xui16>
+    %g32 = pto.vmi.vgather %src32, %idx32, %mask
+        : !pto.ptr<i32, ub>, !pto.vmi.vreg<128xi32>, !pto.vmi.mask<128xpred>
+        -> !pto.vmi.vreg<128xi32>
+    return %g16, %g32 : !pto.vmi.vreg<128xui16>, !pto.vmi.vreg<128xi32>
+  }
+}
+
+// GRAN-LABEL: func.func @gather_pred_conflict_ui16_i32(
+// GRAN: pto.vmi.ensure_mask_granularity
+
+// VPTO-LABEL: func.func @gather_pred_conflict_ui16_i32(
+// VPTO: pto.vgather2
+// VPTO: pto.vgather2_bc
+// VPTO-NOT: pto.vmi.
+// VPTO-NOT: !pto.vmi.
+// VPTO-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_gather_granularity_explicit.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_granularity_explicit.pto
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s
+
+module {
+  func.func @gather_explicit_b16_respected(
+      %src: !pto.ptr<ui16, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>)
+      -> !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>> {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui16, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>
+    return %out : !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>
+  }
+}
+
+// CHECK-LABEL: func.func @gather_explicit_b16_respected(
+// CHECK: pto.vgather2
+// CHECK-NOT: pto.vmi.ensure_mask_granularity
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_gather_granularity_pred.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_granularity_pred.pto
@@ -6,21 +6,21 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: not pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto 2>&1 | FileCheck %s
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment | FileCheck %s
 
 module {
-  func.func @vmi_to_vpto_gather_f16_invalid(
-      %src: !pto.ptr<f16, ub>,
-      %indices: !pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>,
-      %mask: !pto.vmi.mask<128xb16, #pto.vmi.layout<contiguous>>) {
+  func.func @gather_pred_inferred_b16(
+      %src: !pto.ptr<ui16, ub>,
+      %indices: !pto.vmi.vreg<32xui16>,
+      %mask: !pto.vmi.mask<32xpred>)
+      -> !pto.vmi.vreg<32xui16> {
     %out = pto.vmi.vgather %src, %indices, %mask
-        : !pto.ptr<f16, ub>,
-          !pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>,
-          !pto.vmi.mask<128xb16, #pto.vmi.layout<contiguous>>
-        -> !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
-    return
+        : !pto.ptr<ui16, ub>, !pto.vmi.vreg<32xui16>, !pto.vmi.mask<32xpred>
+        -> !pto.vmi.vreg<32xui16>
+    return %out : !pto.vmi.vreg<32xui16>
   }
 }
 
-// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.gather lowers through pto.vgather2/pto.vgather2_bc + pto.vsel only
-// CHECK-SAME: or 32-bit results
+// CHECK-LABEL: func.func @gather_pred_inferred_b16(
+// CHECK: !pto.vmi.mask<32xb16>
+// CHECK-NOT: !pto.vmi.mask<32xpred>

--- a/test/lit/vmi_new/vmi_to_vpto_gather_i16.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_i16.pto
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+module {
+  func.func @vmi_to_vpto_gather_i16(
+      %src: !pto.ptr<i16, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>)
+      -> !pto.vreg<128xi16> {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i16, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xi16, #pto.vmi.layout<contiguous>>
+    %part = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<32xi16, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<128xi16>
+    return %part : !pto.vreg<128xi16>
+  }
+}
+
+// CHECK-LABEL: func.func @vmi_to_vpto_gather_i16(
+// CHECK: %[[GATHER_I16:.*]] = pto.vgather2 %arg0, %arg1, %arg2 : !pto.ptr<i16, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+// CHECK: %[[OUT_I16:.*]] = pto.vsel %[[GATHER_I16]], %{{.*}}, %arg2 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+// CHECK: return %[[OUT_I16]]
+
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_gather_i8_to_i16.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_i8_to_i16.pto
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+module {
+  func.func @vmi_to_vpto_gather_ui8_to_ui16(
+      %src: !pto.ptr<ui8, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>)
+      -> !pto.vreg<128xui16> {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui8, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>
+    %part = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<128xui16>
+    return %part : !pto.vreg<128xui16>
+  }
+
+  func.func @vmi_to_vpto_gather_i8_to_i16(
+      %src: !pto.ptr<i8, ub>,
+      %indices: !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>)
+      -> !pto.vreg<128xi16> {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<i8, ub>,
+          !pto.vmi.vreg<32xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<32xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<32xi16, #pto.vmi.layout<contiguous>>
+    %part = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<32xi16, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<128xi16>
+    return %part : !pto.vreg<128xi16>
+  }
+}
+
+// CHECK-LABEL: func.func @vmi_to_vpto_gather_ui8_to_ui16(
+// CHECK: %[[GATHER_UI8:.*]] = pto.vgather2 %arg0, %arg1, %arg2 : !pto.ptr<ui8, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+// CHECK: %[[OUT_UI8:.*]] = pto.vsel %[[GATHER_UI8]], %{{.*}}, %arg2 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+// CHECK: return %[[OUT_UI8]]
+
+// CHECK-LABEL: func.func @vmi_to_vpto_gather_i8_to_i16(
+// CHECK: %[[GATHER_I8:.*]] = pto.vgather2 %arg0, %arg1, %arg2 : !pto.ptr<i8, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+// CHECK: %[[OUT_I8:.*]] = pto.vsel %[[GATHER_I8]], %{{.*}}, %arg2 : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+// CHECK: return %[[OUT_I8]]
+
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_gather_i8_to_i16_multi_chunk.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_i8_to_i16_multi_chunk.pto
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+module {
+  func.func @vmi_to_vpto_gather_i8_to_i16_256(
+      %src: !pto.ptr<ui8, ub>,
+      %indices: !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui8, ub>,
+          !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<256xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>
+    %p0, %p1 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<256xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>)
+    return %p0, %p1 : !pto.vreg<128xui16>, !pto.vreg<128xui16>
+  }
+
+  func.func @vmi_to_vpto_gather_i8_to_i16_512(
+      %src: !pto.ptr<ui8, ub>,
+      %indices: !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>) {
+    %out = pto.vmi.vgather %src, %indices, %mask
+        : !pto.ptr<ui8, ub>,
+          !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<512xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%out)
+        : (!pto.vmi.vreg<512xui16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>)
+    return %p0, %p1, %p2, %p3
+        : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.vreg<128xui16>
+  }
+}
+
+// CHECK-LABEL: func.func @vmi_to_vpto_gather_i8_to_i16_256(
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK-LABEL: func.func @vmi_to_vpto_gather_i8_to_i16_512(
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK: pto.vgather2
+// CHECK: pto.vsel
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_gather_scatter_shape_invalid.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_scatter_shape_invalid.pto
@@ -22,7 +22,7 @@ module {
   }
 }
 
-// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.gather lowers through pto.vgather2_bc + pto.vsel only
+// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.gather lowers through pto.vgather2/pto.vgather2_bc + pto.vsel only
 // CHECK-SAME: contiguous result, indices, passthru, and mask layouts
 
 // -----
@@ -41,7 +41,7 @@ module {
   }
 }
 
-// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.gather lowers through pto.vgather2_bc + pto.vsel only
+// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.gather lowers through pto.vgather2/pto.vgather2_bc + pto.vsel only
 // CHECK-SAME: result requires full physical chunks
 // CHECK-SAME: found padding lane in physical chunk
 

--- a/test/lit/vmi_new/vmi_to_vpto_gather_too_many_chunks_invalid_i32.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_too_many_chunks_invalid_i32.pto
@@ -9,18 +9,19 @@
 // RUN: not pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto 2>&1 | FileCheck %s
 
 module {
-  func.func @vmi_to_vpto_gather_f16_invalid(
-      %src: !pto.ptr<f16, ub>,
-      %indices: !pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>,
-      %mask: !pto.vmi.mask<128xb16, #pto.vmi.layout<contiguous>>) {
+  func.func @gather_i32_5chunk_invalid(
+      %src: !pto.ptr<i32, ub>,
+      %indices: !pto.vmi.vreg<320xi32, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<320xb32, #pto.vmi.layout<contiguous>>)
+      -> !pto.vmi.vreg<320xi32, #pto.vmi.layout<contiguous>> {
     %out = pto.vmi.vgather %src, %indices, %mask
-        : !pto.ptr<f16, ub>,
-          !pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>,
-          !pto.vmi.mask<128xb16, #pto.vmi.layout<contiguous>>
-        -> !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
-    return
+        : !pto.ptr<i32, ub>,
+          !pto.vmi.vreg<320xi32, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<320xb32, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<320xi32, #pto.vmi.layout<contiguous>>
+    return %out : !pto.vmi.vreg<320xi32, #pto.vmi.layout<contiguous>>
   }
 }
 
-// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.gather lowers through pto.vgather2/pto.vgather2_bc + pto.vsel only
-// CHECK-SAME: or 32-bit results
+// CHECK: VMI-UNSUPPORTED
+// CHECK: exceeds the 4 physical register limit per VMI instruction

--- a/test/lit/vmi_new/vmi_to_vpto_gather_too_many_chunks_invalid_ui16.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_gather_too_many_chunks_invalid_ui16.pto
@@ -9,18 +9,19 @@
 // RUN: not pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto 2>&1 | FileCheck %s
 
 module {
-  func.func @vmi_to_vpto_gather_f16_invalid(
-      %src: !pto.ptr<f16, ub>,
-      %indices: !pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>,
-      %mask: !pto.vmi.mask<128xb16, #pto.vmi.layout<contiguous>>) {
+  func.func @gather_ui16_5chunk_invalid(
+      %src: !pto.ptr<ui16, ub>,
+      %indices: !pto.vmi.vreg<640xui16, #pto.vmi.layout<contiguous>>,
+      %mask: !pto.vmi.mask<640xb16, #pto.vmi.layout<contiguous>>)
+      -> !pto.vmi.vreg<640xui16, #pto.vmi.layout<contiguous>> {
     %out = pto.vmi.vgather %src, %indices, %mask
-        : !pto.ptr<f16, ub>,
-          !pto.vmi.vreg<128xi32, #pto.vmi.layout<contiguous>>,
-          !pto.vmi.mask<128xb16, #pto.vmi.layout<contiguous>>
-        -> !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
-    return
+        : !pto.ptr<ui16, ub>,
+          !pto.vmi.vreg<640xui16, #pto.vmi.layout<contiguous>>,
+          !pto.vmi.mask<640xb16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<640xui16, #pto.vmi.layout<contiguous>>
+    return %out : !pto.vmi.vreg<640xui16, #pto.vmi.layout<contiguous>>
   }
 }
 
-// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.gather lowers through pto.vgather2/pto.vgather2_bc + pto.vsel only
-// CHECK-SAME: or 32-bit results
+// CHECK: VMI-UNSUPPORTED
+// CHECK: exceeds the 4 physical register limit per VMI instruction

--- a/test/lit/vpto/vpto_mask_simplify.pto
+++ b/test/lit/vpto/vpto_mask_simplify.pto
@@ -83,6 +83,47 @@ module {
     return %low, %high, %lhs, %rhs
         : !pto.mask<b16>, !pto.mask<b16>, !pto.mask<b16>, !pto.mask<b16>
   }
+  func.func @vsel_all_true_b16_pset(%a: !pto.vreg<128xi16>,
+                                    %b: !pto.vreg<128xi16>)
+      -> !pto.vreg<128xi16> {
+    %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+    %r = pto.vsel %a, %b, %mask
+        : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16>
+        -> !pto.vreg<128xi16>
+    return %r : !pto.vreg<128xi16>
+  }
+
+  func.func @vsel_all_true_b16_pge(%a: !pto.vreg<128xi16>,
+                                   %b: !pto.vreg<128xi16>)
+      -> !pto.vreg<128xi16> {
+    %mask = pto.pge_b16 "PAT_ALL" : !pto.mask<b16>
+    %r = pto.vsel %a, %b, %mask
+        : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16>
+        -> !pto.vreg<128xi16>
+    return %r : !pto.vreg<128xi16>
+  }
+
+  func.func @vsel_all_true_b32_pset(%a: !pto.vreg<64xi32>,
+                                    %b: !pto.vreg<64xi32>)
+      -> !pto.vreg<64xi32> {
+    %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %r = pto.vsel %a, %b, %mask
+        : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.mask<b32>
+        -> !pto.vreg<64xi32>
+    return %r : !pto.vreg<64xi32>
+  }
+
+  func.func @vsel_nonuniform_b16_preserved(%a: !pto.vreg<128xi16>,
+                                           %b: !pto.vreg<128xi16>)
+      -> !pto.vreg<128xi16> {
+    %mask = pto.pge_b16 "PAT_VL8" : !pto.mask<b16>
+    %r = pto.vsel %a, %b, %mask
+        : !pto.vreg<128xi16>, !pto.vreg<128xi16>, !pto.mask<b16>
+        -> !pto.vreg<128xi16>
+    return %r : !pto.vreg<128xi16>
+  }
+
+
 }
 
 // CHECK-LABEL: func.func @pintlv_b8_pset
@@ -122,3 +163,19 @@ module {
 // CHECK: %[[RHS:.*]] = pto.pge_b16 "PAT_ALL"
 // CHECK-NOT: pto.pintlv_b16
 // CHECK: return %[[LHS]], %[[RHS]], %[[LHS]], %[[RHS]]
+
+// CHECK-LABEL: func.func @vsel_all_true_b16_pset
+// CHECK-NOT: pto.vsel
+// CHECK: return %{{.*}} : !pto.vreg<128xi16>
+
+// CHECK-LABEL: func.func @vsel_all_true_b16_pge
+// CHECK-NOT: pto.vsel
+// CHECK: return %{{.*}} : !pto.vreg<128xi16>
+
+// CHECK-LABEL: func.func @vsel_all_true_b32_pset
+// CHECK-NOT: pto.vsel
+// CHECK: return %{{.*}} : !pto.vreg<64xi32>
+
+// CHECK-LABEL: func.func @vsel_nonuniform_b16_preserved
+// CHECK: pto.vsel
+// CHECK: return %{{.*}} : !pto.vreg<128xi16>

--- a/test/vpto/cases/vmi_new/vgather-dsl-i8-ui8-256.py
+++ b/test/vpto/cases/vmi_new/vgather-dsl-i8-ui8-256.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""PTODSL Python DSL cases for the 256-lane vgather 8-bit promotion paths.
+
+These exercise ``pto.vmi.vgather`` directly and cover the i8 -> i16 and
+ui8 -> ui16 result-type inference added with the vgather board-test commit.
+"""
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+
+def _bootstrap_dsl_st_common() -> None:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        common_dir = candidate / "test" / "dsl-st"
+        if (common_dir / "common.py").exists():
+            sys.path.insert(0, str(common_dir))
+            return
+    raise RuntimeError("Unable to locate test/dsl-st/common.py from vgather-dsl-i8-ui8-256.py")
+
+
+_bootstrap_dsl_st_common()
+
+from common import auto_main, golden_output_case
+from ptodsl import pto
+
+
+ELEMS = 256
+SRC_BYTES = 256
+IDX_BYTES = 512
+DST_BYTES = 512
+
+
+@pto.jit(
+    name="vmi_vgather_i8_to_i16_256_kernel",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+    kernel_kind="vector",
+    insert_sync=False,
+)
+def vmi_vgather_i8_to_i16_256_kernel(
+    src_gm: pto.ptr(pto.i8, "gm"),
+    idx_gm: pto.ptr(pto.ui16, "gm"),
+    dst_gm: pto.ptr(pto.i16, "gm"),
+):
+    ub_src = pto.castptr(pto.const(0, dtype=pto.i64), pto.ptr(pto.i8, "ub"))
+    ub_idx = pto.castptr(pto.const(4096, dtype=pto.i64), pto.ptr(pto.ui16, "ub"))
+    ub_dst = pto.castptr(pto.const(8192, dtype=pto.i64), pto.ptr(pto.i16, "ub"))
+
+    pto.mte_gm_ub(src_gm, ub_src, 0, SRC_BYTES, nburst=(1, SRC_BYTES, SRC_BYTES))
+    pto.mte_gm_ub(idx_gm, ub_idx, 0, IDX_BYTES, nburst=(1, IDX_BYTES, IDX_BYTES))
+
+    pto.set_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=0)
+    pto.wait_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=0)
+
+    offset = pto.const(0, dtype=pto.index)
+    idx = pto.vmi.vload(ub_idx, offset, size=ELEMS)
+    mask = pto.vmi.create_mask(pto.const(ELEMS, dtype=pto.index), size=ELEMS)
+    out = pto.vmi.vgather(ub_src, idx, mask)
+    pto.vmi.vstore(out, ub_dst, offset, mask)
+
+    pto.set_flag(pto.Pipe.V, pto.Pipe.MTE3, event_id=0)
+    pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE3, event_id=0)
+    pto.mte_ub_gm(ub_dst, dst_gm, DST_BYTES, nburst=(1, DST_BYTES, DST_BYTES))
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.jit(
+    name="vmi_vgather_u8_to_u16_256_kernel",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+    kernel_kind="vector",
+    insert_sync=False,
+)
+def vmi_vgather_u8_to_u16_256_kernel(
+    src_gm: pto.ptr(pto.ui8, "gm"),
+    idx_gm: pto.ptr(pto.ui16, "gm"),
+    dst_gm: pto.ptr(pto.ui16, "gm"),
+):
+    ub_src = pto.castptr(pto.const(0, dtype=pto.i64), pto.ptr(pto.ui8, "ub"))
+    ub_idx = pto.castptr(pto.const(4096, dtype=pto.i64), pto.ptr(pto.ui16, "ub"))
+    ub_dst = pto.castptr(pto.const(8192, dtype=pto.i64), pto.ptr(pto.ui16, "ub"))
+
+    pto.mte_gm_ub(src_gm, ub_src, 0, SRC_BYTES, nburst=(1, SRC_BYTES, SRC_BYTES))
+    pto.mte_gm_ub(idx_gm, ub_idx, 0, IDX_BYTES, nburst=(1, IDX_BYTES, IDX_BYTES))
+
+    pto.set_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=0)
+    pto.wait_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=0)
+
+    offset = pto.const(0, dtype=pto.index)
+    idx = pto.vmi.vload(ub_idx, offset, size=ELEMS)
+    mask = pto.vmi.create_mask(pto.const(ELEMS, dtype=pto.index), size=ELEMS)
+    out = pto.vmi.vgather(ub_src, idx, mask)
+    pto.vmi.vstore(out, ub_dst, offset, mask)
+
+    pto.set_flag(pto.Pipe.V, pto.Pipe.MTE3, event_id=0)
+    pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE3, event_id=0)
+    pto.mte_ub_gm(ub_dst, dst_gm, DST_BYTES, nburst=(1, DST_BYTES, DST_BYTES))
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+
+def _non_identity_indices() -> np.ndarray:
+    return ((np.arange(ELEMS, dtype=np.uint16) * 7 + 13) % ELEMS).astype(np.uint16)
+
+
+def _i8_inputs():
+    src = np.arange(ELEMS, dtype=np.uint8)
+    return [src, _non_identity_indices()]
+
+
+def _i8_expected(src, idx):
+    return src.astype(np.uint16)[idx].astype(np.uint16)
+
+
+def _u8_inputs():
+    src = np.arange(ELEMS, dtype=np.uint8)
+    return [src, _non_identity_indices()]
+
+
+def _u8_expected(src, idx):
+    return src.astype(np.uint16)[idx].astype(np.uint16)
+
+
+CASES = [
+    golden_output_case(
+        "vmi_vgather_i8_to_i16_256",
+        vmi_vgather_i8_to_i16_256_kernel,
+        inputs=_i8_inputs,
+        expected=_i8_expected,
+        output_shape=(ELEMS,),
+        output_dtype=np.uint16,
+        rtol=0.0,
+        atol=0.0,
+    ),
+    golden_output_case(
+        "vmi_vgather_u8_to_u16_256",
+        vmi_vgather_u8_to_u16_256_kernel,
+        inputs=_u8_inputs,
+        expected=_u8_expected,
+        output_shape=(ELEMS,),
+        output_dtype=np.uint16,
+        rtol=0.0,
+        atol=0.0,
+    ),
+]
+
+
+KERNELS = [
+    vmi_vgather_i8_to_i16_256_kernel,
+    vmi_vgather_u8_to_u16_256_kernel,
+]
+
+
+auto_main(globals())

--- a/test/vpto/cases/vmi_new/vgather-vmi.py
+++ b/test/vpto/cases/vmi_new/vgather-vmi.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""PTODSL source-backed cases for the 512-lane vgather VMI kernels.
+
+The MLIR is embedded inline so these cases are self-contained and do not depend
+on the old board-test directories.
+"""
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+
+def _bootstrap_dsl_st_common() -> None:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        common_dir = candidate / "test" / "dsl-st"
+        if (common_dir / "common.py").exists():
+            sys.path.insert(0, str(common_dir))
+            return
+    raise RuntimeError("Unable to locate test/dsl-st/common.py from vgather-vmi.py")
+
+
+_bootstrap_dsl_st_common()
+
+from common import auto_main, golden_output_case
+from ptodsl import pto
+
+
+BF16_SRC = r'''// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vmi_vgather_bf16_to_bf16_512_kernel(%src_gm: !pto.ptr<bf16, gm>,
+                                               %idx_gm: !pto.ptr<ui16, gm>,
+                                               %dst_gm: !pto.ptr<bf16, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c512 = arith.constant 512 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<bf16, ub>
+    %ub_idx = pto.castptr %c4096_i64 : i64 -> !pto.ptr<ui16, ub>
+    %ub_dst = pto.castptr %c8192_i64 : i64 -> !pto.ptr<bf16, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<bf16, gm>, !pto.ptr<bf16, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %idx_gm, %ub_idx, %c0_i64, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<ui16, gm>, !pto.ptr<ui16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %idx = pto.vmi.vload %ub_idx[%c0]
+          : !pto.ptr<ui16, ub> -> !pto.vmi.vreg<512xui16>
+      %mask = pto.vmi.create_mask %c512 : index -> !pto.vmi.mask<512xpred>
+      %out = pto.vmi.vgather %ub_src, %idx, %mask
+          : !pto.ptr<bf16, ub>, !pto.vmi.vreg<512xui16>,
+            !pto.vmi.mask<512xpred> -> !pto.vmi.vreg<512xbf16>
+      pto.vmi.vstore %out, %ub_dst[%c0]
+          : !pto.vmi.vreg<512xbf16>, !pto.ptr<bf16, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<bf16, ub>, !pto.ptr<bf16, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}
+'''
+F16_SRC = r'''// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vmi_vgather_f16_to_f16_512_kernel(%src_gm: !pto.ptr<f16, gm>,
+                                               %idx_gm: !pto.ptr<ui16, gm>,
+                                               %dst_gm: !pto.ptr<f16, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c512 = arith.constant 512 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
+    %ub_idx = pto.castptr %c4096_i64 : i64 -> !pto.ptr<ui16, ub>
+    %ub_dst = pto.castptr %c8192_i64 : i64 -> !pto.ptr<f16, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<f16, gm>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %idx_gm, %ub_idx, %c0_i64, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<ui16, gm>, !pto.ptr<ui16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %idx = pto.vmi.vload %ub_idx[%c0]
+          : !pto.ptr<ui16, ub> -> !pto.vmi.vreg<512xui16>
+      %mask = pto.vmi.create_mask %c512 : index -> !pto.vmi.mask<512xpred>
+      %out = pto.vmi.vgather %ub_src, %idx, %mask
+          : !pto.ptr<f16, ub>, !pto.vmi.vreg<512xui16>,
+            !pto.vmi.mask<512xpred> -> !pto.vmi.vreg<512xf16>
+      pto.vmi.vstore %out, %ub_dst[%c0]
+          : !pto.vmi.vreg<512xf16>, !pto.ptr<f16, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}
+'''
+I8_512_SRC = r'''// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vmi_vgather_i8_to_i16_512_kernel(%src_gm: !pto.ptr<i8, gm>,
+                                               %idx_gm: !pto.ptr<ui16, gm>,
+                                               %dst_gm: !pto.ptr<i16, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c512 = arith.constant 512 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<i8, ub>
+    %ub_idx = pto.castptr %c4096_i64 : i64 -> !pto.ptr<ui16, ub>
+    %ub_dst = pto.castptr %c8192_i64 : i64 -> !pto.ptr<i16, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<i8, gm>, !pto.ptr<i8, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %idx_gm, %ub_idx, %c0_i64, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<ui16, gm>, !pto.ptr<ui16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %idx = pto.vmi.vload %ub_idx[%c0]
+          : !pto.ptr<ui16, ub> -> !pto.vmi.vreg<512xui16>
+      %mask = pto.vmi.create_mask %c512 : index -> !pto.vmi.mask<512xpred>
+      %out = pto.vmi.vgather %ub_src, %idx, %mask
+          : !pto.ptr<i8, ub>, !pto.vmi.vreg<512xui16>,
+            !pto.vmi.mask<512xpred> -> !pto.vmi.vreg<512xi16>
+      pto.vmi.vstore %out, %ub_dst[%c0]
+          : !pto.vmi.vreg<512xi16>, !pto.ptr<i16, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<i16, ub>, !pto.ptr<i16, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}
+'''
+U8_512_SRC = r'''// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vmi_vgather_u8_to_u16_512_kernel(%src_gm: !pto.ptr<ui8, gm>,
+                                               %idx_gm: !pto.ptr<ui16, gm>,
+                                               %dst_gm: !pto.ptr<ui16, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c512 = arith.constant 512 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<ui8, ub>
+    %ub_idx = pto.castptr %c4096_i64 : i64 -> !pto.ptr<ui16, ub>
+    %ub_dst = pto.castptr %c8192_i64 : i64 -> !pto.ptr<ui16, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<ui8, gm>, !pto.ptr<ui8, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %idx_gm, %ub_idx, %c0_i64, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<ui16, gm>, !pto.ptr<ui16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %idx = pto.vmi.vload %ub_idx[%c0]
+          : !pto.ptr<ui16, ub> -> !pto.vmi.vreg<512xui16>
+      %mask = pto.vmi.create_mask %c512 : index -> !pto.vmi.mask<512xpred>
+      %out = pto.vmi.vgather %ub_src, %idx, %mask
+          : !pto.ptr<ui8, ub>, !pto.vmi.vreg<512xui16>,
+            !pto.vmi.mask<512xpred> -> !pto.vmi.vreg<512xui16>
+      pto.vmi.vstore %out, %ub_dst[%c0]
+          : !pto.vmi.vreg<512xui16>, !pto.ptr<ui16, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<ui16, ub>, !pto.ptr<ui16, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}
+'''
+UI16_512_SRC = r'''// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vmi_vgather_ui16_to_ui16_512_kernel(%src_gm: !pto.ptr<ui16, gm>,
+                                               %idx_gm: !pto.ptr<ui16, gm>,
+                                               %dst_gm: !pto.ptr<ui16, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c512 = arith.constant 512 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<ui16, ub>
+    %ub_idx = pto.castptr %c4096_i64 : i64 -> !pto.ptr<ui16, ub>
+    %ub_dst = pto.castptr %c8192_i64 : i64 -> !pto.ptr<ui16, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<ui16, gm>, !pto.ptr<ui16, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %idx_gm, %ub_idx, %c0_i64, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<ui16, gm>, !pto.ptr<ui16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %idx = pto.vmi.vload %ub_idx[%c0]
+          : !pto.ptr<ui16, ub> -> !pto.vmi.vreg<512xui16>
+      %mask = pto.vmi.create_mask %c512 : index -> !pto.vmi.mask<512xpred>
+      %out = pto.vmi.vgather %ub_src, %idx, %mask
+          : !pto.ptr<ui16, ub>, !pto.vmi.vreg<512xui16>,
+            !pto.vmi.mask<512xpred> -> !pto.vmi.vreg<512xui16>
+      pto.vmi.vstore %out, %ub_dst[%c0]
+          : !pto.vmi.vreg<512xui16>, !pto.ptr<ui16, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<ui16, ub>, !pto.ptr<ui16, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}
+'''
+@pto.jit(
+    name="vmi_vgather_bf16_to_bf16_512_kernel",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+    source=BF16_SRC,
+)
+def vmi_vgather_bf16_to_bf16_512_kernel(
+    src_gm: pto.ptr(pto.bf16, "gm"),
+    idx_gm: pto.ptr(pto.ui16, "gm"),
+    dst_gm: pto.ptr(pto.bf16, "gm"),
+):
+    pass
+
+
+@pto.jit(
+    name="vmi_vgather_f16_to_f16_512_kernel",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+    source=F16_SRC,
+)
+def vmi_vgather_f16_to_f16_512_kernel(
+    src_gm: pto.ptr(pto.f16, "gm"),
+    idx_gm: pto.ptr(pto.ui16, "gm"),
+    dst_gm: pto.ptr(pto.f16, "gm"),
+):
+    pass
+
+
+@pto.jit(
+    name="vmi_vgather_i8_to_i16_512_kernel",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+    source=I8_512_SRC,
+)
+def vmi_vgather_i8_to_i16_512_kernel(
+    src_gm: pto.ptr(pto.i8, "gm"),
+    idx_gm: pto.ptr(pto.ui16, "gm"),
+    dst_gm: pto.ptr(pto.i16, "gm"),
+):
+    pass
+
+
+@pto.jit(
+    name="vmi_vgather_u8_to_u16_512_kernel",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+    source=U8_512_SRC,
+)
+def vmi_vgather_u8_to_u16_512_kernel(
+    src_gm: pto.ptr(pto.ui8, "gm"),
+    idx_gm: pto.ptr(pto.ui16, "gm"),
+    dst_gm: pto.ptr(pto.ui16, "gm"),
+):
+    pass
+
+
+@pto.jit(
+    name="vmi_vgather_ui16_to_ui16_512_kernel",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+    source=UI16_512_SRC,
+)
+def vmi_vgather_ui16_to_ui16_512_kernel(
+    src_gm: pto.ptr(pto.ui16, "gm"),
+    idx_gm: pto.ptr(pto.ui16, "gm"),
+    dst_gm: pto.ptr(pto.ui16, "gm"),
+):
+    pass
+
+
+def _non_identity_indices(elems: int) -> np.ndarray:
+    # Non-identity deterministic gather (idx[i] != i for most lanes).
+    return ((np.arange(elems, dtype=np.uint16) * 7 + 13) % elems).astype(np.uint16)
+
+
+def _bf16_512_inputs():
+    elems = 512
+    src = np.arange(elems, dtype=np.float16)
+    return [src, _non_identity_indices(elems)]
+
+
+def _bf16_512_expected(src, idx):
+    return src[idx].astype(np.float16)
+
+
+def _f16_512_inputs():
+    elems = 512
+    src = np.arange(elems, dtype=np.float16)
+    return [src, _non_identity_indices(elems)]
+
+
+def _f16_512_expected(src, idx):
+    return src[idx].astype(np.float16)
+
+
+def _i8_512_inputs():
+    elems = 512
+    src = np.arange(elems, dtype=np.uint8)
+    return [src, _non_identity_indices(elems)]
+
+
+def _i8_512_expected(src, idx):
+    return src.astype(np.uint16)[idx].astype(np.uint16)
+
+
+def _u8_512_inputs():
+    elems = 512
+    src = np.arange(elems, dtype=np.uint8)
+    return [src, _non_identity_indices(elems)]
+
+
+def _u8_512_expected(src, idx):
+    return src.astype(np.uint16)[idx].astype(np.uint16)
+
+
+def _ui16_512_inputs():
+    elems = 512
+    src = np.arange(elems, dtype=np.uint16)
+    return [src, _non_identity_indices(elems)]
+
+
+def _ui16_512_expected(src, idx):
+    return src[idx].astype(np.uint16)
+
+
+CASES = [
+    golden_output_case(
+        "vmi_vgather_bf16_to_bf16_512",
+        vmi_vgather_bf16_to_bf16_512_kernel,
+        inputs=_bf16_512_inputs,
+        expected=_bf16_512_expected,
+        output_shape=(512,),
+        output_dtype=np.float16,
+        rtol=0.0,
+        atol=0.0,
+    ),
+    golden_output_case(
+        "vmi_vgather_f16_to_f16_512",
+        vmi_vgather_f16_to_f16_512_kernel,
+        inputs=_f16_512_inputs,
+        expected=_f16_512_expected,
+        output_shape=(512,),
+        output_dtype=np.float16,
+        rtol=0.0,
+        atol=0.0,
+    ),
+    golden_output_case(
+        "vmi_vgather_i8_to_i16_512",
+        vmi_vgather_i8_to_i16_512_kernel,
+        inputs=_i8_512_inputs,
+        expected=_i8_512_expected,
+        output_shape=(512,),
+        output_dtype=np.uint16,
+        rtol=0.0,
+        atol=0.0,
+    ),
+    golden_output_case(
+        "vmi_vgather_u8_to_u16_512",
+        vmi_vgather_u8_to_u16_512_kernel,
+        inputs=_u8_512_inputs,
+        expected=_u8_512_expected,
+        output_shape=(512,),
+        output_dtype=np.uint16,
+        rtol=0.0,
+        atol=0.0,
+    ),
+    golden_output_case(
+        "vmi_vgather_ui16_to_ui16_512",
+        vmi_vgather_ui16_to_ui16_512_kernel,
+        inputs=_ui16_512_inputs,
+        expected=_ui16_512_expected,
+        output_shape=(512,),
+        output_dtype=np.uint16,
+        rtol=0.0,
+        atol=0.0,
+    ),
+]
+
+
+KERNELS = [
+    vmi_vgather_bf16_to_bf16_512_kernel,
+    vmi_vgather_f16_to_f16_512_kernel,
+    vmi_vgather_i8_to_i16_512_kernel,
+    vmi_vgather_u8_to_u16_512_kernel,
+    vmi_vgather_ui16_to_ui16_512_kernel,
+]
+
+
+auto_main(globals())


### PR DESCRIPTION
#### 解决的问题
pto.vmi.vgather 原先只支持 B32 路径（32-bit 结果 + i32 offsets + b32 mask），无法处理量化场景中常见的 byte/halfword gather。本 PR 新增 B16 路径，使 vgather 能直接服务 8-bit/16-bit 数据类型。

#### 主要改动
- 新增 B16 gather 路径
16-bit 结果 + ui16 offsets + b16 mask
支持同宽度 gather：i16/ui16/f16/bf16 source → matching result
支持 8→16 零扩展提升：i8/ui8 source → i16/ui16 result（按符号标签匹配，零扩展，不支持符号扩展）

- 多 chunk gather 支持
移除原先 16-bit gather 只能单物理寄存器的限制
支持最多 4 个物理寄存器（ISA 上限）：16-bit → 最多 512 lanes，32-bit → 最多 256 lanes

- 静态全活跃 mask 下消除冗余 vsel
Lowering 层：当 mask 静态全活跃时（create_mask(active_lanes >= L) 或全 true constant_mask），跳过 trailing vsel，直接返回 gather 结果
VPTO 层：新增 SimplifyVselAllTrueMask pattern，在 VPTOMaskSimplify pass 中消除全 true mask 的 vsel，使该优化对非 gather 路径也生效

- PTODSL 自动推导
pto.vmi.vgather 的 8-bit 整数 source 自动推导为 16-bit 结果类型（i8→i16、ui8→ui16、si8→si16），无需用户显式指定

- 测试
14 个 lit 用例：覆盖 B16/B32 路径、同宽度/提升、multi-chunk、granularity pred/explicit/conflict、all-active mask 优化、invalid 场景
7 个 NPU 板端 runtime case：i8→i16、u8→u16、ui16→ui16、f16→f16、bf16→bf16（256/512 lanes），全部 PASS