### PR TITLE
fix(vmi): preserve ambiguous layout use conflicts

### DIFF
--- a/include/PTO/Transforms/VMILayoutPropagation.h
+++ b/include/PTO/Transforms/VMILayoutPropagation.h
@@ -62,6 +62,7 @@ private:
   bool isTypeRewriteable(Value value) const;
   VMILayoutAttr getOperandLayout(OpOperand &operand) const;
   bool canProduceValueLayout(Value value, VMILayoutAttr layout) const;
+  bool hasUniqueProducerRelation(OpResult result, VMILayoutAttr layout) const;
   bool canMaterializeLayout(Value value, VMILayoutAttr sourceLayout,
                             VMILayoutAttr resultLayout) const;
 

--- a/lib/PTO/Transforms/VMILayoutPropagation.cpp
+++ b/lib/PTO/Transforms/VMILayoutPropagation.cpp
@@ -15,6 +15,8 @@
 #include "PTO/IR/VMIUtils.h"
 #include "PTO/Transforms/VMILayoutSupport.h"
 
+#include "llvm/ADT/STLExtras.h"
+
 using namespace mlir;
 using namespace mlir::pto;
 
@@ -1257,6 +1259,24 @@ bool VMILayoutPropagator::canProduceValueLayout(Value value,
   return false;
 }
 
+bool VMILayoutPropagator::hasUniqueProducerRelation(
+    OpResult result, VMILayoutAttr layout) const {
+  Operation *definingOp = result.getDefiningOp();
+  const VMILayoutTransfer *transfer = getTransfer(definingOp);
+  if (!transfer) {
+    return false;
+  }
+  FailureOr<SmallVector<VMILayoutRelation, mlir::pto::kValue4>> relations =
+      transfer->query(definingOp, result, layout, *this,
+                      /*changedOperand=*/nullptr);
+  if (failed(relations)) {
+    return false;
+  }
+  return llvm::count_if(*relations, [&](const VMILayoutRelation &relation) {
+           return relationContainsValueLayout(relation, result, layout);
+         }) == 1;
+}
+
 bool VMILayoutPropagator::canMaterializeLayout(
     Value value, VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout) const {
   static VMILayoutMaterializationTransfer materializationTransfer;
@@ -1315,7 +1335,10 @@ LogicalResult VMILayoutPropagator::request(OpOperand &operand,
   if (assignment.layout == layout) {
     return propagateOperandFact(operand, layout);
   }
-  if (!assignment.layout && isa<OpResult>(value)) {
+  auto result = dyn_cast<OpResult>(value);
+  bool canPromote = !assignment.layout && result &&
+                    hasUniqueProducerRelation(result, layout);
+  if (canPromote) {
     if (failed(request(value, layout))) {
       return failure();
     }

--- a/test/lit/vmi_new/vmi_layout_assignment_cast_consumer_conflict.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_cast_consumer_conflict.pto
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy \
+// RUN:   -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s
+
+module {
+  func.func @vmi_layout_assignment_cast_consumer_conflict(
+      %src: !pto.ptr<f32, ub>,
+      %scaleSrc: !pto.ptr<f32, ub>,
+      %off: index) {
+    %c1 = arith.constant 1 : index
+    %scale = pto.vmi.vload %scaleSrc[%off], %c1
+        {dist_mode = "brc", group = 8}
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
+    %input = pto.vmi.vload %src[%off]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
+    %scaled = pto.vmi.vmul %input, %scale
+        : !pto.vmi.vreg<256xf32>, !pto.vmi.vreg<256xf32>
+        -> !pto.vmi.vreg<256xf32>
+    %quantized = pto.vmi.vcvt %scaled
+        {rounding = "R", saturate = "SAT"}
+        : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
+    %restored = pto.vmi.vcvt %quantized
+        : !pto.vmi.vreg<256xf8E4M3FN> -> !pto.vmi.vreg<256xf32>
+    %out = pto.vmi.vmul %restored, %scale
+        : !pto.vmi.vreg<256xf32>, !pto.vmi.vreg<256xf32>
+        -> !pto.vmi.vreg<256xf32>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @vmi_layout_assignment_cast_consumer_conflict(
+// CHECK: %[[SCALE:.*]] = pto.vmi.group_broadcast_load
+// CHECK-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
+// CHECK: %[[SCALED:.*]] = pto.vmi.mulf
+// CHECK-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
+// CHECK: %[[DENSE:.*]] = pto.vmi.ensure_layout %[[SCALED]]
+// CHECK-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
+// CHECK: %[[QUANTIZED:.*]] = pto.vmi.truncf %[[DENSE]]
+// CHECK-SAME: -> !pto.vmi.vreg<256xf8E4M3FN, #pto.vmi.layout<contiguous, lane_stride = 4>>
+// CHECK: %[[RESTORED:.*]] = pto.vmi.extf %[[QUANTIZED]]
+// CHECK-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
+// CHECK: %[[RESTORED_D4:.*]] = pto.vmi.ensure_layout %[[RESTORED]]
+// CHECK-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
+// CHECK: pto.vmi.mulf %[[RESTORED_D4]], %[[SCALE]]


### PR DESCRIPTION
## Summary

- promote a consumer operand layout request to its producer only when the defining transfer has one matching relation
- preserve ambiguous requests as use-side conflicts so layout assignment can insert `ensure_layout` after the producer layout becomes known
- add a layout-free FP32/FP8 round-trip regression covering the `contiguous(lane_stride=4) -> contiguous -> d4` handoff

## Root cause

A downstream `d4` operand request was promoted to the `extf` result primary while querying that result still returned two legal producer relations. When the FP8 source later selected the unique `contiguous(lane_stride=4) -> contiguous` cast relation, the earlier primary left an illegal `extf` layout pair and no use conflict from which to materialize `ensure_layout`.

## Validation

- captured issue #1337 TileLang input lowers through full `ptoas --emit-vpto` with the scoped promotion rule
- exact-commit `vmi_new` differential: baseline 511 passed / 17 failed; modified 511 passed / 17 failed, with no new failures
- `python3 .agents/skills/enforce-ptoas-code-compliance/scripts/check_changed_code.py --repo . --base main`: 0 errors, 0 warnings
- `git diff --check`: passed

The focused lit test could not be rerun after publishing the source change because the existing build tree resolves LLVM under `/home/z00824747`, which is no longer traversable by this user. This PR is draft so CI or an accessible LLVM workspace can provide the final branch build result.

Addresses the FP32 `round_sf=True` layout-contract compile blocker in #1337. It intentionally does not close the broader performance tracking issue.