### PR TITLE
fix(vpto): run final CSE before scheduling

### DIFF
--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -3141,6 +3141,7 @@ static void prepareVPTOForEmission(PassManager &pm) {
   // Reconstruct the optimized reduction tree before scheduling so the
   // scheduler sees the final MI instruction set and dependencies.
   kernelModulePM.addPass(pto::createVPTOCombineReductionsPass());
+  kernelModulePM.addPass(createCSEPass());
   if (vptoSchedulerMode != VPTOSchedulerCLIMode::Off) {
     pto::VPTOSchedulerOptions schedulerOptions;
     schedulerOptions.mode = vptoSchedulerMode == VPTOSchedulerCLIMode::Analyze
@@ -3148,7 +3149,6 @@ static void prepareVPTOForEmission(PassManager &pm) {
                                 : "on";
     kernelModulePM.addPass(pto::createVPTOSchedulerPass(schedulerOptions));
   }
-  kernelModulePM.addPass(createCSEPass());
   kernelModulePM.addPass(pto::createPTOValidateVPTOEmissionIRPass());
 }
 


### PR DESCRIPTION
## Summary

Move the final VPTO CSE pass together with `VPTOCombineReductions` so it runs before the optional `VPTOScheduler`.

## Rationale

PR #1358 moved reduction-tree reconstruction before scheduling but left its following cleanup CSE after the scheduler. As a result, the scheduler could still analyze duplicate operations that would be removed from the final emission IR. This change restores the documented contract that scheduling runs after the final CSE and observes the finalized MI instruction set and dependencies.

## Validation

- `git diff --check`
- `ninja -C build-llvm19 tools/ptoas/obj.PTOASCompilerImplementation`
- `llvm-lit -sv` on `vpto_scheduler_cli.pto`, `vpto_scheduler_analyze.pto`, and `vpto_combine_reductions.pto` (3/3 passed)
- PTOAS changed-code compliance check (0 errors, 0 warnings)
