### PR TITLE
feat: update VfSim tile fusion cost model

### DIFF
--- a/docs/designs/vf_costmodel_external_planner_protocol.md
+++ b/docs/designs/vf_costmodel_external_planner_protocol.md
@@ -2,7 +2,10 @@
 
 本文描述 PTOAS 以源码级 submodule 方式接入 VfSimulator costmodel 的当前接口形式。
 当前实现面向 A5 tile fusion 路径：PTOAS 负责生成合法 fusion group，VfSim 基于
-已选 group 做 costmodel 优化决策，并把结果写回同一份 MLIR IR。
+已选 group 对 ABCABC 和 AABBCC 两种 unroll 指令顺序共同寻优，并把最优候选的
+unroll factor 写回同一份 MLIR IR。两种顺序只存在于 costmodel 内部，PTOAS/VfSim
+接口不返回顺序模式。VfSim adaptor 基于 `cpp-native-vfsim` 的 canonical API，
+将 tileop-level MLIR 直接转换为 `CanonicalVfInfo`，不经过旧版 `VfInfo`。
 
 ## 接入形式
 
@@ -58,7 +61,9 @@ vfsim::ir_planner
 ## 编译链路
 
 ```text
-PreFusionAnalysis
+InsertTemplateAttributes
+  - PTOAS 按优先级写入 TileLib candidates
+  -> PreFusionAnalysis
   -> FusionPlan
        - PTOAS 生成合法 fusion group
        - PTOAS 写入 pto.fusion.group_id / pto.fusion.order
@@ -72,8 +77,11 @@ PreFusionAnalysis
   -> PTOLowLevelLoopFusion
   -> PTOUnrollAfterLoopFusion
        - 启用 --enable-unroll-after-loop-fusion 时消费 row/col unroll attrs
+       - 不区分 costmodel 内部的 ABCABC/AABBCC 模式，统一按 ABCABC 展开
        - 成功消费后将对应 factor 复位为 1
   -> FlattenFusionRegion
+  -> VPTOScheduler
+       - 对展开后的 VPTO 指令进行调度和重排序
 ```
 
 EmitC 路径可以运行 FusionPlan 和 VfSim planner，但当前 unroll attrs 只由 VPTO
@@ -115,8 +123,9 @@ mlir::LogicalResult planTileFusionIR(
 | 项 | 约定 |
 |---|---|
 | 输入 IR | FusionPlan 后的 MLIR operation；当前自动 tileop fusion 路线传入 `func::FuncOp`。 |
-| 输入内容 | PTOAS 已写好 `pto.fusion.group_id` 和 `pto.fusion.order` 的 tileop-level IR。 |
+| 输入内容 | PTOAS 已写好 fusion metadata 和 TileLib `candidates` 的 tileop-level IR。 |
 | 输出方式 | VfSim 原地写回 `pto.fusion.row_unroll_factor` / `pto.fusion.col_unroll_factor`。 |
+| 输出语义 | 只返回最优 unroll factor，不返回或写入 ABCABC/AABBCC 模式。 |
 | 返回值 | `success()` 表示 planner 完成、没有可处理 group，或某些 group 被 warning 降级跳过；`failure()` 表示接口级错误。 |
 | 修改范围 | Planner 只能写 attrs，不允许增删、替换、移动 op，也不允许修改 operand/result/type。 |
 
@@ -128,6 +137,7 @@ PTOAS 传给 VfSim 的 IR 必须已经包含：
 |---|---|
 | `pto.fusion.group_id` | PTOAS 已选择的 fusion group ID。 |
 | `pto.fusion.order` | group 内 tileop 的执行顺序。 |
+| `candidates` | PTOAS 已排序的 TileLib 模板候选；adaptor 选择第一个不带 `vmi` tag 的普通模板，与 Legacy `ordinary-only` 策略一致。 |
 
 VfSim 从 IR 中读取：
 
@@ -140,7 +150,7 @@ VfSim 从 IR 中读取：
 | 输入输出 value | tileop operands |
 | dtype | operand/result type |
 | shape | tile buffer type |
-| 模板参数 | tileop attrs |
+| 已选模板 | `candidates` 中第一个非 VMI candidate 的 `name` 和 `loop_depth` |
 
 示例：
 
@@ -159,6 +169,31 @@ pto.tmul ins(%a, %b : !pto.tile_buf<vec, 32x128xf32>,
 ```
 
 VfSim 不重新判断这组 tileop 是否可以融合，只基于 PTOAS 已选 group 生成优化决策。
+同一 fusion group 的成员必须选择兼容的 `loop_depth`；否则该 group 会被 warning
+降级跳过。
+
+## CanonicalVfInfo 转换
+
+adaptor 按 PTOAS 已选模板构造与后续 `ExpandTileOp` 一致的循环结构：
+
+| 第一个非 VMI candidate 的 `loop_depth` | CanonicalVfInfo 循环结构 | 搜索 trip count |
+|---|---|---|
+| `1` | 单个 flat loop，按连续 element range 遍历 | `ceil(rows * cols / vector_lanes)` |
+| `2`，col trip > 1 | row loop 内嵌 col loop | `ceil(cols / vector_lanes)` |
+| `2`，col trip = 1 | 单次 col loop 被折叠，只保留 row loop | `rows` |
+
+表中的 `rows/cols` 是 tile type 的 valid shape。对于带
+`rows/cols/v_row/v_col` 的 verbose type，循环范围使用 `v_row/v_col`，UB
+storage shape 和逐行地址 stride 仍使用 physical `rows/cols`；动态 valid shape
+暂不进入 costmodel。
+
+每个 tile 输入转换为 UB value 和 `VLDS`，融合组内 SSA 依赖转换为 register value
+依赖，最终外部输出转换为 `VSTS`。ABCABC/AABBCC 候选通过复制 canonical
+instruction/value definition 构造，因此两种候选使用相同依赖图，只改变展开后的
+指令顺序。
+
+合法 factor 满足 `1 <= factor <= 8` 且能整除搜索 trip count。baseline 失败时
+跳过整个 group；单个 ABCABC/AABBCC 候选失败时仅 warning 并继续评估其他候选。
 
 ## 输出 IR
 
@@ -173,8 +208,12 @@ VfSim 输出仍然是同一份 tileop-level IR，通过 attrs 表示优化计划
 
 | 情况 | VfSim 输出 |
 |---|---|
-| col trip count 为 1 | `row_unroll_factor > 1`，`col_unroll_factor = 1` |
-| col trip count 大于 1 | `row_unroll_factor = 1`，`col_unroll_factor > 1` |
+| 1D flat 模板 | `row_unroll_factor = 1`，factor 写入 `col_unroll_factor` |
+| 2D 模板且 col trip count 为 1 | factor 写入 `row_unroll_factor`，`col_unroll_factor = 1` |
+| 2D 模板且 col trip count 大于 1 | `row_unroll_factor = 1`，factor 写入 `col_unroll_factor` |
+
+VfSim 在内部保留最优候选的 ABCABC/AABBCC 模式用于调试和 cycle 对比，但该模式
+不是 external planner protocol 的一部分。PTOAS 只接收上表中的 factor attrs。
 
 示例：
 
@@ -230,12 +269,17 @@ pto.fusion.col_unroll_factor
 
 消费规则：
 
+- 无论 VfSim 内部选择的是 ABCABC 还是 AABBCC，后端都按 ABCABC 形式展开。
 - 只展开当前最内层 `scf.for`。
 - 只处理常量 trip count，且 trip count 必须能被 factor 整除。
 - 当前约定下，col loop 存在时消费 `col_unroll_factor`；col loop 已被折叠后，
   row loop 成为最内层时消费 `row_unroll_factor`。
 - 成功消费某个 factor 后，将该 region 上对应 attr 复位为 `1`，避免同一 factor
   在后续 greedy/walk 过程中被重复应用。
+
+展开后的 VPTO 指令继续进入 `VPTOScheduler`。AABBCC 候选表达的是 costmodel 对
+更有利指令顺序的预测；接口不要求 unroll pass 直接复现该顺序，而是由后续 scheduler
+对统一 ABCABC 展开的指令进行重排序。
 
 示意：
 
@@ -283,6 +327,10 @@ VfSim native planner 位于 `3rdparty/VfSimulator/native`。
 - 搜索范围是 `1..maxUnroll`。
 - 当前默认 `maxUnroll = 8`。
 - 只考虑能够整除目标 loop trip count 的 factor。
+- factor 为 `1` 时只预测一次 `NO_UNROLL` baseline。
+- factor 大于 `1` 时分别构造并预测 `ABCABC(factor)` 和 `AABBCC(factor)`。
+- 在 baseline、全部 ABCABC 和全部 AABBCC 候选中选择预测 cycle 最低的候选。
+- 对外只返回最优候选的 factor；候选模式不会写入 MLIR attr。
 
 降级诊断：
 
@@ -295,8 +343,12 @@ VfSim native planner 位于 `3rdparty/VfSimulator/native`。
 `--dump-vfsim-unroll-test` 只额外打印候选值预测结果，例如：
 
 ```text
-unroll=1 trip=2 dtype=fp32 cycles=278
-unroll=2 trip=2 dtype=fp32 cycles=131
+mode=NO_UNROLL unroll=1 trip=32 dtype=fp32 cycles=253
+mode=ABCABC unroll=2 trip=32 dtype=fp32 cycles=253
+mode=AABBCC unroll=2 trip=32 dtype=fp32 cycles=248
+mode=ABCABC unroll=4 trip=32 dtype=fp32 cycles=253
+mode=AABBCC unroll=4 trip=32 dtype=fp32 cycles=245
+selected mode=AABBCC unroll=4 cycles=245
 ```
 
 ## 当前模板覆盖范围

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -201,6 +201,19 @@ add_mlir_dialect_library(PTOTransforms
   ${_ptoas_transforms_private_link_libs}
 )
 
+# VfSim is build-tree-only. Remove its BUILD_INTERFACE links from MLIR's
+# install-time aggregate metadata, which cannot contain generator expressions.
+if(TARGET vfsim::native_core OR TARGET vfsim::ir_planner)
+  get_target_property(_ptoas_aggregate_imported_deps PTOTransforms
+    MLIR_AGGREGATE_DEP_LIBS_IMPORTED)
+  if(_ptoas_aggregate_imported_deps)
+    list(FILTER _ptoas_aggregate_imported_deps EXCLUDE REGEX "vfsim::")
+    set_property(TARGET PTOTransforms PROPERTY
+      MLIR_AGGREGATE_DEP_LIBS_IMPORTED
+      "${_ptoas_aggregate_imported_deps}")
+  endif()
+endif()
+
 install(TARGETS PTOTransforms
   EXPORT PTOASTargets      # 将此 Target 加入导出集
   LIBRARY DESTINATION lib


### PR DESCRIPTION
## 更新tileop到MI编译链路的vfsim侧adaptor

将目前仅对ABCABC进行unroll寻优更新为对AABBCC和ABCABC两种展开方式进行unroll寻优，返回最优unroll值。后续unroll展开pass会以ABCABC形式进行展开，再通过VPTOScheduler pass进行重排。

本次迭代主要修改vfsim侧的adaptor，以及将submodule中vfsim指向最新版本。 Vfsim adaptor主要修改点在于适配PTOAS当前主线改动，主线tileop模板进行了修改，并在tileop fusion group pass前确定了后续展开的模板。

## PTOAS侧更新
1. 更新vfsim submodule
2. 更新cmakelist，当前vfsim仅支持build-tree，主线PTOTransforms 开启了 ENABLE_AGGREGATION，导致 VfSim 的 build-tree-only 依赖被记录进 install/export 元数据，从而触发 CMake 错误。对该问题进行修复。
3. 修改说明文档docs/designs/vf_costmodel_external_planner_protocol.md