### PR TITLE
add vcvt f162bf16 and s82f16

### DIFF
--- a/docs/isa/micro-isa/09-conversion-ops.md
+++ b/docs/isa/micro-isa/09-conversion-ops.md
@@ -154,6 +154,7 @@ destination lane group.
 - `%dst = pto.vcvt %src, %mask {rnd, sat, part} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>`
 - `%dst = pto.vcvt %src, %mask {rnd, sat, part} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xbf16>`
 - `%dst = pto.vcvt %src, %mask {rnd, sat} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<128xf16>`
+- `%dst = pto.vcvt %src, %mask {rnd} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xbf16>`
 - `%dst = pto.vcvt %src, %mask {part} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xf32>`
 - `%dst = pto.vcvt %src, %mask {part} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xf32>`
 
@@ -198,7 +199,7 @@ per-form entries above as the source of truth.
 | `ui32` | Y |  | Y | Y |  |  |  |  |  |  |
 | `si32` | Y |  | Y | Y |  |  | Y |  | Y |  |
 | `si64` |  |  |  |  |  |  |  |  |  |  |
-| `f16` | Y | Y |  | Y |  | Y |  |  | Y |  |
+| `f16` | Y | Y |  | Y |  | Y |  |  | Y | Y |
 | `f32` |  |  |  | Y |  | Y | Y | Y |  | Y |
 | `bf16` |  |  |  |  |  | Y |  | Y | Y |  |
 

--- a/docs/isa/vmi-isa/06-convert.md
+++ b/docs/isa/vmi-isa/06-convert.md
@@ -22,7 +22,7 @@
 
   2. **FpNarrow** — `fp → fp`, `|dst| < |src|` (e.g. `f32 → f16`,
      `f32 → bf16`, `f32 → fp8_e4m3`, `bf16x2 → f4x2`). Same-width `fp → fp`
-     (`|dst| == |src|`, e.g. `bf16 → f16`).
+     (`|dst| == |src|`, e.g. `bf16 → f16`, `f16 → bf16`).
 
   3. **FpToSi** — `fp → signed int`. Supported pairs follow the contract
      table `lookupVMIFpToSiContract`: `f32→s32`, `f16→s16`, `f32→s16`,
@@ -58,7 +58,7 @@
   | Attribute | Values | Valid for | Description |
   |---|---|---|---|
   | `rounding` | `"R"` (nearest-even), `"A"` (away-from-zero), `"H"` (half-up), `"Z"` (toward-zero); for the `bf16x2→f4x2` contract pair the allowed set is `"R"`,`"A"`,`"F"` (floor), `"C"` (ceil), `"Z"` (toward-zero) — `"H"` is **rejected** | fp narrowing | Rounding mode |
-  | `saturate` | `"SAT"`, `"NOSAT"` | required for fp-narrow / int-narrow; for fp→si / fp→ui the requirement follows the vcvt contract's `requiresSat` (e.g. `f16→s8` required, `f16→s32` **forbidden** — no overflow possible; same-width `bf16→f16` required); the `bf16x2→f4x2` narrow has `requiresSat=false` — any `saturate` is **forbidden** | `SAT` clamps to ±max of the destination type; `NOSAT` performs a direct bit truncation of the result representation. |
+  | `saturate` | `"SAT"`, `"NOSAT"` | required for fp-narrow / int-narrow; for fp→si / fp→ui the requirement follows the vcvt contract's `requiresSat` (e.g. `f16→s8` required, `f16→s32` **forbidden** — no overflow possible; same-width `bf16→f16` required, same-width `f16→bf16` **forbidden**); the `bf16x2→f4x2` narrow has `requiresSat=false` — any `saturate` is **forbidden** | `SAT` clamps to ±max of the destination type; `NOSAT` performs a direct bit truncation of the result representation. |
 
 - **datatypes:** Source and destination from `{f32, f16, bf16, fp8_e4m3, fp8_e5m2, i32, i16, i8, ui32, ui16, ui8}`; packed carrier types `{!pto.bf16x2, !pto.f4E1M2x2, !pto.f4E2M1x2}` for the bf16x2↔f4x2 fp-to-fp pair (see contract `lookupVMIFpToFpContract`). `bf16x2` is **conversion-only** — it may not appear as a compute element type (`vfadd`/`vfmul`/`vcmp`/...).
 - **lowering to `pto.mi`:**
@@ -69,7 +69,7 @@
   | 8↔32 (radix-4) | widen: `UNPK_B8` + `vintlv` + `vcvt P0` + `punpack`; narrow: `PK4_B32` store (or `vselr` gather) + `ppack` | `2–3` | `2–3` |
   | f32→fp8 quant | `1 cast` + `PK4_B32` | `K` | `1` |
   | f32→int8 quant | 3-stage cast + `PK4_B32` | `~3K` | `3` |
-  | fp↔fp same-width (`bf16→f16`) | `K × vcvt` (1:1, no part) | `K` | `1` |
+  | fp↔fp same-width (`bf16→f16`, `f16→bf16`) | `K × vcvt` (1:1, no part) | `K` | `1` |
   | fp→si / fp→ui | per contract pair: same-width 1:1, widen EVEN/ODD, narrow EVEN/ODD+Vor | `K`–`~3K` | `2`–`3` |
   | int↔int (same width) | `K × vtrc` or `K × vcvt` | `K` | `1` |
   | `bf16x2→f4x2` narrow (32→8) | source viewed as raw `bf16` lanes (2 bf16/bf16x2); `vcvt{P0}` 1:1, `rnd` set, **no sat**; reuse prior pairing `vbitcast` when present | `K` | `1` |

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -813,7 +813,7 @@ lookupVMIFpToFpContract(Type srcElem, Type dstElem) {
     return VMIFpToFpContract{/*requiresRnd=*/false, /*requiresSat=*/false,
                             /*requiresPart=*/true,
                             /*allowedRndModes=*/StringRef()};
-}
+  }
   if (srcBits != dstBits) {
     return std::nullopt;
   }
@@ -822,7 +822,15 @@ lookupVMIFpToFpContract(Type srcElem, Type dstElem) {
     return VMIFpToFpContract{/*requiresRnd=*/true, /*requiresSat=*/true,
                             /*requiresPart=*/false,
                             /*allowedRndModes=*/StringRef()};
-}
+  }
+  // f16 -> bf16: same-width, rnd, NO sat, no part.
+  bool srcIsF16 = srcElem.isF16();
+  bool dstIsBF16 = dstElem.isBF16();
+  if (srcIsF16 && dstIsBF16) {
+    return VMIFpToFpContract{/*requiresRnd=*/true, /*requiresSat=*/false,
+                            /*requiresPart=*/false,
+                            /*allowedRndModes=*/StringRef()};
+  }
   return std::nullopt;
 }
 
@@ -2304,11 +2312,19 @@ LogicalResult VMISIToFPOp::verify() {
   if (!isVMIFloatLikeType(resultType.getElementType())) {
     return emitOpError("requires floating-point-like result element type");
   }
-  if (getVMIElementBitWidth(sourceType.getElementType()) != mlir::pto::kValue32) {
-    return emitOpError("requires 32-bit integer source element type");
-  }
-  if (!resultType.getElementType().isF32()) {
-    return emitOpError("requires f32 result element type");
+  unsigned srcBits = getVMIElementBitWidth(sourceType.getElementType());
+  if (srcBits == mlir::pto::kValue32) {
+    if (!resultType.getElementType().isF32()) {
+      return emitOpError("requires f32 result element type for 32-bit "
+                         "integer source");
+    }
+  } else if (srcBits == mlir::pto::kValue8) {
+    if (!resultType.getElementType().isF16()) {
+      return emitOpError("requires f16 result element type for 8-bit "
+                         "integer source");
+    }
+  } else {
+    return emitOpError("supports only si32 -> f32 or si8 -> f16");
   }
   return success();
 }

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -1771,6 +1771,9 @@ static std::optional<VcvtContract> lookupVcvtContract(VcvtElemKind src,
     case VcvtElemKind::U8:
       return VcvtContract{/*requiresRnd=*/true, /*requiresSat=*/true,
                           /*requiresPart=*/true};
+    case VcvtElemKind::BF16:
+      return VcvtContract{/*requiresRnd=*/true, /*requiresSat=*/false,
+                          /*requiresPart=*/false};
     default:
       return std::nullopt;
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10869,7 +10869,8 @@ struct OneToNVMITruncFOpPattern : OneToNOpConversionPattern<VMITruncFOp> {
 
     unsigned resultBits = pto::getPTOStorageElemBitWidth(
         resultVRegTypes.front().getElementType());
-    // Same-width fp->fp (bf16 -> f16): dense contiguous 1:1, no part, rnd+sat.
+    // Same-width fp->fp (bf16 -> f16, f16 -> bf16): dense contiguous 1:1,
+    // no part; rnd always, sat follows the fp-to-fp contract.
     if (sourceBits == resultBits && sourceLayout && resultLayout &&
         sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 1 &&
         resultLayout.isContiguous() && resultLayout.getLaneStride() == 1 &&
@@ -12053,40 +12054,96 @@ struct OneToNVMISIToFPOpPattern : OneToNOpConversionPattern<VMISIToFPOp> {
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (sourceParts.size() != resultTypes.size())
+
+    auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
+    if (!sourceType || !isa<IntegerType>(sourceType.getElementType())) {
       return rewriter.notifyMatchFailure(
-          op, "sitofp physical source/result arity mismatch");
+          op, "sitofp requires integer source chunks");
+    }
+    unsigned sourceBits =
+        pto::getPTOStorageElemBitWidth(sourceType.getElementType());
+
+    SmallVector<VRegType> resultVRegTypes;
+    resultVRegTypes.reserve(resultTypes.size());
+    for (Type resultType : resultTypes) {
+      auto resultVRegType = dyn_cast<VRegType>(resultType);
+      if (!resultVRegType ||
+          (!resultVRegTypes.empty() &&
+           resultVRegType != resultVRegTypes.front())) {
+        return rewriter.notifyMatchFailure(
+            op, "unsupported physical sitofp result type");
+      }
+      resultVRegTypes.push_back(resultVRegType);
+    }
+    unsigned resultBits = pto::getPTOStorageElemBitWidth(
+        resultVRegTypes.front().getElementType());
+
+    FailureOr<Value> mask =
+        createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
+    if (failed(mask)) {
+      return rewriter.notifyMatchFailure(op, "failed to build sitofp mask");
+    }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
-    StringAttr rnd = rewriter.getStringAttr("R");
-    for (auto [sourcePart, resultType] :
-         llvm::zip_equal(sourceParts, resultTypes)) {
-      auto sourceType = dyn_cast<VRegType>(sourcePart.getType());
-      auto resultVRegType = dyn_cast<VRegType>(resultType);
-      if (!sourceType || !isa<IntegerType>(sourceType.getElementType()) ||
-          pto::getPTOStorageElemBitWidth(sourceType.getElementType()) != 32 ||
-          !resultVRegType || !resultVRegType.getElementType().isF32())
-        return rewriter.notifyMatchFailure(
-            op, "sitofp requires physical 32-bit integer source and f32 "
-                "result chunks");
 
-      FailureOr<Value> mask =
-          createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
-      if (failed(mask))
-        return rewriter.notifyMatchFailure(op, "failed to build sitofp mask");
-      results.push_back(rewriter
-                            .create<VcvtOp>(op.getLoc(), resultVRegType,
-                                            sourcePart, *mask, rnd,
-                                            /*sat=*/nullptr, /*part=*/nullptr)
-                            .getResult());
+    // si32 -> f32: same-width 1:1, no part, rnd=R.
+    if (sourceBits == 32 && resultBits == 32) {
+      size_t srcArity = sourceParts.size();
+      size_t dstArity = resultTypes.size();
+      if (srcArity != dstArity) {
+        return rewriter.notifyMatchFailure(
+            op, "si32->f32 requires matching physical arity");
+      }
+      StringAttr rnd = rewriter.getStringAttr("R");
+      for (auto [sourcePart, resultVRegType] :
+           llvm::zip_equal(sourceParts, resultVRegTypes)) {
+        results.push_back(rewriter
+                              .create<VcvtOp>(op.getLoc(), resultVRegType,
+                                              sourcePart, *mask, rnd,
+                                              /*sat=*/nullptr,
+                                              /*part=*/nullptr)
+                              .getResult());
+      }
+      replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                       *this->getTypeConverter());
+      return success();
     }
 
-    replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
-    return success();
+    // si8 -> f16: 8->16 widening, EvenOdd parts, no rnd/sat.
+    if (sourceBits == 8 && resultBits == 16) {
+      size_t expectedResults = 2 * sourceParts.size();
+      size_t actualResults = resultTypes.size();
+      if (actualResults != expectedResults) {
+        return rewriter.notifyMatchFailure(
+            op, "si8->f16 requires result arity = 2 x source arity");
+      }
+      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+      for (int64_t partIndex = 0; partIndex < 2; ++partIndex) {
+        for (auto [chunkIndex, sourcePart] :
+             llvm::enumerate(sourceParts)) {
+          VRegType resultType =
+              resultVRegTypes[partIndex * sourceParts.size() + chunkIndex];
+          results.push_back(
+              rewriter
+                  .create<VcvtOp>(op.getLoc(), resultType, sourcePart, *mask,
+                                  /*rnd=*/nullptr, /*sat=*/nullptr,
+                                  rewriter.getStringAttr(
+                                      kEvenOddParts[partIndex]))
+                  .getResult());
+        }
+      }
+      replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                       *this->getTypeConverter());
+      return success();
+    }
+
+    return rewriter.notifyMatchFailure(
+        op, "unsupported sitofp source/result width relation");
   }
 };
 
@@ -12808,8 +12865,9 @@ LogicalResult checkSupportedFPToUIShape(VMIFPToUIOp op,
 LogicalResult checkSupportedSIToFPShape(VMISIToFPOp op,
                                         std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -12817,29 +12875,49 @@ LogicalResult checkSupportedSIToFPShape(VMISIToFPOp op,
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !resultLayout)
+  if (!sourceLayout || !resultLayout) {
     return fail("requires assigned source/result layouts");
-  if (sourceLayout != resultLayout)
-    return fail("requires source/result layouts to match");
-  if (!isa<IntegerType>(sourceType.getElementType()) ||
-      pto::getPTOStorageElemBitWidth(sourceType.getElementType()) != 32)
-    return fail("requires 32-bit integer source element type");
-  if (!resultType.getElementType().isF32())
-    return fail("requires f32 result element type");
-  FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
-  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(sourceArity) || failed(resultArity) ||
-      *sourceArity != *resultArity)
-    return fail("requires matching computable physical arity");
+  }
+  unsigned srcBits = pto::getPTOStorageElemBitWidth(sourceType.getElementType());
+  unsigned dstBits = pto::getPTOStorageElemBitWidth(resultType.getElementType());
+  if (srcBits == 32 && dstBits == 32) {
+    if (sourceLayout != resultLayout) {
+      return fail("si32->f32 requires matching layouts");
+    }
+    if (!resultType.getElementType().isF32()) {
+      return fail("requires f32 result element type");
+    }
+    FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
+    FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
+    bool aritiesOk = succeeded(sourceArity) && succeeded(resultArity) &&
+        *sourceArity == *resultArity;
+    if (!aritiesOk) {
+      return fail("requires matching computable physical arity");
+    }
+  } else if (srcBits == 8 && dstBits == 16) {
+    if (!resultType.getElementType().isF16()) {
+      return fail("requires f16 result element type");
+    }
+    VMILayoutSupport layoutSupport;
+    if (failed(layoutSupport.getCastLayoutFactForLayouts(
+            sourceType, resultType, sourceLayout, resultLayout, reason))) {
+      return failure();
+    }
+  } else {
+    return fail("supports only si32 -> f32 or si8 -> f16");
+  }
   return success();
 }
 
 LogicalResult checkSupportedBitcastShape(VMIBitcastOp op, std::string *reason) {
   VMILayoutSupport supports;
-  if (failed(supports.getBitcastSupport(op, reason)))
+  if (failed(supports.getBitcastSupport(op, reason))) {
     return failure();
+  }
   return success();
 }
+
+
 
 LogicalResult
 checkSupportedChannelSplitShape(VMIChannelSplitOp op,
@@ -14221,13 +14299,13 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto sitofp = dyn_cast<VMISIToFPOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedSIToFPShape(sitofp, &reason)))
+      if (succeeded(checkSupportedSIToFPShape(sitofp, &reason))) {
         return WalkResult::advance();
+      }
 
       sitofp.emitError()
           << kVMIDiagUnsupportedPrefix
-          << "pto.vmi.sitofp supports 32-bit integer source chunks to "
-             "matching f32 result chunks with identical assigned layouts ("
+          << "pto.vmi.sitofp supports si32->f32 or si8->f16 conversion shapes ("
           << reason << ")";
       return WalkResult::interrupt();
     }
@@ -14286,8 +14364,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto bitcast = dyn_cast<VMIBitcastOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedBitcastShape(bitcast, &reason)))
+      if (succeeded(checkSupportedBitcastShape(bitcast, &reason))) {
         return WalkResult::advance();
+      }
 
       bitcast.emitError()
           << kVMIDiagUnsupportedPrefix

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitterTypeHelpers.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitterTypeHelpers.cpp
@@ -1280,6 +1280,7 @@ constexpr VcvtContractEntry kVcvtContractEntries[] = {
     {VcvtElemKind::F16, VcvtElemKind::F8E5M2, {"llvm.hivm.vcvtff.f162f8e5m2.x", true, true, true, 16, false}},
     {VcvtElemKind::F16, VcvtElemKind::HiF8, {"llvm.hivm.vcvtff.f162hif8.x", true, true, true, 16, false}},
     {VcvtElemKind::F16, VcvtElemKind::F32, {"llvm.hivm.vcvtff.f162f32.x", false, false, true, 16, false}},
+    {VcvtElemKind::F16, VcvtElemKind::BF16, {"llvm.hivm.vcvtff.f162bf16.x", true, false, false, 16, false}},
     {VcvtElemKind::F16, VcvtElemKind::S32, {"llvm.hivm.vcvtfi.f162s32.x", true, false, true, 16, false}},
     {VcvtElemKind::F16, VcvtElemKind::S16, {"llvm.hivm.vcvtfi.f162s16.x", true, true, false, 16, false}},
     {VcvtElemKind::F16, VcvtElemKind::S8, {"llvm.hivm.vcvtfi.f162s8.x", true, true, true, 16, false}},

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -1662,6 +1662,8 @@ static std::optional<VcvtContract> lookupVcvtContract(VcvtElemKind src,
       return VcvtContract{"llvm.hivm.vcvtfi.f162s8.x", true, true, true, 16};
     case VcvtElemKind::U8:
       return VcvtContract{"llvm.hivm.vcvtfi.f162u8.x", true, true, true, 16};
+    case VcvtElemKind::BF16:
+      return VcvtContract{"llvm.hivm.vcvtff.f162bf16.x", true, false, false, 16};
     default:
       return std::nullopt;
     }

--- a/test/lit/vmi_new/vmi_conversion_contract_matrix.pto
+++ b/test/lit/vmi_new/vmi_conversion_contract_matrix.pto
@@ -13,6 +13,7 @@
 module {
   func.func @positive(%f16: !pto.vmi.vreg<64xf16>, %f32: !pto.vmi.vreg<64xf32>, %si8: !pto.vmi.vreg<64xsi8>, %ui8: !pto.vmi.vreg<64xui8>, %si16: !pto.vmi.vreg<64xsi16>, %si32: !pto.vmi.vreg<64xsi32>) {
     %fw = pto.vmi.vcvt %f16 : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xf32>
+    %fb = pto.vmi.vcvt %f16 {rounding = "R"} : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xbf16>
     %fn_r = pto.vmi.vcvt %f32 {rounding = "R", saturate = "SAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf16>
     %fn_a = pto.vmi.vcvt %f32 {rounding = "A", saturate = "NOSAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf16>
     %fn_h = pto.vmi.vcvt %f32 {rounding = "H", saturate = "SAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xbf16>
@@ -66,3 +67,5 @@ module {
     return
   }
 }
+
+// CHECK: pto.vmi.vcvt {{.*}} {rounding = "R"} : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xbf16>

--- a/test/lit/vmi_new/vmi_to_vpto_vcvt_f16_to_bf16_same_width.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vcvt_f16_to_bf16_same_width.pto
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Same-width fp->fp conversion (f16 -> bf16) supported by lookupVMIFpToFpContract.
+// This is a VMI-level same-width path: the lowered pto.vcvt must carry
+// rnd="R" and NO saturate/part.
+
+module {
+  func.func @f16_to_bf16_same_width(
+      %input: !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>)
+      -> !pto.vreg<128xbf16> {
+    %cvt = pto.vmi.vcvt %input {rounding = "R"}
+        : !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>
+    %r = "pto.vmi.unpack"(%cvt)
+        : (!pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<128xbf16>
+    return %r : !pto.vreg<128xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @f16_to_bf16_same_width(
+// CHECK: pto.vcvt {{.*}} {rnd = "R"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xbf16>
+// CHECK-NOT: sat
+
+// Omitting rounding is allowed on the VMI surface; lowering defaults to R.
+module {
+  func.func @f16_to_bf16_default_rounding(
+      %input: !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>)
+      -> !pto.vreg<128xbf16> {
+    %cvt = pto.vmi.vcvt %input
+        : !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>
+    %r = "pto.vmi.unpack"(%cvt)
+        : (!pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<128xbf16>
+    return %r : !pto.vreg<128xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @f16_to_bf16_default_rounding(
+// CHECK: pto.vcvt {{.*}} {rnd = "R"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xbf16>
+// CHECK-NOT: sat

--- a/test/lit/vmi_new/vmi_vcvt_f16_to_bf16_invalid_attrs.pto
+++ b/test/lit/vmi_new/vmi_vcvt_f16_to_bf16_invalid_attrs.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS DOCUMENT IS PROVIDED "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --emit-pto-ir %s 2>&1 | FileCheck %s
+
+// f16 -> bf16 is a same-width fp-to-fp contract pair with requiresSat=false,
+// so any saturate attribute must be rejected.
+
+// CHECK: 'pto.vmi.vcvt' op 'saturate' attribute is not valid for this fp-to-fp narrow conversion
+
+module {
+  func.func @f16_to_bf16_with_saturate(%source: !pto.vmi.vreg<64xf16>) {
+    %result = pto.vmi.vcvt %source {rounding = "R", saturate = "SAT"}
+        : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xbf16>
+    return
+  }
+}

--- a/test/lit/vmi_new/vmi_vcvt_s8_to_f16_lower.pto
+++ b/test/lit/vmi_new/vmi_vcvt_s8_to_f16_lower.pto
@@ -6,20 +6,14 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: not ptoas --emit-pto-ir %s 2>&1 | FileCheck %s
-
-// Negative tests for same-width fp->fp vcvt: only bf16->f16 and f16->bf16
-// are in the VMI fp-to-fp contract (lookupVMIFpToFpContract); every other
-// same-width fp pair must be rejected. Each function is independently
-// invalid; the first verifier error wins.
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy | FileCheck %s
 
 module {
-  // f32->f32 same-width: not in lookupVMIFpToFpContract -> rejected
-  func.func @f32_to_f32_same_width(%source: !pto.vmi.vreg<64xf32>) {
-    %result = pto.vmi.vcvt %source
-        : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
-    return
+  func.func @s8_to_f16(%s: !pto.vmi.vreg<64xsi8>) -> !pto.vmi.vreg<64xf16> {
+    %r = pto.vmi.vcvt %s : !pto.vmi.vreg<64xsi8> -> !pto.vmi.vreg<64xf16>
+    return %r : !pto.vmi.vreg<64xf16>
   }
 }
 
-// CHECK: same-width fp-to-fp conversion is not supported
+// CHECK-LABEL: func.func @s8_to_f16(
+// CHECK: pto.vmi.sitofp %{{.*}} : !pto.vmi.vreg<64xsi8> -> !pto.vmi.vreg<64xf16>

--- a/test/lit/vpto/vcvt_f16_to_bf16_rejects_part.pto
+++ b/test/lit/vpto/vcvt_f16_to_bf16_rejects_part.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS DOCUMENT IS PROVIDED "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
+
+// f16 -> bf16 has requiresPart=false, so part must be rejected.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vcvt_f16_to_bf16_rejects_part(%f16_seed: f16) attributes {pto.kernel} {
+    pto.vecscope {
+      %mask_b16 = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %src = pto.vdup %f16_seed, %mask_b16 : f16, !pto.mask<b16> -> !pto.vreg<128xf16>
+      // CHECK: error: 'pto.vcvt' op part attr is not supported for this vcvt width relation
+      %bf16 = pto.vcvt %src, %mask_b16 {rnd = "R", part = "EVEN"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xbf16>
+    }
+    return
+  }
+}

--- a/test/lit/vpto/vcvt_f16_to_bf16_rejects_sat.pto
+++ b/test/lit/vpto/vcvt_f16_to_bf16_rejects_sat.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS DOCUMENT IS PROVIDED "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
+
+// f16 -> bf16 has requiresSat=false, so sat must be rejected.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vcvt_f16_to_bf16_rejects_sat(%f16_seed: f16) attributes {pto.kernel} {
+    pto.vecscope {
+      %mask_b16 = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %src = pto.vdup %f16_seed, %mask_b16 : f16, !pto.mask<b16> -> !pto.vreg<128xf16>
+      // CHECK: error: 'pto.vcvt' op sat attr is not valid for this vcvt type pair
+      %bf16 = pto.vcvt %src, %mask_b16 {rnd = "R", sat = "SAT"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xbf16>
+    }
+    return
+  }
+}

--- a/test/lit/vpto/vcvt_f16_to_bf16_vpto_llvm.pto
+++ b/test/lit/vpto/vcvt_f16_to_bf16_vpto_llvm.pto
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vcvt_f16_to_bf16(%f16_seed: f16, %dst_bf16: !pto.ptr<bf16, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask_b16 = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %src = pto.vdup %f16_seed, %mask_b16 : f16, !pto.mask<b16> -> !pto.vreg<128xf16>
+      %bf16 = pto.vcvt %src, %mask_b16 {rnd = "R"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xbf16>
+      pto.vsts %bf16, %dst_bf16[%c0], %mask_b16 : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.mask<b16>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @vcvt_f16_to_bf16_mix_aiv
+// CHECK: llvm.call @llvm.hivm.vcvtff.f162bf16.x

--- a/test/vpto/cases/vmi_new/vcvt_f16_to_bf16.py
+++ b/test/vpto/cases/vmi_new/vcvt_f16_to_bf16.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+
+def _bootstrap_dsl_st_common() -> None:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        common_dir = candidate / "test" / "dsl-st"
+        if (common_dir / "common.py").exists():
+            sys.path.insert(0, str(common_dir))
+            return
+    raise RuntimeError("Unable to locate test/dsl-st/common.py from vcvt_f16_to_bf16.py")
+
+
+_bootstrap_dsl_st_common()
+
+from common import auto_main, golden_output_case
+from ptodsl import pto
+
+
+ELEMS = 256
+
+VCVT_SOURCE = """module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vcvt_f16_to_bf16_kernel(
+      %src_gm: !pto.ptr<f16, gm>,
+      %dst_gm: !pto.ptr<bf16, gm>)
+      attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
+    %ub_dst = pto.castptr %c4096_i64 : i64 -> !pto.ptr<bf16, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<f16, gm>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %wide = pto.vmi.vload %ub_src[%c0] : !pto.ptr<f16, ub> -> !pto.vmi.vreg<256xf16>
+      %cvt = pto.vmi.vcvt %wide {rounding = "R"}
+          : !pto.vmi.vreg<256xf16> -> !pto.vmi.vreg<256xbf16>
+      pto.vmi.vstore %cvt, %ub_dst[%c0]
+          : !pto.vmi.vreg<256xbf16>, !pto.ptr<bf16, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<bf16, ub>, !pto.ptr<bf16, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}
+"""
+
+
+@pto.jit(
+    name="vcvt_f16_to_bf16_kernel",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+    source=VCVT_SOURCE,
+)
+def vcvt_f16_to_bf16_kernel(
+    src_gm: pto.ptr(pto.f16, "gm"),
+    dst_gm: pto.ptr(pto.bf16, "gm"),
+):
+    pass
+
+
+def to_bf16_bits(x):
+    """f32 -> bfloat16 bit pattern (uint16), round-to-nearest-even."""
+    x = np.asarray(x, dtype=np.float32)
+    u = x.view(np.uint32)
+    lsb = (u >> np.uint32(16)) & np.uint32(1)
+    rounding_bias = np.uint32(0x7FFF) + lsb
+    r = ((u + rounding_bias) >> np.uint32(16)).astype(np.uint16)
+    r = np.where(np.isnan(x), np.uint16(0x7FC0), r)
+    return r
+
+
+def make_inputs():
+    probe = np.array(
+        [
+            0.0, 1.0, -1.0, 2.0, -2.0, 0.5, -0.5, 1.5,
+            -1.5, 3.0, -3.0, 127.0, -128.0, 255.0, -255.0,
+            1023.0, -1024.0, 0.333251953125, -0.333251953125,
+            0.1, -0.1, 100.5, -100.5, 10000.0, -10000.0,
+            65504.0, -65504.0, 0.0001, -0.0001,
+            2.0 ** -14, -(2.0 ** -14), 5.5,
+        ],
+        dtype=np.float16,
+    )
+    src = np.tile(probe, ELEMS // len(probe))[:ELEMS].astype(np.float16)
+    return [src]
+
+
+def make_expected(src):
+    return to_bf16_bits(src.astype(np.float32))
+
+
+CASES = [
+    golden_output_case(
+        "vcvt_f16_to_bf16",
+        vcvt_f16_to_bf16_kernel,
+        inputs=make_inputs,
+        expected=make_expected,
+        rtol=0.0,
+        atol=0.0,
+    ),
+]
+
+
+auto_main(globals())

--- a/test/vpto/cases/vmi_new/vcvt_s8_to_f16.py
+++ b/test/vpto/cases/vmi_new/vcvt_s8_to_f16.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+
+def _bootstrap_dsl_st_common() -> None:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        common_dir = candidate / "test" / "dsl-st"
+        if (common_dir / "common.py").exists():
+            sys.path.insert(0, str(common_dir))
+            return
+    raise RuntimeError("Unable to locate test/dsl-st/common.py from vcvt_s8_to_f16.py")
+
+
+_bootstrap_dsl_st_common()
+
+from common import auto_main, golden_output_case
+from ptodsl import pto
+
+
+ELEMS = 256
+
+VCVT_SOURCE = """module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vcvt_s8_to_f16_kernel(
+      %src_gm: !pto.ptr<si8, gm>,
+      %dst_gm: !pto.ptr<f16, gm>)
+      attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<si8, ub>
+    %ub_dst = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f16, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c256_i64
+      nburst(%c1_i64, %c256_i64, %c256_i64)
+      : !pto.ptr<si8, gm>, !pto.ptr<si8, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %wide = pto.vmi.vload %ub_src[%c0] : !pto.ptr<si8, ub> -> !pto.vmi.vreg<256xsi8>
+      %cvt = pto.vmi.vcvt %wide
+          : !pto.vmi.vreg<256xsi8> -> !pto.vmi.vreg<256xf16>
+      pto.vmi.vstore %cvt, %ub_dst[%c0]
+          : !pto.vmi.vreg<256xf16>, !pto.ptr<f16, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}
+"""
+
+
+@pto.jit(
+    name="vcvt_s8_to_f16_kernel",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+    source=VCVT_SOURCE,
+)
+def vcvt_s8_to_f16_kernel(
+    src_gm: pto.ptr(pto.si8, "gm"),
+    dst_gm: pto.ptr(pto.f16, "gm"),
+):
+    pass
+
+
+def make_inputs():
+    src = np.arange(-128, 128, dtype=np.int8)
+    if src.size < ELEMS:
+        src = np.tile(src, ELEMS // src.size + 1)[:ELEMS]
+    src = src.astype(np.int8)
+    return [src]
+
+
+def make_expected(src):
+    golden_f16 = src.astype(np.float16)
+    return golden_f16.view(np.uint16).astype(np.uint16)
+
+
+CASES = [
+    golden_output_case(
+        "vcvt_s8_to_f16",
+        vcvt_s8_to_f16_kernel,
+        inputs=make_inputs,
+        expected=make_expected,
+        rtol=0.0,
+        atol=0.0,
+    ),
+]
+
+
+auto_main(globals())


### PR DESCRIPTION
### 概述
本 PR 在 VPTO 和 VMI 两层新增三条 vcvt 转换路径：

- VPTO pto.vcvt f16→bf16
在 lookupVcvtContract 中新增 F16→BF16 合约：requiresRnd=true、requiresSat=false、requiresPart=false。
生成 intrinsic：llvm.hivm.vcvtff.f162bf16.x。
与已有的 bf16→f16 不同，f16→bf16 不需要 SAT：f16 的指数范围是 bf16 的子集，不会溢出。

- VMI pto.vmi.vcvt f16→bf16
在 lookupVMIFpToFpContract 中新增同语义的 f16→bf16 合约。
现有同宽度 lowering 路径 OneToNVMITruncFOpPattern 可直接处理，不需要额外 lowering 改动。

- VMI pto.vmi.vcvt s8→f16
扩展 VMISIToFPOp::verify()，允许 si8→f16。
扩展 OneToNVMISIToFPOpPattern 和 checkSupportedSIToFPShape，将 8→16 整型转浮点直接 lowering 为 pto.vcvt {part=EVEN/ODD}。
最终目标 intrinsic 为 llvm.hivm.vcvtif.s82f16.x。

### 代码改动
#### VPTO 层
- lib/PTO/IR/VPTO.cpp
在 lookupVcvtContract 中新增 F16→BF16 分支：requiresRnd=true, requiresSat=false, requiresPart=false。
lib/PTO/Transforms/VPTOLLVMEmitter.cpp
为非 CANN900 / A2-A3（dav-c220）VPTO LLVM 路径新增 llvm.hivm.vcvtff.f162bf16.x intrinsic 映射。
- lib/PTO/Transforms/VPTOCANN900LLVMEmitterTypeHelpers.cpp
在 kVcvtContractEntries 中为 CANN900 路径新增一行 F16→BF16 表项。
本 PR 不修改 VPTOCANN900LLVMEmitter.cpp；它仍保持为 stub，由拆分后的 CANN900 emitter 实现分发。
**VMI** 层
- lib/PTO/IR/VMI.cpp
lookupVMIFpToFpContract：新增 f16→bf16 合约（requiresRnd=true、requiresSat=false）。
VMISIToFPOp::verify()：在原有 si32→f32 基础上允许 si8→f16。
- lib/PTO/Transforms/VMIToVPTO.cpp
OneToNVMISIToFPOpPattern：同时支持同宽度 si32→f32（1:1，rnd=R）和扩宽 si8→f16（EVEN/ODD 分片，无 rnd/sat）。
checkSupportedSIToFPShape：通过 cast-layout 框架支持 si8→f16。
OneToNVMITruncFOpPattern：更新注释，补充 f16→bf16。