### PR TITLE
fix(pto): use valid columns for tmrgsort format2

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -8286,6 +8286,9 @@ pto.tmrgsort ins(<src0>, <src1>[, <src2>[, <src3>]], <tmp> {exhausted = <bool>} 
   - `dst` and `tmp` must both be rank-2 single-row tiles (`rows == 1` when statically known).
   - Every `src` must also be a rank-2 single-row tile.
   - `tmp.cols >= dst.cols`.
+  - `tmp.cols` must be at least the sum of the sources' effective valid column
+    extents. For a subview, this uses the subview window's valid columns, not
+    the capacity of its backing tile.
   - `excuted` must be `vector<4xi16>`.
 
 **Hardware Mapping:**

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -11334,7 +11334,8 @@ mlir::LogicalResult mlir::pto::TMrgSortOp::verify() {
     for (Value src : getSrcs()) {
       Type srcTy = src.getType();
       auto srcShape = getShapeVec(srcTy);
-      if (srcShape.size() != 2) {
+      auto srcValidShape = getValidShapeVec(src);
+      if (srcShape.size() != 2 || srcValidShape.size() != 2) {
         return emitOpError() << "format2 expects src to be rank-2 tile-shaped";
       }
       if (srcShape[0] != mlir::ShapedType::kDynamic && srcShape[0] != 1) {
@@ -11343,10 +11344,10 @@ mlir::LogicalResult mlir::pto::TMrgSortOp::verify() {
       if (getElemTy(srcTy) != elemTy) {
         return emitOpError() << "format2 expects src/dst/tmp element types to match";
       }
-      if (srcShape[1] == mlir::ShapedType::kDynamic) {
+      if (srcValidShape[1] == mlir::ShapedType::kDynamic) {
         requiredTmpCols = mlir::ShapedType::kDynamic;
       } else if (requiredTmpCols != mlir::ShapedType::kDynamic) {
-        requiredTmpCols += srcShape[1];
+        requiredTmpCols += srcValidShape[1];
       }
     }
     if (tmpTy && requiredTmpCols != mlir::ShapedType::kDynamic &&

--- a/test/lit/pto/tmrgsort_format2_subview_valid_cols.pto
+++ b/test/lit/pto/tmrgsort_format2_subview_valid_cols.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+
+// Format2 merge of two column subviews: tmp must cover the valid input
+// columns (1024 + 1024), not parent tile capacity (8192 + 8192).
+
+module {
+  func.func @tmrgsort_format2_subview_valid_cols(%ex: vector<4xi16>) {
+    %parent = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c1024 = arith.constant 1024 : index
+    %c4096 = arith.constant 4096 : index
+    %half0 = pto.subview %parent[%c0, %c0] sizes [1, 1024] valid [%c1, %c1024] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=1, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %half1 = pto.subview %parent[%c0, %c4096] sizes [1, 1024] valid [%c1, %c1024] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=1, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=2048, v_row=1, v_col=2048, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=2048, v_row=1, v_col=2048, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tmrgsort ins(%half0, %half1, %tmp {exhausted = false} :
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=1, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=1, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=2048, v_row=1, v_col=2048, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst, %ex :
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=2048, v_row=1, v_col=2048, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        vector<4xi16>)
+    return
+  }
+}
+
+// CHECK: {{^}}#include "pto/pto-inst.hpp"


### PR DESCRIPTION
## Summary
- validate tmrgsort format2 temporary capacity against effective valid source columns instead of backing-tile capacity
- add an A3 regression test and document the temporary-space rule

## Root cause
After subview buffer resolution, each source can retain the parent physical shape for addressing while exposing a smaller valid window. The verifier summed the physical columns, so two 1024-column windows backed by 8192-column tiles incorrectly required 16384 temporary columns.

## Validation
- Issue PTO IR: PASS with --pto-arch=a3
- tmrgsort Lit subset: 7/7 PASS
- full Lit suite: 1822 PASS, 1 existing UNSUPPORTED, 0 FAIL
- incremental PTO.cpp object and ptoas_runtime_deps builds: PASS
- git diff --check: PASS

Closes hw-native-sys/PTOAS#1318