### PR TITLE
fix(ptodsl): preserve signless integer literals in arithmetic

### DIFF
--- a/ptodsl/ptodsl/_types.py
+++ b/ptodsl/ptodsl/_types.py
@@ -428,9 +428,15 @@ def _materialize_integer_literal(target_type, value):
     signless_type = _signless_integer_type(target_type)
     raw_value = _parse_integer_value(value, target_type=target_type)
     constant = arith.ConstantOp(signless_type, raw_value).result
-    if target_type == signless_type:
-        return constant
-    return _restore_integer_signedness(constant, target_type)
+    # Keep integer literals signless in the builtin arithmetic dialect.  A
+    # signed ``siN`` target is an authored PTODSL type, but MLIR integer
+    # constants are signless and arithmetic ops canonicalize their operands
+    # to that type.  Restoring signedness here creates a conversion cast which
+    # can be printed with the wrong source annotation (``siN to iN``), yielding
+    # invalid SSA and PTOAS parse failures.  Consumers that require an
+    # explicitly signed value can still call ``_restore_integer_signedness``
+    # at the operation boundary.
+    return constant
 
 
 def _parse_integer_value(value, *, target_type=None):


### PR DESCRIPTION
Fixes #1405.

## Problem
When a signed runtime scalar such as `pto.si32` is combined with a Python integer literal, PTODSL materializes the literal as signless `i32` and then incorrectly restores it to `si32`. The generated conversion can be printed with a mismatched source type (`si32 to i32` for an `i32` operand), producing invalid SSA and causing PTOAS to reject the module (`si32` vs `i32`).

## Change
Keep integer literals as signless `iN` values in `_materialize_integer_literal`. Consumers that require authored signedness can still call `_restore_integer_signedness` at the operation boundary.

## Validation
The failure was reproduced with TileLang `229e194466fae98073cf6f65ecde2aafa79095e5`, PTOAS `cc519bc92db7`, A5 `vpto` lowering, and `(num_tokens + 3) // 4` in a multi-core top-k kernel. The patch removes the malformed literal conversion; full CI should exercise existing PTODSL integer and VMI tests.