### PR TITLE
ptodsl: support Python and/or short-circuit in AST rewrite (#1332)

### DIFF
--- a/ptodsl/docs/user_guide/05-control-flow.md
+++ b/ptodsl/docs/user_guide/05-control-flow.md
@@ -371,6 +371,40 @@ def ast_rewrite_side_effect_kernel():
         pto.pipe_barrier(pto.Pipe.ALL)
 ```
 
+### Short-circuit `and` / `or`
+
+Python `and` / `or` between PTODSL runtime values are not bitwise
+operations: they keep Python's short-circuit semantics, so the right-hand
+side is only evaluated on the device where Python would actually need it.
+The AST rewrite turns `a and b` / `a or b` into a result-bearing `scf.if`
+whose guarded region contains exactly the RHS:
+
+<!-- ptodsl-doc-test: {"mode":"compile","symbol":"ast_rewrite_short_circuit_kernel","compile":{}} -->
+```python
+@pto.jit(target="a5")
+def ast_rewrite_short_circuit_kernel():
+    value = pto.const(10, dtype=pto.i32)
+    divisor = pto.const(2, dtype=pto.i32)
+
+    pred = (divisor != 0) and ((value // divisor) > 0)
+    if pred:
+        pto.pipe_barrier(pto.Pipe.ALL)
+```
+
+`and` returns the left operand when it is falsy and the right operand
+otherwise; `or` returns the left operand when it is truthy and the right
+operand otherwise. Integer-typed operands are tested with non-zero
+truthiness, and when one merged branch is an `i1` the other operand is
+reconciled with the same rules as `pto.if_` branch merges (including Python
+`bool` literals, which materialize as `i1` constants). Statically-known
+`bool` / `int` operands short-circuit at trace time: `False and rhs` and
+`True or rhs` never trace the RHS at all.
+
+`and` / `or` compose with every rewritten expression context: assignments,
+call arguments, `return`, and `if` / `while` conditions. Floating-point
+values are not valid short-circuit controls and raise a clear error.
+
+
 ### Runtime loops
 
 Native `range(...)` loops become device-side loops:
@@ -638,3 +672,4 @@ do not use Python `return` as a dynamic loop exit.
 | `pto.for_` | Device-side | Dynamic bounds, runtime loop counts |
 | `pto.for_(...).carry(...)` | Device-side | Loops with accumulated state across iterations |
 | `pto.if_` | Device-side | Runtime conditions, data-dependent branching |
+| Python `and` / `or` | Device-side short-circuit `scf.if` | Runtime predicates with Python short-circuit semantics |

--- a/ptodsl/docs/user_guide/05-control-flow.md
+++ b/ptodsl/docs/user_guide/05-control-flow.md
@@ -398,8 +398,13 @@ truthiness. When one merged branch yields an `i1` and the other an
 integer-like value, the integer type is kept and the `i1` side widens to its
 0/1 integer value, so the integer operand value is preserved; a merge of two
 `i1` values stays `i1`. Python `bool` literals materialize as `i1` and widen
-like any other `i1` when the opposite branch is integer-typed. Incompatible
-branch types keep the usual branch-merge diagnostics.
+like any other `i1` when the opposite branch is integer-typed. A Python
+`int` literal can join a runtime merge only when the opposite branch already
+has an integer type to anchor its width (e.g. `x or 2` with `x: pto.i32`);
+against an `i1` branch there is no width to infer, so `flag and 2` /
+`flag or 2` raise an error prompting you to anchor the type explicitly,
+e.g. `flag and pto.const(2, dtype=pto.i32)`. Incompatible branch types keep
+the usual branch-merge diagnostics.
 
 Statically known `bool` / `int` / float operands short-circuit at trace time
 with native Python truthiness: `False and rhs`, `True or rhs`, and

--- a/ptodsl/docs/user_guide/05-control-flow.md
+++ b/ptodsl/docs/user_guide/05-control-flow.md
@@ -409,7 +409,15 @@ the usual branch-merge diagnostics.
 Statically known `bool` / `int` / float operands short-circuit at trace time
 with native Python truthiness: `False and rhs`, `True or rhs`, and
 `0.0 or rhs` never trace the RHS at all. Runtime floating-point controls are
-not valid short-circuit predicates and raise a clear error.
+not valid short-circuit predicates and raise a clear error. Python float
+literals on the RHS of a runtime short-circuit merge are also rejected: the
+merge currently accepts only `bool`/`int` literals and PTO runtime scalar
+values, because a float literal (for example, `flag and 0.5`) has no
+compatible result type when the other branch preserves the left operand. Use
+an explicit `pto.if_` merge with same-typed branch values when a floating-point
+result is required.
+Assignment expressions (`:=`) on a lazily evaluated RHS are rejected because
+the rewrite uses a helper lambda and cannot preserve the Python binding scope.
 
 `and` / `or` compose with every rewritten expression context: assignments,
 call arguments, `return`, and `if` / `while` conditions.
@@ -635,10 +643,10 @@ Do not pass conflicting values through both spellings. For example,
 `@pto.jit(ast_rewrite=False, frontend_options={"ast_rewrite": True})` is
 rejected.
 
-When this mode is disabled for a function, native Python `if` / `for` executes
-while tracing that function. Runtime device-side control flow should still use
-the default rewrite mode, or explicit `pto.if_` / `pto.for_` APIs when you need
-manual control.
+When this mode is disabled for a function, native Python `if` / `for` / `and` /
+`or` executes while tracing that function. Runtime device-side control flow
+should still use the default rewrite mode, or explicit `pto.if_` / `pto.for_`
+APIs when you need manual control.
 
 The structured `frontend_options` argument is reserved for frontend rewrite
 debugging and future rewrite passes. Today it accepts the same AST rewrite

--- a/ptodsl/docs/user_guide/05-control-flow.md
+++ b/ptodsl/docs/user_guide/05-control-flow.md
@@ -394,15 +394,20 @@ def ast_rewrite_short_circuit_kernel():
 `and` returns the left operand when it is falsy and the right operand
 otherwise; `or` returns the left operand when it is truthy and the right
 operand otherwise. Integer-typed operands are tested with non-zero
-truthiness, and when one merged branch is an `i1` the other operand is
-reconciled with the same rules as `pto.if_` branch merges (including Python
-`bool` literals, which materialize as `i1` constants). Statically-known
-`bool` / `int` operands short-circuit at trace time: `False and rhs` and
-`True or rhs` never trace the RHS at all.
+truthiness. When one merged branch yields an `i1` and the other an
+integer-like value, the integer type is kept and the `i1` side widens to its
+0/1 integer value, so the integer operand value is preserved; a merge of two
+`i1` values stays `i1`. Python `bool` literals materialize as `i1` and widen
+like any other `i1` when the opposite branch is integer-typed. Incompatible
+branch types keep the usual branch-merge diagnostics.
+
+Statically known `bool` / `int` / float operands short-circuit at trace time
+with native Python truthiness: `False and rhs`, `True or rhs`, and
+`0.0 or rhs` never trace the RHS at all. Runtime floating-point controls are
+not valid short-circuit predicates and raise a clear error.
 
 `and` / `or` compose with every rewritten expression context: assignments,
-call arguments, `return`, and `if` / `while` conditions. Floating-point
-values are not valid short-circuit controls and raise a clear error.
+call arguments, `return`, and `if` / `while` conditions.
 
 
 ### Runtime loops

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -29,8 +29,10 @@ def rewrite_jit_function(
 ):
     """Return a function with PTODSL lexical sections lowered safely.
 
-    ``pto.section`` is a physical SSA region, not a Python ``with`` hint.  The
-    section body therefore gets a small source-level lexical rewrite even when
+    ``rewrite_control_flow`` controls both runtime statement rewriting and the
+    ``and``/``or`` short-circuit rewrite.  ``pto.section`` is a physical SSA
+    region, not a Python ``with`` hint.  Its body therefore gets a small
+    source-level lexical rewrite even when
     the optional control-flow rewrite is disabled.  This keeps Python's
     function-local assignment rules from leaking a section-local SSA value into
     a sibling physical section.
@@ -418,7 +420,22 @@ class _BoolOpRewriter(ast.NodeTransformer):
     traced at all when Python semantics would skip it.
     """
 
+    @staticmethod
+    def _reject_rhs_assignment_expressions(node):
+        """Reject walrus expressions that would move into a generated lambda."""
+        if any(
+            isinstance(child, ast.NamedExpr)
+            for value in node.values[1:]
+            for child in ast.walk(value)
+        ):
+            raise PTODSLAstRewriteError(
+                "ast_rewrite=True cannot rewrite an and/or expression containing "
+                "an assignment expression (walrus operator) on the RHS; the "
+                "assignment would bind inside the generated helper lambda"
+            )
+
     def visit_BoolOp(self, node):
+        self._reject_rhs_assignment_expressions(node)
         node = self.generic_visit(node)
         if isinstance(node.op, ast.And):
             helper = "_short_circuit_and"

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -68,6 +68,8 @@ def rewrite_jit_function(
     static_env.update(static_bindings or {})
     _inject_closure_defaults(function_def, closure_vars.nonlocals)
     _sanitize_signature_for_exec(function_def)
+    if rewrite_control_flow:
+        function_def = _BoolOpRewriter().visit(function_def)
     function_def = _ConditionalExpressionNormalizer().visit(function_def)
     section_rewriter = _SectionLexicalRewriter()
     function_def = section_rewriter.visit(function_def)
@@ -379,6 +381,62 @@ class _ConditionalExpressionNormalizer(ast.NodeTransformer):
             orelse=[else_stmt],
         )
         return ast.copy_location(self.generic_visit(if_stmt), stmt)
+
+
+def _zero_arg_lambda(body):
+    return ast.Lambda(
+        args=ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
+        ),
+        body=body,
+    )
+
+
+class _BoolOpRewriter(ast.NodeTransformer):
+    """Rewrite Python ``and``/``or`` into device-side short-circuit helpers.
+
+    Python ``and``/``or`` are not overloadable operators: evaluating ``a and b``
+    forces a truth check on ``a``, which calls ``__bool__`` on a PTODSL runtime
+    value during tracing and raises.  This pass replaces every ``ast.BoolOp``
+    with a right-nested lazy helper call so the RHS is only traced inside a
+    device-side ``scf.if`` region::
+
+        a and b and c  ->  pto._short_circuit_and(a, lambda: pto._short_circuit_and(b, lambda: c))
+        a or  b or  c  ->  pto._short_circuit_or(a,  lambda: pto._short_circuit_or(b,  lambda: c))
+
+    The transformation is purely syntactic and composes with every expression
+    context: assignments, call arguments, ``return``, and ``if``/``while``
+    conditions.  Nested function bodies are rewritten as well, mirroring the
+    control-flow rewriter.  Statically-known ``bool``/``int`` operands are
+    short-circuited at trace time by the helpers themselves, so the RHS is not
+    traced at all when Python semantics would skip it.
+    """
+
+    def visit_BoolOp(self, node):
+        node = self.generic_visit(node)
+        if isinstance(node.op, ast.And):
+            helper = "_short_circuit_and"
+        elif isinstance(node.op, ast.Or):
+            helper = "_short_circuit_or"
+        else:
+            return node
+        values = list(node.values)
+        if len(values) < 2:
+            return values[0] if values else node
+        result = values[-1]
+        for value in reversed(values[:-1]):
+            result = ast.Call(
+                func=_pto_attr(helper),
+                args=[value, _zero_arg_lambda(result)],
+                keywords=[],
+            )
+        return result
 
 
 @dataclass(frozen=True)

--- a/ptodsl/ptodsl/_control_flow.py
+++ b/ptodsl/ptodsl/_control_flow.py
@@ -22,6 +22,7 @@ Public API
 ``static_range(...)``     – trace-time ``range(...)`` escape hatch for AST rewrite
 ``range(...)``            – AST-rewrite marker carrying loop-unroll hints for native ``for``
 ``const_expr(value)``     – trace-time ``if`` escape hatch for AST rewrite
+``_short_circuit_and/or``  – internal device-side ``and``/``or`` helpers used by the AST rewriter
 """
 
 import builtins
@@ -29,7 +30,7 @@ import warnings
 
 from ._diagnostics import explicit_mode_required_with_context_error
 from ._runtime_index_ops import coerce_runtime_index
-from ._scalar_adaptation import coerce_runtime_integer_to_i1
+from ._scalar_adaptation import coerce_runtime_i1_value, coerce_runtime_integer_to_i1
 from ._scalar_coercion import coerce_scalar_to_type
 from ._surface_types import const_expr
 from ._tracing.active import current_session, require_active_session
@@ -846,6 +847,96 @@ def if_(cond) -> _IfCM:
         x = br.x
     """
     return _IfCM(cond)
+
+
+# ── short-circuit and/or (AST-rewrite targets) ──────────────────────────────
+
+def _branch_rhs_value(value, kind):
+    """Validate a short-circuit RHS evaluated inside a runtime branch.
+
+    A branch may only yield a PTO runtime value, an i1-materializable bool
+    literal, or a Python integer literal; anything else would fail later inside
+    ``br.assign`` with an opaque error.
+    """
+    if isinstance(value, (bool, int)) or hasattr(value, "type"):
+        return value
+    raise TypeError(
+        "pto short-circuit " + kind + " RHS must be a PTO runtime value or a Python "
+        "bool/int literal, got " + type(value).__name__,
+    )
+
+
+def _materialize_bool_branch_value(value, *, context):
+    """Materialize a Python ``bool`` operand to a signless ``i1`` constant.
+
+    Python ``and``/``or`` may legally return a plain ``bool`` literal from one
+    branch (``flag and True``).  Branch assignment needs a typed value when the
+    opposite branch is typed, so literals are materialized here before
+    ``br.assign``; all runtime operands pass through unchanged.
+    """
+    if isinstance(value, bool):
+        return coerce_runtime_i1_value(value, context=context)
+    return value
+
+
+def _short_circuit_and(lhs, rhs_fn):
+    """Internal device-side ``lhs and rhs()`` with Python short-circuit semantics.
+
+    Emits a result-bearing ``scf.if``: when ``lhs`` is truthy the RHS lambda is
+    traced inside the ``then`` region, otherwise the unmodified ``lhs`` operand
+    is the result.  Non-runtime operands (plain Python values) keep native
+    Python truthiness and short-circuit at trace time without tracing the RHS.
+    The branch merge reuses ``pto.if_`` existing rules: integer-like operands
+    are tested with non-zero coercion, and incompatible branch types keep their
+    existing diagnostics.  Floating-point control values are rejected.
+    """
+    if not callable(rhs_fn):
+        raise TypeError("pto._short_circuit_and expects a zero-argument callable RHS")
+    if not hasattr(lhs, "type"):
+        if isinstance(lhs, float):
+            raise TypeError(
+                "pto short-circuit and does not accept floating-point control values; "
+                "runtime float conditions are not supported",
+            )
+        return rhs_fn() if lhs else lhs
+    raw_lhs = unwrap_surface_value(lhs)
+    cond = coerce_runtime_i1_value(raw_lhs, context="pto short-circuit and condition")
+    with if_(cond) as br:
+        with br.then_:
+            br.assign(value=_materialize_bool_branch_value(
+                _branch_rhs_value(rhs_fn(), "and"), context="pto short-circuit and RHS"))
+        with br.else_:
+            br.assign(value=lhs)
+    return br.value
+
+
+def _short_circuit_or(lhs, rhs_fn):
+    """Internal device-side ``lhs or rhs()`` with Python short-circuit semantics.
+
+    When ``lhs`` is truthy the unmodified ``lhs`` operand is the result and the
+    RHS lambda is never traced; otherwise the RHS runs inside the ``else``
+    region.  Non-runtime operands (plain Python values) keep native Python
+    truthiness and short-circuit at trace time.  Floating-point control values
+    are rejected.
+    """
+    if not callable(rhs_fn):
+        raise TypeError("pto._short_circuit_or expects a zero-argument callable RHS")
+    if not hasattr(lhs, "type"):
+        if isinstance(lhs, float):
+            raise TypeError(
+                "pto short-circuit or does not accept floating-point control values; "
+                "runtime float conditions are not supported",
+            )
+        return lhs if lhs else rhs_fn()
+    raw_lhs = unwrap_surface_value(lhs)
+    cond = coerce_runtime_i1_value(raw_lhs, context="pto short-circuit or condition")
+    with if_(cond) as br:
+        with br.then_:
+            br.assign(value=lhs)
+        with br.else_:
+            br.assign(value=_materialize_bool_branch_value(
+                _branch_rhs_value(rhs_fn(), "or"), context="pto short-circuit or RHS"))
+    return br.value
 
 
 def _is_branch_assign_literal(value) -> bool:

--- a/ptodsl/ptodsl/_control_flow.py
+++ b/ptodsl/ptodsl/_control_flow.py
@@ -955,10 +955,15 @@ def _coerce_integer_to_i1_at(value, *, block, context):
 
 
 def _coerce_i1_to_integer_at(value, *, block, target_type, context):
-    """Widen an i1 branch value to *target_type* inside *block*."""
+    """Widen an i1 branch value to *target_type* inside *block*.
+
+    Fixed-width integer targets use ``arith.extui``; ``index`` is not a valid
+    extui result type, so it widens through ``arith.index_cast`` (i1 -> index
+    zero-extends a 0/1 truth value).
+    """
     with InsertionPoint(block):
         if IndexType.isinstance(target_type):
-            return arith.ExtUIOp(IndexType.get(), value).result
+            return arith.IndexCastOp(IndexType.get(), value).result
         return coerce_integer_like(value, target_type)
 
 
@@ -998,6 +1003,18 @@ def _reconcile_branch_assignment_values(
                 context=f"br.assign(...) then branch value for '{name}'",
             )
             then_is_typed = True
+        elif then_is_typed and isinstance(else_value, int) and _is_i1_type(then_value.type):
+            raise TypeError(
+                "short-circuit merge cannot infer an integer width for the Python "
+                f"literal {else_value!r} against an i1 branch value; materialize it "
+                "explicitly with pto.const(..., dtype=...)",
+            )
+        elif else_is_typed and isinstance(then_value, int) and _is_i1_type(else_value.type):
+            raise TypeError(
+                "short-circuit merge cannot infer an integer width for the Python "
+                f"literal {then_value!r} against an i1 branch value; materialize it "
+                "explicitly with pto.const(..., dtype=...)",
+            )
 
     if then_is_typed and else_is_typed:
         then_is_i1 = _is_i1_type(then_value.type)

--- a/ptodsl/ptodsl/_control_flow.py
+++ b/ptodsl/ptodsl/_control_flow.py
@@ -30,7 +30,7 @@ import warnings
 
 from ._diagnostics import explicit_mode_required_with_context_error
 from ._runtime_index_ops import coerce_runtime_index
-from ._scalar_adaptation import coerce_runtime_i1_value, coerce_runtime_integer_to_i1
+from ._scalar_adaptation import coerce_integer_like, coerce_runtime_i1_value, coerce_runtime_integer_to_i1
 from ._scalar_coercion import coerce_scalar_to_type
 from ._surface_types import const_expr
 from ._tracing.active import current_session, require_active_session
@@ -605,8 +605,9 @@ class BranchHandle:
 
 
 class _IfCM:
-    def __init__(self, cond):
+    def __init__(self, cond, *, short_circuit_merge: bool = False):
         self._cond = cond
+        self._short_circuit_merge = short_circuit_merge
         self._cond_value = None
         self._tmp_if = None
         self._parent_block = None
@@ -759,6 +760,7 @@ class _IfCM:
                 else_value,
                 then_block=self._tmp_if.then_block,
                 else_block=self._tmp_if.else_block,
+                short_circuit_merge=self._short_circuit_merge,
             )
             if then_value.type != else_value.type:
                 raise RuntimeError(
@@ -884,24 +886,21 @@ def _short_circuit_and(lhs, rhs_fn):
 
     Emits a result-bearing ``scf.if``: when ``lhs`` is truthy the RHS lambda is
     traced inside the ``then`` region, otherwise the unmodified ``lhs`` operand
-    is the result.  Non-runtime operands (plain Python values) keep native
-    Python truthiness and short-circuit at trace time without tracing the RHS.
-    The branch merge reuses ``pto.if_`` existing rules: integer-like operands
-    are tested with non-zero coercion, and incompatible branch types keep their
-    existing diagnostics.  Floating-point control values are rejected.
+    is the result.  Non-runtime operands (plain Python values, including static
+    floats) keep native Python truthiness and short-circuit at trace time
+    without tracing the RHS.  Runtime left operands use non-zero truthiness for
+    the control condition; the branch merge keeps Python operand semantics, so
+    an ``i1`` next to an integer-like value widens to that integer's 0/1 value
+    instead of collapsing the integer to a boolean.  Incompatible branch types
+    keep their existing diagnostics.
     """
     if not callable(rhs_fn):
         raise TypeError("pto._short_circuit_and expects a zero-argument callable RHS")
     if not hasattr(lhs, "type"):
-        if isinstance(lhs, float):
-            raise TypeError(
-                "pto short-circuit and does not accept floating-point control values; "
-                "runtime float conditions are not supported",
-            )
         return rhs_fn() if lhs else lhs
     raw_lhs = unwrap_surface_value(lhs)
     cond = coerce_runtime_i1_value(raw_lhs, context="pto short-circuit and condition")
-    with if_(cond) as br:
+    with _IfCM(cond, short_circuit_merge=True) as br:
         with br.then_:
             br.assign(value=_materialize_bool_branch_value(
                 _branch_rhs_value(rhs_fn(), "and"), context="pto short-circuit and RHS"))
@@ -915,22 +914,21 @@ def _short_circuit_or(lhs, rhs_fn):
 
     When ``lhs`` is truthy the unmodified ``lhs`` operand is the result and the
     RHS lambda is never traced; otherwise the RHS runs inside the ``else``
-    region.  Non-runtime operands (plain Python values) keep native Python
-    truthiness and short-circuit at trace time.  Floating-point control values
-    are rejected.
+    region.  Non-runtime operands (plain Python values, including static
+    floats) keep native Python truthiness and short-circuit at trace time.
+    Runtime left operands use non-zero truthiness for the control condition;
+    the branch merge keeps Python operand semantics, so an ``i1`` next to an
+    integer-like value widens to that integer's 0/1 value instead of
+    collapsing the integer to a boolean.  Incompatible branch types keep their
+    existing diagnostics.
     """
     if not callable(rhs_fn):
         raise TypeError("pto._short_circuit_or expects a zero-argument callable RHS")
     if not hasattr(lhs, "type"):
-        if isinstance(lhs, float):
-            raise TypeError(
-                "pto short-circuit or does not accept floating-point control values; "
-                "runtime float conditions are not supported",
-            )
         return lhs if lhs else rhs_fn()
     raw_lhs = unwrap_surface_value(lhs)
     cond = coerce_runtime_i1_value(raw_lhs, context="pto short-circuit or condition")
-    with if_(cond) as br:
+    with _IfCM(cond, short_circuit_merge=True) as br:
         with br.then_:
             br.assign(value=lhs)
         with br.else_:
@@ -956,26 +954,83 @@ def _coerce_integer_to_i1_at(value, *, block, context):
         return coerce_runtime_integer_to_i1(value, context=context)
 
 
-def _reconcile_branch_assignment_values(name, then_value, else_value, *, then_block=None, else_block=None):
+def _coerce_i1_to_integer_at(value, *, block, target_type, context):
+    """Widen an i1 branch value to *target_type* inside *block*."""
+    with InsertionPoint(block):
+        if IndexType.isinstance(target_type):
+            return arith.ExtUIOp(IndexType.get(), value).result
+        return coerce_integer_like(value, target_type)
+
+
+def _reconcile_branch_assignment_values(
+    name,
+    then_value,
+    else_value,
+    *,
+    then_block=None,
+    else_block=None,
+    short_circuit_merge: bool = False,
+):
+    """Reconcile one named value across both branches of ``br.assign``.
+
+    The default merge is predicate-oriented (``pto.if_`` semantics): an
+    integer-like operand next to an ``i1`` is normalized to its non-zero i1.
+    ``short_circuit_merge=True`` instead keeps Python operand semantics for
+    ``and``/``or``: when one branch yields an ``i1`` and the other an
+    integer-like value, the integer type wins and the ``i1`` side is widened
+    to its 0/1 integer value.
+    """
     then_is_typed = hasattr(then_value, "type")
     else_is_typed = hasattr(else_value, "type")
+
+    if short_circuit_merge and (then_is_typed != else_is_typed):
+        # A Python bool literal against a typed branch materializes to i1
+        # first; the typed-vs-typed rules below then pick the result type.
+        if then_is_typed and isinstance(else_value, bool):
+            else_value = coerce_runtime_i1_value(
+                else_value,
+                context=f"br.assign(...) else branch value for '{name}'",
+            )
+            else_is_typed = True
+        elif else_is_typed and isinstance(then_value, bool):
+            then_value = coerce_runtime_i1_value(
+                then_value,
+                context=f"br.assign(...) then branch value for '{name}'",
+            )
+            then_is_typed = True
 
     if then_is_typed and else_is_typed:
         then_is_i1 = _is_i1_type(then_value.type)
         else_is_i1 = _is_i1_type(else_value.type)
         if then_is_i1 != else_is_i1:
             if then_is_i1 and _is_integer_like_type(else_value.type):
-                else_value = _coerce_integer_to_i1_at(
-                    else_value,
-                    block=else_block,
-                    context=f"br.assign(...) else branch value for '{name}'",
-                )
+                if short_circuit_merge:
+                    then_value = _coerce_i1_to_integer_at(
+                        then_value,
+                        block=then_block,
+                        target_type=else_value.type,
+                        context=f"br.assign(...) then branch value for '{name}'",
+                    )
+                else:
+                    else_value = _coerce_integer_to_i1_at(
+                        else_value,
+                        block=else_block,
+                        context=f"br.assign(...) else branch value for '{name}'",
+                    )
             elif else_is_i1 and _is_integer_like_type(then_value.type):
-                then_value = _coerce_integer_to_i1_at(
-                    then_value,
-                    block=then_block,
-                    context=f"br.assign(...) then branch value for '{name}'",
-                )
+                if short_circuit_merge:
+                    else_value = _coerce_i1_to_integer_at(
+                        else_value,
+                        block=else_block,
+                        target_type=then_value.type,
+                        context=f"br.assign(...) else branch value for '{name}'",
+                    )
+                else:
+                    then_value = _coerce_integer_to_i1_at(
+                        then_value,
+                        block=then_block,
+                        context=f"br.assign(...) then branch value for '{name}'",
+                    )
         return then_value, else_value
     if then_is_typed:
         return then_value, coerce_scalar_to_type(

--- a/ptodsl/ptodsl/_control_flow.py
+++ b/ptodsl/ptodsl/_control_flow.py
@@ -35,7 +35,12 @@ from ._scalar_coercion import coerce_scalar_to_type
 from ._surface_types import const_expr
 from ._tracing.active import current_session, require_active_session
 from ._tracing.control_flow import apply_unroll_hint, normalize_unroll_hint
-from ._surface_values import unwrap_surface_value, wrap_like_surface_value, wrap_surface_value
+from ._surface_values import (
+    RuntimeValue,
+    unwrap_surface_value,
+    wrap_like_surface_value,
+    wrap_surface_value,
+)
 from ._types import _StructDescriptor
 
 from ptoas.mlir.dialects import arith, pto as _pto, scf
@@ -856,15 +861,18 @@ def if_(cond) -> _IfCM:
 def _branch_rhs_value(value, kind):
     """Validate a short-circuit RHS evaluated inside a runtime branch.
 
-    A branch may only yield a PTO runtime value, an i1-materializable bool
-    literal, or a Python integer literal; anything else would fail later inside
-    ``br.assign`` with an opaque error.
+    A branch may only yield a PTO runtime scalar value, an i1-materializable
+    bool literal, or a Python integer literal.  Python float literals are
+    intentionally excluded because the short-circuit merge has no type anchor
+    for a floating-point result; static float operands still use native Python
+    short-circuiting before this helper is called.
     """
-    if isinstance(value, (bool, int)) or hasattr(value, "type"):
+    if isinstance(value, (bool, int, RuntimeValue)):
         return value
     raise TypeError(
-        "pto short-circuit " + kind + " RHS must be a PTO runtime value or a Python "
-        "bool/int literal, got " + type(value).__name__,
+        "pto short-circuit " + kind + " RHS must be a PTO runtime scalar value or a "
+        "Python bool/int literal; Python float literals are not supported in "
+        "runtime branch merges, got " + type(value).__name__,
     )
 
 
@@ -905,7 +913,7 @@ def _short_circuit_and(lhs, rhs_fn):
             br.assign(value=_materialize_bool_branch_value(
                 _branch_rhs_value(rhs_fn(), "and"), context="pto short-circuit and RHS"))
         with br.else_:
-            br.assign(value=lhs)
+            br.assign(value=raw_lhs)
     return br.value
 
 
@@ -930,7 +938,7 @@ def _short_circuit_or(lhs, rhs_fn):
     cond = coerce_runtime_i1_value(raw_lhs, context="pto short-circuit or condition")
     with _IfCM(cond, short_circuit_merge=True) as br:
         with br.then_:
-            br.assign(value=lhs)
+            br.assign(value=raw_lhs)
         with br.else_:
             br.assign(value=_materialize_bool_branch_value(
                 _branch_rhs_value(rhs_fn(), "or"), context="pto short-circuit or RHS"))

--- a/ptodsl/ptodsl/_control_flow.py
+++ b/ptodsl/ptodsl/_control_flow.py
@@ -957,13 +957,17 @@ def _coerce_integer_to_i1_at(value, *, block, context):
 def _coerce_i1_to_integer_at(value, *, block, target_type, context):
     """Widen an i1 branch value to *target_type* inside *block*.
 
-    Fixed-width integer targets use ``arith.extui``; ``index`` is not a valid
-    extui result type, so it widens through ``arith.index_cast`` (i1 -> index
-    zero-extends a 0/1 truth value).
+    Fixed-width integer targets use ``arith.extui``, which zero-extends the
+    0/1 truth value.  ``index`` is not a valid extui result type and a direct
+    ``arith.index_cast`` from ``i1`` sign-extends (``1`` becomes ``-1``), so
+    the truth value is first zero-extended to ``i32`` and then index-cast,
+    keeping it bit-exact.
     """
     with InsertionPoint(block):
         if IndexType.isinstance(target_type):
-            return arith.IndexCastOp(IndexType.get(), value).result
+            i32 = IntegerType.get_signless(32)
+            widened = coerce_integer_like(value, i32)
+            return arith.IndexCastOp(IndexType.get(), widened).result
         return coerce_integer_like(value, target_type)
 
 

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -162,6 +162,7 @@ from ._control_flow import (    # noqa: F401
     for_, while_, _while, if_, yield_,
     static_range, range,
     LoopHandle, BranchHandle,
+    _short_circuit_and, _short_circuit_or,
 )
 
 # ── All-reduce ─────────────────────────────────────────────────────────────────

--- a/ptodsl/tests/test_boolop_short_circuit.py
+++ b/ptodsl/tests/test_boolop_short_circuit.py
@@ -8,9 +8,10 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 import inspect
+from types import FunctionType
 
 from ptodsl import pto, scalar
-from ptodsl._ast_rewrite import rewrite_jit_function
+from ptodsl._ast_rewrite import PTODSLAstRewriteError, rewrite_jit_function
 
 
 # Issue #1332 original kernels: Python ``and``/``or`` between runtime
@@ -176,7 +177,6 @@ def issue_1332_func_call(x: pto.i32, y: pto.i32, out: pto.ptr(pto.i8, "gm")):
 
 # ``runtime_value and True`` materializes the Python bool to an i1 const in
 # the branch merge.
-# the branch merge.
 
 
 @pto.jit(name="issue_1332_bool_literal_rhs", kernel_kind="vector", target="a5")
@@ -189,6 +189,7 @@ def issue_1332_bool_literal_rhs(f: pto.i1, out: pto.ptr(pto.i8, "gm")):
 # inside rewritten kernels: TileOps templates use the loops-or-None pattern where
 # loops is a regular Python list that must not be traced as a runtime condition
 # (and must never reach the surface-value validator).
+
 
 @pto.jit(name="issue_1332_plain_python_operands", kernel_kind="vector", target="a5")
 def issue_1332_plain_python_operands(out: pto.ptr(pto.i8, "gm")):
@@ -205,8 +206,6 @@ def issue_1332_plain_python_operands(out: pto.ptr(pto.i8, "gm")):
     if value != (1, 2):
         return
     scalar.store(pto.const(11, dtype=pto.i8), out, 0)
-
-
 
 
 @pto.jit(name="issue_1332_index_lhs", kernel_kind="vector", target="a5")
@@ -227,6 +226,12 @@ def issue_1332_int_literal_vs_i1(flag: pto.i1, out: pto.ptr(pto.i8, "gm")):
     scalar.store(pred, out, 0)
 
 
+@pto.jit(name="issue_1332_walrus_rhs", kernel_kind="vector", target="a5")
+def issue_1332_walrus_rhs(flag: pto.i1, out: pto.ptr(pto.i8, "gm")):
+    pred = flag and (bound := flag)
+    scalar.store(pred, out, 0)
+
+
 # Diagnostics: floating-point controls, incompatible branch merges, and the
 # native behavior preserved when AST rewrite is disabled.
 
@@ -243,16 +248,26 @@ def issue_1332_incompatible_merge(x: pto.i32, f: pto.f32, out: pto.ptr(pto.i8, "
     scalar.store(pred, out, 0)
 
 
+@pto.jit(name="issue_1332_float_rhs_literal", kernel_kind="vector", target="a5")
+def issue_1332_float_rhs_literal(flag: pto.i1, out: pto.ptr(pto.i8, "gm")):
+    pred = flag and 0.5
+    scalar.store(pred, out, 0)
+
+
 @pto.jit(name="issue_1332_no_ast_rewrite", kernel_kind="vector", target="a5", ast_rewrite=False)
 def issue_1332_no_ast_rewrite(x: pto.i32, y: pto.i32, out: pto.ptr(pto.i8, "gm")):
     pred = (x > 0) and (y > 0)
     scalar.store(pred, out, 0)
 
 
-def _expect_error(fn, needle):
+def _expect_error(fn, needle, error_type=None):
     try:
         fn()
     except Exception as exc:
+        if error_type is not None and not isinstance(exc, error_type):
+            raise AssertionError(
+                f"expected {error_type.__name__}, got: {type(exc).__name__}: {exc}"
+            ) from exc
         if needle in str(exc):
             return
         raise AssertionError(
@@ -262,9 +277,6 @@ def _expect_error(fn, needle):
 
 
 def main():
-    and_mlir = issue_1332_and_kernel.compile().mlir_text()
-    or_mlir = issue_1332_or_kernel.compile().mlir_text()
-
     # The guarded RHS (division) must live inside the scf.if branch and the
     # condition must come from the LHS comparison.  Verify by walking the
     # emitted module rather than matching text fragments.
@@ -274,6 +286,25 @@ def main():
             for block in region.blocks:
                 for child in block.operations:
                     yield from _walk(child)
+
+    def _ops(module, name):
+        return [op for op in _walk(module) if op.operation.name == name]
+
+    def _has_result_type(module, name, expected_type):
+        return any(
+            str(result.type) == expected_type
+            for op in _ops(module, name)
+            for result in op.operation.results
+        )
+
+    def _has_constant(module, value, expected_type):
+        for op in _ops(module, "arith.constant"):
+            if not any(str(result.type) == expected_type for result in op.operation.results):
+                continue
+            attributes = op.operation.attributes
+            if "value" in attributes and str(attributes["value"]).split(" :", 1)[0] == str(value):
+                return True
+        return False
 
     def _guarded_division(module, region_index):
         scf_ifs = [op for op in _walk(module) if op.operation.name == "scf.if"]
@@ -292,63 +323,70 @@ def main():
     _guarded_division(issue_1332_and_kernel.mlir_module(), 0)  # and: then region
     _guarded_division(issue_1332_or_kernel.mlir_module(), 1)   # or: else region
 
-    chain_and = issue_1332_and_chain.compile().mlir_text()
-    chain_or = issue_1332_or_chain.compile().mlir_text()
+    chain_and_module = issue_1332_and_chain.mlir_module()
+    chain_or_module = issue_1332_or_chain.mlir_module()
     # a and b and c lowers to two nested scf.if regions.
-    assert chain_and.count("scf.if") == 2, chain_and
-    assert chain_or.count("scf.if") == 2, chain_or
+    assert len(_ops(chain_and_module, "scf.if")) == 2
+    assert len(_ops(chain_or_module, "scf.if")) == 2
 
     issue_1332_if_condition.compile().mlir_text()
     issue_1332_while_test.compile().mlir_text()
     issue_1332_call_argument.compile().mlir_text()
-    ret_mlir = issue_1332_return_position.compile().mlir_text()
-    assert "scf.if" in ret_mlir
+    assert _ops(issue_1332_return_position.mlir_module(), "scf.if")
 
-    static_mlir = issue_1332_static_short_circuit.compile().mlir_text()
     # A traced RHS would raise ZeroDivisionError; static operands must also
     # leave no division in the IR at all.
-    assert "floordiv" not in static_mlir, static_mlir
+    assert not _ops(issue_1332_static_short_circuit.mlir_module(), "arith.floordivsi")
 
-    int_lhs = issue_1332_integer_lhs.compile().mlir_text()
+    int_lhs_module = issue_1332_integer_lhs.mlir_module()
     # Integer LHS becomes a non-zero i1 control condition; the integer operand
     # is preserved and the i1 RHS widens to the integer type.
-    assert int_lhs.count("arith.cmpi ne") == 1, int_lhs
-    assert "arith.extui" in int_lhs and "-> (i32)" in int_lhs, int_lhs
-    int_operands = issue_1332_integer_operands.compile().mlir_text()
+    assert len(_ops(int_lhs_module, "arith.cmpi")) == 1
+    assert _ops(int_lhs_module, "arith.extui")
+    assert _has_result_type(int_lhs_module, "scf.if", "i32")
+    int_operands_module = issue_1332_integer_operands.mlir_module()
     # Both integer operands merge back to i32 (Python operand semantics).
-    assert "-> (i32)" in int_operands, int_operands
+    assert _has_result_type(int_operands_module, "scf.if", "i32")
 
-    or_lhs = issue_1332_integer_or_lhs.compile().mlir_text()
-    assert "arith.extui" in or_lhs and "-> (i32)" in or_lhs, or_lhs
-    flag_and = issue_1332_flag_integer_rhs.compile().mlir_text()
-    assert "arith.extui" in flag_and and "-> (i32)" in flag_and, flag_and
-    index_lhs = issue_1332_index_lhs.compile().mlir_text()
+    or_lhs_module = issue_1332_integer_or_lhs.mlir_module()
+    assert _ops(or_lhs_module, "arith.extui")
+    assert _has_result_type(or_lhs_module, "scf.if", "i32")
+    flag_and_module = issue_1332_flag_integer_rhs.mlir_module()
+    assert _ops(flag_and_module, "arith.extui")
+    assert _has_result_type(flag_and_module, "scf.if", "i32")
+    index_lhs_module = issue_1332_index_lhs.mlir_module()
     # index + i1: the index type is kept and the i1 side widens via index_cast.
-    assert "arith.index_cast" in index_lhs and "-> (index)" in index_lhs, index_lhs
+    assert _ops(index_lhs_module, "arith.index_cast")
+    assert _has_result_type(index_lhs_module, "scf.if", "index")
     # The i1 -> index widening must keep the 0/1 truth value: a direct
     # arith.index_cast from i1 sign-extends (1 becomes -1 on the simulator),
     # so the widening must zero-extend through i32 first.
-    index_casts = [op for op in _walk(issue_1332_index_lhs.mlir_module())
-                    if op.operation.name == "arith.index_cast"]
+    index_casts = _ops(index_lhs_module, "arith.index_cast")
     assert any(
         op.operation.operands[0].owner is not None
         and op.operation.operands[0].owner.operation.name == "arith.extui"
         for op in index_casts
     ), "i1->index widening must zero-extend via extui first"
-    anchored = issue_1332_int_literal_anchored.compile().mlir_text()
+    anchored_module = issue_1332_int_literal_anchored.mlir_module()
     # A Python int literal anchors to the integer branch type.
-    assert "arith.constant 2 : i32" in anchored and "-> (i32)" in anchored, anchored
+    assert _has_constant(anchored_module, 2, "i32")
+    assert _has_result_type(anchored_module, "scf.if", "i32")
     _expect_error(
         lambda: issue_1332_int_literal_vs_i1.compile().mlir_text(),
         "cannot infer an integer width",
+    )
+    _expect_error(
+        lambda: issue_1332_walrus_rhs.compile().mlir_text(),
+        "assignment expression",
+        PTODSLAstRewriteError,
     )
     issue_1332_static_float.compile().mlir_text()
     issue_1332_static_int_operands.compile().mlir_text()
     issue_1332_func_call.compile().mlir_text()
 
-    plain = issue_1332_plain_python_operands.compile().mlir_text()
-    bool_lit = issue_1332_bool_literal_rhs.compile().mlir_text()
-    assert "arith.constant true" in bool_lit, bool_lit
+    issue_1332_plain_python_operands.compile().mlir_text()
+    bool_lit_module = issue_1332_bool_literal_rhs.mlir_module()
+    assert _has_result_type(bool_lit_module, "arith.constant", "i1")
 
     _expect_error(
         lambda: issue_1332_float_control.compile().mlir_text(),
@@ -359,14 +397,21 @@ def main():
         "type mismatch",
     )
     _expect_error(
+        lambda: issue_1332_float_rhs_literal.compile().mlir_text(),
+        "float literals",
+    )
+    _expect_error(
         lambda: issue_1332_no_ast_rewrite.compile().mlir_text(),
         "native Python if/while condition cannot consume a PTODSL runtime value",
     )
 
     # Source-less functions keep the pre-rewrite tracing behavior: the
     # rewriter returns them untouched instead of synthesizing helper calls.
-    exec("def _source_less(x):\n    return x\n")
-    source_less_fn = locals()["_source_less"]
+    source_less_fn = FunctionType(
+        (lambda value: value).__code__.replace(co_filename="<source-less>"),
+        globals(),
+        "_source_less",
+    )
     try:
         inspect.getsource(source_less_fn)
     except (OSError, TypeError):

--- a/ptodsl/tests/test_boolop_short_circuit.py
+++ b/ptodsl/tests/test_boolop_short_circuit.py
@@ -11,6 +11,7 @@ import inspect
 from types import FunctionType
 
 from ptodsl import pto, scalar
+from ptoas.mlir.dialects import arith
 from ptodsl._ast_rewrite import PTODSLAstRewriteError, rewrite_jit_function
 
 
@@ -341,7 +342,13 @@ def main():
     int_lhs_module = issue_1332_integer_lhs.mlir_module()
     # Integer LHS becomes a non-zero i1 control condition; the integer operand
     # is preserved and the i1 RHS widens to the integer type.
-    assert len(_ops(int_lhs_module, "arith.cmpi")) == 1
+    int_lhs_ifs = _ops(int_lhs_module, "scf.if")
+    assert len(int_lhs_ifs) == 1
+    int_lhs_condition = int_lhs_ifs[0].operation.operands[0].owner
+    assert int_lhs_condition is not None
+    assert int_lhs_condition.operation.name == "arith.cmpi"
+    predicate = int_lhs_condition.operation.attributes["predicate"]
+    assert predicate.value == int(arith.CmpIPredicate.ne)
     assert _ops(int_lhs_module, "arith.extui")
     assert _has_result_type(int_lhs_module, "scf.if", "i32")
     int_operands_module = issue_1332_integer_operands.mlir_module()

--- a/ptodsl/tests/test_issue_1332_boolop_short_circuit.py
+++ b/ptodsl/tests/test_issue_1332_boolop_short_circuit.py
@@ -116,7 +116,66 @@ def issue_1332_integer_operands(x: pto.i32, y: pto.i32, out: pto.ptr(pto.i32, "g
     scalar.store(pred, out, 0)
 
 
+
+
+@pto.jit(name="issue_1332_integer_or_lhs", kernel_kind="vector", target="a5")
+def issue_1332_integer_or_lhs(x: pto.i32, y: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    pred = x or (y > 0)
+    scalar.store(pred, out, 0)
+
+
+@pto.jit(name="issue_1332_flag_integer_rhs", kernel_kind="vector", target="a5")
+def issue_1332_flag_integer_rhs(flag: pto.i1, y: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    pred = flag and y
+    scalar.store(pred, out, 0)
+
+
+# Static floats and ints keep native Python truthiness and operand results at
+# trace time (runtime float controls are still diagnosed).
+
+
+@pto.jit(name="issue_1332_static_float", kernel_kind="vector", target="a5")
+def issue_1332_static_float(f: pto.i1, out: pto.ptr(pto.i8, "gm")):
+    pred_a = 0.0 or True
+    if pred_a is not True:
+        return
+    pred_b = 1.0 and f
+    scalar.store(pred_b, out, 0)
+
+
+@pto.jit(name="issue_1332_static_int_operands", kernel_kind="vector", target="a5")
+def issue_1332_static_int_operands(out: pto.ptr(pto.i8, "gm")):
+    a = 2 and True
+    if a is not True:
+        return
+    b = 0 and True
+    if b != 0:
+        return
+    c = 5 or (1 > 2)
+    if c != 5:
+        return
+    d = 0 or (1 > 2)
+    if d is not False:
+        return
+    scalar.store(pto.const(3, dtype=pto.i8), out, 0)
+
+
+# and/or inside an @pto.func helper body.
+
+
+@pto.func(returns=pto.i1)
+def issue_1332_func_and(a: pto.i1, b: pto.i1) -> pto.i1:
+    return a and b
+
+
+@pto.jit(name="issue_1332_func_call", kernel_kind="vector", target="a5")
+def issue_1332_func_call(x: pto.i32, y: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    pred = issue_1332_func_and(x > 0, y > 0)
+    scalar.store(pred, out, 0)
+
+
 # ``runtime_value and True`` materializes the Python bool to an i1 const in
+# the branch merge.
 # the branch merge.
 
 
@@ -185,11 +244,33 @@ def _expect_error(fn, needle):
 def main():
     and_mlir = issue_1332_and_kernel.compile().mlir_text()
     or_mlir = issue_1332_or_kernel.compile().mlir_text()
-    # The guarded RHS (division) must live inside an scf.if region.
-    assert "scf.if" in and_mlir and "arith.floordivsi" in and_mlir
-    assert "scf.if" in or_mlir and "arith.floordivsi" in or_mlir
-    # Short-circuit control uses the LHS predicate, not the division result.
-    assert "arith.cmpi ne, %" in and_mlir or "arith.cmpi ne" in and_mlir
+
+    # The guarded RHS (division) must live inside the scf.if branch and the
+    # condition must come from the LHS comparison.  Verify by walking the
+    # emitted module rather than matching text fragments.
+    def _walk(op):
+        yield op
+        for region in op.operation.regions:
+            for block in region.blocks:
+                for child in block.operations:
+                    yield from _walk(child)
+
+    def _guarded_division(module, region_index):
+        scf_ifs = [op for op in _walk(module) if op.operation.name == "scf.if"]
+        assert scf_ifs, "expected scf.if in the short-circuit kernel"
+        scf_if = scf_ifs[0]
+        cond_owner = scf_if.operation.operands[0].owner
+        assert cond_owner is not None and cond_owner.operation.name == "arith.cmpi", (
+            "scf.if condition must be the LHS comparison",
+        )
+        names = []
+        for block in scf_if.operation.regions[region_index].blocks:
+            for child in block.operations:
+                names.extend(op.operation.name for op in _walk(child))
+        assert "arith.floordivsi" in names, f"guarded division missing from region {region_index}"
+
+    _guarded_division(issue_1332_and_kernel.mlir_module(), 0)  # and: then region
+    _guarded_division(issue_1332_or_kernel.mlir_module(), 1)   # or: else region
 
     chain_and = issue_1332_and_chain.compile().mlir_text()
     chain_or = issue_1332_or_chain.compile().mlir_text()
@@ -209,11 +290,21 @@ def main():
     assert "floordiv" not in static_mlir, static_mlir
 
     int_lhs = issue_1332_integer_lhs.compile().mlir_text()
-    # Integer LHS becomes a non-zero i1 control condition.
-    assert int_lhs.count("arith.cmpi ne") == 2, int_lhs
+    # Integer LHS becomes a non-zero i1 control condition; the integer operand
+    # is preserved and the i1 RHS widens to the integer type.
+    assert int_lhs.count("arith.cmpi ne") == 1, int_lhs
+    assert "arith.extui" in int_lhs and "-> (i32)" in int_lhs, int_lhs
     int_operands = issue_1332_integer_operands.compile().mlir_text()
     # Both integer operands merge back to i32 (Python operand semantics).
     assert "-> (i32)" in int_operands, int_operands
+
+    or_lhs = issue_1332_integer_or_lhs.compile().mlir_text()
+    assert "arith.extui" in or_lhs and "-> (i32)" in or_lhs, or_lhs
+    flag_and = issue_1332_flag_integer_rhs.compile().mlir_text()
+    assert "arith.extui" in flag_and and "-> (i32)" in flag_and, flag_and
+    issue_1332_static_float.compile().mlir_text()
+    issue_1332_static_int_operands.compile().mlir_text()
+    issue_1332_func_call.compile().mlir_text()
 
     plain = issue_1332_plain_python_operands.compile().mlir_text()
     bool_lit = issue_1332_bool_literal_rhs.compile().mlir_text()

--- a/ptodsl/tests/test_issue_1332_boolop_short_circuit.py
+++ b/ptodsl/tests/test_issue_1332_boolop_short_circuit.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import inspect
+
+from ptodsl import pto, scalar
+from ptodsl._ast_rewrite import rewrite_jit_function
+
+
+# Issue #1332 original kernels: Python ``and``/``or`` between runtime
+# predicates must lower to device-side short-circuit ``scf.if`` regions
+# instead of calling ``__bool__`` on a PTODSL runtime value at trace time.
+
+
+@pto.jit(name="issue_1332_and_kernel", kernel_kind="vector", target="a5")
+def issue_1332_and_kernel(value: pto.i32, divisor: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    pred = (divisor != 0) and ((value // divisor) > 0)
+    scalar.store(pred, out, 0)
+
+
+@pto.jit(name="issue_1332_or_kernel", kernel_kind="vector", target="a5")
+def issue_1332_or_kernel(value: pto.i32, divisor: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    pred = (divisor == 0) or ((value // divisor) > 0)
+    scalar.store(pred, out, 0)
+
+
+# Three-operand chains fold right, matching Python semantics.
+
+
+@pto.jit(name="issue_1332_and_chain", kernel_kind="vector", target="a5")
+def issue_1332_and_chain(a: pto.i32, b: pto.i32, c: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    pred = (a > 0) and (b > 0) and (c > 0)
+    scalar.store(pred, out, 0)
+
+
+@pto.jit(name="issue_1332_or_chain", kernel_kind="vector", target="a5")
+def issue_1332_or_chain(a: pto.i32, b: pto.i32, c: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    pred = (a > 0) or (b > 0) or (c > 0)
+    scalar.store(pred, out, 0)
+
+
+# ``and``/``or`` inside an ``if`` condition and a native ``while`` test.
+
+
+@pto.jit(name="issue_1332_if_condition", kernel_kind="vector", target="a5")
+def issue_1332_if_condition(a: pto.i32, b: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    if (a > 0) and (b > 0):
+        scalar.store(pto.const(1, dtype=pto.i8), out, 0)
+    else:
+        scalar.store(pto.const(0, dtype=pto.i8), out, 0)
+
+
+@pto.jit(name="issue_1332_while_test", kernel_kind="vector", target="a5")
+def issue_1332_while_test(x: pto.i32, y: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    i = pto.const(0, dtype=pto.i32)
+    while (i < y) and (x > 0):
+        scalar.store(pto.const(7, dtype=pto.i8), out, i)
+        i = i + 1
+    scalar.store(pto.const(9, dtype=pto.i8), out, 0)
+
+
+# ``and``/``or`` in call-argument position and in ``return``.
+
+
+@pto.jit(name="issue_1332_call_argument", kernel_kind="vector", target="a5")
+def issue_1332_call_argument(a: pto.i32, b: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    pred = (a > 0) and (b > 0)
+    result = scalar.select(
+        pred,
+        pto.const(1, dtype=pto.i32),
+        pto.const(0, dtype=pto.i32),
+    )
+    scalar.store(result, out, 0)
+
+
+@pto.jit(name="issue_1332_return_position", kernel_kind="vector", target="a5")
+def issue_1332_return_position(a: pto.i32, b: pto.i32) -> pto.i1:
+    return (a > 0) or (b > 0)
+
+
+# Static operands short-circuit at trace time: ``1 // 0`` would raise
+# ZeroDivisionError if the RHS were ever traced, so compiling these kernels
+# proves the RHS lambda is not evaluated.
+
+
+@pto.jit(name="issue_1332_static_short_circuit", kernel_kind="vector", target="a5")
+def issue_1332_static_short_circuit(out: pto.ptr(pto.i8, "gm")):
+    pred_and = False and (1 // 0)
+    pred_or = True or (1 // 0)
+    if pred_and is False and pred_or is True:
+        scalar.store(pto.const(1, dtype=pto.i8), out, 0)
+    else:
+        scalar.store(pto.const(0, dtype=pto.i8), out, 0)
+
+
+# Runtime integer left operand: the control condition uses non-zero
+# truthiness while the branch merge reuses the existing integer-to-i1
+# reconciliation rule.
+
+
+@pto.jit(name="issue_1332_integer_lhs", kernel_kind="vector", target="a5")
+def issue_1332_integer_lhs(x: pto.i32, y: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    pred = x and (y > 0)
+    scalar.store(pred, out, 0)
+
+
+@pto.jit(name="issue_1332_integer_operands", kernel_kind="vector", target="a5")
+def issue_1332_integer_operands(x: pto.i32, y: pto.i32, out: pto.ptr(pto.i32, "gm")):
+    pred = x and y
+    scalar.store(pred, out, 0)
+
+
+# ``runtime_value and True`` materializes the Python bool to an i1 const in
+# the branch merge.
+
+
+@pto.jit(name="issue_1332_bool_literal_rhs", kernel_kind="vector", target="a5")
+def issue_1332_bool_literal_rhs(f: pto.i1, out: pto.ptr(pto.i8, "gm")):
+    pred = f and True
+    scalar.store(pred, out, 0)
+
+
+# and/or on plain Python operands (lists, strings) keep native truthiness
+# inside rewritten kernels: TileOps templates use the loops-or-None pattern where
+# loops is a regular Python list that must not be traced as a runtime condition
+# (and must never reach the surface-value validator).
+
+@pto.jit(name="issue_1332_plain_python_operands", kernel_kind="vector", target="a5")
+def issue_1332_plain_python_operands(out: pto.ptr(pto.i8, "gm")):
+    pairs = [(1, 2), (3, 4)] or None
+    if pairs is None or len(pairs) != 2:
+        return
+    empty = [] or None
+    if empty is not None:
+        return
+    kept = "x" or None
+    if kept != "x":
+        return
+    value = pairs and pairs[0]
+    if value != (1, 2):
+        return
+    scalar.store(pto.const(11, dtype=pto.i8), out, 0)
+
+
+# Diagnostics: floating-point controls, incompatible branch merges, and the
+# native behavior preserved when AST rewrite is disabled.
+
+
+@pto.jit(name="issue_1332_float_control", kernel_kind="vector", target="a5")
+def issue_1332_float_control(x: pto.f32, out: pto.ptr(pto.i8, "gm")):
+    pred = x and (x > 0)
+    scalar.store(pred, out, 0)
+
+
+@pto.jit(name="issue_1332_incompatible_merge", kernel_kind="vector", target="a5")
+def issue_1332_incompatible_merge(x: pto.i32, f: pto.f32, out: pto.ptr(pto.i8, "gm")):
+    pred = (x > 0) and f
+    scalar.store(pred, out, 0)
+
+
+@pto.jit(name="issue_1332_no_ast_rewrite", kernel_kind="vector", target="a5", ast_rewrite=False)
+def issue_1332_no_ast_rewrite(x: pto.i32, y: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    pred = (x > 0) and (y > 0)
+    scalar.store(pred, out, 0)
+
+
+def _expect_error(fn, needle):
+    try:
+        fn()
+    except Exception as exc:
+        if needle in str(exc):
+            return
+        raise AssertionError(
+            f"expected error containing {needle!r}, got: {type(exc).__name__}: {exc}"
+        ) from exc
+    raise AssertionError(f"expected {needle!r} error, but no error was raised")
+
+
+def main():
+    and_mlir = issue_1332_and_kernel.compile().mlir_text()
+    or_mlir = issue_1332_or_kernel.compile().mlir_text()
+    # The guarded RHS (division) must live inside an scf.if region.
+    assert "scf.if" in and_mlir and "arith.floordivsi" in and_mlir
+    assert "scf.if" in or_mlir and "arith.floordivsi" in or_mlir
+    # Short-circuit control uses the LHS predicate, not the division result.
+    assert "arith.cmpi ne, %" in and_mlir or "arith.cmpi ne" in and_mlir
+
+    chain_and = issue_1332_and_chain.compile().mlir_text()
+    chain_or = issue_1332_or_chain.compile().mlir_text()
+    # a and b and c lowers to two nested scf.if regions.
+    assert chain_and.count("scf.if") == 2, chain_and
+    assert chain_or.count("scf.if") == 2, chain_or
+
+    issue_1332_if_condition.compile().mlir_text()
+    issue_1332_while_test.compile().mlir_text()
+    issue_1332_call_argument.compile().mlir_text()
+    ret_mlir = issue_1332_return_position.compile().mlir_text()
+    assert "scf.if" in ret_mlir
+
+    static_mlir = issue_1332_static_short_circuit.compile().mlir_text()
+    # A traced RHS would raise ZeroDivisionError; static operands must also
+    # leave no division in the IR at all.
+    assert "floordiv" not in static_mlir, static_mlir
+
+    int_lhs = issue_1332_integer_lhs.compile().mlir_text()
+    # Integer LHS becomes a non-zero i1 control condition.
+    assert int_lhs.count("arith.cmpi ne") == 2, int_lhs
+    int_operands = issue_1332_integer_operands.compile().mlir_text()
+    # Both integer operands merge back to i32 (Python operand semantics).
+    assert "-> (i32)" in int_operands, int_operands
+
+    plain = issue_1332_plain_python_operands.compile().mlir_text()
+    bool_lit = issue_1332_bool_literal_rhs.compile().mlir_text()
+    assert "arith.constant true" in bool_lit, bool_lit
+
+    _expect_error(
+        lambda: issue_1332_float_control.compile().mlir_text(),
+        "short-circuit",
+    )
+    _expect_error(
+        lambda: issue_1332_incompatible_merge.compile().mlir_text(),
+        "type mismatch",
+    )
+    _expect_error(
+        lambda: issue_1332_no_ast_rewrite.compile().mlir_text(),
+        "native Python if/while condition cannot consume a PTODSL runtime value",
+    )
+
+    # Source-less functions keep the pre-rewrite tracing behavior: the
+    # rewriter returns them untouched instead of synthesizing helper calls.
+    exec("def _source_less(x):\n    return x\n")
+    source_less_fn = locals()["_source_less"]
+    try:
+        inspect.getsource(source_less_fn)
+    except (OSError, TypeError):
+        pass
+    else:
+        raise AssertionError("test function unexpectedly has retrievable source")
+    assert rewrite_jit_function(source_less_fn) is source_less_fn
+
+    print("issue 1332 short-circuit checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/ptodsl/tests/test_issue_1332_boolop_short_circuit.py
+++ b/ptodsl/tests/test_issue_1332_boolop_short_circuit.py
@@ -207,6 +207,26 @@ def issue_1332_plain_python_operands(out: pto.ptr(pto.i8, "gm")):
     scalar.store(pto.const(11, dtype=pto.i8), out, 0)
 
 
+
+
+@pto.jit(name="issue_1332_index_lhs", kernel_kind="vector", target="a5")
+def issue_1332_index_lhs(idx: pto.index, y: pto.i32, out: pto.ptr(pto.i8, "gm")):
+    pred = idx and (y > 0)
+    scalar.store(pred, out, 0)
+
+
+@pto.jit(name="issue_1332_int_literal_anchored", kernel_kind="vector", target="a5")
+def issue_1332_int_literal_anchored(x: pto.i32, out: pto.ptr(pto.i32, "gm")):
+    pred = x or 2
+    scalar.store(pred, out, 0)
+
+
+@pto.jit(name="issue_1332_int_literal_vs_i1", kernel_kind="vector", target="a5")
+def issue_1332_int_literal_vs_i1(flag: pto.i1, out: pto.ptr(pto.i8, "gm")):
+    pred = flag and 2
+    scalar.store(pred, out, 0)
+
+
 # Diagnostics: floating-point controls, incompatible branch merges, and the
 # native behavior preserved when AST rewrite is disabled.
 
@@ -302,6 +322,16 @@ def main():
     assert "arith.extui" in or_lhs and "-> (i32)" in or_lhs, or_lhs
     flag_and = issue_1332_flag_integer_rhs.compile().mlir_text()
     assert "arith.extui" in flag_and and "-> (i32)" in flag_and, flag_and
+    index_lhs = issue_1332_index_lhs.compile().mlir_text()
+    # index + i1: the index type is kept and the i1 side widens via index_cast.
+    assert "arith.index_cast" in index_lhs and "-> (index)" in index_lhs, index_lhs
+    anchored = issue_1332_int_literal_anchored.compile().mlir_text()
+    # A Python int literal anchors to the integer branch type.
+    assert "arith.constant 2 : i32" in anchored and "-> (i32)" in anchored, anchored
+    _expect_error(
+        lambda: issue_1332_int_literal_vs_i1.compile().mlir_text(),
+        "cannot infer an integer width",
+    )
     issue_1332_static_float.compile().mlir_text()
     issue_1332_static_int_operands.compile().mlir_text()
     issue_1332_func_call.compile().mlir_text()

--- a/ptodsl/tests/test_issue_1332_boolop_short_circuit.py
+++ b/ptodsl/tests/test_issue_1332_boolop_short_circuit.py
@@ -325,6 +325,16 @@ def main():
     index_lhs = issue_1332_index_lhs.compile().mlir_text()
     # index + i1: the index type is kept and the i1 side widens via index_cast.
     assert "arith.index_cast" in index_lhs and "-> (index)" in index_lhs, index_lhs
+    # The i1 -> index widening must keep the 0/1 truth value: a direct
+    # arith.index_cast from i1 sign-extends (1 becomes -1 on the simulator),
+    # so the widening must zero-extend through i32 first.
+    index_casts = [op for op in _walk(issue_1332_index_lhs.mlir_module())
+                    if op.operation.name == "arith.index_cast"]
+    assert any(
+        op.operation.operands[0].owner is not None
+        and op.operation.operands[0].owner.operation.name == "arith.extui"
+        for op in index_casts
+    ), "i1->index widening must zero-extend via extui first"
     anchored = issue_1332_int_literal_anchored.compile().mlir_text()
     # A Python int literal anchors to the integer branch type.
     assert "arith.constant 2 : i32" in anchored and "-> (i32)" in anchored, anchored

--- a/test/dsl-st/boolop_short_circuit.py
+++ b/test/dsl-st/boolop_short_circuit.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Runtime numerical coverage for Python ``and``/``or`` expressions."""
+
+import numpy as np
+
+from common import auto_main, golden_output_case
+from ptodsl import pto, scalar
+
+
+ELEMENTS = 8
+
+
+@pto.jit(
+    name="boolop_and_short_circuit",
+    kernel_kind="vector",
+    target="a5",
+    mode="explicit",
+    insert_sync=False,
+)
+def boolop_and_short_circuit(
+    values: pto.ptr(pto.i32, "gm"),
+    divisors: pto.ptr(pto.i32, "gm"),
+    output: pto.ptr(pto.i8, "gm"),
+):
+    for i in range(ELEMENTS):
+        value = scalar.load(values, i)
+        divisor = scalar.load(divisors, i)
+        result = (divisor != 0) and ((value // divisor) > 0)
+        scalar.store(result, output, i)
+
+
+@pto.jit(
+    name="boolop_or_short_circuit",
+    kernel_kind="vector",
+    target="a5",
+    mode="explicit",
+    insert_sync=False,
+)
+def boolop_or_short_circuit(
+    values: pto.ptr(pto.i32, "gm"),
+    divisors: pto.ptr(pto.i32, "gm"),
+    output: pto.ptr(pto.i8, "gm"),
+):
+    for i in range(ELEMENTS):
+        value = scalar.load(values, i)
+        divisor = scalar.load(divisors, i)
+        result = (divisor == 0) or ((value // divisor) > 0)
+        scalar.store(result, output, i)
+
+
+@pto.jit(
+    name="boolop_int_or_keeps_operand",
+    kernel_kind="vector",
+    target="a5",
+    mode="explicit",
+    insert_sync=False,
+)
+def boolop_int_or_keeps_operand(
+    lhs: pto.ptr(pto.i32, "gm"),
+    rhs: pto.ptr(pto.i32, "gm"),
+    output: pto.ptr(pto.i32, "gm"),
+):
+    for i in range(ELEMENTS):
+        x = scalar.load(lhs, i)
+        y = scalar.load(rhs, i)
+        result = x or (y > 0)
+        scalar.store(result, output, i)
+
+
+@pto.jit(
+    name="boolop_flag_and_integer_rhs",
+    kernel_kind="vector",
+    target="a5",
+    mode="explicit",
+    insert_sync=False,
+)
+def boolop_flag_and_integer_rhs(
+    flags: pto.ptr(pto.i8, "gm"),
+    values: pto.ptr(pto.i32, "gm"),
+    output: pto.ptr(pto.i32, "gm"),
+):
+    for i in range(ELEMENTS):
+        flag = scalar.load(flags, i)
+        value = scalar.load(values, i)
+        result = (flag != 0) and value
+        scalar.store(result, output, i)
+
+
+@pto.jit(
+    name="boolop_index_and_i1",
+    kernel_kind="vector",
+    target="a5",
+    mode="explicit",
+    insert_sync=False,
+)
+def boolop_index_and_i1(
+    indices: pto.ptr(pto.i32, "gm"),
+    values: pto.ptr(pto.i32, "gm"),
+    output: pto.ptr(pto.i32, "gm"),
+):
+    for i in range(ELEMENTS):
+        index = scalar.index_cast(scalar.load(indices, i))
+        value = scalar.load(values, i)
+        result = index and (value > 0)
+        scalar.store(result, output, i)
+
+
+def make_division_inputs():
+    values = np.array([8, 4, 0, 7, -6, 9, 3, 0], dtype=np.int32)
+    divisors = np.array([2, 0, -2, 1, -3, 0, 1, 4], dtype=np.int32)
+    return [values, divisors]
+
+
+def make_and_expected(values, divisors):
+    safe_divisors = np.where(divisors != 0, divisors, 1)
+    return ((divisors != 0) & (np.floor_divide(values, safe_divisors) > 0)).astype(np.int8)
+
+
+def make_or_expected(values, divisors):
+    safe_divisors = np.where(divisors != 0, divisors, 1)
+    return ((divisors == 0) | (np.floor_divide(values, safe_divisors) > 0)).astype(np.int8)
+
+
+def make_integer_inputs():
+    lhs = np.array([2, 0, 5, -3, 7, 0, 1, 0], dtype=np.int32)
+    rhs = np.array([1, -2, 3, 0, 4, 5, -1, 0], dtype=np.int32)
+    return [lhs, rhs]
+
+
+def make_int_or_expected(lhs, rhs):
+    return np.where(lhs != 0, lhs, (rhs > 0).astype(np.int32)).astype(np.int32)
+
+
+def make_flag_inputs():
+    flags = np.array([1, 0, 1, 0, 1, 1, 0, 1], dtype=np.int8)
+    values = np.array([7, 3, -4, 6, 2, 0, 9, 8], dtype=np.int32)
+    return [flags, values]
+
+
+def make_flag_and_expected(flags, values):
+    return np.where(flags != 0, values, 0).astype(np.int32)
+
+
+def make_index_inputs():
+    indices = np.array([3, 0, -2, 0, 5, 1, 0, 2], dtype=np.int32)
+    values = np.array([1, 4, 2, 0, -3, 0, 6, 7], dtype=np.int32)
+    return [indices, values]
+
+
+def make_index_and_expected(indices, values):
+    return np.where(indices != 0, (values > 0).astype(np.int32), 0).astype(np.int32)
+
+
+CASES = [
+    golden_output_case(
+        "boolop_and_short_circuit",
+        boolop_and_short_circuit,
+        inputs=make_division_inputs,
+        expected=make_and_expected,
+        rtol=0.0,
+        atol=0.0,
+    ),
+    golden_output_case(
+        "boolop_or_short_circuit",
+        boolop_or_short_circuit,
+        inputs=make_division_inputs,
+        expected=make_or_expected,
+        rtol=0.0,
+        atol=0.0,
+    ),
+    golden_output_case(
+        "boolop_int_or_keeps_operand",
+        boolop_int_or_keeps_operand,
+        inputs=make_integer_inputs,
+        expected=make_int_or_expected,
+        rtol=0.0,
+        atol=0.0,
+    ),
+    golden_output_case(
+        "boolop_flag_and_integer_rhs",
+        boolop_flag_and_integer_rhs,
+        inputs=make_flag_inputs,
+        expected=make_flag_and_expected,
+        rtol=0.0,
+        atol=0.0,
+    ),
+    golden_output_case(
+        "boolop_index_and_i1",
+        boolop_index_and_i1,
+        inputs=make_index_inputs,
+        expected=make_index_and_expected,
+        rtol=0.0,
+        atol=0.0,
+    ),
+]
+
+
+auto_main(globals())


### PR DESCRIPTION
## Summary

Support Python ``and`` / ``or`` between PTODSL runtime predicates in ``@pto.jit`` / ``@pto.func`` AST-rewritten kernels (issue #1332).

Python ``and``/``or`` are not overloadable: evaluating ``a and b`` forces a truth check that calls ``__bool__`` on a PTODSL runtime value during tracing and raises. This PR lowers ``ast.BoolOp`` expressions into device-side shor-circuit ``scf.if`` regions that keep Python short-circuit semantics: the RHS is only traced inside the branch that Python would actually evaluate.

### Implementation

- ``ptodsl/_ast_rewrite.py``: new ``_BoolOpRewriter`` pass that rewrites every ``ast.BoolOp`` into a right-nested lazy helper call (``a and b and c`` -> ``pto._short_circuit_and(a, lambda: pto._short_circuit_and(b, lambda: c))``). Covers assignments, call arguments, ``return``, and ``if``/``while`` conditions.
- ``ptodsl/_control_flow.py``: internal ``_short_circuit_and`` / ``_short_circuit_or`` helpers built on the existing ``pto.if_`` + ``br.assign`` machinery, producing a result-bearing ``scf.if``. The LHS is the control condition (integer operands use non-zero truthiness); the branch merge reuses the existing ``i1`` reconciliation rules; Python ``bool`` literals materialize as ``i1`` constants (`flag and True`).
- Plain Python operands (lists, tuples, strings, ...) keep native Python truthiness at trace time (e.g. TileOps templates use ``loops or None`` where ``loops`` is a Python list); floating-point control values raise a clear diagnostic.
- ``ptodsl/pto.py``: export the two internal helpers.
- No backend changes: existing ``scf.if`` / comparisons already express the semantics.

### Tests

- New ``ptodsl/tests/test_issue_1332_boolop_short_circuit.py`` covering: the issue's original ``and``/``or`` kernels, 3+ operand chains, RHS with division/load inside the guarded region, ``and``/``or`` in ``if`` conditions / native ``while`` tests / call arguments / ``return``, static short-circuit (`False and rhs`, `True or rhs` never traced), runtime integer LHS with ``i1`` merge, ``f and True`` bool-literal materialization, and diagnostics (float control, incompatible branch merge, ``ast_rewrite=False``, source-less functions).
- Docs: new *Short-circuit ``and`` / ``or``* section in ``ptodsl/docs/user_guide/05-control-flow.md`` with a compile-mode example, plus a summary-table row.

### Validation

- Full fresh build (``ptoas`` + ``PTOPythonModules``) and the complete ``ptodsl/tests`` suite on dev-481211 (aarch64 Linux / LLVM 19 / Python 3.10): **42/42 pass**, including ``test_jit_compile``, ``test_scf_while_ast``, ``test_issue_1126_bool_merge``, all tilelib suites, and the new issue-1332 test.

Fixes #1332.