### PR TITLE
fix(vmi): propagate layouts through integer negation

### DIFF
--- a/lib/PTO/Transforms/VMILayoutPropagation.cpp
+++ b/lib/PTO/Transforms/VMILayoutPropagation.cpp
@@ -199,10 +199,11 @@ static bool isSameLayoutOp(Operation *op) {
   return isa<VMIAddFOp, VMIAddIOp, VMISubFOp, VMISubIOp, VMIMulFOp, VMIMulIOp,
              VMIVaddcOp, VMIVaddcsOp, VMIAddSOp, VMIMulSOp, VMIMaxSOp,
              VMIMinSOp, VMIShlSOp, VMIShrSOp, VMIVmullOp, VMIFmaOp, VMIDivFOp,
-             VMIMinFOp, VMIMinIOp, VMIMaxFOp, VMIMaxIOp, VMINegFOp, VMIAbsFOp,
-             VMIAbsIOp, VMISqrtOp, VMIExpOp, VMILnOp, VMIReluOp, VMIFPToSIOp,
-             VMISIToFPOp, VMIAndIOp, VMIOrIOp, VMIXOrIOp, VMIShLIOp, VMIShRUIOp,
-             VMIShRSIOp, VMINotOp, VMICmpFOp, VMICmpIOp, VMISelectOp,
+             VMIMinFOp, VMIMinIOp, VMIMaxFOp, VMIMaxIOp, VMINegFOp, VMINegIOp,
+             VMIAbsFOp, VMIAbsIOp, VMISqrtOp, VMIExpOp, VMILnOp, VMIReluOp,
+             VMIFPToSIOp, VMISIToFPOp, VMIAndIOp, VMIOrIOp, VMIXOrIOp,
+             VMIShLIOp, VMIShRUIOp, VMIShRSIOp, VMINotOp, VMICmpFOp, VMICmpIOp,
+             VMISelectOp,
              VMIMaskAndOp, VMIMaskOrOp, VMIMaskXOrOp, VMIMaskNotOp,
              VMIActivePrefixIndexOp, VMICompressOp, VMIExpandLoadOp>(op);
 }

--- a/test/lit/vmi_new/vmi_ptoas_cli_integer_vneg_layout.pto
+++ b/test/lit/vmi_new/vmi_ptoas_cli_integer_vneg_layout.pto
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -pto-validate-vmi-layout-ir | FileCheck %s --check-prefix=ASSIGN
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s --check-prefix=EMIT --implicit-check-not=pto.vmi. --implicit-check-not='!pto.vmi.' --implicit-check-not=unrealized_conversion_cast
+
+// Regression coverage for the integer non-mask cases from issue #1373. The
+// production pipeline lowers vneg to negi before layout assignment. The negi
+// source/result relation must propagate the load layout through to the store
+// instead of assigning the two ports incompatible layouts.
+//
+// The ASSIGN run is the primary regression: it stops right after layout
+// assignment, so it isolates the layout-propagation invariant from every later
+// stage. Each negi below is checked to carry the *same, non-contiguous* layout
+// on both ports. Pinning the concrete layout matters -- a bare "negi exists"
+// check would keep passing if a future change collapsed these cases to plain
+// contiguous, silently retiring the coverage this test exists to provide.
+//
+// The EMIT run additionally proves the whole pipeline completes. It needs the
+// dynamic memory accesses to be provably 32-byte aligned, otherwise physical
+// read legalization fails first and masks the layout regression; the ASSIGN run
+// has no such prerequisite.
+module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.backend = "vpto", pto.kernel_kind = #pto.kernel_kind<vector>} {
+    func.func @vneg_i8_vl1(
+        %src: !pto.ptr<i8, ub>, %dst: !pto.ptr<i8, ub>, %offset: index) {
+      %c32 = arith.constant 32 : index
+      %aligned_offset = arith.muli %offset, %c32 : index
+      %value = pto.vmi.vload %src[%aligned_offset]
+          : !pto.ptr<i8, ub> -> !pto.vmi.vreg<1xi8>
+      %result = pto.vmi.vneg %value
+          : !pto.vmi.vreg<1xi8> -> !pto.vmi.vreg<1xi8>
+      pto.vmi.vstore %result, %dst[%aligned_offset]
+          : !pto.vmi.vreg<1xi8>, !pto.ptr<i8, ub>
+      return
+    }
+
+    func.func @vneg_i8_vl64(
+        %src: !pto.ptr<i8, ub>, %dst: !pto.ptr<i8, ub>, %offset: index) {
+      %c32 = arith.constant 32 : index
+      %aligned_offset = arith.muli %offset, %c32 : index
+      %value = pto.vmi.vload %src[%aligned_offset]
+          : !pto.ptr<i8, ub> -> !pto.vmi.vreg<64xi8>
+      %result = pto.vmi.vneg %value
+          : !pto.vmi.vreg<64xi8> -> !pto.vmi.vreg<64xi8>
+      pto.vmi.vstore %result, %dst[%aligned_offset]
+          : !pto.vmi.vreg<64xi8>, !pto.ptr<i8, ub>
+      return
+    }
+
+    func.func @vneg_i8_vl128(
+        %src: !pto.ptr<i8, ub>, %dst: !pto.ptr<i8, ub>, %offset: index) {
+      %c32 = arith.constant 32 : index
+      %aligned_offset = arith.muli %offset, %c32 : index
+      %value = pto.vmi.vload %src[%aligned_offset]
+          : !pto.ptr<i8, ub> -> !pto.vmi.vreg<128xi8>
+      %result = pto.vmi.vneg %value
+          : !pto.vmi.vreg<128xi8> -> !pto.vmi.vreg<128xi8>
+      pto.vmi.vstore %result, %dst[%aligned_offset]
+          : !pto.vmi.vreg<128xi8>, !pto.ptr<i8, ub>
+      return
+    }
+
+    func.func @vneg_i16_vl1(
+        %src: !pto.ptr<i16, ub>, %dst: !pto.ptr<i16, ub>, %offset: index) {
+      %c16 = arith.constant 16 : index
+      %aligned_offset = arith.muli %offset, %c16 : index
+      %value = pto.vmi.vload %src[%aligned_offset]
+          : !pto.ptr<i16, ub> -> !pto.vmi.vreg<1xi16>
+      %result = pto.vmi.vneg %value
+          : !pto.vmi.vreg<1xi16> -> !pto.vmi.vreg<1xi16>
+      pto.vmi.vstore %result, %dst[%aligned_offset]
+          : !pto.vmi.vreg<1xi16>, !pto.ptr<i16, ub>
+      return
+    }
+
+    func.func @vneg_i16_vl64(
+        %src: !pto.ptr<i16, ub>, %dst: !pto.ptr<i16, ub>, %offset: index) {
+      %c16 = arith.constant 16 : index
+      %aligned_offset = arith.muli %offset, %c16 : index
+      %value = pto.vmi.vload %src[%aligned_offset]
+          : !pto.ptr<i16, ub> -> !pto.vmi.vreg<64xi16>
+      %result = pto.vmi.vneg %value
+          : !pto.vmi.vreg<64xi16> -> !pto.vmi.vreg<64xi16>
+      pto.vmi.vstore %result, %dst[%aligned_offset]
+          : !pto.vmi.vreg<64xi16>, !pto.ptr<i16, ub>
+      return
+    }
+
+    func.func @vneg_i32_vl1(
+        %src: !pto.ptr<i32, ub>, %dst: !pto.ptr<i32, ub>, %offset: index) {
+      %c8 = arith.constant 8 : index
+      %aligned_offset = arith.muli %offset, %c8 : index
+      %value = pto.vmi.vload %src[%aligned_offset]
+          : !pto.ptr<i32, ub> -> !pto.vmi.vreg<1xi32>
+      %result = pto.vmi.vneg %value
+          : !pto.vmi.vreg<1xi32> -> !pto.vmi.vreg<1xi32>
+      pto.vmi.vstore %result, %dst[%aligned_offset]
+          : !pto.vmi.vreg<1xi32>, !pto.ptr<i32, ub>
+      return
+    }
+  }
+}
+
+// Layout assignment must give both negi ports the identical layout that the
+// surrounding load/store pair uses. Before the fix each of these six negi ops
+// ended up with mismatched source/result layouts and tripped the VMI verifier.
+
+// ASSIGN-LABEL: func.func @vneg_i8_vl1(
+// ASSIGN: pto.vmi.negi
+// ASSIGN-SAME: !pto.vmi.vreg<1xi8, #pto.vmi.layout<num_groups = 1, slots = 8>>
+// ASSIGN-SAME: -> !pto.vmi.vreg<1xi8, #pto.vmi.layout<num_groups = 1, slots = 8>>
+
+// ASSIGN-LABEL: func.func @vneg_i8_vl64(
+// ASSIGN: pto.vmi.load
+// ASSIGN-SAME: -> !pto.vmi.vreg<64xi8, #pto.vmi.layout<contiguous, lane_stride = 4>>
+// ASSIGN: pto.vmi.negi
+// ASSIGN-SAME: !pto.vmi.vreg<64xi8, #pto.vmi.layout<contiguous, lane_stride = 4>>
+// ASSIGN-SAME: -> !pto.vmi.vreg<64xi8, #pto.vmi.layout<contiguous, lane_stride = 4>>
+// ASSIGN: pto.vmi.store
+// ASSIGN-SAME: !pto.vmi.vreg<64xi8, #pto.vmi.layout<contiguous, lane_stride = 4>>
+
+// ASSIGN-LABEL: func.func @vneg_i8_vl128(
+// ASSIGN: pto.vmi.negi
+// ASSIGN-SAME: !pto.vmi.vreg<128xi8, #pto.vmi.layout<contiguous, lane_stride = 2>>
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xi8, #pto.vmi.layout<contiguous, lane_stride = 2>>
+
+// ASSIGN-LABEL: func.func @vneg_i16_vl1(
+// ASSIGN: pto.vmi.negi
+// ASSIGN-SAME: !pto.vmi.vreg<1xi16, #pto.vmi.layout<num_groups = 1, slots = 8>>
+// ASSIGN-SAME: -> !pto.vmi.vreg<1xi16, #pto.vmi.layout<num_groups = 1, slots = 8>>
+
+// ASSIGN-LABEL: func.func @vneg_i16_vl64(
+// ASSIGN: pto.vmi.negi
+// ASSIGN-SAME: !pto.vmi.vreg<64xi16, #pto.vmi.layout<contiguous, lane_stride = 2>>
+// ASSIGN-SAME: -> !pto.vmi.vreg<64xi16, #pto.vmi.layout<contiguous, lane_stride = 2>>
+
+// ASSIGN-LABEL: func.func @vneg_i32_vl1(
+// ASSIGN: pto.vmi.negi
+// ASSIGN-SAME: !pto.vmi.vreg<1xi32, #pto.vmi.layout<num_groups = 1, slots = 8>>
+// ASSIGN-SAME: -> !pto.vmi.vreg<1xi32, #pto.vmi.layout<num_groups = 1, slots = 8>>
+
+// The residual-VMI guard is supplied by --implicit-check-not on the EMIT RUN
+// line so that it applies to the whole output rather than only to the region
+// following the last match.
+
+// EMIT-LABEL: func.func @vneg_i8_vl1(
+// EMIT: pto.vneg
+// EMIT-LABEL: func.func @vneg_i8_vl64(
+// EMIT: pto.vneg
+// EMIT-LABEL: func.func @vneg_i8_vl128(
+// EMIT: pto.vneg
+// EMIT-LABEL: func.func @vneg_i16_vl1(
+// EMIT: pto.vneg
+// EMIT-LABEL: func.func @vneg_i16_vl64(
+// EMIT: pto.vneg
+// EMIT-LABEL: func.func @vneg_i32_vl1(
+// EMIT: pto.vneg


### PR DESCRIPTION
## Summary
- treat `VMINegIOp` as a same-layout VMI op during layout propagation
- add regression coverage for the six integer non-mask `vneg` cases from #1373, at both the layout-assignment and full-pipeline levels

## Root cause

The unified integer `vneg` lowers to `pto.vmi.negi` before layout assignment (`ptoas_pipeline.cpp` runs `vmi-lower-unified-to-legacy` ahead of `vmi-layout-assignment`), but `VMINegIOp` was missing from `isSameLayoutOp` in `VMILayoutPropagation.cpp`.

`VMILayoutPropagator::propagateThrough` is fail-open: when no transfer is registered for an op it returns `success()` without recording any constraint. Propagation therefore had no edge between `negi`'s source and result, the two ports were assigned incompatible layouts independently, and the VMI verifier rejected the result:

```
'pto.vmi.negi' op requires all layout-assigned VMI data values to have the same layout
```

This also explains why the identical `vnot` code reported in the issue worked: `VMINotOp` was already in the list.

The constraint added here is exactly as strong as the op's own contract — `VMINegIOp::verify()` already calls `verifyAllSameVRegShapeAndLayout(..., requireSameElement=true)` — so it cannot over-constrain. It also restores consistency across the layout passes: `VMINegIOp` was already registered in `VMILayoutAssignment.cpp`, `VMILayoutRematerialize.cpp` and `VMILayoutSinkMaterialization.cpp`; propagation was the only one missing it.

## Tests

`test/lit/vmi_new/vmi_ptoas_cli_integer_vneg_layout.pto` covers all six failing cases from the issue (i8 vl1/vl64/vl128, i16 vl1/vl64, i32 vl1) with two RUN lines:

1. **`pto-test-opt` stopping after layout assignment** — the primary regression. It isolates the layout invariant from every later stage and asserts the concrete, non-contiguous layout on both `negi` ports (`num_groups = 1, slots = 8` for the vl1 cases, `contiguous, lane_stride = 2|4` for the rest), plus the full load/negi/store chain for `vneg_i8_vl64`. Pinning the concrete layout matters: a bare "a vneg survived" check would keep passing if a future change collapsed these cases to plain contiguous, silently retiring the coverage.
2. **`ptoas --emit-vpto`** — proves the whole pipeline completes, guarded by `--implicit-check-not` so the residual-VMI check applies to the entire output rather than only the region after the last match. This run needs provably 32-byte-aligned dynamic offsets, otherwise physical read legalization fails first and masks the layout regression; the first run has no such prerequisite.

Verification:
- both RUN lines fail on a pre-fix compiler and pass with this change; the layout-assignment run surfaces all six failures directly, whereas the end-to-end run aborts on the first one
- `test/lit/vmi_new`: 553/553 pass
- full `test/lit`: no related failures (the only red test locally is `npu_validation/deepseek_score_inputs.test`, which needs `numpy`, absent from the local environment)
- built locally in Release with `PTOAS_ENABLE_WERROR=ON`

## Note on the current CI status

`vmi-source-patch-check` and `build-and-test` are red for reasons unrelated to this change; both reproduce on other open PRs and on plain `main`:

- `vmi-source-patch-check`: `packaging/ptoas-vmi/pyproject.toml.patch` no longer applies to `main`'s `pyproject.toml`. Verified by applying the patch to `main` content directly, with no PR involved.
- `build-and-test`: the "Validate strict CMake 4 configure" step errors on the deprecated `FetchContent_Populate` call at `cmake/fetch_cann_cmake.cmake:67` under CMake 4.1.3. It fails at configure time, before anything is compiled or any test is run.

As a consequence CI has not yet exercised the new lit test; the results above are from local runs against a build carrying this fix.

## Follow-up

#1458 tracks the underlying fragility this bug came from: the same-layout op set is hand-maintained in four separate lists, and layout propagation is fail-open for unregistered ops.

Fixes #1373
