### PR TITLE
ci: send A5 nightly failure details to Feishu

### DIFF
--- a/.github/scripts/report_a5_board_results.py
+++ b/.github/scripts/report_a5_board_results.py
@@ -13,6 +13,7 @@ import argparse
 import csv
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -26,6 +27,8 @@ class BoardSummary:
     results_found: bool
     counts: Counter[str]
     failed_cases: tuple[str, ...]
+    failure_details: tuple[tuple[str, str], ...] = ()
+    log_errors: tuple[str, ...] = ()
 
     @property
     def total(self) -> int:
@@ -41,9 +44,94 @@ class BoardSummary:
         )
 
 
-def load_results(path: Path) -> BoardSummary:
+def _case_key_from_marker(path_text: str) -> str:
+    """Convert a run log CASE path to the TSV's ``Sample/testcase`` key."""
+    case_path = Path(path_text.strip())
+    filename = case_path.name
+    if filename.endswith("-pto.cpp"):
+        filename = filename[: -len("-pto.cpp")]
+    return f"{case_path.parent.name}/{filename}"
+
+
+_ERROR_LINE = re.compile(
+    r"(?:\[ERROR\]|\bERROR:\s*testcase failed|\b(?:fatal )?error:|"
+    r"static assertion failed|Segmentation fault|core dumped|CMake Error|"
+    r"aclrtSetDevice|halDeviceOpen|TsdOpen|open device .* failed|"
+    r"Mismatch:|Packed mask mismatch:|compare failed|gmake: \*\*)",
+    re.IGNORECASE,
+)
+_ERROR_PRIORITIES = (
+    re.compile(r"Mismatch:|Packed mask mismatch", re.IGNORECASE),
+    re.compile(r"Segmentation fault|core dumped", re.IGNORECASE),
+    re.compile(r"aclrtSetDevice|halDeviceOpen|TsdOpen|open device .* failed", re.IGNORECASE),
+    re.compile(r"no member named|undefined reference|CMake Error", re.IGNORECASE),
+    re.compile(r"static assertion failed|compare failed", re.IGNORECASE),
+    re.compile(r"ERROR:\s*testcase failed|gmake: \*\*", re.IGNORECASE),
+)
+
+
+def _select_error_lines(lines: list[str]) -> list[str]:
+    candidates: list[str] = []
+    for line in lines:
+        text = line.strip()
+        if text and _ERROR_LINE.search(text) and text not in candidates:
+            candidates.append(text)
+    selected: list[str] = []
+    for priority in _ERROR_PRIORITIES:
+        selected.extend(line for line in candidates if priority.search(line) and line not in selected[:])
+        if len(selected) >= 8:
+            break
+    if len(selected) < 8:
+        selected.extend(line for line in candidates if line not in selected)
+    return selected[:10]
+
+
+def load_log_failure_details(path: Path | None) -> dict[str, str]:
+    """Extract concise, actionable error lines from each CASE section."""
+    if path is None or not path.is_file():
+        return {}
+
+    sections: dict[str, list[str]] = {}
+    current: list[str] | None = None
+    current_key = ""
+    case_marker = re.compile(r"=== CASE:\s*(.*?)\s*===")
+    with path.open(encoding="utf-8", errors="replace") as stream:
+        for raw_line in stream:
+            marker = case_marker.search(raw_line)
+            if marker:
+                current_key = _case_key_from_marker(marker.group(1))
+                current = sections.setdefault(current_key, [])
+                continue
+            if current is not None:
+                current.append(raw_line.rstrip())
+
+    details: dict[str, str] = {}
+    for key, lines in sections.items():
+        selected = _select_error_lines(lines)
+        if selected:
+            # Keep one testcase's excerpt compact enough for a Feishu card.
+            details[key] = "\n".join(selected)[:1400]
+    return details
+
+
+def load_log_errors(path: Path | None, *, limit: int = 12) -> tuple[str, ...]:
+    """Extract global errors for failures that happen before a CASE section."""
+    if path is None or not path.is_file():
+        return ()
+    errors: list[str] = []
+    with path.open(encoding="utf-8", errors="replace") as stream:
+        for raw_line in stream:
+            text = raw_line.strip()
+            if text and _ERROR_LINE.search(text) and text not in errors:
+                errors.append(text)
+            if len(errors) >= limit:
+                break
+    return tuple(errors)
+
+
+def load_results(path: Path, log_path: Path | None = None) -> BoardSummary:
     if not path.is_file():
-        return BoardSummary(False, Counter(), ())
+        return BoardSummary(False, Counter(), (), (), load_log_errors(log_path))
 
     counts: Counter[str] = Counter()
     failed_cases: list[str] = []
@@ -55,7 +143,32 @@ def load_results(path: Path) -> BoardSummary:
             counts[status] += 1
             if status == "FAIL":
                 failed_cases.append(testcase)
-    return BoardSummary(True, counts, tuple(failed_cases))
+    log_details = load_log_failure_details(log_path)
+    failure_details = tuple(
+        (
+            testcase,
+            log_details.get(testcase, "No detailed error line found in board-validation.log; see the run log."),
+        )
+        for testcase in failed_cases
+    )
+    return BoardSummary(True, counts, tuple(failed_cases), failure_details)
+
+
+def render_failure_details(summary: BoardSummary, *, max_chars: int | None = None) -> str:
+    """Render per-case excerpts, optionally bounded for webhook card limits."""
+    if not summary.failure_details:
+        return ""
+    blocks: list[str] = []
+    used = 0
+    for testcase, detail in summary.failure_details:
+        block = f"- `{testcase}`\n```text\n{detail}\n```"
+        if max_chars is not None and blocks and used + len(block) + 1 > max_chars:
+            remaining = len(summary.failure_details) - len(blocks)
+            blocks.append(f"- ... and {remaining} more; open the GitHub run for the full log")
+            break
+        blocks.append(block)
+        used += len(block) + 1
+    return "\n\n".join(blocks)
 
 
 def render_markdown(
@@ -79,11 +192,17 @@ def render_markdown(
         lines.append(f"- Run: {run_url}")
     if not summary.results_found:
         lines.extend(["", "No board result TSV was produced. Inspect the workflow log."])
+        if summary.log_errors:
+            lines.extend(["", "### Concrete errors", ""])
+            lines.extend(f"```text\n{error}\n```" for error in summary.log_errors)
     elif summary.failed_cases:
         lines.extend(["", "### Failed cases", ""])
         lines.extend(f"- `{case}`" for case in summary.failed_cases[:50])
         if len(summary.failed_cases) > 50:
             lines.append(f"- ... and {len(summary.failed_cases) - 50} more")
+        details = render_failure_details(summary)
+        if details:
+            lines.extend(["", "### Concrete errors", "", details])
     return "\n".join(lines) + "\n"
 
 
@@ -105,11 +224,16 @@ def build_feishu_payload(
     ]
     if not summary.results_found:
         detail_lines.append("**Error**: result TSV was not produced")
+        if summary.log_errors:
+            detail_lines.append("**Concrete errors**:\n```text\n" + "\n".join(summary.log_errors) + "\n```")
     elif summary.failed_cases:
         failed = ", ".join(summary.failed_cases[:20])
         if len(summary.failed_cases) > 20:
             failed += f", ... (+{len(summary.failed_cases) - 20})"
         detail_lines.append(f"**Failed cases**: {failed}")
+        details = render_failure_details(summary, max_chars=7600)
+        if details:
+            detail_lines.append(f"**Concrete errors**:\n{details}")
 
     elements: list[dict[str, object]] = [
         {
@@ -138,7 +262,7 @@ def build_feishu_payload(
                 "template": "green" if succeeded else "red",
                 "title": {
                     "tag": "plain_text",
-                    "content": f"PTOAS A5 nightly board validation: {status}",
+                    "content": f"PTOAS A5 夜间看护：{status}",
                 },
             },
             "elements": elements,
@@ -173,12 +297,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--conclusion", default="failure")
     parser.add_argument("--run-url", default="")
     parser.add_argument("--sha", default="")
+    parser.add_argument(
+        "--log",
+        type=Path,
+        default=None,
+        help="Optional board-validation.log used to include concrete failure lines.",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
-    summary = load_results(args.results)
+    summary = load_results(args.results, args.log)
     markdown = render_markdown(
         summary,
         conclusion=args.conclusion,

--- a/.github/scripts/report_a5_board_results.py
+++ b/.github/scripts/report_a5_board_results.py
@@ -135,6 +135,7 @@ def load_results(path: Path, log_path: Path | None = None) -> BoardSummary:
 
     counts: Counter[str] = Counter()
     failed_cases: list[str] = []
+    failed_info: dict[str, str] = {}
     with path.open(encoding="utf-8", errors="replace", newline="") as stream:
         reader = csv.DictReader(stream, delimiter="\t")
         for row in reader:
@@ -143,11 +144,16 @@ def load_results(path: Path, log_path: Path | None = None) -> BoardSummary:
             counts[status] += 1
             if status == "FAIL":
                 failed_cases.append(testcase)
+                failed_info[testcase] = (row.get("info") or "exit status unavailable").strip()
     log_details = load_log_failure_details(log_path)
     failure_details = tuple(
         (
             testcase,
-            log_details.get(testcase, "No detailed error line found in board-validation.log; see the run log."),
+            log_details.get(
+                testcase,
+                "No recognized error line found in board-validation.log; "
+                f"result info: {failed_info.get(testcase, 'exit status unavailable')}",
+            ),
         )
         for testcase in failed_cases
     )
@@ -270,6 +276,71 @@ def build_feishu_payload(
     }
 
 
+def build_feishu_detail_payloads(
+    summary: BoardSummary,
+    *,
+    run_url: str,
+) -> list[dict[str, object]]:
+    """Build bounded cards so every failed case gets its own concrete excerpt."""
+    if not summary.failure_details:
+        return []
+    # Keep each card comfortably below Feishu's interactive-card text limit.
+    groups: list[list[tuple[str, str]]] = []
+    current: list[tuple[str, str]] = []
+    current_chars = 0
+    for testcase, detail in summary.failure_details:
+        block_chars = len(testcase) + len(detail) + 40
+        if current and current_chars + block_chars > 7000:
+            groups.append(current)
+            current = []
+            current_chars = 0
+        current.append((testcase, detail))
+        current_chars += block_chars
+    if current:
+        groups.append(current)
+
+    cards: list[dict[str, object]] = []
+    total = len(groups)
+    for index, group in enumerate(groups, start=1):
+        blocks = "\n\n".join(
+            f"### `{testcase}`\n```text\n{detail}\n```" for testcase, detail in group
+        )
+        elements: list[dict[str, object]] = [
+            {"tag": "div", "text": {"tag": "lark_md", "content": blocks}}
+        ]
+        if run_url:
+            elements.append(
+                {
+                    "tag": "action",
+                    "actions": [
+                        {
+                            "tag": "button",
+                            "text": {"tag": "plain_text", "content": "打开 GitHub 运行"},
+                            "url": run_url,
+                            "type": "primary",
+                        }
+                    ],
+                }
+            )
+        cards.append(
+            {
+                "msg_type": "interactive",
+                "card": {
+                    "config": {"wide_screen_mode": True},
+                    "header": {
+                        "template": "red",
+                        "title": {
+                            "tag": "plain_text",
+                            "content": f"PTOAS A5 夜间看护失败详情 {index}/{total}",
+                        },
+                    },
+                    "elements": elements,
+                },
+            }
+        )
+    return cards
+
+
 def append_file(path_text: str, content: str) -> None:
     if not path_text:
         return
@@ -338,14 +409,16 @@ def main() -> int:
             run_url=args.run_url,
             sha=args.sha,
         )
-        try:
-            send_feishu(webhook_url, payload)
-        except (OSError, ValueError, urllib.error.URLError) as exc:
-            print(
-                "WARNING: failed to send Feishu notification "
-                f"({type(exc).__name__})",
-                file=sys.stderr,
-            )
+        payloads = [payload] + build_feishu_detail_payloads(summary, run_url=args.run_url)
+        for index, card_payload in enumerate(payloads, start=1):
+            try:
+                send_feishu(webhook_url, card_payload)
+            except (OSError, ValueError, urllib.error.URLError) as exc:
+                print(
+                    "WARNING: failed to send Feishu notification "
+                    f"part {index}/{len(payloads)} ({type(exc).__name__})",
+                    file=sys.stderr,
+                )
     return 0 if args.conclusion == "success" and summary.passed else 1
 
 

--- a/.github/scripts/report_a5_board_results_test.py
+++ b/.github/scripts/report_a5_board_results_test.py
@@ -55,6 +55,46 @@ class BoardResultReportTest(unittest.TestCase):
             self.assertIn("`Add/add`", markdown)
             self.assertIn("`0123456789ab`", markdown)
 
+    def test_log_errors_are_attached_to_failed_cases(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="a5-board-report-") as temp_dir:
+            root = pathlib.Path(temp_dir)
+            results = root / "results.tsv"
+            results.write_text(
+                "testcase\tstatus\tstage\tinfo\n"
+                "Rowexpandsub/rowexpandsub\tFAIL\trun\texit=2\n"
+                "DeepseekV4DecodeA5/rope_cs\tFAIL\trun\texit=139\n"
+                "TquantMx/tquant_mx\tFAIL\trun\texit=2\n",
+                encoding="utf-8",
+            )
+            log = root / "board-validation.log"
+            log.write_text(
+                "[time] === CASE: /tmp/payload/test/samples/Rowexpandsub/rowexpandsub-pto.cpp ===\n"
+                "[ERROR] Mismatch: golden_v3.bin vs v3.bin, max diff=5.5\n"
+                "[time] ERROR: testcase failed (exit 2): rowexpandsub\n"
+                "[time] === CASE: /tmp/payload/test/samples/DeepseekV4DecodeA5/rope_cs-pto.cpp ===\n"
+                "run_remote_npu_validation.sh: line 792: Segmentation fault (core dumped)\n"
+                "[time] === CASE: /tmp/payload/test/samples/TquantMx/tquant_mx-pto.cpp ===\n"
+                "error: no member named 'assignData' in 'pto::Tile'\n",
+                encoding="utf-8",
+            )
+
+            summary = REPORT.load_results(results, log)
+            details = dict(summary.failure_details)
+            self.assertIn("Mismatch: golden_v3.bin", details["Rowexpandsub/rowexpandsub"])
+            self.assertIn("Segmentation fault", details["DeepseekV4DecodeA5/rope_cs"])
+            self.assertIn("no member named 'assignData'", details["TquantMx/tquant_mx"])
+            markdown = REPORT.render_markdown(
+                summary, conclusion="failure", run_url="", sha=""
+            )
+            self.assertIn("### Concrete errors", markdown)
+
+            payload = REPORT.build_feishu_payload(
+                summary, conclusion="failure", run_url="", sha=""
+            )
+            content = payload["card"]["elements"][0]["text"]["content"]
+            self.assertIn("**Concrete errors**", content)
+            self.assertIn("Segmentation fault", content)
+
     def test_missing_results_are_reported_as_failure(self) -> None:
         summary = REPORT.load_results(pathlib.Path("/path/that/does/not/exist"))
         self.assertFalse(summary.results_found)
@@ -66,6 +106,7 @@ class BoardResultReportTest(unittest.TestCase):
             sha="",
         )
         self.assertEqual(payload["card"]["header"]["template"], "red")
+        self.assertIn("夜间看护", payload["card"]["header"]["title"]["content"])
 
     def test_successful_results_are_reported_as_pass(self) -> None:
         summary = REPORT.BoardSummary(

--- a/.github/scripts/report_a5_board_results_test.py
+++ b/.github/scripts/report_a5_board_results_test.py
@@ -95,6 +95,17 @@ class BoardResultReportTest(unittest.TestCase):
             self.assertIn("**Concrete errors**", content)
             self.assertIn("Segmentation fault", content)
 
+            detail_payloads = REPORT.build_feishu_detail_payloads(
+                summary, run_url="https://github.example/actions/runs/3"
+            )
+            self.assertGreaterEqual(len(detail_payloads), 1)
+            detail_content = "\n".join(
+                card["card"]["elements"][0]["text"]["content"]
+                for card in detail_payloads
+            )
+            for testcase in summary.failed_cases:
+                self.assertIn(f"`{testcase}`", detail_content)
+
     def test_missing_results_are_reported_as_failure(self) -> None:
         summary = REPORT.load_results(pathlib.Path("/path/that/does/not/exist"))
         self.assertFalse(summary.results_found)

--- a/.github/workflows/ci_a5.yml
+++ b/.github/workflows/ci_a5.yml
@@ -380,6 +380,7 @@ jobs:
           results_tsv="${RESULTS_TSV:-${RUNNER_TEMP}/a5-board-results-missing.tsv}"
           "${report_python}" .github/scripts/report_a5_board_results.py \
             --results "${results_tsv}" \
+            --log "${BOARD_LOG:-}" \
             --conclusion "${BOARD_CONCLUSION}" \
             --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             --sha "${GITHUB_SHA}"


### PR DESCRIPTION
## 变更

- 将 A5 `board-validation.log` 传给结果报告脚本。
- 按失败 testcase 提取 `Mismatch`、`compare failed`、`Segmentation fault`、设备初始化错误和编译器错误等具体日志行。
- 将具体错误写入 GitHub Step Summary，并加入飞书卡片；卡片标题标识为「PTOAS A5 夜间看护」。
- 当结果 TSV 未生成时，从 workflow 日志提取全局错误作为兜底。

## 验证

- `python3 -m unittest discover -s .github/scripts -p 'report_a5_board_results_test.py'`
- 使用 run `33228746221` 的真实 artifact 回放，确认 19 个失败项均能关联到具体日志。
- `git diff --check`
- `actionlint .github/workflows/ci_a5.yml`：仅保留仓库已有的自定义 runner label `ptoas-a5` 提示。
