### PR TITLE
feat(vmi): rename vstore dist mode dintlv→intlv, drop unpack vload

### DIFF
--- a/.agents/skills/rewrite-kernel-with-vmi/references/vmi-dsl-spec.md
+++ b/.agents/skills/rewrite-kernel-with-vmi/references/vmi-dsl-spec.md
@@ -31,7 +31,6 @@ vec = pto.vmi.vcvt(src, to_dtype=OUT_DTYPE)
 ```python
 vec = pto.vmi.vload(ub_src, offset, size=128)
 even, odd = pto.vmi.vload(ub_src, offset, size=128, dist_mode="dintlv")
-wide = pto.vmi.vload(ub_src, offset, size=128, dist_mode="unpack", to_dtype=pto.f32)
 pto.vmi.vstore(vec, ub_dst, offset, mask)
 pto.vmi.vstore(vec, ub_dst, offset, group=8, stride=row_stride)
 ```
@@ -43,8 +42,8 @@ Useful options:
 
 - `size` is required for every `vload`.
 - `dist_mode=None` or `"continuous"` is the default contiguous load/store form.
-- `dist_mode="dintlv"` returns an `(even, odd)` pair.
-- `dist_mode="unpack", to_dtype=<dtype>` widens by one adjacent bit-width step.
+- `dist_mode="dintlv"` (load) returns an `(even, odd)` pair; `dist_mode="intlv"`
+  (store) writes an interleaved `(even, odd)` pair.
 - `group=...`, `stride=...` select grouped access.
 - `block_stride=...`, `repeat_stride=...` select block-strided access.
 - `vload` does not take `mask`.

--- a/docs/isa/vmi-isa/00-architecture-overview.md
+++ b/docs/isa/vmi-isa/00-architecture-overview.md
@@ -177,7 +177,7 @@ type's `C`).
 
 | # | Group | Ops | Category | Mask |
 |---|---|---|---|---|
-| 1 | **Load / Store** | `vload`, `vstore` | A (+B on dintlv/unpack) | load: none; store: `Pg` |
+| 1 | **Load / Store** | `vload`, `vstore` | A (+B on dintlv/intlv) | load: none; store: `Pg` |
 | 2 | **Index-gen** | `vci` | A | none |
 | 3 | **Eltwise Compute** | `vadd`, `vsub`, `vmul`, `vdiv`, `vmax`, `vmin`, `vabs`, `vneg`, `vrelu`, `vexp`, `vln`, `vsqrt`, `vand`, `vor`, `vxor`, `vnot`, `vshl`, `vshr`, `vadds`, `vmuls`, `vmaxs`, `vmins`, `vshls`, `vshrs`, `vcmp`, `vcmps`, `vsel`, `vselr` | A | `Pg` (except `vselr`: none) |
 | 4 | **Broadcast** | `vbrc` | A (ungrouped) / B (grouped) | none |

--- a/docs/isa/vmi-isa/01-load-store.md
+++ b/docs/isa/vmi-isa/01-load-store.md
@@ -63,7 +63,7 @@
 
   | Attribute | Values | Default | Description |
   |---|---|---|---|
-  | `dist_mode` | `"continuous"`, `"unpack"`, `"brc"` | `"continuous"` | Memory access pattern |
+  | `dist_mode` | `"continuous"`, `"dintlv"`, `"brc"` | `"continuous"` | Memory access pattern |
   | `group` | positive integer | *(none)* | Strided group load arity; mutually exclusive with `dist_mode`; requires `stride` |
   | `pmode` | `"zero"`, `"merge"` | `"zero"` | Inactive-lane behavior (applied at consumer, not on load) |
 
@@ -74,7 +74,7 @@ declaring the memory access pattern. Default is `"continuous"`.
   | `dist_mode` | Physical lowering |
   |---|---|
   | `"continuous"` | `K × pto.vlds {dist="NORM"}` (element-width-independent `NORM` load) |
-  | `"unpack"` | `K × pto.vlds {dist="UNPK_B*"}` (widening unpack; suffix from `Ptr<T>`) |
+  | `"dintlv"` | `K × pto.vldsx2 {dist="DINTLV_B*"}` (deinterleaved dual load; suffix from `Ptr<T>`) |
   | `"brc"` | `1 × pto.vlds {dist="BRC_B*"}` or `BRC_BLK`; broadcast-axis (1-reg backing, replicate-read) |
 
   **Group mode** (`{group = C}` + `stride`) has two sub-cases, decided by the
@@ -119,10 +119,6 @@ declaring the memory access pattern. Default is `"continuous"`.
   // Broadcast load: scalar/block replicate into vreg
   %vb = pto.vmi.vload %ub[%offset] {dist_mode = "brc"} : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64×f32>
   // → pto.as: Ptr<f32> → B32, dist_mode=brc → pto.mi.vlds {dist="BRC_B32"}
-
-  // Widening unpack load: narrow source expanded to wide lanes
-  %u = pto.vmi.vload %ub[%offset] {dist_mode = "unpack"} : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<64×f32>
-  // → pto.as: Ptr<bf16> → B16, dist_mode=unpack → pto.mi.vlds {dist="UNPK_B16"}
   ```
 
 - **notes:**
@@ -199,7 +195,7 @@ declaring the memory access pattern. Default is `"continuous"`.
 
   | Attribute | Values | Default | Description |
   |---|---|---|---|
-  | `dist_mode` | `"continuous"` | `"continuous"` | Memory access pattern |
+  | `dist_mode` | `"continuous"`, `"intlv"` | `"continuous"` | Memory access pattern |
   | `group` | positive integer | *(none)* | Strided group store arity; mutually exclusive with `dist_mode`; requires `stride`; forbids `mask` |
   | `pmode` | `"zero"`, `"merge"` | `"zero"` | Inactive-lane behavior: `"zero"` (default) stores 0; `"merge"` skips write on inactive lanes |
 
@@ -210,6 +206,7 @@ declaring the memory access pattern. Default is `"continuous"`.
   | `dist_mode` | Physical lowering |
   |---|---|
   | `"continuous"` | `K × pto.vsts {dist="NORM_B*"}` |
+  | `"intlv"` | `K × pto.vstsx2 {dist="INTLV_B*"}` (interleaved dual store; suffix from `Ptr<T>`) |
 
   **Group mode** (`{group = C}` + `stride`): row-strided tile store. Not combinable with
   `dist_mode` or `mask` (group stores are unpredicated).

--- a/include/PTO/IR/VMIAttrs.td
+++ b/include/PTO/IR/VMIAttrs.td
@@ -78,13 +78,13 @@ def VMIPredicationMode : I32EnumAttr<"PredicationMode",
 //===----------------------------------------------------------------------===//
 
 def VMI_DistMode_Continuous : I32EnumAttrCase<"Continuous", 0, "continuous">;
-def VMI_DistMode_Unpack     : I32EnumAttrCase<"Unpack",     1, "unpack">;
 def VMI_DistMode_Dintlv     : I32EnumAttrCase<"Dintlv",     2, "dintlv">;
-def VMI_DistMode_Brc        : I32EnumAttrCase<"Brc",        3, "brc">;
+def VMI_DistMode_Intlv      : I32EnumAttrCase<"Intlv",      3, "intlv">;
+def VMI_DistMode_Brc        : I32EnumAttrCase<"Brc",        4, "brc">;
 def VMIDistMode : I32EnumAttr<"DistMode",
     "VMI distribution mode for load/store", [
-  VMI_DistMode_Continuous, VMI_DistMode_Unpack,
-  VMI_DistMode_Dintlv, VMI_DistMode_Brc
+  VMI_DistMode_Continuous, VMI_DistMode_Dintlv,
+  VMI_DistMode_Intlv, VMI_DistMode_Brc
 ]> {
   let cppNamespace = "::mlir::pto";
 }

--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -1435,7 +1435,6 @@ def VMIvLoadOp : VMI_Op<"vload",
     - "continuous" (default): contiguous stride-1 load  → 1 result;
       1/2/4/8-lane results alias group=1/2/4/8 with unit stride
     - "dintlv":             deinterleaved dual load      → 2 results (%lo, %hi)
-    - "unpack":             widening unpack load         → 1 result
     - "brc":                broadcast load               → 1 result
 
     group mode (mutually exclusive with dist-mode):
@@ -1473,7 +1472,7 @@ def VMIvStoreOp : VMI_Op<"vstore",
     dist-mode controls the memory access pattern:
     - "continuous" (default): contiguous stride-1 store  → 1 value;
       1/2/4/8-lane inputs alias group=1/2/4/8 with unit stride
-    - "dintlv":             interleaved dual store        → 2 values (%lo, %hi)
+    - "intlv":              interleaved dual store        → 2 values (%lo, %hi)
 
     group mode (mutually exclusive with dist-mode):
     - {group = C}: grouped vector store with row stride

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -3219,8 +3219,12 @@ static bool isSupportedVCmpPredicate(StringRef cmpMode) {
 //===----------------------------------------------------------------------===//
 
 static const std::set<StringRef> &validDistModes() {
-  static const std::set<StringRef> modes = {"continuous", "unpack", "dintlv",
-                                            "brc"};
+  static const std::set<StringRef> modes = {"continuous", "dintlv", "brc"};
+  return modes;
+}
+
+static const std::set<StringRef> &validStoreDistModes() {
+  static const std::set<StringRef> modes = {"continuous", "intlv"};
   return modes;
 }
 
@@ -4880,15 +4884,18 @@ LogicalResult VMIvStoreOp::verify() {
   }
 
   auto distMode = getDistMode();
-  bool isDintlv = distMode && *distMode == "dintlv";
+  if (distMode && !validStoreDistModes().count(*distMode)) {
+    return emitOpError("invalid dist-mode: \"") << *distMode << "\"";
+  }
+  bool isIntlv = distMode && *distMode == "intlv";
   size_t nValues = getValues().size();
   if (nValues < 1) {
     return emitOpError("requires at least 1 value");
   }
-  if (isDintlv && nValues != mlir::pto::kValue2) {
-    return emitOpError("dist-mode \"dintlv\" requires exactly 2 values");
+  if (isIntlv && nValues != mlir::pto::kValue2) {
+    return emitOpError("dist-mode \"intlv\" requires exactly 2 values");
   }
-  if (!isDintlv && nValues != 1) {
+  if (!isIntlv && nValues != 1) {
     return emitOpError("requires exactly 1 value for dist-mode \"")
            << (distMode ? *distMode : "continuous") << "\"";
   }
@@ -4896,14 +4903,6 @@ LogicalResult VMIvStoreOp::verify() {
   bool hasMask = !getMask().empty();
   if (getMask().size() > 1) {
     return emitOpError("at most one mask allowed");
-  }
-
-  if (distMode && !validDistModes().count(*distMode)) {
-    return emitOpError("invalid dist-mode: \"") << *distMode << "\"";
-  }
-  if (distMode && (*distMode == "unpack" || *distMode == "brc")) {
-    return emitOpError("dist-mode \"")
-           << *distMode << "\" is not valid for vstore";
   }
 
   auto pmode = getPmode();
@@ -5337,6 +5336,9 @@ LogicalResult VMIvLoadOp::verify() {
 
   // result count vs dist-mode
   auto distMode = getDistMode();
+  if (distMode && !validDistModes().count(*distMode)) {
+    return emitOpError("invalid dist-mode: \"") << *distMode << "\"";
+  }
   bool isDintlv = distMode && *distMode == "dintlv";
   size_t nResults = getResults().size();
   if (isDintlv && nResults != mlir::pto::kValue2) {
@@ -5347,20 +5349,14 @@ LogicalResult VMIvLoadOp::verify() {
            << (distMode ? *distMode : "continuous") << "\"";
   }
 
-  if (distMode && !validDistModes().count(*distMode)) {
-    return emitOpError("invalid dist-mode: \"") << *distMode << "\"";
-  }
   auto pmode = getPmode();
   if (pmode && !validPModes().count(*pmode)) {
     return emitOpError("invalid pmode: \"") << *pmode << "\"";
   }
 
-  bool isUnpack = distMode && *distMode == "unpack";
   for (auto res : getResults()) {
     auto resType = cast<VMIVRegType>(res.getType());
-    // unpack: source element type intentionally differs from result
-    if (!isUnpack &&
-        failed(verifyMemoryElementMatches(getOperation(),
+    if (failed(verifyMemoryElementMatches(getOperation(),
                                           getSource().getType(), resType,
                                           "source"))) {
       return failure();

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -658,7 +658,7 @@ static LogicalResult lowerDistributedStore(VMIvStoreOp op,
   if (mode == "continuous") {
     return lowerContinuousStore(op, builder);
   }
-  if (mode == "dintlv") {
+  if (mode == "intlv") {
     ValueRange values = op.getValues();
     if (values.size() < mlir::pto::kValue2) {
       return failure();

--- a/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
+++ b/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
@@ -145,7 +145,7 @@ Pick exactly one family per call. Do not mix `dist_mode`, `group`, and
 
 ### `vload`
 
-### `pto.vmi.vload(source, offset, *, size, dist_mode=None, to_dtype=None) -> VRegType`
+### `pto.vmi.vload(source, offset, *, size, dist_mode=None) -> VRegType`
 ### `pto.vmi.vload(source, offset, *, size, dist_mode="dintlv") -> (VRegType, VRegType)`
 ### `pto.vmi.vload(source, offset, *, size, group, stride) -> VRegType`
 ### `pto.vmi.vload(source, offset, *, size, group, stride, dist_mode="brc") -> VRegType`
@@ -182,14 +182,12 @@ default contiguous load.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `dist_mode` | `str` or `None` | One of `None`, `"continuous"`, `"dintlv"`, `"unpack"`, or `"brc"` |
-| `to_dtype` | `DType` or `None` | Required only when `dist_mode="unpack"` |
+| `dist_mode` | `str` or `None` | One of `None`, `"continuous"`, `"dintlv"`, or `"brc"` |
 
 Dist-mode behavior:
 
 - `None` or `"continuous"`: contiguous stride-1 load, returning one VMI vector.
 - `"dintlv"`: deinterleaved load, returning an `(even, odd)` pair.
-- `"unpack"`: widening unpack load, returning one widened VMI vector.
 - `"brc"`: broadcast load from one source element, returning one VMI vector.
 
 **Mode 2: `group`**
@@ -221,7 +219,7 @@ Use this family for block-strided accesses.
 
 | Return Value | Type | Description |
 |--------------|------|-------------|
-| `vec` | `VRegType` | Single vector result for continuous, unpack, brc, group, and block-stride modes |
+| `vec` | `VRegType` | Single vector result for continuous, brc, group, and block-stride modes |
 | `(even, odd)` | `(VRegType, VRegType)` | Two-vector result for `dist_mode="dintlv"` |
 
 **Examples**:
@@ -231,18 +229,6 @@ Continuous load:
 ```python
 lhs = pto.vmi.vload(src_ptr, offset, size=64)
 rhs = pto.vmi.vload(other_ptr, offset, size=64)
-```
-
-Dist-mode unpack load:
-
-```python
-wide = pto.vmi.vload(
-    src_ptr,
-    offset,
-    size=128,
-    dist_mode="unpack",
-    to_dtype=pto.i16,
-)
 ```
 
 Broadcast load:
@@ -298,16 +284,14 @@ blocks = pto.vmi.vload(
 - `block_stride` mode is mutually exclusive with both `dist_mode` and `group`.
 - `group` and `dist_mode` are mutually exclusive except for grouped broadcast,
   spelled as `group=...`, `stride=...`, `dist_mode="brc"`.
-- `to_dtype` is only accepted when `dist_mode="unpack"`.
 - `stride` is only accepted when `group` is provided.
-- The unpack form widens by exactly one adjacent bit-width step.
 
 ---
 
 ### `vstore`
 
 ### `pto.vmi.vstore(values, destination, offset, mask=None, *, dist_mode=None, pmode=None) -> None`
-### `pto.vmi.vstore((even, odd), destination, offset, mask=None, *, dist_mode="dintlv", pmode=None) -> None`
+### `pto.vmi.vstore((even, odd), destination, offset, mask=None, *, dist_mode="intlv", pmode=None) -> None`
 ### `pto.vmi.vstore(values, destination, offset, *, group, stride, pmode=None) -> None`
 ### `pto.vmi.vstore(values, destination, offset, mask=None, *, block_stride, pmode=None) -> None`
 
@@ -319,7 +303,7 @@ three mutually exclusive mode families.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `values` | `VRegType` or `(VRegType, VRegType)` | One VMI vector for normal forms, or an `(even, odd)` pair for `dist_mode="dintlv"` |
+| `values` | `VRegType` or `(VRegType, VRegType)` | One VMI vector for normal forms, or an `(even, odd)` pair for `dist_mode="intlv"` |
 | `destination` | `PtrType` (ub) | UB destination pointer |
 | `offset` | `IndexLike` | Element offset into the destination buffer |
 | `pmode` | `str` or `None` | Optional inactive-lane mode: `"zero"` stores 0 to masked-off lanes; `"merge"` skips the write for masked-off lanes |
@@ -339,12 +323,12 @@ three mutually exclusive mode families.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `mask` | VMI mask or `None` | Optional predicate mask gating which lanes are written |
-| `dist_mode` | `str` or `None` | One of `None`, `"continuous"`, or `"dintlv"` |
+| `dist_mode` | `str` or `None` | One of `None`, `"continuous"`, or `"intlv"` |
 
 Dist-mode behavior:
 
 - `None` or `"continuous"`: contiguous store of one VMI vector.
-- `"dintlv"`: interleaved store of an `(even, odd)` pair.
+- `"intlv"`: interleaved store of an `(even, odd)` pair.
 
 **Mode 2: `group`**
 
@@ -401,7 +385,7 @@ pto.vmi.vstore(
 
 - `dist_mode`, `group`, and `block_stride` mode selection are mutually
   exclusive.
-- `dist_mode="dintlv"` requires `values` to be an `(even, odd)` pair.
+- `dist_mode="intlv"` requires `values` to be an `(even, odd)` pair.
 - Group mode requires `group` and `stride`, and does not accept `mask`.
 - Block-stride lowering fixes the physical repeat stride to zero.
 
@@ -1390,8 +1374,6 @@ surface no longer asks you to spell the full result type manually.
 
 **Ops that infer when given the right hint**:
 
-- `vload` with `dist_mode="unpack"` requires `to_dtype` to derive the widened
-  element type.
 - `vcvt` requires `to_dtype`.
 - `vinterpret_cast` requires `to_dtype`; its lane count is derived by
   preserving the source vector's total bit footprint.

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -565,28 +565,9 @@ def _vmi_vreg_element_count(type_obj, *, context: str):
     raise TypeError(f"{context} could not determine VMI vector lane count from {type_obj}")
 
 
-def _resolve_vmi_unpack_result_type(source, size, to_dtype, *, context: str):
-    if to_dtype is None:
-        raise TypeError(f'{context} requires to_dtype when dist_mode="unpack"')
-    source_type = _pointer_element_type(_type_of(source), context=context)
-    result_type = _ensure_tensor_storage_dtype(to_dtype, context=context)
-    source_bits = _type_bit_width(source_type, context=context)
-    result_bits = _type_bit_width(result_type, context=context)
-    if source_bits * 2 != result_bits:
-        raise TypeError(
-            f"{context} requires unpack to widen by exactly one step; got "
-            f"{source_type} -> {result_type}"
-        )
-    return _pto.VMIVRegType.get(size, result_type)
-
-
-def _resolve_vmi_vload_result_types(source, size, *, dist_mode, to_dtype, context: str):
-    if to_dtype is not None and dist_mode != "unpack":
-        raise TypeError(f'{context} accepts to_dtype only when dist_mode="unpack"')
+def _resolve_vmi_vload_result_types(source, size, *, dist_mode, context: str):
     if size is None:
         raise TypeError(f"{context} requires size")
-    if dist_mode == "unpack":
-        return [_resolve_vmi_unpack_result_type(source, size, to_dtype, context=context)]
     element_type = _pointer_element_type(_type_of(source), context=context)
     resolved = _pto.VMIVRegType.get(size, element_type)
     if dist_mode == "dintlv":
@@ -744,7 +725,6 @@ class _VMINamespace:
         offset,
         *,
         size,
-        to_dtype=None,
         stride=None,
         block_stride=None,
         dist_mode=None,
@@ -759,13 +739,12 @@ class _VMINamespace:
             stride=stride,
             block_stride=block_stride,
             allow_group_brc=True,
-            allowed_dist_modes={None, "continuous", "dintlv", "unpack", "brc"},
+            allowed_dist_modes={None, "continuous", "dintlv", "brc"},
         )
         result_types = _resolve_vmi_vload_result_types(
             source,
             size,
             dist_mode=dist_mode,
-            to_dtype=to_dtype,
             context="pto.vmi.vload(...)",
         )
         return _call_value(
@@ -803,15 +782,15 @@ class _VMINamespace:
             stride=stride,
             block_stride=block_stride,
             allow_group_brc=False,
-            allowed_dist_modes={None, "continuous", "dintlv"},
+            allowed_dist_modes={None, "continuous", "intlv"},
         )
         if group is not None and mask is not None:
             raise TypeError("pto.vmi.vstore(...) group mode does not take a mask operand")
-        if dist_mode == "dintlv":
+        if dist_mode == "intlv":
             if not _is_sequence(values) or len(values) != 2:
-                raise TypeError('pto.vmi.vstore(...) with dist_mode="dintlv" requires an (even, odd) pair')
+                raise TypeError('pto.vmi.vstore(...) with dist_mode="intlv" requires an (even, odd) pair')
         elif _is_sequence(values):
-            raise TypeError("pto.vmi.vstore(...) expects a single VMI vector unless dist_mode=\"dintlv\"")
+            raise TypeError("pto.vmi.vstore(...) expects a single VMI vector unless dist_mode=\"intlv\"")
         return _generated("vstore")(
             _raw_sequence(values),
             _raw(destination),

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -4033,21 +4033,6 @@ def vmi_f4x2_to_bf16x2_sat_probe():
 
 
 @pto.jit(target="a5", backend="vpto", mode="explicit")
-def vmi_unpack_vload_probe():
-    src_tile = pto.alloc_tile(shape=[1, 128], dtype=pto.i8)
-    src_ptr = src_tile.as_ptr()
-    offset = pto.const(0, dtype=pto.index)
-
-    _ = pto.vmi.vload(
-        src_ptr,
-        offset,
-        size=128,
-        dist_mode="unpack",
-        to_dtype=pto.i16,
-    )
-
-
-@pto.jit(target="a5", backend="vpto", mode="explicit")
 def vmi_brc_vload_probe():
     src_tile = pto.alloc_tile(shape=[1, 64], dtype=pto.f32)
     src_ptr = src_tile.as_ptr()
@@ -4089,20 +4074,6 @@ def vmi_block_stride_memory_probe():
     )
     pto.vmi.vstore(
         value, dst_tile.as_ptr(), offset, block_stride=pto.i16(2)
-    )
-
-
-@pto.jit(target="a5", backend="vpto", mode="explicit")
-def vmi_unpack_vload_missing_dtype_probe():
-    src_tile = pto.alloc_tile(shape=[1, 128], dtype=pto.i8)
-    src_ptr = src_tile.as_ptr()
-    offset = pto.const(0, dtype=pto.index)
-
-    _ = pto.vmi.vload(
-        src_ptr,
-        offset,
-        size=128,
-        dist_mode="unpack",
     )
 
 
@@ -8139,8 +8110,6 @@ def main() -> None:
         "pto.vmi.vdhist(...)" in str(vmi_vhist_bad_acc_error),
         "vdhist bad-acc rejection should carry the pto.vmi.vdhist call-site context",
     )
-    vmi_unpack_vload_text = vmi_unpack_vload_probe.compile().mlir_text()
-    expect_parse_roundtrip_and_verify(vmi_unpack_vload_text, "public VMI unpack vload specialization")
     vmi_brc_vload_text = vmi_brc_vload_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(vmi_brc_vload_text, "public VMI brc vload specialization")
     expect(
@@ -8316,15 +8285,6 @@ def main() -> None:
         vmi_f4x2_to_bf16x2_sat_probe.compile,
         "does not support saturate for",
     )
-    unpack_missing_dtype_error = expect_raises(
-        TypeError,
-        vmi_unpack_vload_missing_dtype_probe.compile,
-        'to_dtype when dist_mode="unpack"',
-    )
-    expect(
-        'to_dtype when dist_mode="unpack"' in str(unpack_missing_dtype_error),
-        "unpack vload without to_dtype should diagnose the missing widened element type",
-    )
 
     expected_vmi_ops = [
         "pto.vmi.vload",
@@ -8453,10 +8413,6 @@ def main() -> None:
     expect(
         "reassoc" in vmi_wrapper_dispatch_text,
         "PTODSL VMI vcadd should preserve the reassoc attr in MLIR",
-    )
-    expect(
-        "!pto.vmi.vreg<128xi16>" in vmi_unpack_vload_text,
-        "PTODSL VMI unpack vload should infer the widened logical VMI vector result type from to_dtype",
     )
     expect("pto.mte_gm_ub" in public_surface_text, "mte_load(...) should lower to pto.mte_gm_ub")
     expect("pto.mte_ub_gm" in public_surface_text, "mte_store(...) should lower to pto.mte_ub_gm")

--- a/test/lit/vmi_new/vmi_interleaved_memory_ops.pto
+++ b/test/lit/vmi_new/vmi_interleaved_memory_ops.pto
@@ -23,7 +23,7 @@ module {
       %high: !pto.vmi.vreg<64xf32>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) {
-    pto.vmi.vstore %low, %high, %dst[%offset] {dist_mode = "dintlv"}
+    pto.vmi.vstore %low, %high, %dst[%offset] {dist_mode = "intlv"}
         : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_interleaved_memory_ops_invalid.pto
+++ b/test/lit/vmi_new/vmi_interleaved_memory_ops_invalid.pto
@@ -14,7 +14,7 @@ module {
       %high: !pto.vmi.vreg<128xf32>,
       %dst: !pto.ptr<f32, ub>,
       %offset: index) {
-    pto.vmi.vstore %low, %high, %dst[%offset] {dist_mode = "dintlv"}
+    pto.vmi.vstore %low, %high, %dst[%offset] {dist_mode = "intlv"}
         : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>
     return
   }

--- a/test/lit/vmi_new/vmi_to_vpto_memory_x2_widths.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_memory_x2_widths.pto
@@ -26,7 +26,7 @@ module {
       %lo: !pto.vmi.vreg<256xi8, #pto.vmi.layout<contiguous>>,
       %hi: !pto.vmi.vreg<256xi8, #pto.vmi.layout<contiguous>>,
       %dst: !pto.ptr<i8, ub>, %offset: index) {
-    pto.vmi.vstore %lo, %hi, %dst[%offset] {dist_mode = "dintlv"}
+    pto.vmi.vstore %lo, %hi, %dst[%offset] {dist_mode = "intlv"}
         : !pto.vmi.vreg<256xi8, #pto.vmi.layout<contiguous>>, !pto.vmi.vreg<256xi8, #pto.vmi.layout<contiguous>>, !pto.ptr<i8, ub>
     return
   }


### PR DESCRIPTION
## Summary

Rename the VMI store interleave dist-mode from `"dintlv"` to `"intlv"` and remove the never-lowered `"unpack"` load dist-mode.

### Background

`pto.vmi.vstore` with `dist_mode="dintlv"` was semantically an **interleave** store
(it lowers to `pto.vstsx2 "INTLV_B*"`), while `pto.vmi.vload` with
`dist_mode="dintlv"` is a deinterleave load (`pto.vldsx2 "DINTLV_B*"`). Reusing
one token for two mirror semantics made the store side read as "deinterleave"
when it actually interleaves. The store mode is renamed to `"intlv"` to match the
micro-ISA naming (`INTLV_B*` for stores, `DINTLV_B*` for loads).

`pto.vmi.vload` with `dist_mode="unpack"` had no working lowering: the legacy
path (`VMILowerUnifiedToLegacy`) explicitly skips it
(`Skipped: dist_mode "unpack" (physical widening, no legacy equivalent)`) and
no lit test, vpto case, or end-to-end probe exercised it (the ptodsl probe only
checked `mlir_text` round-trip). It is removed from the surface; widening loads
continue to be expressed via `pto.vmi.vcvt`.

### Changes

- `include/PTO/IR/VMIOps.td` — vload ODS doc drops `"unpack"`; vstore ODS doc
  renames `"dintlv"` → `"intlv"` (interleaved dual store).
- `include/PTO/IR/VMIAttrs.td` — `VMIDistMode` enum drops `Unpack`, adds `Intlv`.
- `lib/PTO/IR/VMI.cpp` — `validDistModes()` (load) drops `unpack`;
  new `validStoreDistModes() = {continuous, intlv}`; vstore verifier checks the
  store set and requires 2 values for `intlv`; vload verifier drops the
  `isUnpack` element-type exemption; invalid dist-mode diagnostics now fire
  before value/result-count checks.
- `lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp` — store dispatch keyed on
  `"intlv"` instead of `"dintlv"`.
- `ptodsl/ptodsl/_vmi_namespace.py` — `vload` drops `to_dtype`/`unpack` support;
  `vstore` accepts `dist_mode="intlv"` (pair) instead of `"dintlv"`.
- Docs — `ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md`,
  `docs/isa/vmi-isa/01-load-store.md`, `docs/isa/vmi-isa/00-architecture-overview.md`,
  `.agents/skills/rewrite-kernel-with-vmi/references/vmi-dsl-spec.md` updated.
- Tests — lit: `vmi_interleaved_memory_ops.pto`,
  `vmi_interleaved_memory_ops_invalid.pto`, `vmi_to_vpto_memory_x2_widths.pto`
  use `dist_mode="intlv"`; ptodsl: removed the unpack-vload probes and their
  assertions from `test_jit_compile.py`.

### Validation

- Full `test/lit/vmi_new` suite: **520/520 PASS** (run with the rebuilt
  `pto-test-opt` + FileCheck).
- `ptodsl/tests/test_jit_compile.py`: **PASS** (unbuffered run; the suite
  exits via `os._exit(0)`).
- ptodsl VMI unit tests (`test_vmi_isa_inventory.py` and others): PASS.
- Spot checks: `vstore {dist_mode="intlv"}` lowers to `pto.vstsx2 "INTLV_B32"`;
  `vstore {dist_mode="dintlv"}` and `vload {dist_mode="unpack"}` are rejected
  with `invalid dist-mode` diagnostics.
