### PR TITLE
feat(pto): support A2/A3 V2C odd pipe splits

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -117,9 +117,9 @@ jobs:
       PYPTO_WORKSPACE: ${{ github.workspace }}/.work/pypto-ci
       PYPTO_RUN_WORKSPACE: ${{ github.workspace }}/.work/pypto-run-ci
       # GitHub pin containing the unified TFILLPAD API, the two-argument Soft
-      # SYNCALL ABI, and the follow-up CPU-Sim duplicate-stub fix. Keep this
-      # separate from the GitCode pins managed by update_pto_isa_pin.py.
-      PTO_ISA_COMMIT: e948507e18ec4f39037a04914b97e77f5b9d75e3
+      # SYNCALL ABI, the CPU-Sim duplicate-stub fix, and A2/A3 V2C odd-split
+      # TPUSH support. Keep this separate from the GitCode pins.
+      PTO_ISA_COMMIT: 927253b784344d4ecbed524fd44737097c2bc3e0
       PTO_ISA_ROOT: ${{ github.workspace }}/.work/pto-isa-ci
     steps:
       - name: Checkout

--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -9254,15 +9254,19 @@ frontend/framework generated IR. The detailed design document is:
 - `TILE_UP_DOWN_ODD` splits an odd valid-row count so AIV0 receives
   `ceil(valid_rows / 2)` rows and AIV1 receives `floor(valid_rows / 2)` rows.
   `TILE_LEFT_RIGHT_ODD` applies the same rule to valid columns.
-- Odd split modes are currently supported only by a unidirectional C2V
-  GM-backed tile pipe. The frontend initialize op must provide both
-  `gm_slot_tensor` and `c2v_consumer_buf`; local C2V, V2C, bidirectional, and
-  GlobalTensor-entry odd splits are rejected because the pinned pto-isa does
-  not implement those transfer paths.
+- Odd split modes are supported by GM-backed tile pipes in the C2V direction
+  on A2/A3/A5 and in the V2C direction on A2/A3. A2/A3 also supports odd V2C
+  on the enabled direction of a bidirectional pipe. The initialize op must
+  provide GM slot backing and the matching direction's consumer buffer.
+  Local-only pipes, A5 odd V2C, and GlobalTensor-entry odd splits are rejected.
 - For an odd C2V tile pop, AIV0 and AIV1 must pass different
   `valid_row` / `valid_col` operands. The frontend must derive these operands
   from `pto.get_subblock_idx`: AIV0 supplies the `ceil` half and AIV1 supplies
   the `floor` half. PTO-ISA does not derive the two valid shapes automatically.
+- For an odd V2C tile push, the two AIV producers must likewise set their tile
+  valid shapes to the `ceil` and `floor` halves before `pto.tpush_to_aic`. The
+  Cube-side `pto.tpop_from_aiv` describes the complete unsplit tile and, when
+  its valid shape is dynamic, receives the full `valid_row` / `valid_col`.
 - `pto.tpop_from_aic` and `pto.tpop_from_aiv` are result-valued frontend ops.
 - Pipe entries support two forms:
   - tile entry: `!pto.tile_buf<...>` or the equivalent local memref after view
@@ -9280,18 +9284,17 @@ frontend/framework generated IR. The detailed design document is:
   and may carry `slot_num`; `gm_slot_buffer`, `c2v_consumer_buf`,
   `v2c_consumer_buf`, `local_slot_num`, `pto.reserve_buffer`, and
   `pto.import_reserved_buffer` are not used.
-- A C2V GM-backed tile pipe instead carries both `gm_slot_tensor` and
-  `c2v_consumer_buf`. The GM tensor describes the complete FIFO slot, while
-  the consumer buffer supplies the local vector-tile staging area. This mixed
-  form is currently limited to `dir_mask = 1`.
+- A GM-backed tile pipe carries GM slot backing plus the consumer buffer for
+  each enabled direction: `c2v_consumer_buf` for C2V and
+  `v2c_consumer_buf` for V2C. The GM descriptor describes the complete FIFO
+  slot, while each consumer buffer supplies its direction's local staging
+  area. `dir_mask = 3` requires both consumer buffers.
 - For global entries, the matched initialize op's `gm_slot_tensor` describes
   one FIFO slot entry, not the full multi-slot FIFO buffer. Its dtype, shape,
   stride, and layout must match the `tensor_view` returned by `talloc` /
-  `tpop` and form the pto-isa `GlobalData` template argument. `TILE_UP_DOWN`,
-  `TILE_LEFT_RIGHT`, `TILE_UP_DOWN_ODD`, and `TILE_LEFT_RIGHT_ODD` split modes
-  derive each sub-core's GM view from the single-slot descriptor and the
-  runtime tile valid shape. For odd modes, the two sub-cores' valid shapes must
-  be the explicit `ceil` and `floor` halves described above.
+  `tpop` and form the pto-isa `GlobalData` template argument. Global entries
+  support `TILE_NO_SPLIT`, `TILE_UP_DOWN`, and `TILE_LEFT_RIGHT`; odd split
+  modes are limited to tile entries.
 - If a global-entry result op does not carry explicit stride/layout metadata,
   PTOAS treats it as a row-major contiguous GM view. Non-contiguous cases must
   preserve stride/layout through the producing op metadata, the source view, or
@@ -9459,14 +9462,14 @@ pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
   paths that also use a local consumer FIFO buffer
 - `gm_slot_tensor`: optional single-slot entry descriptor
   (`!pto.tensor_view<...>`), required by global-only GM FIFO and by the A5
-  C2V GM-backed tile path. For a global entry, its type describes the
+  GM-backed tile paths. For a global entry, its type describes the
   `tensor_view` returned by `talloc` / `tpop`. This descriptor is retained in
   IR for entry type validation; EmitC lowers the `TPipe` constructor argument
   to only the GM FIFO start address
 - `c2v_consumer_buf`: optional C2V consumer local base address; omitted for
   global-only GM FIFO, but required when `gm_slot_tensor` backs a C2V tile pipe
 - `v2c_consumer_buf`: optional V2C consumer local base address; omitted for
-  global-only GM FIFO
+  global-only GM FIFO, but required when `gm_slot_tensor` backs a V2C tile pipe
 
 **Results:** None.
 

--- a/docs/designs/ptoas-tpush-tpop-design.md
+++ b/docs/designs/ptoas-tpush-tpop-design.md
@@ -424,10 +424,11 @@ handle。
 - `TILE_UP_DOWN_ODD`
 - `TILE_LEFT_RIGHT_ODD`
 
-当前 odd 模式仅允许单向 C2V 的 GM-backed tile pipe。前端 initialize 必须同时提供
-`gm_slot_tensor` 和 `c2v_consumer_buf`，lowering 后对应带 local consumer buffer 的
-`pto.initialize_l2g2l_pipe`。local C2V、V2C、双向 pipe 以及 GlobalTensor entry
-暂不允许 odd 模式，因为固定版本的 pto-isa 尚未实现这些数据传输/offset 路径。
+当前 odd 模式允许 A2/A3/A5 GM-backed tile pipe 的 C2V 方向，以及 A2/A3 GM-backed
+tile pipe 的 V2C 方向；A2/A3 双向 pipe 中具有对应 consumer buffer 的 V2C 方向也支持。
+initialize 必须提供 GM slot backing，并为 C2V 提供 `c2v_consumer_buf`、为 V2C 提供
+`v2c_consumer_buf`；双向 pipe 必须同时提供两个 consumer buffer。A5 odd V2C、local-only
+pipe 与 GlobalTensor entry 仍不允许 odd 模式。
 
 在 PTOAS 设计中，`split` 的角色定义为：
 
@@ -463,9 +464,11 @@ handle。
 
 GM tile 路径中的偶数和奇数切分模式都使用运行时 valid shape 计算 offset 与
 row stride。odd 模式不会自动推导两个子核的 valid shape：前端必须根据
-`pto.get_subblock_idx` 为 AIV0 传入 `ceil` 半块、为 AIV1 传入 `floor` 半块，
-并把不同的 `valid_row` / `valid_col` operand 传给 `tpop`。描述 GM slot 的
-metadata 仍必须覆盖切分前的完整 FIFO slot。
+`pto.get_subblock_idx` 为 AIV0 计算 `ceil` 半块、为 AIV1 计算 `floor` 半块。C2V
+方向把这两个 valid shape 作为 `tpop_from_aic` 的 `valid_row` / `valid_col` operand；
+V2C 方向则在 `tpush_to_aic` 前把它们设置到两个 AIV producer tile 上，Cube 侧
+`tpop_from_aiv` 使用切分前的完整 valid shape。描述 GM slot 的 metadata 仍必须覆盖
+切分前的完整 FIFO slot。
 
 ### 4.4 `SLOT_NUM` 规则
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -18604,11 +18604,19 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
       return op.emitOpError(
           "'gm_slot_tensor' cannot be combined with 'gm_slot_buffer'");
     }
-    if ((hasC2vConsumerBuf || hasV2cConsumerBuf) &&
-        (dirMask != 1 || !hasC2vConsumerBuf || hasV2cConsumerBuf)) {
-      return op.emitOpError(
-          "GM-backed tile pipe init currently supports only dir_mask = 1 "
-          "with 'gm_slot_tensor' and 'c2v_consumer_buf'");
+    if (hasC2vConsumerBuf || hasV2cConsumerBuf) {
+      bool supportsC2V =
+          dirMask == 1 && hasC2vConsumerBuf && !hasV2cConsumerBuf;
+      bool supportsA2A3V2C =
+          arch != PTOArch::A5 &&
+          ((dirMask == 2 && !hasC2vConsumerBuf && hasV2cConsumerBuf) ||
+           (dirMask == 3 && hasC2vConsumerBuf && hasV2cConsumerBuf));
+      if (!supportsC2V && !supportsA2A3V2C) {
+        return op.emitOpError(
+            "GM-backed tile pipe init supports dir_mask = 1 with "
+            "'c2v_consumer_buf' on all targets and dir_mask = 2/3 with "
+            "matching consumer buffers only on a2/a3");
+      }
     }
     if (!hasC2vConsumerBuf && !hasV2cConsumerBuf) {
       if (op.getLocalSlotNumAttr()) {
@@ -19147,11 +19155,6 @@ static LogicalResult verifyFrontendSplitOp(Operation *op,
   if (!isOddSplit(split)) {
     return success();
   }
-  if (!expectC2V) {
-    return op->emitOpError(
-        "supports odd split modes (split = 3 or 4) only for C2V "
-        "GM-backed tile pipes");
-  }
 
   auto funcOp = op->getParentOfType<func::FuncOp>();
   if (!funcOp) {
@@ -19161,27 +19164,35 @@ static LogicalResult verifyFrontendSplitOp(Operation *op,
   if (failed(initOr)) {
     return failure();
   }
+  if (!expectC2V && getTargetArch(op) == PTOArch::A5) {
+    return op->emitOpError(
+        "supports odd V2C split modes (split = 3 or 4) only on a2/a3");
+  }
 
-  auto supportsOddC2V = [op](auto init) {
+  auto supportsOddDirection = [&](auto init) {
     PTOArch arch = getTargetArch(op);
     bool hasSupportedGmBacking =
         static_cast<bool>(init.getGmSlotTensor()) ||
         (arch != PTOArch::A5 && static_cast<bool>(init.getGmSlotBuffer()));
-    return init.getDirMask() == 1 && hasSupportedGmBacking &&
-           static_cast<bool>(init.getC2vConsumerBuf());
+    int8_t directionMask = expectC2V ? 1 : 2;
+    Value consumerBuffer = expectC2V ? init.getC2vConsumerBuf()
+                                     : init.getV2cConsumerBuf();
+    return (init.getDirMask() & directionMask) != 0 &&
+           hasSupportedGmBacking && static_cast<bool>(consumerBuffer);
   };
 
   bool supported = false;
   if (auto aic = dyn_cast<AicInitializePipeOp>(*initOr)) {
-    supported = supportsOddC2V(aic);
+    supported = supportsOddDirection(aic);
   } else {
-    supported = supportsOddC2V(cast<AivInitializePipeOp>(*initOr));
-}
+    supported = supportsOddDirection(cast<AivInitializePipeOp>(*initOr));
+  }
   if (!supported) {
-    return op->emitOpError(
-        "supports odd split modes (split = 3 or 4) only for a "
-        "unidirectional C2V GM-backed tile pipe with both GM slot and "
-        "C2V consumer buffers");
+    return op->emitOpError()
+           << "supports odd split modes (split = 3 or 4) only for a "
+              "GM-backed tile pipe whose dir_mask enables "
+           << (expectC2V ? "C2V" : "V2C")
+           << " and provides the matching consumer buffer";
   }
   return success();
 }
@@ -19196,8 +19207,8 @@ static LogicalResult verifyOddSplitTileEntry(Operation *op, int64_t split,
   return success();
 }
 
-static LogicalResult verifyC2VProducerSplitParity(Operation *op, int64_t split,
-                                                  Type entryTy) {
+static LogicalResult verifyFullTileSplitParity(Operation *op, int64_t split,
+                                               Type entryTy) {
   if (split == 0) {
     return success();
   }
@@ -19378,6 +19389,11 @@ static LogicalResult verifyFrontendPopOp(FrontendPopOpT op,
                                                   op.getTile().getType()))) {
     return failure();
   }
+  if (!expectC2V &&
+      failed(verifyFullTileSplitParity(op.getOperation(), op.getSplit(),
+                                       op.getTile().getType()))) {
+    return failure();
+  }
 
   bool hasValidRow = static_cast<bool>(op.getValidRow());
   bool hasValidCol = static_cast<bool>(op.getValidCol());
@@ -19385,7 +19401,7 @@ static LogicalResult verifyFrontendPopOp(FrontendPopOpT op,
     return op.emitOpError(
         "expects valid_row and valid_col operands to be provided together");
   }
-  if (isOddSplit(op.getSplit()) && !hasValidRow &&
+  if (expectC2V && isOddSplit(op.getSplit()) && !hasValidRow &&
       !isa<TensorViewType>(op.getTile().getType())) {
     return op.emitOpError(
         "expects odd C2V split tpop to provide per-sub-core valid_row and "
@@ -19719,15 +19735,28 @@ static LogicalResult verifyInternalOddSplitSupport(Operation *op,
     return success();
   }
 
-  bool isC2VSide = producerSide ? isInsideCubeKernelOrSection(op)
-                                : isInsideVectorKernelOrSection(op);
+  bool isCubeSide = isInsideCubeKernelOrSection(op);
+  bool isVectorSide = isInsideVectorKernelOrSection(op);
+  bool isC2VSide = producerSide ? isCubeSide : isVectorSide;
+  bool isV2CSide = producerSide ? isVectorSide : isCubeSide;
+  int8_t directionMask = isC2VSide ? 1 : (isV2CSide ? 2 : 0);
+  if (isV2CSide && getTargetArch(op) == PTOArch::A5) {
+    return op->emitOpError(
+        "supports odd V2C split modes (split = 3 or 4) only on a2/a3");
+  }
   auto initOp = pipeHandle.getDefiningOp<InitializeL2G2LPipeOp>();
-  if (!isC2VSide || !initOp || initOp.getDirMask() != 1 ||
-      !initOp.getLocalAddr()) {
+  Value consumerBuffer;
+  if (initOp && directionMask != 0) {
+    consumerBuffer = directionMask == 2 && initOp.getDirMask() == 3
+                         ? initOp.getPeerLocalAddr()
+                         : initOp.getLocalAddr();
+  }
+  if (!initOp || directionMask == 0 ||
+      (initOp.getDirMask() & directionMask) == 0 || !consumerBuffer) {
     return op->emitOpError(
         "supports odd split modes (split = 3 or 4) only for a "
-        "unidirectional C2V pto.initialize_l2g2l_pipe with a local "
-        "consumer buffer");
+        "pto.initialize_l2g2l_pipe whose dir_mask enables the operation "
+        "direction and provides its local consumer buffer");
   }
   return success();
 }
@@ -20550,6 +20579,10 @@ LogicalResult TAllocToAicOp::verify() {
                                            /*expectC2V=*/false))) {
     return failure();
   }
+  if (failed(verifyOddSplitTileEntry(getOperation(), getSplit(),
+                                     getEntry().getType()))) {
+    return failure();
+  }
   return verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
                                               getEntry().getType());
 }
@@ -20575,8 +20608,8 @@ LogicalResult TPushToAivOp::verify() {
                                      getTile().getType()))) {
     return failure();
   }
-  if (failed(verifyC2VProducerSplitParity(getOperation(), getSplit(),
-                                          getTile().getType()))) {
+  if (failed(verifyFullTileSplitParity(getOperation(), getSplit(),
+                                       getTile().getType()))) {
     return failure();
   }
 
@@ -20716,6 +20749,10 @@ LogicalResult TPushToAicOp::verify() {
   }
   if (failed(verifyFrontendTensorEntryMatchesInit(getOperation(), getId(),
                                                   getTile().getType()))) {
+    return failure();
+  }
+  if (failed(verifyOddSplitTileEntry(getOperation(), getSplit(),
+                                     getTile().getType()))) {
     return failure();
   }
   return verifyAivSubblockIdOperand(getOperation(), getAivSubblockid(),
@@ -21030,8 +21067,9 @@ LogicalResult TPushOp::verify() {
                                      getTile().getType()))) {
     return failure();
   }
-  if (failed(verifyC2VProducerSplitParity(getOperation(), getSplit(),
-                                          getTile().getType()))) {
+  if (isInsideCubeKernelOrSection(getOperation()) &&
+      failed(verifyFullTileSplitParity(getOperation(), getSplit(),
+                                       getTile().getType()))) {
     return failure();
   }
   if (failed(verifyAivSubblockIdOperand(getOperation(), getAivSubblockid(),
@@ -21092,6 +21130,11 @@ LogicalResult TPopOp::verify() {
   }
   if (failed(verifyOddSplitTileEntry(getOperation(), getSplit(),
                                      getTile().getType()))) {
+    return failure();
+  }
+  if (isInsideCubeKernelOrSection(getOperation()) &&
+      failed(verifyFullTileSplitParity(getOperation(), getSplit(),
+                                       getTile().getType()))) {
     return failure();
   }
   if (failed(verifyAivSubblockIdOperand(getOperation(), getAivSubblockid(),

--- a/test/lit/pto/tpush_tpop_odd_split_emitc.pto
+++ b/test/lit/pto/tpush_tpop_odd_split_emitc.pto
@@ -6,12 +6,15 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 //
-// Verifies that odd valid-shape split modes use the supported C2V GM-backed
-// tile path and select the matching PTO-ISA template arguments.
+// Verifies that odd valid-shape split modes use the supported C2V and A2/A3
+// V2C GM-backed tile paths and select the matching PTO-ISA template arguments.
 //
 // RUN: split-file %s %t
 // RUN: ptoas --pto-arch=a5 %t/up-down.pto 2>&1 | FileCheck %s --check-prefix=UP-DOWN
 // RUN: ptoas --pto-arch=a5 %t/left-right.pto 2>&1 | FileCheck %s --check-prefix=LEFT-RIGHT
+// RUN: ptoas --pto-arch=a3 %t/v2c-up-down.pto 2>&1 | FileCheck %s --check-prefix=V2C-UP-DOWN
+// RUN: ptoas --pto-arch=a3 %t/v2c-left-right.pto 2>&1 | FileCheck %s --check-prefix=V2C-LEFT-RIGHT
+// RUN: ptoas --pto-arch=a3 %t/bidir-v2c-up-down.pto 2>&1 | FileCheck %s --check-prefix=BIDIR-V2C-UP-DOWN
 
 //--- up-down.pto
 module {
@@ -70,6 +73,201 @@ module {
     %tile = pto.tpop_from_aic(%half_rows, %c16) {id = 3, split = 3}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tfree_from_aic {id = 3, split = 3}
+    return
+  }
+}
+
+//--- v2c-up-down.pto
+module {
+  func.func @vector_v2c_up_down(%gm_slot_buffer: !pto.ptr<f32>,
+                                %full_rows: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<16x16xf32>
+
+    %consumer_import = pto.import_reserved_buffer {
+      name = "v2c_up_down_fifo",
+      peer_func = @cube_v2c_up_down
+    } -> i32
+
+    pto.aiv_initialize_pipe {id = 5, dir_mask = 2, slot_size = 1024}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>,
+       v2c_consumer_buf = %consumer_import : i32)
+
+    %subblock_idx = pto.get_subblock_idx
+    %is_aiv0 = arith.cmpi eq, %subblock_idx, %c0_i64 : i64
+    %rounded_rows = arith.addi %full_rows, %c1 : index
+    %ceil_rows = arith.divui %rounded_rows, %c2 : index
+    %floor_rows = arith.divui %full_rows, %c2 : index
+    %half_rows = arith.select %is_aiv0, %ceil_rows, %floor_rows : index
+    %tile = pto.alloc_tile valid_row = %half_rows valid_col = %c16
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tpush_to_aic(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 5, split = 3}
+    return
+  }
+
+  func.func @cube_v2c_up_down(%gm_slot_buffer: !pto.ptr<f32>,
+                              %full_rows: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<16x16xf32>
+
+    %consumer_local = pto.reserve_buffer {
+      name = "v2c_up_down_fifo",
+      size = 8192,
+      location = #pto.address_space<mat>,
+      auto = true
+    } -> i32
+
+    pto.aic_initialize_pipe {id = 5, dir_mask = 2, slot_size = 1024}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>,
+       v2c_consumer_buf = %consumer_local : i32)
+
+    %tile = pto.tpop_from_aiv(%full_rows, %c16) {id = 5, split = 3}
+      -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tfree_from_aiv {id = 5, split = 3}
+    return
+  }
+}
+
+//--- v2c-left-right.pto
+module {
+  func.func @vector_v2c_left_right(%gm_slot_buffer: !pto.ptr<f32>,
+                                   %full_cols: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<16x16xf32>
+
+    %consumer_import = pto.import_reserved_buffer {
+      name = "v2c_left_right_fifo",
+      peer_func = @cube_v2c_left_right
+    } -> i32
+
+    pto.aiv_initialize_pipe {id = 6, dir_mask = 2, slot_size = 1024}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>,
+       v2c_consumer_buf = %consumer_import : i32)
+
+    %subblock_idx = pto.get_subblock_idx
+    %is_aiv0 = arith.cmpi eq, %subblock_idx, %c0_i64 : i64
+    %rounded_cols = arith.addi %full_cols, %c1 : index
+    %ceil_cols = arith.divui %rounded_cols, %c2 : index
+    %floor_cols = arith.divui %full_cols, %c2 : index
+    %half_cols = arith.select %is_aiv0, %ceil_cols, %floor_cols : index
+    %tile = pto.alloc_tile valid_row = %c16 valid_col = %half_cols
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=8, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tpush_to_aic(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=8, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 6, split = 4}
+    return
+  }
+
+  func.func @cube_v2c_left_right(%gm_slot_buffer: !pto.ptr<f32>,
+                                 %full_cols: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<16x16xf32>
+
+    %consumer_local = pto.reserve_buffer {
+      name = "v2c_left_right_fifo",
+      size = 8192,
+      location = #pto.address_space<mat>,
+      auto = true
+    } -> i32
+
+    pto.aic_initialize_pipe {id = 6, dir_mask = 2, slot_size = 1024}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>,
+       v2c_consumer_buf = %consumer_local : i32)
+
+    %tile = pto.tpop_from_aiv(%c16, %full_cols) {id = 6, split = 4}
+      -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tfree_from_aiv {id = 6, split = 4}
+    return
+  }
+}
+
+//--- bidir-v2c-up-down.pto
+module {
+  func.func @vector_bidir_v2c_up_down(%gm_slot_buffer: !pto.ptr<f32>,
+                                      %full_rows: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<16x16xf32>
+
+    %c2v_consumer_local = pto.reserve_buffer {
+      name = "bidir_c2v_fifo",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+    %v2c_consumer_import = pto.import_reserved_buffer {
+      name = "bidir_v2c_fifo",
+      peer_func = @cube_bidir_v2c_up_down
+    } -> i32
+
+    pto.aiv_initialize_pipe {id = 7, dir_mask = 3, slot_size = 1024}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>,
+       c2v_consumer_buf = %c2v_consumer_local : i32,
+       v2c_consumer_buf = %v2c_consumer_import : i32)
+
+    %subblock_idx = pto.get_subblock_idx
+    %is_aiv0 = arith.cmpi eq, %subblock_idx, %c0_i64 : i64
+    %rounded_rows = arith.addi %full_rows, %c1 : index
+    %ceil_rows = arith.divui %rounded_rows, %c2 : index
+    %floor_rows = arith.divui %full_rows, %c2 : index
+    %half_rows = arith.select %is_aiv0, %ceil_rows, %floor_rows : index
+    %tile = pto.alloc_tile valid_row = %half_rows valid_col = %c16
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tpush_to_aic(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 7, split = 3}
+    return
+  }
+
+  func.func @cube_bidir_v2c_up_down(%gm_slot_buffer: !pto.ptr<f32>,
+                                    %full_rows: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<16x16xf32>
+
+    %c2v_consumer_import = pto.import_reserved_buffer {
+      name = "bidir_c2v_fifo",
+      peer_func = @vector_bidir_v2c_up_down
+    } -> i32
+    %v2c_consumer_local = pto.reserve_buffer {
+      name = "bidir_v2c_fifo",
+      size = 4096,
+      location = #pto.address_space<mat>,
+      auto = true
+    } -> i32
+
+    pto.aic_initialize_pipe {id = 7, dir_mask = 3, slot_size = 1024}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>,
+       c2v_consumer_buf = %c2v_consumer_import : i32,
+       v2c_consumer_buf = %v2c_consumer_local : i32)
+
+    %tile = pto.tpop_from_aiv(%full_rows, %c16) {id = 7, split = 3}
+      -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tfree_from_aiv {id = 7, split = 3}
     return
   }
 }
@@ -152,3 +350,30 @@ module {
 // LEFT-RIGHT: TPipe<0, Direction::DIR_C2V_GM, 1024, 8, 8, false>(
 // LEFT-RIGHT: TPOP<{{.*}}TileSplitAxis::TILE_LEFT_RIGHT_ODD>(
 // LEFT-RIGHT: TFREE<{{.*}}TileSplitAxis::TILE_LEFT_RIGHT_ODD>(
+
+// V2C-UP-DOWN-LABEL: AICORE void vector_v2c_up_down(__gm__ float*
+// V2C-UP-DOWN: TPipe<0, Direction::DIR_V2C, 1024, 8, 8, false>(
+// V2C-UP-DOWN: TPUSH<{{.*}}TileSplitAxis::TILE_UP_DOWN_ODD>(
+
+// V2C-UP-DOWN-LABEL: AICORE void cube_v2c_up_down(__gm__ float*
+// V2C-UP-DOWN: TPipe<0, Direction::DIR_V2C, 1024, 8, 8, false>(
+// V2C-UP-DOWN: TPOP<{{.*}}TileSplitAxis::TILE_UP_DOWN_ODD>(
+// V2C-UP-DOWN: TFREE<{{.*}}TileSplitAxis::TILE_UP_DOWN_ODD>(
+
+// V2C-LEFT-RIGHT-LABEL: AICORE void vector_v2c_left_right(__gm__ float*
+// V2C-LEFT-RIGHT: TPipe<0, Direction::DIR_V2C, 1024, 8, 8, false>(
+// V2C-LEFT-RIGHT: TPUSH<{{.*}}TileSplitAxis::TILE_LEFT_RIGHT_ODD>(
+
+// V2C-LEFT-RIGHT-LABEL: AICORE void cube_v2c_left_right(__gm__ float*
+// V2C-LEFT-RIGHT: TPipe<0, Direction::DIR_V2C, 1024, 8, 8, false>(
+// V2C-LEFT-RIGHT: TPOP<{{.*}}TileSplitAxis::TILE_LEFT_RIGHT_ODD>(
+// V2C-LEFT-RIGHT: TFREE<{{.*}}TileSplitAxis::TILE_LEFT_RIGHT_ODD>(
+
+// BIDIR-V2C-UP-DOWN-LABEL: AICORE void vector_bidir_v2c_up_down(__gm__ float*
+// BIDIR-V2C-UP-DOWN: TPipe<0, Direction::DIR_BOTH, 1024, 4, 4, false>(
+// BIDIR-V2C-UP-DOWN: TPUSH<{{.*}}TileSplitAxis::TILE_UP_DOWN_ODD>(
+
+// BIDIR-V2C-UP-DOWN-LABEL: AICORE void cube_bidir_v2c_up_down(__gm__ float*
+// BIDIR-V2C-UP-DOWN: TPipe<0, Direction::DIR_BOTH, 1024, 4, 4, false>(
+// BIDIR-V2C-UP-DOWN: TPOP<{{.*}}TileSplitAxis::TILE_UP_DOWN_ODD>(
+// BIDIR-V2C-UP-DOWN: TFREE<{{.*}}TileSplitAxis::TILE_UP_DOWN_ODD>(

--- a/test/lit/pto/tpush_tpop_odd_split_unsupported_invalid.pto
+++ b/test/lit/pto/tpush_tpop_odd_split_unsupported_invalid.pto
@@ -8,18 +8,24 @@
 //
 // RUN: split-file %s %t
 // RUN: not ptoas --pto-arch=a5 %t/local_c2v.pto 2>&1 | FileCheck %s --check-prefix=LOCAL
-// RUN: not ptoas --pto-arch=a5 %t/v2c.pto 2>&1 | FileCheck %s --check-prefix=V2C
+// RUN: not ptoas --pto-arch=a3 %t/v2c.pto 2>&1 | FileCheck %s --check-prefix=V2C
+// RUN: not ptoas --pto-arch=a5 %t/a5_v2c.pto 2>&1 | FileCheck %s --check-prefix=A5-V2C
 // RUN: not ptoas --pto-arch=a5 %t/global_entry.pto 2>&1 | FileCheck %s --check-prefix=GLOBAL
+// RUN: not ptoas --pto-arch=a3 %t/global_v2c_entry.pto 2>&1 | FileCheck %s --check-prefix=GLOBAL-V2C
 // RUN: not ptoas --pto-arch=a5 %t/even_axis.pto 2>&1 | FileCheck %s --check-prefix=PARITY
+// RUN: not ptoas --pto-arch=a3 %t/v2c_even_axis.pto 2>&1 | FileCheck %s --check-prefix=V2C-PARITY
 // RUN: not ptoas --pto-arch=a5 %t/missing_valid_shape.pto 2>&1 | FileCheck %s --check-prefix=VALID
 // RUN: not ptoas --pto-arch=a5 %t/internal_local.pto 2>&1 | FileCheck %s --check-prefix=INTERNAL
 
-// LOCAL: supports odd split modes (split = 3 or 4) only for a unidirectional C2V GM-backed tile pipe
-// V2C: supports odd split modes (split = 3 or 4) only for C2V GM-backed tile pipes
+// LOCAL: supports odd split modes (split = 3 or 4) only for a GM-backed tile pipe whose dir_mask enables C2V and provides the matching consumer buffer
+// V2C: supports odd split modes (split = 3 or 4) only for a GM-backed tile pipe whose dir_mask enables V2C and provides the matching consumer buffer
+// A5-V2C: GM-backed tile pipe init supports dir_mask = 1 with 'c2v_consumer_buf' on all targets and dir_mask = 2/3 with matching consumer buffers only on a2/a3
 // GLOBAL: supports odd split modes (split = 3 or 4) only for tile entries
+// GLOBAL-V2C: supports odd split modes (split = 3 or 4) only for tile entries
 // PARITY: expects a statically odd valid-row count for split = 3
+// V2C-PARITY: expects a statically odd valid-row count for split = 3
 // VALID: expects odd C2V split tpop to provide per-sub-core valid_row and valid_col operands
-// INTERNAL: supports odd split modes (split = 3 or 4) only for a unidirectional C2V pto.initialize_l2g2l_pipe
+// INTERNAL: supports odd split modes (split = 3 or 4) only for a pto.initialize_l2g2l_pipe whose dir_mask enables the operation direction and provides its local consumer buffer
 
 //--- local_c2v.pto
 module {
@@ -40,6 +46,25 @@ module {
       attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
     pto.aiv_initialize_pipe {id = 0, dir_mask = 2, slot_size = 1024}
       (v2c_consumer_buf = %consumer_buf : i32)
+    %tile = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tpush_to_aic(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0, split = 3}
+    return
+  }
+}
+
+//--- a5_v2c.pto
+module {
+  func.func @vector_kernel(%gm_slot_buffer: !pto.ptr<f32>, %consumer_buf: i32)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<16x16xf32>
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 2, slot_size = 1024}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>,
+       v2c_consumer_buf = %consumer_buf : i32)
     %tile = pto.alloc_tile
       : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tpush_to_aic(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0, split = 3}
@@ -81,6 +106,43 @@ module {
     %tile = pto.alloc_tile
       : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
     pto.tpush_to_aiv(%tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 3}
+    return
+  }
+}
+
+//--- global_v2c_entry.pto
+module {
+  func.func @vector_kernel(%gm_slot_buffer: !pto.ptr<f32>, %consumer_buf: i32)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c1 = arith.constant 1 : index
+    %c15 = arith.constant 15 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c15, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<15x16xf32>
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 2, slot_size = 960}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<15x16xf32>,
+       v2c_consumer_buf = %consumer_buf : i32)
+    %entry = pto.talloc_to_aic {id = 0, split = 3}
+      -> !pto.tensor_view<15x16xf32>
+    return
+  }
+}
+
+//--- v2c_even_axis.pto
+module {
+  func.func @cube_kernel(%gm_slot_buffer: !pto.ptr<f32>, %consumer_buf: i32)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<16x16xf32>
+    pto.aic_initialize_pipe {id = 0, dir_mask = 2, slot_size = 1024}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>,
+       v2c_consumer_buf = %consumer_buf : i32)
+    %tile = pto.tpop_from_aiv {id = 0, split = 3}
+      -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     return
   }
 }


### PR DESCRIPTION
## Summary

- enable GM-backed V2C odd tile splits on A2/A3, including bidirectional pipes
- validate full Cube consumer shapes while keeping A5 V2C and GlobalTensor odd splits rejected
- document the platform contract and add positive and negative regression coverage

Downstream dependency: https://gitcode.com/cann/pto-isa/pull/1507

## Validation

- isolated PTO.cpp object build with Ninja, single job
- ptoas_runtime_deps build: 439/439 steps passed
- focused tpush/tpop lit tests: 36/36 passed
- Bisheng dav-c220 compilation of generated V2C UP_DOWN_ODD and LEFT_RIGHT_ODD kernels against pto-isa PR #1507 headers: 2/2 passed
