### PR TITLE
fix: stabilize remaining A5 board samples

### DIFF
--- a/docs/designs/fixpipe-tpipe-design.md
+++ b/docs/designs/fixpipe-tpipe-design.md
@@ -505,8 +505,8 @@ PTOAS 中 `nosplit = false` 则对应 `TPipe<..., IsNoSplit = false>`。
 - 当前实现已经把 `vector quant payload` 的一部分公共下限约束前移到了
   `pto.set_quant_vector` 公共 verifier：
   - 输入必须是 `loc=scaling`
-  - element type 按目标平台收紧：A5 为 `f16` / `bf16` / `f32` family，
-    A3 为 packed 64-bit integer payload（`i64` / `ui64`）
+  - element type 按目标平台收紧：A3/A5 均为 packed 64-bit integer payload
+    （`i64` / `ui64` / `si64`）
 - 但 `vector quant payload` 的精确 shape 与更细的 layout / 打包约束，仍不建议在
   当前阶段一次性写死成所有 target 共享的唯一公共 contract
 - 更稳妥的做法是：公共 verifier 负责上述 arch-aware 下限约束，其余 payload
@@ -789,8 +789,8 @@ acc-store `pre_quant` payload surface。
 `SET_QUANT_VECTOR(fpTile)` 的输入下限收紧为：
 
 - `loc=scaling`
-- element type 按目标平台收紧：A5 属于 `f16` / `bf16` / `f32` family，
-  A3 属于 packed 64-bit integer payload（`i64` / `ui64`）
+- element type 按目标平台收紧：A3/A5 均属于 packed 64-bit integer payload
+  （`i64` / `ui64` / `si64`）
 
 但它仍不需要像 scalar quant 那样额外暴露一份 `out_type`；更细的 payload
 shape / layout 约束仍可继续留给 arch-specific verifier 与 lowering 处理。
@@ -1485,8 +1485,8 @@ fixpipe 的生产语义由 producer `TPUSH` 和 pipe contract 保证，而不是
     `SubBlockId = 0`，即仅覆盖 `AccToVecMode::SingleModeVec0`。`SingleModeVec1`
     及更复杂的 dual-vector 目标选择不属于当前前端 contract。
 24. `pto.set_quant_vector` 的输入必须是 `loc=scaling` 的 tile；其 element type
-    按目标平台收紧：A5 必须属于 `f16` / `bf16` / `f32` family，A3 必须属于
-    packed 64-bit integer payload（`i64` / `ui64`）。其大小与更细的 layout
+    按目标平台收紧：A3/A5 必须属于 packed 64-bit integer payload
+    （`i64` / `ui64` / `si64`）。其大小与更细的 layout
     约束仍应满足目标平台 fixpipe vector quant payload 的参数布局要求。
 25. 对 `pto.set_quant_vector`，第一版公共 verifier 至少检查 `loc=scaling` 与
     上述 arch-aware element type family；其余 payload shape / layout 约束，

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1860,10 +1860,11 @@ def SetQuantVectorOp : PTO_Op<"set_quant_vector", [
   let description = [{
     Producer-side vector quantization configuration for fixpipe TPUSH.
     Binds a vector quant payload (scaling tile) to a logical pipe id.
-    The input tile must have loc=scaling. A5 consumes a direct scaling
-    payload with an element type in the f16/bf16/f32 family; A3 consumes
-    a packed 64-bit integer payload (i64/ui64). This binding persists
-    until overwritten by another set_quant_vector with the same id.
+    The input tile must have loc=scaling. A5 accepts direct scaling payloads
+    in the f16/bf16/f32 family and packed 64-bit integer payloads (i64/ui64),
+    including the packed VDEQF16 format used by pto-isa. A3 consumes packed
+    64-bit integer payloads. This binding persists until overwritten by
+    another set_quant_vector with the same id.
     Used by vector quant modes: deqf16_vec, req8_vec, qf322b8_pre_vec,
     qs322bf16_pre_vec.
   }];

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1860,11 +1860,12 @@ def SetQuantVectorOp : PTO_Op<"set_quant_vector", [
   let description = [{
     Producer-side vector quantization configuration for fixpipe TPUSH.
     Binds a vector quant payload (scaling tile) to a logical pipe id.
-    The input tile must have loc=scaling. A5 accepts direct scaling payloads
-    in the f16/bf16/f32 family and packed 64-bit integer payloads (i64/ui64),
-    including the packed VDEQF16 format used by pto-isa. A3 consumes packed
-    64-bit integer payloads. This binding persists until overwritten by
-    another set_quant_vector with the same id.
+    The input tile must have loc=scaling and use a packed 64-bit integer
+    payload (i64/ui64/si64), including the packed VDEQF16 format used by
+    pto-isa. SET_QUANT_VECTOR passes each column directly as a hardware
+    control word; floating-point payloads are not converted to this format.
+    This binding persists until overwritten by another set_quant_vector with
+    the same id.
     Used by vector quant modes: deqf16_vec, req8_vec, qf322b8_pre_vec,
     qs322bf16_pre_vec.
   }];

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -19573,12 +19573,11 @@ static bool isFixpipeQuantPayloadElemType(Type elemTy, PTOArch arch) {
   bool isPackedI64 = elemTy.isUnsignedInteger(64) ||
                      elemTy.isSignlessInteger(64) ||
                      elemTy.isSignedInteger(64);
-  if (arch == PTOArch::A3) {
-    return isPackedI64;
-  }
-  // A5 pto-isa uses packed uint64_t FBUF entries for VDEQF16, while other A5
-  // vector-quant forms expose direct floating-point scaling payloads.
-  return isPackedI64 || elemTy.isF16() || elemTy.isBF16() || elemTy.isF32();
+  // SET_QUANT_VECTOR passes each column to the hardware as a packed 64-bit
+  // control word. The frontend does not convert floating-point elements into
+  // that representation, so accepting f16/bf16/f32 would produce invalid
+  // quantization parameters on both A3 and A5.
+  return (arch == PTOArch::A3 || arch == PTOArch::A5) && isPackedI64;
 }
 
 static bool matchesFixpipeProducerAndConsumerTypes(FixpipeQuant quant,
@@ -21029,10 +21028,10 @@ LogicalResult SetQuantVectorOp::verify() {
   if (!isFixpipeQuantPayloadElemType(scalingElemTy, arch)) {
     if (arch == PTOArch::A3) {
       return emitOpError(
-          "expects 'scaling_tile' element type to be packed i64/ui64 on A3");
+          "expects 'scaling_tile' element type to be packed i64/ui64/si64 on A3");
     }
-    return emitOpError("expects 'scaling_tile' element type to be f16, bf16, "
-                       "f32, or packed i64/ui64 on A5");
+    return emitOpError(
+        "expects 'scaling_tile' element type to be packed i64/ui64/si64 on A5");
   }
 
   return success();

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -19570,11 +19570,15 @@ static bool isFixpipeQuantPayloadElemType(Type elemTy, PTOArch arch) {
   if (!elemTy) {
     return false;
   }
+  bool isPackedI64 = elemTy.isUnsignedInteger(64) ||
+                     elemTy.isSignlessInteger(64) ||
+                     elemTy.isSignedInteger(64);
   if (arch == PTOArch::A3) {
-    return elemTy.isUnsignedInteger(64) || elemTy.isSignlessInteger(64) ||
-           elemTy.isSignedInteger(64);
+    return isPackedI64;
   }
-  return elemTy.isF16() || elemTy.isBF16() || elemTy.isF32();
+  // A5 pto-isa uses packed uint64_t FBUF entries for VDEQF16, while other A5
+  // vector-quant forms expose direct floating-point scaling payloads.
+  return isPackedI64 || elemTy.isF16() || elemTy.isBF16() || elemTy.isF32();
 }
 
 static bool matchesFixpipeProducerAndConsumerTypes(FixpipeQuant quant,
@@ -21027,8 +21031,8 @@ LogicalResult SetQuantVectorOp::verify() {
       return emitOpError(
           "expects 'scaling_tile' element type to be packed i64/ui64 on A3");
     }
-    return emitOpError(
-        "expects 'scaling_tile' element type to be f16, bf16, or f32 on A5");
+    return emitOpError("expects 'scaling_tile' element type to be f16, bf16, "
+                       "f32, or packed i64/ui64 on A5");
   }
 
   return success();

--- a/test/lit/pto/fixpipe_frontend_emitc_nested_quant_block_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_emitc_nested_quant_block_a5.pto
@@ -44,7 +44,7 @@ module {
       (c2v_consumer_buf = %c2v_import1 : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %acc_scalar = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
     %acc_vector = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
 
@@ -52,7 +52,7 @@ module {
       pto.set_quant_scalar(%scale : f32) {id = 0}
       pto.tpush_to_aiv(%acc_scalar : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
 
-      pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
+      pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
       pto.tpush_to_aiv(%acc_vector : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 1, split = 0}
     }
     return

--- a/test/lit/pto/fixpipe_frontend_emitc_qs322bf16_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_emitc_qs322bf16_a5.pto
@@ -43,14 +43,14 @@ module {
       (c2v_consumer_buf = %c2v_import1 : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %acc0 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
     %acc1 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
 
     pto.set_quant_scalar(%scale : f32) {id = 0}
     pto.tpush_to_aiv(%acc0 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
 
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
     pto.tpush_to_aiv(%acc1 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 1, split = 0}
     return
   }

--- a/test/lit/pto/fixpipe_frontend_emitc_quant_reuse_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_emitc_quant_reuse_a5.pto
@@ -43,7 +43,7 @@ module {
       (c2v_consumer_buf = %c2v_import1 : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %acc_scalar0 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
     %acc_scalar1 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
     %acc_vector0 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
@@ -53,7 +53,7 @@ module {
     pto.tpush_to_aiv(%acc_scalar0 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
     pto.tpush_to_aiv(%acc_scalar1 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
 
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
     pto.tpush_to_aiv(%acc_vector0 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 1, split = 0}
     pto.tpush_to_aiv(%acc_vector1 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 1, split = 0}
     return

--- a/test/lit/pto/fixpipe_frontend_emitc_signed_vector8_quant_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_emitc_signed_vector8_quant_a5.pto
@@ -42,15 +42,15 @@ module {
       (c2v_consumer_buf = %c2v_import1 : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
-    %fp0 = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %fp1 = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp0 = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp1 = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %acc0 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
     %acc1 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
 
-    pto.set_quant_vector(%fp0 : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
+    pto.set_quant_vector(%fp0 : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
     pto.tpush_to_aiv(%acc0 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
 
-    pto.set_quant_vector(%fp1 : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
+    pto.set_quant_vector(%fp1 : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
     pto.tpush_to_aiv(%acc1 : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 1, split = 0}
     return
   }

--- a/test/lit/pto/fixpipe_frontend_emitc_vector_payload_types_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_emitc_vector_payload_types_a5.pto
@@ -42,15 +42,15 @@ module {
       (c2v_consumer_buf = %c2v_import1 : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
-    %fp_bf16 = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=bf16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %fp_f32 = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp_i64 = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=i64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp_ui64 = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %acc0 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
     %acc1 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
 
-    pto.set_quant_vector(%fp_bf16 : !pto.tile_buf<loc=scaling, dtype=bf16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
+    pto.set_quant_vector(%fp_i64 : !pto.tile_buf<loc=scaling, dtype=i64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
     pto.tpush_to_aiv(%acc0 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
 
-    pto.set_quant_vector(%fp_f32 : !pto.tile_buf<loc=scaling, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
+    pto.set_quant_vector(%fp_ui64 : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
     pto.tpush_to_aiv(%acc1 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 1, split = 0}
     return
   }
@@ -105,8 +105,8 @@ module {
 // A5-LABEL: AICORE void cube_kernel(
 // A5: using Pipe0FixpipeConfig = FixpipeParams<LayoutMode_t::NZ2ND, QuantMode_t::VDEQF16, ReluPreMode::NoRelu>;
 // A5: using Pipe1FixpipeConfig = FixpipeParams<LayoutMode_t::NZ2ND, QuantMode_t::VREQ8, ReluPreMode::NoRelu>;
-// A5: Tile<TileType::Scaling, bfloat16_t, 1, 32
-// A5: Tile<TileType::Scaling, float, 1, 32
+// A5: Tile<TileType::Scaling, int64_t, 1, 32
+// A5: Tile<TileType::Scaling, uint64_t, 1, 32
 // A5: SET_QUANT_VECTOR(
 // A5-NEXT: TPUSH<{{.*}}, Pipe0FixpipeConfig>(
 // A5: SET_QUANT_VECTOR(

--- a/test/lit/pto/fixpipe_frontend_emitc_vector_remat_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_emitc_vector_remat_a5.pto
@@ -43,16 +43,16 @@ module {
       (c2v_consumer_buf = %c2v_import1 : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
-    %fp0 = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %fp1 = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp0 = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp1 = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %acc0 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
     %acc1 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
     %acc2 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
 
-    pto.set_quant_vector(%fp0 : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
+    pto.set_quant_vector(%fp0 : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
     pto.tpush_to_aiv(%acc0 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
 
-    pto.set_quant_vector(%fp1 : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
+    pto.set_quant_vector(%fp1 : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
     pto.tpush_to_aiv(%acc1 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 1, split = 0}
 
     pto.tpush_to_aiv(%acc2 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
@@ -120,9 +120,9 @@ module {
 // A5-NEXT: TPUSH<{{.*}}, Pipe0FixpipeConfig>(
 
 // PLAN-LABEL: func.func @cube_kernel()
-// PLAN: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xf16>) {id = 0}
+// PLAN: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xui64>) {id = 0}
 // PLAN-NEXT: pto.tpush(
-// PLAN: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xf16>) {id = 1}
+// PLAN: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xui64>) {id = 1}
 // PLAN-NEXT: pto.tpush(
-// PLAN: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xf16>) {id = 0}
+// PLAN: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xui64>) {id = 0}
 // PLAN-NEXT: pto.tpush(

--- a/test/lit/pto/fixpipe_frontend_quant_state_preserve_ir_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_quant_state_preserve_ir_a5.pto
@@ -48,16 +48,16 @@ module {
     %acc_scalar1 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
     %acc_vector0 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
     %acc_vector1 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
     pto.set_quant_scalar(%scale : f32) {id = 0}
     pto.tpush_to_aiv(%acc_scalar0 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
     pto.set_quant_scalar(%scale : f32) {id = 0}
     pto.tpush_to_aiv(%acc_scalar1 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
 
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
     pto.tpush_to_aiv(%acc_vector0 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 1, split = 0}
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
     pto.tpush_to_aiv(%acc_vector1 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 1, split = 0}
     return
   }
@@ -120,9 +120,9 @@ module {
 // IR-NEXT: pto.tpush(
 // IR: pto.set_quant_scalar(%{{.*}} : f32) {id = 0}
 // IR-NEXT: pto.tpush(
-// IR: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xf16>) {id = 1}
+// IR: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xui64>) {id = 1}
 // IR-NEXT: pto.tpush(
-// IR: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xf16>) {id = 1}
+// IR: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xui64>) {id = 1}
 // IR-NEXT: pto.tpush(
 
 // LATE-LABEL: func.func @cube_kernel()
@@ -130,7 +130,7 @@ module {
 // LATE-NEXT: pto.tpush(
 // LATE: pto.set_quant_scalar(%{{.*}} : f32) {id = 0}
 // LATE-NEXT: pto.tpush(
-// LATE: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xf16>) {id = 1}
+// LATE: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xui64>) {id = 1}
 // LATE-NEXT: pto.tpush(
-// LATE: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xf16>) {id = 1}
+// LATE: pto.set_quant_vector(%{{.*}} : !pto.tile_buf<scaling, 1x32xui64>) {id = 1}
 // LATE-NEXT: pto.tpush(

--- a/test/lit/pto/fixpipe_frontend_verify_additional_invalid.pto
+++ b/test/lit/pto/fixpipe_frontend_verify_additional_invalid.pto
@@ -58,8 +58,8 @@ module {
     pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 512, nosplit = true,
       acc_push_epilogue = #pto.acc_push_epilogue<layout = nz2nd, quant = deqf16_scalar, relu = no_relu>}
       (c2v_consumer_buf = %c2v_import : i32, v2c_consumer_buf = %c0_i32 : i32)
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
     return
   }
 
@@ -114,8 +114,8 @@ module {
     pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 512, nosplit = true,
       acc_push_epilogue = #pto.acc_push_epilogue<layout = nz2nd, quant = deqf16_vec, relu = no_relu>}
       (c2v_consumer_buf = %c2v_import : i32, v2c_consumer_buf = %c0_i32 : i32)
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
     return
   }
 
@@ -142,8 +142,8 @@ module {
     pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 512, nosplit = true,
       acc_push_epilogue = #pto.acc_push_epilogue<layout = nz2nd, quant = deqf16_vec, relu = no_relu>}
       (c2v_consumer_buf = %c2v_import : i32, v2c_consumer_buf = %c0_i32 : i32)
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=vec, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
     return
   }
 

--- a/test/lit/pto/fixpipe_frontend_verify_contract_invalid_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_verify_contract_invalid_a5.pto
@@ -57,12 +57,12 @@ module {
     %c0_i32 = arith.constant 0 : i32
     %true = arith.constant true
     %c2v_import = pto.import_reserved_buffer {name = "c2v_fifo", peer_func = @vector_kernel} -> i32
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 512, nosplit = true,
       acc_push_epilogue = #pto.acc_push_epilogue<layout = nz2nd, quant = deqf16_vec, relu = no_relu>}
       (c2v_consumer_buf = %c2v_import : i32, v2c_consumer_buf = %c0_i32 : i32)
     %acc = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
     scf.if %true {
       pto.tpush_to_aiv(%acc : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
     }

--- a/test/lit/pto/fixpipe_frontend_verify_hidden_fixpipe_attrs_invalid.pto
+++ b/test/lit/pto/fixpipe_frontend_verify_hidden_fixpipe_attrs_invalid.pto
@@ -138,8 +138,8 @@ module {
 //--- set_quant_vector_channel_split.pto
 module {
   func.func @cube_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0} {isChannelSplit = true}
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0} {isChannelSplit = true}
     return
   }
 }

--- a/test/lit/pto/fixpipe_frontend_verify_quant_state_binding_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_verify_quant_state_binding_a5.pto
@@ -317,7 +317,7 @@ module {
 module {
   func.func @cube_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
     %c0_i32 = arith.constant 0 : i32
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %c2v_import0 = pto.import_reserved_buffer {name = "c2v_fifo0", peer_func = @vector_kernel} -> i32
     %c2v_import1 = pto.import_reserved_buffer {name = "c2v_fifo1", peer_func = @vector_kernel} -> i32
     pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 512, nosplit = true,
@@ -327,7 +327,7 @@ module {
       acc_push_epilogue = #pto.acc_push_epilogue<layout = nz2nd, quant = qf322b8_pre_vec, relu = no_relu>}
       (c2v_consumer_buf = %c2v_import1 : i32, v2c_consumer_buf = %c0_i32 : i32)
     %acc0 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
     pto.tpush_to_aiv(%acc0 : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
     return
   }

--- a/test/lit/pto/fixpipe_frontend_verify_set_quant_vector_bad_payload_type_a3.pto
+++ b/test/lit/pto/fixpipe_frontend_verify_set_quant_vector_bad_payload_type_a3.pto
@@ -59,4 +59,4 @@ module {
   }
 }
 
-// CHECK: error: 'pto.set_quant_vector' op expects 'scaling_tile' element type to be packed i64/ui64 on A3
+// CHECK: error: 'pto.set_quant_vector' op expects 'scaling_tile' element type to be packed i64/ui64/si64 on A3

--- a/test/lit/pto/fixpipe_frontend_verify_set_quant_vector_bad_payload_type_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_verify_set_quant_vector_bad_payload_type_a5.pto
@@ -59,4 +59,4 @@ module {
   }
 }
 
-// CHECK: error: 'pto.set_quant_vector' op expects 'scaling_tile' element type to be f16, bf16, f32, or packed i64/ui64 on A5
+// CHECK: error: 'pto.set_quant_vector' op expects 'scaling_tile' element type to be packed i64/ui64/si64 on A5

--- a/test/lit/pto/fixpipe_frontend_verify_set_quant_vector_bad_payload_type_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_verify_set_quant_vector_bad_payload_type_a5.pto
@@ -27,8 +27,8 @@ module {
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
     return
   }
 
@@ -59,4 +59,4 @@ module {
   }
 }
 
-// CHECK: error: 'pto.set_quant_vector' op expects 'scaling_tile' element type to be f16, bf16, or f32 on A5
+// CHECK: error: 'pto.set_quant_vector' op expects 'scaling_tile' element type to be f16, bf16, f32, or packed i64/ui64 on A5

--- a/test/lit/pto/fixpipe_frontend_verify_set_quant_vector_float_payload_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_verify_set_quant_vector_float_payload_a5.pto
@@ -6,7 +6,17 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 //
-// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
+// Verify that floating-point payloads are rejected for every public A5 vector
+// quantization mode. The placeholder is substituted in each RUN line so the
+// same frontend fixture covers f16, bf16, and f32 without duplicating it.
+//
+// RUN: mkdir -p %t
+// RUN: sed 's/FLOAT_PAYLOAD/f16/g' %s > %t/f16.pto
+// RUN: not ptoas --pto-arch=a5 %t/f16.pto 2>&1 | FileCheck %s --check-prefix=F16
+// RUN: sed 's/FLOAT_PAYLOAD/bf16/g' %s > %t/bf16.pto
+// RUN: not ptoas --pto-arch=a5 %t/bf16.pto 2>&1 | FileCheck %s --check-prefix=BF16
+// RUN: sed 's/FLOAT_PAYLOAD/f32/g' %s > %t/f32.pto
+// RUN: not ptoas --pto-arch=a5 %t/f32.pto 2>&1 | FileCheck %s --check-prefix=F32
 
 module {
   func.func @cube_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
@@ -27,11 +37,8 @@ module {
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=FLOAT_PAYLOAD, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=FLOAT_PAYLOAD, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
     return
   }
 
@@ -62,10 +69,6 @@ module {
   }
 }
 
-// A5-LABEL: AICORE void cube_kernel(
-// A5: using Pipe0FixpipeConfig = FixpipeParams<LayoutMode_t::NZ2ND, QuantMode_t::VDEQF16, ReluPreMode::NoRelu>;
-// A5: SET_QUANT_VECTOR(
-// A5-NEXT: TPUSH<{{.*}}, Pipe0FixpipeConfig>(
-// A5-LABEL: AICORE void vector_kernel(
-// A5: #if defined(__DAV_VEC__)
-// A5: if (get_subblockid() == 0) {
+// F16: error: 'pto.set_quant_vector' op expects 'scaling_tile' element type to be packed i64/ui64/si64 on A5
+// BF16: error: 'pto.set_quant_vector' op expects 'scaling_tile' element type to be packed i64/ui64/si64 on A5
+// F32: error: 'pto.set_quant_vector' op expects 'scaling_tile' element type to be packed i64/ui64/si64 on A5

--- a/test/lit/pto/fixpipe_frontend_verify_src_type_invalid.pto
+++ b/test/lit/pto/fixpipe_frontend_verify_src_type_invalid.pto
@@ -199,12 +199,12 @@ module {
   func.func @cube_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
     %c0_i32 = arith.constant 0 : i32
     %c2v_import = pto.import_reserved_buffer {name = "c2v_fifo", peer_func = @vector_kernel} -> i32
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 256, nosplit = true,
       acc_push_epilogue = #pto.acc_push_epilogue<layout = nz2nd, quant = req8_vec, relu = no_relu>}
       (c2v_consumer_buf = %c2v_import : i32, v2c_consumer_buf = %c0_i32 : i32)
     %acc = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
     pto.tpush_to_aiv(%acc : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
     return
   }
@@ -259,12 +259,12 @@ module {
   func.func @cube_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
     %c0_i32 = arith.constant 0 : i32
     %c2v_import = pto.import_reserved_buffer {name = "c2v_fifo", peer_func = @vector_kernel} -> i32
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 256, nosplit = true,
       acc_push_epilogue = #pto.acc_push_epilogue<layout = nz2nd, quant = qf322b8_pre_vec, relu = no_relu>}
       (c2v_consumer_buf = %c2v_import : i32, v2c_consumer_buf = %c0_i32 : i32)
     %acc = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
     pto.tpush_to_aiv(%acc : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
     return
   }
@@ -349,12 +349,12 @@ module {
   func.func @cube_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
     %c0_i32 = arith.constant 0 : i32
     %c2v_import = pto.import_reserved_buffer {name = "c2v_fifo", peer_func = @vector_kernel} -> i32
-    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 512, nosplit = true,
       acc_push_epilogue = #pto.acc_push_epilogue<layout = nz2nd, quant = qs322bf16_pre_vec, relu = no_relu>}
       (c2v_consumer_buf = %c2v_import : i32, v2c_consumer_buf = %c0_i32 : i32)
     %acc = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
+    pto.set_quant_vector(%fp : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
     pto.tpush_to_aiv(%acc : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
     return
   }

--- a/test/samples/Movfp/movfp_fixpipe_reuse-pto.pto
+++ b/test/samples/Movfp/movfp_fixpipe_reuse-pto.pto
@@ -10,8 +10,8 @@ module {
   func.func @movfp_fixpipe_reuse_aic(
       %gm_lhs: !pto.ptr<i8>,
       %gm_rhs: !pto.ptr<i8>,
-      %gm_fp0: !pto.ptr<f16>,
-      %gm_fp1: !pto.ptr<f16>,
+      %gm_fp0: !pto.ptr<ui64>,
+      %gm_fp1: !pto.ptr<ui64>,
       %gm_out0: !pto.ptr<f16>,
       %gm_out1: !pto.ptr<f16>,
       %gm_out2: !pto.ptr<f16>)
@@ -57,48 +57,54 @@ module {
     %rhs_view = pto.make_tensor_view %gm_rhs, shape = [%c32, %c32], strides = [%c32, %c1]
       : !pto.tensor_view<?x?xi8>
     %fp0_view = pto.make_tensor_view %gm_fp0, shape = [%c1, %c32], strides = [%c32, %c1]
-      : !pto.tensor_view<?x?xf16>
+      : !pto.tensor_view<?x?xui64>
     %fp1_view = pto.make_tensor_view %gm_fp1, shape = [%c1, %c32], strides = [%c32, %c1]
-      : !pto.tensor_view<?x?xf16>
+      : !pto.tensor_view<?x?xui64>
 
     %lhs_part = pto.partition_view %lhs_view, offsets = [%c0, %c0], sizes = [%c16, %c32]
       : !pto.tensor_view<?x?xi8> -> !pto.partition_tensor_view<16x32xi8>
     %rhs_part = pto.partition_view %rhs_view, offsets = [%c0, %c0], sizes = [%c32, %c32]
       : !pto.tensor_view<?x?xi8> -> !pto.partition_tensor_view<32x32xi8>
     %fp0_part = pto.partition_view %fp0_view, offsets = [%c0, %c0], sizes = [%c1, %c32]
-      : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<1x32xf16>
+      : !pto.tensor_view<?x?xui64> -> !pto.partition_tensor_view<1x32xui64>
     %fp1_part = pto.partition_view %fp1_view, offsets = [%c0, %c0], sizes = [%c1, %c32]
-      : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<1x32xf16>
+      : !pto.tensor_view<?x?xui64> -> !pto.partition_tensor_view<1x32xui64>
 
     %lhs_mat = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=i8, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     %rhs_mat = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     %lhs_left = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=i8, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     %rhs_right = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>
-    %fp0_tile = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %fp1_tile = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp0_mat = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp1_mat = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp0_tile = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp1_tile = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
 
     pto.tload ins(%lhs_part : !pto.partition_tensor_view<16x32xi8>)
               outs(%lhs_mat : !pto.tile_buf<loc=mat, dtype=i8, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
     pto.tload ins(%rhs_part : !pto.partition_tensor_view<32x32xi8>)
               outs(%rhs_mat : !pto.tile_buf<loc=mat, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
-    pto.tload ins(%fp0_part : !pto.partition_tensor_view<1x32xf16>)
-              outs(%fp0_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tload ins(%fp1_part : !pto.partition_tensor_view<1x32xf16>)
-              outs(%fp1_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%fp0_part : !pto.partition_tensor_view<1x32xui64>)
+              outs(%fp0_mat : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%fp1_part : !pto.partition_tensor_view<1x32xui64>)
+              outs(%fp1_mat : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
     pto.tmov ins(%lhs_mat : !pto.tile_buf<loc=mat, dtype=i8, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
              outs(%lhs_left : !pto.tile_buf<loc=left, dtype=i8, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
     pto.tmov ins(%rhs_mat : !pto.tile_buf<loc=mat, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
              outs(%rhs_right : !pto.tile_buf<loc=right, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+    pto.tmov ins(%fp0_mat : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%fp0_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmov ins(%fp1_mat : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%fp1_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
     pto.tmatmul ins(%lhs_left, %rhs_right : !pto.tile_buf<loc=left, dtype=i8, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
                 outs(%acc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
 
-    pto.set_quant_vector(%fp0_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
+    pto.set_quant_vector(%fp0_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0}
     pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
 
-    pto.set_quant_vector(%fp1_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
+    pto.set_quant_vector(%fp1_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 1}
     pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 1, split = 0}
 
     pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
@@ -108,8 +114,8 @@ module {
   func.func @movfp_fixpipe_reuse_aiv(
       %gm_lhs: !pto.ptr<i8>,
       %gm_rhs: !pto.ptr<i8>,
-      %gm_fp0: !pto.ptr<f16>,
-      %gm_fp1: !pto.ptr<f16>,
+      %gm_fp0: !pto.ptr<ui64>,
+      %gm_fp1: !pto.ptr<ui64>,
       %gm_out0: !pto.ptr<f16>,
       %gm_out1: !pto.ptr<f16>,
       %gm_out2: !pto.ptr<f16>)

--- a/test/samples/Movfp/movfp_fixpipe_reuse_golden.py
+++ b/test/samples/Movfp/movfp_fixpipe_reuse_golden.py
@@ -8,6 +8,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from pathlib import Path
+import struct
 import sys
 
 import numpy as np
@@ -30,6 +31,14 @@ def clip_to_f16(values: np.ndarray) -> np.ndarray:
     return np.clip(values, -F16_MAX, F16_MAX).astype(np.float16)
 
 
+def pack_vector_quant(values: np.ndarray) -> np.ndarray:
+    flat = np.asarray(values, dtype=np.float32).reshape(-1)
+    packed = np.empty(flat.size, dtype=np.uint64)
+    for i, value in enumerate(flat):
+        packed[i] = struct.unpack("!I", struct.pack("!f", float(value)))[0]
+    return packed
+
+
 def main():
     meta = load_case_meta()
     generator = rng()
@@ -48,15 +57,13 @@ def main():
     rhs = generator.integers(-3, 4, size=(K, N), dtype=np.int16).astype(np.int8)
 
     cols = np.arange(N, dtype=np.float32)
-    fp0 = (np.float32(0.5) + cols * np.float32(0.03125)).astype(meta.np_types[fp0_name]).reshape(1, N)
-    fp1 = (np.float32(1.0) + (cols % np.float32(7.0)) * np.float32(0.0625)).astype(
-        meta.np_types[fp1_name]
-    ).reshape(1, N)
+    fp0_f32 = (np.float32(0.5) + cols * np.float32(0.03125)).reshape(1, N)
+    fp1_f32 = (np.float32(1.0) + (cols % np.float32(7.0)) * np.float32(0.0625)).reshape(1, N)
+
+    fp0 = pack_vector_quant(fp0_f32).astype(meta.np_types[fp0_name], copy=False).reshape(1, N)
+    fp1 = pack_vector_quant(fp1_f32).astype(meta.np_types[fp1_name], copy=False).reshape(1, N)
 
     acc = lhs.astype(np.int32) @ rhs.astype(np.int32)
-    fp0_f32 = fp0.astype(np.float32, copy=False).reshape(1, N)
-    fp1_f32 = fp1.astype(np.float32, copy=False).reshape(1, N)
-
     out0 = clip_to_f16(acc.astype(np.float32) * fp0_f32)
     out1 = clip_to_f16(acc.astype(np.float32) * fp1_f32)
     out2 = clip_to_f16(acc.astype(np.float32) * fp0_f32)

--- a/test/samples/Partmin/partmin_compare.py
+++ b/test/samples/Partmin/partmin_compare.py
@@ -1,4 +1,12 @@
 #!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
 import numpy as np
 from pathlib import Path
 import sys

--- a/test/samples/Partmin/partmin_compare.py
+++ b/test/samples/Partmin/partmin_compare.py
@@ -11,4 +11,4 @@ for search_root in (Path(__file__).resolve().parent, Path(__file__).resolve().pa
 from validation_runtime import compare_outputs
 
 if __name__ == '__main__':
-    compare_outputs(np.float16, atol=0.0005)
+    compare_outputs(np.float32, atol=0.0005)

--- a/test/samples/Partmin/partmin_golden.py
+++ b/test/samples/Partmin/partmin_golden.py
@@ -1,4 +1,12 @@
 #!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
 import numpy as np
 from pathlib import Path
 import sys

--- a/test/samples/Partmin/partmin_golden.py
+++ b/test/samples/Partmin/partmin_golden.py
@@ -22,7 +22,7 @@ def main():
     buffers[rhs_name] = rhs
     write_buffers(meta, buffers)
     out = np.minimum(lhs, rhs)
-    write_golden(meta, {single_output(meta): np.asarray(out, dtype=np.float16)})
+    write_golden(meta, {single_output(meta): np.asarray(out, dtype=np.float32)})
 
 
 if __name__ == '__main__':

--- a/test/samples/Rowexpanddiv/rowexpanddiv.py
+++ b/test/samples/Rowexpanddiv/rowexpanddiv.py
@@ -23,14 +23,18 @@ def build():
 
             tv2_f32 = pto.TensorViewType.get(2, f32, ctx)
             tile_view_32 = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
+            tile_view_32x1 = pto.PartitionTensorViewType.get([32, 1], f32, ctx)
             vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
             bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            bl_col = pto.BLayoutAttr.get(pto.BLayout.ColMajor, ctx)
             sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
             pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
 
             fractal_ab_size = pto.TileConfig.fractalABSize
             cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+            cfg_col = pto.TileBufConfigAttr.get(bl_col, sl, fractal_ab_size, pd, ctx)
             tile_buf_32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
+            tile_buf_32x1_col = pto.TileBufType.get([32, 1], f32, vec, [32, 1], cfg_col, ctx)
 
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
@@ -49,16 +53,16 @@ def build():
                 # %0/%1/%2 = pto.make_tensor_view %arg?, shape=[%c32,%c32] strides=[%c32,%c1]
                 # 这里用原生 builder：通常签名会是 (result_type, ptr, shape, strides)
                 tv0 = pto.MakeTensorViewOp(tv2_f32, arg0, [c32, c32], [c32, c1]).result
-                tv1 = pto.MakeTensorViewOp(tv2_f32, arg1, [c32, c32], [c32, c1]).result
+                tv1 = pto.MakeTensorViewOp(tv2_f32, arg1, [c32, c1], [c1, c1]).result
                 tv2 = pto.MakeTensorViewOp(tv2_f32, arg2, [c32, c32], [c32, c1]).result
 
                 # Replaced immediate numbers with constants c0 and c32
                 sv0 = pto.PartitionViewOp(tile_view_32, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
-                sv1 = pto.PartitionViewOp(tile_view_32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
+                sv1 = pto.PartitionViewOp(tile_view_32x1, tv1, offsets=[c0, c0], sizes=[c32, c1]).result
 
                 # %5/%6/%7 = pto.alloc_tile : <32x32xf32>
                 tb0 = pto.AllocTileOp(tile_buf_32).result
-                tb1 = pto.AllocTileOp(tile_buf_32).result
+                tb1 = pto.AllocTileOp(tile_buf_32x1_col).result
                 tb2 = pto.AllocTileOp(tile_buf_32).result
 
                 pto.TLoadOp(None, sv0, tb0)  # result=None

--- a/test/samples/Rowexpandmul/rowexpandmul.py
+++ b/test/samples/Rowexpandmul/rowexpandmul.py
@@ -23,14 +23,18 @@ def build():
 
             tv2_f32 = pto.TensorViewType.get(2, f32, ctx)
             tile_view_32 = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
+            tile_view_32x1 = pto.PartitionTensorViewType.get([32, 1], f32, ctx)
             vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
             bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            bl_col = pto.BLayoutAttr.get(pto.BLayout.ColMajor, ctx)
             sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
             pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
 
             fractal_ab_size = pto.TileConfig.fractalABSize
             cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+            cfg_col = pto.TileBufConfigAttr.get(bl_col, sl, fractal_ab_size, pd, ctx)
             tile_buf_32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
+            tile_buf_32x1_col = pto.TileBufType.get([32, 1], f32, vec, [32, 1], cfg_col, ctx)
 
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
@@ -48,16 +52,16 @@ def build():
 
                 # %0/%1/%2 = pto.make_tensor_view %arg?, shape=[%c32,%c32] strides=[%c32,%c1]
                 tv0 = pto.MakeTensorViewOp(tv2_f32, arg0, [c32, c32], [c32, c1]).result
-                tv1 = pto.MakeTensorViewOp(tv2_f32, arg1, [c32, c32], [c32, c1]).result
+                tv1 = pto.MakeTensorViewOp(tv2_f32, arg1, [c32, c1], [c1, c1]).result
                 tv2 = pto.MakeTensorViewOp(tv2_f32, arg2, [c32, c32], [c32, c1]).result
 
                 # %3/%4/%8 = pto.subview %tv, offsets=[%c0,%c0], sizes=[32,32]
                 sv0 = pto.PartitionViewOp(tile_view_32, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
-                sv1 = pto.PartitionViewOp(tile_view_32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
+                sv1 = pto.PartitionViewOp(tile_view_32x1, tv1, offsets=[c0, c0], sizes=[c32, c1]).result
 
                 # %5/%6/%7 = pto.alloc_tile : <32x32xf32>
                 tb0 = pto.AllocTileOp(tile_buf_32).result
-                tb1 = pto.AllocTileOp(tile_buf_32).result
+                tb1 = pto.AllocTileOp(tile_buf_32x1_col).result
                 tb2 = pto.AllocTileOp(tile_buf_32).result
 
                 # pto.load_dps_tb ins(%sv) outs(%tb)

--- a/test/samples/Rowexpandsub/rowexpandsub.py
+++ b/test/samples/Rowexpandsub/rowexpandsub.py
@@ -23,14 +23,18 @@ def build():
 
             tv2_f32 = pto.TensorViewType.get(2, f32, ctx)
             tile_view_32 = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
+            tile_view_32x1 = pto.PartitionTensorViewType.get([32, 1], f32, ctx)
             vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
             bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            bl_col = pto.BLayoutAttr.get(pto.BLayout.ColMajor, ctx)
             sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
             pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
 
             fractal_ab_size = pto.TileConfig.fractalABSize
             cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+            cfg_col = pto.TileBufConfigAttr.get(bl_col, sl, fractal_ab_size, pd, ctx)
             tile_buf_32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
+            tile_buf_32x1_col = pto.TileBufType.get([32, 1], f32, vec, [32, 1], cfg_col, ctx)
 
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
@@ -48,17 +52,17 @@ def build():
 
                 # %0/%1/%2 = pto.make_tensor_view %arg?, shape=[%c32,%c32] strides=[%c32,%c1]
                 tv0 = pto.MakeTensorViewOp(tv2_f32, arg0, [c32, c32], [c32, c1]).result
-                tv1 = pto.MakeTensorViewOp(tv2_f32, arg1, [c32, c32], [c32, c1]).result
+                tv1 = pto.MakeTensorViewOp(tv2_f32, arg1, [c32, c1], [c1, c1]).result
                 tv2 = pto.MakeTensorViewOp(tv2_f32, arg2, [c32, c32], [c32, c1]).result
 
                 # %3/%4/%8 = pto.subview %tv, offsets=[%c0,%c0], sizes=[32,32]
                 # Replaced the immediate numbers with constants (c0 and c32)
                 sv0 = pto.PartitionViewOp(tile_view_32, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
-                sv1 = pto.PartitionViewOp(tile_view_32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
+                sv1 = pto.PartitionViewOp(tile_view_32x1, tv1, offsets=[c0, c0], sizes=[c32, c1]).result
 
                 # %5/%6/%7 = pto.alloc_tile : <32x32xf32>
                 tb0 = pto.AllocTileOp(tile_buf_32).result
-                tb1 = pto.AllocTileOp(tile_buf_32).result
+                tb1 = pto.AllocTileOp(tile_buf_32x1_col).result
                 tb2 = pto.AllocTileOp(tile_buf_32).result
 
                 # pto.load_dps_tb ins(%sv) outs(%tb)

--- a/test/samples/Scatter/scatter_golden.py
+++ b/test/samples/Scatter/scatter_golden.py
@@ -1,4 +1,12 @@
 #!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
 import numpy as np
 from pathlib import Path
 import sys
@@ -26,8 +34,14 @@ def main():
             break
     rows = n_src // cols
     src = float_values(generator, n_src, style='signed').astype(src_dtype, copy=False)
-    idx = np.arange(n_idx, dtype=np.int64).reshape(rows, cols)
-    out = src.reshape(rows, cols)
+    src_2d = src.reshape(rows, cols)
+    col_idx = np.arange(cols, dtype=np.int64).reshape(1, cols)
+    row_perm = generator.permutation(rows).astype(np.int64).reshape(rows, 1)
+    if rows > 1 and np.array_equal(row_perm.reshape(-1), np.arange(rows, dtype=np.int64)):
+        row_perm = np.roll(row_perm, 1, axis=0)
+    idx = row_perm * cols + col_idx
+    out = np.zeros((rows, cols), dtype=src_dtype)
+    out.reshape(-1)[idx.reshape(-1)] = src_2d.reshape(-1)
     buffers = default_buffers(meta)
     buffers[src_name] = src
     buffers[idx_name] = idx.astype(meta.np_types[idx_name], copy=False).reshape(-1)[:n_idx]

--- a/test/samples/Scatter/scatter_golden.py
+++ b/test/samples/Scatter/scatter_golden.py
@@ -26,11 +26,8 @@ def main():
             break
     rows = n_src // cols
     src = float_values(generator, n_src, style='signed').astype(src_dtype, copy=False)
-    src_2d = src.reshape(rows, cols)
-    row_dest = (np.arange(rows, dtype=np.int64) * 17) % rows
-    idx = np.repeat(row_dest[:, None], cols, axis=1)
-    out = np.zeros((rows, cols), dtype=src_dtype)
-    out[row_dest, :] = src_2d
+    idx = np.arange(n_idx, dtype=np.int64).reshape(rows, cols)
+    out = src.reshape(rows, cols)
     buffers = default_buffers(meta)
     buffers[src_name] = src
     buffers[idx_name] = idx.astype(meta.np_types[idx_name], copy=False).reshape(-1)[:n_idx]

--- a/test/samples/Sels/sels.py
+++ b/test/samples/Sels/sels.py
@@ -6,9 +6,9 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from ptoas.mlir.ir import Context, Location, Module, InsertionPoint, IntegerType, UnitAttr
-from ptoas.mlir.dialects import func, arith, pto
-from ptoas.mlir.ir import F32Type, IndexType
+from mlir.ir import Context, Location, Module, InsertionPoint, IntegerType, UnitAttr
+from mlir.dialects import func, arith, pto
+from mlir.ir import F32Type, IndexType
 
 def build():
     with Context() as ctx:
@@ -18,9 +18,13 @@ def build():
             m = Module.create()
 
             f32 = F32Type.get(ctx)
+            u8 = IntegerType.get_unsigned(8, ctx)
+            ptr_u8 = pto.PtrType.get(u8, ctx)
             ptr_f32 = pto.PtrType.get(f32, ctx)
 
+            tv2_u8 = pto.TensorViewType.get(2, u8, ctx)
             tv2_f32 = pto.TensorViewType.get(2, f32, ctx)
+            tile_view_mask = pto.PartitionTensorViewType.get([32, 32], u8, ctx)
             tile_view_32 = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
             vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
             bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
@@ -29,9 +33,10 @@ def build():
 
             fractal_ab_size = pto.TileConfig.fractalABSize
             cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+            tile_buf_mask = pto.TileBufType.get([32, 32], u8, vec, [32, 32], cfg, ctx)
             tile_buf_32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
 
-            fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
+            fn_ty = func.FunctionType.get([ptr_u8, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("sels_kernel_2d", fn_ty)
                 fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
@@ -42,37 +47,30 @@ def build():
                 c0 = arith.ConstantOp(IndexType.get(ctx), 0).result
                 c1 = arith.ConstantOp(IndexType.get(ctx), 1).result
                 c32 = arith.ConstantOp(IndexType.get(ctx), 32).result
-                i32 = IntegerType.get_signless(32, ctx)
-                c64 = arith.ConstantOp(i32, 64).result
+                c64 = arith.ConstantOp(f32, 64.0).result
 
-                arg0, arg1, arg2 = entry.arguments
+                mask_arg, src_arg, dst_arg = entry.arguments
 
-                # %0/%1/%2 = pto.make_tensor_view %arg?, shape=[%c32,%c32] strides=[%c32,%c1]
-                tv0 = pto.MakeTensorViewOp(tv2_f32, arg0, [c32, c32], [c32, c1]).result
-                tv1 = pto.MakeTensorViewOp(tv2_f32, arg1, [c32, c32], [c32, c1]).result
-                tv2 = pto.MakeTensorViewOp(tv2_f32, arg2, [c32, c32], [c32, c1]).result
+                tv0 = pto.MakeTensorViewOp(tv2_u8, mask_arg, [c32, c32], [c32, c1]).result
+                tv1 = pto.MakeTensorViewOp(tv2_f32, src_arg, [c32, c32], [c32, c1]).result
+                tv2 = pto.MakeTensorViewOp(tv2_f32, dst_arg, [c32, c32], [c32, c1]).result
 
-                # Replace offsets and sizes with constants
-                # %3/%4/%8 = pto.subview %tv, offsets=[%c0,%c0], sizes=[%c32,%c32]
-                sv0 = pto.PartitionViewOp(tile_view_32, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
+                sv0 = pto.PartitionViewOp(tile_view_mask, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
                 sv1 = pto.PartitionViewOp(tile_view_32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
 
-                # %5/%6/%7 = pto.alloc_tile : <32x32xf32>
-                tb0 = pto.AllocTileOp(tile_buf_32).result
+                tb0 = pto.AllocTileOp(tile_buf_mask).result
                 tb1 = pto.AllocTileOp(tile_buf_32).result
                 tb2 = pto.AllocTileOp(tile_buf_32).result
+                tb3 = pto.AllocTileOp(tile_buf_32).result
 
                 pto.TLoadOp(None, sv0, tb0)  # result=None
                 pto.TLoadOp(None, sv1, tb1)  # result=None
 
-                # TSELS(mask=tb0, src=tb1, dst=tb2, tmp=tb2, scalar=c64)
-                pto.TSelSOp(tb0, tb1, c64, tb2, tmp=tb2)
+                pto.TSelSOp(tb0, tb1, tb2, c64, tb3)
 
-                # %8 = subview on output tensor_view
                 sv2 = pto.PartitionViewOp(tile_view_32, tv2, offsets=[c0, c0], sizes=[c32, c32]).result
 
-                # pto.store_dps_tb ins(%tb2) outs(%sv2)
-                pto.TStoreOp(None, tb2, sv2)
+                pto.TStoreOp(None, tb3, sv2)
 
                 func.ReturnOp([])
 

--- a/test/samples/Sels/sels.py
+++ b/test/samples/Sels/sels.py
@@ -6,9 +6,9 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, IntegerType, UnitAttr
-from mlir.dialects import func, arith, pto
-from mlir.ir import F32Type, IndexType
+from ptoas.mlir.ir import Context, Location, Module, InsertionPoint, IntegerType, UnitAttr
+from ptoas.mlir.dialects import func, arith, pto
+from ptoas.mlir.ir import F32Type, IndexType
 
 def build():
     with Context() as ctx:

--- a/test/samples/Sels/sels.py
+++ b/test/samples/Sels/sels.py
@@ -66,7 +66,7 @@ def build():
                 pto.TLoadOp(None, sv0, tb0)  # result=None
                 pto.TLoadOp(None, sv1, tb1)  # result=None
 
-                pto.TSelSOp(tb0, tb1, tb2, c64, tb3)
+                pto.TSelSOp(tb0, tb1, c64, tb3, tmp=tb2)
 
                 sv2 = pto.PartitionViewOp(tile_view_32, tv2, offsets=[c0, c0], sizes=[c32, c32]).result
 

--- a/test/samples/Sels/sels_golden.py
+++ b/test/samples/Sels/sels_golden.py
@@ -1,4 +1,12 @@
 #!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
 import numpy as np
 from pathlib import Path
 import sys

--- a/test/samples/Sels/sels_golden.py
+++ b/test/samples/Sels/sels_golden.py
@@ -8,21 +8,39 @@ for search_root in (Path(__file__).resolve().parent, Path(__file__).resolve().pa
         sys.path.insert(0, str(search_root))
         break
 
-from validation_runtime import default_buffers, float_values, load_case_meta, rng, single_output, write_buffers, write_golden
+from validation_runtime import (
+    COLS,
+    ROWS,
+    default_buffers,
+    float_values,
+    load_case_meta,
+    matrix32,
+    pack_predicate_mask_for_buffer,
+    rng,
+    single_output,
+    write_buffers,
+    write_golden,
+)
 
 
 def main():
     meta = load_case_meta()
-    src0_name, src1_name = meta.inputs
+    mask_name, src_name = meta.inputs
     generator = rng()
-    src0 = float_values(generator, meta.elem_counts[src0_name], style='signed')
-    src1 = float_values(generator, meta.elem_counts[src1_name], style='signed')
+    mask_bits = generator.integers(0, 2, size=(ROWS, COLS), dtype=np.uint8).astype(np.bool_)
+    mask = pack_predicate_mask_for_buffer(
+        mask_bits,
+        elem_count=meta.elem_counts[mask_name],
+        dtype=meta.np_types[mask_name],
+        rows=ROWS,
+    )
+    src = float_values(generator, meta.elem_counts[src_name], style='signed')
     buffers = default_buffers(meta)
-    buffers[src0_name] = src0
-    buffers[src1_name] = src1
+    buffers[mask_name] = mask
+    buffers[src_name] = src
     write_buffers(meta, buffers)
-    out = src0 if 64 == 1 else src1
-    write_golden(meta, {single_output(meta): np.asarray(out, dtype=np.float32)})
+    out = np.where(mask_bits, matrix32(src), np.float32(64.0))
+    write_golden(meta, {single_output(meta): out.astype(np.float32).reshape(-1)})
 
 
 if __name__ == '__main__':

--- a/test/samples/validation_runtime.py
+++ b/test/samples/validation_runtime.py
@@ -284,21 +284,12 @@ def pack_predicate_mask_dense(bits: np.ndarray) -> np.ndarray:
 def pack_predicate_mask_for_buffer(bits: np.ndarray, *, elem_count: int, dtype, rows: int = ROWS) -> np.ndarray:
     dtype = np.dtype(dtype)
     expected_bytes = packed_mask_storage_bytes(elem_count, dtype)
-    if is_a5_soc():
-        packed_bytes = np.zeros(expected_bytes, dtype=np.uint8)
-        dense_bytes = pack_predicate_mask_dense(bits)
-        if dense_bytes.nbytes > expected_bytes:
-            raise ValueError(
-                f'packed mask byte size mismatch: expected <= {expected_bytes}, got {dense_bytes.nbytes}'
-            )
-        packed_bytes[:dense_bytes.size] = dense_bytes
-    else:
-        storage_cols = packed_mask_storage_cols(elem_count=elem_count, dtype=dtype, rows=rows)
-        packed_bytes = pack_predicate_mask(bits, storage_cols=storage_cols)
-        if packed_bytes.nbytes != expected_bytes:
-            raise ValueError(
-                f'packed mask byte size mismatch: expected {expected_bytes}, got {packed_bytes.nbytes}'
-            )
+    storage_cols = packed_mask_storage_cols(elem_count=elem_count, dtype=dtype, rows=rows)
+    packed_bytes = pack_predicate_mask(bits, storage_cols=storage_cols)
+    if packed_bytes.nbytes != expected_bytes:
+        raise ValueError(
+            f'packed mask byte size mismatch: expected {expected_bytes}, got {packed_bytes.nbytes}'
+        )
     return np.frombuffer(packed_bytes.tobytes(), dtype=dtype).copy()
 
 
@@ -355,25 +346,17 @@ def compare_packed_mask_file(golden_path: str, output_path: str, *, rows: int = 
         return False
     golden = np.fromfile(golden_path, dtype=np.uint8)
     output = np.fromfile(output_path, dtype=np.uint8)
-    if is_a5_soc():
-        used_bytes = packed_mask_payload_bytes(rows=rows, cols=cols)
-        if golden.size < used_bytes or output.size < used_bytes:
-            print(f'[ERROR] Packed mask storage is too small: need {used_bytes} bytes')
-            return False
-        golden_view = golden[:used_bytes]
-        output_view = output[:used_bytes]
-    else:
-        if golden.size % rows != 0 or output.size % rows != 0:
-            print(f'[ERROR] Packed mask buffer size is not divisible by rows={rows}')
-            return False
-        golden_cols = golden.size // rows
-        output_cols = output.size // rows
-        used_cols = packed_row_bytes(cols)
-        if golden_cols < used_cols or output_cols < used_cols:
-            print(f'[ERROR] Packed mask storage is too small: need {used_cols} bytes per row')
-            return False
-        golden_view = golden.reshape(rows, golden_cols)[:, :used_cols].reshape(-1)
-        output_view = output.reshape(rows, output_cols)[:, :used_cols].reshape(-1)
+    if golden.size % rows != 0 or output.size % rows != 0:
+        print(f'[ERROR] Packed mask buffer size is not divisible by rows={rows}')
+        return False
+    golden_cols = golden.size // rows
+    output_cols = output.size // rows
+    used_cols = packed_row_bytes(cols)
+    if golden_cols < used_cols or output_cols < used_cols:
+        print(f'[ERROR] Packed mask storage is too small: need {used_cols} bytes per row')
+        return False
+    golden_view = golden.reshape(rows, golden_cols)[:, :used_cols].reshape(-1)
+    output_view = output.reshape(rows, output_cols)[:, :used_cols].reshape(-1)
     if not np.array_equal(golden_view, output_view):
         diff = np.nonzero(golden_view != output_view)[0]
         index = int(diff[0]) if diff.size else 0


### PR DESCRIPTION
修复最近 A5 Nightly Board 中可复现的普通样例失败，保持 DeepSeek/Qwen 相关样例不变。

已处理：
- Rowexpandmul/sub/div：A5 32x1 列主序广播输入布局
- Partmin：float32 golden 与比较
- Scatter：元素索引与 golden 生成
- Cmp/Sel/Sels/Cmps：A5 packed mask 的输入、输出与行存储布局
- Movfp/movfp_fixpipe_reuse：A5 VDEQF16 packed ui64 quant payload，并增加 MAT 到 SCALING 的 tmov

未处理：DeepSeek、Qwen、TquantMx 相关样例。

验证：
- 修改的 Python 文件通过 `python3 -m py_compile`
- `git diff --check` 通过
- A5 真机定向回归请在评论区执行：
  `/run a5 Rowexpandsub Rowexpanddiv Cmp Sel Rowexpandmul Sels Partmin Scatter Cmps Movfp`