### PR TITLE
perf(vpto): hoist common scalar expressions across branches

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -103,6 +103,7 @@ std::unique_ptr<Pass> createPTOMaterializeSIMTPersistentFragmentPass();
 std::unique_ptr<Pass> createPTOOutlineSIMTSectionsPass();
 std::unique_ptr<Pass> createPTOInferVPTOVecScopePass();
 std::unique_ptr<Pass> createVPTOExpandWrapperOpsPass();
+std::unique_ptr<Pass> createPTOHoistCommonScalarExpressionsPass();
 std::unique_ptr<Pass> createVPTOSoftPostUpdatePass();
 std::unique_ptr<Pass> createVPTOGuardedLICMPass();
 std::unique_ptr<Pass> createPTOPrintAddressAnalysisPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -1411,6 +1411,23 @@ def VPTOGuardedLICM : Pass<"vpto-guarded-licm", "func::FuncOp"> {
                            "mlir::scf::SCFDialect"];
 }
 
+def PTOHoistCommonScalarExpressions
+    : Pass<"pto-hoist-common-scalar-expressions", "func::FuncOp"> {
+  let summary = "Hoist profitable scalar expressions shared across structured branches";
+  let description = [{
+    Complements dominance-based CSE by finding structurally equivalent, pure
+    scalar integer/index arithmetic in nested scf.if regions and materializing
+    one copy at their nearest common dominating block. The pass never crosses
+    loops, SIMT scopes, or other region-bearing execution boundaries, rejects
+    mutually-exclusive-only occurrences, and requires a conservative weighted
+    reduction in arithmetic before rewriting.
+  }];
+  let constructor = "mlir::pto::createPTOHoistCommonScalarExpressionsPass()";
+  let dependentDialects = ["mlir::arith::ArithDialect",
+                           "mlir::func::FuncDialect",
+                           "mlir::scf::SCFDialect"];
+}
+
 def PTOPrintAddressAnalysis
     : Pass<"pto-print-address-analysis", "func::FuncOp"> {
   let summary = "Print cached PTO value-evolution and VPTO address facts";

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -48,6 +48,7 @@ add_mlir_dialect_library(PTOTransforms
   VPTOOptimizeVcvt.cpp
   VPTOMaskSimplify.cpp
   VPTOExpandWrapperOps.cpp
+  PTOHoistCommonScalarExpressions.cpp
   VPTOSoftPostUpdate.cpp
   VPTOGuardedLICM.cpp
   PTOPrintAddressAnalysis.cpp

--- a/lib/PTO/Transforms/PTOHoistCommonScalarExpressions.cpp
+++ b/lib/PTO/Transforms/PTOHoistCommonScalarExpressions.cpp
@@ -72,8 +72,9 @@ static std::optional<unsigned> getScalarOpWeight(Operation *op) {
     return std::nullopt;
   }
 
-  // Remainder ops are modeled as pure by Arith, but a zero divisor is still
-  // undefined. Require a known-safe divisor before moving division/remainder.
+  // Division and remainder ops are modeled as pure by Arith, but zero divisors
+  // and signed minimum values with a -1 divisor are still undefined. Require a
+  // known-safe divisor before moving these operations.
   if (name == "arith.divsi" || name == "arith.divui" || name == "arith.remsi" ||
       name == "arith.remui") {
     auto constant = op->getOperand(1).getDefiningOp<arith::ConstantOp>();
@@ -82,7 +83,9 @@ static std::optional<unsigned> getScalarOpWeight(Operation *op) {
     if (!value || value.getValue().isZero()) {
       return std::nullopt;
     }
-    if (name == "arith.divsi" && value.getValue().isAllOnes()) {
+    bool isSignedDivisionOrRemainder =
+        name == "arith.divsi" || name == "arith.remsi";
+    if (isSignedDivisionOrRemainder && value.getValue().isAllOnes()) {
       return std::nullopt;
     }
   }

--- a/lib/PTO/Transforms/PTOHoistCommonScalarExpressions.cpp
+++ b/lib/PTO/Transforms/PTOHoistCommonScalarExpressions.cpp
@@ -1,0 +1,513 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- PTOHoistCommonScalarExpressions.cpp - Cross-branch scalar CSE -----===//
+
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringSwitch.h"
+
+#include <optional>
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOHOISTCOMMONSCALAREXPRESSIONS
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::pto;
+
+namespace {
+
+constexpr unsigned kMaxClonedExpressionOps = 64;
+constexpr unsigned kMinimumWeightedSaving = 2;
+
+// The weights are deliberately approximate. They are used only to reject
+// rewrites that cannot remove more scalar work than they introduce.
+static std::optional<unsigned> getScalarOpWeight(Operation *op) {
+  if (op->getNumRegions() != 0 || op->getNumResults() != 1 || !isPure(op)) {
+    return std::nullopt;
+  }
+
+  auto isScalarIntegerLike = [](Type type) {
+    return type.isIndex() || isa<IntegerType>(type);
+  };
+  if (!llvm::all_of(op->getOperandTypes(), isScalarIntegerLike) ||
+      !llvm::all_of(op->getResultTypes(), isScalarIntegerLike)) {
+    return std::nullopt;
+  }
+
+  StringRef name = op->getName().getStringRef();
+  std::optional<unsigned> weight =
+      llvm::StringSwitch<std::optional<unsigned>>(name)
+          .Case("arith.constant", 0)
+          .Cases("arith.extsi", "arith.extui", "arith.trunci", 2)
+          .Cases("arith.index_cast", "arith.index_castui", 2)
+          .Cases("arith.addi", "arith.subi", "arith.muli", 1)
+          .Cases("arith.andi", "arith.ori", "arith.xori", 1)
+          .Cases("arith.shli", "arith.shrsi", "arith.shrui", 2)
+          .Case("arith.cmpi", 1)
+          .Cases("arith.divsi", "arith.divui", 8)
+          .Cases("arith.remsi", "arith.remui", 8)
+          .Default(std::nullopt);
+  if (!weight) {
+    return std::nullopt;
+  }
+
+  // Remainder ops are modeled as pure by Arith, but a zero divisor is still
+  // undefined. Require a known-safe divisor before moving division/remainder.
+  if (name == "arith.divsi" || name == "arith.divui" || name == "arith.remsi" ||
+      name == "arith.remui") {
+    auto constant = op->getOperand(1).getDefiningOp<arith::ConstantOp>();
+    auto value =
+        constant ? dyn_cast<IntegerAttr>(constant.getValue()) : IntegerAttr();
+    if (!value || value.getValue().isZero()) {
+      return std::nullopt;
+    }
+    if (name == "arith.divsi" && value.getValue().isAllOnes()) {
+      return std::nullopt;
+    }
+  }
+  return weight;
+}
+
+static bool isEligibleScalarOp(Operation *op) {
+  return getScalarOpWeight(op).has_value();
+}
+
+static llvm::hash_code hashExpression(Value value,
+                                      DenseMap<Value, llvm::hash_code> &memo) {
+  if (auto it = memo.find(value); it != memo.end()) {
+    return it->second;
+  }
+  Operation *def = value.getDefiningOp();
+  if (!def || !isEligibleScalarOp(def)) {
+    return hash_value(value);
+  }
+  llvm::hash_code hash = OperationEquivalence::computeHash(
+      def, [&](Value operand) { return hashExpression(operand, memo); },
+      OperationEquivalence::ignoreHashValue,
+      OperationEquivalence::IgnoreLocations);
+  memo.try_emplace(value, hash);
+  return hash;
+}
+
+static bool equivalentExpressions(
+    Value lhs, Value rhs,
+    DenseMap<std::pair<Value, Value>, bool> &equivalenceMemo) {
+  if (lhs == rhs) {
+    return true;
+  }
+  std::pair<Value, Value> key(lhs, rhs);
+  if (auto it = equivalenceMemo.find(key); it != equivalenceMemo.end()) {
+    return it->second;
+  }
+
+  Operation *lhsDef = lhs.getDefiningOp();
+  Operation *rhsDef = rhs.getDefiningOp();
+  if (!lhsDef || !rhsDef || !isEligibleScalarOp(lhsDef) ||
+      !isEligibleScalarOp(rhsDef)) {
+    equivalenceMemo.try_emplace(key, false);
+    return false;
+  }
+
+  // Scalar expressions are acyclic. Seed the memo to guard against malformed
+  // IR and to avoid repeatedly comparing shared sub-DAGs.
+  equivalenceMemo.try_emplace(key, false);
+  bool equivalent = OperationEquivalence::isEquivalentTo(
+      lhsDef, rhsDef,
+      [&](Value lhsOperand, Value rhsOperand) {
+        return success(
+            equivalentExpressions(lhsOperand, rhsOperand, equivalenceMemo));
+      },
+      nullptr, OperationEquivalence::IgnoreLocations);
+  equivalenceMemo[key] = equivalent;
+  return equivalent;
+}
+
+struct ExpressionGroup {
+  SmallVector<Operation *> operations;
+};
+
+static SmallVector<ExpressionGroup> collectExpressionGroups(func::FuncOp func) {
+  SmallVector<ExpressionGroup> groups;
+  DenseMap<size_t, SmallVector<unsigned>> groupsByHash;
+  DenseMap<Value, llvm::hash_code> hashMemo;
+
+  func.walk([&](Operation *op) {
+    if (!isEligibleScalarOp(op) || op->use_empty()) {
+      return;
+    }
+    size_t hash =
+        static_cast<size_t>(hashExpression(op->getResult(0), hashMemo));
+    SmallVector<unsigned> &bucket = groupsByHash[hash];
+    for (unsigned groupIndex : bucket) {
+      DenseMap<std::pair<Value, Value>, bool> equivalenceMemo;
+      if (equivalentExpressions(
+              groups[groupIndex].operations.front()->getResult(0),
+              op->getResult(0), equivalenceMemo)) {
+        groups[groupIndex].operations.push_back(op);
+        return;
+      }
+    }
+    bucket.push_back(groups.size());
+    groups.push_back({{op}});
+  });
+  return groups;
+}
+
+static SmallVector<Operation *> getExecutionBarriers(Operation *op,
+                                                     func::FuncOp func) {
+  SmallVector<Operation *> barriers;
+  for (Operation *parent = op->getParentOp(); parent && parent != func;
+       parent = parent->getParentOp()) {
+    // scf.if is the only boundary this pass is allowed to cross. Exact barrier
+    // equality keeps expressions inside loops, SIMT scopes, execute_region,
+    // and every unknown region-bearing operation.
+    if (parent->getNumRegions() != 0 && !isa<scf::IfOp>(parent)) {
+      barriers.push_back(parent);
+    }
+  }
+  return barriers;
+}
+
+static Region *getDirectChildRegion(Operation *descendant,
+                                    Operation *ancestor) {
+  Operation *cursor = descendant;
+  while (cursor && cursor->getParentOp() != ancestor) {
+    cursor = cursor->getParentOp();
+  }
+  return cursor ? cursor->getParentRegion() : nullptr;
+}
+
+static bool areMutuallyExclusive(Operation *lhs, Operation *rhs) {
+  for (Operation *parent = lhs->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    auto ifOp = dyn_cast<scf::IfOp>(parent);
+    if (!ifOp || !ifOp->isProperAncestor(rhs)) {
+      continue;
+    }
+    Region *lhsRegion = getDirectChildRegion(lhs, ifOp);
+    Region *rhsRegion = getDirectChildRegion(rhs, ifOp);
+    if (lhsRegion && rhsRegion && lhsRegion != rhsRegion) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool hasCoExecutablePair(ArrayRef<Operation *> operations) {
+  for (auto [index, lhs] : llvm::enumerate(operations)) {
+    for (Operation *rhs : operations.drop_front(index + 1)) {
+      if (!areMutuallyExclusive(lhs, rhs)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+static SmallVector<Block *> getBlockAncestors(Operation *op,
+                                              func::FuncOp func) {
+  SmallVector<Block *> blocks;
+  for (Block *block = op->getBlock(); block;) {
+    blocks.push_back(block);
+    Operation *parent = block->getParentOp();
+    if (!parent || parent == func) {
+      break;
+    }
+    block = parent->getBlock();
+  }
+  return blocks;
+}
+
+static Block *findDeepestCommonBlock(ArrayRef<Operation *> operations,
+                                     func::FuncOp func) {
+  SmallVector<Block *> firstAncestors =
+      getBlockAncestors(operations.front(), func);
+  for (Block *candidate : firstAncestors) {
+    bool common = llvm::all_of(operations.drop_front(), [&](Operation *op) {
+      SmallVector<Block *> ancestors = getBlockAncestors(op, func);
+      return llvm::is_contained(ancestors, candidate);
+    });
+    if (common) {
+      return candidate;
+    }
+  }
+  return nullptr;
+}
+
+static Operation *getAnchorInBlock(Operation *op, Block *block) {
+  Operation *anchor = op;
+  while (anchor && anchor->getBlock() != block) {
+    anchor = anchor->getParentOp();
+  }
+  return anchor;
+}
+
+static Operation *findInsertionPoint(ArrayRef<Operation *> operations,
+                                     func::FuncOp func) {
+  Block *block = findDeepestCommonBlock(operations, func);
+  if (!block) {
+    return nullptr;
+  }
+  Operation *insertionPoint = nullptr;
+  for (Operation *op : operations) {
+    Operation *anchor = getAnchorInBlock(op, block);
+    if (!anchor) {
+      return nullptr;
+    }
+    if (!insertionPoint || anchor->isBeforeInBlock(insertionPoint)) {
+      insertionPoint = anchor;
+    }
+  }
+  return insertionPoint;
+}
+
+static bool canMaterializeBefore(Value value, Operation *insertionPoint,
+                                 DominanceInfo &dominance,
+                                 DenseMap<Value, bool> &memo) {
+  if (dominance.dominates(value, insertionPoint)) {
+    return true;
+  }
+  if (auto it = memo.find(value); it != memo.end()) {
+    return it->second;
+  }
+  memo.try_emplace(value, false);
+  Operation *def = value.getDefiningOp();
+  if (!def || !isEligibleScalarOp(def)) {
+    return false;
+  }
+  bool available = llvm::all_of(def->getOperands(), [&](Value operand) {
+    return canMaterializeBefore(operand, insertionPoint, dominance, memo);
+  });
+  memo[value] = available;
+  return available;
+}
+
+static bool collectCloneOps(Value value, Operation *insertionPoint,
+                            DominanceInfo &dominance,
+                            SmallPtrSetImpl<Operation *> &cloneOps) {
+  if (dominance.dominates(value, insertionPoint)) {
+    return true;
+  }
+  Operation *def = value.getDefiningOp();
+  if (!def || !isEligibleScalarOp(def)) {
+    return false;
+  }
+  if (!cloneOps.insert(def).second) {
+    return true;
+  }
+  if (cloneOps.size() > kMaxClonedExpressionOps) {
+    return false;
+  }
+  return llvm::all_of(def->getOperands(), [&](Value operand) {
+    return collectCloneOps(operand, insertionPoint, dominance, cloneOps);
+  });
+}
+
+static void collectExpressionDAG(Value value,
+                                 SmallPtrSetImpl<Operation *> &dagOps) {
+  Operation *def = value.getDefiningOp();
+  if (!def || !isEligibleScalarOp(def) || !dagOps.insert(def).second) {
+    return;
+  }
+  for (Value operand : def->getOperands()) {
+    collectExpressionDAG(operand, dagOps);
+  }
+}
+
+static SmallPtrSet<Operation *, 32>
+findRemovableOps(ArrayRef<Operation *> roots) {
+  SmallPtrSet<Operation *, 32> dagOps;
+  SmallPtrSet<Operation *, 32> removable;
+  for (Operation *root : roots) {
+    removable.insert(root);
+    collectExpressionDAG(root->getResult(0), dagOps);
+  }
+
+  bool changed;
+  do {
+    changed = false;
+    for (Operation *op : dagOps) {
+      if (removable.contains(op)) {
+        continue;
+      }
+      if (llvm::all_of(op->getUsers(), [&](Operation *user) {
+            return removable.contains(user);
+          })) {
+        changed |= removable.insert(op).second;
+      }
+    }
+  } while (changed);
+  return removable;
+}
+
+static unsigned getWeightedCost(const SmallPtrSetImpl<Operation *> &ops) {
+  unsigned cost = 0;
+  for (Operation *op : ops) {
+    cost += *getScalarOpWeight(op);
+  }
+  return cost;
+}
+
+static bool hasDominatingOccurrence(ArrayRef<Operation *> operations,
+                                    DominanceInfo &dominance) {
+  return llvm::any_of(operations, [&](Operation *candidate) {
+    Value value = candidate->getResult(0);
+    return llvm::all_of(operations, [&](Operation *other) {
+      return candidate == other || dominance.dominates(value, other);
+    });
+  });
+}
+
+struct HoistCandidate {
+  SmallVector<Operation *> occurrences;
+  Operation *insertionPoint = nullptr;
+  unsigned weightedSaving = 0;
+  unsigned cloneCost = 0;
+};
+
+static std::optional<HoistCandidate>
+findBestCandidate(func::FuncOp func, DominanceInfo &dominance) {
+  std::optional<HoistCandidate> best;
+  for (ExpressionGroup &group : collectExpressionGroups(func)) {
+    if (group.operations.size() < 2 ||
+        hasDominatingOccurrence(group.operations, dominance) ||
+        !hasCoExecutablePair(group.operations)) {
+      continue;
+    }
+
+    SmallVector<Operation *> barriers =
+        getExecutionBarriers(group.operations.front(), func);
+    if (!llvm::all_of(ArrayRef(group.operations).drop_front(),
+                      [&](Operation *op) {
+                        return getExecutionBarriers(op, func) == barriers;
+                      })) {
+      continue;
+    }
+
+    Operation *insertionPoint = findInsertionPoint(group.operations, func);
+    if (!insertionPoint) {
+      continue;
+    }
+    DenseMap<Value, bool> availabilityMemo;
+    if (!canMaterializeBefore(group.operations.front()->getResult(0),
+                              insertionPoint, dominance, availabilityMemo)) {
+      continue;
+    }
+
+    SmallPtrSet<Operation *, 32> cloneOps;
+    if (!collectCloneOps(group.operations.front()->getResult(0), insertionPoint,
+                         dominance, cloneOps)) {
+      continue;
+    }
+    SmallPtrSet<Operation *, 32> removable = findRemovableOps(group.operations);
+    unsigned cloneCost = getWeightedCost(cloneOps);
+    unsigned removableCost = getWeightedCost(removable);
+    if (removableCost < cloneCost + kMinimumWeightedSaving) {
+      continue;
+    }
+
+    HoistCandidate candidate{group.operations, insertionPoint,
+                             removableCost - cloneCost, cloneCost};
+    if (!best || candidate.weightedSaving > best->weightedSaving ||
+        (candidate.weightedSaving == best->weightedSaving &&
+         candidate.cloneCost > best->cloneCost)) {
+      best = std::move(candidate);
+    }
+  }
+  return best;
+}
+
+static Value materializeBefore(Value value, Operation *insertionPoint,
+                               DominanceInfo &dominance, OpBuilder &builder,
+                               DenseMap<Value, Value> &memo) {
+  if (dominance.dominates(value, insertionPoint)) {
+    return value;
+  }
+  if (auto it = memo.find(value); it != memo.end()) {
+    return it->second;
+  }
+
+  Operation *def = value.getDefiningOp();
+  SmallVector<Value> operands;
+  operands.reserve(def->getNumOperands());
+  for (Value operand : def->getOperands()) {
+    operands.push_back(
+        materializeBefore(operand, insertionPoint, dominance, builder, memo));
+  }
+  builder.setInsertionPoint(insertionPoint);
+  Operation *clone = builder.clone(*def);
+  clone->setOperands(operands);
+  Value result = clone->getResult(0);
+  memo.try_emplace(value, result);
+  return result;
+}
+
+static void eraseDeadExpressionDAGs(ArrayRef<Operation *> roots) {
+  SmallPtrSet<Operation *, 32> dagOps;
+  for (Operation *root : roots) {
+    collectExpressionDAG(root->getResult(0), dagOps);
+  }
+
+  while (true) {
+    Operation *dead = nullptr;
+    for (Operation *op : dagOps) {
+      if (isOpTriviallyDead(op)) {
+        dead = op;
+        break;
+      }
+    }
+    if (!dead) {
+      return;
+    }
+    dagOps.erase(dead);
+    dead->erase();
+  }
+}
+
+struct PTOHoistCommonScalarExpressionsPass
+    : public pto::impl::PTOHoistCommonScalarExpressionsBase<
+          PTOHoistCommonScalarExpressionsPass> {
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    DominanceInfo dominance(func);
+    while (std::optional<HoistCandidate> candidate =
+               findBestCandidate(func, dominance)) {
+      OpBuilder builder(candidate->insertionPoint);
+      DenseMap<Value, Value> materialized;
+      Value hoisted = materializeBefore(
+          candidate->occurrences.front()->getResult(0),
+          candidate->insertionPoint, dominance, builder, materialized);
+      for (Operation *op : candidate->occurrences) {
+        op->getResult(0).replaceAllUsesWith(hoisted);
+      }
+      eraseDeadExpressionDAGs(candidate->occurrences);
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOHoistCommonScalarExpressionsPass() {
+  return std::make_unique<PTOHoistCommonScalarExpressionsPass>();
+}

--- a/test/lit/vpto/hoist_common_scalar_expressions.pto
+++ b/test/lit/vpto/hoist_common_scalar_expressions.pto
@@ -144,6 +144,26 @@ module {
     return %sum : i32
   }
 
+  func.func @signed_remainder_minus_one_is_not_speculated() -> i32 {
+    %false = arith.constant false
+    %min = arith.constant -2147483648 : i32
+    %minusOne = arith.constant -1 : i32
+    %left = scf.if %false -> i32 {
+      %value = arith.remsi %min, %minusOne : i32
+      scf.yield %value : i32
+    } else {
+      scf.yield %min : i32
+    }
+    %right = scf.if %false -> i32 {
+      %value = arith.remsi %min, %minusOne : i32
+      scf.yield %value : i32
+    } else {
+      scf.yield %min : i32
+    }
+    %sum = arith.addi %left, %right : i32
+    return %sum : i32
+  }
+
   func.func @cheap_add_is_not_speculated(%arg: i32, %first: i1,
                                           %second: i1) -> i32 {
     %c1 = arith.constant 1 : i32
@@ -220,6 +240,16 @@ module {
 // CHECK: scf.yield %[[DIV]] : i32
 // CHECK-NOT: arith.divsi
 // CHECK: scf.yield %[[DIV]] : i32
+
+// CHECK-LABEL: func.func @signed_remainder_minus_one_is_not_speculated
+// CHECK: %[[FALSE:.*]] = arith.constant false
+// CHECK: %[[MIN:.*]] = arith.constant -2147483648 : i32
+// CHECK: %[[MINUS_ONE:.*]] = arith.constant -1 : i32
+// CHECK-NOT: arith.remsi
+// CHECK: scf.if %[[FALSE]]
+// CHECK: arith.remsi %[[MIN]], %[[MINUS_ONE]] : i32
+// CHECK: scf.if %[[FALSE]]
+// CHECK: arith.remsi %[[MIN]], %[[MINUS_ONE]] : i32
 
 // CHECK-LABEL: func.func @cheap_add_is_not_speculated
 // CHECK-SAME: (%[[ARG:[a-zA-Z0-9_]+]]: i32

--- a/test/lit/vpto/hoist_common_scalar_expressions.pto
+++ b/test/lit/vpto/hoist_common_scalar_expressions.pto
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -pto-hoist-common-scalar-expressions | FileCheck %s
+
+module {
+  func.func @co_executable_branches(%arg: i32, %first: i1, %second: i1)
+      -> i64 {
+    %left = scf.if %first -> i64 {
+      %c4 = arith.constant 4 : i32
+      %add = arith.addi %arg, %c4 : i32
+      %shift = arith.shrsi %add, %c4 : i32
+      %wide = arith.extsi %shift : i32 to i64
+      scf.yield %wide : i64
+    } else {
+      %zero = arith.constant 0 : i64
+      scf.yield %zero : i64
+    }
+    %right = scf.if %second -> i64 {
+      %c4 = arith.constant 4 : i32
+      %add = arith.addi %arg, %c4 : i32
+      %shift = arith.shrsi %add, %c4 : i32
+      %wide = arith.extsi %shift : i32 to i64
+      scf.yield %wide : i64
+    } else {
+      %zero = arith.constant 0 : i64
+      scf.yield %zero : i64
+    }
+    %sum = arith.addi %left, %right : i64
+    return %sum : i64
+  }
+
+  func.func @shared_subdag(%arg: i32, %first: i1, %second: i1) -> i64 {
+    %left = scf.if %first -> i64 {
+      %c2 = arith.constant 2 : i32
+      %base = arith.muli %arg, %c2 : i32
+      %sum = arith.addi %base, %base : i32
+      %wide = arith.extsi %sum : i32 to i64
+      scf.yield %wide : i64
+    } else {
+      %zero = arith.constant 0 : i64
+      scf.yield %zero : i64
+    }
+    %right = scf.if %second -> i64 {
+      %c2 = arith.constant 2 : i32
+      %base = arith.muli %arg, %c2 : i32
+      %sum = arith.addi %base, %base : i32
+      %wide = arith.extsi %sum : i32 to i64
+      scf.yield %wide : i64
+    } else {
+      %zero = arith.constant 0 : i64
+      scf.yield %zero : i64
+    }
+    %result = arith.addi %left, %right : i64
+    return %result : i64
+  }
+
+  func.func @mutually_exclusive_branches(%arg: i32, %condition: i1) -> i64 {
+    %result = scf.if %condition -> i64 {
+      %c4 = arith.constant 4 : i32
+      %add = arith.addi %arg, %c4 : i32
+      %shift = arith.shrsi %add, %c4 : i32
+      %wide = arith.extsi %shift : i32 to i64
+      scf.yield %wide : i64
+    } else {
+      %c4 = arith.constant 4 : i32
+      %add = arith.addi %arg, %c4 : i32
+      %shift = arith.shrsi %add, %c4 : i32
+      %wide = arith.extsi %shift : i32 to i64
+      scf.yield %wide : i64
+    }
+    return %result : i64
+  }
+
+  func.func @does_not_cross_loops(%arg: i32, %condition: i1) -> i64 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %loop = scf.for %i = %c0 to %c1 step %c1 iter_args(%acc = %arg) -> i32 {
+      %value = scf.if %condition -> i32 {
+        %c4 = arith.constant 4 : i32
+        %add = arith.addi %arg, %c4 : i32
+        %shift = arith.shrsi %add, %c4 : i32
+        scf.yield %shift : i32
+      } else {
+        scf.yield %acc : i32
+      }
+      scf.yield %value : i32
+    }
+    %outside = scf.if %condition -> i32 {
+      %c4 = arith.constant 4 : i32
+      %add = arith.addi %arg, %c4 : i32
+      %shift = arith.shrsi %add, %c4 : i32
+      scf.yield %shift : i32
+    } else {
+      scf.yield %arg : i32
+    }
+    %wideLoop = arith.extsi %loop : i32 to i64
+    %wideOutside = arith.extsi %outside : i32 to i64
+    %sum = arith.addi %wideLoop, %wideOutside : i64
+    return %sum : i64
+  }
+
+  func.func @dynamic_divisor_is_not_speculated(%arg: i32, %divisor: i32,
+                                                %first: i1, %second: i1)
+      -> i32 {
+    %left = scf.if %first -> i32 {
+      %value = arith.divsi %arg, %divisor : i32
+      scf.yield %value : i32
+    } else {
+      scf.yield %arg : i32
+    }
+    %right = scf.if %second -> i32 {
+      %value = arith.divsi %arg, %divisor : i32
+      scf.yield %value : i32
+    } else {
+      scf.yield %arg : i32
+    }
+    %sum = arith.addi %left, %right : i32
+    return %sum : i32
+  }
+
+  func.func @constant_divisor_can_be_hoisted(%arg: i32, %first: i1,
+                                              %second: i1) -> i32 {
+    %left = scf.if %first -> i32 {
+      %c4 = arith.constant 4 : i32
+      %value = arith.divsi %arg, %c4 : i32
+      scf.yield %value : i32
+    } else {
+      scf.yield %arg : i32
+    }
+    %right = scf.if %second -> i32 {
+      %c4 = arith.constant 4 : i32
+      %value = arith.divsi %arg, %c4 : i32
+      scf.yield %value : i32
+    } else {
+      scf.yield %arg : i32
+    }
+    %sum = arith.addi %left, %right : i32
+    return %sum : i32
+  }
+
+  func.func @cheap_add_is_not_speculated(%arg: i32, %first: i1,
+                                          %second: i1) -> i32 {
+    %c1 = arith.constant 1 : i32
+    %left = scf.if %first -> i32 {
+      %value = arith.addi %arg, %c1 : i32
+      scf.yield %value : i32
+    } else {
+      scf.yield %arg : i32
+    }
+    %right = scf.if %second -> i32 {
+      %value = arith.addi %arg, %c1 : i32
+      scf.yield %value : i32
+    } else {
+      scf.yield %arg : i32
+    }
+    %sum = arith.addi %left, %right : i32
+    return %sum : i32
+  }
+}
+
+// CHECK-LABEL: func.func @co_executable_branches
+// CHECK-SAME: (%[[ARG:[a-zA-Z0-9_]+]]: i32
+// CHECK: %[[C4:.*]] = arith.constant 4 : i32
+// CHECK: %[[ADD:.*]] = arith.addi %[[ARG]], %[[C4]] : i32
+// CHECK: %[[SHIFT:.*]] = arith.shrsi %[[ADD]], %[[C4]] : i32
+// CHECK: %[[WIDE:.*]] = arith.extsi %[[SHIFT]] : i32 to i64
+// CHECK-NOT: arith.addi %[[ARG]]
+// CHECK: scf.if
+// CHECK: scf.yield %[[WIDE]] : i64
+// CHECK-NOT: arith.addi %[[ARG]]
+// CHECK: scf.if
+// CHECK: scf.yield %[[WIDE]] : i64
+
+// CHECK-LABEL: func.func @shared_subdag
+// CHECK-SAME: (%[[ARG:[a-zA-Z0-9_]+]]: i32
+// CHECK: %[[C2:.*]] = arith.constant 2 : i32
+// CHECK: %[[BASE:.*]] = arith.muli %[[ARG]], %[[C2]] : i32
+// CHECK: %[[SUM:.*]] = arith.addi %[[BASE]], %[[BASE]] : i32
+// CHECK: %[[WIDE:.*]] = arith.extsi %[[SUM]] : i32 to i64
+// CHECK-NOT: arith.muli %[[ARG]]
+// CHECK: scf.if
+// CHECK: scf.yield %[[WIDE]] : i64
+// CHECK-NOT: arith.muli %[[ARG]]
+// CHECK: scf.if
+// CHECK: scf.yield %[[WIDE]] : i64
+
+// CHECK-LABEL: func.func @mutually_exclusive_branches
+// CHECK-SAME: (%[[ARG:[a-zA-Z0-9_]+]]: i32
+// CHECK: scf.if
+// CHECK: arith.addi %[[ARG]]
+// CHECK: arith.shrsi
+// CHECK: } else {
+// CHECK: arith.addi %[[ARG]]
+// CHECK: arith.shrsi
+
+// CHECK-LABEL: func.func @does_not_cross_loops
+// CHECK-SAME: (%[[ARG:[a-zA-Z0-9_]+]]: i32
+// CHECK: scf.for
+// CHECK: arith.addi %[[ARG]]
+// CHECK: arith.shrsi
+// CHECK: scf.if
+// CHECK: arith.addi %[[ARG]]
+// CHECK: arith.shrsi
+
+// CHECK-LABEL: func.func @dynamic_divisor_is_not_speculated
+// CHECK-SAME: (%[[ARG:[a-zA-Z0-9_]+]]: i32, %[[DIVISOR:[a-zA-Z0-9_]+]]: i32
+// CHECK-COUNT-2: arith.divsi %[[ARG]], %[[DIVISOR]]
+
+// CHECK-LABEL: func.func @constant_divisor_can_be_hoisted
+// CHECK-SAME: (%[[ARG:[a-zA-Z0-9_]+]]: i32
+// CHECK: %[[C4:.*]] = arith.constant 4 : i32
+// CHECK: %[[DIV:.*]] = arith.divsi %[[ARG]], %[[C4]] : i32
+// CHECK-NOT: arith.divsi
+// CHECK: scf.yield %[[DIV]] : i32
+// CHECK-NOT: arith.divsi
+// CHECK: scf.yield %[[DIV]] : i32
+
+// CHECK-LABEL: func.func @cheap_add_is_not_speculated
+// CHECK-SAME: (%[[ARG:[a-zA-Z0-9_]+]]: i32
+// CHECK: scf.if
+// CHECK: arith.addi %[[ARG]]
+// CHECK: scf.if
+// CHECK: arith.addi %[[ARG]]

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -3106,6 +3106,10 @@ static void prepareVPTOForEmission(PassManager &pm) {
   kernelModulePM.addPass(createCanonicalizerPass());
   kernelModulePM.addPass(createCSEPass());
   kernelModulePM.addNestedPass<func::FuncOp>(
+      pto::createPTOHoistCommonScalarExpressionsPass());
+  kernelModulePM.addPass(createCanonicalizerPass());
+  kernelModulePM.addPass(createCSEPass());
+  kernelModulePM.addNestedPass<func::FuncOp>(
       pto::createPTOAnalyzeSIMTPersistentFragmentPass());
   kernelModulePM.addNestedPass<func::FuncOp>(
       pto::createPTOMaterializeSIMTPersistentFragmentPass());


### PR DESCRIPTION
Add a conservative PTOAS pass to eliminate profitable scalar expression DAGs shared across structured branches. Enable it in the VPTO emission pipeline and add regression coverage for safety boundaries.