### PR TITLE
Set op conv

### DIFF
--- a/include/PTO/IR/PTOAttrs.td
+++ b/include/PTO/IR/PTOAttrs.td
@@ -505,6 +505,47 @@ def PTO_LayoutAttr : PTO_Attr<"Layout", "layout"> {
 }
 
 //===----------------------------------------------------------------------===//
+// ConvTile layout
+//===----------------------------------------------------------------------===//
+
+def PTO_ConvLayout_NC1HWC0 :
+    I32EnumAttrCase<"NC1HWC0", 0, "nc1hwc0">;
+def PTO_ConvLayout_NDC1HWC0 :
+    I32EnumAttrCase<"NDC1HWC0", 1, "ndc1hwc0">;
+def PTO_ConvLayout_FRACTAL_Z :
+    I32EnumAttrCase<"FRACTAL_Z", 2, "fractal_z">;
+def PTO_ConvLayout_FRACTAL_Z_3D :
+    I32EnumAttrCase<"FRACTAL_Z_3D", 3, "fractal_z_3d">;
+def PTO_ConvLayout_NCHW :
+    I32EnumAttrCase<"NCHW", 4, "nchw">;
+def PTO_ConvLayout_NHWC :
+    I32EnumAttrCase<"NHWC", 5, "nhwc">;
+def PTO_ConvLayout_GNCHW :
+    I32EnumAttrCase<"GNCHW", 6, "gnchw">;
+def PTO_ConvLayout_GNC1HWC0 :
+    I32EnumAttrCase<"GNC1HWC0", 7, "gnc1hwc0">;
+
+def PTO_ConvLayoutEnum : PTO_I32Enum<
+  "ConvLayout", "PTO ConvTile storage layout", [
+    PTO_ConvLayout_NC1HWC0,
+    PTO_ConvLayout_NDC1HWC0,
+    PTO_ConvLayout_FRACTAL_Z,
+    PTO_ConvLayout_FRACTAL_Z_3D,
+    PTO_ConvLayout_NCHW,
+    PTO_ConvLayout_NHWC,
+    PTO_ConvLayout_GNCHW,
+    PTO_ConvLayout_GNC1HWC0
+  ]>;
+
+def PTO_ConvLayoutAttr : PTO_Attr<"ConvLayout", "conv_layout"> {
+  let parameters = (ins EnumParameter<PTO_ConvLayoutEnum>:$value);
+  let assemblyFormat = "`<` params `>`";
+  let description = [{
+    Physical layout carried by a PTO ConvTile.
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Function and Module Core Type
 //===----------------------------------------------------------------------===//
 

--- a/include/PTO/IR/PTOAttrs.td
+++ b/include/PTO/IR/PTOAttrs.td
@@ -1278,6 +1278,78 @@ def TileBufConfigAttr : AttrDef<PTO_Dialect, "TileBufConfig"> {
   }];
 }
 
+// ---------- conv_tile_config ----------
+def ConvTileConfigAttr : AttrDef<PTO_Dialect, "ConvTileConfig"> {
+  let mnemonic = "conv_tile_config";
+  let parameters = (ins
+    "mlir::IntegerAttr":$fmapH,
+    "mlir::IntegerAttr":$fmapW,
+    ArrayRefParameter<"int64_t">:$padList,
+    "mlir::IntegerAttr":$filterH,
+    "mlir::IntegerAttr":$filterW,
+    "mlir::IntegerAttr":$dilationH,
+    "mlir::IntegerAttr":$dilationW,
+    "mlir::IntegerAttr":$strideH,
+    "mlir::IntegerAttr":$strideW,
+    "mlir::Attribute":$padValue,
+    "mlir::IntegerAttr":$channelSize,
+    "mlir::IntegerAttr":$repeatStride,
+    "mlir::IntegerAttr":$repeatTime,
+    "mlir::IntegerAttr":$repeatMode,
+    "mlir::IntegerAttr":$dstStride,
+    "mlir::IntegerAttr":$dstMposition,
+    "mlir::BoolAttr":$transpose
+  );
+
+  let hasCustomAssemblyFormat = 1;
+
+  let builders = [
+    AttrBuilder<(ins
+      "mlir::IntegerAttr":$fmapH,
+      "mlir::IntegerAttr":$fmapW,
+      ArrayRefParameter<"int64_t">:$padList,
+      "mlir::IntegerAttr":$filterH,
+      "mlir::IntegerAttr":$filterW,
+      "mlir::IntegerAttr":$dilationH,
+      "mlir::IntegerAttr":$dilationW,
+      "mlir::IntegerAttr":$strideH,
+      "mlir::IntegerAttr":$strideW,
+      "mlir::Attribute":$padValue,
+      "mlir::IntegerAttr":$channelSize,
+      "mlir::IntegerAttr":$repeatStride,
+      "mlir::IntegerAttr":$repeatTime,
+      "mlir::IntegerAttr":$repeatMode,
+      "mlir::IntegerAttr":$dstStride,
+      "mlir::IntegerAttr":$dstMposition,
+      "mlir::BoolAttr":$transpose
+    )>
+  ];
+
+  let extraClassDeclaration = [{
+    static ConvTileConfigAttr getDefault(MLIRContext *ctx);
+    bool isDefault() const;
+
+    static LogicalResult verify(function_ref<InFlightDiagnostic()> emitError,
+                                mlir::IntegerAttr fmapH,
+                                mlir::IntegerAttr fmapW,
+                                ArrayRef<int64_t> padList,
+                                mlir::IntegerAttr filterH,
+                                mlir::IntegerAttr filterW,
+                                mlir::IntegerAttr dilationH,
+                                mlir::IntegerAttr dilationW,
+                                mlir::IntegerAttr strideH,
+                                mlir::IntegerAttr strideW,
+                                mlir::Attribute padValue,
+                                mlir::IntegerAttr channelSize,
+                                mlir::IntegerAttr repeatStride,
+                                mlir::IntegerAttr repeatTime,
+                                mlir::IntegerAttr repeatMode,
+                                mlir::IntegerAttr dstStride,
+                                mlir::IntegerAttr dstMposition,
+                                mlir::BoolAttr transpose);
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // QuantType
 //===----------------------------------------------------------------------===//

--- a/include/PTO/IR/PTOAttrs.td
+++ b/include/PTO/IR/PTOAttrs.td
@@ -95,6 +95,29 @@ def PTO_SignednessAttr : PTO_Attr<"Signedness", "signedness"> {
 }
 
 //===----------------------------------------------------------------------===//
+// FMATRIX mode
+//===----------------------------------------------------------------------===//
+
+def PTO_FmatrixMode_AutoA : I32EnumAttrCase<"FMATRIX_A_AUTO", 0, "a_auto">;
+def PTO_FmatrixMode_AutoB : I32EnumAttrCase<"FMATRIX_B_AUTO", 1, "b_auto">;
+def PTO_FmatrixMode_ManualA : I32EnumAttrCase<"FMATRIX_A_MANUAL", 2, "a_manual">;
+def PTO_FmatrixMode_ManualB : I32EnumAttrCase<"FMATRIX_B_MANUAL", 3, "b_manual">;
+
+def PTO_FmatrixModeEnum : PTO_I32Enum<
+  "FmatrixMode", "PTO FMATRIX selector", [
+    PTO_FmatrixMode_AutoA,
+    PTO_FmatrixMode_AutoB,
+    PTO_FmatrixMode_ManualA,
+    PTO_FmatrixMode_ManualB
+  ]>;
+
+def PTO_FmatrixModeAttr : PTO_Attr<"FmatrixMode", "fmatrix_mode"> {
+  let parameters = (ins EnumParameter<PTO_FmatrixModeEnum>:$value);
+  let assemblyFormat = "`<` params `>`";
+  let summary = "A/B selector for FMATRIX-related ops";
+}
+
+//===----------------------------------------------------------------------===//
 // SIMT GM load/store L1 and L2 cache controls
 //===----------------------------------------------------------------------===//
 

--- a/include/PTO/IR/PTOAttrs.td
+++ b/include/PTO/IR/PTOAttrs.td
@@ -111,8 +111,7 @@ def PTO_FmatrixModeEnum : PTO_I32Enum<
     PTO_FmatrixMode_ManualB
   ]>;
 
-def PTO_FmatrixModeAttr : PTO_Attr<"FmatrixMode", "fmatrix_mode"> {
-  let parameters = (ins EnumParameter<PTO_FmatrixModeEnum>:$value);
+def PTO_FmatrixModeAttr : EnumAttr<PTO_Dialect, PTO_FmatrixModeEnum, "fmatrix_mode"> {
   let assemblyFormat = "`<` params `>`";
   let summary = "A/B selector for FMATRIX-related ops";
 }
@@ -507,6 +506,16 @@ def PTO_Layout_DN : I32EnumAttrCase<"DN", 1, "dn">;
 def PTO_Layout_NZ : I32EnumAttrCase<"NZ", 2, "nz">;
 def PTO_Layout_MX_A_ZZ : I32EnumAttrCase<"MX_A_ZZ", 3, "mx_a_zz">;
 def PTO_Layout_MX_B_NN : I32EnumAttrCase<"MX_B_NN", 4, "mx_b_nn">;
+def PTO_Layout_NCHW : I32EnumAttrCase<"NCHW", 5, "nchw">;
+def PTO_Layout_NC1HWC0 : I32EnumAttrCase<"NC1HWC0", 6, "nc1hwc0">;
+def PTO_Layout_NCDHW : I32EnumAttrCase<"NCDHW", 7, "ncdhw">;
+def PTO_Layout_NDC1HWC0 : I32EnumAttrCase<"NDC1HWC0", 8, "ndc1hwc0">;
+def PTO_Layout_GNCHW : I32EnumAttrCase<"GNCHW", 9, "gnchw">;
+def PTO_Layout_GNC1HWC0 : I32EnumAttrCase<"GNC1HWC0", 10, "gnc1hwc0">;
+def PTO_Layout_NHWC : I32EnumAttrCase<"NHWC", 11, "nhwc">;
+def PTO_Layout_FRACTAL_Z : I32EnumAttrCase<"FRACTAL_Z", 12, "fractal_z">;
+def PTO_Layout_FRACTAL_Z_3D :
+    I32EnumAttrCase<"FRACTAL_Z_3D", 13, "fractal_z_3d">;
 
 def PTO_LayoutEnum : PTO_I32Enum<
   "Layout", "Global tensor layout (row/col/fractal)", [
@@ -514,16 +523,26 @@ def PTO_LayoutEnum : PTO_I32Enum<
     PTO_Layout_DN,
     PTO_Layout_NZ,
     PTO_Layout_MX_A_ZZ,
-    PTO_Layout_MX_B_NN
+    PTO_Layout_MX_B_NN,
+    PTO_Layout_NCHW,
+    PTO_Layout_NC1HWC0,
+    PTO_Layout_NCDHW,
+    PTO_Layout_NDC1HWC0,
+    PTO_Layout_GNCHW,
+    PTO_Layout_GNC1HWC0,
+    PTO_Layout_NHWC,
+    PTO_Layout_FRACTAL_Z,
+    PTO_Layout_FRACTAL_Z_3D
   ]>;
 
 def PTO_LayoutAttr : PTO_Attr<"Layout", "layout"> {
   let parameters = (ins EnumParameter<PTO_LayoutEnum>:$layout);
   let assemblyFormat = "`<` params `>`";
   let description = [{
-    Layout inferred from shape/stride for GlobalTensor:
+    Layout inferred from shape/stride for GlobalTensor and ConvTile:
       ND (row-major), DN (col-major), NZ (fractal),
-      MX_A_ZZ (A-side MX scale), MX_B_NN (B-side MX scale).
+      MX_A_ZZ (A-side MX scale), MX_B_NN (B-side MX scale),
+      NCHW/NC1HWC0/NCDHW/NDC1HWC0/GNCHW/GNC1HWC0/NHWC/FRACTAL_Z/FRACTAL_Z_3D for conv layouts.
   }];
 }
 
@@ -1325,28 +1344,6 @@ def ConvTileConfigAttr : AttrDef<PTO_Dialect, "ConvTileConfig"> {
   );
 
   let hasCustomAssemblyFormat = 1;
-
-  let builders = [
-    AttrBuilder<(ins
-      "mlir::IntegerAttr":$fmapH,
-      "mlir::IntegerAttr":$fmapW,
-      ArrayRefParameter<"int64_t">:$padList,
-      "mlir::IntegerAttr":$filterH,
-      "mlir::IntegerAttr":$filterW,
-      "mlir::IntegerAttr":$dilationH,
-      "mlir::IntegerAttr":$dilationW,
-      "mlir::IntegerAttr":$strideH,
-      "mlir::IntegerAttr":$strideW,
-      "mlir::Attribute":$padValue,
-      "mlir::IntegerAttr":$channelSize,
-      "mlir::IntegerAttr":$repeatStride,
-      "mlir::IntegerAttr":$repeatTime,
-      "mlir::IntegerAttr":$repeatMode,
-      "mlir::IntegerAttr":$dstStride,
-      "mlir::IntegerAttr":$dstMposition,
-      "mlir::BoolAttr":$transpose
-    )>
-  ];
 
   let extraClassDeclaration = [{
     static ConvTileConfigAttr getDefault(MLIRContext *ctx);

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -35,15 +35,17 @@ include "mlir/Interfaces/ViewLikeInterface.td"
 //===----------------------------------------------------------------------===//
 
 def PTODpsType :
-  AnyTypeOf<[AnyRankedTensor, PartitionTensorViewType, TileBufType]>;
+  AnyTypeOf<[AnyRankedTensor, PartitionTensorViewType, TileBufType,
+             ConvTileType]>;
 
 def PTOPipeEntryType :
-  AnyTypeOf<[AnyRankedTensor, TensorViewType, TileBufType],
-            "TensorView, TileBuf, or Tensor">;
+  AnyTypeOf<[AnyRankedTensor, TensorViewType, TileBufType, ConvTileType],
+            "TensorView, TileBuf, ConvTile, or Tensor">;
 
 def PTOCommType :
   AnyTypeOf<[AnyRankedTensor, TensorViewType, PartitionTensorViewType,
-             TileBufType], "TensorView, PartitionTensorView, TileBuf, or Tensor">;
+             TileBufType, ConvTileType],
+            "TensorView, PartitionTensorView, TileBuf, ConvTile, or Tensor">;
 
 def PtrOrMemRef :
   AnyTypeOf<[PtrType, AnyMemRef], "Ptr or MemRef">;
@@ -331,7 +333,7 @@ def AllocTileOp : PTO_Op<"alloc_tile", [AttrSizedOperandSegments]> {
     Optional<Index>:$valid_col
   );
 
-  let results = (outs TileBufType:$result);
+  let results = (outs AnyTypeOf<[TileBufType, ConvTileType]>:$result);
 
   let assemblyFormat = [{
     (`addr` `=` $addr^)?

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1899,7 +1899,10 @@ def SetQuantVectorOp : PTO_Op<"set_quant_vector", [
 
 def SetFmatrixOp : PTO_Op<"set_fmatrix", [MemoryEffects<[MemWrite]>]> {
   let summary = "Set FMATRIX registers from a ConvTile config";
-  let arguments = (ins ConvTileType:$src);
+  let arguments = (ins
+    ConvTileType:$src,
+    DefaultValuedAttr<PTO_FmatrixModeAttr, "::mlir::pto::FmatrixMode::FMATRIX_A_MANUAL">:$fmatrixMode
+  );
   let results = (outs);
   let hasVerifier = 1;
   let assemblyFormat = [{
@@ -1909,7 +1912,10 @@ def SetFmatrixOp : PTO_Op<"set_fmatrix", [MemoryEffects<[MemWrite]>]> {
 
 def SetImg2colRptOp : PTO_Op<"set_img2col_rpt", [MemoryEffects<[MemWrite]>]> {
   let summary = "Set IMG2COL repeat control from a ConvTile config";
-  let arguments = (ins ConvTileType:$src);
+  let arguments = (ins
+    ConvTileType:$src,
+    DefaultValuedAttr<PTO_FmatrixModeAttr, "::mlir::pto::FmatrixMode::FMATRIX_A_MANUAL">:$fmatrixMode
+  );
   let results = (outs);
   let hasVerifier = 1;
   let assemblyFormat = [{
@@ -1919,7 +1925,10 @@ def SetImg2colRptOp : PTO_Op<"set_img2col_rpt", [MemoryEffects<[MemWrite]>]> {
 
 def SetImg2colPaddingOp : PTO_Op<"set_img2col_padding", [MemoryEffects<[MemWrite]>]> {
   let summary = "Set IMG2COL padding control from a ConvTile config";
-  let arguments = (ins ConvTileType:$src);
+  let arguments = (ins
+    ConvTileType:$src,
+    DefaultValuedAttr<PTO_FmatrixModeAttr, "::mlir::pto::FmatrixMode::FMATRIX_A_MANUAL">:$fmatrixMode
+  );
   let results = (outs);
   let hasVerifier = 1;
   let assemblyFormat = [{
@@ -1935,7 +1944,8 @@ def TImg2colOp : PTO_Op<"timg2col", [
     TileBufType:$dst,
     ConvTileType:$src,
     DefaultValuedOptionalAttr<I32Attr, "0">:$posM,
-    DefaultValuedOptionalAttr<I32Attr, "0">:$posK
+    DefaultValuedOptionalAttr<I32Attr, "0">:$posK,
+    DefaultValuedAttr<PTO_FmatrixModeAttr, "::mlir::pto::FmatrixMode::FMATRIX_A_MANUAL">:$fmatrixMode
   );
   let results = (outs);
   let hasVerifier = 1;

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -333,7 +333,10 @@ def AllocTileOp : PTO_Op<"alloc_tile", [AttrSizedOperandSegments]> {
     Optional<Index>:$valid_col
   );
 
-  let results = (outs AnyTypeOf<[TileBufType, ConvTileType]>:$result);
+  // ConvTile values reuse the same allocation surface but carry a different
+  // type/metadata payload. The lowering selects the emitted C++ type from the
+  // result type.
+  let results = (outs AnyTypeOf<[TileBufType, ConvTileType], "TileBuf or ConvTile">:$result);
 
   let assemblyFormat = [{
     (`addr` `=` $addr^)?
@@ -1362,6 +1365,12 @@ def TMovOp  : PTO_TOp<"tmov", [
             return as.getAddressSpace();
           return std::nullopt;
         }
+        if (auto ct = llvm::dyn_cast<::mlir::pto::ConvTileType>(ty)) {
+          if (auto as = llvm::dyn_cast_or_null<::mlir::pto::AddressSpaceAttr>(
+                  ct.getMemorySpace()))
+            return as.getAddressSpace();
+          return std::nullopt;
+        }
         return std::nullopt;
       };
 
@@ -1881,6 +1890,57 @@ def SetQuantVectorOp : PTO_Op<"set_quant_vector", [
   let assemblyFormat = [{
     `(` $scaling_tile `:` qualified(type($scaling_tile)) `)`
     `{` `id` `=` $id `}` attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// ConvTile / IMG2COL config ops
+//===----------------------------------------------------------------------===//
+
+def SetFmatrixOp : PTO_Op<"set_fmatrix", [MemoryEffects<[MemWrite]>]> {
+  let summary = "Set FMATRIX registers from a ConvTile config";
+  let arguments = (ins ConvTileType:$src);
+  let results = (outs);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $src attr-dict `:` qualified(type($src))
+  }];
+}
+
+def SetImg2colRptOp : PTO_Op<"set_img2col_rpt", [MemoryEffects<[MemWrite]>]> {
+  let summary = "Set IMG2COL repeat control from a ConvTile config";
+  let arguments = (ins ConvTileType:$src);
+  let results = (outs);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $src attr-dict `:` qualified(type($src))
+  }];
+}
+
+def SetImg2colPaddingOp : PTO_Op<"set_img2col_padding", [MemoryEffects<[MemWrite]>]> {
+  let summary = "Set IMG2COL padding control from a ConvTile config";
+  let arguments = (ins ConvTileType:$src);
+  let results = (outs);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $src attr-dict `:` qualified(type($src))
+  }];
+}
+
+def TImg2colOp : PTO_Op<"timg2col", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "Image-to-column transform from ConvTile to TileBuf";
+  let arguments = (ins
+    TileBufType:$dst,
+    ConvTileType:$src,
+    DefaultValuedOptionalAttr<I32Attr, "0">:$posM,
+    DefaultValuedOptionalAttr<I32Attr, "0">:$posK
+  );
+  let results = (outs);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $dst `,` $src attr-dict `:` qualified(type($dst)) `,` qualified(type($src))
   }];
 }
 
@@ -6241,7 +6301,6 @@ def TDeInterleaveOp: PTO_TOp<"tdeinterleave", [
     ::mlir::Value getDst1() { return getDsts()[1]; }
   }];
 }
-
 def TRowProdOp: PTO_TOp<"trowprod", [
   PTO_DpsInitOpInterface,
   OpPipeInterface,

--- a/include/PTO/IR/PTOTypeDefs.td
+++ b/include/PTO/IR/PTOTypeDefs.td
@@ -228,6 +228,36 @@ def TileBufType : TypeDef<PTO_Dialect, "TileBuf"> {
   }];
 }
 
+def ConvTileType : TypeDef<PTO_Dialect, "ConvTile"> {
+  let mnemonic = "conv_tile";
+  let summary = "A convolution tile buffer with an explicit physical capacity";
+  let description = [{
+    Represents the PTO-ISA ConvTile object. Shape describes the logical
+    convolution dimensions, while bufferSize is the number of storage elements
+    reserved by the hardware tile object.
+  }];
+
+  let parameters = (ins
+    ArrayRefParameter<"int64_t">:$shape,
+    "mlir::Type":$elementType,
+    "mlir::Attribute":$memorySpace,
+    "int64_t":$bufferSize,
+    "mlir::pto::ConvLayoutAttr":$layout
+  );
+
+  let hasCustomAssemblyFormat = 1;
+
+  let extraClassDeclaration = [{
+    int64_t getRank() const { return getShape().size(); }
+    int64_t getDimSize(unsigned idx) const { return getShape()[idx]; }
+    bool hasDynamicShape() const {
+      return llvm::any_of(getShape(), [](int64_t dim) {
+        return dim == mlir::ShapedType::kDynamic;
+      });
+    }
+  }];
+}
+
 // =============================================================================
 // MultiTileBufType
 // =============================================================================

--- a/include/PTO/IR/PTOTypeDefs.td
+++ b/include/PTO/IR/PTOTypeDefs.td
@@ -230,19 +230,13 @@ def TileBufType : TypeDef<PTO_Dialect, "TileBuf"> {
 
 def ConvTileType : TypeDef<PTO_Dialect, "ConvTile"> {
   let mnemonic = "conv_tile";
-  let summary = "A convolution tile buffer with an explicit physical capacity";
-  let description = [{
-    Represents the PTO-ISA ConvTile object. Shape describes the logical
-    convolution dimensions, while bufferSize is the number of storage elements
-    reserved by the hardware tile object.
-  }];
-
   let parameters = (ins
     ArrayRefParameter<"int64_t">:$shape,
     "mlir::Type":$elementType,
-    "mlir::Attribute":$memorySpace,
-    "int64_t":$bufferSize,
-    "mlir::pto::ConvLayoutAttr":$layout
+    "mlir::IntegerAttr":$bufferSize,
+    "mlir::pto::AddressSpaceAttr":$memorySpace,
+    "mlir::pto::LayoutAttr":$layout,
+    "mlir::pto::ConvTileConfigAttr":$config
   );
 
   let hasCustomAssemblyFormat = 1;
@@ -250,11 +244,16 @@ def ConvTileType : TypeDef<PTO_Dialect, "ConvTile"> {
   let extraClassDeclaration = [{
     int64_t getRank() const { return getShape().size(); }
     int64_t getDimSize(unsigned idx) const { return getShape()[idx]; }
-    bool hasDynamicShape() const {
-      return llvm::any_of(getShape(), [](int64_t dim) {
-        return dim == mlir::ShapedType::kDynamic;
-      });
+    int64_t getNumElements() const {
+      int64_t num = 1;
+      for (int64_t dim : getShape()) num *= dim;
+      return num;
     }
+
+    int64_t getBufferSizeValue() const { return getBufferSize().getInt(); }
+
+    mlir::pto::ConvTileConfigAttr getConfigAttr() const;
+    bool hasNonDefaultConfig() const;
   }];
 }
 

--- a/include/pto-c/Dialect/PTO.h
+++ b/include/pto-c/Dialect/PTO.h
@@ -152,6 +152,19 @@ MLIR_CAPI_EXPORTED MlirType mlirPTOTileBufTypeGet(
 MLIR_CAPI_EXPORTED MlirType mlirPTOTileBufTypeGetWithConfig(
     MlirContext ctx, intptr_t rank, const int64_t *shape,
     MlirType elementType, MlirAttribute memorySpace, MlirAttribute config);
+
+// ---- ConvTileType ----
+MLIR_CAPI_EXPORTED bool mlirPTOTypeIsAConvTileType(MlirType type);
+
+MLIR_CAPI_EXPORTED MlirType mlirPTOConvTileTypeGet(
+    MlirContext ctx, intptr_t rank, const int64_t *shape,
+    MlirType elementType, MlirAttribute bufferSize,
+    MlirAttribute memorySpace, MlirAttribute layout, MlirAttribute config);
+
+MLIR_CAPI_EXPORTED intptr_t mlirPTOConvTileTypeGetRank(MlirType type);
+MLIR_CAPI_EXPORTED MlirType mlirPTOConvTileTypeGetElementType(MlirType type);
+MLIR_CAPI_EXPORTED const int64_t *mlirPTOConvTileTypeGetShape(MlirType type,
+                                                               intptr_t *numDimsOut);
 // ---- Enum attrs helpers (BLayout/SLayout/PadValue in mlir::pto) ----
 MLIR_CAPI_EXPORTED bool mlirPTOAttrIsABLayoutAttr(MlirAttribute attr);
 MLIR_CAPI_EXPORTED MlirAttribute mlirPTOBLayoutAttrGet(MlirContext ctx, int32_t value);
@@ -219,6 +232,9 @@ MLIR_CAPI_EXPORTED int32_t mlirPTOFmodPrecisionAttrGetValue(MlirAttribute attr);
 MLIR_CAPI_EXPORTED MlirAttribute mlirPTOSaturationModeAttrGet(MlirContext ctx, int32_t value);
 MLIR_CAPI_EXPORTED bool mlirPTOAttrIsASaturationModeAttr(MlirAttribute attr);
 MLIR_CAPI_EXPORTED int32_t mlirPTOSaturationModeAttrGetValue(MlirAttribute attr);
+MLIR_CAPI_EXPORTED MlirAttribute mlirPTOFmatrixModeAttrGet(MlirContext ctx, int32_t value);
+MLIR_CAPI_EXPORTED bool mlirPTOAttrIsAFmatrixModeAttr(MlirAttribute attr);
+MLIR_CAPI_EXPORTED int32_t mlirPTOFmatrixModeAttrGetValue(MlirAttribute attr);
 // ---- Pipe attr ----
 MLIR_CAPI_EXPORTED MlirAttribute mlirPTOPipeAttrGet(MlirContext ctx, int32_t value);
 MLIR_CAPI_EXPORTED bool mlirPTOAttrIsAPipeAttr(MlirAttribute attr);
@@ -293,6 +309,22 @@ MLIR_CAPI_EXPORTED MlirAttribute mlirPTOTileBufConfigAttrGetWithCompactMode(
     MlirAttribute bLayout, MlirAttribute sLayout,
     MlirAttribute sFractalSize, MlirAttribute pad,
     MlirAttribute compactMode);
+
+// ---- ConvTileConfigAttr ----
+MLIR_CAPI_EXPORTED bool mlirPTOAttrIsAConvTileConfigAttr(MlirAttribute attr);
+
+MLIR_CAPI_EXPORTED MlirAttribute mlirPTOConvTileConfigAttrGetDefault(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirAttribute mlirPTOConvTileConfigAttrGet(
+    MlirContext ctx, MlirAttribute fmapH, MlirAttribute fmapW,
+    intptr_t padListSize, const int64_t *padList,
+    MlirAttribute filterH, MlirAttribute filterW,
+    MlirAttribute dilationH, MlirAttribute dilationW,
+    MlirAttribute strideH, MlirAttribute strideW,
+    MlirAttribute padValue, MlirAttribute channelSize,
+    MlirAttribute repeatStride, MlirAttribute repeatTime,
+    MlirAttribute repeatMode, MlirAttribute dstStride,
+    MlirAttribute dstMposition, MlirAttribute transpose);
 MLIR_CAPI_EXPORTED MlirType mlirPTOTileBufTypeGetWithValidShape(
     MlirContext ctx, intptr_t rank, const int64_t *shape, MlirType elementType,
     MlirAttribute memorySpace, intptr_t validRank, const int64_t *validShape);

--- a/lib/Bindings/Python/PTOModule.cpp
+++ b/lib/Bindings/Python/PTOModule.cpp
@@ -66,6 +66,17 @@ static MlirContext inferContextFromElementType(MlirContext context,
   return mlirTypeGetContext(elementType);
 }
 
+static MlirContext inferContextFromAttribute(py::object contextObj,
+                                             MlirAttribute attr) {
+  if (!contextObj.is_none()) {
+    return contextObj.cast<MlirContext>();
+  }
+  if (mlirAttributeIsNull(attr)) {
+    throw py::value_error("context is required when attribute is null");
+  }
+  return mlirAttributeGetContext(attr);
+}
+
 static int32_t enumValueFromPy(py::object value, const char *attrName,
                                const char *enumName) {
   if (py::isinstance<py::int_>(value)) {
@@ -226,6 +237,12 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
     py::enum_<mlir::pto::SaturationMode>(m, "SaturationMode")
     .value("ON", mlir::pto::SaturationMode::ON)
     .value("OFF", mlir::pto::SaturationMode::OFF);
+
+    py::enum_<mlir::pto::FmatrixMode>(m, "FmatrixMode")
+    .value("FMATRIX_A_AUTO", mlir::pto::FmatrixMode::FMATRIX_A_AUTO)
+    .value("FMATRIX_B_AUTO", mlir::pto::FmatrixMode::FMATRIX_B_AUTO)
+    .value("FMATRIX_A_MANUAL", mlir::pto::FmatrixMode::FMATRIX_A_MANUAL)
+    .value("FMATRIX_B_MANUAL", mlir::pto::FmatrixMode::FMATRIX_B_MANUAL);
 
     py::enum_<MlirPTOCmpMode>(m, "CmpMode")
       .value("EQ", MlirPTOCmpMode_EQ)
@@ -621,6 +638,10 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
                     mlirPTOAttrIsAFmodPrecisionAttr,
                     mlirPTOFmodPrecisionAttrGet,
                     mlirPTOFmodPrecisionAttrGetValue);
+    bindPTOEnumAttr(m, "FmatrixModeAttr", "FmatrixMode",
+                    mlirPTOAttrIsAFmatrixModeAttr,
+                    mlirPTOFmatrixModeAttrGet,
+                    mlirPTOFmatrixModeAttrGetValue);
 
     mlir_attribute_subclass(
         m, "SaturationModeAttr",
@@ -1444,6 +1465,74 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             py::arg("context") = py::none(),
             py::arg("compact_mode") = py::none());
 
+    // ---- ConvTileConfigAttr ----
+    mlir_attribute_subclass(m, "ConvTileConfigAttr",
+                            [](MlirAttribute a) -> bool {
+                                return mlirPTOAttrIsAConvTileConfigAttr(a);
+                            })
+        .def_classmethod(
+            "get_default",
+            [](py::object cls, MlirContext ctx) -> py::object {
+                MlirAttribute a = mlirPTOConvTileConfigAttrGetDefault(ctx);
+                if (mlirAttributeIsNull(a)) {
+                  return py::none();
+                }
+                return cls(a);
+            },
+            py::arg("cls"), py::arg("context"))
+        .def_classmethod(
+            "get",
+            [](py::object cls,
+               MlirAttribute fmapH,
+               MlirAttribute fmapW,
+               std::vector<int64_t> padList,
+               MlirAttribute filterH,
+               MlirAttribute filterW,
+               MlirAttribute dilationH,
+               MlirAttribute dilationW,
+               MlirAttribute strideH,
+               MlirAttribute strideW,
+               MlirAttribute padValue,
+               MlirAttribute channelSize,
+               MlirAttribute repeatStride,
+               MlirAttribute repeatTime,
+               MlirAttribute repeatMode,
+               MlirAttribute dstStride,
+               MlirAttribute dstMposition,
+               MlirAttribute transpose,
+               py::object contextObj) -> py::object {
+                MlirContext ctx = inferContextFromAttribute(contextObj, fmapH);
+                MlirAttribute a = mlirPTOConvTileConfigAttrGet(
+                    ctx, fmapH, fmapW, static_cast<intptr_t>(padList.size()),
+                    padList.data(), filterH, filterW, dilationH, dilationW,
+                    strideH, strideW, padValue, channelSize, repeatStride,
+                    repeatTime, repeatMode, dstStride, dstMposition,
+                    transpose);
+                if (mlirAttributeIsNull(a)) {
+                  return py::none();
+                }
+                return cls(a);
+            },
+            py::arg("cls"),
+            py::arg("fmap_h"),
+            py::arg("fmap_w"),
+            py::arg("pad_list"),
+            py::arg("filter_h"),
+            py::arg("filter_w"),
+            py::arg("dilation_h"),
+            py::arg("dilation_w"),
+            py::arg("stride_h"),
+            py::arg("stride_w"),
+            py::arg("pad_value"),
+            py::arg("channel_size"),
+            py::arg("repeat_stride"),
+            py::arg("repeat_time"),
+            py::arg("repeat_mode"),
+            py::arg("dst_stride"),
+            py::arg("dst_mposition"),
+            py::arg("transpose"),
+            py::arg("context") = py::none());
+
     // ---- TileBufType ----
     mlir_type_subclass(m, "TileBufType", [](MlirType t) -> bool { return mlirPTOTypeIsATileBufType(t); })
         .def_classmethod(
@@ -1548,6 +1637,66 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
         .def_property_readonly("s_fractal_size", [](MlirType self) -> int32_t {
           return mlirPTOTileBufTypeGetSFractalSize(self);
         });
+
+    // ---- ConvTileType ----
+    mlir_type_subclass(m, "ConvTileType",
+                       [](MlirType t) -> bool {
+                         return mlirPTOTypeIsAConvTileType(t);
+                       })
+        .def_classmethod(
+            "get",
+            [](py::object cls,
+               std::vector<int64_t> shape,
+               MlirType elementType,
+               MlirAttribute bufferSize,
+               MlirAttribute memorySpace,
+               MlirAttribute layout,
+               py::object configObj,
+               MlirContext ctx) -> py::object {
+                ctx = inferContextFromElementType(ctx, elementType);
+                MlirAttribute config = optionalAttributeFromPy(configObj);
+                MlirType ty = mlirPTOConvTileTypeGet(
+                    ctx, static_cast<intptr_t>(shape.size()), shape.data(),
+                    elementType, bufferSize, memorySpace, layout, config);
+                if (mlirTypeIsNull(ty)) {
+                  return py::none();
+                }
+                return cls(ty);
+            },
+            py::arg("cls"),
+            py::arg("shape"),
+            py::arg("element_type"),
+            py::arg("buffer_size"),
+            py::arg("memory_space"),
+            py::arg("layout"),
+            py::arg("config") = py::none(),
+            py::arg("context") = py::none())
+        .def_classmethod(
+            "upcast_type",
+            [](py::object cls, MlirType t) -> py::object {
+              if (mlirPTOTypeIsAConvTileType(t)) {
+                return cls(t);
+              }
+              return py::none();
+            },
+            py::arg("cls"), py::arg("type"))
+        .def_property_readonly(
+            "rank",
+            [](MlirType self) -> intptr_t {
+              return mlirPTOConvTileTypeGetRank(self);
+            })
+        .def_property_readonly(
+            "element_type",
+            [](MlirType self) -> MlirType {
+              return mlirPTOConvTileTypeGetElementType(self);
+            })
+        .def_property_readonly(
+            "shape",
+            [](MlirType self) -> py::list {
+              intptr_t n = 0;
+              const int64_t *d = mlirPTOConvTileTypeGetShape(self, &n);
+              return shapeToPyList(d, n);
+            });
 
     populatePTODialectSubmodule(m);
 }

--- a/lib/Bindings/Python/PTOModule.cpp
+++ b/lib/Bindings/Python/PTOModule.cpp
@@ -258,7 +258,14 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
       .value("DN", mlir::pto::Layout::DN)
       .value("NZ", mlir::pto::Layout::NZ)
       .value("MX_A_ZZ", mlir::pto::Layout::MX_A_ZZ)
-      .value("MX_B_NN", mlir::pto::Layout::MX_B_NN);
+      .value("MX_B_NN", mlir::pto::Layout::MX_B_NN)
+      .value("NCHW", mlir::pto::Layout::NCHW)
+      .value("NC1HWC0", mlir::pto::Layout::NC1HWC0)
+      .value("NCDHW", mlir::pto::Layout::NCDHW)
+      .value("NDC1HWC0", mlir::pto::Layout::NDC1HWC0)
+      .value("GNCHW", mlir::pto::Layout::GNCHW)
+      .value("GNC1HWC0", mlir::pto::Layout::GNC1HWC0)
+      .value("NHWC", mlir::pto::Layout::NHWC);
 
     py::enum_<mlir::pto::AccToVecMode>(m, "AccToVecMode")
       .value("SingleModeVec0", mlir::pto::AccToVecMode::SingleModeVec0)

--- a/lib/CAPI/Dialect/PTO.cpp
+++ b/lib/CAPI/Dialect/PTO.cpp
@@ -352,6 +352,57 @@ MlirType mlirPTOTileBufTypeGetWithValidShapeAndConfig(MlirContext ctx,
   return wrap(ty);
 }
 
+bool mlirPTOTypeIsAConvTileType(MlirType type) {
+  return mlir::isa<mlir::pto::ConvTileType>(unwrap(type));
+}
+
+MlirType mlirPTOConvTileTypeGet(MlirContext ctx, intptr_t rank,
+                                const int64_t *shape, MlirType elementType,
+                                MlirAttribute bufferSize,
+                                MlirAttribute memorySpace,
+                                MlirAttribute layout,
+                                MlirAttribute config) {
+  MLIRContext *c = unwrap(ctx);
+  auto shp = llvm::ArrayRef<int64_t>(shape, rank);
+  auto bufferSizeAttr = mlir::dyn_cast<mlir::IntegerAttr>(unwrap(bufferSize));
+  auto memorySpaceAttr =
+      mlir::dyn_cast<mlir::pto::AddressSpaceAttr>(unwrap(memorySpace));
+  auto layoutAttr = mlir::dyn_cast<mlir::pto::LayoutAttr>(unwrap(layout));
+  mlir::pto::ConvTileConfigAttr configAttr;
+  if (!mlirAttributeIsNull(config)) {
+    configAttr =
+        mlir::dyn_cast_or_null<mlir::pto::ConvTileConfigAttr>(unwrap(config));
+  }
+  if (!configAttr) {
+    configAttr = mlir::pto::ConvTileConfigAttr::getDefault(c);
+  }
+  if (!bufferSizeAttr || !memorySpaceAttr || !layoutAttr) {
+    return MlirType{nullptr};
+  }
+
+  auto ty = mlir::pto::ConvTileType::get(c, shp, unwrap(elementType),
+                                         bufferSizeAttr, memorySpaceAttr,
+                                         layoutAttr, configAttr);
+  return wrap(ty);
+}
+
+intptr_t mlirPTOConvTileTypeGetRank(MlirType type) {
+  return mlir::cast<mlir::pto::ConvTileType>(unwrap(type)).getRank();
+}
+
+MlirType mlirPTOConvTileTypeGetElementType(MlirType type) {
+  return wrap(mlir::cast<mlir::pto::ConvTileType>(unwrap(type)).getElementType());
+}
+
+const int64_t *mlirPTOConvTileTypeGetShape(MlirType type,
+                                           intptr_t *numDimsOut) {
+  static thread_local llvm::SmallVector<int64_t, 8> shape;
+  auto dims = mlir::cast<mlir::pto::ConvTileType>(unwrap(type)).getShape();
+  shape.assign(dims.begin(), dims.end());
+  *numDimsOut = static_cast<intptr_t>(shape.size());
+  return shape.data();
+}
+
 bool mlirPTOAttrIsABLayoutAttr(MlirAttribute attr) {
   return mlir::isa<mlir::pto::BLayoutAttr>(unwrap(attr));
 }
@@ -436,6 +487,7 @@ DEFINE_PTO_ENUM_ATTR_CAPI(RemPrecision, RemPrecisionAttr, RemPrecision)
 DEFINE_PTO_ENUM_ATTR_CAPI(RsqrtPrecision, RsqrtPrecisionAttr, RsqrtPrecision)
 DEFINE_PTO_ENUM_ATTR_CAPI(SqrtPrecision, SqrtPrecisionAttr, SqrtPrecision)
 DEFINE_PTO_ENUM_ATTR_CAPI(FmodPrecision, FmodPrecisionAttr, FmodPrecision)
+DEFINE_PTO_ENUM_ATTR_CAPI(FmatrixMode, FmatrixModeAttr, FmatrixMode)
 
 #undef DEFINE_PTO_ENUM_ATTR_CAPI
 
@@ -760,6 +812,14 @@ static mlir::pto::CompactModeAttr toCompactModeAttr(mlir::MLIRContext *c,
   return {};
 }
 
+static mlir::IntegerAttr toI32IntegerAttr(mlir::Attribute a) {
+  auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(a);
+  if (!intAttr || !intAttr.getType().isSignlessInteger(kI32BitWidth)) {
+    return {};
+  }
+  return intAttr;
+}
+
 bool mlirPTOAttrIsACompactModeAttr(MlirAttribute attr) {
   return mlir::isa<mlir::pto::CompactModeAttr>(unwrap(attr));
 }
@@ -910,6 +970,56 @@ MlirAttribute mlirPTOTileBufConfigAttrGetWithCompactMode(
   }
 
   return wrap(mlir::pto::TileBufConfigAttr::get(c, blA, slA, sz, pvA, cmA));
+}
+
+bool mlirPTOAttrIsAConvTileConfigAttr(MlirAttribute attr) {
+  return mlir::isa<mlir::pto::ConvTileConfigAttr>(unwrap(attr));
+}
+
+MlirAttribute mlirPTOConvTileConfigAttrGetDefault(MlirContext ctx) {
+  auto *c = unwrap(ctx);
+  return wrap(mlir::pto::ConvTileConfigAttr::getDefault(c));
+}
+
+MlirAttribute mlirPTOConvTileConfigAttrGet(
+    MlirContext ctx, MlirAttribute fmapH, MlirAttribute fmapW,
+    intptr_t padListSize, const int64_t *padList, MlirAttribute filterH,
+    MlirAttribute filterW, MlirAttribute dilationH, MlirAttribute dilationW,
+    MlirAttribute strideH, MlirAttribute strideW, MlirAttribute padValue,
+    MlirAttribute channelSize, MlirAttribute repeatStride,
+    MlirAttribute repeatTime, MlirAttribute repeatMode, MlirAttribute dstStride,
+    MlirAttribute dstMposition, MlirAttribute transpose) {
+  auto *c = unwrap(ctx);
+  auto fmapHAttr = toI32IntegerAttr(unwrap(fmapH));
+  auto fmapWAttr = toI32IntegerAttr(unwrap(fmapW));
+  auto filterHAttr = toI32IntegerAttr(unwrap(filterH));
+  auto filterWAttr = toI32IntegerAttr(unwrap(filterW));
+  auto dilationHAttr = toI32IntegerAttr(unwrap(dilationH));
+  auto dilationWAttr = toI32IntegerAttr(unwrap(dilationW));
+  auto strideHAttr = toI32IntegerAttr(unwrap(strideH));
+  auto strideWAttr = toI32IntegerAttr(unwrap(strideW));
+  auto channelSizeAttr = toI32IntegerAttr(unwrap(channelSize));
+  auto repeatStrideAttr = toI32IntegerAttr(unwrap(repeatStride));
+  auto repeatTimeAttr = toI32IntegerAttr(unwrap(repeatTime));
+  auto repeatModeAttr = toI32IntegerAttr(unwrap(repeatMode));
+  auto dstStrideAttr = toI32IntegerAttr(unwrap(dstStride));
+  auto dstMpositionAttr = toI32IntegerAttr(unwrap(dstMposition));
+  auto transposeAttr = mlir::dyn_cast<mlir::BoolAttr>(unwrap(transpose));
+  if (!fmapHAttr || !fmapWAttr || !filterHAttr || !filterWAttr ||
+      !dilationHAttr || !dilationWAttr || !strideHAttr || !strideWAttr ||
+      !channelSizeAttr || !repeatStrideAttr || !repeatTimeAttr ||
+      !repeatModeAttr || !dstStrideAttr || !dstMpositionAttr ||
+      !transposeAttr) {
+    return MlirAttribute{nullptr};
+  }
+
+  auto pads =
+      llvm::ArrayRef<int64_t>(padList, static_cast<size_t>(padListSize));
+  return wrap(mlir::pto::ConvTileConfigAttr::get(
+      c, fmapHAttr, fmapWAttr, pads, filterHAttr, filterWAttr, dilationHAttr,
+      dilationWAttr, strideHAttr, strideWAttr, unwrap(padValue),
+      channelSizeAttr, repeatStrideAttr, repeatTimeAttr, repeatModeAttr,
+      dstStrideAttr, dstMpositionAttr, transposeAttr));
 }
 
 MlirType mlirPTOGMTypeGet(MlirContext ctx, intptr_t rank, const int64_t *shape,

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -293,6 +293,10 @@ static int64_t getPTOTypeRank(Type type) {
     return tileBufTy.getRank();
   }
 
+  if (auto convTileTy = dyn_cast<pto::ConvTileType>(type)) {
+    return convTileTy.getRank();
+  }
+
   // 3. 不支持的类型
   return -1;
 }
@@ -3585,14 +3589,50 @@ static LogicalResult verifyConstantLocalAddress(Operation *op, Value addr,
 }
 
 LogicalResult AllocTileOp::verify() {
-  auto ty = getResult().getType(); // TileBufType
+  auto ty = getResult().getType();
 
-  if (failed(verifyTileBufLayoutConstraints(*this, ty, "result"))) {
+  if (auto convTy = dyn_cast<ConvTileType>(ty)) {
+    const bool invalidRank = convTy.getRank() == 0 || convTy.getRank() > 6;
+    if (invalidRank) {
+      return emitOpError("ConvTile result rank must be between 1 and 6");
+    }
+    for (int64_t dim : convTy.getShape()) {
+      if (dim <= 0) {
+        return emitOpError("ConvTile result dimensions must be positive");
+      }
+    }
+    const bool invalidBuffer = convTy.getBufferSize() <= 0;
+    if (invalidBuffer) {
+      return emitOpError("ConvTile buffer size must be positive");
+    }
+    const bool invalidElementSize =
+        getElemByteSize(convTy.getElementType()) == 0;
+    if (invalidElementSize) {
+      return emitOpError("ConvTile element type must have a byte size");
+    }
+    const bool hasValidOperands = getValidRow() || getValidCol();
+    if (hasValidOperands) {
+      return emitOpError(
+          "ConvTile allocation does not accept valid_row or valid_col operands");
+    }
+    if (failed(verifyConstantLocalAddress(getOperation(), getAddr(),
+                                          convTy.getMemorySpace()))) {
+      return failure();
+    }
+    return success();
+  }
+
+  auto tileTy = dyn_cast<TileBufType>(ty);
+  if (!tileTy) {
+    return emitOpError("result must be !pto.tile_buf or !pto.conv_tile");
+  }
+
+  if (failed(verifyTileBufLayoutConstraints(*this, tileTy, "result"))) {
     return failure();
   }
 
   if (failed(verifyConstantLocalAddress(getOperation(), getAddr(),
-                                        ty.getMemorySpace()))) {
+                                        tileTy.getMemorySpace()))) {
     return failure();
   }
 
@@ -3601,7 +3641,7 @@ LogicalResult AllocTileOp::verify() {
   bool hasVC = getValidCol() != nullptr;
 
   // type 上的 validShape
-  auto vs = ty.getValidShape();
+  auto vs = tileTy.getValidShape();
   if (vs.size() != 2) {
     return emitOpError("result tile_buf must have rank-2 validShape");
   }
@@ -3789,9 +3829,21 @@ LogicalResult TAssignOp::verify() {
     return emitOpError("result type must match tile operand type");
   }
 
+  if (auto convTy = dyn_cast<ConvTileType>(getTile().getType())) {
+    const bool invalidConvTile =
+        convTy.getBufferSize() <= 0 || convTy.getRank() == 0 ||
+        convTy.getRank() > 6;
+    if (invalidConvTile) {
+      return emitOpError("expects a valid ConvTile type");
+    }
+    return verifyConstantLocalAddress(getOperation(), getAddr(),
+                                      convTy.getMemorySpace());
+  }
+
   auto tileTy = dyn_cast<TileBufType>(getTile().getType());
   if (!tileTy) {
-    return emitOpError("expects tile operand and result to be !pto.tile_buf");
+    return emitOpError(
+        "expects tile operand and result to be !pto.tile_buf or !pto.conv_tile");
   }
 
   if (failed(verifyConstantLocalAddress(getOperation(), getAddr(),
@@ -3803,6 +3855,42 @@ LogicalResult TAssignOp::verify() {
 }
 
 LogicalResult TLoadOp::verify() {
+  if (auto convDst = dyn_cast<ConvTileType>(getDst().getType())) {
+    auto srcPart = dyn_cast<PartitionTensorViewType>(getSrc().getType());
+    if (!srcPart) {
+      return emitOpError(
+          "ConvTile tload expects src to be !pto.partition_tensor_view");
+    }
+    const bool invalidRank = convDst.getRank() == 0 || convDst.getRank() > 6;
+    if (invalidRank) {
+      return emitOpError("ConvTile tload dst rank must be between 1 and 6");
+    }
+    const bool invalidCapacity =
+        convDst.getBufferSize() <= 0 ||
+        getElemByteSize(convDst.getElementType()) == 0;
+    if (invalidCapacity) {
+      return emitOpError("ConvTile tload dst must have a positive buffer and "
+                         "a byte-sized element type");
+    }
+    auto dstSpace = getPTOMemorySpaceEnum(convDst);
+    if (!dstSpace || *dstSpace != AddressSpace::MAT) {
+      return emitOpError("ConvTile tload dst must use loc=mat");
+    }
+    for (int64_t dim : srcPart.getShape()) {
+      if (dim != ShapedType::kDynamic && dim <= 0) {
+        return emitOpError() << "expects src shape dimension to be positive";
+      }
+    }
+    const bool mismatchedElementSize =
+        getElemByteSize(srcPart.getElementType()) !=
+        getElemByteSize(convDst.getElementType());
+    if (mismatchedElementSize) {
+      return emitOpError(
+          "ConvTile tload src and dst must have the same element size");
+    }
+    return success();
+  }
+
   auto verifyCommon =
       [&](bool allowLowPrecision)
       -> FailureOr<std::pair<pto::PartitionTensorViewType, pto::TileBufType>> {
@@ -4871,6 +4959,21 @@ static LogicalResult verifyCommPingPongSameType(Operation *op, Value ping,
 }
 
 static std::optional<uint64_t> getStaticByteSize(Type ty) {
+  if (auto conv = dyn_cast<pto::ConvTileType>(ty)) {
+    uint64_t elemBytes = getElemByteSize(conv.getElementType());
+    const bool invalidCapacity = elemBytes == 0 || conv.getBufferSize() <= 0;
+    if (invalidCapacity) {
+      return std::nullopt;
+    }
+    uint64_t bufferSize = static_cast<uint64_t>(conv.getBufferSize());
+    const bool overflows =
+        bufferSize > std::numeric_limits<uint64_t>::max() / elemBytes;
+    if (overflows) {
+      return std::nullopt;
+    }
+    return bufferSize * elemBytes;
+  }
+
   SmallVector<int64_t, 4> shape = getShapeVec(ty);
   if (shape.empty()) {
     return std::nullopt;
@@ -4916,6 +5019,13 @@ static std::optional<pto::AddressSpace> getPTOMemorySpaceEnum(Type ty) {
   }
   if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
     if (auto as = dyn_cast_or_null<pto::AddressSpaceAttr>(tb.getMemorySpace())) {
+      return as.getAddressSpace();
+    }
+    return std::nullopt;
+  }
+  if (auto conv = dyn_cast<pto::ConvTileType>(ty)) {
+    if (auto as =
+            dyn_cast_or_null<pto::AddressSpaceAttr>(conv.getMemorySpace())) {
       return as.getAddressSpace();
     }
     return std::nullopt;

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -293,10 +293,6 @@ static int64_t getPTOTypeRank(Type type) {
     return tileBufTy.getRank();
   }
 
-  if (auto convTileTy = dyn_cast<pto::ConvTileType>(type)) {
-    return convTileTy.getRank();
-  }
-
   // 3. 不支持的类型
   return -1;
 }
@@ -3589,50 +3585,14 @@ static LogicalResult verifyConstantLocalAddress(Operation *op, Value addr,
 }
 
 LogicalResult AllocTileOp::verify() {
-  auto ty = getResult().getType();
+  auto ty = getResult().getType(); // TileBufType
 
-  if (auto convTy = dyn_cast<ConvTileType>(ty)) {
-    const bool invalidRank = convTy.getRank() == 0 || convTy.getRank() > 6;
-    if (invalidRank) {
-      return emitOpError("ConvTile result rank must be between 1 and 6");
-    }
-    for (int64_t dim : convTy.getShape()) {
-      if (dim <= 0) {
-        return emitOpError("ConvTile result dimensions must be positive");
-      }
-    }
-    const bool invalidBuffer = convTy.getBufferSize() <= 0;
-    if (invalidBuffer) {
-      return emitOpError("ConvTile buffer size must be positive");
-    }
-    const bool invalidElementSize =
-        getElemByteSize(convTy.getElementType()) == 0;
-    if (invalidElementSize) {
-      return emitOpError("ConvTile element type must have a byte size");
-    }
-    const bool hasValidOperands = getValidRow() || getValidCol();
-    if (hasValidOperands) {
-      return emitOpError(
-          "ConvTile allocation does not accept valid_row or valid_col operands");
-    }
-    if (failed(verifyConstantLocalAddress(getOperation(), getAddr(),
-                                          convTy.getMemorySpace()))) {
-      return failure();
-    }
-    return success();
-  }
-
-  auto tileTy = dyn_cast<TileBufType>(ty);
-  if (!tileTy) {
-    return emitOpError("result must be !pto.tile_buf or !pto.conv_tile");
-  }
-
-  if (failed(verifyTileBufLayoutConstraints(*this, tileTy, "result"))) {
+  if (failed(verifyTileBufLayoutConstraints(*this, ty, "result"))) {
     return failure();
   }
 
   if (failed(verifyConstantLocalAddress(getOperation(), getAddr(),
-                                        tileTy.getMemorySpace()))) {
+                                        ty.getMemorySpace()))) {
     return failure();
   }
 
@@ -3641,7 +3601,7 @@ LogicalResult AllocTileOp::verify() {
   bool hasVC = getValidCol() != nullptr;
 
   // type 上的 validShape
-  auto vs = tileTy.getValidShape();
+  auto vs = ty.getValidShape();
   if (vs.size() != 2) {
     return emitOpError("result tile_buf must have rank-2 validShape");
   }
@@ -3829,25 +3789,20 @@ LogicalResult TAssignOp::verify() {
     return emitOpError("result type must match tile operand type");
   }
 
-  if (auto convTy = dyn_cast<ConvTileType>(getTile().getType())) {
-    const bool invalidConvTile =
-        convTy.getBufferSize() <= 0 || convTy.getRank() == 0 ||
-        convTy.getRank() > 6;
-    if (invalidConvTile) {
-      return emitOpError("expects a valid ConvTile type");
-    }
-    return verifyConstantLocalAddress(getOperation(), getAddr(),
-                                      convTy.getMemorySpace());
+  auto tileTy = getTile().getType();
+  if (!isa<TileBufType, ConvTileType>(tileTy)) {
+    return emitOpError("expects tile operand and result to be !pto.tile_buf or !pto.conv_tile");
   }
 
-  auto tileTy = dyn_cast<TileBufType>(getTile().getType());
-  if (!tileTy) {
-    return emitOpError(
-        "expects tile operand and result to be !pto.tile_buf or !pto.conv_tile");
+  Attribute memorySpace;
+  if (auto tb = dyn_cast<TileBufType>(tileTy)) {
+    memorySpace = tb.getMemorySpace();
+  } else if (auto ct = dyn_cast<ConvTileType>(tileTy)) {
+    memorySpace = ct.getMemorySpace();
   }
 
   if (failed(verifyConstantLocalAddress(getOperation(), getAddr(),
-                                        tileTy.getMemorySpace()))) {
+                                        memorySpace))) {
     return failure();
   }
 
@@ -3855,52 +3810,16 @@ LogicalResult TAssignOp::verify() {
 }
 
 LogicalResult TLoadOp::verify() {
-  if (auto convDst = dyn_cast<ConvTileType>(getDst().getType())) {
-    auto srcPart = dyn_cast<PartitionTensorViewType>(getSrc().getType());
-    if (!srcPart) {
-      return emitOpError(
-          "ConvTile tload expects src to be !pto.partition_tensor_view");
-    }
-    const bool invalidRank = convDst.getRank() == 0 || convDst.getRank() > 6;
-    if (invalidRank) {
-      return emitOpError("ConvTile tload dst rank must be between 1 and 6");
-    }
-    const bool invalidCapacity =
-        convDst.getBufferSize() <= 0 ||
-        getElemByteSize(convDst.getElementType()) == 0;
-    if (invalidCapacity) {
-      return emitOpError("ConvTile tload dst must have a positive buffer and "
-                         "a byte-sized element type");
-    }
-    auto dstSpace = getPTOMemorySpaceEnum(convDst);
-    if (!dstSpace || *dstSpace != AddressSpace::MAT) {
-      return emitOpError("ConvTile tload dst must use loc=mat");
-    }
-    for (int64_t dim : srcPart.getShape()) {
-      if (dim != ShapedType::kDynamic && dim <= 0) {
-        return emitOpError() << "expects src shape dimension to be positive";
-      }
-    }
-    const bool mismatchedElementSize =
-        getElemByteSize(srcPart.getElementType()) !=
-        getElemByteSize(convDst.getElementType());
-    if (mismatchedElementSize) {
-      return emitOpError(
-          "ConvTile tload src and dst must have the same element size");
-    }
-    return success();
-  }
-
   auto verifyCommon =
       [&](bool allowLowPrecision)
-      -> FailureOr<std::pair<pto::PartitionTensorViewType, pto::TileBufType>> {
+      -> FailureOr<std::pair<pto::PartitionTensorViewType, Type>> {
     auto srcPart = dyn_cast<pto::PartitionTensorViewType>(getSrc().getType());
-    auto dstTile = dyn_cast<pto::TileBufType>(getDst().getType());
-    if (!srcPart || !dstTile) {
-      emitOpError("expects src to be !pto.partition_tensor_view and dst to be !pto.tile_buf");
+    Type dstTy = getDst().getType();
+    if (!srcPart || !isa<pto::TileBufType, pto::ConvTileType>(dstTy)) {
+      emitOpError("expects src to be !pto.partition_tensor_view and dst to be !pto.tile_buf or !pto.conv_tile");
       return failure();
     }
-    if (failed(verifyTileBufCommon(*this, dstTile, "dst", allowLowPrecision))) {
+    if (failed(verifyTileLikeCommon(*this, dstTy, "dst", allowLowPrecision))) {
       return failure();
     }
 
@@ -3911,14 +3830,14 @@ LogicalResult TLoadOp::verify() {
         return failure();
       }
     }
-    auto dstValid = dstTile.getValidShape();
+    auto dstValid = getValidShapeVec(dstTy);
     for (unsigned i = 0; i < dstValid.size(); ++i) {
       if (dstValid[i] != ShapedType::kDynamic && dstValid[i] < 0) {
         emitOpError() << "expects dst valid_shape[" << i << "] to be non-negative";
         return failure();
       }
     }
-    return std::make_pair(srcPart, dstTile);
+    return std::make_pair(srcPart, dstTy);
   };
 
   auto verifyA2A3 = [&]() -> LogicalResult {
@@ -3929,7 +3848,7 @@ LogicalResult TLoadOp::verify() {
     auto [srcPart, dstTile] = *common;
 
     Type srcElem = srcPart.getElementType();
-    Type dstElem = dstTile.getElementType();
+    Type dstElem = getElemTy(dstTile);
     if (isPTOLowPrecisionType(srcElem) || isPTOLowPrecisionType(dstElem)) {
       return emitOpError("expects A2/A3 tload low-precision element types to be unsupported");
     }
@@ -3958,7 +3877,7 @@ LogicalResult TLoadOp::verify() {
     auto [srcPart, dstTile] = *common;
 
     Type srcElem = srcPart.getElementType();
-    Type dstElem = dstTile.getElementType();
+    Type dstElem = getElemTy(dstTile);
     unsigned srcBytes = getElemByteSize(srcElem);
     unsigned dstBytes = getElemByteSize(dstElem);
     if (srcBytes != dstBytes) {
@@ -3984,8 +3903,12 @@ LogicalResult TLoadOp::verify() {
 
     auto dstSpace = getPTOMemorySpaceEnum(dstTile);
     if (dstSpace && *dstSpace == pto::AddressSpace::VEC) {
-      int32_t bl = dstTile.getBLayoutValueI32();
-      int32_t sl = dstTile.getSLayoutValueI32();
+      auto dstTB = dyn_cast<pto::TileBufType>(dstTile);
+      if (!dstTB) {
+        return emitOpError("expects A5 tload vec dst to be a tile_buf");
+      }
+      int32_t bl = dstTB.getBLayoutValueI32();
+      int32_t sl = dstTB.getSLayoutValueI32();
       bool isND = (bl == static_cast<int32_t>(pto::BLayout::RowMajor) &&
                    sl == static_cast<int32_t>(pto::SLayout::NoneBox));
       bool isDN = (bl == static_cast<int32_t>(pto::BLayout::ColMajor) &&
@@ -4001,6 +3924,52 @@ LogicalResult TLoadOp::verify() {
   };
 
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
+}
+
+LogicalResult mlir::pto::SetFmatrixOp::verify() {
+  return verifyConvTileCommon(*this, getSrc().getType(), "src",
+                              /*allowLowPrecision=*/true);
+}
+
+LogicalResult mlir::pto::SetImg2colRptOp::verify() {
+  return verifyConvTileCommon(*this, getSrc().getType(), "src",
+                              /*allowLowPrecision=*/true);
+}
+
+LogicalResult mlir::pto::SetImg2colPaddingOp::verify() {
+  return verifyConvTileCommon(*this, getSrc().getType(), "src",
+                              /*allowLowPrecision=*/true);
+}
+
+LogicalResult mlir::pto::TImg2colOp::verify() {
+  if (failed(verifyTileBufCommon(*this, getDst().getType(), "dst",
+                                 /*allowLowPrecision=*/true))) {
+    return failure();
+  }
+  if (failed(verifyConvTileCommon(*this, getSrc().getType(), "src",
+                                  /*allowLowPrecision=*/true))) {
+    return failure();
+  }
+  if (getElemTy(getDst().getType()) != getElemTy(getSrc().getType())) {
+    return emitOpError() << "expects src and dst to have the same element type";
+  }
+
+  auto checkPos = [&](IntegerAttr posAttr, StringRef name) -> LogicalResult {
+    if (!posAttr || !posAttr.getType().isSignlessInteger(32)) {
+      return emitOpError() << "expects " << name << " to be an i32 attr";
+    }
+    int64_t value = posAttr.getInt();
+    if (value < 0 || value > std::numeric_limits<uint16_t>::max()) {
+      return emitOpError() << "expects " << name
+                           << " to fit in an unsigned 16-bit integer";
+    }
+    return success();
+  };
+  if (failed(checkPos(getPosM(), "posM")) || failed(checkPos(getPosK(), "posK"))) {
+    return failure();
+  }
+
+  return success();
 }
 
 LogicalResult TPrefetchOp::verify() {
@@ -4701,7 +4670,7 @@ static bool isPTOShapedLike(Type ty) {
 }
 
 static bool isTileLikeType(Type ty) {
-  return isa<pto::TileBufType>(ty);
+  return isa<pto::TileBufType, pto::ConvTileType>(ty);
 }
 
 static Type getElemTy(Type ty) {
@@ -4713,6 +4682,9 @@ static Type getElemTy(Type ty) {
   }
   if (auto tb = mlir::dyn_cast<pto::TileBufType>(ty)) {
     return tb.getElementType();
+  }
+  if (auto ct = mlir::dyn_cast<pto::ConvTileType>(ty)) {
+    return ct.getElementType();
   }
   if (auto tv = mlir::dyn_cast<pto::PartitionTensorViewType>(ty)) {
     return tv.getElementType();
@@ -4730,6 +4702,9 @@ static SmallVector<int64_t, 4> getShapeVec(Type ty) {
   }
   if (auto tb = mlir::dyn_cast<pto::TileBufType>(ty)) {
     return SmallVector<int64_t, 4>(tb.getShape().begin(), tb.getShape().end());
+  }
+  if (auto ct = mlir::dyn_cast<pto::ConvTileType>(ty)) {
+    return SmallVector<int64_t, 4>(ct.getShape().begin(), ct.getShape().end());
   }
   if (auto tv = mlir::dyn_cast<pto::PartitionTensorViewType>(ty)) {
     return SmallVector<int64_t, 4>(tv.getShape().begin(), tv.getShape().end());
@@ -4959,21 +4934,6 @@ static LogicalResult verifyCommPingPongSameType(Operation *op, Value ping,
 }
 
 static std::optional<uint64_t> getStaticByteSize(Type ty) {
-  if (auto conv = dyn_cast<pto::ConvTileType>(ty)) {
-    uint64_t elemBytes = getElemByteSize(conv.getElementType());
-    const bool invalidCapacity = elemBytes == 0 || conv.getBufferSize() <= 0;
-    if (invalidCapacity) {
-      return std::nullopt;
-    }
-    uint64_t bufferSize = static_cast<uint64_t>(conv.getBufferSize());
-    const bool overflows =
-        bufferSize > std::numeric_limits<uint64_t>::max() / elemBytes;
-    if (overflows) {
-      return std::nullopt;
-    }
-    return bufferSize * elemBytes;
-  }
-
   SmallVector<int64_t, 4> shape = getShapeVec(ty);
   if (shape.empty()) {
     return std::nullopt;
@@ -5023,9 +4983,8 @@ static std::optional<pto::AddressSpace> getPTOMemorySpaceEnum(Type ty) {
     }
     return std::nullopt;
   }
-  if (auto conv = dyn_cast<pto::ConvTileType>(ty)) {
-    if (auto as =
-            dyn_cast_or_null<pto::AddressSpaceAttr>(conv.getMemorySpace())) {
+  if (auto ct = dyn_cast<pto::ConvTileType>(ty)) {
+    if (auto as = dyn_cast_or_null<pto::AddressSpaceAttr>(ct.getMemorySpace())) {
       return as.getAddressSpace();
     }
     return std::nullopt;
@@ -5392,6 +5351,75 @@ static bool isA5SupportedTCvtPair(Type srcElem, Type dstElem) {
     return isA5LowPrecisionTCvtPair(srcElem, dstElem);
   }
   return true;
+}
+
+static LogicalResult verifyConvTileCommon(Operation *op, Type ty, StringRef name,
+                                          bool allowLowPrecision = false) {
+  auto ct = dyn_cast<pto::ConvTileType>(ty);
+  if (!ct) {
+    return op->emitOpError() << "expects " << name << " to be a !pto.conv_tile";
+  }
+
+  auto as = getPTOMemorySpaceEnum(ty);
+  if (!as || *as != pto::AddressSpace::MAT) {
+    return op->emitOpError() << "expects " << name
+                             << " to be in the mat address space";
+  }
+
+  if (!allowLowPrecision && isPTOLowPrecisionType(ct.getElementType())) {
+    return op->emitOpError() << name << ": dtype " << ct.getElementType()
+                             << " is not supported by this op yet";
+  }
+
+  auto shape = getShapeVec(ty);
+  if (shape.empty() || shape.size() > 6) {
+    return op->emitOpError() << "expects " << name
+                             << " to have a rank in [1, 6]";
+  }
+  for (unsigned i = 0; i < shape.size(); ++i) {
+    if (shape[i] <= 0) {
+      return op->emitOpError() << "expects " << name << " shape[" << i
+                               << "] to be positive";
+    }
+  }
+
+  auto bufferSize = dyn_cast<IntegerAttr>(ct.getBufferSize());
+  if (!bufferSize) {
+    return op->emitOpError() << "expects " << name
+                             << " to have a signless integer buffer_size";
+  }
+  if (bufferSize.getInt() <= 0) {
+    return op->emitOpError() << "expects " << name
+                             << " buffer_size to be positive";
+  }
+
+  int64_t logicalSize = 1;
+  for (int64_t dim : shape) {
+    if (logicalSize > std::numeric_limits<int64_t>::max() / dim) {
+      return op->emitOpError() << "cannot compute logical size of " << name
+                               << " without overflow";
+    }
+    logicalSize *= dim;
+  }
+  if (bufferSize.getInt() < logicalSize) {
+    return op->emitOpError() << "expects " << name
+                             << " buffer_size to cover at least "
+                             << logicalSize << " elements";
+  }
+
+  return success();
+}
+
+static LogicalResult verifyTileLikeCommon(Operation *op, Type ty, StringRef name,
+                                          bool allowLowPrecision = false) {
+  if (isa<pto::TileBufType>(ty)) {
+    return verifyTileBufCommon(op, ty, name, allowLowPrecision);
+  }
+  if (isa<pto::ConvTileType>(ty)) {
+    return verifyConvTileCommon(op, ty, name, allowLowPrecision);
+  }
+  return op->emitOpError() << "expects " << name
+                           << " to be a !pto.tile_buf or !pto.conv_tile";
 }
 
 static LogicalResult verifyTileBufCommon(Operation *op, Type ty, StringRef name,
@@ -8042,6 +8070,17 @@ static bool isRowMajorNoneBoxND(pto::TileBufType ty) {
          ty.getSLayoutValueI32() == static_cast<int32_t>(pto::SLayout::NoneBox);
 }
 
+static bool isConvTileExtractElem(Type ty) {
+  if (ty.isF16() || ty.isBF16() || ty.isF32()) {
+    return true;
+  }
+  if (auto intTy = dyn_cast<IntegerType>(ty)) {
+    unsigned width = intTy.getWidth();
+    return width == 8 || width == 16 || width == 32;
+  }
+  return false;
+}
+
 struct TExtractCommon {
   Type srcTy;
   Type dstTy;
@@ -8185,6 +8224,54 @@ static LogicalResult verifyTExtractA2A3(TExtractOp op) {
   const bool hasFp = static_cast<bool>(op.getFp());
   const bool hasPreQuantScalar = static_cast<bool>(op.getPreQuantScalar());
   const bool hasRelu = op.getReluPreMode() != pto::ReluPreMode::NoRelu;
+  if (isa<pto::ConvTileType>(getSrc().getType())) {
+    Type srcTy = getSrc().getType();
+    Type dstTy = getDst().getType();
+    if (failed(verifyTileLikeCommon(*this, srcTy, "src",
+                                    /*allowLowPrecision=*/false)) ||
+        failed(verifyTileBufCommon(*this, dstTy, "dst",
+                                   /*allowLowPrecision=*/false)) ||
+        failed(verifyNonNegativeIndexRowCol(
+            *getOperation(), getIndexRow(), getIndexCol(),
+            /*includeIndexAndIntOpsInConstFold=*/hasFp))) {
+      return failure();
+    }
+    if (hasFp || hasPreQuantScalar || hasRelu || op.getAccToVecModeAttr()) {
+      return emitOpError("expects convtile textract to use the base form");
+    }
+    auto srcCT = dyn_cast<pto::ConvTileType>(srcTy);
+    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
+    auto dstSpace = getPTOMemorySpaceEnum(dstTy);
+    if (!srcSpace || *srcSpace != pto::AddressSpace::MAT) {
+      return emitOpError("expects convtile textract src to use loc=mat");
+    }
+    if (!dstSpace || *dstSpace != pto::AddressSpace::RIGHT) {
+      return emitOpError("expects convtile textract dst to use loc=right");
+    }
+    auto srcLayout = dyn_cast_or_null<pto::LayoutAttr>(srcCT.getLayout());
+    if (!srcLayout ||
+        (srcLayout.getLayout() != pto::Layout::FRACTAL_Z &&
+         srcLayout.getLayout() != pto::Layout::FRACTAL_Z_3D)) {
+      return emitOpError(
+          "expects convtile textract src to use layout=FRACTAL_Z or FRACTAL_Z_3D");
+    }
+    auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
+    if (!dstTb ||
+        dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
+        dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor)) {
+      return emitOpError(
+          "expects convtile textract dst to use blayout=row_major and slayout=col_major");
+    }
+    Type srcElem = getElemTy(srcTy);
+    Type dstElem = getElemTy(dstTy);
+    if (!srcElem || !dstElem || srcElem != dstElem) {
+      return emitOpError("expects convtile textract src and dst to have the same element type");
+    }
+    if (!isConvTileExtractElem(srcElem)) {
+      return emitOpError("expects convtile textract element type to be i8/i16/i32/f16/bf16/f32");
+    }
+    return success();
+  }
   if (!isA2A3ExtractElemType(c.dstElem) && !(hasFp && c.dstElem.isInteger(16))) {
     return op.emitOpError("expects A2/A3 textract element type to be i8/f16/bf16/f32");
   }
@@ -8288,6 +8375,54 @@ static LogicalResult verifyTExtractA5(TExtractOp op) {
   const TExtractCommon &c = *common;
   const bool hasPreQuantScalar = static_cast<bool>(op.getPreQuantScalar());
   const bool hasRelu = op.getReluPreMode() != pto::ReluPreMode::NoRelu;
+  if (isa<pto::ConvTileType>(getSrc().getType())) {
+    Type srcTy = getSrc().getType();
+    Type dstTy = getDst().getType();
+    if (failed(verifyTileLikeCommon(*this, srcTy, "src",
+                                    /*allowLowPrecision=*/true)) ||
+        failed(verifyTileBufCommon(*this, dstTy, "dst",
+                                   /*allowLowPrecision=*/true)) ||
+        failed(verifyNonNegativeIndexRowCol(
+            *getOperation(), getIndexRow(), getIndexCol(),
+            /*includeIndexAndIntOpsInConstFold=*/hasFp))) {
+      return failure();
+    }
+    if (hasFp || hasPreQuantScalar || hasRelu || op.getAccToVecModeAttr()) {
+      return emitOpError("expects convtile textract to use the base form");
+    }
+    auto srcCT = dyn_cast<pto::ConvTileType>(srcTy);
+    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
+    auto dstSpace = getPTOMemorySpaceEnum(dstTy);
+    if (!srcSpace || *srcSpace != pto::AddressSpace::MAT) {
+      return emitOpError("expects convtile textract src to use loc=mat");
+    }
+    if (!dstSpace || *dstSpace != pto::AddressSpace::RIGHT) {
+      return emitOpError("expects convtile textract dst to use loc=right");
+    }
+    auto srcLayout = dyn_cast_or_null<pto::LayoutAttr>(srcCT.getLayout());
+    if (!srcLayout ||
+        (srcLayout.getLayout() != pto::Layout::FRACTAL_Z &&
+         srcLayout.getLayout() != pto::Layout::FRACTAL_Z_3D)) {
+      return emitOpError(
+          "expects convtile textract src to use layout=FRACTAL_Z or FRACTAL_Z_3D");
+    }
+    auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
+    if (!dstTb ||
+        dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
+        dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor)) {
+      return emitOpError(
+          "expects convtile textract dst to use blayout=row_major and slayout=col_major");
+    }
+    Type srcElem = getElemTy(srcTy);
+    Type dstElem = getElemTy(dstTy);
+    if (!srcElem || !dstElem || srcElem != dstElem) {
+      return emitOpError("expects convtile textract src and dst to have the same element type");
+    }
+    if (!isConvTileExtractElem(srcElem)) {
+      return emitOpError("expects convtile textract element type to be i8/i16/i32/f16/bf16/f32");
+    }
+    return success();
+  }
   if (!isA5ExtractElemType(c.dstElem)) {
     return op.emitOpError("expects A5 textract element type to be an fp8/f16/bf16/f32 or int8 family type");
   }
@@ -9765,6 +9900,48 @@ static LogicalResult verifyTMovImpl(TMovOp op, bool isA5) {
   }
   if (classifyTMovForm(fp) == TMovForm::XToZz) {
     return verifyTMovXToZz(op, isA5);
+  }
+  if (auto srcCT = dyn_cast<pto::ConvTileType>(op.getSrc().getType())) {
+    Type srcTy = op.getSrc().getType();
+    Type dstTy = op.getDst().getType();
+    Value preQuantScalar = op.getPreQuantScalar();
+    auto accToVecModeAttr = op.getAccToVecModeAttr();
+    auto reluMode = op.getReluPreMode();
+    const bool hasFp = static_cast<bool>(fp);
+    const bool hasPreQuantScalar = static_cast<bool>(preQuantScalar);
+    auto srcTb = dyn_cast<pto::TileBufType>(srcTy);
+    auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
+    Type srcElem = getElemTy(srcTy);
+    Type dstElem = getElemTy(dstTy);
+    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
+    auto dstSpace = getPTOMemorySpaceEnum(dstTy);
+
+    if (!srcTb || !dstTb || !srcSpace || !dstSpace || !srcElem || !dstElem) {
+      return op.emitOpError("expects convtile tmov operands to be valid tile types");
+    }
+    if (hasFp || hasPreQuantScalar || accToVecModeAttr ||
+        reluMode != pto::ReluPreMode::NoRelu) {
+      return op.emitOpError("expects convtile tmov to use the base form");
+    }
+    if (*srcSpace != pto::AddressSpace::MAT) {
+      return op.emitOpError("expects convtile tmov src to use loc=mat");
+    }
+    if (*dstSpace != pto::AddressSpace::RIGHT) {
+      return op.emitOpError("expects convtile tmov dst to use loc=right");
+    }
+    auto srcLayout = dyn_cast_or_null<pto::LayoutAttr>(srcCT.getLayout());
+    if (!srcLayout || srcLayout.getLayout() != pto::Layout::FRACTAL_Z) {
+      return op.emitOpError("expects convtile tmov src to use layout=FRACTAL_Z");
+    }
+    if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
+        dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor)) {
+      return op.emitOpError(
+          "expects convtile tmov dst to use blayout=row_major and slayout=col_major");
+    }
+    if (srcElem != dstElem) {
+      return op.emitOpError("expects convtile tmov src and dst to have the same element type");
+    }
+    return success();
   }
   return verifyTMovGeneric(op, isA5);
 }
@@ -16542,8 +16719,210 @@ static LogicalResult verifyTTransA5(TTransOp op) {
 }
 
 mlir::LogicalResult mlir::pto::TTransOp::verify() {
+  auto verifyConvTile = [&]() -> LogicalResult {
+    Type srcTy = getSrc().getType();
+    Type tmpTy = getTmp() ? getTmp().getType() : Type{};
+    Type dstTy = getDst().getType();
+    auto srcCT = dyn_cast<pto::ConvTileType>(srcTy);
+    auto dstCT = dyn_cast<pto::ConvTileType>(dstTy);
+    auto tmpCT = dyn_cast<pto::ConvTileType>(tmpTy);
+
+    if (!srcCT || !dstCT) {
+      return emitOpError("expects convtile ttrans src and dst to be !pto.conv_tile");
+    }
+    if (!tmpTy) {
+      return emitOpError("expects convtile ttrans to provide a tmp operand");
+    }
+    if (!tmpCT) {
+      return emitOpError("expects convtile ttrans tmp to be !pto.conv_tile");
+    }
+
+    if (failed(verifyConvTileCommon(*this, srcTy, "src",
+                                    /*allowLowPrecision=*/false)) ||
+        failed(verifyConvTileCommon(*this, dstTy, "dst",
+                                    /*allowLowPrecision=*/false)) ||
+        failed(verifyConvTileCommon(*this, tmpTy, "tmp",
+                                    /*allowLowPrecision=*/false))) {
+      return failure();
+    }
+
+    Type srcElem = getElemTy(srcTy);
+    Type dstElem = getElemTy(dstTy);
+    Type tmpElem = getElemTy(tmpTy);
+    if (!srcElem || !dstElem || !tmpElem || srcElem != dstElem || srcElem != tmpElem) {
+      return emitOpError() << "expects convtile src, dst, and tmp to have the same element type";
+    }
+
+    auto srcLayout = dyn_cast_or_null<pto::LayoutAttr>(srcCT.getLayout());
+    auto dstLayout = dyn_cast_or_null<pto::LayoutAttr>(dstCT.getLayout());
+    if (!srcLayout || !dstLayout) {
+      return emitOpError("expects convtile ttrans src and dst to have a layout attr");
+    }
+
+    const int64_t elemBytes = getPTOStorageElemByteSize(srcElem);
+    if (elemBytes != 1 && elemBytes != 2 && elemBytes != 4) {
+      return emitOpError("expects convtile ttrans element size to be 1, 2, or 4 bytes");
+    }
+    const int64_t c0 = 32 / elemBytes;
+
+    auto checkedAdd = [](int64_t lhs, int64_t rhs) -> std::optional<int64_t> {
+      if (lhs < 0 || rhs < 0 || lhs > std::numeric_limits<int64_t>::max() - rhs) {
+        return std::nullopt;
+      }
+      return lhs + rhs;
+    };
+    auto checkedMul = [](int64_t lhs, int64_t rhs) -> std::optional<int64_t> {
+      if (lhs < 0 || rhs < 0 || (rhs != 0 && lhs > std::numeric_limits<int64_t>::max() / rhs)) {
+        return std::nullopt;
+      }
+      return lhs * rhs;
+    };
+    auto checkedCeilDiv = [&](int64_t lhs, int64_t rhs) -> std::optional<int64_t> {
+      if (lhs < 0 || rhs <= 0) {
+        return std::nullopt;
+      }
+      auto biased = checkedAdd(lhs, rhs - 1);
+      if (!biased) {
+        return std::nullopt;
+      }
+      return *biased / rhs;
+    };
+
+    auto srcShape = getShapeVec(srcTy);
+    auto dstShape = getShapeVec(dstTy);
+    auto expectShape = [&](ArrayRef<int64_t> actual, ArrayRef<int64_t> expected,
+                           StringRef name) -> LogicalResult {
+      if (actual.size() != expected.size()) {
+        return emitOpError() << "expects " << name << " rank to be " << expected.size();
+      }
+      for (size_t i = 0; i < expected.size(); ++i) {
+        if (actual[i] != expected[i]) {
+          return emitOpError() << "expects " << name << " shape[" << i << "] to be "
+                               << expected[i] << " (got " << actual[i] << ")";
+        }
+      }
+      return success();
+    };
+
+    auto verifyPair = [&](pto::Layout srcLayoutKind,
+                          pto::Layout dstLayoutKind) -> LogicalResult {
+      switch (srcLayoutKind) {
+      case pto::Layout::NCHW: {
+        if (dstLayoutKind != pto::Layout::NC1HWC0) {
+          return emitOpError("expects convtile ttrans NCHW src to lower to NC1HWC0 dst");
+        }
+        if (srcShape.size() != 4 || dstShape.size() != 5) {
+          return emitOpError("expects convtile ttrans NCHW->NC1HWC0 to use 4D src and 5D dst");
+        }
+        auto expectedC1 = checkedCeilDiv(srcShape[1], c0);
+        if (!expectedC1) {
+          return emitOpError("cannot compute convtile ttrans NCHW->NC1HWC0 channel split");
+        }
+        SmallVector<int64_t, 6> expected{srcShape[0], *expectedC1, srcShape[2], srcShape[3], c0};
+        return expectShape(dstShape, expected, "dst");
+      }
+      case pto::Layout::NC1HWC0: {
+        if (dstLayoutKind != pto::Layout::FRACTAL_Z) {
+          return emitOpError("expects convtile ttrans NC1HWC0 src to lower to FRACTAL_Z dst");
+        }
+        if (srcShape.size() != 5 || dstShape.size() != 4) {
+          return emitOpError("expects convtile ttrans NC1HWC0->FRACTAL_Z to use 5D src and 4D dst");
+        }
+        auto expectedN1 = checkedCeilDiv(srcShape[0], 16);
+        if (!expectedN1) {
+          return emitOpError("cannot compute convtile ttrans NC1HWC0->FRACTAL_Z batch split");
+        }
+        auto expectedC1HW = checkedMul(srcShape[1], srcShape[2]);
+        if (!expectedC1HW) {
+          return emitOpError("cannot compute convtile ttrans NC1HWC0->FRACTAL_Z output size");
+        }
+        expectedC1HW = checkedMul(*expectedC1HW, srcShape[3]);
+        if (!expectedC1HW) {
+          return emitOpError("cannot compute convtile ttrans NC1HWC0->FRACTAL_Z output size");
+        }
+        SmallVector<int64_t, 6> expected{*expectedC1HW, *expectedN1, 16, srcShape[4]};
+        return expectShape(dstShape, expected, "dst");
+      }
+      case pto::Layout::GNCHW: {
+        if (dstLayoutKind != pto::Layout::GNC1HWC0) {
+          return emitOpError("expects convtile ttrans GNCHW src to lower to GNC1HWC0 dst");
+        }
+        if (srcShape.size() != 5 || dstShape.size() != 6) {
+          return emitOpError("expects convtile ttrans GNCHW->GNC1HWC0 to use 5D src and 6D dst");
+        }
+        auto expectedC1 = checkedCeilDiv(srcShape[2], c0);
+        if (!expectedC1) {
+          return emitOpError("cannot compute convtile ttrans GNCHW->GNC1HWC0 channel split");
+        }
+        SmallVector<int64_t, 6> expected{srcShape[0], srcShape[1], *expectedC1, srcShape[3],
+                                         srcShape[4], c0};
+        return expectShape(dstShape, expected, "dst");
+      }
+      case pto::Layout::GNC1HWC0: {
+        if (dstLayoutKind != pto::Layout::FRACTAL_Z) {
+          return emitOpError("expects convtile ttrans GNC1HWC0 src to lower to FRACTAL_Z dst");
+        }
+        if (srcShape.size() != 6 || dstShape.size() != 4) {
+          return emitOpError("expects convtile ttrans GNC1HWC0->FRACTAL_Z to use 6D src and 4D dst");
+        }
+        auto expectedN1 = checkedCeilDiv(srcShape[1], 16);
+        if (!expectedN1) {
+          return emitOpError("cannot compute convtile ttrans GNC1HWC0->FRACTAL_Z batch split");
+        }
+        auto expectedGC1HW = checkedMul(srcShape[0], srcShape[2]);
+        if (!expectedGC1HW) {
+          return emitOpError("cannot compute convtile ttrans GNC1HWC0->FRACTAL_Z output size");
+        }
+        expectedGC1HW = checkedMul(*expectedGC1HW, srcShape[3]);
+        if (!expectedGC1HW) {
+          return emitOpError("cannot compute convtile ttrans GNC1HWC0->FRACTAL_Z output size");
+        }
+        expectedGC1HW = checkedMul(*expectedGC1HW, srcShape[4]);
+        if (!expectedGC1HW) {
+          return emitOpError("cannot compute convtile ttrans GNC1HWC0->FRACTAL_Z output size");
+        }
+        SmallVector<int64_t, 6> expected{*expectedGC1HW, *expectedN1, 16, srcShape[5]};
+        return expectShape(dstShape, expected, "dst");
+      }
+      case pto::Layout::NCDHW: {
+        if (dstLayoutKind != pto::Layout::FRACTAL_Z_3D) {
+          return emitOpError("expects convtile ttrans NCDHW src to lower to FRACTAL_Z_3D dst");
+        }
+        if (srcShape.size() != 5 || dstShape.size() != 4) {
+          return emitOpError("expects convtile ttrans NCDHW->FRACTAL_Z_3D to use 5D src and 4D dst");
+        }
+        auto expectedC1 = checkedCeilDiv(srcShape[1], c0);
+        auto expectedN1 = checkedCeilDiv(srcShape[0], 16);
+        if (!expectedC1 || !expectedN1) {
+          return emitOpError("cannot compute convtile ttrans NCDHW->FRACTAL_Z_3D split");
+        }
+        auto expectedDst0 = checkedMul(srcShape[2], *expectedC1);
+        if (!expectedDst0) {
+          return emitOpError("cannot compute convtile ttrans NCDHW->FRACTAL_Z_3D output size");
+        }
+        expectedDst0 = checkedMul(*expectedDst0, srcShape[3]);
+        if (!expectedDst0) {
+          return emitOpError("cannot compute convtile ttrans NCDHW->FRACTAL_Z_3D output size");
+        }
+        expectedDst0 = checkedMul(*expectedDst0, srcShape[4]);
+        if (!expectedDst0) {
+          return emitOpError("cannot compute convtile ttrans NCDHW->FRACTAL_Z_3D output size");
+        }
+        SmallVector<int64_t, 6> expected{*expectedDst0, *expectedN1, 16, c0};
+        return expectShape(dstShape, expected, "dst");
+      }
+      default:
+        return emitOpError("expects convtile ttrans src to use NCHW, NC1HWC0, GNCHW, GNC1HWC0, or NCDHW layout");
+      }
+    };
+
+    return verifyPair(srcLayout.getLayout(), dstLayout.getLayout());
+  };
   auto verifyA2A3 = [&]() -> LogicalResult { return verifyTTransA2A3(*this); };
   auto verifyA5 = [&]() -> LogicalResult { return verifyTTransA5(*this); };
+  if (isa<pto::ConvTileType>(getSrc().getType())) {
+    return verifyConvTile();
+  }
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -18621,6 +18621,12 @@ void TPrefetchOp::getEffects(
   addEffect(effects, &getDstMutable(), MemoryEffects::Write::get());
 }
 
+void TImg2colOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
+  addEffect(effects, &getSrcMutable(), MemoryEffects::Read::get());
+  addEffect(effects, &getDstMutable(), MemoryEffects::Write::get());
+}
+
 // === TAbsOp ===
 // Read: src, Write: dst
 void TAbsOp::getEffects(

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -126,6 +126,10 @@ static bool isKnownZeroOrUnitExtent(int64_t value);
 static bool isByteIntegerType(Type ty);
 static LogicalResult verifyTileBufCommon(Operation *op, Type ty, StringRef name,
                                          bool allowLowPrecision = false);
+static LogicalResult verifyConvTileCommon(Operation *op, Type ty, StringRef name,
+                                          bool allowLowPrecision = false);
+static LogicalResult verifyTileLikeCommon(Operation *op, Type ty, StringRef name,
+                                          bool allowLowPrecision = false);
 static LogicalResult verifyTmpCapacityAtLeast(Operation *op, Type tmpTy,
                                               uint64_t requiredBytes,
                                               StringRef tmpName = "tmp");
@@ -1956,9 +1960,12 @@ static unsigned getElemByteSize(Type ty) {
   return getPTOStorageElemByteSize(ty);
 }
 
-static LogicalResult verifyTileBufLayoutConstraints(Operation *op,
-                                                    pto::TileBufType tb,
+static LogicalResult verifyTileBufLayoutConstraints(Operation *op, Type ty,
                                                     StringRef name) {
+  auto tb = dyn_cast<pto::TileBufType>(ty);
+  if (!tb) {
+    return op->emitOpError() << "expects " << name << " to be a !pto.tile_buf";
+  }
   auto shape = tb.getShape();
   if (shape.size() != 2) {
     return op->emitOpError() << "expects " << name << " to be rank-2";
@@ -3585,7 +3592,10 @@ static LogicalResult verifyConstantLocalAddress(Operation *op, Value addr,
 }
 
 LogicalResult AllocTileOp::verify() {
-  auto ty = getResult().getType(); // TileBufType
+  auto ty = dyn_cast<pto::TileBufType>(getResult().getType());
+  if (!ty) {
+    return emitOpError("result must be `!pto.tile_buf`");
+  }
 
   if (failed(verifyTileBufLayoutConstraints(*this, ty, "result"))) {
     return failure();
@@ -3894,10 +3904,12 @@ LogicalResult TLoadOp::verify() {
     }
 
     if (dstElem.isInteger(64)) {
-      auto pad = dstTile.getPadValueI32();
-      if (pad != static_cast<int32_t>(pto::PadValue::Null) &&
-          pad != static_cast<int32_t>(pto::PadValue::Zero)) {
-        return emitOpError("expects A5 i64/u64 tload dst pad to be null or zero");
+      if (auto dstTB = dyn_cast<pto::TileBufType>(dstTile)) {
+        auto pad = dstTB.getPadValueI32();
+        if (pad != static_cast<int32_t>(pto::PadValue::Null) &&
+            pad != static_cast<int32_t>(pto::PadValue::Zero)) {
+          return emitOpError("expects A5 i64/u64 tload dst pad to be null or zero");
+        }
       }
     }
 
@@ -4007,12 +4019,8 @@ LogicalResult mlir::pto::TImg2colOp::verify() {
     return emitOpError("expects dst to use loc=left");
   }
 
-  auto checkPos = [&](IntegerAttr posAttr, StringRef name) -> LogicalResult {
-    if (!posAttr || !posAttr.getType().isSignlessInteger(32)) {
-      return emitOpError() << "expects " << name << " to be an i32 attr";
-    }
-    int64_t value = posAttr.getInt();
-    if (value < 0 || value > std::numeric_limits<uint16_t>::max()) {
+  auto checkPos = [&](uint32_t value, StringRef name) -> LogicalResult {
+    if (value > std::numeric_limits<uint16_t>::max()) {
       return emitOpError() << "expects " << name
                            << " to fit in an unsigned 16-bit integer";
     }
@@ -5415,7 +5423,7 @@ static bool isA5SupportedTCvtPair(Type srcElem, Type dstElem) {
 }
 
 static LogicalResult verifyConvTileCommon(Operation *op, Type ty, StringRef name,
-                                          bool allowLowPrecision = false) {
+                                          bool allowLowPrecision) {
   auto ct = dyn_cast<pto::ConvTileType>(ty);
   if (!ct) {
     return op->emitOpError() << "expects " << name << " to be a !pto.conv_tile";
@@ -5472,7 +5480,7 @@ static LogicalResult verifyConvTileCommon(Operation *op, Type ty, StringRef name
 }
 
 static LogicalResult verifyTileLikeCommon(Operation *op, Type ty, StringRef name,
-                                          bool allowLowPrecision = false) {
+                                          bool allowLowPrecision) {
   if (isa<pto::TileBufType>(ty)) {
     return verifyTileBufCommon(op, ty, name, allowLowPrecision);
   }
@@ -8277,6 +8285,60 @@ static LogicalResult verifyTExtractA2A3Mat(TExtractOp op,
 }
 
 static LogicalResult verifyTExtractA2A3(TExtractOp op) {
+  if (isa<pto::ConvTileType>(op.getSrc().getType())) {
+    Type srcTy = op.getSrc().getType();
+    Type dstTy = op.getDst().getType();
+    const bool hasFp = static_cast<bool>(op.getFp());
+    if (failed(verifyTileLikeCommon(op, srcTy, "src",
+                                    /*allowLowPrecision=*/false)) ||
+        failed(verifyTileBufCommon(op, dstTy, "dst",
+                                   /*allowLowPrecision=*/false)) ||
+        failed(verifyNonNegativeIndexRowCol(
+            *op.getOperation(), op.getIndexRow(), op.getIndexCol(),
+            /*includeIndexAndIntOpsInConstFold=*/hasFp)) ||
+        failed(verifyExtractStaticBoundsCommon(
+            *op.getOperation(), op.getIndexRow(), op.getIndexCol(), srcTy,
+            dstTy, /*includeIndexAndIntOpsInConstFold=*/hasFp))) {
+      return failure();
+    }
+    if (hasFp || op.getPreQuantScalar() ||
+        op.getReluPreMode() != pto::ReluPreMode::NoRelu ||
+        op.getAccToVecModeAttr()) {
+      return op.emitOpError("expects convtile textract to use the base form");
+    }
+    auto srcCT = dyn_cast<pto::ConvTileType>(srcTy);
+    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
+    auto dstSpace = getPTOMemorySpaceEnum(dstTy);
+    if (!srcSpace || *srcSpace != pto::AddressSpace::MAT) {
+      return op.emitOpError("expects convtile textract src to use loc=mat");
+    }
+    if (!dstSpace || *dstSpace != pto::AddressSpace::RIGHT) {
+      return op.emitOpError("expects convtile textract dst to use loc=right");
+    }
+    auto srcLayout = dyn_cast_or_null<pto::LayoutAttr>(srcCT.getLayout());
+    if (!srcLayout ||
+        (srcLayout.getLayout() != pto::Layout::FRACTAL_Z &&
+         srcLayout.getLayout() != pto::Layout::FRACTAL_Z_3D)) {
+      return op.emitOpError(
+          "expects convtile textract src to use layout=FRACTAL_Z or FRACTAL_Z_3D");
+    }
+    auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
+    if (!dstTb ||
+        dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
+        dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor)) {
+      return op.emitOpError(
+          "expects convtile textract dst to use blayout=row_major and slayout=col_major");
+    }
+    Type srcElem = getElemTy(srcTy);
+    Type dstElem = getElemTy(dstTy);
+    if (!srcElem || !dstElem || srcElem != dstElem) {
+      return op.emitOpError("expects convtile textract src and dst to have the same element type");
+    }
+    if (!isConvTileExtractElem(srcElem)) {
+      return op.emitOpError("expects convtile textract element type to be i8/i16/i32/f16/bf16/f32");
+    }
+    return success();
+  }
   auto common = verifyTExtractCommon(op, /*allowLowPrecision=*/false);
   if (failed(common)) {
     return failure();
@@ -8285,54 +8347,6 @@ static LogicalResult verifyTExtractA2A3(TExtractOp op) {
   const bool hasFp = static_cast<bool>(op.getFp());
   const bool hasPreQuantScalar = static_cast<bool>(op.getPreQuantScalar());
   const bool hasRelu = op.getReluPreMode() != pto::ReluPreMode::NoRelu;
-  if (isa<pto::ConvTileType>(getSrc().getType())) {
-    Type srcTy = getSrc().getType();
-    Type dstTy = getDst().getType();
-    if (failed(verifyTileLikeCommon(*this, srcTy, "src",
-                                    /*allowLowPrecision=*/false)) ||
-        failed(verifyTileBufCommon(*this, dstTy, "dst",
-                                   /*allowLowPrecision=*/false)) ||
-        failed(verifyNonNegativeIndexRowCol(
-            *getOperation(), getIndexRow(), getIndexCol(),
-            /*includeIndexAndIntOpsInConstFold=*/hasFp))) {
-      return failure();
-    }
-    if (hasFp || hasPreQuantScalar || hasRelu || op.getAccToVecModeAttr()) {
-      return emitOpError("expects convtile textract to use the base form");
-    }
-    auto srcCT = dyn_cast<pto::ConvTileType>(srcTy);
-    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
-    auto dstSpace = getPTOMemorySpaceEnum(dstTy);
-    if (!srcSpace || *srcSpace != pto::AddressSpace::MAT) {
-      return emitOpError("expects convtile textract src to use loc=mat");
-    }
-    if (!dstSpace || *dstSpace != pto::AddressSpace::RIGHT) {
-      return emitOpError("expects convtile textract dst to use loc=right");
-    }
-    auto srcLayout = dyn_cast_or_null<pto::LayoutAttr>(srcCT.getLayout());
-    if (!srcLayout ||
-        (srcLayout.getLayout() != pto::Layout::FRACTAL_Z &&
-         srcLayout.getLayout() != pto::Layout::FRACTAL_Z_3D)) {
-      return emitOpError(
-          "expects convtile textract src to use layout=FRACTAL_Z or FRACTAL_Z_3D");
-    }
-    auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
-    if (!dstTb ||
-        dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
-        dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor)) {
-      return emitOpError(
-          "expects convtile textract dst to use blayout=row_major and slayout=col_major");
-    }
-    Type srcElem = getElemTy(srcTy);
-    Type dstElem = getElemTy(dstTy);
-    if (!srcElem || !dstElem || srcElem != dstElem) {
-      return emitOpError("expects convtile textract src and dst to have the same element type");
-    }
-    if (!isConvTileExtractElem(srcElem)) {
-      return emitOpError("expects convtile textract element type to be i8/i16/i32/f16/bf16/f32");
-    }
-    return success();
-  }
   if (!isA2A3ExtractElemType(c.dstElem) && !(hasFp && c.dstElem.isInteger(16))) {
     return op.emitOpError("expects A2/A3 textract element type to be i8/f16/bf16/f32");
   }
@@ -8429,6 +8443,60 @@ static LogicalResult verifyTExtractA5Acc(TExtractOp op,
 }
 
 static LogicalResult verifyTExtractA5(TExtractOp op) {
+  if (isa<pto::ConvTileType>(op.getSrc().getType())) {
+    Type srcTy = op.getSrc().getType();
+    Type dstTy = op.getDst().getType();
+    const bool hasFp = static_cast<bool>(op.getFp());
+    const bool hasPreQuantScalar = static_cast<bool>(op.getPreQuantScalar());
+    const bool hasRelu = op.getReluPreMode() != pto::ReluPreMode::NoRelu;
+    if (failed(verifyTileLikeCommon(op, srcTy, "src",
+                                    /*allowLowPrecision=*/true)) ||
+        failed(verifyTileBufCommon(op, dstTy, "dst",
+                                   /*allowLowPrecision=*/true)) ||
+        failed(verifyNonNegativeIndexRowCol(
+            *op.getOperation(), op.getIndexRow(), op.getIndexCol(),
+            /*includeIndexAndIntOpsInConstFold=*/hasFp)) ||
+        failed(verifyExtractStaticBoundsCommon(
+            *op.getOperation(), op.getIndexRow(), op.getIndexCol(), srcTy,
+            dstTy, /*includeIndexAndIntOpsInConstFold=*/hasFp))) {
+      return failure();
+    }
+    if (hasFp || hasPreQuantScalar || hasRelu || op.getAccToVecModeAttr()) {
+      return op.emitOpError("expects convtile textract to use the base form");
+    }
+    auto srcCT = dyn_cast<pto::ConvTileType>(srcTy);
+    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
+    auto dstSpace = getPTOMemorySpaceEnum(dstTy);
+    if (!srcSpace || *srcSpace != pto::AddressSpace::MAT) {
+      return op.emitOpError("expects convtile textract src to use loc=mat");
+    }
+    if (!dstSpace || *dstSpace != pto::AddressSpace::RIGHT) {
+      return op.emitOpError("expects convtile textract dst to use loc=right");
+    }
+    auto srcLayout = dyn_cast_or_null<pto::LayoutAttr>(srcCT.getLayout());
+    if (!srcLayout ||
+        (srcLayout.getLayout() != pto::Layout::FRACTAL_Z &&
+         srcLayout.getLayout() != pto::Layout::FRACTAL_Z_3D)) {
+      return op.emitOpError(
+          "expects convtile textract src to use layout=FRACTAL_Z or FRACTAL_Z_3D");
+    }
+    auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
+    if (!dstTb ||
+        dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
+        dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor)) {
+      return op.emitOpError(
+          "expects convtile textract dst to use blayout=row_major and slayout=col_major");
+    }
+    Type srcElem = getElemTy(srcTy);
+    Type dstElem = getElemTy(dstTy);
+    if (!srcElem || !dstElem || srcElem != dstElem) {
+      return op.emitOpError("expects convtile textract src and dst to have the same element type");
+    }
+    if (!isConvTileExtractElem(srcElem)) {
+      return op.emitOpError("expects convtile textract element type to be i8/i16/i32/f16/bf16/f32");
+    }
+    return success();
+  }
   auto common = verifyTExtractCommon(op, /*allowLowPrecision=*/true);
   if (failed(common)) {
     return failure();
@@ -8436,54 +8504,6 @@ static LogicalResult verifyTExtractA5(TExtractOp op) {
   const TExtractCommon &c = *common;
   const bool hasPreQuantScalar = static_cast<bool>(op.getPreQuantScalar());
   const bool hasRelu = op.getReluPreMode() != pto::ReluPreMode::NoRelu;
-  if (isa<pto::ConvTileType>(getSrc().getType())) {
-    Type srcTy = getSrc().getType();
-    Type dstTy = getDst().getType();
-    if (failed(verifyTileLikeCommon(*this, srcTy, "src",
-                                    /*allowLowPrecision=*/true)) ||
-        failed(verifyTileBufCommon(*this, dstTy, "dst",
-                                   /*allowLowPrecision=*/true)) ||
-        failed(verifyNonNegativeIndexRowCol(
-            *getOperation(), getIndexRow(), getIndexCol(),
-            /*includeIndexAndIntOpsInConstFold=*/hasFp))) {
-      return failure();
-    }
-    if (hasFp || hasPreQuantScalar || hasRelu || op.getAccToVecModeAttr()) {
-      return emitOpError("expects convtile textract to use the base form");
-    }
-    auto srcCT = dyn_cast<pto::ConvTileType>(srcTy);
-    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
-    auto dstSpace = getPTOMemorySpaceEnum(dstTy);
-    if (!srcSpace || *srcSpace != pto::AddressSpace::MAT) {
-      return emitOpError("expects convtile textract src to use loc=mat");
-    }
-    if (!dstSpace || *dstSpace != pto::AddressSpace::RIGHT) {
-      return emitOpError("expects convtile textract dst to use loc=right");
-    }
-    auto srcLayout = dyn_cast_or_null<pto::LayoutAttr>(srcCT.getLayout());
-    if (!srcLayout ||
-        (srcLayout.getLayout() != pto::Layout::FRACTAL_Z &&
-         srcLayout.getLayout() != pto::Layout::FRACTAL_Z_3D)) {
-      return emitOpError(
-          "expects convtile textract src to use layout=FRACTAL_Z or FRACTAL_Z_3D");
-    }
-    auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
-    if (!dstTb ||
-        dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
-        dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor)) {
-      return emitOpError(
-          "expects convtile textract dst to use blayout=row_major and slayout=col_major");
-    }
-    Type srcElem = getElemTy(srcTy);
-    Type dstElem = getElemTy(dstTy);
-    if (!srcElem || !dstElem || srcElem != dstElem) {
-      return emitOpError("expects convtile textract src and dst to have the same element type");
-    }
-    if (!isConvTileExtractElem(srcElem)) {
-      return emitOpError("expects convtile textract element type to be i8/i16/i32/f16/bf16/f32");
-    }
-    return success();
-  }
   if (!isA5ExtractElemType(c.dstElem)) {
     return op.emitOpError("expects A5 textract element type to be an fp8/f16/bf16/f32 or int8 family type");
   }

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3927,18 +3927,42 @@ LogicalResult TLoadOp::verify() {
 }
 
 LogicalResult mlir::pto::SetFmatrixOp::verify() {
-  return verifyConvTileCommon(*this, getSrc().getType(), "src",
-                              /*allowLowPrecision=*/true);
+  if (failed(verifyConvTileCommon(*this, getSrc().getType(), "src",
+                                  /*allowLowPrecision=*/true))) {
+    return failure();
+  }
+  auto mode = getFmatrixMode();
+  if (mode != pto::FmatrixMode::FMATRIX_A_MANUAL &&
+      mode != pto::FmatrixMode::FMATRIX_B_MANUAL) {
+    return emitOpError("expects fmatrix_mode to be a_manual or b_manual");
+  }
+  return success();
 }
 
 LogicalResult mlir::pto::SetImg2colRptOp::verify() {
-  return verifyConvTileCommon(*this, getSrc().getType(), "src",
-                              /*allowLowPrecision=*/true);
+  if (failed(verifyConvTileCommon(*this, getSrc().getType(), "src",
+                                  /*allowLowPrecision=*/true))) {
+    return failure();
+  }
+  auto mode = getFmatrixMode();
+  if (mode != pto::FmatrixMode::FMATRIX_A_MANUAL &&
+      mode != pto::FmatrixMode::FMATRIX_B_MANUAL) {
+    return emitOpError("expects fmatrix_mode to be a_manual or b_manual");
+  }
+  return success();
 }
 
 LogicalResult mlir::pto::SetImg2colPaddingOp::verify() {
-  return verifyConvTileCommon(*this, getSrc().getType(), "src",
-                              /*allowLowPrecision=*/true);
+  if (failed(verifyConvTileCommon(*this, getSrc().getType(), "src",
+                                  /*allowLowPrecision=*/true))) {
+    return failure();
+  }
+  auto mode = getFmatrixMode();
+  if (mode != pto::FmatrixMode::FMATRIX_A_MANUAL &&
+      mode != pto::FmatrixMode::FMATRIX_B_MANUAL) {
+    return emitOpError("expects fmatrix_mode to be a_manual or b_manual");
+  }
+  return success();
 }
 
 LogicalResult mlir::pto::TImg2colOp::verify() {
@@ -3954,6 +3978,35 @@ LogicalResult mlir::pto::TImg2colOp::verify() {
     return emitOpError() << "expects src and dst to have the same element type";
   }
 
+  auto srcCT = dyn_cast<pto::ConvTileType>(getSrc().getType());
+  if (!srcCT) {
+    return emitOpError("expects src to be a !pto.conv_tile");
+  }
+  auto srcLayout = dyn_cast_or_null<pto::LayoutAttr>(srcCT.getLayout());
+  if (!srcLayout ||
+      (srcLayout.getLayout() != pto::Layout::NC1HWC0 &&
+       srcLayout.getLayout() != pto::Layout::NDC1HWC0)) {
+    return emitOpError(
+        "expects src layout to be NC1HWC0 or NDC1HWC0");
+  }
+
+  auto dstTile = dyn_cast<pto::TileBufType>(getDst().getType());
+  if (!dstTile) {
+    return emitOpError("expects dst to be a !pto.tile_buf");
+  }
+  if (failed(verifyTileBufLayoutConstraints(*this, dstTile, "dst"))) {
+    return failure();
+  }
+  if (dstTile.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor) ||
+      dstTile.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor)) {
+    return emitOpError(
+        "expects dst layout to be BLayout=col_major and SLayout=row_major");
+  }
+  auto dstSpace = getPTOMemorySpaceEnum(dstTile);
+  if (!dstSpace || *dstSpace != pto::AddressSpace::LEFT) {
+    return emitOpError("expects dst to use loc=left");
+  }
+
   auto checkPos = [&](IntegerAttr posAttr, StringRef name) -> LogicalResult {
     if (!posAttr || !posAttr.getType().isSignlessInteger(32)) {
       return emitOpError() << "expects " << name << " to be an i32 attr";
@@ -3967,6 +4020,14 @@ LogicalResult mlir::pto::TImg2colOp::verify() {
   };
   if (failed(checkPos(getPosM(), "posM")) || failed(checkPos(getPosK(), "posK"))) {
     return failure();
+  }
+
+  auto mode = getFmatrixMode();
+  if (mode != pto::FmatrixMode::FMATRIX_A_AUTO &&
+      mode != pto::FmatrixMode::FMATRIX_B_AUTO &&
+      mode != pto::FmatrixMode::FMATRIX_A_MANUAL &&
+      mode != pto::FmatrixMode::FMATRIX_B_MANUAL) {
+    return emitOpError("expects fmatrix_mode to be one of a_auto, b_auto, a_manual, or b_manual");
   }
 
   return success();

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3592,9 +3592,20 @@ static LogicalResult verifyConstantLocalAddress(Operation *op, Value addr,
 }
 
 LogicalResult AllocTileOp::verify() {
-  auto ty = dyn_cast<pto::TileBufType>(getResult().getType());
+  auto resultType = getResult().getType();
+  if (auto convTy = dyn_cast<pto::ConvTileType>(resultType)) {
+    bool hasValidShapeOperands = getValidRow() || getValidCol();
+    if (hasValidShapeOperands) {
+      return emitOpError("valid_row and valid_col operands require result to be `!pto.tile_buf`");
+    }
+
+    return verifyConstantLocalAddress(getOperation(), getAddr(),
+                                      convTy.getMemorySpace());
+  }
+
+  auto ty = dyn_cast<pto::TileBufType>(resultType);
   if (!ty) {
-    return emitOpError("result must be `!pto.tile_buf`");
+    return emitOpError("result must be `!pto.tile_buf` or `!pto.conv_tile`");
   }
 
   if (failed(verifyTileBufLayoutConstraints(*this, ty, "result"))) {

--- a/lib/PTO/IR/PTOAttrs.cpp
+++ b/lib/PTO/IR/PTOAttrs.cpp
@@ -264,3 +264,462 @@ void TileBufConfigAttr::print(AsmPrinter &p) const {
   p << ", compact=" << getCompactMode();
   p << ">";
 }
+
+namespace {
+
+constexpr unsigned kConvTilePadListSize = 4;
+constexpr int32_t kConvTileDefaultZero = 0;
+constexpr int32_t kConvTileDefaultOne = 1;
+
+static LogicalResult parseConvTileIntField(AsmParser &parser, StringRef key,
+                                           IntegerAttr &value) {
+  if (failed(parseTileBufKeyEq(parser, key))) {
+    return failure();
+  }
+  int64_t parsed = 0;
+  if (failed(parser.parseInteger(parsed))) {
+    return failure();
+  }
+  value = IntegerAttr::get(IntegerType::get(parser.getContext(), kI32BitWidth),
+                           parsed);
+  return success();
+}
+
+static LogicalResult parseConvTileBoolField(AsmParser &parser, StringRef key,
+                                            BoolAttr &value) {
+  if (failed(parseTileBufKeyEq(parser, key))) {
+    return failure();
+  }
+  bool parsed = false;
+  if (succeeded(parser.parseOptionalKeyword("true"))) {
+    parsed = true;
+  } else if (succeeded(parser.parseOptionalKeyword("false"))) {
+    parsed = false;
+  } else {
+    parser.emitError(parser.getCurrentLocation())
+        << key << " must be true or false";
+    return failure();
+  }
+  value = BoolAttr::get(parser.getContext(), parsed);
+  return success();
+}
+
+static LogicalResult parseConvTileAttrField(AsmParser &parser, StringRef key,
+                                            Attribute &value) {
+  if (failed(parseTileBufKeyEq(parser, key))) {
+    return failure();
+  }
+  if (failed(parser.parseAttribute(value))) {
+    return failure();
+  }
+  return success();
+}
+
+static LogicalResult parseConvTilePadListField(AsmParser &parser,
+                                               SmallVectorImpl<int64_t> &padList) {
+  if (failed(parseTileBufKeyEq(parser, "pad_list"))) {
+    return failure();
+  }
+  SmallVector<int64_t, kConvTilePadListSize> parsed;
+  if (failed(parser.parseDimensionList(parsed, /*allowDynamic=*/false,
+                                       /*withTrailingX=*/false))) {
+    return failure();
+  }
+  if (parsed.size() != kConvTilePadListSize) {
+    parser.emitError(parser.getCurrentLocation())
+        << "pad_list must have exactly " << kConvTilePadListSize
+        << " dimensions";
+    return failure();
+  }
+  padList.assign(parsed.begin(), parsed.end());
+  return success();
+}
+
+static void printConvTileIntField(AsmPrinter &p, StringRef key, IntegerAttr value) {
+  p << key << "=" << value.getInt();
+}
+
+static void printConvTilePadList(AsmPrinter &p, ArrayRef<int64_t> padList) {
+  for (auto it = padList.begin(); it != padList.end(); ++it) {
+    if (it != padList.begin()) {
+      p << "x";
+    }
+    p << *it;
+  }
+}
+
+static StringRef printBoolAttr(BoolAttr value) {
+  return value.getValue() ? "true" : "false";
+}
+
+} // namespace
+
+ConvTileConfigAttr ConvTileConfigAttr::getDefault(MLIRContext *ctx) {
+  Builder b(ctx);
+  auto zero = b.getI32IntegerAttr(kConvTileDefaultZero);
+  auto one = b.getI32IntegerAttr(kConvTileDefaultOne);
+  SmallVector<int64_t, kConvTilePadListSize> padList(kConvTilePadListSize,
+                                                     kConvTileDefaultZero);
+  auto padValue = b.getI32IntegerAttr(kConvTileDefaultZero);
+  auto transpose = BoolAttr::get(ctx, false);
+  return ConvTileConfigAttr::get(ctx, zero, zero, padList, one, one, one, one,
+                                 one, one, padValue, zero, zero, one, zero,
+                                 zero, transpose);
+}
+
+bool ConvTileConfigAttr::isDefault() const {
+  auto d = getDefault(getContext());
+  return getFmapH() == d.getFmapH() && getFmapW() == d.getFmapW() &&
+         getPadList() == d.getPadList() && getFilterH() == d.getFilterH() &&
+         getFilterW() == d.getFilterW() &&
+         getDilationH() == d.getDilationH() &&
+         getDilationW() == d.getDilationW() &&
+         getStrideH() == d.getStrideH() && getStrideW() == d.getStrideW() &&
+         getPadValue() == d.getPadValue() &&
+         getChannelSize() == d.getChannelSize() &&
+         getRepeatStride() == d.getRepeatStride() &&
+         getRepeatTime() == d.getRepeatTime() &&
+         getRepeatMode() == d.getRepeatMode() &&
+         getDstStride() == d.getDstStride() &&
+         getDstMposition() == d.getDstMposition() &&
+         getTranspose() == d.getTranspose();
+}
+
+LogicalResult ConvTileConfigAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                                         IntegerAttr fmapH,
+                                         IntegerAttr fmapW,
+                                         ArrayRef<int64_t> padList,
+                                         IntegerAttr filterH,
+                                         IntegerAttr filterW,
+                                         IntegerAttr dilationH,
+                                         IntegerAttr dilationW,
+                                         IntegerAttr strideH,
+                                         IntegerAttr strideW,
+                                         Attribute padValue,
+                                         IntegerAttr channelSize,
+                                         IntegerAttr repeatStride,
+                                         IntegerAttr repeatTime,
+                                         IntegerAttr repeatMode,
+                                         IntegerAttr dstStride,
+                                         IntegerAttr dstMposition,
+                                         BoolAttr transpose) {
+  auto checkI32 = [&](IntegerAttr attr, StringRef name) -> LogicalResult {
+    if (!attr || !attr.getType().isSignlessInteger(kI32BitWidth)) {
+      return emitError() << name << " must be an i32 integer attr", failure();
+    }
+    return success();
+  };
+
+  if (failed(checkI32(fmapH, "fmap_h")) || failed(checkI32(fmapW, "fmap_w")) ||
+      failed(checkI32(filterH, "filter_h")) ||
+      failed(checkI32(filterW, "filter_w")) ||
+      failed(checkI32(dilationH, "dilation_h")) ||
+      failed(checkI32(dilationW, "dilation_w")) ||
+      failed(checkI32(strideH, "stride_h")) ||
+      failed(checkI32(strideW, "stride_w")) ||
+      failed(checkI32(channelSize, "channel_size")) ||
+      failed(checkI32(repeatStride, "repeat_stride")) ||
+      failed(checkI32(repeatTime, "repeat_time")) ||
+      failed(checkI32(repeatMode, "repeat_mode")) ||
+      failed(checkI32(dstStride, "dst_stride")) ||
+      failed(checkI32(dstMposition, "dst_mposition"))) {
+    return failure();
+  }
+
+  if (!transpose) {
+    return emitError() << "transpose must be a bool attr", failure();
+  }
+
+  if (padList.size() != kConvTilePadListSize) {
+    return emitError() << "pad_list must have exactly 4 elements", failure();
+  }
+  for (int64_t dim : padList) {
+    if (dim < 0 || dim > 255) {
+      return emitError() << "pad_list entries must be in [0, 255]", failure();
+    }
+  }
+
+  auto checkNonNegative = [&](IntegerAttr attr, StringRef name) -> LogicalResult {
+    if (attr.getInt() < 0) {
+      return emitError() << name << " must be non-negative", failure();
+    }
+    return success();
+  };
+
+  if (failed(checkNonNegative(fmapH, "fmap_h")) ||
+      failed(checkNonNegative(fmapW, "fmap_w")) ||
+      failed(checkNonNegative(filterH, "filter_h")) ||
+      failed(checkNonNegative(filterW, "filter_w")) ||
+      failed(checkNonNegative(dilationH, "dilation_h")) ||
+      failed(checkNonNegative(dilationW, "dilation_w")) ||
+      failed(checkNonNegative(strideH, "stride_h")) ||
+      failed(checkNonNegative(strideW, "stride_w")) ||
+      failed(checkNonNegative(channelSize, "channel_size")) ||
+      failed(checkNonNegative(repeatStride, "repeat_stride")) ||
+      failed(checkNonNegative(repeatTime, "repeat_time")) ||
+      failed(checkNonNegative(repeatMode, "repeat_mode")) ||
+      failed(checkNonNegative(dstStride, "dst_stride")) ||
+      failed(checkNonNegative(dstMposition, "dst_mposition"))) {
+    return failure();
+  }
+
+  if (!padValue || (!isa<IntegerAttr>(padValue) && !isa<FloatAttr>(padValue))) {
+    return emitError() << "pad_value must be an integer or float attr", failure();
+  }
+
+  return success();
+}
+
+Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
+  MLIRContext *ctx = p.getContext();
+  auto def = ConvTileConfigAttr::getDefault(ctx);
+  IntegerAttr fmapH = def.getFmapH();
+  IntegerAttr fmapW = def.getFmapW();
+  SmallVector<int64_t, kConvTilePadListSize> padList(def.getPadList().begin(),
+                                                     def.getPadList().end());
+  IntegerAttr filterH = def.getFilterH();
+  IntegerAttr filterW = def.getFilterW();
+  IntegerAttr dilationH = def.getDilationH();
+  IntegerAttr dilationW = def.getDilationW();
+  IntegerAttr strideH = def.getStrideH();
+  IntegerAttr strideW = def.getStrideW();
+  Attribute padValue = def.getPadValue();
+  IntegerAttr channelSize = def.getChannelSize();
+  IntegerAttr repeatStride = def.getRepeatStride();
+  IntegerAttr repeatTime = def.getRepeatTime();
+  IntegerAttr repeatMode = def.getRepeatMode();
+  IntegerAttr dstStride = def.getDstStride();
+  IntegerAttr dstMposition = def.getDstMposition();
+  BoolAttr transpose = def.getTranspose();
+  bool parsedGreater = false;
+
+  auto consumeFieldTerminator = [&]() -> LogicalResult {
+    if (succeeded(p.parseOptionalGreater())) {
+      parsedGreater = true;
+      return success();
+    }
+    return p.parseComma();
+  };
+
+  if (p.parseLess()) {
+    return {};
+  }
+
+  if (succeeded(p.parseOptionalGreater())) {
+    return ConvTileConfigAttr::get(ctx, fmapH, fmapW, padList, filterH, filterW,
+                                   dilationH, dilationW, strideH, strideW,
+                                   padValue, channelSize, repeatStride,
+                                   repeatTime, repeatMode, dstStride,
+                                   dstMposition, transpose);
+  }
+
+  while (!parsedGreater) {
+    StringRef key;
+    if (p.parseKeyword(&key)) {
+      return {};
+    }
+    if (p.parseEqual()) {
+      return {};
+    }
+
+    if (key == "fmap_h") {
+      if (failed(parseConvTileIntField(p, key, fmapH))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "fmap_w") {
+      if (failed(parseConvTileIntField(p, key, fmapW))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "pad_list") {
+      if (failed(parseConvTilePadListField(p, padList))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "filter_h") {
+      if (failed(parseConvTileIntField(p, key, filterH))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "filter_w") {
+      if (failed(parseConvTileIntField(p, key, filterW))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "dilation_h") {
+      if (failed(parseConvTileIntField(p, key, dilationH))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "dilation_w") {
+      if (failed(parseConvTileIntField(p, key, dilationW))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "stride_h") {
+      if (failed(parseConvTileIntField(p, key, strideH))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "stride_w") {
+      if (failed(parseConvTileIntField(p, key, strideW))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "pad_value") {
+      if (failed(parseConvTileAttrField(p, key, padValue))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "channel_size") {
+      if (failed(parseConvTileIntField(p, key, channelSize))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "repeat_stride") {
+      if (failed(parseConvTileIntField(p, key, repeatStride))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "repeat_time") {
+      if (failed(parseConvTileIntField(p, key, repeatTime))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "repeat_mode") {
+      if (failed(parseConvTileIntField(p, key, repeatMode))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "dst_stride") {
+      if (failed(parseConvTileIntField(p, key, dstStride))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "dst_mposition") {
+      if (failed(parseConvTileIntField(p, key, dstMposition))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+    if (key == "transpose") {
+      if (failed(parseConvTileBoolField(p, key, transpose))) {
+        return {};
+      }
+      if (failed(consumeFieldTerminator())) {
+        return {};
+      }
+      continue;
+    }
+
+    p.emitError(p.getCurrentLocation(), "unknown key in conv_tile_config: ")
+        << key;
+    return {};
+  }
+
+  return ConvTileConfigAttr::get(ctx, fmapH, fmapW, padList, filterH, filterW,
+                                 dilationH, dilationW, strideH, strideW,
+                                 padValue, channelSize, repeatStride,
+                                 repeatTime, repeatMode, dstStride, dstMposition,
+                                 transpose);
+}
+
+void ConvTileConfigAttr::print(AsmPrinter &p) const {
+  p << "<";
+  printConvTileIntField(p, "fmap_h", getFmapH());
+  p << ", ";
+  printConvTileIntField(p, "fmap_w", getFmapW());
+  p << ", pad_list=";
+  printConvTilePadList(p, getPadList());
+  p << ", ";
+  printConvTileIntField(p, "filter_h", getFilterH());
+  p << ", ";
+  printConvTileIntField(p, "filter_w", getFilterW());
+  p << ", ";
+  printConvTileIntField(p, "dilation_h", getDilationH());
+  p << ", ";
+  printConvTileIntField(p, "dilation_w", getDilationW());
+  p << ", ";
+  printConvTileIntField(p, "stride_h", getStrideH());
+  p << ", ";
+  printConvTileIntField(p, "stride_w", getStrideW());
+  p << ", pad_value=" << getPadValue();
+  p << ", ";
+  printConvTileIntField(p, "channel_size", getChannelSize());
+  p << ", ";
+  printConvTileIntField(p, "repeat_stride", getRepeatStride());
+  p << ", ";
+  printConvTileIntField(p, "repeat_time", getRepeatTime());
+  p << ", ";
+  printConvTileIntField(p, "repeat_mode", getRepeatMode());
+  p << ", ";
+  printConvTileIntField(p, "dst_stride", getDstStride());
+  p << ", ";
+  printConvTileIntField(p, "dst_mposition", getDstMposition());
+  p << ", transpose=" << printBoolAttr(getTranspose());
+  p << ">";
+}

--- a/lib/PTO/IR/PTOAttrs.cpp
+++ b/lib/PTO/IR/PTOAttrs.cpp
@@ -271,6 +271,8 @@ constexpr unsigned kConvTilePadListSize = 4;
 constexpr int32_t kConvTileDefaultZero = 0;
 constexpr int32_t kConvTileDefaultOne = 1;
 
+static LogicalResult parseTileBufKeyEq(AsmParser &parser, StringRef expectedKey);
+
 static LogicalResult parseConvTileIntField(AsmParser &parser, StringRef key,
                                            IntegerAttr &value) {
   if (failed(parseTileBufKeyEq(parser, key))) {
@@ -364,7 +366,7 @@ ConvTileConfigAttr ConvTileConfigAttr::getDefault(MLIRContext *ctx) {
   auto transpose = BoolAttr::get(ctx, false);
   return ConvTileConfigAttr::get(ctx, zero, zero, padList, one, one, one, one,
                                  one, one, padValue, zero, zero, one, zero,
-                                 zero, transpose);
+                                 zero, zero, transpose);
 }
 
 bool ConvTileConfigAttr::isDefault() const {
@@ -395,7 +397,7 @@ LogicalResult ConvTileConfigAttr::verify(function_ref<InFlightDiagnostic()> emit
                                          IntegerAttr dilationW,
                                          IntegerAttr strideH,
                                          IntegerAttr strideW,
-                                         Attribute padValue,
+                                         Attribute padValueAttr,
                                          IntegerAttr channelSize,
                                          IntegerAttr repeatStride,
                                          IntegerAttr repeatTime,
@@ -463,7 +465,9 @@ LogicalResult ConvTileConfigAttr::verify(function_ref<InFlightDiagnostic()> emit
     return failure();
   }
 
-  if (!padValue || (!isa<IntegerAttr>(padValue) && !isa<FloatAttr>(padValue))) {
+  if (!padValueAttr ||
+      (!llvm::isa<IntegerAttr>(padValueAttr) &&
+       !llvm::isa<FloatAttr>(padValueAttr))) {
     return emitError() << "pad_value must be an integer or float attr", failure();
   }
 

--- a/lib/PTO/IR/PTOAttrs.cpp
+++ b/lib/PTO/IR/PTOAttrs.cpp
@@ -33,6 +33,14 @@ constexpr int32_t kCompactModeNull = static_cast<int32_t>(CompactMode::Null);
 constexpr int32_t kCompactModeRowPlusOne =
     static_cast<int32_t>(CompactMode::RowPlusOne);
 
+static LogicalResult parseTileBufKeyEq(AsmParser &parser,
+                                       StringRef expectedKey) {
+  if (failed(parser.parseKeyword(expectedKey))) {
+    return failure();
+  }
+  return parser.parseEqual();
+}
+
 } // namespace
 
 TileBufConfigAttr TileBufConfigAttr::getDefault(MLIRContext *ctx) {

--- a/lib/PTO/IR/PTOAttrs.cpp
+++ b/lib/PTO/IR/PTOAttrs.cpp
@@ -33,14 +33,6 @@ constexpr int32_t kCompactModeNull = static_cast<int32_t>(CompactMode::Null);
 constexpr int32_t kCompactModeRowPlusOne =
     static_cast<int32_t>(CompactMode::RowPlusOne);
 
-static LogicalResult parseTileBufKeyEq(AsmParser &parser,
-                                       StringRef expectedKey) {
-  if (failed(parser.parseKeyword(expectedKey))) {
-    return failure();
-  }
-  return parser.parseEqual();
-}
-
 } // namespace
 
 TileBufConfigAttr TileBufConfigAttr::getDefault(MLIRContext *ctx) {
@@ -279,13 +271,8 @@ constexpr unsigned kConvTilePadListSize = 4;
 constexpr int32_t kConvTileDefaultZero = 0;
 constexpr int32_t kConvTileDefaultOne = 1;
 
-static LogicalResult parseTileBufKeyEq(AsmParser &parser, StringRef expectedKey);
-
-static LogicalResult parseConvTileIntField(AsmParser &parser, StringRef key,
+static LogicalResult parseConvTileIntField(AsmParser &parser,
                                            IntegerAttr &value) {
-  if (failed(parseTileBufKeyEq(parser, key))) {
-    return failure();
-  }
   int64_t parsed = 0;
   if (failed(parser.parseInteger(parsed))) {
     return failure();
@@ -297,9 +284,6 @@ static LogicalResult parseConvTileIntField(AsmParser &parser, StringRef key,
 
 static LogicalResult parseConvTileBoolField(AsmParser &parser, StringRef key,
                                             BoolAttr &value) {
-  if (failed(parseTileBufKeyEq(parser, key))) {
-    return failure();
-  }
   bool parsed = false;
   if (succeeded(parser.parseOptionalKeyword("true"))) {
     parsed = true;
@@ -314,11 +298,8 @@ static LogicalResult parseConvTileBoolField(AsmParser &parser, StringRef key,
   return success();
 }
 
-static LogicalResult parseConvTileAttrField(AsmParser &parser, StringRef key,
+static LogicalResult parseConvTileAttrField(AsmParser &parser,
                                             Attribute &value) {
-  if (failed(parseTileBufKeyEq(parser, key))) {
-    return failure();
-  }
   if (failed(parser.parseAttribute(value))) {
     return failure();
   }
@@ -327,9 +308,6 @@ static LogicalResult parseConvTileAttrField(AsmParser &parser, StringRef key,
 
 static LogicalResult parseConvTilePadListField(AsmParser &parser,
                                                SmallVectorImpl<int64_t> &padList) {
-  if (failed(parseTileBufKeyEq(parser, "pad_list"))) {
-    return failure();
-  }
   SmallVector<int64_t, kConvTilePadListSize> parsed;
   if (failed(parser.parseDimensionList(parsed, /*allowDynamic=*/false,
                                        /*withTrailingX=*/false))) {
@@ -535,7 +513,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
     }
 
     if (key == "fmap_h") {
-      if (failed(parseConvTileIntField(p, key, fmapH))) {
+      if (failed(parseConvTileIntField(p, fmapH))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -544,7 +522,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "fmap_w") {
-      if (failed(parseConvTileIntField(p, key, fmapW))) {
+      if (failed(parseConvTileIntField(p, fmapW))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -562,7 +540,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "filter_h") {
-      if (failed(parseConvTileIntField(p, key, filterH))) {
+      if (failed(parseConvTileIntField(p, filterH))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -571,7 +549,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "filter_w") {
-      if (failed(parseConvTileIntField(p, key, filterW))) {
+      if (failed(parseConvTileIntField(p, filterW))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -580,7 +558,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "dilation_h") {
-      if (failed(parseConvTileIntField(p, key, dilationH))) {
+      if (failed(parseConvTileIntField(p, dilationH))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -589,7 +567,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "dilation_w") {
-      if (failed(parseConvTileIntField(p, key, dilationW))) {
+      if (failed(parseConvTileIntField(p, dilationW))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -598,7 +576,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "stride_h") {
-      if (failed(parseConvTileIntField(p, key, strideH))) {
+      if (failed(parseConvTileIntField(p, strideH))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -607,7 +585,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "stride_w") {
-      if (failed(parseConvTileIntField(p, key, strideW))) {
+      if (failed(parseConvTileIntField(p, strideW))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -616,7 +594,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "pad_value") {
-      if (failed(parseConvTileAttrField(p, key, padValue))) {
+      if (failed(parseConvTileAttrField(p, padValue))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -625,7 +603,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "channel_size") {
-      if (failed(parseConvTileIntField(p, key, channelSize))) {
+      if (failed(parseConvTileIntField(p, channelSize))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -634,7 +612,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "repeat_stride") {
-      if (failed(parseConvTileIntField(p, key, repeatStride))) {
+      if (failed(parseConvTileIntField(p, repeatStride))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -643,7 +621,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "repeat_time") {
-      if (failed(parseConvTileIntField(p, key, repeatTime))) {
+      if (failed(parseConvTileIntField(p, repeatTime))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -652,7 +630,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "repeat_mode") {
-      if (failed(parseConvTileIntField(p, key, repeatMode))) {
+      if (failed(parseConvTileIntField(p, repeatMode))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -661,7 +639,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "dst_stride") {
-      if (failed(parseConvTileIntField(p, key, dstStride))) {
+      if (failed(parseConvTileIntField(p, dstStride))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {
@@ -670,7 +648,7 @@ Attribute ConvTileConfigAttr::parse(AsmParser &p, Type) {
       continue;
     }
     if (key == "dst_mposition") {
-      if (failed(parseConvTileIntField(p, key, dstMposition))) {
+      if (failed(parseConvTileIntField(p, dstMposition))) {
         return {};
       }
       if (failed(consumeFieldTerminator())) {

--- a/lib/PTO/IR/PTOTypeDefs.cpp
+++ b/lib/PTO/IR/PTOTypeDefs.cpp
@@ -190,6 +190,19 @@ static std::optional<AddressSpace> resolveTileBufMemorySpace(StringRef locStr) {
       .Default(::std::nullopt);
 }
 
+static std::optional<ConvLayout> resolveConvLayout(StringRef layoutStr) {
+  return ::llvm::StringSwitch<::std::optional<ConvLayout>>(layoutStr)
+      .Case("nc1hwc0", ConvLayout::NC1HWC0)
+      .Case("ndc1hwc0", ConvLayout::NDC1HWC0)
+      .Case("fractal_z", ConvLayout::FRACTAL_Z)
+      .Case("fractal_z_3d", ConvLayout::FRACTAL_Z_3D)
+      .Case("nchw", ConvLayout::NCHW)
+      .Case("nhwc", ConvLayout::NHWC)
+      .Case("gnchw", ConvLayout::GNCHW)
+      .Case("gnc1hwc0", ConvLayout::GNC1HWC0)
+      .Default(::std::nullopt);
+}
+
 static BLayout resolveTileBufBLayout(MLIRContext *context,
                                      AddressSpace memorySpace,
                                      BLayout parsedLayout) {
@@ -754,6 +767,162 @@ void mlir::pto::TileBufType::print(mlir::AsmPrinter &printer) const {
     printer << ", compact=" << stringifyCompactModeInt(cfg.getCompactMode());
   }
 
+  printer << ">";
+}
+
+// ---- ConvTileType custom asm ----
+// !pto.conv_tile<mat, buffer=4096, layout=nc1hwc0, shape=1x1x16x16x16xi8>
+Type ConvTileType::parse(AsmParser &parser) {
+  if (failed(parser.parseLess())) {
+    return Type();
+  }
+
+  std::string locStr;
+  std::string layoutStr;
+  SmallVector<int64_t, 6> shape;
+  Type dtype;
+  int64_t bufferSize = 0;
+
+  ParseResult parseResult = parser.parseKeywordOrString(&locStr);
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseComma();
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseKeyword("buffer");
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseEqual();
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseInteger(bufferSize);
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseComma();
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseKeyword("layout");
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseEqual();
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseKeywordOrString(&layoutStr);
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseComma();
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseKeyword("shape");
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseEqual();
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseDimensionList(shape, /*allowDynamic=*/false);
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseType(dtype);
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+  parseResult = parser.parseGreater();
+  if (!parseResult.succeeded()) {
+    return Type();
+  }
+
+  auto emitError = [&]() -> InFlightDiagnostic {
+    return parser.emitError(parser.getNameLoc());
+  };
+  auto memorySpace = resolveTileBufMemorySpace(locStr);
+  if (!memorySpace.has_value()) {
+    emitError() << "unknown ConvTile loc: " << locStr;
+    return Type();
+  }
+  auto layout = resolveConvLayout(layoutStr);
+  if (!layout.has_value()) {
+    emitError() << "unknown ConvTile layout: " << layoutStr;
+    return Type();
+  }
+  if (bufferSize <= 0) {
+    emitError() << "ConvTile buffer must be positive";
+    return Type();
+  }
+  const bool invalidRank = shape.empty() || shape.size() > 6;
+  if (invalidRank) {
+    emitError() << "ConvTile shape rank must be between 1 and 6";
+    return Type();
+  }
+  for (int64_t dim : shape) {
+    if (dim <= 0) {
+      emitError() << "ConvTile shape dimensions must be positive";
+      return Type();
+    }
+  }
+
+  auto memorySpaceAttr = AddressSpaceAttr::get(parser.getContext(),
+                                                memorySpace.value());
+  auto layoutAttr = ConvLayoutAttr::get(parser.getContext(), layout.value());
+  return ConvTileType::get(parser.getContext(), shape, dtype, memorySpaceAttr,
+                           bufferSize, layoutAttr);
+}
+
+void mlir::pto::ConvTileType::print(mlir::AsmPrinter &printer) const {
+  auto memorySpace =
+      llvm::dyn_cast_or_null<AddressSpaceAttr>(getMemorySpace());
+  auto layout = getLayout();
+  if (!memorySpace || !layout) {
+    printer << "<unknown>";
+    return;
+  }
+
+  auto layoutName = [&]() -> llvm::StringRef {
+    switch (layout.getValue()) {
+    case ConvLayout::NC1HWC0:
+      return "nc1hwc0";
+    case ConvLayout::NDC1HWC0:
+      return "ndc1hwc0";
+    case ConvLayout::FRACTAL_Z:
+      return "fractal_z";
+    case ConvLayout::FRACTAL_Z_3D:
+      return "fractal_z_3d";
+    case ConvLayout::NCHW:
+      return "nchw";
+    case ConvLayout::NHWC:
+      return "nhwc";
+    case ConvLayout::GNCHW:
+      return "gnchw";
+    case ConvLayout::GNC1HWC0:
+      return "gnc1hwc0";
+    }
+    return "unknown";
+  };
+
+  printer << "<" << stringifyLocFromMemorySpace(memorySpace)
+          << ", buffer=" << getBufferSize()
+          << ", layout=" << layoutName()
+          << ", shape=";
+  for (auto [index, dim] : llvm::enumerate(getShape())) {
+    if (index != 0) {
+      printer << "x";
+    }
+    printTileBufDim(printer, dim);
+  }
+  printer << "x";
+  printer.printType(getElementType());
   printer << ">";
 }
 

--- a/lib/PTO/IR/PTOTypeDefs.cpp
+++ b/lib/PTO/IR/PTOTypeDefs.cpp
@@ -910,7 +910,7 @@ Type ConvTileType::parse(AsmParser &parser) {
   }
 
   if (failed(parser.parseDimensionList(fields.shape, /*allowDynamic=*/false,
-                                       /*withTrailingX=*/false))) {
+                                       /*withTrailingX=*/true))) {
     return Type();
   }
 

--- a/lib/PTO/IR/PTOTypeDefs.cpp
+++ b/lib/PTO/IR/PTOTypeDefs.cpp
@@ -884,7 +884,7 @@ static Type buildConvTileType(AsmParser &parser,
     return Type();
   }
 
-  auto layoutAttr = dyn_cast_or_null<LayoutAttr>(fields.layoutAttr);
+  auto layoutAttr = llvm::dyn_cast_or_null<LayoutAttr>(fields.layoutAttr);
   if (!layoutAttr) {
     emitError() << "layout must be a pto.layout attr";
     return Type();
@@ -951,7 +951,7 @@ Type ConvTileType::parse(AsmParser &parser) {
       if (failed(parser.parseAttribute(attr))) {
         return Type();
       }
-      layoutAttr = dyn_cast<LayoutAttr>(attr);
+      layoutAttr = llvm::dyn_cast<LayoutAttr>(attr);
       if (!layoutAttr || seenLayout) {
         return Type();
       }
@@ -964,7 +964,7 @@ Type ConvTileType::parse(AsmParser &parser) {
       if (failed(parser.parseAttribute(attr))) {
         return Type();
       }
-      bufferSizeAttr = dyn_cast_or_null<IntegerAttr>(attr);
+      bufferSizeAttr = llvm::dyn_cast_or_null<IntegerAttr>(attr);
       if (!bufferSizeAttr || seenBufferSize) {
         return Type();
       }
@@ -977,7 +977,7 @@ Type ConvTileType::parse(AsmParser &parser) {
       if (failed(parser.parseAttribute(attr))) {
         return Type();
       }
-      configAttr = dyn_cast_or_null<ConvTileConfigAttr>(attr);
+      configAttr = llvm::dyn_cast_or_null<ConvTileConfigAttr>(attr);
       if (!configAttr || seenConfig) {
         return Type();
       }

--- a/lib/PTO/IR/PTOTypeDefs.cpp
+++ b/lib/PTO/IR/PTOTypeDefs.cpp
@@ -190,19 +190,6 @@ static std::optional<AddressSpace> resolveTileBufMemorySpace(StringRef locStr) {
       .Default(::std::nullopt);
 }
 
-static std::optional<ConvLayout> resolveConvLayout(StringRef layoutStr) {
-  return ::llvm::StringSwitch<::std::optional<ConvLayout>>(layoutStr)
-      .Case("nc1hwc0", ConvLayout::NC1HWC0)
-      .Case("ndc1hwc0", ConvLayout::NDC1HWC0)
-      .Case("fractal_z", ConvLayout::FRACTAL_Z)
-      .Case("fractal_z_3d", ConvLayout::FRACTAL_Z_3D)
-      .Case("nchw", ConvLayout::NCHW)
-      .Case("nhwc", ConvLayout::NHWC)
-      .Case("gnchw", ConvLayout::GNCHW)
-      .Case("gnc1hwc0", ConvLayout::GNC1HWC0)
-      .Default(::std::nullopt);
-}
-
 static BLayout resolveTileBufBLayout(MLIRContext *context,
                                      AddressSpace memorySpace,
                                      BLayout parsedLayout) {
@@ -280,6 +267,26 @@ int32_t TileBufType::getCompactModeI32() const {
     return static_cast<int32_t>(a.getValue());
   }
   return 0;
+}
+
+ConvTileConfigAttr ConvTileType::getConfigAttr() const {
+  if constexpr (std::is_same_v<decltype(getConfig()), ConvTileConfigAttr>) {
+    auto cfg = getConfig();
+    if (!cfg) {
+      cfg = ConvTileConfigAttr::getDefault(getContext());
+    }
+    return cfg;
+  } else {
+    auto cfg = llvm::dyn_cast_or_null<ConvTileConfigAttr>(getConfig());
+    if (!cfg) {
+      cfg = ConvTileConfigAttr::getDefault(getContext());
+    }
+    return cfg;
+  }
+}
+
+bool ConvTileType::hasNonDefaultConfig() const {
+  return !getConfigAttr().isDefault();
 }
 
 namespace {
@@ -770,159 +777,266 @@ void mlir::pto::TileBufType::print(mlir::AsmPrinter &printer) const {
   printer << ">";
 }
 
-// ---- ConvTileType custom asm ----
-// !pto.conv_tile<mat, buffer=4096, layout=nc1hwc0, shape=1x1x16x16x16xi8>
+namespace {
+
+struct ParsedConvTileFields {
+  std::string locStr;
+  SmallVector<int64_t, 6> shape;
+  Type dtype;
+  IntegerAttr bufferSize;
+  Attribute layoutAttr;
+  ConvTileConfigAttr config;
+};
+
+static std::optional<int64_t> computeConvTileBufferSize(ArrayRef<int64_t> shape) {
+  if (shape.empty()) {
+    return std::nullopt;
+  }
+
+  int64_t capacity = 1;
+  for (int64_t dim : shape) {
+    if (dim <= 0) {
+      return std::nullopt;
+    }
+    if (capacity > std::numeric_limits<int64_t>::max() / dim) {
+      return std::nullopt;
+    }
+    capacity *= dim;
+  }
+  return capacity;
+}
+
+static LogicalResult parseConvTileLayoutField(AsmParser &parser,
+                                              Attribute &layoutAttr) {
+  if (failed(parseTileBufKeyEq(parser, "layout"))) {
+    return failure();
+  }
+  if (failed(parser.parseAttribute(layoutAttr))) {
+    return failure();
+  }
+  return success();
+}
+
+static LogicalResult parseConvTileConfigField(AsmParser &parser,
+                                              Attribute &configAttr) {
+  if (failed(parseTileBufKeyEq(parser, "config"))) {
+    return failure();
+  }
+  if (failed(parser.parseAttribute(configAttr))) {
+    return failure();
+  }
+  return success();
+}
+
+static void printConvTileLayoutField(AsmPrinter &printer, Attribute layoutAttr) {
+  printer << "layout=";
+  printer.printAttribute(layoutAttr);
+}
+
+static void printConvTileConfigField(AsmPrinter &printer,
+                                     ConvTileConfigAttr configAttr) {
+  printer << "config=";
+  printer.printAttribute(configAttr);
+}
+
+static Type buildConvTileType(AsmParser &parser,
+                              const ParsedConvTileFields &fields) {
+  MLIRContext *ctx = parser.getContext();
+  auto emitError = [&]() -> InFlightDiagnostic {
+    return parser.emitError(parser.getNameLoc());
+  };
+
+  if (fields.shape.empty()) {
+    emitError() << "conv_tile shape must be non-empty";
+    return Type();
+  }
+  if (fields.shape.size() > 6) {
+    emitError() << "conv_tile shape must have rank in [1, 6]";
+    return Type();
+  }
+  if (llvm::is_contained(fields.shape, ShapedType::kDynamic)) {
+    emitError() << "conv_tile shape must be static";
+    return Type();
+  }
+
+  auto defaultBufferSize = computeConvTileBufferSize(fields.shape);
+  if (!defaultBufferSize) {
+    emitError() << "conv_tile shape must have a positive, overflow-free element count";
+    return Type();
+  }
+
+  IntegerAttr bufferSize = fields.bufferSize;
+  if (!bufferSize) {
+    bufferSize = IntegerAttr::get(parser.getBuilder().getI64Type(),
+                                  *defaultBufferSize);
+  } else if (bufferSize.getInt() < *defaultBufferSize) {
+    emitError() << "conv_tile buffer_size must be at least the logical element count";
+    return Type();
+  }
+
+  auto memorySpace = resolveTileBufMemorySpace(fields.locStr);
+  if (!memorySpace.has_value()) {
+    emitError() << "unknown loc: " << fields.locStr;
+    return Type();
+  }
+  if (*memorySpace != AddressSpace::MAT) {
+    emitError() << "conv_tile only supports loc=mat";
+    return Type();
+  }
+
+  auto layoutAttr = dyn_cast_or_null<LayoutAttr>(fields.layoutAttr);
+  if (!layoutAttr) {
+    emitError() << "layout must be a pto.layout attr";
+    return Type();
+  }
+  auto cfg = fields.config ? fields.config : ConvTileConfigAttr::getDefault(ctx);
+
+  return ConvTileType::get(ctx, fields.shape, fields.dtype, bufferSize,
+                           AddressSpaceAttr::get(ctx, *memorySpace),
+                           layoutAttr, cfg);
+}
+
+} // namespace
+
 Type ConvTileType::parse(AsmParser &parser) {
   if (failed(parser.parseLess())) {
     return Type();
   }
 
-  std::string locStr;
-  std::string layoutStr;
-  SmallVector<int64_t, 6> shape;
-  Type dtype;
-  int64_t bufferSize = 0;
-
-  ParseResult parseResult = parser.parseKeywordOrString(&locStr);
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseComma();
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseKeyword("buffer");
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseEqual();
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseInteger(bufferSize);
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseComma();
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseKeyword("layout");
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseEqual();
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseKeywordOrString(&layoutStr);
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseComma();
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseKeyword("shape");
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseEqual();
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseDimensionList(shape, /*allowDynamic=*/false);
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseType(dtype);
-  if (!parseResult.succeeded()) {
-    return Type();
-  }
-  parseResult = parser.parseGreater();
-  if (!parseResult.succeeded()) {
+  std::string firstToken;
+  if (failed(parser.parseKeywordOrString(&firstToken))) {
     return Type();
   }
 
-  auto emitError = [&]() -> InFlightDiagnostic {
-    return parser.emitError(parser.getNameLoc());
-  };
-  auto memorySpace = resolveTileBufMemorySpace(locStr);
-  if (!memorySpace.has_value()) {
-    emitError() << "unknown ConvTile loc: " << locStr;
+  ParsedConvTileFields fields;
+  fields.locStr = firstToken;
+
+  if (failed(parser.parseComma())) {
     return Type();
   }
-  auto layout = resolveConvLayout(layoutStr);
-  if (!layout.has_value()) {
-    emitError() << "unknown ConvTile layout: " << layoutStr;
+
+  if (failed(parser.parseDimensionList(fields.shape, /*allowDynamic=*/false,
+                                       /*withTrailingX=*/false))) {
     return Type();
   }
-  if (bufferSize <= 0) {
-    emitError() << "ConvTile buffer must be positive";
+
+  if (failed(parser.parseType(fields.dtype))) {
     return Type();
   }
-  const bool invalidRank = shape.empty() || shape.size() > 6;
-  if (invalidRank) {
-    emitError() << "ConvTile shape rank must be between 1 and 6";
-    return Type();
-  }
-  for (int64_t dim : shape) {
-    if (dim <= 0) {
-      emitError() << "ConvTile shape dimensions must be positive";
+
+  bool parsedGreater = false;
+  bool seenLayout = false;
+  bool seenConfig = false;
+  bool seenBufferSize = false;
+  LayoutAttr layoutAttr;
+  IntegerAttr bufferSizeAttr;
+  ConvTileConfigAttr configAttr;
+  configAttr = ConvTileConfigAttr::getDefault(parser.getContext());
+  while (!parsedGreater) {
+    if (succeeded(parser.parseOptionalGreater())) {
+      parsedGreater = true;
+      break;
+    }
+    if (failed(parser.parseComma())) {
       return Type();
     }
+
+    StringRef key;
+    if (failed(parser.parseKeyword(&key)) || failed(parser.parseEqual())) {
+      return Type();
+    }
+
+    if (key == "layout") {
+      Attribute attr;
+      if (failed(parser.parseAttribute(attr))) {
+        return Type();
+      }
+      layoutAttr = dyn_cast<LayoutAttr>(attr);
+      if (!layoutAttr || seenLayout) {
+        return Type();
+      }
+      seenLayout = true;
+      continue;
+    }
+
+    if (key == "buffer_size") {
+      Attribute attr;
+      if (failed(parser.parseAttribute(attr))) {
+        return Type();
+      }
+      bufferSizeAttr = dyn_cast_or_null<IntegerAttr>(attr);
+      if (!bufferSizeAttr || seenBufferSize) {
+        return Type();
+      }
+      seenBufferSize = true;
+      continue;
+    }
+
+    if (key == "config") {
+      Attribute attr;
+      if (failed(parser.parseAttribute(attr))) {
+        return Type();
+      }
+      configAttr = dyn_cast_or_null<ConvTileConfigAttr>(attr);
+      if (!configAttr || seenConfig) {
+        return Type();
+      }
+      seenConfig = true;
+      continue;
+    }
+
+    parser.emitError(parser.getCurrentLocation(),
+                     "unknown key in conv_tile syntax: ")
+        << key;
+    return Type();
   }
 
-  auto memorySpaceAttr = AddressSpaceAttr::get(parser.getContext(),
-                                                memorySpace.value());
-  auto layoutAttr = ConvLayoutAttr::get(parser.getContext(), layout.value());
-  return ConvTileType::get(parser.getContext(), shape, dtype, memorySpaceAttr,
-                           bufferSize, layoutAttr);
+  if (!layoutAttr) {
+    layoutAttr = LayoutAttr::get(parser.getContext(), Layout::NC1HWC0);
+  }
+
+  if (!bufferSizeAttr) {
+    auto defaultBufferSize = computeConvTileBufferSize(fields.shape);
+    if (!defaultBufferSize) {
+      parser.emitError(parser.getCurrentLocation(),
+                       "conv_tile shape must have a positive, overflow-free element count");
+      return Type();
+    }
+    bufferSizeAttr =
+        IntegerAttr::get(parser.getBuilder().getI64Type(), *defaultBufferSize);
+  }
+
+  if (!seenConfig) {
+    configAttr = ConvTileConfigAttr::getDefault(parser.getContext());
+  }
+
+  return buildConvTileType(parser, {fields.locStr, fields.shape, fields.dtype,
+                                    bufferSizeAttr, layoutAttr, configAttr});
 }
 
-void mlir::pto::ConvTileType::print(mlir::AsmPrinter &printer) const {
-  auto memorySpace =
-      llvm::dyn_cast_or_null<AddressSpaceAttr>(getMemorySpace());
-  auto layout = getLayout();
-  if (!memorySpace || !layout) {
-    printer << "<unknown>";
-    return;
-  }
-
-  auto layoutName = [&]() -> llvm::StringRef {
-    switch (layout.getValue()) {
-    case ConvLayout::NC1HWC0:
-      return "nc1hwc0";
-    case ConvLayout::NDC1HWC0:
-      return "ndc1hwc0";
-    case ConvLayout::FRACTAL_Z:
-      return "fractal_z";
-    case ConvLayout::FRACTAL_Z_3D:
-      return "fractal_z_3d";
-    case ConvLayout::NCHW:
-      return "nchw";
-    case ConvLayout::NHWC:
-      return "nhwc";
-    case ConvLayout::GNCHW:
-      return "gnchw";
-    case ConvLayout::GNC1HWC0:
-      return "gnc1hwc0";
-    }
-    return "unknown";
-  };
-
-  printer << "<" << stringifyLocFromMemorySpace(memorySpace)
-          << ", buffer=" << getBufferSize()
-          << ", layout=" << layoutName()
-          << ", shape=";
-  for (auto [index, dim] : llvm::enumerate(getShape())) {
-    if (index != 0) {
+void ConvTileType::print(AsmPrinter &printer) const {
+  printer << "<";
+  printer << stringifyLocFromMemorySpace(getMemorySpace());
+  printer << ", ";
+  auto shape = getShape();
+  for (auto it = shape.begin(); it != shape.end(); ++it) {
+    if (it != shape.begin()) {
       printer << "x";
     }
-    printTileBufDim(printer, dim);
+    if (*it == ShapedType::kDynamic) {
+      printer << "?";
+    } else {
+      printer << *it;
+    }
   }
   printer << "x";
   printer.printType(getElementType());
+  printer << ", buffer_size=";
+  printer.printAttribute(getBufferSize());
+  printer << ", ";
+  printConvTileLayoutField(printer, getLayout());
+  printer << ", ";
+  printConvTileConfigField(printer, getConfigAttr());
   printer << ">";
 }
 

--- a/lib/PTO/IR/PTOTypeDefs.cpp
+++ b/lib/PTO/IR/PTOTypeDefs.cpp
@@ -808,9 +808,6 @@ static std::optional<int64_t> computeConvTileBufferSize(ArrayRef<int64_t> shape)
 
 static LogicalResult parseConvTileLayoutField(AsmParser &parser,
                                               Attribute &layoutAttr) {
-  if (failed(parseTileBufKeyEq(parser, "layout"))) {
-    return failure();
-  }
   if (failed(parser.parseAttribute(layoutAttr))) {
     return failure();
   }
@@ -819,9 +816,6 @@ static LogicalResult parseConvTileLayoutField(AsmParser &parser,
 
 static LogicalResult parseConvTileConfigField(AsmParser &parser,
                                               Attribute &configAttr) {
-  if (failed(parseTileBufKeyEq(parser, "config"))) {
-    return failure();
-  }
   if (failed(parser.parseAttribute(configAttr))) {
     return failure();
   }
@@ -948,7 +942,7 @@ Type ConvTileType::parse(AsmParser &parser) {
 
     if (key == "layout") {
       Attribute attr;
-      if (failed(parser.parseAttribute(attr))) {
+      if (failed(parseConvTileLayoutField(parser, attr))) {
         return Type();
       }
       layoutAttr = llvm::dyn_cast<LayoutAttr>(attr);
@@ -974,7 +968,7 @@ Type ConvTileType::parse(AsmParser &parser) {
 
     if (key == "config") {
       Attribute attr;
-      if (failed(parser.parseAttribute(attr))) {
+      if (failed(parseConvTileConfigField(parser, attr))) {
         return Type();
       }
       configAttr = llvm::dyn_cast_or_null<ConvTileConfigAttr>(attr);

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -94,6 +94,22 @@ static std::optional<int64_t> getTileBufferFootprintBytes(TileBufType type) {
          static_cast<int64_t>(elemBytes);
 }
 
+static std::optional<int64_t> getConvTileFootprintBytes(ConvTileType type) {
+  unsigned elemBytes = getPTOStorageElemByteSize(type.getElementType());
+  int64_t bufferSize = type.getBufferSizeValue();
+  bool invalidCapacity = elemBytes == 0 || bufferSize <= 0;
+  if (invalidCapacity) {
+    return std::nullopt;
+  }
+
+  int64_t elemBytesI64 = static_cast<int64_t>(elemBytes);
+  bool overflows = bufferSize > std::numeric_limits<int64_t>::max() / elemBytesI64;
+  if (overflows) {
+    return std::nullopt;
+  }
+  return bufferSize * elemBytesI64;
+}
+
 static int64_t ceilDivBitsToBytes(int64_t bits) {
   return (bits + kBitsPerByte - 1) / kBitsPerByte;
 }
@@ -1115,6 +1131,9 @@ BufferInfo MemLivenessAnalysis::GetBufferInfo(Operation *op, Value operand,
   if (auto tileType = dyn_cast<TileBufType>(operand.getType())) {
     elementType = tileType.getElementType();
     footprintBytes = getTileBufferFootprintBytes(tileType);
+  } else if (auto convType = dyn_cast<ConvTileType>(operand.getType())) {
+    elementType = convType.getElementType();
+    footprintBytes = getConvTileFootprintBytes(convType);
   } else if (auto multiType = dyn_cast<MultiTileBufType>(operand.getType())) {
     TileBufType slotType = multiType.getSlotType();
     elementType = slotType.getElementType();
@@ -2663,8 +2682,8 @@ public:
       return failure();
     }
 
-    auto tileType = dyn_cast<TileBufType>(op.getResult().getType());
-    if (!tileType) {
+    Type tileType = op.getResult().getType();
+    if (!isa<TileBufType, ConvTileType>(tileType)) {
       return failure();
     }
 

--- a/lib/PTO/Transforms/PTOPlanMemoryModern.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemoryModern.cpp
@@ -107,6 +107,14 @@ static std::optional<AddressSpace> getBufferAddressSpace(Type type) {
     return std::nullopt;
   }
 
+  if (auto convType = dyn_cast<ConvTileType>(type)) {
+    if (auto attr =
+            dyn_cast_or_null<AddressSpaceAttr>(convType.getMemorySpace())) {
+      return attr.getAddressSpace();
+    }
+    return std::nullopt;
+  }
+
   if (auto multiType = dyn_cast<MultiTileBufType>(type)) {
     return getBufferAddressSpace(multiType.getSlotType());
   }
@@ -247,6 +255,21 @@ static FailureOr<uint64_t> computeStaticBufferBytes(Value value) {
 
   if (auto tileType = dyn_cast<TileBufType>(value.getType())) {
     return computeTileBytes(tileType);
+  }
+  if (auto convType = dyn_cast<ConvTileType>(value.getType())) {
+    uint64_t elemBytes = getPTOStorageElemByteSize(convType.getElementType());
+    const bool invalidCapacity =
+        elemBytes == 0 || convType.getBufferSize() <= 0;
+    if (invalidCapacity) {
+      return failure();
+    }
+    uint64_t bufferSize = static_cast<uint64_t>(convType.getBufferSize());
+    const bool overflows =
+        bufferSize > std::numeric_limits<uint64_t>::max() / elemBytes;
+    if (overflows) {
+      return failure();
+    }
+    return bufferSize * elemBytes;
   }
   if (auto multiType = dyn_cast<MultiTileBufType>(value.getType())) {
     return computeTileBytes(multiType.getSlotType());

--- a/lib/PTO/Transforms/PTOPlanMemoryModern.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemoryModern.cpp
@@ -1591,8 +1591,8 @@ public:
       return failure();
     }
 
-    auto tileType = dyn_cast<TileBufType>(op.getResult().getType());
-    if (!tileType) {
+    Type tileType = op.getResult().getType();
+    if (!isa<TileBufType, ConvTileType>(tileType)) {
       return failure();
     }
 

--- a/lib/PTO/Transforms/PTOPlanMemoryModern.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemoryModern.cpp
@@ -259,11 +259,11 @@ static FailureOr<uint64_t> computeStaticBufferBytes(Value value) {
   if (auto convType = dyn_cast<ConvTileType>(value.getType())) {
     uint64_t elemBytes = getPTOStorageElemByteSize(convType.getElementType());
     const bool invalidCapacity =
-        elemBytes == 0 || convType.getBufferSize() <= 0;
+        elemBytes == 0 || convType.getBufferSizeValue() <= 0;
     if (invalidCapacity) {
       return failure();
     }
-    uint64_t bufferSize = static_cast<uint64_t>(convType.getBufferSize());
+    uint64_t bufferSize = static_cast<uint64_t>(convType.getBufferSizeValue());
     const bool overflows =
         bufferSize > std::numeric_limits<uint64_t>::max() / elemBytes;
     if (overflows) {

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -336,6 +336,30 @@ static void createLastUseAwareOpaqueCall(
                                        operands);
 }
 
+static StringRef getFmatrixModeToken(pto::FmatrixMode mode) {
+  switch (mode) {
+  case pto::FmatrixMode::FMATRIX_A_AUTO:
+    return "pto::SetFmatrixMode::FMATRIX_A_AUTO";
+  case pto::FmatrixMode::FMATRIX_B_AUTO:
+    return "pto::SetFmatrixMode::FMATRIX_B_AUTO";
+  case pto::FmatrixMode::FMATRIX_A_MANUAL:
+    return "pto::SetFmatrixMode::FMATRIX_A_MANUAL";
+  case pto::FmatrixMode::FMATRIX_B_MANUAL:
+    return "pto::SetFmatrixMode::FMATRIX_B_MANUAL";
+  }
+  llvm_unreachable("unknown FmatrixMode");
+}
+
+static ArrayAttr getFmatrixModeTemplateArgs(ConversionPatternRewriter &rewriter,
+                                            pto::FmatrixMode mode) {
+  if (mode == pto::FmatrixMode::FMATRIX_A_MANUAL) {
+    return ArrayAttr{};
+  }
+  auto *ctx = rewriter.getContext();
+  return rewriter.getArrayAttr(
+      {emitc::OpaqueAttr::get(ctx, getFmatrixModeToken(mode))});
+}
+
 static Value buildGlobalTensorFromMemref(ConversionPatternRewriter &rewriter,
                                          Location loc, Value basePtr,
                                          MemRefType mrTy, Operation *anchor,
@@ -12384,9 +12408,11 @@ struct PTOSetFmatrixToEmitC : public OpConversionPattern<pto::SetFmatrixOp> {
 
   LogicalResult matchAndRewrite(pto::SetFmatrixOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
+    auto templateArgs = getFmatrixModeTemplateArgs(rewriter, op.getFmatrixMode());
     createLastUseAwareOpaqueCall(rewriter, op.getOperation(), TypeRange{},
                                  "SETFMATRIX",
-                                 ValueRange{peelUnrealized(adaptor.getSrc())});
+                                 ValueRange{peelUnrealized(adaptor.getSrc())},
+                                 ArrayAttr{}, templateArgs);
     rewriter.eraseOp(op);
     return success();
   }
@@ -12398,9 +12424,11 @@ struct PTOSetImg2colRptToEmitC
 
   LogicalResult matchAndRewrite(pto::SetImg2colRptOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
+    auto templateArgs = getFmatrixModeTemplateArgs(rewriter, op.getFmatrixMode());
     createLastUseAwareOpaqueCall(rewriter, op.getOperation(), TypeRange{},
                                  "SET_IMG2COL_RPT",
-                                 ValueRange{peelUnrealized(adaptor.getSrc())});
+                                 ValueRange{peelUnrealized(adaptor.getSrc())},
+                                 ArrayAttr{}, templateArgs);
     rewriter.eraseOp(op);
     return success();
   }
@@ -12412,9 +12440,11 @@ struct PTOSetImg2colPaddingToEmitC
 
   LogicalResult matchAndRewrite(pto::SetImg2colPaddingOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
+    auto templateArgs = getFmatrixModeTemplateArgs(rewriter, op.getFmatrixMode());
     createLastUseAwareOpaqueCall(rewriter, op.getOperation(), TypeRange{},
                                  "SET_IMG2COL_PADDING",
-                                 ValueRange{peelUnrealized(adaptor.getSrc())});
+                                 ValueRange{peelUnrealized(adaptor.getSrc())},
+                                 ArrayAttr{}, templateArgs);
     rewriter.eraseOp(op);
     return success();
   }
@@ -12435,10 +12465,12 @@ struct PTOTImg2colToEmitC : public OpConversionPattern<pto::TImg2colOp> {
                                       static_cast<int64_t>(op.getPosM().getInt()));
     Value posK = makeEmitCIntConstant(rewriter, loc, u16Ty,
                                       static_cast<int64_t>(op.getPosK().getInt()));
+    auto templateArgs = getFmatrixModeTemplateArgs(rewriter, op.getFmatrixMode());
 
     createLastUseAwareOpaqueCall(rewriter, op.getOperation(), TypeRange{},
                                  "TIMG2COL",
-                                 ValueRange{dst, src, posM, posK});
+                                 ValueRange{dst, src, posM, posK}, ArrayAttr{},
+                                 templateArgs);
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -424,6 +424,24 @@ static std::string layoutToEmitCString(mlir::pto::Layout layout) {
     return "pto::Layout::MX_A_ZZ";
   case mlir::pto::Layout::MX_B_NN:
     return "pto::Layout::MX_B_NN";
+  case mlir::pto::Layout::NCHW:
+    return "pto::Layout::NCHW";
+  case mlir::pto::Layout::NC1HWC0:
+    return "pto::Layout::NC1HWC0";
+  case mlir::pto::Layout::NCDHW:
+    return "pto::Layout::NCDHW";
+  case mlir::pto::Layout::NDC1HWC0:
+    return "pto::Layout::NDC1HWC0";
+  case mlir::pto::Layout::GNCHW:
+    return "pto::Layout::GNCHW";
+  case mlir::pto::Layout::GNC1HWC0:
+    return "pto::Layout::GNC1HWC0";
+  case mlir::pto::Layout::NHWC:
+    return "pto::Layout::NHWC";
+  case mlir::pto::Layout::FRACTAL_Z:
+    return "pto::Layout::FRACTAL_Z";
+  case mlir::pto::Layout::FRACTAL_Z_3D:
+    return "pto::Layout::FRACTAL_Z_3D";
   }
   return "pto::Layout::ND";
 }
@@ -12462,9 +12480,9 @@ struct PTOTImg2colToEmitC : public OpConversionPattern<pto::TImg2colOp> {
     Value src = peelUnrealized(adaptor.getSrc());
     Type u16Ty = emitc::OpaqueType::get(ctx, "uint16_t");
     Value posM = makeEmitCIntConstant(rewriter, loc, u16Ty,
-                                      static_cast<int64_t>(op.getPosM().getInt()));
+                                      static_cast<int64_t>(op.getPosM()));
     Value posK = makeEmitCIntConstant(rewriter, loc, u16Ty,
-                                      static_cast<int64_t>(op.getPosK().getInt()));
+                                      static_cast<int64_t>(op.getPosK()));
     auto templateArgs = getFmatrixModeTemplateArgs(rewriter, op.getFmatrixMode());
 
     createLastUseAwareOpaqueCall(rewriter, op.getOperation(), TypeRange{},

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -217,7 +217,7 @@ static int64_t getIntegerAttrSignedValue(IntegerAttr attr) {
 static SmallVector<unsigned, 4> collectTileOperandNumbers(Operation *op) {
   SmallVector<unsigned, 4> tileOperandNumbers;
   for (OpOperand &operand : op->getOpOperands()) {
-    if (isa<pto::TileBufType>(operand.get().getType()))
+    if (isa<pto::TileBufType, pto::ConvTileType>(operand.get().getType()))
       tileOperandNumbers.push_back(operand.getOperandNumber());
   }
   return tileOperandNumbers;
@@ -843,54 +843,23 @@ static std::optional<std::string> getEmitCTileTypeString(pto::TileBufType type) 
          tileBufCompactToken(configAttr) + ">";
 }
 
-static StringRef convLayoutToken(pto::ConvLayout layout) {
-  switch (layout) {
-  case pto::ConvLayout::NC1HWC0:
-    return "Layout::NC1HWC0";
-  case pto::ConvLayout::NDC1HWC0:
-    return "Layout::NDC1HWC0";
-  case pto::ConvLayout::FRACTAL_Z:
-    return "Layout::FRACTAL_Z";
-  case pto::ConvLayout::FRACTAL_Z_3D:
-    return "Layout::FRACTAL_Z_3D";
-  case pto::ConvLayout::NCHW:
-    return "Layout::NCHW";
-  case pto::ConvLayout::NHWC:
-    return "Layout::NHWC";
-  case pto::ConvLayout::GNCHW:
-    return "Layout::GNCHW";
-  case pto::ConvLayout::GNC1HWC0:
-    return "Layout::GNC1HWC0";
-  }
-  return "Layout::NC1HWC0";
-}
-
-static std::optional<std::string>
-getEmitCConvTileTypeString(pto::ConvTileType type) {
-  auto memorySpace =
-      dyn_cast_or_null<pto::AddressSpaceAttr>(type.getMemorySpace());
-  auto layout = type.getLayout();
-  const bool invalidType =
-      !memorySpace || !layout || type.getRank() == 0 || type.getRank() > 6 ||
-      type.getBufferSize() <= 0;
-  if (invalidType) {
+static std::optional<std::string> getEmitCConvTileTypeString(pto::ConvTileType type) {
+  auto shape = type.getShape();
+  if (shape.empty() || shape.size() > 6)
     return std::nullopt;
-  }
 
-  std::string shape = "ConvTileShape<";
-  for (auto [index, dim] : llvm::enumerate(type.getShape())) {
-    if (index != 0) {
-      shape += ", ";
-    }
-    shape += std::to_string(dim);
-  }
-  shape += ">";
+  Type elemTy = type.getElementType();
+  auto layoutAttr = dyn_cast_or_null<pto::LayoutAttr>(type.getLayout());
+  if (!layoutAttr)
+    layoutAttr = pto::LayoutAttr::get(type.getContext(), pto::Layout::NC1HWC0);
 
+  std::string shapeType = "pto::ConvTileShape<" + joinIntTemplateParams(shape) + ">";
   return std::string("ConvTile<") +
-         tileRoleToken(type.getMemorySpace(), type.getElementType(), nullptr) +
-         ", " + getEmitCScalarTypeToken(type.getElementType()) + ", " +
-         std::to_string(type.getBufferSize()) + ", " +
-         convLayoutToken(layout.getValue()).str() + ", " + shape + ">";
+         tileRoleToken(type.getMemorySpace(), elemTy) + ", " +
+         getEmitCScalarTypeToken(elemTy) + ", " +
+         std::to_string(type.getBufferSizeValue()) + ", " +
+         layoutToEmitCString(layoutAttr.getLayout()) + ", " +
+         shapeType + ">";
 }
 
 //===----------------------------------------------------------------------===//
@@ -1067,19 +1036,17 @@ public:
                                               type.getShape());
     });
 
-  addConversion([Ctx](pto::TileBufType type) -> std::optional<Type> {
+    addConversion([Ctx](pto::TileBufType type) -> std::optional<Type> {
       auto typeString = getEmitCTileTypeString(type);
-      if (!typeString) {
+      if (!typeString)
         return std::nullopt;
-      }
       return emitc::OpaqueType::get(Ctx, *typeString);
     });
 
     addConversion([Ctx](pto::ConvTileType type) -> std::optional<Type> {
       auto typeString = getEmitCConvTileTypeString(type);
-      if (!typeString) {
+      if (!typeString)
         return std::nullopt;
-      }
       return emitc::OpaqueType::get(Ctx, *typeString);
     });
 
@@ -12411,6 +12378,72 @@ struct PTOXORSToEmitC : public OpConversionPattern<pto::TXorSOp> {
     return success();
   }
 };
+
+struct PTOSetFmatrixToEmitC : public OpConversionPattern<pto::SetFmatrixOp> {
+  using OpConversionPattern<pto::SetFmatrixOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(pto::SetFmatrixOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    createLastUseAwareOpaqueCall(rewriter, op.getOperation(), TypeRange{},
+                                 "SETFMATRIX",
+                                 ValueRange{peelUnrealized(adaptor.getSrc())});
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct PTOSetImg2colRptToEmitC
+    : public OpConversionPattern<pto::SetImg2colRptOp> {
+  using OpConversionPattern<pto::SetImg2colRptOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(pto::SetImg2colRptOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    createLastUseAwareOpaqueCall(rewriter, op.getOperation(), TypeRange{},
+                                 "SET_IMG2COL_RPT",
+                                 ValueRange{peelUnrealized(adaptor.getSrc())});
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct PTOSetImg2colPaddingToEmitC
+    : public OpConversionPattern<pto::SetImg2colPaddingOp> {
+  using OpConversionPattern<pto::SetImg2colPaddingOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(pto::SetImg2colPaddingOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    createLastUseAwareOpaqueCall(rewriter, op.getOperation(), TypeRange{},
+                                 "SET_IMG2COL_PADDING",
+                                 ValueRange{peelUnrealized(adaptor.getSrc())});
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct PTOTImg2colToEmitC : public OpConversionPattern<pto::TImg2colOp> {
+  using OpConversionPattern<pto::TImg2colOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(pto::TImg2colOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+
+    Value dst = peelUnrealized(adaptor.getDst());
+    Value src = peelUnrealized(adaptor.getSrc());
+    Type u16Ty = emitc::OpaqueType::get(ctx, "uint16_t");
+    Value posM = makeEmitCIntConstant(rewriter, loc, u16Ty,
+                                      static_cast<int64_t>(op.getPosM().getInt()));
+    Value posK = makeEmitCIntConstant(rewriter, loc, u16Ty,
+                                      static_cast<int64_t>(op.getPosK().getInt()));
+
+    createLastUseAwareOpaqueCall(rewriter, op.getOperation(), TypeRange{},
+                                 "TIMG2COL",
+                                 ValueRange{dst, src, posM, posK});
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct PTOPrintToTPRINT : public OpConversionPattern<pto::TPrintOp> {
   using OpConversionPattern<pto::TPrintOp>::OpConversionPattern;
 
@@ -12535,57 +12568,7 @@ struct PTOAllocTileToEmitC
                                 ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     MLIRContext *ctx = rewriter.getContext();
-    Type resultTy = op.getResult().getType();
-    if (auto convTy = dyn_cast<pto::ConvTileType>(resultTy)) {
-      auto convTypeString = getEmitCConvTileTypeString(convTy);
-      if (!convTypeString) {
-        return rewriter.notifyMatchFailure(
-            op, "invalid ConvTile type for EmitC conversion");
-      }
-      Type convertedTy = getTypeConverter()->convertType(convTy);
-      if (!convertedTy) {
-        convertedTy = emitc::OpaqueType::get(ctx, *convTypeString);
-      }
-      Value tile =
-          rewriter
-              .create<emitc::VariableOp>(
-                  loc, getEmitCVariableResultType(convertedTy),
-                  emitc::OpaqueAttr::get(ctx, ""))
-              .getResult();
-      tile = loadEmitCVariableIfNeeded(rewriter, loc, tile);
-
-      Value addr = adaptor.getAddr();
-      if (addr) {
-        addr = peelUnrealized(addr);
-        auto u64Ty = emitc::OpaqueType::get(ctx, "uint64_t");
-        const bool isPointer =
-            isa<emitc::PointerType>(addr.getType()) ||
-            (isa<emitc::OpaqueType>(addr.getType()) &&
-             cast<emitc::OpaqueType>(addr.getType()).getValue().ends_with("*"));
-        if (isPointer) {
-          auto rcU64 =
-              rewriter.getArrayAttr({emitc::OpaqueAttr::get(ctx, "uint64_t")});
-          addr = rewriter
-                     .create<emitc::CallOpaqueOp>(
-                         loc, u64Ty, "reinterpret_cast", ArrayAttr{}, rcU64,
-                         ValueRange{addr})
-                     .getResult(0);
-        } else if (addr.getType() != u64Ty) {
-          addr = rewriter.create<emitc::CastOp>(loc, u64Ty, addr).getResult();
-        }
-        rewriter.create<emitc::CallOpaqueOp>(
-            loc, TypeRange{}, "TASSIGN", ArrayAttr{}, ArrayAttr{},
-            ValueRange{tile, addr});
-      }
-      rewriter.replaceOp(op, tile);
-      return success();
-    }
-
-    auto tileTy = dyn_cast<pto::TileBufType>(resultTy);
-    if (!tileTy) {
-      return rewriter.notifyMatchFailure(
-          op, "expected tile_buf or conv_tile result");
-    }
+    auto tileTy = cast<pto::TileBufType>(op.getResult().getType());
     auto tileTypeString = getEmitCTileTypeString(tileTy);
     if (!tileTypeString)
       return rewriter.notifyMatchFailure(
@@ -13821,6 +13804,9 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOPrintToTPRINT>(typeConverter, ctx);
   patterns.add<PTOPrintOpToEmitC>(typeConverter, ctx);
   patterns.add<PTOTrapOpToEmitC>(typeConverter, ctx);
+  patterns.add<PTOSetFmatrixToEmitC, PTOSetImg2colRptToEmitC,
+               PTOSetImg2colPaddingToEmitC, PTOTImg2colToEmitC>(
+      typeConverter, ctx);
   patterns.add<
     PTOTMatmulBiasToTMATMUL_BIAS,
     PTOTMatmulMXToTMATMUL_MX,

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -336,6 +336,47 @@ static void createLastUseAwareOpaqueCall(
                                        operands);
 }
 
+static void emitConvTileConfigInitCall(ConversionPatternRewriter &rewriter,
+                                       Location loc, Value tile,
+                                       pto::ConvTileType convTy) {
+  auto *ctx = rewriter.getContext();
+  auto cfg = convTy.getConfigAttr();
+
+  SmallVector<Attribute, 24> args;
+  args.push_back(IntegerAttr::get(IndexType::get(ctx), 0));
+
+  auto appendI32 = [&](IntegerAttr attr) {
+    args.push_back(IntegerAttr::get(rewriter.getI32Type(), attr.getInt()));
+  };
+  auto appendPad = [&](int64_t value) {
+    args.push_back(IntegerAttr::get(rewriter.getI32Type(), value));
+  };
+
+  appendI32(cfg.getFmapH());
+  appendI32(cfg.getFmapW());
+  for (int64_t pad : cfg.getPadList())
+    appendPad(pad);
+  appendI32(cfg.getFilterH());
+  appendI32(cfg.getFilterW());
+  appendI32(cfg.getDilationH());
+  appendI32(cfg.getDilationW());
+  appendI32(cfg.getStrideH());
+  appendI32(cfg.getStrideW());
+  args.push_back(cfg.getPadValue());
+  appendI32(cfg.getChannelSize());
+  appendI32(cfg.getRepeatStride());
+  appendI32(cfg.getRepeatTime());
+  appendI32(cfg.getRepeatMode());
+  appendI32(cfg.getDstStride());
+  appendI32(cfg.getDstMposition());
+  args.push_back(cfg.getTranspose());
+
+  rewriter.create<emitc::CallOpaqueOp>(
+      loc, TypeRange{}, "PTOAS__INIT_CONVTILE_CONFIG",
+      /*args=*/rewriter.getArrayAttr(args),
+      /*templateArgs=*/ArrayAttr{}, /*operands=*/ValueRange{tile});
+}
+
 static StringRef getFmatrixModeToken(pto::FmatrixMode mode) {
   switch (mode) {
   case pto::FmatrixMode::FMATRIX_A_AUTO:
@@ -12618,19 +12659,30 @@ struct PTOAllocTileToEmitC
                                 ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     MLIRContext *ctx = rewriter.getContext();
-    auto tileTy = cast<pto::TileBufType>(op.getResult().getType());
-    auto tileTypeString = getEmitCTileTypeString(tileTy);
+    Type resultTy = op.getResult().getType();
+    auto tileTy = dyn_cast<pto::TileBufType>(resultTy);
+    auto convTy = dyn_cast<pto::ConvTileType>(resultTy);
+    if (!tileTy && !convTy)
+      return rewriter.notifyMatchFailure(
+          op, "expected alloc_tile to produce a tile_buf or conv_tile");
+
+    std::optional<std::string> tileTypeString;
+    if (tileTy)
+      tileTypeString = getEmitCTileTypeString(tileTy);
+    else
+      tileTypeString = getEmitCConvTileTypeString(convTy);
     if (!tileTypeString)
       return rewriter.notifyMatchFailure(
           op, "only rank-2 alloc_tile handles can be converted to EmitC");
 
-    Type convertedTy = getTypeConverter()->convertType(tileTy);
+    Type convertedTy = getTypeConverter()->convertType(resultTy);
     if (!convertedTy)
       convertedTy = emitc::OpaqueType::get(ctx, *tileTypeString);
 
-    auto validShape = tileTy.getValidShape();
+    ArrayRef<int64_t> validShape = tileTy ? tileTy.getValidShape()
+                                          : ArrayRef<int64_t>{};
     bool hasDynamicValidDim =
-        llvm::any_of(validShape, [](int64_t dim) { return dim < 0; });
+        tileTy && llvm::any_of(validShape, [](int64_t dim) { return dim < 0; });
     bool useConstructor = hasDynamicValidDim;
 
     SmallVector<Value> constructorArgs;
@@ -12685,6 +12737,9 @@ struct PTOAllocTileToEmitC
               .getResult();
       tile = loadEmitCVariableIfNeeded(rewriter, loc, tile);
     }
+
+    if (convTy)
+      emitConvTileConfigInitCall(rewriter, loc, tile, convTy);
 
     Value addr = adaptor.getAddr();
     if (addr) {
@@ -13935,6 +13990,7 @@ struct EmitPTOManualPass
         bool needsEventIdArrayHelper = false;
         bool needsTRandomHelper = false;
         bool needsGlobalTensorDataHelper = false;
+        bool needsConvTileInitHelper = false;
         mop.walk([&](Operation *op) {
           if (isa<mlir::pto::DeclareEventIdArrayOp>(op))
             needsEventIdArrayHelper = true;
@@ -13950,6 +14006,10 @@ struct EmitPTOManualPass
           }
           if (isa<mlir::pto::PartitionViewOp>(op))
             needsGlobalTensorDataHelper = true;
+          if (auto alloc = dyn_cast<mlir::pto::AllocTileOp>(op)) {
+            if (isa<mlir::pto::ConvTileType>(alloc.getResult().getType()))
+              needsConvTileInitHelper = true;
+          }
         });
 
 		    // 1. 插入头文件
@@ -14017,6 +14077,41 @@ static AICORE inline void PTOAS__TRANDOM(
   TRandomKey key = {key0, key1};
   TRandomCounter counter = {counter0, counter1, counter2, counter3};
   TRANDOM<Rounds>(dst, key, counter);
+}
+)cpp"));
+        }
+        if (needsConvTileInitHelper) {
+	      builder.create<emitc::VerbatimOp>(
+	          loc, builder.getStringAttr(R"cpp(
+template <typename Tile, typename PadValueT>
+static AICORE inline void PTOAS__INIT_CONVTILE_CONFIG(
+    Tile &tile, uint16_t fmapH, uint16_t fmapW, uint8_t padLeft,
+    uint8_t padRight, uint8_t padTop, uint8_t padBottom, uint16_t filterH,
+    uint16_t filterW, uint16_t dilationH, uint16_t dilationW,
+    uint16_t strideH, uint16_t strideW, PadValueT padValue,
+    uint16_t channelSize, uint16_t repeatStride, uint8_t repeatTime,
+    uint8_t repeatMode, uint16_t dstStride, uint16_t dstMposition,
+    bool transpose) {
+  const uint8_t padList[4] = {padLeft, padRight, padTop, padBottom};
+  tile.SetFmapH(fmapH);
+  tile.SetFmapW(fmapW);
+  tile.SetPadListArray(padList);
+  tile.SetFilterH(filterH);
+  tile.SetFilterW(filterW);
+  tile.SetDilationH(dilationH);
+  tile.SetDilationW(dilationW);
+  tile.SetStrideH(strideH);
+  tile.SetStrideW(strideW);
+  tile.SetPadValue(padValue);
+  tile.SetChannelSize(channelSize);
+  tile.SetRepeatStride(repeatStride);
+  tile.SetRepeatTime(repeatTime);
+  tile.SetRepeatMode(repeatMode);
+#ifndef PTO_NPU_ARCH_A2A3
+  tile.SetDstStride(dstStride);
+  tile.SetDstMposition(dstMposition);
+#endif
+  tile.SetTranspose(transpose);
 }
 )cpp"));
         }

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -843,6 +843,56 @@ static std::optional<std::string> getEmitCTileTypeString(pto::TileBufType type) 
          tileBufCompactToken(configAttr) + ">";
 }
 
+static StringRef convLayoutToken(pto::ConvLayout layout) {
+  switch (layout) {
+  case pto::ConvLayout::NC1HWC0:
+    return "Layout::NC1HWC0";
+  case pto::ConvLayout::NDC1HWC0:
+    return "Layout::NDC1HWC0";
+  case pto::ConvLayout::FRACTAL_Z:
+    return "Layout::FRACTAL_Z";
+  case pto::ConvLayout::FRACTAL_Z_3D:
+    return "Layout::FRACTAL_Z_3D";
+  case pto::ConvLayout::NCHW:
+    return "Layout::NCHW";
+  case pto::ConvLayout::NHWC:
+    return "Layout::NHWC";
+  case pto::ConvLayout::GNCHW:
+    return "Layout::GNCHW";
+  case pto::ConvLayout::GNC1HWC0:
+    return "Layout::GNC1HWC0";
+  }
+  return "Layout::NC1HWC0";
+}
+
+static std::optional<std::string>
+getEmitCConvTileTypeString(pto::ConvTileType type) {
+  auto memorySpace =
+      dyn_cast_or_null<pto::AddressSpaceAttr>(type.getMemorySpace());
+  auto layout = type.getLayout();
+  const bool invalidType =
+      !memorySpace || !layout || type.getRank() == 0 || type.getRank() > 6 ||
+      type.getBufferSize() <= 0;
+  if (invalidType) {
+    return std::nullopt;
+  }
+
+  std::string shape = "ConvTileShape<";
+  for (auto [index, dim] : llvm::enumerate(type.getShape())) {
+    if (index != 0) {
+      shape += ", ";
+    }
+    shape += std::to_string(dim);
+  }
+  shape += ">";
+
+  return std::string("ConvTile<") +
+         tileRoleToken(type.getMemorySpace(), type.getElementType(), nullptr) +
+         ", " + getEmitCScalarTypeToken(type.getElementType()) + ", " +
+         std::to_string(type.getBufferSize()) + ", " +
+         convLayoutToken(layout.getValue()).str() + ", " + shape + ">";
+}
+
 //===----------------------------------------------------------------------===//
 // Type Converter
 //===----------------------------------------------------------------------===//
@@ -1017,10 +1067,19 @@ public:
                                               type.getShape());
     });
 
-    addConversion([Ctx](pto::TileBufType type) -> std::optional<Type> {
+  addConversion([Ctx](pto::TileBufType type) -> std::optional<Type> {
       auto typeString = getEmitCTileTypeString(type);
-      if (!typeString)
+      if (!typeString) {
         return std::nullopt;
+      }
+      return emitc::OpaqueType::get(Ctx, *typeString);
+    });
+
+    addConversion([Ctx](pto::ConvTileType type) -> std::optional<Type> {
+      auto typeString = getEmitCConvTileTypeString(type);
+      if (!typeString) {
+        return std::nullopt;
+      }
       return emitc::OpaqueType::get(Ctx, *typeString);
     });
 
@@ -12476,7 +12535,57 @@ struct PTOAllocTileToEmitC
                                 ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     MLIRContext *ctx = rewriter.getContext();
-    auto tileTy = cast<pto::TileBufType>(op.getResult().getType());
+    Type resultTy = op.getResult().getType();
+    if (auto convTy = dyn_cast<pto::ConvTileType>(resultTy)) {
+      auto convTypeString = getEmitCConvTileTypeString(convTy);
+      if (!convTypeString) {
+        return rewriter.notifyMatchFailure(
+            op, "invalid ConvTile type for EmitC conversion");
+      }
+      Type convertedTy = getTypeConverter()->convertType(convTy);
+      if (!convertedTy) {
+        convertedTy = emitc::OpaqueType::get(ctx, *convTypeString);
+      }
+      Value tile =
+          rewriter
+              .create<emitc::VariableOp>(
+                  loc, getEmitCVariableResultType(convertedTy),
+                  emitc::OpaqueAttr::get(ctx, ""))
+              .getResult();
+      tile = loadEmitCVariableIfNeeded(rewriter, loc, tile);
+
+      Value addr = adaptor.getAddr();
+      if (addr) {
+        addr = peelUnrealized(addr);
+        auto u64Ty = emitc::OpaqueType::get(ctx, "uint64_t");
+        const bool isPointer =
+            isa<emitc::PointerType>(addr.getType()) ||
+            (isa<emitc::OpaqueType>(addr.getType()) &&
+             cast<emitc::OpaqueType>(addr.getType()).getValue().ends_with("*"));
+        if (isPointer) {
+          auto rcU64 =
+              rewriter.getArrayAttr({emitc::OpaqueAttr::get(ctx, "uint64_t")});
+          addr = rewriter
+                     .create<emitc::CallOpaqueOp>(
+                         loc, u64Ty, "reinterpret_cast", ArrayAttr{}, rcU64,
+                         ValueRange{addr})
+                     .getResult(0);
+        } else if (addr.getType() != u64Ty) {
+          addr = rewriter.create<emitc::CastOp>(loc, u64Ty, addr).getResult();
+        }
+        rewriter.create<emitc::CallOpaqueOp>(
+            loc, TypeRange{}, "TASSIGN", ArrayAttr{}, ArrayAttr{},
+            ValueRange{tile, addr});
+      }
+      rewriter.replaceOp(op, tile);
+      return success();
+    }
+
+    auto tileTy = dyn_cast<pto::TileBufType>(resultTy);
+    if (!tileTy) {
+      return rewriter.notifyMatchFailure(
+          op, "expected tile_buf or conv_tile result");
+    }
     auto tileTypeString = getEmitCTileTypeString(tileTy);
     if (!tileTypeString)
       return rewriter.notifyMatchFailure(

--- a/lib/PTO/Transforms/Utils.cpp
+++ b/lib/PTO/Transforms/Utils.cpp
@@ -278,6 +278,13 @@ std::optional<AddressSpaceAttr> GetBufferSpaceAttr(Value operand) {
     }
     return std::nullopt;
   }
+  if (auto convTy = dyn_cast<pto::ConvTileType>(operand.getType())) {
+    if (auto memorySpaceAttr = dyn_cast_or_null<AddressSpaceAttr>(
+            convTy.getMemorySpace())) {
+      return memorySpaceAttr;
+    }
+    return std::nullopt;
+  }
 
   if (!llvm::isa<MemRefType>(operand.getType())) {
     return std::nullopt;
@@ -500,6 +507,21 @@ static std::optional<uint64_t> getStaticTileBytes(TileBufType type) {
   return *elements * elemBytes;
 }
 
+static std::optional<uint64_t> getStaticConvTileBytes(ConvTileType type) {
+  unsigned elemBytes = getPTOStorageElemByteSize(type.getElementType());
+  const bool invalidCapacity = elemBytes == 0 || type.getBufferSize() <= 0;
+  if (invalidCapacity) {
+    return std::nullopt;
+  }
+  uint64_t bufferSize = static_cast<uint64_t>(type.getBufferSize());
+  const bool overflows =
+      bufferSize > std::numeric_limits<uint64_t>::max() / elemBytes;
+  if (overflows) {
+    return std::nullopt;
+  }
+  return bufferSize * elemBytes;
+}
+
 static std::optional<uint64_t> getConstantAddress(Value value) {
   IntegerAttr attr;
   bool isInvalid =
@@ -561,6 +583,14 @@ getStaticTileStrides(TileBufType type) {
 }
 
 static std::optional<AddressSpace> getTileAddressSpace(TileBufType type) {
+  auto attr = dyn_cast_or_null<AddressSpaceAttr>(type.getMemorySpace());
+  if (!attr) {
+    return std::nullopt;
+  }
+  return attr.getAddressSpace();
+}
+
+static std::optional<AddressSpace> getConvTileAddressSpace(ConvTileType type) {
   auto attr = dyn_cast_or_null<AddressSpaceAttr>(type.getMemorySpace());
   if (!attr) {
     return std::nullopt;
@@ -667,13 +697,27 @@ static std::optional<SemanticRange> makeTileRange(Value root, TileBufType type,
 
 static std::optional<SemanticRange> resolveAllocTileRange(AllocTileOp alloc) {
   auto tileType = dyn_cast<TileBufType>(alloc.getResult().getType());
-  std::optional<uint64_t> bytes =
-      tileType ? getStaticTileBytes(tileType) : std::nullopt;
-  if (!tileType || !bytes) {
+  if (tileType) {
+    std::optional<uint64_t> bytes = getStaticTileBytes(tileType);
+    if (!bytes) {
+      return std::nullopt;
+    }
+    return makeTileRange(alloc.getResult(), tileType, *bytes,
+                         getConstantAddress(alloc.getAddr()));
+  }
+
+  auto convType = dyn_cast<ConvTileType>(alloc.getResult().getType());
+  if (!convType) {
     return std::nullopt;
   }
-  return makeTileRange(alloc.getResult(), tileType, *bytes,
-                       getConstantAddress(alloc.getAddr()));
+
+  std::optional<uint64_t> bytes = getStaticConvTileBytes(convType);
+  if (!bytes) {
+    return std::nullopt;
+  }
+  return SemanticRange{
+      alloc.getResult(), 0, *bytes, getConstantAddress(alloc.getAddr()),
+      getConvTileAddressSpace(convType), std::nullopt, std::nullopt, 0};
 }
 
 static FailureOr<std::optional<uint64_t>> getMultiTileSlotBase(

--- a/lib/PTO/Transforms/Utils.cpp
+++ b/lib/PTO/Transforms/Utils.cpp
@@ -509,11 +509,11 @@ static std::optional<uint64_t> getStaticTileBytes(TileBufType type) {
 
 static std::optional<uint64_t> getStaticConvTileBytes(ConvTileType type) {
   unsigned elemBytes = getPTOStorageElemByteSize(type.getElementType());
-  const bool invalidCapacity = elemBytes == 0 || type.getBufferSize() <= 0;
+  const bool invalidCapacity = elemBytes == 0 || type.getBufferSizeValue() <= 0;
   if (invalidCapacity) {
     return std::nullopt;
   }
-  uint64_t bufferSize = static_cast<uint64_t>(type.getBufferSize());
+  uint64_t bufferSize = static_cast<uint64_t>(type.getBufferSizeValue());
   const bool overflows =
       bufferSize > std::numeric_limits<uint64_t>::max() / elemBytes;
   if (overflows) {

--- a/python/pto/dialects/pto.py
+++ b/python/pto/dialects/pto.py
@@ -61,11 +61,13 @@ TensorViewType = _pto_mod.TensorViewType
 PartitionTensorViewType = _pto_mod.PartitionTensorViewType
 TileType = _pto_mod.TileType
 TileBufType = _pto_mod.TileBufType
+ConvTileType = _pto_mod.ConvTileType
 AddressSpace = _pto_mod.AddressSpace
 AddressSpaceAttr = _pto_mod.AddressSpaceAttr
 FenceScope = _pto_mod.FenceScope
 FenceScopeAttr = _pto_mod.FenceScopeAttr
 TileBufConfigAttr = _pto_mod.TileBufConfigAttr
+ConvTileConfigAttr = _pto_mod.ConvTileConfigAttr
 BLayout = _pto_mod.BLayout
 BLayoutAttr = _pto_mod.BLayoutAttr
 SLayout = _pto_mod.SLayout
@@ -108,6 +110,8 @@ FmodPrecision = _pto_mod.FmodPrecision
 FmodPrecisionAttr = _pto_mod.FmodPrecisionAttr
 SaturationMode = _pto_mod.SaturationMode
 SaturationModeAttr = _pto_mod.SaturationModeAttr
+FmatrixMode = _pto_mod.FmatrixMode
+FmatrixModeAttr = _pto_mod.FmatrixModeAttr
 CmpMode = _pto_mod.CmpMode
 CmpModeAttr = _pto_mod.CmpModeAttr
 PIPE = _pto_mod.PIPE
@@ -290,6 +294,8 @@ __all__ = [
     "FmodPrecisionAttr",
     "SaturationMode",
     "SaturationModeAttr",
+    "FmatrixMode",
+    "FmatrixModeAttr",
     "CmpMode",
     "CmpModeAttr",
     "PIPE",
@@ -313,6 +319,8 @@ __all__ = [
     "VecStoreMode",
     "VecStoreModeAttr",
     "TileBufConfigAttr",
+    "ConvTileConfigAttr",
+    "ConvTileType",
     "TileConfig",
     # High-level sync helpers
     "record_event",

--- a/test/lit/pto/conv_tile_config_parse.pto
+++ b/test/lit/pto/conv_tile_config_parse.pto
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --emit-pto-ir %s -o - | FileCheck %s
+
+module {
+  func.func @conv_tile_config_parse(
+      %src: !pto.conv_tile<
+          mat, 1x1x3x4x8xf16,
+          config=#pto.conv_tile_config<
+            fmap_h=3, fmap_w=4, pad_list=1x2x3x4,
+            filter_h=1, filter_w=1, dilation_h=1, dilation_w=1,
+            stride_h=1, stride_w=1, pad_value=0 : i32,
+            channel_size=8, repeat_stride=16, repeat_time=2,
+            repeat_mode=0, dst_stride=32, dst_mposition=0,
+            transpose=false>>) {
+    pto.set_fmatrix %src : !pto.conv_tile<
+        mat, 1x1x3x4x8xf16,
+        config=#pto.conv_tile_config<
+          fmap_h=3, fmap_w=4, pad_list=1x2x3x4,
+          filter_h=1, filter_w=1, dilation_h=1, dilation_w=1,
+          stride_h=1, stride_w=1, pad_value=0 : i32,
+          channel_size=8, repeat_stride=16, repeat_time=2,
+          repeat_mode=0, dst_stride=32, dst_mposition=0,
+          transpose=false>>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @conv_tile_config_parse
+// CHECK: !pto.conv_tile<mat, 1x1x3x4x8xf16
+// CHECK-SAME: config=#pto.conv_tile_config<fmap_h=3, fmap_w=4, pad_list=1x2x3x4

--- a/test/lit/pto/fmatrix_mode_emitc.pto
+++ b/test/lit/pto/fmatrix_mode_emitc.pto
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 %s -o - | FileCheck %s
+
+module {
+  func.func @fmatrix_mode_default(
+      %cfg: !pto.conv_tile<mat, 1x1x1x1x16xf16>,
+      %dst: !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>) {
+    pto.set_fmatrix %cfg : !pto.conv_tile<mat, 1x1x1x1x16xf16>
+    pto.set_img2col_rpt %cfg : !pto.conv_tile<mat, 1x1x1x1x16xf16>
+    pto.set_img2col_padding %cfg : !pto.conv_tile<mat, 1x1x1x1x16xf16>
+    pto.timg2col %dst, %cfg
+      : !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>,
+        !pto.conv_tile<mat, 1x1x1x1x16xf16>
+    return
+  }
+
+  func.func @fmatrix_mode_b(
+      %cfg: !pto.conv_tile<mat, 1x1x1x1x16xf16>,
+      %dst: !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>) {
+    pto.set_fmatrix %cfg {fmatrixMode = #pto.fmatrix_mode<b_manual>}
+      : !pto.conv_tile<mat, 1x1x1x1x16xf16>
+    pto.set_img2col_rpt %cfg {fmatrixMode = #pto.fmatrix_mode<b_manual>}
+      : !pto.conv_tile<mat, 1x1x1x1x16xf16>
+    pto.set_img2col_padding %cfg {fmatrixMode = #pto.fmatrix_mode<b_manual>}
+      : !pto.conv_tile<mat, 1x1x1x1x16xf16>
+    pto.timg2col %dst, %cfg {fmatrixMode = #pto.fmatrix_mode<b_auto>}
+      : !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>,
+        !pto.conv_tile<mat, 1x1x1x1x16xf16>
+    return
+  }
+
+  func.func @fmatrix_mode_a_auto(
+      %cfg: !pto.conv_tile<mat, 1x1x1x1x16xf16>,
+      %dst: !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>) {
+    pto.timg2col %dst, %cfg {fmatrixMode = #pto.fmatrix_mode<a_auto>}
+      : !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>,
+        !pto.conv_tile<mat, 1x1x1x1x16xf16>
+    return
+  }
+}
+
+// CHECK-LABEL: fmatrix_mode_default
+// CHECK: SETFMATRIX(
+// CHECK: SET_IMG2COL_RPT(
+// CHECK: SET_IMG2COL_PADDING(
+// CHECK: TIMG2COL(
+
+// CHECK-LABEL: fmatrix_mode_b
+// CHECK: SETFMATRIX<pto::SetFmatrixMode::FMATRIX_B_MANUAL>
+// CHECK: SET_IMG2COL_RPT<pto::SetFmatrixMode::FMATRIX_B_MANUAL>
+// CHECK: SET_IMG2COL_PADDING<pto::SetFmatrixMode::FMATRIX_B_MANUAL>
+// CHECK: TIMG2COL<pto::SetFmatrixMode::FMATRIX_B_AUTO>
+
+// CHECK-LABEL: fmatrix_mode_a_auto
+// CHECK: TIMG2COL<pto::SetFmatrixMode::FMATRIX_A_AUTO>

--- a/test/lit/pto/fmatrix_mode_invalid_dst_layout.pto
+++ b/test/lit/pto/fmatrix_mode_invalid_dst_layout.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @invalid_timg2col_dst_layout(
+      %src: !pto.conv_tile<mat, 1x1x1x1x16xf16>,
+      %dst: !pto.tile_buf<left, 16x16xf16, blayout=row_major, slayout=none_box, fractal=512>) {
+    // CHECK: expects dst layout to be BLayout=col_major and SLayout=row_major
+    pto.timg2col %dst, %src
+      : !pto.tile_buf<left, 16x16xf16, blayout=row_major, slayout=none_box, fractal=512>,
+        !pto.conv_tile<mat, 1x1x1x1x16xf16>
+    return
+  }
+}

--- a/test/lit/pto/fmatrix_mode_invalid_set.pto
+++ b/test/lit/pto/fmatrix_mode_invalid_set.pto
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @invalid_set_mode(
+      %cfg: !pto.conv_tile<mat, 1x1x1x1x16xf16>) {
+    // CHECK: expects fmatrix_mode to be a_manual or b_manual
+    pto.set_fmatrix %cfg {fmatrixMode = #pto.fmatrix_mode<a_auto>}
+      : !pto.conv_tile<mat, 1x1x1x1x16xf16>
+    return
+  }
+}

--- a/test/lit/pto/fmatrix_mode_invalid_src_layout.pto
+++ b/test/lit/pto/fmatrix_mode_invalid_src_layout.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @invalid_timg2col_src_layout(
+      %src: !pto.conv_tile<mat, 1x1x1x1x16xf16, layout=#pto.layout<nchw>>,
+      %dst: !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>) {
+    // CHECK: expects src layout to be NC1HWC0 or NDC1HWC0
+    pto.timg2col %dst, %src
+      : !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>,
+        !pto.conv_tile<mat, 1x1x1x1x16xf16, layout=#pto.layout<nchw>>
+    return
+  }
+}

--- a/test/lit/pto/timg2col_alloc_conv_tile_emitc.pto
+++ b/test/lit/pto/timg2col_alloc_conv_tile_emitc.pto
@@ -3,21 +3,23 @@
 // CANN Open Software License Agreement Version 2.0 (the "License").
 // Please refer to the License for details. You may not use this file except in compliance with the License.
 // THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-module attributes {pto.target_arch = "a5"} {
-  func.func @timg2col_sample(
-      %src: !pto.conv_tile<
-          mat, 1x1x3x4x8xf32,
-          config=#pto.conv_tile_config<
-            fmap_h=3, fmap_w=4, pad_list=1x0x1x0,
-            filter_h=2, filter_w=2, dilation_h=1, dilation_w=1,
-            stride_h=1, stride_w=1, pad_value=0 : i32,
-            channel_size=8, repeat_stride=0, repeat_time=1,
-            repeat_mode=0, dst_stride=1, dst_mposition=0,
-            transpose=false>>,
+// RUN: ptoas --pto-arch=a5 %s -o - | FileCheck %s
+
+module {
+  func.func @timg2col_alloc_conv_tile_emitc(
       %dst: !pto.tile_buf<left, 16x32xf32, valid=9x32, blayout=col_major, slayout=row_major, fractal=512>) {
+    %src = pto.alloc_tile : !pto.conv_tile<
+        mat, 1x1x3x4x8xf32,
+        config=#pto.conv_tile_config<
+          fmap_h=3, fmap_w=4, pad_list=1x0x1x0,
+          filter_h=2, filter_w=2, dilation_h=1, dilation_w=1,
+          stride_h=1, stride_w=1, pad_value=0 : i32,
+          channel_size=8, repeat_stride=0, repeat_time=1,
+          repeat_mode=0, dst_stride=1, dst_mposition=0,
+          transpose=false>>
     pto.set_fmatrix %src {fmatrixMode = #pto.fmatrix_mode<b_manual>}
       : !pto.conv_tile<
           mat, 1x1x3x4x8xf32,
@@ -63,3 +65,10 @@ module attributes {pto.target_arch = "a5"} {
     return
   }
 }
+
+// CHECK-LABEL: timg2col_alloc_conv_tile_emitc(
+// CHECK: PTOAS__INIT_CONVTILE_CONFIG(
+// CHECK: SETFMATRIX<pto::SetFmatrixMode::FMATRIX_B_MANUAL>
+// CHECK: SET_IMG2COL_RPT<pto::SetFmatrixMode::FMATRIX_B_MANUAL>
+// CHECK: SET_IMG2COL_PADDING<pto::SetFmatrixMode::FMATRIX_B_MANUAL>
+// CHECK: TIMG2COL<pto::SetFmatrixMode::FMATRIX_B_MANUAL>

--- a/test/lit/pto/timg2col_invalid_pos.pto
+++ b/test/lit/pto/timg2col_invalid_pos.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @timg2col_invalid_pos(
+      %src: !pto.conv_tile<mat, 1x1x3x4x8xf16>,
+      %dst: !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>) {
+    // CHECK: expects posM to fit in an unsigned 16-bit integer
+    pto.timg2col %dst, %src {posM = 65536 : i32}
+      : !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>,
+        !pto.conv_tile<mat, 1x1x3x4x8xf16>
+    return
+  }
+}

--- a/test/lit/pto/timg2col_memory_effects.pto
+++ b/test/lit/pto/timg2col_memory_effects.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --enable-insert-sync --emit-pto-ir %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @timg2col_memory_effects(
+      %src: !pto.conv_tile<mat, 1x1x3x4x8xf16>,
+      %dst: !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>) {
+    pto.timg2col %dst, %src
+      : !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>,
+        !pto.conv_tile<mat, 1x1x3x4x8xf16>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @timg2col_memory_effects
+// CHECK: pto.timg2col

--- a/test/lit/pto/timg2col_pos_offsets.pto
+++ b/test/lit/pto/timg2col_pos_offsets.pto
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 %s -o - | FileCheck %s
+
+module {
+  func.func @timg2col_pos_offsets(
+      %src: !pto.conv_tile<mat, 1x1x3x4x8xf16>,
+      %dst: !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>) {
+    pto.timg2col %dst, %src {posM = 1 : i32, posK = 8 : i32}
+      : !pto.tile_buf<left, 16x16xf16, blayout=col_major, slayout=row_major, fractal=512>,
+        !pto.conv_tile<mat, 1x1x3x4x8xf16>
+    return
+  }
+}
+
+// CHECK-LABEL: timg2col_pos_offsets(
+// CHECK: const uint16_t {{.*}} = 1;
+// CHECK: const uint16_t {{.*}} = 8;
+// CHECK: TIMG2COL(

--- a/test/samples/Img2col/timg2col-pto.pto
+++ b/test/samples/Img2col/timg2col-pto.pto
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @timg2col_sample(
+      %src: !pto.conv_tile<
+          mat, 1x1x3x4x8xf32,
+          config=#pto.conv_tile_config<
+            fmap_h=3, fmap_w=4, pad_list=1x0x1x0,
+            filter_h=2, filter_w=2, dilation_h=1, dilation_w=1,
+            stride_h=1, stride_w=1, pad_value=0 : i32,
+            channel_size=8, repeat_stride=0, repeat_time=1,
+            repeat_mode=0, dst_stride=1, dst_mposition=0,
+            transpose=false>>,
+      %dst: !pto.tile_buf<left, 16x32xf32, valid=9x32, blayout=col_major, slayout=row_major, fractal=512>) {
+    pto.set_fmatrix %src {fmatrix_mode = #pto.fmatrix_mode<b_manual>}
+      : !pto.conv_tile<
+          mat, 1x1x3x4x8xf32,
+          config=#pto.conv_tile_config<
+            fmap_h=3, fmap_w=4, pad_list=1x0x1x0,
+            filter_h=2, filter_w=2, dilation_h=1, dilation_w=1,
+            stride_h=1, stride_w=1, pad_value=0 : i32,
+            channel_size=8, repeat_stride=0, repeat_time=1,
+            repeat_mode=0, dst_stride=1, dst_mposition=0,
+            transpose=false>>
+    pto.set_img2col_rpt %src {fmatrix_mode = #pto.fmatrix_mode<b_manual>}
+      : !pto.conv_tile<
+          mat, 1x1x3x4x8xf32,
+          config=#pto.conv_tile_config<
+            fmap_h=3, fmap_w=4, pad_list=1x0x1x0,
+            filter_h=2, filter_w=2, dilation_h=1, dilation_w=1,
+            stride_h=1, stride_w=1, pad_value=0 : i32,
+            channel_size=8, repeat_stride=0, repeat_time=1,
+            repeat_mode=0, dst_stride=1, dst_mposition=0,
+            transpose=false>>
+    pto.set_img2col_padding %src {fmatrix_mode = #pto.fmatrix_mode<b_manual>}
+      : !pto.conv_tile<
+          mat, 1x1x3x4x8xf32,
+          config=#pto.conv_tile_config<
+            fmap_h=3, fmap_w=4, pad_list=1x0x1x0,
+            filter_h=2, filter_w=2, dilation_h=1, dilation_w=1,
+            stride_h=1, stride_w=1, pad_value=0 : i32,
+            channel_size=8, repeat_stride=0, repeat_time=1,
+            repeat_mode=0, dst_stride=1, dst_mposition=0,
+            transpose=false>>
+    pto.timg2col %dst, %src {posM = 1 : i32, posK = 8 : i32,
+                             fmatrix_mode = #pto.fmatrix_mode<b_manual>}
+      : !pto.tile_buf<left, 16x32xf32, valid=9x32, blayout=col_major, slayout=row_major, fractal=512>,
+        !pto.conv_tile<
+            mat, 1x1x3x4x8xf32,
+            config=#pto.conv_tile_config<
+              fmap_h=3, fmap_w=4, pad_list=1x0x1x0,
+              filter_h=2, filter_w=2, dilation_h=1, dilation_w=1,
+              stride_h=1, stride_w=1, pad_value=0 : i32,
+              channel_size=8, repeat_stride=0, repeat_time=1,
+              repeat_mode=0, dst_stride=1, dst_mposition=0,
+              transpose=false>>
+    return
+  }
+}

--- a/test/samples/Img2col/timg2col-pto.pto
+++ b/test/samples/Img2col/timg2col-pto.pto
@@ -3,6 +3,7 @@
 // CANN Open Software License Agreement Version 2.0 (the "License").
 // Please refer to the License for details. You may not use this file except in compliance with the License.
 // THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
 module attributes {pto.target_arch = "a5"} {

--- a/test/samples/Img2col/timg2col_runtime.py
+++ b/test/samples/Img2col/timg2col_runtime.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. Please ensure you do not use this file except in compliance with the
+# License. THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+
+from ptoas.mlir.dialects import arith, func, pto
+from ptoas.mlir.ir import (
+    BoolAttr,
+    Context,
+    F32Type,
+    InsertionPoint,
+    IndexType,
+    IntegerAttr,
+    IntegerType,
+    Location,
+    Module,
+    StringAttr,
+    UnitAttr,
+)
+
+
+def build():
+    with Context() as ctx:
+        pto.register_dialect(ctx, load=True)
+        with Location.unknown(ctx):
+            module = Module.create()
+            arch = os.environ.get("PTOAS_SAMPLE_ARCH", "a5")
+            module.operation.attributes["pto.target_arch"] = StringAttr.get(arch)
+
+            f32 = F32Type.get(ctx)
+            i32 = IntegerType.get_signless(32, ctx)
+            i64 = IntegerType.get_signless(64, ctx)
+
+            ptr_f32 = pto.PtrType.get(f32, ctx)
+            tv5_f32 = pto.TensorViewType.get(5, f32, ctx)
+            src_ptv = pto.PartitionTensorViewType.get([1, 1, 3, 4, 8], f32, ctx)
+            dst_tv = pto.TensorViewType.get(2, f32, ctx)
+            dst_ptv = pto.PartitionTensorViewType.get([16, 32], f32, ctx)
+
+            vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
+            left = pto.AddressSpaceAttr.get(pto.AddressSpace.LEFT, ctx)
+            mat = pto.AddressSpaceAttr.get(pto.AddressSpace.MAT, ctx)
+            layout = pto.LayoutAttr.get(pto.Layout.NC1HWC0, ctx)
+            col_major = pto.BLayoutAttr.get(pto.BLayout.ColMajor, ctx)
+            row_box = pto.SLayoutAttr.get(pto.SLayout.RowMajor, ctx)
+            null_pad = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+            tile_cfg = pto.TileBufConfigAttr.get(
+                col_major,
+                row_box,
+                pto.TileConfig.fractalABSize,
+                null_pad,
+                ctx,
+            )
+            dst_tile_ty = pto.TileBufType.get([16, 32], f32, left, [9, 32], tile_cfg, ctx)
+
+            conv_cfg = pto.ConvTileConfigAttr.get(
+                IntegerAttr.get(i32, 3),
+                IntegerAttr.get(i32, 4),
+                [1, 0, 1, 0],
+                IntegerAttr.get(i32, 2),
+                IntegerAttr.get(i32, 2),
+                IntegerAttr.get(i32, 1),
+                IntegerAttr.get(i32, 1),
+                IntegerAttr.get(i32, 1),
+                IntegerAttr.get(i32, 1),
+                IntegerAttr.get(i32, 0),
+                IntegerAttr.get(i32, 8),
+                IntegerAttr.get(i32, 0),
+                IntegerAttr.get(i32, 1),
+                IntegerAttr.get(i32, 0),
+                IntegerAttr.get(i32, 1),
+                IntegerAttr.get(i32, 0),
+                BoolAttr.get(False),
+            )
+            src_tile_ty = pto.ConvTileType.get(
+                [1, 1, 3, 4, 8],
+                f32,
+                IntegerAttr.get(i64, 1 * 1 * 3 * 4 * 8),
+                mat,
+                layout,
+                conv_cfg,
+                ctx,
+            )
+
+            fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
+            with InsertionPoint(module.body):
+                fn = func.FuncOp("timg2col_runtime_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
+                entry = fn.add_entry_block()
+
+            with InsertionPoint(entry):
+                c0 = arith.ConstantOp(IndexType.get(ctx), 0).result
+                c1 = arith.ConstantOp(IndexType.get(ctx), 1).result
+                c3 = arith.ConstantOp(IndexType.get(ctx), 3).result
+                c4 = arith.ConstantOp(IndexType.get(ctx), 4).result
+                c8 = arith.ConstantOp(IndexType.get(ctx), 8).result
+                c16 = arith.ConstantOp(IndexType.get(ctx), 16).result
+                c32 = arith.ConstantOp(IndexType.get(ctx), 32).result
+                c96 = arith.ConstantOp(IndexType.get(ctx), 96).result
+                src_ptr, dst_ptr = entry.arguments
+
+                src_view = pto.MakeTensorViewOp(
+                    tv5_f32, src_ptr, [c1, c1, c3, c4, c8], [c96, c96, c32, c8, c1]
+                ).result
+                dst_view = pto.MakeTensorViewOp(
+                    dst_tv, dst_ptr, [c16, c32], [c32, c1]
+                ).result
+
+                src_part = pto.PartitionViewOp(
+                    src_ptv,
+                    src_view,
+                    offsets=[c0, c0, c0, c0, c0],
+                    sizes=[c1, c1, c3, c4, c8],
+                ).result
+                dst_part = pto.PartitionViewOp(
+                    dst_ptv, dst_view, offsets=[c0, c0], sizes=[c16, c32]
+                ).result
+
+                src_tile = pto.AllocTileOp(src_tile_ty).result
+                dst_tile = pto.AllocTileOp(dst_tile_ty).result
+                pto.TLoadOp(None, src_part, src_tile)
+                pto.SetFmatrixOp(src_tile, pto.FmatrixModeAttr.get(pto.FmatrixMode.FMATRIX_B_MANUAL, ctx))
+                pto.SetImg2colRptOp(src_tile, pto.FmatrixModeAttr.get(pto.FmatrixMode.FMATRIX_B_MANUAL, ctx))
+                pto.SetImg2colPaddingOp(src_tile, pto.FmatrixModeAttr.get(pto.FmatrixMode.FMATRIX_B_MANUAL, ctx))
+                pto.TImg2colOp(
+                    dst_tile,
+                    src_tile,
+                    posM=1,
+                    posK=8,
+                    fmatrixMode=pto.FmatrixModeAttr.get(pto.FmatrixMode.FMATRIX_B_MANUAL, ctx),
+                )
+                pto.TStoreOp(None, dst_tile, dst_part)
+                func.ReturnOp([])
+
+            module.operation.verify()
+            return module
+
+
+if __name__ == "__main__":
+    print(build())

--- a/test/samples/Img2col/timg2col_runtime.py
+++ b/test/samples/Img2col/timg2col_runtime.py
@@ -2,9 +2,9 @@
 # Copyright (c) 2026 Huawei Technologies Co., Ltd.
 # This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 # CANN Open Software License Agreement Version 2.0 (the "License").
-# Please refer to the License for details. Please ensure you do not use this file except in compliance with the
-# License. THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
-# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
 import os

--- a/test/samples/Img2col/timg2col_runtime.py
+++ b/test/samples/Img2col/timg2col_runtime.py
@@ -40,8 +40,6 @@ def build():
             ptr_f32 = pto.PtrType.get(f32, ctx)
             tv5_f32 = pto.TensorViewType.get(5, f32, ctx)
             src_ptv = pto.PartitionTensorViewType.get([1, 1, 3, 4, 8], f32, ctx)
-            dst_tv = pto.TensorViewType.get(2, f32, ctx)
-            dst_ptv = pto.PartitionTensorViewType.get([16, 32], f32, ctx)
 
             vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
             left = pto.AddressSpaceAttr.get(pto.AddressSpace.LEFT, ctx)
@@ -88,7 +86,7 @@ def build():
                 ctx,
             )
 
-            fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
+            fn_ty = func.FunctionType.get([ptr_f32], [])
             with InsertionPoint(module.body):
                 fn = func.FuncOp("timg2col_runtime_kernel", fn_ty)
                 fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
@@ -100,16 +98,12 @@ def build():
                 c3 = arith.ConstantOp(IndexType.get(ctx), 3).result
                 c4 = arith.ConstantOp(IndexType.get(ctx), 4).result
                 c8 = arith.ConstantOp(IndexType.get(ctx), 8).result
-                c16 = arith.ConstantOp(IndexType.get(ctx), 16).result
                 c32 = arith.ConstantOp(IndexType.get(ctx), 32).result
                 c96 = arith.ConstantOp(IndexType.get(ctx), 96).result
-                src_ptr, dst_ptr = entry.arguments
+                src_ptr = entry.arguments[0]
 
                 src_view = pto.MakeTensorViewOp(
                     tv5_f32, src_ptr, [c1, c1, c3, c4, c8], [c96, c96, c32, c8, c1]
-                ).result
-                dst_view = pto.MakeTensorViewOp(
-                    dst_tv, dst_ptr, [c16, c32], [c32, c1]
                 ).result
 
                 src_part = pto.PartitionViewOp(
@@ -118,24 +112,25 @@ def build():
                     offsets=[c0, c0, c0, c0, c0],
                     sizes=[c1, c1, c3, c4, c8],
                 ).result
-                dst_part = pto.PartitionViewOp(
-                    dst_ptv, dst_view, offsets=[c0, c0], sizes=[c16, c32]
-                ).result
 
                 src_tile = pto.AllocTileOp(src_tile_ty).result
                 dst_tile = pto.AllocTileOp(dst_tile_ty).result
-                pto.TLoadOp(None, src_part, src_tile)
-                pto.SetFmatrixOp(src_tile, pto.FmatrixModeAttr.get(pto.FmatrixMode.FMATRIX_B_MANUAL, ctx))
-                pto.SetImg2colRptOp(src_tile, pto.FmatrixModeAttr.get(pto.FmatrixMode.FMATRIX_B_MANUAL, ctx))
-                pto.SetImg2colPaddingOp(src_tile, pto.FmatrixModeAttr.get(pto.FmatrixMode.FMATRIX_B_MANUAL, ctx))
-                pto.TImg2colOp(
-                    dst_tile,
-                    src_tile,
-                    posM=1,
-                    posK=8,
-                    fmatrixMode=pto.FmatrixModeAttr.get(pto.FmatrixMode.FMATRIX_B_MANUAL, ctx),
-                )
-                pto.TStoreOp(None, dst_tile, dst_part)
+                cube_section = pto.SectionCubeOp()
+                with InsertionPoint(cube_section.body.blocks.append()):
+                    fmatrix_mode = pto.FmatrixModeAttr.get(
+                        pto.FmatrixMode.FMATRIX_B_MANUAL, ctx
+                    )
+                    pto.TLoadOp(None, src_part, src_tile)
+                    pto.SetFmatrixOp(src_tile, fmatrixMode=fmatrix_mode)
+                    pto.SetImg2colRptOp(src_tile, fmatrixMode=fmatrix_mode)
+                    pto.SetImg2colPaddingOp(src_tile, fmatrixMode=fmatrix_mode)
+                    pto.TImg2colOp(
+                        dst_tile,
+                        src_tile,
+                        posM=1,
+                        posK=8,
+                        fmatrixMode=fmatrix_mode,
+                    )
                 func.ReturnOp([])
 
             module.operation.verify()

--- a/test/samples/Img2col/timg2col_runtime_compare.py
+++ b/test/samples/Img2col/timg2col_runtime_compare.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. Please ensure you do not use this file except in compliance with the
+# License. THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+for search_root in (Path(__file__).resolve().parent, Path(__file__).resolve().parents[1]):
+    if (search_root / "validation_runtime.py").is_file():
+        sys.path.insert(0, str(search_root))
+        break
+
+from validation_runtime import compare_outputs
+
+
+if __name__ == "__main__":
+    compare_outputs(np.float32, atol=0.001)

--- a/test/samples/Img2col/timg2col_runtime_compare.py
+++ b/test/samples/Img2col/timg2col_runtime_compare.py
@@ -2,9 +2,9 @@
 # Copyright (c) 2026 Huawei Technologies Co., Ltd.
 # This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 # CANN Open Software License Agreement Version 2.0 (the "License").
-# Please refer to the License for details. Please ensure you do not use this file except in compliance with the
-# License. THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
-# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from pathlib import Path

--- a/test/samples/Img2col/timg2col_runtime_golden.py
+++ b/test/samples/Img2col/timg2col_runtime_golden.py
@@ -2,9 +2,9 @@
 # Copyright (c) 2026 Huawei Technologies Co., Ltd.
 # This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 # CANN Open Software License Agreement Version 2.0 (the "License").
-# Please refer to the License for details. Please ensure you do not use this file except in compliance with the
-# License. THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
-# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from pathlib import Path

--- a/test/samples/Img2col/timg2col_runtime_golden.py
+++ b/test/samples/Img2col/timg2col_runtime_golden.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. Please ensure you do not use this file except in compliance with the
+# License. THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+for search_root in (Path(__file__).resolve().parent, Path(__file__).resolve().parents[1]):
+    if (search_root / "validation_runtime.py").is_file():
+        sys.path.insert(0, str(search_root))
+        break
+
+from validation_runtime import default_buffers, float_values, load_case_meta, rng, write_buffers, write_golden
+
+
+def _src_offset(n: int, c1: int, h: int, w: int, c0: int, *, c1_size: int, h_size: int, w_size: int, c0_size: int) -> int:
+    return (((n * c1_size + c1) * h_size + h) * w_size + w) * c0_size + c0
+
+
+def main():
+    meta = load_case_meta()
+    src_name, dst_name = meta.inputs
+    generator = rng()
+    src = np.asarray(float_values(generator, meta.elem_counts[src_name], style="signed"), dtype=np.float32)
+    src = src.reshape(1, 1, 3, 4, 8)
+
+    fmap_h = 3
+    fmap_w = 4
+    c0_size = 8
+    filter_h = 2
+    filter_w = 2
+    stride_h = 1
+    stride_w = 1
+    dilation_h = 1
+    dilation_w = 1
+    pad_left = 1
+    pad_right = 0
+    pad_top = 1
+    pad_bottom = 0
+    pos_m = 1
+    pos_k = 8
+    valid_rows = 9
+    valid_cols = 32
+    pad_value = np.float32(0.0)
+
+    out_h = (fmap_h + pad_top + pad_bottom - dilation_h * (filter_h - 1) - 1) // stride_h + 1
+    out_w = (fmap_w + pad_left + pad_right - dilation_w * (filter_w - 1) - 1) // stride_w + 1
+    assert pos_m + valid_rows <= out_h * out_w
+    golden = np.zeros((16, 32), dtype=np.float32)
+
+    for row in range(valid_rows):
+        m = pos_m + row
+        out_row = m // out_w
+        out_col = m % out_w
+        for col in range(valid_cols):
+            k = pos_k + col
+            c1 = k // (c0_size * filter_h * filter_w)
+            kernel_offset = (k % (c0_size * filter_h * filter_w)) // c0_size
+            c0 = k % c0_size
+            kernel_h = kernel_offset // filter_w
+            kernel_w = kernel_offset % filter_w
+            input_h = out_row * stride_h + kernel_h * dilation_h - pad_top
+            input_w = out_col * stride_w + kernel_w * dilation_w - pad_left
+            value = pad_value
+            if 0 <= input_h < fmap_h and 0 <= input_w < fmap_w and c1 < 1:
+                value = src[
+                    _src_offset(
+                        0,
+                        c1,
+                        input_h,
+                        input_w,
+                        c0,
+                        c1_size=1,
+                        h_size=fmap_h,
+                        w_size=fmap_w,
+                        c0_size=c0_size,
+                    )
+                ]
+            golden[row, col] = value
+
+    buffers = default_buffers(meta)
+    buffers[src_name] = src.reshape(-1)
+    write_buffers(meta, buffers)
+    write_golden(meta, {dst_name: golden.reshape(-1)})
+
+
+if __name__ == "__main__":
+    main()

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -35,7 +35,9 @@ for model_path in "${BASE_DIR}"/Qwen* "${BASE_DIR}"/Deepseek*; do
       ;;
   esac
 done
-PTO_PTO_DIRS="${PTO_PTO_DIRS:-Sync${MODEL_PTO_DIRS} CommSync Prelu Rem Rems Gemvmx MatmulMxLowPrecision TquantMx TquantMxDn Movfp Interleave DeInterleave PairReduceSum}"
+PTO_PTO_DIRS="${PTO_PTO_DIRS:-Sync${MODEL_PTO_DIRS} CommSync Img2col \
+Prelu Rem Rems Gemvmx MatmulMxLowPrecision TquantMx TquantMxDn Movfp \
+Interleave DeInterleave PairReduceSum}"
 ENABLE_BC=0
 
 usage() {
@@ -82,7 +84,7 @@ sample_dir_arch() {
   case "$1" in
     TPipe|TAxpy|TColArgMax|TColArgMin|TConcatIdx|\
       TRowArgMax|TRowArgMin|Qwen*A3|Deepseek*A3) printf 'a3\n' ;;
-    Qwen*A5|Deepseek*A5|TquantMx|TquantMxDn|Interleave|DeInterleave|PairReduceSum) printf 'a5\n' ;;
+    Qwen*A5|Deepseek*A5|Img2col|TquantMx|TquantMxDn|Interleave|DeInterleave|PairReduceSum) printf 'a5\n' ;;
   esac
 }
 


### PR DESCRIPTION
  ConvTile：
      独立 ConvTileType
      复用地址、地址空间、内存规划框架
      复用 AllocTileOp、TASSIGN、TLOAD 的操作壳
      在 EmitC 中生成 PTO-ISA ConvTile 类型
      暂时只承诺 EmitC 后端支持

| 项目 | 原有 Tile | 新增 ConvTile |
| --- | --- | --- |
| PTOAS IR 类型 | TileBufType | ConvTileType |
| MLIR 类型语法 | !pto.tile_buf<...> | !pto.conv_tile<...> |
| 主要用途 | 普通二维 Tile buffer | 卷积相关硬件 Tile buffer |
| 逻辑 shape | 固定二维，例如 32x32 | 卷积维度，可为 1 到 6 维 |
| 存储容量计算 | shape[0] * shape[1] * sizeof(dtype) | bufferSize * sizeof(dtype) |
| layout 表达 | BLayout + SLayout | 独立的 ConvLayoutAttr |
| valid shape | 有 valid_row、valid_col | 当前不使用普通 Tile 的 valid shape |
| 地址空间 | vec、mat、left、right、acc 等 | 复用相同的 PTO address space |
| 内存规划 | 已有成熟路径 | 已接入，按照 bufferSize 计算 |
| AllocTileOp | 原有支持 | 已支持 |
| TLOAD | 普通 PartitionTensorView -> TileBuf | 当前支持 PartitionTensorView -> ConvTile |
| TASSIGN | 已支持 | 已支持 |
| TLOAD EmitC | 生成 TLOAD(tile, global_tensor) | 同样生成 TLOAD(conv_tile, global_tensor) |
| EmitC 类型 | PTO-ISA Tile<...> | PTO-ISA ConvTile<...> |
| VPTO 后端 | 已有原有 Tile 路径 | 当前没有完整 ConvTile VPTO lowering |


未修改comment：
https://github.com/and0d0/PTOAS/pull/13(查看comment)