### PR TITLE
Remove repeat_stride from VMI memory APIs

### DIFF
--- a/docs/designs/vmi-implementation-manual.md
+++ b/docs/designs/vmi-implementation-manual.md
@@ -3791,7 +3791,8 @@ vmi.masked_load:
 vmi.stride_load:
   semantics:
     result lane order is contiguous VMI logical order
-    source addresses are described by the VPTO block/repeat stride operands
+    source addresses start at source + offset and advance by block_stride
+    32-byte blocks; VMI does not expose a repeat stride
     mask false lanes are inactive for the underlying block-strided load
   layout assignment:
     result natural layout is contiguous
@@ -3800,7 +3801,7 @@ vmi.stride_load:
     source must be !pto.ptr<T, ub>
     result and mask must be one contiguous physical chunk
     base = pto.addptr source, offset
-    result = pto.vsldb base, block_stride, repeat_stride, mask
+    result = pto.vsldb base, block_stride, repeat_stride=0, mask
   unsupported cases:
     multi-chunk result or mask
     non-contiguous layouts
@@ -3809,7 +3810,8 @@ vmi.stride_load:
 vmi.stride_store:
   semantics:
     value lane order is contiguous VMI logical order
-    destination addresses are described by the VPTO block/repeat stride operands
+    destination addresses start at destination + offset and advance by
+    block_stride 32-byte blocks; VMI does not expose a repeat stride
     mask false lanes do not write memory
   layout assignment:
     value use is requested as contiguous
@@ -3818,9 +3820,9 @@ vmi.stride_store:
     destination must be !pto.ptr<T, ub>
     value and mask must be one contiguous physical chunk
     base = pto.addptr destination, offset
-    updated_base = pto.vsstb value, base, block_stride, repeat_stride, mask
-      The updated base result is intentionally unused by VMI lowering, but the
-      post-update VPTO form matches CCE block-strided staging behavior.
+    pto.vsstb value, base, block_stride, repeat_stride=0, mask
+      VMI lowering uses the ordinary resultless VPTO form. The fixed zero
+      repeat stride preserves base-start addressing without post-update.
   unsupported cases:
     multi-chunk value or mask
     non-contiguous layouts

--- a/docs/designs/vmi-introduction.md
+++ b/docs/designs/vmi-introduction.md
@@ -991,9 +991,9 @@ compute:
 row-wise staging:
   for row in 0..31:
     q8_row = vmi.stride_load(nd + row * 64,
-                             block_stride=1, repeat_stride=1)
+                             block_stride=1)
     vmi.stride_store(q8_row, nz + row * 32,
-                     block_stride=33, repeat_stride=1)
+                     block_stride=33)
 
 copy-out:
   2D MTE copies two 1024B NZ planes from UB to GM
@@ -1002,12 +1002,12 @@ copy-out:
 这里 `q8_row` 的 VMI value 仍然是 contiguous `64xf8` 逻辑向量：
 
 ```mlir
-%q8_row = pto.vmi.stride_load %nd[%nd_off], %c1_i16, %c1_i16, %mask
-    : !pto.ptr<f8E4M3FN, ub>, i16, i16, !pto.vmi.mask<64xpred>
+%q8_row = pto.vmi.stride_load %nd[%nd_off], %c1_i16, %mask
+    : !pto.ptr<f8E4M3FN, ub>, i16, !pto.vmi.mask<64xpred>
     -> !pto.vmi.vreg<64xf8E4M3FN>
 
-pto.vmi.stride_store %q8_row, %nz[%nz_off], %c33_i16, %c1_i16, %mask
-    : !pto.vmi.vreg<64xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, i16, i16,
+pto.vmi.stride_store %q8_row, %nz[%nz_off], %c33_i16, %mask
+    : !pto.vmi.vreg<64xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, i16,
       !pto.vmi.mask<64xpred>
 ```
 
@@ -1024,11 +1024,10 @@ VPTO 形状：
 
 ```text
 base_in  = pto.addptr nd, nd_off
-q8_row   = pto.vsldb base_in, block_stride=1, repeat_stride=1, mask
+q8_row   = pto.vsldb base_in, block_stride=1, repeat_stride=0, mask
 
 base_out = pto.addptr nz, nz_off
-updated = pto.vsstb q8_row, base_out, block_stride=33, repeat_stride=1, mask
-          -> updated_base
+pto.vsstb q8_row, base_out, block_stride=33, repeat_stride=0, mask
 ```
 
 这个场景说明：memory layout transformation 不一定要变成 VMI data layout。

--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -691,11 +691,13 @@ def VMIGroupBroadcastLoadOp : VMI_Op<"group_broadcast_load", [DeclareOpInterface
 def VMIStrideLoadOp : VMI_Op<"stride_load", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "VMI block-strided vector load";
   let arguments = (ins PtrOrMemRef:$source, Index:$offset,
-                       I16:$block_stride, I16:$repeat_stride,
-                       VMI_MaskTypeConstraint:$mask);
+                       I16:$block_stride, VMI_MaskTypeConstraint:$mask);
   let results = (outs VMI_VRegTypeConstraint:$result);
   let hasVerifier = 1;
-  let assemblyFormat = "$source `[` $offset `]` `,` $block_stride `,` $repeat_stride `,` $mask attr-dict `:` type($source) `,` type($block_stride) `,` type($repeat_stride) `,` type($mask) `->` type($result)";
+  let assemblyFormat = [{
+    $source `[` $offset `]` `,` $block_stride `,` $mask attr-dict `:`
+    type($source) `,` type($block_stride) `,` type($mask) `->` type($result)
+  }];
 }
 
 def VMIMaskedLoadOp : VMI_Op<"masked_load", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
@@ -767,11 +769,14 @@ def VMIMaskedStoreOp : VMI_Op<"masked_store", [DeclareOpInterfaceMethods<MemoryE
 def VMIStrideStoreOp : VMI_Op<"stride_store", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "VMI block-strided vector store";
   let arguments = (ins VMI_VRegTypeConstraint:$value, PtrOrMemRef:$destination,
-                       Index:$offset, I16:$block_stride, I16:$repeat_stride,
+                       Index:$offset, I16:$block_stride,
                        VMI_MaskTypeConstraint:$mask);
   let results = (outs);
   let hasVerifier = 1;
-  let assemblyFormat = "$value `,` $destination `[` $offset `]` `,` $block_stride `,` $repeat_stride `,` $mask attr-dict `:` type($value) `,` type($destination) `,` type($block_stride) `,` type($repeat_stride) `,` type($mask)";
+  let assemblyFormat = [{
+    $value `,` $destination `[` $offset `]` `,` $block_stride `,` $mask attr-dict `:`
+    type($value) `,` type($destination) `,` type($block_stride) `,` type($mask)
+  }];
 }
 
 def VMIScatterOp : VMI_Op<"scatter", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
@@ -1437,7 +1442,7 @@ def VMIvLoadOp : VMI_Op<"vload",
     - {group = C}: grouped vector load with row stride  → 1 result
 
     block-stride mode (mutually exclusive with dist-mode and group):
-    - {block_stride = B, repeat_stride = R}: block-strided masked load → 1 result
+    - {block_stride = B}: block-strided masked load → 1 result
 
     pmode ("zero"|"merge") governs inactive-lane behavior on the result.
     vload itself has no mask operand; A5 loads are not predicable — masks
@@ -1448,7 +1453,6 @@ def VMIvLoadOp : VMI_Op<"vload",
     Index:$offset,
     Optional<Index>:$stride,
     Optional<I16>:$block_stride,
-    Optional<I16>:$repeat_stride,
     OptionalAttr<StrAttr>:$dist_mode,
     OptionalAttr<I64Attr>:$group,
     OptionalAttr<StrAttr>:$pmode
@@ -1475,7 +1479,7 @@ def VMIvStoreOp : VMI_Op<"vstore",
     - {group = C}: grouped vector store with row stride
 
     block-stride mode (mutually exclusive with dist-mode and group):
-    - {block_stride = B, repeat_stride = R}: block-strided masked store
+    - {block_stride = B}: block-strided masked store
 
     pmode governs inactive lane behavior:
     - "zero" (default):  inactive lanes store 0
@@ -1489,7 +1493,6 @@ def VMIvStoreOp : VMI_Op<"vstore",
     Index:$offset,
     Optional<Index>:$stride,
     Optional<I16>:$block_stride,
-    Optional<I16>:$repeat_stride,
     Variadic<VMI_MaskTypeConstraint>:$mask,
     OptionalAttr<StrAttr>:$dist_mode,
     OptionalAttr<I64Attr>:$group,

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -4691,8 +4691,8 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
                             "expected at least one value and one destination");
   }
 
-  // Optional post-bracket operands: stride, block_stride/repeat_stride, mask.
-  // Up to 3, disambiguated after parsing attrs.
+  // Optional post-bracket operands: stride, block_stride, and/or mask.
+  // Up to 2, disambiguated after parsing attrs and the type list.
   while (succeeded(parser.parseOptionalComma())) {
     OpAsmParser::UnresolvedOperand postOp;
     if (parser.parseOperand(postOp)) {
@@ -4716,12 +4716,12 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
   bool hasGroup = result.attributes.get("group") != nullptr;
   bool hasStride = false;
   bool hasBlock = false;
-  bool hasRepeat = false;
   bool hasMask = false;
   int strideIdx = -1;
   int blockIdx = -1;
-  int repeatIdx = -1;
   int maskIdx = -1;
+  size_t nValues = preBracketOperands.size() - 1;
+  size_t nTypes = types.size();
 
   if (hasGroup) {
     // Group mode: post-bracket ops are stride[, mask]
@@ -4733,24 +4733,23 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
       hasMask = true;
       maskIdx = 1;
     }
-  } else if (postBracketOps.size() >= mlir::pto::kValue2) {
-    // Block-stride mode: post-bracket ops are block_stride, repeat_stride[, mask]
+  } else if (postBracketOps.size() == mlir::pto::kValue2) {
+    // Block-stride mode with a mask: block_stride, mask.
     hasBlock = true;
-    hasRepeat = true;
-    blockIdx = 0;
-    repeatIdx = 1;
-    if (postBracketOps.size() >= mlir::pto::kValue3) {
-      hasMask = true;
-      maskIdx = mlir::pto::kValue2;
-    }
-  } else if (postBracketOps.size() == 1) {
-    // Single post-bracket operand without group: mask
     hasMask = true;
-    maskIdx = 0;
+    blockIdx = 0;
+    maskIdx = 1;
+  } else if (postBracketOps.size() == 1) {
+    // The type list includes mask types, but never block-stride types.
+    if (nTypes == nValues + 2) {
+      hasMask = true;
+      maskIdx = 0;
+    } else {
+      hasBlock = true;
+      blockIdx = 0;
+    }
   }
 
-  size_t nValues = preBracketOperands.size() - 1;
-  size_t nTypes = types.size();
   size_t expectedTypes = nValues + 1 + (hasMask ? 1 : 0);
 
   if (nTypes != expectedTypes) {
@@ -4790,13 +4789,6 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
                             result.operands)) {
     return failure();
   }
-  if (hasRepeat &&
-      parser.resolveOperand(postBracketOps[repeatIdx],
-                            parser.getBuilder().getIntegerType(mlir::pto::kValue16),
-                            result.operands)) {
-    return failure();
-  }
-
   if (hasMask) {
     Type maskType = types.back();
     if (parser.resolveOperand(postBracketOps[maskIdx], maskType,
@@ -4809,7 +4801,7 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
                       parser.getBuilder().getDenseI32ArrayAttr(
                           {static_cast<int32_t>(nValues), 1, 1,
                            hasStride ? 1 : 0, hasBlock ? 1 : 0,
-                           hasRepeat ? 1 : 0, hasMask ? 1 : 0}));
+                           hasMask ? 1 : 0}));
   return success();
 }
 
@@ -4827,8 +4819,6 @@ void VMIvStoreOp::print(OpAsmPrinter &p) {
   if (getBlockStride()) {
     p << ", ";
     p.printOperand(getBlockStride());
-    p << ", ";
-    p.printOperand(getRepeatStride());
   }
   if (!getMask().empty()) {
     p << ", ";
@@ -4874,18 +4864,15 @@ LogicalResult VMIvStoreOp::verify() {
     }
   }
 
-  // block_stride / repeat_stride: paired, mutually exclusive with
-  // dist_mode and group
+  // block_stride is mutually exclusive with dist_mode and group.
   bool hasBlock = static_cast<bool>(getBlockStride());
-  bool hasRepeat = static_cast<bool>(getRepeatStride());
-  if (hasBlock != hasRepeat) {
-    return emitOpError(
-        "block_stride and repeat_stride must both be present or absent");
-  }
   if (hasBlock) {
     if (getDistMode()) {
       return emitOpError(
           "block_stride and dist_mode are mutually exclusive");
+    }
+    if (getGroup()) {
+      return emitOpError("block_stride and group are mutually exclusive");
     }
     if (getValues().size() != 1) {
       return emitOpError("block-stride mode requires exactly 1 value");
@@ -5214,7 +5201,6 @@ ParseResult VMIvLoadOp::parse(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::UnresolvedOperand offsetOperand;
   OpAsmParser::UnresolvedOperand strideOperand;
   OpAsmParser::UnresolvedOperand blockStrideOperand;
-  OpAsmParser::UnresolvedOperand repeatStrideOperand;
 
   // Parse: %source[%offset]
   if (parser.parseOperand(sourceOperand) || parser.parseLSquare() ||
@@ -5223,21 +5209,14 @@ ParseResult VMIvLoadOp::parse(OpAsmParser &parser, OperationState &result) {
   }
 
   // Optional comma-separated post-bracket operands.
-  // 1 operand  + group attr   → stride (group mode)
-  // 2 operands                → block_stride, repeat_stride (block-stride mode)
+  // 1 operand + group attr → stride; otherwise → block_stride.
   int numPostBracket = 0;
-  OpAsmParser::UnresolvedOperand postOp1, postOp2;
+  OpAsmParser::UnresolvedOperand postOp1;
   if (succeeded(parser.parseOptionalComma())) {
     if (parser.parseOperand(postOp1)) {
       return failure();
     }
     numPostBracket = 1;
-    if (succeeded(parser.parseOptionalComma())) {
-      if (parser.parseOperand(postOp2)) {
-        return failure();
-      }
-      numPostBracket = mlir::pto::kValue2;
-    }
   }
 
   if (parser.parseOptionalAttrDict(result.attributes)) {
@@ -5261,20 +5240,15 @@ ParseResult VMIvLoadOp::parse(OpAsmParser &parser, OperationState &result) {
   // Disambiguate post-bracket operands
   bool hasStride = false;
   bool hasBlock = false;
-  bool hasRepeat = false;
 
-  if (numPostBracket == mlir::pto::kValue2) {
-    // block_stride + repeat_stride pair
-    hasBlock = true;
-    hasRepeat = true;
-    blockStrideOperand = postOp1;
-    repeatStrideOperand = postOp2;
-  } else if (numPostBracket == 1) {
-    // Single post-bracket operand: only valid as group stride.
-    // block_stride without repeat_stride is invalid; verifier catches
-    // stride without group attr.
-    hasStride = true;
-    strideOperand = postOp1;
+  if (numPostBracket == 1) {
+    if (result.attributes.get("group")) {
+      hasStride = true;
+      strideOperand = postOp1;
+    } else {
+      hasBlock = true;
+      blockStrideOperand = postOp1;
+    }
   }
 
   if (parser.resolveOperand(sourceOperand, sourceType, result.operands)) {
@@ -5295,17 +5269,9 @@ ParseResult VMIvLoadOp::parse(OpAsmParser &parser, OperationState &result) {
                             result.operands)) {
     return failure();
   }
-  if (hasRepeat &&
-      parser.resolveOperand(repeatStrideOperand,
-                            parser.getBuilder().getIntegerType(mlir::pto::kValue16),
-                            result.operands)) {
-    return failure();
-  }
-
   result.addAttribute("operandSegmentSizes",
                       parser.getBuilder().getDenseI32ArrayAttr(
-                          {1, 1, hasStride ? 1 : 0, hasBlock ? 1 : 0,
-                           hasRepeat ? 1 : 0}));
+                          {1, 1, hasStride ? 1 : 0, hasBlock ? 1 : 0}));
 
   result.addTypes(resultTypes);
   return success();
@@ -5322,8 +5288,6 @@ void VMIvLoadOp::print(OpAsmPrinter &p) {
   if (getBlockStride()) {
     p << ", ";
     p.printOperand(getBlockStride());
-    p << ", ";
-    p.printOperand(getRepeatStride());
   }
   p.printOptionalAttrDict((*this)->getAttrs(), {"operandSegmentSizes"});
   p << " : " << getSource().getType() << " -> " << getResults().getTypes();
@@ -5356,18 +5320,15 @@ LogicalResult VMIvLoadOp::verify() {
     }
   }
 
-  // block_stride and repeat_stride must be paired, mutually exclusive
-  // with dist_mode and group
+  // block_stride is mutually exclusive with dist_mode and group.
   bool hasBlock = static_cast<bool>(getBlockStride());
-  bool hasRepeat = static_cast<bool>(getRepeatStride());
-  if (hasBlock != hasRepeat) {
-    return emitOpError(
-        "block_stride and repeat_stride must both be present or absent");
-  }
   if (hasBlock) {
     if (getDistMode()) {
       return emitOpError(
           "block_stride and dist_mode are mutually exclusive");
+    }
+    if (getGroup()) {
+      return emitOpError("block_stride and group are mutually exclusive");
     }
     if (getResults().size() != 1) {
       return emitOpError("block-stride mode requires exactly 1 result");

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -503,7 +503,7 @@ static LogicalResult lowerVLoad(VMIvLoadOp op, OpBuilder &builder) {
     return success();
   }
 
-  // Block-stride mode: vload {block_stride, repeat_stride} → stride_load
+  // Block-stride mode: vload {block_stride} → stride_load
   if (op.getBlockStride()) {
     auto resultType = op.getResults().front().getType();
     // Create default all-active mask via create_mask with proper granularity
@@ -528,9 +528,8 @@ static LogicalResult lowerVLoad(VMIvLoadOp op, OpBuilder &builder) {
     auto mask = builder.create<VMICreateMaskOp>(op->getLoc(), maskType,
                                                 fullLanes.getResult());
     Value bs = op.getBlockStride();
-    Value rs = op.getRepeatStride();
     auto strideLoad = builder.create<VMIStrideLoadOp>(
-        op->getLoc(), resultType, op.getSource(), op.getOffset(), bs, rs,
+        op->getLoc(), resultType, op.getSource(), op.getOffset(), bs,
         mask.getResult());
     op.getResults().front().replaceAllUsesWith(strideLoad.getResult());
     op->erase();
@@ -617,7 +616,7 @@ static LogicalResult lowerVStore(VMIvStoreOp op, OpBuilder &builder) {
     return success();
   }
 
-  // Block-stride mode: vstore {block_stride, repeat_stride} → stride_store
+  // Block-stride mode: vstore {block_stride} → stride_store
   if (op.getBlockStride()) {
     auto valueType = cast<VMIVRegType>(op.getValues()[0].getType());
     // Use existing mask or create default all-active via create_mask
@@ -645,9 +644,8 @@ static LogicalResult lowerVStore(VMIvStoreOp op, OpBuilder &builder) {
                  .getResult();
     }
     Value bs = op.getBlockStride();
-    Value rs = op.getRepeatStride();
     builder.create<VMIStrideStoreOp>(op->getLoc(), op.getValues()[0],
-                                    op.getDestination(), op.getOffset(), bs, rs,
+                                    op.getDestination(), op.getOffset(), bs,
                                     mask);
     op->erase();
     return success();
@@ -1368,11 +1366,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
       if (hasMergePmode(vop)) {
         continue;
       }
-      Value repeatStride = builder.create<arith::ConstantOp>(
-          vop.getLoc(), builder.getI16IntegerAttr(0));
       builder.create<VMIStrideStoreOp>(
           vop.getLoc(), vop.getValue(), vop.getDestination(), vop.getOffset(),
-          vop.getBlockStride(), repeatStride, vop.getMask());
+          vop.getBlockStride(), vop.getMask());
       vop->erase();
       continue;
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8425,9 +8425,8 @@ struct OneToNVMIStrideLoadOpPattern
     FailureOr<Value> blockStride = getSingleValue(
         op, adaptor.getBlockStride(),
         "stride_load block_stride must convert to one value", rewriter);
-    FailureOr<Value> repeatStride = getSingleValue(
-        op, adaptor.getRepeatStride(),
-        "stride_load repeat_stride must convert to one value", rewriter);
+    FailureOr<Value> repeatStride = Value(
+        rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0, 16));
     if (failed(source) || failed(offset) || failed(blockStride) ||
         failed(repeatStride))
       return failure();
@@ -8478,9 +8477,8 @@ struct OneToNVMIStrideStoreOpPattern
     FailureOr<Value> blockStride = getSingleValue(
         op, adaptor.getBlockStride(),
         "stride_store block_stride must convert to one value", rewriter);
-    FailureOr<Value> repeatStride = getSingleValue(
-        op, adaptor.getRepeatStride(),
-        "stride_store repeat_stride must convert to one value", rewriter);
+    FailureOr<Value> repeatStride = Value(
+        rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0, 16));
     if (failed(destination) || failed(offset) || failed(blockStride) ||
         failed(repeatStride))
       return failure();

--- a/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
+++ b/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
@@ -137,8 +137,8 @@ mode families:
 - `dist_mode`: the regular logical memory surface. This covers the default
   contiguous case plus other access patterns selected by `dist_mode`.
 - `group`: grouped row-strided load/store.
-- `block_stride`: block-strided load/store using paired
-  `block_stride` / `repeat_stride` operands.
+- `block_stride`: block-strided load/store. The VMI contract exposes only the
+  logical block stride; lowering fixes the physical repeat stride to zero.
 
 Pick exactly one family per call. Do not mix `dist_mode`, `group`, and
 `block_stride` parameters in the same `vload` / `vstore`.
@@ -149,7 +149,7 @@ Pick exactly one family per call. Do not mix `dist_mode`, `group`, and
 ### `pto.vmi.vload(source, offset, *, size, dist_mode="dintlv") -> (VRegType, VRegType)`
 ### `pto.vmi.vload(source, offset, *, size, group, stride) -> VRegType`
 ### `pto.vmi.vload(source, offset, *, size, group, stride, dist_mode="brc") -> VRegType`
-### `pto.vmi.vload(source, offset, *, size, block_stride, repeat_stride) -> VRegType`
+### `pto.vmi.vload(source, offset, *, size, block_stride) -> VRegType`
 
 **Description**: Loads a logical VMI vector from a UB pointer. The element
 type is derived from the source pointer; `size` determines the logical lane
@@ -216,7 +216,6 @@ Use this family for block-strided accesses.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `block_stride` | `int` | 16-bit block stride operand |
-| `repeat_stride` | `int` | 16-bit repeat stride operand |
 
 **Returns**:
 
@@ -290,7 +289,6 @@ blocks = pto.vmi.vload(
     offset,
     size=64,
     block_stride=pto.i16(8),
-    repeat_stride=pto.i16(0),
 )
 ```
 
@@ -302,7 +300,6 @@ blocks = pto.vmi.vload(
   spelled as `group=...`, `stride=...`, `dist_mode="brc"`.
 - `to_dtype` is only accepted when `dist_mode="unpack"`.
 - `stride` is only accepted when `group` is provided.
-- `block_stride` and `repeat_stride` must be provided together.
 - The unpack form widens by exactly one adjacent bit-width step.
 
 ---
@@ -312,7 +309,7 @@ blocks = pto.vmi.vload(
 ### `pto.vmi.vstore(values, destination, offset, mask=None, *, dist_mode=None, pmode=None) -> None`
 ### `pto.vmi.vstore((even, odd), destination, offset, mask=None, *, dist_mode="dintlv", pmode=None) -> None`
 ### `pto.vmi.vstore(values, destination, offset, *, group, stride, pmode=None) -> None`
-### `pto.vmi.vstore(values, destination, offset, mask=None, *, block_stride, repeat_stride, pmode=None) -> None`
+### `pto.vmi.vstore(values, destination, offset, mask=None, *, block_stride, pmode=None) -> None`
 
 **Description**: Writes one logical VMI vector, or a deinterleaved pair, back
 to a UB pointer. As with `vload`, the PTODSL surface is organized into the same
@@ -365,7 +362,6 @@ group-mode store does not take a mask operand.
 |-----------|------|-------------|
 | `mask` | VMI mask or `None` | Optional store mask; omitting it means all lanes are active |
 | `block_stride` | `int` | 16-bit block stride operand |
-| `repeat_stride` | `int` | 16-bit repeat stride operand |
 
 **Returns**: None (side-effect operation).
 
@@ -398,7 +394,6 @@ pto.vmi.vstore(
     offset,
     mask,
     block_stride=pto.i16(8),
-    repeat_stride=pto.i16(0),
 )
 ```
 
@@ -408,7 +403,7 @@ pto.vmi.vstore(
   exclusive.
 - `dist_mode="dintlv"` requires `values` to be an `(even, odd)` pair.
 - Group mode requires `group` and `stride`, and does not accept `mask`.
-- `block_stride` and `repeat_stride` must be provided together.
+- Block-stride lowering fixes the physical repeat stride to zero.
 
 ---
 

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -555,7 +555,6 @@ def _validate_vmi_load_modes(
     group,
     stride,
     block_stride,
-    repeat_stride,
     allow_group_brc: bool,
     allowed_dist_modes,
 ):
@@ -566,17 +565,15 @@ def _validate_vmi_load_modes(
     if group is not None:
         if dist_mode is not None and (not allow_group_brc or dist_mode != "brc"):
             raise TypeError(f"{context} does not allow dist_mode together with group")
-        if block_stride is not None or repeat_stride is not None:
+        if block_stride is not None:
             raise TypeError(f"{context} does not allow block_stride together with group")
         if stride is None:
             raise TypeError(f"{context} with group=... requires stride")
         return
 
-    if block_stride is not None or repeat_stride is not None:
+    if block_stride is not None:
         if dist_mode is not None:
             raise TypeError(f"{context} does not allow dist_mode together with block_stride")
-        if block_stride is None or repeat_stride is None:
-            raise TypeError(f"{context} requires block_stride and repeat_stride together")
         if stride is not None:
             raise TypeError(f"{context} does not allow stride together with block_stride")
         return
@@ -704,7 +701,6 @@ class _VMINamespace:
         to_dtype=None,
         stride=None,
         block_stride=None,
-        repeat_stride=None,
         dist_mode=None,
         group=None,
         loc=None,
@@ -716,7 +712,6 @@ class _VMINamespace:
             group=group,
             stride=stride,
             block_stride=block_stride,
-            repeat_stride=repeat_stride,
             allow_group_brc=True,
             allowed_dist_modes={None, "continuous", "dintlv", "unpack", "brc"},
         )
@@ -734,7 +729,6 @@ class _VMINamespace:
             _coerce_index_value(offset),
             stride=None if stride is None else _coerce_index_value(stride),
             block_stride=_i16_value(block_stride, context="pto.vmi.vload(block_stride)"),
-            repeat_stride=_i16_value(repeat_stride, context="pto.vmi.vload(repeat_stride)"),
             dist_mode=dist_mode,
             group=group,
             loc=loc,
@@ -750,7 +744,6 @@ class _VMINamespace:
         *,
         stride=None,
         block_stride=None,
-        repeat_stride=None,
         dist_mode=None,
         group=None,
         pmode=None,
@@ -763,7 +756,6 @@ class _VMINamespace:
             group=group,
             stride=stride,
             block_stride=block_stride,
-            repeat_stride=repeat_stride,
             allow_group_brc=False,
             allowed_dist_modes={None, "continuous", "dintlv"},
         )
@@ -781,7 +773,6 @@ class _VMINamespace:
             _variadic_mask(mask),
             stride=None if stride is None else _coerce_index_value(stride),
             block_stride=_i16_value(block_stride, context="pto.vmi.vstore(block_stride)"),
-            repeat_stride=_i16_value(repeat_stride, context="pto.vmi.vstore(repeat_stride)"),
             dist_mode=dist_mode,
             group=group,
             pmode=pmode,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -9,6 +9,7 @@
 
 from dataclasses import replace
 from pathlib import Path
+import inspect
 import os
 import re
 import subprocess
@@ -4025,6 +4026,20 @@ def vmi_group_brc_vload_probe():
         group=8,
         stride=row_stride,
         dist_mode="brc",
+    )
+
+
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def vmi_block_stride_memory_probe():
+    src_tile = pto.alloc_tile(shape=[1, 64], dtype=pto.f32)
+    dst_tile = pto.alloc_tile(shape=[1, 64], dtype=pto.f32)
+    offset = pto.const(0, dtype=pto.index)
+
+    value = pto.vmi.vload(
+        src_tile.as_ptr(), offset, size=64, block_stride=pto.i16(2)
+    )
+    pto.vmi.vstore(
+        value, dst_tile.as_ptr(), offset, block_stride=pto.i16(2)
     )
 
 
@@ -8077,6 +8092,20 @@ def main() -> None:
     expect(
         'dist_mode = "brc"' in vmi_group_brc_vload_text and "group = 8" in vmi_group_brc_vload_text,
         "pto.vmi.vload should allow the grouped brc form exposed by the VMI IR contract",
+    )
+    vmi_block_stride_memory_text = vmi_block_stride_memory_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        vmi_block_stride_memory_text, "public VMI block-stride memory specialization"
+    )
+    expect(
+        vmi_block_stride_memory_text.count("pto.vmi.vload") == 1
+        and vmi_block_stride_memory_text.count("pto.vmi.vstore") == 1,
+        "VMI block-stride memory forms should compile with block_stride alone",
+    )
+    expect(
+        "repeat_stride" not in inspect.signature(pto.vmi.vload).parameters
+        and "repeat_stride" not in inspect.signature(pto.vmi.vstore).parameters,
+        "VMI load/store Python signatures must not expose repeat_stride",
     )
     fixed_width_integer_text = fixed_width_integer_specialization_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(fixed_width_integer_text, "fixed-width integer specialization")

--- a/test/lit/vmi_new/vmi_repeat_stride_removed_invalid.pto
+++ b/test/lit/vmi_new/vmi_repeat_stride_removed_invalid.pto
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -split-input-file 2>&1 | FileCheck %s
+
+module {
+  func.func @unified_load_repeat_stride(
+      %src: !pto.ptr<f32, ub>, %offset: index, %block: i16, %repeat: i16) {
+    %value = pto.vmi.vload %src[%offset], %block, %repeat
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @unified_store_repeat_stride(
+      %value: !pto.vmi.vreg<64xf32>, %dst: !pto.ptr<f32, ub>,
+      %offset: index, %block: i16, %repeat: i16) {
+    pto.vmi.vstore %value, %dst[%offset], %block, %repeat
+        : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @legacy_load_repeat_stride(
+      %src: !pto.ptr<f32, ub>, %offset: index, %block: i16,
+      %repeat: i16, %mask: !pto.vmi.mask<64xpred>) {
+    %value = pto.vmi.stride_load %src[%offset], %block, %repeat, %mask
+        : !pto.ptr<f32, ub>, i16, i16, !pto.vmi.mask<64xpred>
+        -> !pto.vmi.vreg<64xf32>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @legacy_store_repeat_stride(
+      %value: !pto.vmi.vreg<64xf32>, %dst: !pto.ptr<f32, ub>,
+      %offset: index, %block: i16, %repeat: i16,
+      %mask: !pto.vmi.mask<64xpred>) {
+    pto.vmi.stride_store %value, %dst[%offset], %block, %repeat, %mask
+        : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16,
+          !pto.vmi.mask<64xpred>
+    return
+  }
+}
+
+// CHECK-COUNT-4: error:

--- a/test/lit/vmi_new/vmi_to_vpto_stride_load.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_stride_load.pto
@@ -15,8 +15,8 @@ module {
       %mask: !pto.vmi.mask<64xb8, #pto.vmi.layout<contiguous>>)
       -> !pto.vreg<256xf8E4M3FN> {
     %c1 = arith.constant 1 : i16
-    %out = pto.vmi.stride_load %src[%offset], %c1, %c1, %mask
-        : !pto.ptr<f8E4M3FN, ub>, i16, i16,
+    %out = pto.vmi.stride_load %src[%offset], %c1, %mask
+        : !pto.ptr<f8E4M3FN, ub>, i16,
           !pto.vmi.mask<64xb8, #pto.vmi.layout<contiguous>>
         -> !pto.vmi.vreg<64xf8E4M3FN, #pto.vmi.layout<contiguous>>
     %part = "pto.vmi.unpack"(%out)
@@ -28,7 +28,7 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_stride_load(
 // CHECK: %[[BASE:.*]] = pto.addptr %arg0, %arg1 : <f8E4M3FN, ub> -> <f8E4M3FN, ub>
-// CHECK: %[[LOAD:.*]] = pto.vsldb %[[BASE]], %c1{{[^,]*}}, %c1{{[^,]*}}, %arg2 : !pto.ptr<f8E4M3FN, ub>, i16, i16, !pto.mask<b8> -> !pto.vreg<256xf8E4M3FN>
+// CHECK: %[[LOAD:.*]] = pto.vsldb %[[BASE]], %c1{{[^,]*}}, %c0_i16, %arg2 : !pto.ptr<f8E4M3FN, ub>, i16, i16, !pto.mask<b8> -> !pto.vreg<256xf8E4M3FN>
 // CHECK: return %[[LOAD]] : !pto.vreg<256xf8E4M3FN>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_stride_store.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_stride_store.pto
@@ -15,8 +15,7 @@ module {
       %mask: !pto.vmi.mask<64xpred>) {
     %c0 = arith.constant 0 : index
     %c2 = arith.constant 2 : i16
-    %c4 = arith.constant 4 : i16
-    pto.vmi.vstore %value, %dst[%c0], %c2, %c4, %mask
+    pto.vmi.vstore %value, %dst[%c0], %c2, %mask
         : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>,
           !pto.vmi.mask<64xpred>
     return
@@ -25,7 +24,7 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_stride_store(
 // CHECK: %[[BASE:.*]] = pto.addptr %arg1, %c0 : <f32, ub> -> <f32, ub>
-// CHECK: pto.vsstb %arg0, %[[BASE]], %c2{{[^,]*}}, %c4{{[^,]*}}, %arg2 : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>{{$}}
+// CHECK: pto.vsstb %arg0, %[[BASE]], %c2{{[^,]*}}, %c0_i16, %arg2 : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>{{$}}
 // CHECK: return
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_vsstb_merge_invalid.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vsstb_merge_invalid.pto
@@ -31,8 +31,7 @@ module {
       %mask: !pto.vmi.mask<64xpred>) {
     %c0 = arith.constant 0 : index
     %c2 = arith.constant 2 : i16
-    %c4 = arith.constant 4 : i16
-    pto.vmi.vstore %value, %dst[%c0], %c2, %c4, %mask {pmode = "merge"}
+    pto.vmi.vstore %value, %dst[%c0], %c2, %mask {pmode = "merge"}
         : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<64xpred>
     return
   }

--- a/test/lit/vmi_new/vmi_unified_memory_modes_invalid.pto
+++ b/test/lit/vmi_new/vmi_unified_memory_modes_invalid.pto
@@ -37,8 +37,8 @@ module {
 
 module {
   func.func @block_stride_load_element_type_mismatch(
-      %src: !pto.ptr<f32, ub>, %offset: index, %block: i16, %repeat: i16) {
-    %value = pto.vmi.vload %src[%offset], %block, %repeat
+      %src: !pto.ptr<f32, ub>, %offset: index, %block: i16) {
+    %value = pto.vmi.vload %src[%offset], %block
         : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf16>
     return
   }
@@ -51,8 +51,8 @@ module {
 module {
   func.func @block_stride_store_element_type_mismatch(
       %value: !pto.vmi.vreg<64xf16>, %dst: !pto.ptr<f32, ub>,
-      %offset: index, %block: i16, %repeat: i16) {
-    pto.vmi.vstore %value, %dst[%offset], %block, %repeat
+      %offset: index, %block: i16) {
+    pto.vmi.vstore %value, %dst[%offset], %block
         : !pto.vmi.vreg<64xf16>, !pto.ptr<f32, ub>
     return
   }


### PR DESCRIPTION
## Summary

- 删除 VMI `vload`/`vstore` 及 legacy stride memory op 的 `repeat_stride` 接口。
- VMI block-stride lowering 固定使用物理 `repeat_stride = 0`，生成普通 `vsldb/vsstb`；底层 VPTO/micro-op 接口保持不变。
- 同步 PTODSL API、parser/verifier、文档和回归测试。

## Motivation

`repeat_stride` 是底层 `vsstb/vsldb` 的控制字段。对 VMI 用户来说，block 间地址跳跃由 `block_stride` 描述，VMI 不暴露 post-update base 语义，因此继续暴露该参数会把底层控制细节泄漏到 VMI，并可能使普通形态产生错误的首地址偏移。

## Validation

- PTOAS 增量构建通过。
- 5 个定向 VMI lit 测试通过，包括旧双 stride 语法的拒绝测试。
- changed-code compliance：0 errors / 0 warnings。
- CA model 实跑 VMI `block_stride=65` case 通过，首个写入 block 从 base 开始，结果与 golden 一致。

## Scope

底层 VPTO `repeat_stride`、post-update 指令形态和相关 emitter 能力未删除，仍可供直接使用底层 VPTO 的用户使用。
