### PR TITLE
ci: route A5 compiler temporary files to /home

### DIFF
--- a/.github/workflows/ci_a5.yml
+++ b/.github/workflows/ci_a5.yml
@@ -182,12 +182,16 @@ jobs:
           esac
           rm -rf -- "${work_root}"
           mkdir -p \
+            "${work_root}/tmp" \
             "${work_root}/payload/test/samples" \
             "${work_root}/payload/test/npu_validation/scripts" \
             "${work_root}/payload/test/npu_validation/templates"
 
           {
             echo "WORK_ROOT=${work_root}"
+            echo "TMPDIR=${work_root}/tmp"
+            echo "TMP=${work_root}/tmp"
+            echo "TEMP=${work_root}/tmp"
             echo "PTO_BUILD_DIR=${work_root}/build"
             echo "PTO_INSTALL_DIR=${work_root}/install"
             echo "PAYLOAD_DIR=${work_root}/payload"
@@ -308,6 +312,9 @@ jobs:
             "EXPECTED_CASES_FILTER=${RUN_ONLY_CASES}" \
             "PTO_ISA_REPO=${PTO_ISA_REPO}" \
             "PTO_ISA_COMMIT=${PTO_ISA_COMMIT}" \
+            "TMPDIR=${TMPDIR}" \
+            "TMP=${TMP}" \
+            "TEMP=${TEMP}" \
             "OUTPUT_ROOT=${OUTPUT_ROOT}" \
             "RESULTS_TSV=${RESULTS_TSV}" \
             > "${env_file}"


### PR DESCRIPTION
### Summary
- route A5 workflow temporary files (`TMPDIR`, `TMP`, `TEMP`) into the per-run workspace on the runner
- pass the same environment through TaskQueue so bisheng/cceld testcase builds do not fill the small root `/tmp` filesystem
- cleanup remains scoped to the existing per-run WORK_ROOT

### Validation
- `git diff --check`
- A5 board results from run 33147353759 showed the root cause: 219 cascade failures contained `No space left on device /tmp/...`
- report script unit tests passed

The existing actionlint warning for the repository custom runner label is unchanged.