### PR TITLE
fix(vmi): constrain cast layouts by type class

### DIFF
--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -525,7 +525,9 @@ getHighPriorityCastLayoutFactImpl(VMIVRegType sourceType,
   for (const HighPriorityCastLayoutPattern &pattern :
        kHighPriorityCastLayoutPatterns) {
     if (!matchesElementBitsPattern(pattern.sourceBits, sourceBits) ||
-        !matchesElementBitsPattern(pattern.resultBits, resultBits)) {
+        !matchesElementBitsPattern(pattern.resultBits, resultBits) ||
+        !matchesCastTypeClass(pattern.typeClass, sourceType.getElementType(),
+                              resultType.getElementType())) {
       continue;
     }
 
@@ -596,6 +598,8 @@ struct PreferredCastPatternQuery {
   int64_t sourceBits;
   int64_t resultBits;
   int64_t elementCount;
+  Type sourceElementType;
+  Type resultElementType;
   StringRef tableName;
   std::string *reason;
 };
@@ -618,7 +622,9 @@ selectPreferredCastLayoutPattern(
     bool elementBitsMismatch =
         !matchesElementBitsPattern(pattern.sourceBits, query.sourceBits) ||
         !matchesElementBitsPattern(pattern.resultBits, query.resultBits);
-    if (elementBitsMismatch) {
+    if (elementBitsMismatch ||
+        !matchesCastTypeClass(pattern.typeClass, query.sourceElementType,
+                              query.resultElementType)) {
       continue;
     }
     bool isExact = pattern.elementCount != 0;
@@ -654,9 +660,14 @@ static FailureOr<VMICastLayoutFact> getPreferredCastLayoutFactImpl(
     const PreferredCastLayoutRequest &request) {
   auto [sourceBits, resultBits] =
       getCastElementBits(request.sourceType, request.resultType);
-  PreferredCastPatternQuery query{sourceBits, resultBits,
-                                  request.sourceType.getElementCount(),
-                                  request.tableName, request.reason};
+  PreferredCastPatternQuery query{
+      sourceBits,
+      resultBits,
+      request.sourceType.getElementCount(),
+      request.sourceType.getElementType(),
+      request.resultType.getElementType(),
+      request.tableName,
+      request.reason};
   FailureOr<const PreferredCastLayoutPattern *> selected =
       selectPreferredCastLayoutPattern(patterns, query);
   if (failed(selected)) {
@@ -727,7 +738,9 @@ VMILayoutSupport::getCastLayoutFactsForLayout(VMIVRegType sourceType,
       layout && layout.isGroupSlots() ? layout.getNumGroups() : 0;
   for (const LegalCastLayoutPattern &pattern : kLegalCastLayoutPatterns) {
     if (!matchesElementBitsPattern(pattern.sourceBits, sourceBits) ||
-        !matchesElementBitsPattern(pattern.resultBits, resultBits)) {
+        !matchesElementBitsPattern(pattern.resultBits, resultBits) ||
+        !matchesCastTypeClass(pattern.typeClass, sourceType.getElementType(),
+                              resultType.getElementType())) {
       continue;
     }
 

--- a/lib/PTO/Transforms/VMILayoutSupportPatternDSL.inc
+++ b/lib/PTO/Transforms/VMILayoutSupportPatternDSL.inc
@@ -21,6 +21,15 @@ enum class LayoutPatternKind {
   GroupSlots,
 };
 
+enum class CastTypeClass {
+  // The layout relation is independent of the source/result value semantics.
+  Any,
+  // Both source and result are floating-point-like VMI element types.
+  Float,
+  // Both source and result are integer element types.
+  Integer,
+};
+
 struct LayoutPattern {
   LayoutPatternKind kind = LayoutPatternKind::Contiguous;
   int64_t value = 1;
@@ -115,6 +124,20 @@ static bool matchesElementBitsPattern(ElementBitsPattern pattern,
                                       Type elementType) {
   unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
   return matchesElementBitsPattern(pattern, elementBits);
+}
+
+static bool matchesCastTypeClass(CastTypeClass typeClass, Type sourceType,
+                                 Type resultType) {
+  switch (typeClass) {
+  case CastTypeClass::Any:
+    return true;
+  case CastTypeClass::Float:
+    return isVMIFloatLikeType(sourceType) &&
+           isVMIFloatLikeType(resultType);
+  case CastTypeClass::Integer:
+    return isa<IntegerType>(sourceType) && isa<IntegerType>(resultType);
+  }
+  llvm_unreachable("unknown cast type class");
 }
 
 static bool matchesElementCountPattern(ElementCountPattern pattern,

--- a/lib/PTO/Transforms/VMILayoutSupportPatternDSL.inc
+++ b/lib/PTO/Transforms/VMILayoutSupportPatternDSL.inc
@@ -132,8 +132,10 @@ static bool matchesCastTypeClass(CastTypeClass typeClass, Type sourceType,
   case CastTypeClass::Any:
     return true;
   case CastTypeClass::Float:
-    return isVMIFloatLikeType(sourceType) &&
-           isVMIFloatLikeType(resultType);
+    return (isa<FloatType>(sourceType) ||
+            pto::isPTOLowPrecisionType(sourceType)) &&
+           (isa<FloatType>(resultType) ||
+            pto::isPTOLowPrecisionType(resultType));
   case CastTypeClass::Integer:
     return isa<IntegerType>(sourceType) && isa<IntegerType>(resultType);
   }

--- a/lib/PTO/Transforms/VMILayoutSupportTables.inc
+++ b/lib/PTO/Transforms/VMILayoutSupportTables.inc
@@ -139,6 +139,7 @@ struct PreferredCastLayoutPattern {
   int64_t elementCount = 0; // 0 means the default row for this bit-width pair.
   LayoutPattern sourceLayout;
   LayoutPattern resultLayout;
+  CastTypeClass typeClass = CastTypeClass::Any;
 };
 
 struct HighPriorityCastLayoutPattern {
@@ -148,6 +149,7 @@ struct HighPriorityCastLayoutPattern {
   PhysicalChunkCountPattern resultChunks;
   LayoutPattern sourceLayout;
   LayoutPattern resultLayout;
+  CastTypeClass typeClass = CastTypeClass::Any;
 };
 
 struct LegalCastLayoutPattern {
@@ -155,6 +157,7 @@ struct LegalCastLayoutPattern {
   ElementBitsPattern resultBits;
   LayoutPattern sourceLayout;
   LayoutPattern resultLayout;
+  CastTypeClass typeClass = CastTypeClass::Any;
 };
 
 struct LegalMaskGranularityCastLayoutPattern {
@@ -215,7 +218,7 @@ static constexpr HighPriorityCastLayoutPattern
 
 static constexpr LegalCastLayoutPattern kLegalCastLayoutPatterns[] = {
     // Same-width fp-to-fp (bf16 -> f16): dense contiguous 1:1.
-    {bits<16>(), bits<16>(), c(), c()},
+    {bits<16>(), bits<16>(), c(), c(), CastTypeClass::Float},
 
     // 2x widening.
     {bits<8>(), bits<16>(), c(), d(2)},
@@ -250,15 +253,15 @@ static constexpr LegalCastLayoutPattern kLegalCastLayoutPatterns[] = {
     {bits<16>(), bits<32>(), gs(8, 2), gs(8)},
     {bits<8>(), bits<32>(), gs(1), gs(1)},
     {bits<8>(), bits<32>(), gs(8, 4), gs(8)},
-    {bits<8>(), bits<16>(), gs(2), gs(2)},
-    {bits<8>(), bits<16>(), gs(4), gs(4)},
-    {bits<8>(), bits<16>(), gs(8), gs(8)},
-    {bits<16>(), bits<32>(), gs(2), gs(2)},
-    {bits<16>(), bits<32>(), gs(4), gs(4)},
-    {bits<16>(), bits<32>(), gs(8), gs(8)},
-    {bits<8>(), bits<32>(), gs(2), gs(2)},
-    {bits<8>(), bits<32>(), gs(4), gs(4)},
-    {bits<8>(), bits<32>(), gs(8), gs(8)},
+    {bits<8>(), bits<16>(), gs(2), gs(2), CastTypeClass::Integer},
+    {bits<8>(), bits<16>(), gs(4), gs(4), CastTypeClass::Integer},
+    {bits<8>(), bits<16>(), gs(8), gs(8), CastTypeClass::Integer},
+    {bits<16>(), bits<32>(), gs(2), gs(2), CastTypeClass::Integer},
+    {bits<16>(), bits<32>(), gs(4), gs(4), CastTypeClass::Integer},
+    {bits<16>(), bits<32>(), gs(8), gs(8), CastTypeClass::Integer},
+    {bits<8>(), bits<32>(), gs(2), gs(2), CastTypeClass::Integer},
+    {bits<8>(), bits<32>(), gs(4), gs(4), CastTypeClass::Integer},
+    {bits<8>(), bits<32>(), gs(8), gs(8), CastTypeClass::Integer},
     {bits<16>(), bits<8>(), gs(1), gs(1)},
     {bits<16>(), bits<8>(), gs(8), gs(8, 2)},
     {bits<32>(), bits<16>(), gs(1), gs(1)},

--- a/test/lit/vmi_new/vmi_layout_assignment_group_slot_load.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_slot_load.pto
@@ -49,6 +49,24 @@ module {
     return %wide
         : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
   }
+
+  func.func @vmi_layout_assignment_group_slot_load_extf(
+      %src: !pto.ptr<bf16, ub>, %off: index)
+      -> !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8>> {
+    %c1 = arith.constant 1 : index
+    %narrow = pto.vmi.vload %src[%off], %c1 {group = 8}
+        : !pto.ptr<bf16, ub>
+        -> !pto.vmi.vreg<8xbf16,
+            #pto.vmi.layout<num_groups = 8, slots = 8>>
+    %wide = pto.vmi.vcvt %narrow
+        : !pto.vmi.vreg<8xbf16,
+            #pto.vmi.layout<num_groups = 8, slots = 8>>
+        -> !pto.vmi.vreg<8xf32,
+            #pto.vmi.layout<num_groups = 8, slots = 8>>
+    return %wide
+        : !pto.vmi.vreg<8xf32,
+            #pto.vmi.layout<num_groups = 8, slots = 8>>
+  }
 }
 
 // CHECK-LABEL: func.func @vmi_layout_assignment_group_slot_load_slots8(
@@ -75,4 +93,13 @@ module {
 // CHECK-SAME: -> !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>
 // CHECK: %[[WIDE:.*]] = pto.vmi.extui %[[NARROW]]
 // CHECK-SAME: -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+// CHECK: return %[[WIDE]]
+
+// CHECK-LABEL: func.func @vmi_layout_assignment_group_slot_load_extf(
+// CHECK: %[[NARROW:.*]] = pto.vmi.group_slot_load
+// CHECK-SAME: -> !pto.vmi.vreg<8xbf16, #pto.vmi.layout<num_groups = 8, slots = 8>>
+// CHECK: %[[STRIDED:.*]] = pto.vmi.ensure_layout %[[NARROW]]
+// CHECK-SAME: -> !pto.vmi.vreg<8xbf16, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
+// CHECK: %[[WIDE:.*]] = pto.vmi.extf %[[STRIDED]]
+// CHECK-SAME: -> !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8>>
 // CHECK: return %[[WIDE]]


### PR DESCRIPTION
## Summary

- add Float, Integer, and Any semantic classes to VMI cast layout patterns
- restrict compact group-slot widening rows to integer-to-integer casts
- keep the same-width BF16-to-F16 relation float-only
- add a layout-assignment regression requiring an ensure_layout before BF16-to-FP32 conversion while preserving integer compact widening

## Validation

- `git diff --check`
- `python3 .agents/skills/enforce-ptoas-code-compliance/scripts/check_changed_code.py --repo . --base origin/main` (`errors=0`, `warnings=0`)

Build and lit execution are currently blocked because `.work/issue1337-env/build/ptoas-main` references LLVM and pybind11 under `/home/z00824747/llvm-workspace`, while `/home/z00824747` is mode 700 for another user. ABI-mismatched LLVM installations on the host were not used as substitutes.