### PR TITLE
fix(vpto): combine reductions before scheduling

### DIFF
--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -3104,6 +3104,9 @@ static void prepareVPTOForEmission(PassManager &pm) {
   kernelModulePM.addPass(pto::createPTOInlineLibCallPass());
   kernelModulePM.addPass(createCanonicalizerPass());
   kernelModulePM.addPass(createCSEPass());
+  // Reconstruct the optimized reduction tree before scheduling so the
+  // scheduler sees the final MI instruction set and dependencies.
+  kernelModulePM.addPass(pto::createVPTOCombineReductionsPass());
   if (vptoSchedulerMode != VPTOSchedulerCLIMode::Off) {
     pto::VPTOSchedulerOptions schedulerOptions;
     schedulerOptions.mode = vptoSchedulerMode == VPTOSchedulerCLIMode::Analyze
@@ -3111,7 +3114,6 @@ static void prepareVPTOForEmission(PassManager &pm) {
                                 : "on";
     kernelModulePM.addPass(pto::createVPTOSchedulerPass(schedulerOptions));
   }
-  kernelModulePM.addPass(pto::createVPTOCombineReductionsPass());
   kernelModulePM.addPass(createCSEPass());
   kernelModulePM.addPass(pto::createPTOValidateVPTOEmissionIRPass());
 }


### PR DESCRIPTION
## Summary

Move `VPTOCombineReductions` before the optional `VPTOScheduler` in the VPTO emission pipeline.

## Rationale

`VPTOCombineReductions` changes the physical reduction tree and therefore the MI instruction set and dependencies. Scheduling after the combine pass ensures the scheduler analyzes the final reduction form while retaining the pass prerequisite that mask simplification, LICM, and CSE have already stabilized VPTO producers.

## Validation

- `git diff --check`
- `ninja -C build-llvm19 tools/ptoas/obj.PTOASCompilerImplementation`

Related context: the pass was previously left after scheduler when scheduler integration was added, which made scheduling observe the pre-combine reduction tree.