### PR TITLE
Prefer E2B layouts for group broadcast loads

### DIFF
--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -62,10 +62,11 @@ enum class DataLayoutSeedPhase {
   Reduce,
   GroupSlotLoad,
   GroupBroadcast,
-  GroupBroadcastLoad,
   CompactCast,
   GroupStore,
+  GroupBroadcastLoadWidening,
   LaneStrideNarrowCast,
+  GroupBroadcastLoad,
   Cast,
   WeakReduce,
   Store,
@@ -399,10 +400,6 @@ struct LayoutSolver {
   VMILayoutAttr
   getPreferredGroupBroadcastLoadLayout(VMIGroupBroadcastLoadOp op) {
     auto type = cast<VMIVRegType>(op.getResult().getType());
-    if (VMILayoutAttr existing = type.getLayoutAttr()) {
-      return existing;
-    }
-
     VMILayoutSupport supports;
     FailureOr<VMIGroupBroadcastLoadDirectFact> fact =
         supports.getGroupBroadcastLoadDirectFact(
@@ -412,6 +409,23 @@ struct LayoutSolver {
       return {};
     }
     return fact->layout.resultLayout;
+  }
+
+  bool hasWideningCastUser(VMIGroupBroadcastLoadOp op) {
+    auto sourceType = cast<VMIVRegType>(op.getResult().getType());
+    unsigned sourceBits =
+        pto::getPTOStorageElemBitWidth(sourceType.getElementType());
+    for (Operation *user : op.getResult().getUsers()) {
+      if (!isa<VMIExtFOp, VMIExtSIOp, VMIExtUIOp>(user)) {
+        continue;
+      }
+      auto resultType = dyn_cast<VMIVRegType>(user->getResult(0).getType());
+      if (resultType && sourceBits < pto::getPTOStorageElemBitWidth(
+                                         resultType.getElementType())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   VMILayoutAttr getPreferredGroupBroadcastSourceLayout(Value value,
@@ -1517,13 +1531,15 @@ struct LayoutSolver {
             load.getNumGroupsAttr().getInt() == 1;
         if (scalarBroadcast)
           return WalkResult::advance();
-        DataLayoutSeedPhase phase =
-            succeeded(directFact)
-                ? DataLayoutSeedPhase::GroupBroadcastLoad
-                : DataLayoutSeedPhase::Other;
-        if (failed(setNaturalLayout(load.getResult(),
-                                    getPreferredGroupBroadcastLoadLayout(load),
-                                    op, phase))) {
+        DataLayoutSeedPhase phase = DataLayoutSeedPhase::Other;
+        if (succeeded(directFact)) {
+          phase = hasWideningCastUser(load)
+                      ? DataLayoutSeedPhase::GroupBroadcastLoadWidening
+                      : DataLayoutSeedPhase::GroupBroadcastLoad;
+        }
+        if (failed(setPreferredLayout(
+                load.getResult(), getPreferredGroupBroadcastLoadLayout(load),
+                op, phase))) {
           return WalkResult::interrupt();
         }
         return WalkResult::advance();

--- a/lib/PTO/Transforms/VMILayoutPropagation.cpp
+++ b/lib/PTO/Transforms/VMILayoutPropagation.cpp
@@ -1230,9 +1230,6 @@ bool VMILayoutPropagator::canProduceValueLayout(Value value,
   if (!layout || !isLayoutValue(value)) {
     return false;
   }
-  if (getCurrentLayout(value) == layout) {
-    return true;
-  }
   if (isa<BlockArgument>(value)) {
     return isTypeRewriteable(value);
   }
@@ -1240,10 +1237,11 @@ bool VMILayoutPropagator::canProduceValueLayout(Value value,
     Operation *definingOp = result.getDefiningOp();
     const VMILayoutTransfer *transfer = getTransfer(definingOp);
     if (!transfer) {
-      return isTypeRewriteable(value);
+      return getCurrentLayout(value) == layout || isTypeRewriteable(value);
     }
-    FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>> relations = transfer->query(
-        definingOp, value, layout, *this, /*changedOperand=*/nullptr);
+    FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>> relations =
+        transfer->query(definingOp, value, layout, *this,
+                        /*changedOperand=*/nullptr);
     if (failed(relations)) {
       return false;
     }

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -762,6 +762,7 @@ static constexpr GroupBroadcastLoadLayoutPattern
     kGroupBroadcastLoadLayoutPatterns[] = {
         {gb(1, 4), bits<8, 16, 32>(), memContiguous(), ls(4)},
         {gb(1, 2), bits<8, 16, 32>(), memContiguous(), ls(2)},
+        {gb(1), bits<16, 32>(), memContiguous(), d(4)},
         {gb(1), bits<8, 16, 32>(), memContiguous(), c()},
         {gb(2), bits<8, 16, 32>(), memContiguous(), c()},
         {gb(2), bits<8, 16, 32>(), memContiguous(), d(2)},
@@ -786,7 +787,7 @@ struct GroupBroadcastLoadDirectPattern {
 static constexpr GroupBroadcastLoadDirectPattern
     kGroupBroadcastLoadDirectPatterns[] = {
         {VMIGroupBroadcastLoadDirectKind::E2B, G<8>(), gb(1), bits<16, 32>(),
-         memContiguous(), c()},
+         memContiguous(), d(4)},
         {VMIGroupBroadcastLoadDirectKind::E2B, G<8>(), gb(2), bits<16, 32>(),
          memContiguous(), d(2)},
         {VMIGroupBroadcastLoadDirectKind::E2B, G<8>(), gb(4), bits<16, 32>(),
@@ -1077,6 +1078,25 @@ static bool matchesGroupBlockPattern(GroupBlockPattern pattern,
     return false;
   }
   return key.groupSize == numerator / pattern.denominator;
+}
+
+static bool isGroupBroadcastLoadE2BCompatible(GroupLayoutKey key,
+                                              int64_t numGroups,
+                                              int64_t elementBits,
+                                              std::optional<int64_t> stride) {
+  for (const GroupBroadcastLoadDirectPattern &pattern :
+       kGroupBroadcastLoadDirectPatterns) {
+    if (pattern.kind != VMIGroupBroadcastLoadDirectKind::E2B ||
+        !matchesElementCountPattern(pattern.numGroups, numGroups) ||
+        !matchesGroupBlockPattern(pattern.block, key) ||
+        !matchesElementBitsPattern(pattern.elementBits, elementBits) ||
+        !matchesGroupBroadcastLoadMemoryPattern(pattern.memory, stride,
+                                                elementBits)) {
+      continue;
+    }
+    return true;
+  }
+  return false;
 }
 
 static bool matchesGroupStoreLayoutPattern(
@@ -1578,6 +1598,9 @@ VMILayoutSupport::getGroupBroadcastLoadLayoutFact(VMIVRegType resultType,
     return failure();
   }
 
+  bool e2bCompatible =
+      isGroupBroadcastLoadE2BCompatible(*key, numGroups, elementBits, stride);
+
   for (const GroupBroadcastLoadLayoutPattern &pattern :
        kGroupBroadcastLoadLayoutPatterns) {
     if (!matchesGroupBlockPattern(pattern.block, *key)) {
@@ -1594,6 +1617,9 @@ VMILayoutSupport::getGroupBroadcastLoadLayoutFact(VMIVRegType resultType,
     }
     if (!matchesLayoutPattern(resultType.getContext(), pattern.resultLayout,
                               resultLayout, numGroups)) {
+      continue;
+    }
+    if (e2bCompatible && resultLayout.isContiguous()) {
       continue;
     }
     return VMIGroupBroadcastLoadLayoutFact{
@@ -1653,7 +1679,6 @@ VMILayoutSupport::getGroupBroadcastLoadDirectFact(
     return failure();
   }
 
-  VMILayoutAttr existing = resultType.getLayoutAttr();
   for (const GroupBroadcastLoadDirectPattern &pattern :
        kGroupBroadcastLoadDirectPatterns) {
     if (!matchesElementCountPattern(pattern.numGroups, numGroups)) {
@@ -1671,17 +1696,11 @@ VMILayoutSupport::getGroupBroadcastLoadDirectFact(
     }
     VMILayoutAttr resultLayout = materializeLayoutPattern(
         resultType.getContext(), pattern.resultLayout, numGroups);
-    if (existing && existing != resultLayout) {
-      continue;
-    }
     return VMIGroupBroadcastLoadDirectFact{
         pattern.kind,
         VMIGroupBroadcastLoadLayoutFact{
-            getGroupBlockClassFromPattern(pattern.block),
-            resultLayout,
-            key->groupSize,
-            key->lanesPerPart,
-            key->vcgBlockElems,
+            getGroupBlockClassFromPattern(pattern.block), resultLayout,
+            key->groupSize, key->lanesPerPart, key->vcgBlockElems,
             static_cast<int64_t>(elementBits)}};
   }
 

--- a/test/lit/vmi_new/opt/group_broadcast_load_e2b_layout_opt.pto
+++ b/test/lit/vmi_new/opt/group_broadcast_load_e2b_layout_opt.pto
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under
+// the terms and conditions of CANN Open Software License Agreement Version 2.0
+// (the "License"). Please refer to the License for details. You may not use
+// this file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON
+// AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=VPTO --implicit-check-not=pto.vmi. --implicit-check-not='!pto.vmi'
+
+// An E2B-compatible group broadcast is seeded as deinterleaved-by-four. The
+// narrow/widen cast chain then requests contiguous data explicitly in
+// assignment, leaving the conversion visible instead of hiding it in lowering.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @group_broadcast_load_e2b_layout_opt(
+      %scale_src: !pto.ptr<f32, ub>, %value_src: !pto.ptr<f32, ub>,
+      %dst: !pto.ptr<f32, ub>, %offset: index) {
+    %one = arith.constant 1 : index
+    %scale = pto.vmi.vload %scale_src[%offset], %one
+        {dist_mode = "brc", group = 8}
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
+    %value = pto.vmi.vload %value_src[%offset] {dist_mode = "continuous"}
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
+    %full = arith.constant 256 : index
+    %mask = pto.vmi.create_mask %full : index -> !pto.vmi.mask<256xpred>
+    %scaled = pto.vmi.vmul %value, %scale, %mask
+        : !pto.vmi.vreg<256xf32>, !pto.vmi.vreg<256xf32>,
+          !pto.vmi.mask<256xpred> -> !pto.vmi.vreg<256xf32>
+    %narrow = pto.vmi.vcvt %scaled {rounding = "R", saturate = "SAT"}
+        : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
+    %wide = pto.vmi.vcvt %narrow
+        : !pto.vmi.vreg<256xf8E4M3FN> -> !pto.vmi.vreg<256xf32>
+    pto.vmi.vstore %wide, %dst[%offset] {dist_mode = "continuous"}
+        : !pto.vmi.vreg<256xf32>, !pto.ptr<f32, ub>
+    return
+  }
+}
+
+// ASSIGN-LABEL: func.func @group_broadcast_load_e2b_layout_opt(
+// ASSIGN: pto.vmi.group_broadcast_load %{{.*}} {num_groups = 8 : i64}
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
+// ASSIGN: pto.vmi.ensure_layout
+// ASSIGN-SAME: !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>> -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
+// ASSIGN: pto.vmi.mulf
+
+// VPTO-LABEL: func.func @group_broadcast_load_e2b_layout_opt(
+// VPTO: pto.vlds {{.*}} {dist = "E2B_B32"}
+// VPTO-NOT: pto.vselr

--- a/test/lit/vmi_new/vmi_layout_assignment_group_broadcast_load_contiguous_fallback.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_broadcast_load_contiguous_fallback.pto
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under
+// the terms and conditions of CANN Open Software License Agreement Version 2.0
+// (the "License"). Please refer to the License for details. You may not use
+// this file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON
+// AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s
+
+// E2B supports only b16/b32, so a b8 group broadcast load must retain the
+// generic contiguous fallback candidate.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @group_broadcast_load_contiguous_fallback(
+      %src: !pto.ptr<f8E4M3FN, ub>, %dst: !pto.ptr<f8E4M3FN, ub>,
+      %offset: index) {
+    %one = arith.constant 1 : index
+    %value = pto.vmi.vload %src[%offset], %one
+        {dist_mode = "brc", group = 8}
+        : !pto.ptr<f8E4M3FN, ub> -> !pto.vmi.vreg<256xf8E4M3FN>
+    pto.vmi.vstore %value, %dst[%offset] {dist_mode = "continuous"}
+        : !pto.vmi.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @group_broadcast_load_contiguous_fallback(
+// CHECK: pto.vmi.group_broadcast_load
+// CHECK-SAME: -> !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous>>
+// CHECK-NOT: pto.vmi.ensure_layout
+// CHECK: pto.vmi.store

--- a/test/lit/vmi_new/vmi_layout_assignment_group_broadcast_load_e2b_b16.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_broadcast_load_e2b_b16.pto
@@ -6,7 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --implicit-check-not=pto.vselr
 
 module {
   func.func @vmi_layout_assignment_group_broadcast_load_e2b_b16(
@@ -44,15 +44,13 @@ module {
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_broadcast_load_e2b_b16
 // CHECK-SAME: (%[[SRC:.*]]: !pto.ptr<bf16, ub>, %[[OFF:.*]]: index)
-// CHECK: pto.vsldb %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !pto.ptr<bf16, ub>, i16, i16, !pto.mask<b16> -> !pto.vreg<128xbf16>
-// CHECK: pto.vselr
-// CHECK: pto.vselr
-// CHECK: return %{{.*}}, %{{.*}} : !pto.vreg<128xbf16>, !pto.vreg<128xbf16>
+// CHECK: %[[E2B16:.*]] = pto.vlds %[[SRC]][%[[OFF]]] {dist = "E2B_B16"} : !pto.ptr<bf16, ub> -> !pto.vreg<128xbf16>
+// CHECK: return %[[E2B16]], %[[E2B16]] : !pto.vreg<128xbf16>, !pto.vreg<128xbf16>
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_broadcast_load_e2b_b32
 // CHECK-SAME: (%[[SRC32:.*]]: !pto.ptr<f32, ub>, %[[OFF32:.*]]: index)
 // CHECK: %[[E2B32:.*]] = pto.vlds %[[SRC32]][%[[OFF32]]] {dist = "E2B_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-// CHECK: return %[[E2B32]] : !pto.vreg<64xf32>
+// CHECK: return %[[E2B32]], %[[E2B32]], %[[E2B32]], %[[E2B32]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_broadcast_load_e2b_b32_deint4
 // CHECK-SAME: (%[[SRC32D4:.*]]: !pto.ptr<f32, ub>, %[[OFF32D4:.*]]: index)

--- a/test/lit/vmi_new/vmi_layout_assignment_group_slot_broadcast_load_e2b_b16.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_slot_broadcast_load_e2b_b16.pto
@@ -60,14 +60,17 @@ module {
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_slot_broadcast_load_e2b_b16_deint2
 // CHECK-SAME: (%[[SRC2:.*]]: !pto.ptr<bf16, ub>, %[[OFF2:.*]]: index)
 // CHECK: %[[E2B2:.*]] = pto.vlds %[[SRC2]][%[[OFF2]]] {dist = "E2B_B16"} : !pto.ptr<bf16, ub> -> !pto.vreg<128xbf16>
+// CHECK-NOT: pto.vselr
 // CHECK: return %[[E2B2]], %[[E2B2]] : !pto.vreg<128xbf16>, !pto.vreg<128xbf16>
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_slot_broadcast_load_e2b_b32
 // CHECK-SAME: (%[[SRC3:.*]]: !pto.ptr<f32, ub>, %[[OFF3:.*]]: index)
 // CHECK: %[[E2B3:.*]] = pto.vlds %[[SRC3]][%[[OFF3]]] {dist = "E2B_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-// CHECK: return %[[E2B3]] : !pto.vreg<64xf32>
+// CHECK-NOT: pto.vselr
+// CHECK: return %[[E2B3]], %[[E2B3]], %[[E2B3]], %[[E2B3]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_slot_broadcast_load_e2b_b32_deint2
 // CHECK-SAME: (%[[SRC4:.*]]: !pto.ptr<f32, ub>, %[[OFF4:.*]]: index)
 // CHECK: %[[E2B4:.*]] = pto.vlds %[[SRC4]][%[[OFF4]]] {dist = "E2B_B32"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+// CHECK-NOT: pto.vselr
 // CHECK: return %[[E2B4]], %[[E2B4]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>


### PR DESCRIPTION
## 背景

E2B-compatible 的 `group_broadcast_load` 之前仍可在 support table 中选择 contiguous layout。这样 assignment 无法表达 E2B producer 的真实物理 layout，也会让 contiguous 决策继续影响下游 cast 链；部分形态会回退到 `vsldb + vselr`，而 issue 原始整核则因此生成带 `vor` 合并的 FP8 carrier 路径。

Closes #1320

## 修改

- 将 G=8、group block=1 的 E2B direct producer layout 从 contiguous 改为 deinterleaved-by-four。
- 当 `group_broadcast_load` 满足 E2B 条件时，从候选 layout 中移除 contiguous；只有无法使用 E2B 时才继续允许 contiguous fallback，并增加 b8 反向回归覆盖该条件。
- 让 layout propagation 即使面对输入 IR 上已有的默认 layout，也通过 op support table 验证 producer 能力。
- 将 `group_broadcast_load` 保持为低优先级 preferred producer：consumer 可先选择 contiguous，producer 随后选择 d4，并由 assignment 显式插入 `ensure_layout(d4 -> c)`。
- 对直接进入 widening cast 的 E2B broadcast load 提前 producer seed，避免下游 lane-stride narrowing 把 f16 producer 锁成不可物化的 `d2 -> ls2` 冲突；普通 broadcast load 仍保持 consumer 优先。
- 增加最小优化回归用例，并更新 E2B layout matrix，检查 `E2B_B16/E2B_B32` 且禁止 E2B case 回退到 `vselr`。

## 性能

使用 issue 原始完整 `vmi_kernel.input.pto`，在同一个 `origin/main@ca7ccb40` 上分别构建 baseline 和本 PR，使用相同 VPTO flags 与 A5 CA model harness 测试：

- baseline：block `[15, 8238]`，kernel 区间 8223 cycles
- 本 PR：block `[17, 7876]`，kernel 区间 7859 cycles
- 减少 364 cycles，约 4.43%

两边整核都没有 `vselr`，因此这里的收益不能归因于 `vselr`。完整 popped instruction 统计从 4107 条降到 4057 条；其中 `RV_VOR` 从 192 条降到 0。当前热点使用 `E2B_B32 + 3 x vintlv` 显式完成 d4 -> c，fp32 -> fp8 -> fp32 roundtrip 保持四条独立 P0 路径，不再通过 3 个 `vor` 合并共享 FP8 carrier。该整核使用 in-place scratch harness，模拟器执行通过，框架按既有设置跳过数值 compare。

## 验证

- `ninja -C .work/issue_1320/build-llvm19 pto-test-opt PTOAS_Python`
- 相关 E2B、non-E2B fallback、scalar BRC、group-store、ComputeY1 用例：8/8 passed
- `ninja -C .work/issue_1320/build-llvm19 check-pto`：1830 passed，1 unsupported，0 failed
- `python3 .codex/skills/enforce-ptoas-code-compliance/scripts/check_changed_code.py --repo . --base origin/main`：0 errors，0 warnings
- 原始完整 kernel 在同基线 baseline/PR 上分别完整编译并运行 A5 CA model：8223 -> 7859 cycles
