### PR TITLE
ci: parallelize sample compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,7 @@ jobs:
           PTOBC_BIN: ${{ env.PTO_BUILD_DIR }}/tools/ptobc/ptobc
           PTO_BUILD_DIR: ${{ env.PTO_BUILD_DIR }}
           PYTHON_BIN: ${{ env.PTOAS_VENV }}/bin/python
+          PTOAS_SAMPLE_JOBS: "4"
         run: |
           set -euo pipefail
           export PATH="${PTOAS_VENV}/bin:${PATH}"

--- a/test/lit/npu_validation/Inputs/runop_kill_python.sh
+++ b/test/lit/npu_validation/Inputs/runop_kill_python.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+if [[ "$1" == */Killed/* ]]; then
+  kill -KILL "${PPID}"
+fi

--- a/test/lit/npu_validation/runop_worker_exit_status.test
+++ b/test/lit/npu_validation/runop_worker_exit_status.test
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# RUN: rm -rf %t
+# RUN: mkdir -p %t/samples/Killed %t/samples/Passed
+# RUN: cp %S/../../samples/runop.sh %t/samples/runop.sh
+# RUN: touch %t/samples/Killed/killed.py %t/samples/Passed/passed.py
+# RUN: not env PTOAS_BIN=/usr/bin/true \
+# RUN:   PYTHON_BIN=%S/Inputs/runop_kill_python.sh PTOAS_OUT_DIR=%t/out \
+# RUN:   PTOAS_SAMPLE_JOBS=4 bash %t/samples/runop.sh all > %t/output 2>&1
+# RUN: FileCheck %s < %t/output
+
+# CHECK: Killed       FAIL process_one_dir exited with status {{[1-9][0-9]*}}
+# CHECK: Passed(passed.py) OK generated: passed-pto.cpp
+# CHECK: OK=1  FAIL=1  SKIP=0

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -21,6 +21,7 @@ PTO_BUILD_DIR="${PTO_BUILD_DIR:-}"
 PTOAS_ENABLE_INSERT_SYNC="${PTOAS_ENABLE_INSERT_SYNC:-1}"
 PTOAS_FLAGS="${PTOAS_FLAGS:-}"
 PTOAS_SKIP_CASES="${PTOAS_SKIP_CASES:-}"
+PTOAS_SAMPLE_JOBS="${PTOAS_SAMPLE_JOBS:-1}"
 PTOAS_SKIP_CASES_NORM="$(printf '%s\n' "${PTOAS_SKIP_CASES}" | tr ',[:space:]' '\n' | awk 'NF')"
 MODEL_PTO_DIRS=""
 for model_path in "${BASE_DIR}"/Qwen* "${BASE_DIR}"/Deepseek*; do
@@ -53,6 +54,7 @@ Env:
   PTOAS_FLAGS  # extra flags passed to ptoas (e.g. --enable-insert-sync)
   PTOAS_ENABLE_INSERT_SYNC  # 1 to append --enable-insert-sync to PTOAS_FLAGS (default: 1)
   PTOAS_SKIP_CASES  # comma/space-separated testcase basenames to skip while generating outputs
+  PTOAS_SAMPLE_JOBS  # number of sample directories to process concurrently (default: 1)
   PTO_PTO_DIRS  # space-separated dirs to run .pto directly (default: Sync, every Qwen*/Deepseek* A3/A5 model dir, and the legacy direct-PTO dirs)
 
 Flags:
@@ -1600,8 +1602,30 @@ write_board_case_manifest() {
   echo "BOARD_CASE_MANIFEST=${manifest} ($(wc -l < "${manifest}") cases)"
 }
 
+wait_for_sample_batch() {
+  local summary_file="$1"
+  shift
+
+  local pid result_file
+  while [[ $# -ge 2 ]]; do
+    pid="$1"
+    result_file="$2"
+    shift 2
+    wait "${pid}" || true
+    cat "${result_file}" >>"${summary_file}"
+  done
+}
+
 run_all() {
-  local tmp out_dir summary_rc soc_arch="" dir_name dir_arch
+  local tmp out_dir result_dir result_file summary_rc soc_arch="" dir_name dir_arch
+  local dir_index=0
+  local -a batch=()
+
+  if [[ ! "${PTOAS_SAMPLE_JOBS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "PTOAS_SAMPLE_JOBS must be a positive integer, got: ${PTOAS_SAMPLE_JOBS}" >&2
+    return 2
+  fi
+
   out_dir="${PTOAS_OUT_DIR}"
   if [[ -z "${out_dir}" ]]; then
     out_dir="$(mktemp -d -t ptoas.samples.XXXXXX)"
@@ -1612,6 +1636,7 @@ run_all() {
   echo "PTOAS_OUT_DIR=${out_dir}"
 
   tmp="$(mktemp -t ptoas.runop.XXXXXX)"
+  result_dir="$(mktemp -d -t ptoas.runop.results.XXXXXX)"
   if [[ -n "${SOC_VERSION:-}" ]]; then
     local soc_lc
     soc_lc="$(printf '%s' "${SOC_VERSION}" | tr '[:upper:]' '[:lower:]')"
@@ -1628,8 +1653,17 @@ run_all() {
     if [[ -n "${soc_arch}" && -n "${dir_arch}" && "${dir_arch}" != "${soc_arch}" ]]; then
       continue
     fi
-    process_one_dir "${dir_name}" "$out_dir" >>"$tmp"
+    result_file="${result_dir}/${dir_index}.log"
+    process_one_dir "${dir_name}" "$out_dir" >"${result_file}" &
+    batch+=("$!" "${result_file}")
+    dir_index=$((dir_index + 1))
+    if [[ ${#batch[@]} -ge $((PTOAS_SAMPLE_JOBS * 2)) ]]; then
+      wait_for_sample_batch "${tmp}" "${batch[@]}"
+      batch=()
+    fi
   done
+  wait_for_sample_batch "${tmp}" "${batch[@]}"
+  rm -rf -- "${result_dir}"
 
   echo "========== SUMMARY =========="
   sort "$tmp" | awk -F'\t' '

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -1606,13 +1606,22 @@ wait_for_sample_batch() {
   local summary_file="$1"
   shift
 
-  local pid result_file
-  while [[ $# -ge 2 ]]; do
+  local pid dir_name result_file worker_rc
+  while [[ $# -ge 3 ]]; do
     pid="$1"
-    result_file="$2"
-    shift 2
-    wait "${pid}" || true
+    dir_name="$2"
+    result_file="$3"
+    shift 3
+    if wait "${pid}"; then
+      worker_rc=0
+    else
+      worker_rc=$?
+    fi
     cat "${result_file}" >>"${summary_file}"
+    if [[ ${worker_rc} -ne 0 ]] && ! grep -q $'\tFAIL\t' "${result_file}"; then
+      printf '%s\tFAIL\tprocess_one_dir exited with status %d\n' \
+        "${dir_name}" "${worker_rc}" >>"${summary_file}"
+    fi
   done
 }
 
@@ -1655,14 +1664,16 @@ run_all() {
     fi
     result_file="${result_dir}/${dir_index}.log"
     process_one_dir "${dir_name}" "$out_dir" >"${result_file}" &
-    batch+=("$!" "${result_file}")
+    batch+=("$!" "${dir_name}" "${result_file}")
     dir_index=$((dir_index + 1))
-    if [[ ${#batch[@]} -ge $((PTOAS_SAMPLE_JOBS * 2)) ]]; then
+    if [[ ${#batch[@]} -ge $((PTOAS_SAMPLE_JOBS * 3)) ]]; then
       wait_for_sample_batch "${tmp}" "${batch[@]}"
       batch=()
     fi
   done
-  wait_for_sample_batch "${tmp}" "${batch[@]}"
+  if ((${#batch[@]})); then
+    wait_for_sample_batch "${tmp}" "${batch[@]}"
+  fi
   rm -rf -- "${result_dir}"
 
   echo "========== SUMMARY =========="


### PR DESCRIPTION
## Summary

- add `PTOAS_SAMPLE_JOBS` to process independent sample directories concurrently
- keep the script default at 1 job so local behavior remains unchanged
- run the CI sample stage with 4 jobs
- preserve deterministic summary aggregation and validate the job count

## Motivation

The `build-and-test` job spends a significant portion of its runtime compiling sample directories serially. These directories are independent and already write to separate output subdirectories, so bounded directory-level parallelism can reduce this stage without changing which samples run.

This targets the sample stage only; editable builds and lit tests remain unchanged.

## Validation

- `bash -n test/samples/runop.sh`
- `git diff --check`
- invalid `PTOAS_SAMPLE_JOBS` returns exit code 2
- `shellcheck test/samples/runop.sh` (only reports pre-existing SC2295 at line 175)
- `actionlint .github/workflows/ci.yml` (only reports pre-existing shell/style warnings and the repository custom runner label)

A full local sample run was not performed because this isolated worktree does not contain built `ptoas`/`ptobc` binaries; the draft CI run will provide the end-to-end timing and correctness check.