### PR TITLE
Support composed dense layout materialization

### DIFF
--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -342,6 +342,10 @@ static constexpr EnsureLayoutPattern kEnsureLayoutPatterns[] = {
     {bits<8, 16>(), anyN(), ls(2), c()},
     {bits<8>(), anyN(), c(), ls(4)},
     {bits<8>(), anyN(), ls(4), c()},
+    {bits<16>(), N<256>(), d(2), ls(2)},
+    {bits<16>(), N<256>(), ls(2), d(2)},
+    {bits<8>(), anyN(), ls(2), ls(4)},
+    {bits<8>(), anyN(), ls(4), ls(2)},
 
     // Group-slot lane-stride materialization keeps num_groups and slots=8.
     // Each physical part carries at most eight row-local group values, so the

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -4090,12 +4090,48 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
         sourceLayout.getLaneStride(), rewriter);
   }
 
+  VMILayoutAttr contiguous =
+      VMILayoutAttr::getContiguous(rewriter.getContext());
+  bool deint2ToLaneStride =
+      sourceLayout.isDeinterleaved() && sourceLayout.getFactor() == 2 &&
+      sourceLayout.getLaneStride() == 1 && resultLayout.isContiguous() &&
+      resultLayout.getLaneStride() == 2;
+  bool laneStrideToDeint2 =
+      sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 2 &&
+      resultLayout.isDeinterleaved() && resultLayout.getFactor() == 2 &&
+      resultLayout.getLaneStride() == 1;
+  bool laneStride2ToLaneStride4 =
+      sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 2 &&
+      resultLayout.isContiguous() && resultLayout.getLaneStride() == 4;
+  bool laneStride4ToLaneStride2 =
+      sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 4 &&
+      resultLayout.isContiguous() && resultLayout.getLaneStride() == 2;
+  if (deint2ToLaneStride || laneStrideToDeint2 ||
+      laneStride2ToLaneStride4 || laneStride4ToLaneStride2) {
+    size_t intermediateCount = sourceParts.size();
+    if (!deint2ToLaneStride) {
+      intermediateCount = (sourceParts.size() + 1) / 2;
+    }
+    if (sourceParts.empty()) {
+      return failure();
+    }
+    SmallVector<Type> intermediateTypes(intermediateCount,
+                                        sourceParts.front().getType());
+    FailureOr<SmallVector<Value>> dense = materializeDataLayoutConversion(
+        op, sourceParts, intermediateTypes, sourceLayout, contiguous,
+        sourceVMIElementType, rewriter);
+    if (failed(dense)) {
+      return failure();
+    }
+    return materializeDataLayoutConversion(
+        op, *dense, resultTypes, contiguous, resultLayout,
+        sourceVMIElementType, rewriter);
+  }
+
   if (sourceLayout.isDeinterleaved() && resultLayout.isDeinterleaved() &&
       sourceLayout.getLaneStride() == 1 && resultLayout.getLaneStride() == 1 &&
       (sourceLayout.getFactor() == 2 || sourceLayout.getFactor() == 4) &&
       (resultLayout.getFactor() == 2 || resultLayout.getFactor() == 4)) {
-    VMILayoutAttr contiguous =
-        VMILayoutAttr::getContiguous(rewriter.getContext());
     FailureOr<SmallVector<Value>> dense = materializeDataLayoutConversion(
         op, sourceParts, resultTypes, sourceLayout, contiguous,
         sourceVMIElementType, rewriter);

--- a/test/lit/vmi_new/vmi_to_vpto_ensure_layout_dense_composed.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_ensure_layout_dense_composed.pto
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software; you can redistribute it and/or modify it under
+// the terms and conditions of CANN Open Software License Agreement Version 2.0
+// (the "License"). Please refer to the License for details. This software is
+// provided on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -pto-validate-vmi-layout-ir -vmi-to-vpto | FileCheck %s
+
+module {
+  func.func @d2_to_ls2_f16(
+      %v: !pto.vmi.vreg<256xf16, #pto.vmi.layout<deinterleaved = 2>>,
+      %dst: !pto.ptr<f16, ub>, %off: index) {
+    %r = pto.vmi.ensure_layout %v
+        : !pto.vmi.vreg<256xf16, #pto.vmi.layout<deinterleaved = 2>>
+        -> !pto.vmi.vreg<256xf16, #pto.vmi.layout<contiguous, lane_stride = 2>>
+    pto.vmi.vstore %r, %dst[%off]
+        : !pto.vmi.vreg<256xf16, #pto.vmi.layout<contiguous, lane_stride = 2>>,
+          !pto.ptr<f16, ub>
+    return
+  }
+
+  func.func @ls2_to_ls4_f8(
+      %v: !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous, lane_stride = 2>>,
+      %dst: !pto.ptr<f8E4M3FN, ub>, %off: index) {
+    %r = pto.vmi.ensure_layout %v
+        : !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous, lane_stride = 2>>
+        -> !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous, lane_stride = 4>>
+    pto.vmi.vstore %r, %dst[%off]
+        : !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous, lane_stride = 4>>,
+          !pto.ptr<f8E4M3FN, ub>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @d2_to_ls2_f16
+// CHECK: pto.vintlv
+// CHECK: pto.vzunpack
+// CHECK-NOT: pto.vmi.
+// CHECK-LABEL: func.func @ls2_to_ls4_f8
+// CHECK: pto.vpack
+// CHECK: pto.vzunpack
+// CHECK-NOT: pto.vmi.


### PR DESCRIPTION
## 背景

`ensure_layout` 已支持 dense contiguous 与 lane-stride、deinterleaved 与 contiguous 的部分转换，但缺少可由现有转换组合得到的 dense layout 关系：`f16/256 d2 <-> ls2` 和 `f8 ls2 <-> ls4`。这会使合法的 layout 物化在 VPTO lowering 阶段残留 `ensure_layout`。

## 修改

- 在 layout support table 中补充 `f16/256 d2 <-> ls2`。
- 补充 dense `f8 ls2 <-> ls4`。
- 复用已有 `d <-> c` 与 `c <-> ls` materializer，按中间 contiguous layout 组合转换，保持物理 part arity 正确。
- 增加完整 VPTO lowering 回归，检查生成 `vintlv`、`vzunpack`、`vpack` 等指令且不残留 VMI op。

## 验证

- `ninja -C .work/dense-layout-pr-build check-pto`
  - 1829 passed
  - 1 unsupported
  - 0 failed
- `vmi_to_vpto_ensure_layout_dense_composed.pto`：passed
- `check_changed_code.py --base origin/main`：0 errors, 0 warnings

## 关联

为 E2B broadcast layout 场景中的 `d2 -> ls2` 物化提供基础支持。
