### PR TITLE
fix(ptodsl): preserve signless arithmetic operand types

### DIFF
--- a/ptodsl/ptodsl/_runtime_scalar_ops.py
+++ b/ptodsl/ptodsl/_runtime_scalar_ops.py
@@ -33,12 +33,11 @@ _FLOAT_BINARY_OPS = {
 
 def emit_runtime_binary_op(op_name: str, lhs, rhs):
     """Lower one authored runtime scalar binary operator."""
-    lhs, rhs, kind = normalize_runtime_binary_operands(lhs, rhs)
+    lhs, rhs, kind, authored_type = normalize_runtime_binary_operands(lhs, rhs)
     if kind in {"index", "integer"}:
-        op_cls = _integer_binary_op(op_name, lhs.type)
+        op_cls = _integer_binary_op(op_name, authored_type)
         if op_cls is None:
             raise TypeError(f"runtime scalar operator '{op_name}' is not supported for integer/index values")
-        authored_type = lhs.type
         if kind == "integer":
             lhs = _strip_integer_signedness(lhs)
             rhs = _strip_integer_signedness(rhs)
@@ -56,18 +55,18 @@ def emit_runtime_binary_op(op_name: str, lhs, rhs):
 
 def emit_runtime_max(lhs, rhs):
     """Lower one authored runtime scalar max operation."""
-    lhs, rhs, kind = normalize_runtime_binary_operands(lhs, rhs)
+    lhs, rhs, kind, authored_type = normalize_runtime_binary_operands(lhs, rhs)
     if kind == "float":
         return arith.MaximumFOp(lhs, rhs).result
     if kind == "integer":
-        signedness = _integer_signedness(lhs.type)
+        signedness = _integer_signedness(authored_type)
         signless_lhs = _strip_integer_signedness(lhs)
         signless_rhs = _strip_integer_signedness(rhs)
         if signedness == "unsigned":
             result = arith.MaxUIOp(signless_lhs, signless_rhs).result
         else:
             result = arith.MaxSIOp(signless_lhs, signless_rhs).result
-        return _restore_integer_signedness(result, lhs.type)
+        return _restore_integer_signedness(result, authored_type)
     if kind == "index":
         cond = arith.CmpIOp(arith.CmpIPredicate.sge, lhs, rhs).result
         return arith.SelectOp(cond, lhs, rhs).result
@@ -76,18 +75,18 @@ def emit_runtime_max(lhs, rhs):
 
 def emit_runtime_min(lhs, rhs):
     """Lower one authored runtime scalar min operation."""
-    lhs, rhs, kind = normalize_runtime_binary_operands(lhs, rhs)
+    lhs, rhs, kind, authored_type = normalize_runtime_binary_operands(lhs, rhs)
     if kind == "float":
         return arith.MinimumFOp(lhs, rhs).result
     if kind == "integer":
-        signedness = _integer_signedness(lhs.type)
+        signedness = _integer_signedness(authored_type)
         signless_lhs = _strip_integer_signedness(lhs)
         signless_rhs = _strip_integer_signedness(rhs)
         if signedness == "unsigned":
             result = arith.MinUIOp(signless_lhs, signless_rhs).result
         else:
             result = arith.MinSIOp(signless_lhs, signless_rhs).result
-        return _restore_integer_signedness(result, lhs.type)
+        return _restore_integer_signedness(result, authored_type)
     if kind == "index":
         cond = arith.CmpIOp(arith.CmpIPredicate.sle, lhs, rhs).result
         return arith.SelectOp(cond, lhs, rhs).result
@@ -104,7 +103,7 @@ def _restore_runtime_integer_result(result, authored_type):
 
 def emit_runtime_compare(op_name: str, lhs, rhs):
     """Lower one authored runtime scalar comparison operator."""
-    lhs, rhs, kind = normalize_runtime_binary_operands(lhs, rhs)
+    lhs, rhs, kind, authored_type = normalize_runtime_binary_operands(lhs, rhs)
 
     if kind == "float":
         predicate = {
@@ -133,7 +132,7 @@ def emit_runtime_compare(op_name: str, lhs, rhs):
         return arith.CmpIOp(predicate, lhs, rhs).result
 
     if kind == "integer":
-        signedness = _integer_signedness(lhs.type)
+        signedness = _integer_signedness(authored_type)
         signed_predicates = {
             "lt": arith.CmpIPredicate.slt,
             "le": arith.CmpIPredicate.sle,
@@ -160,7 +159,7 @@ def emit_runtime_compare(op_name: str, lhs, rhs):
 
 def emit_runtime_bitwise_op(op_name: str, lhs, rhs):
     """Lower one authored runtime scalar bitwise operator."""
-    lhs, rhs, kind = normalize_runtime_binary_operands(lhs, rhs)
+    lhs, rhs, kind, authored_type = normalize_runtime_binary_operands(lhs, rhs)
     op_cls = {
         "and": arith.AndIOp,
         "or": arith.OrIOp,
@@ -177,7 +176,6 @@ def emit_runtime_bitwise_op(op_name: str, lhs, rhs):
             f"runtime scalar bitwise operator '{op_name}' expects integer-like operands, got {lhs.type} and {rhs.type}"
         )
 
-    authored_type = lhs.type
     result = op_cls(_strip_integer_signedness(lhs), _strip_integer_signedness(rhs)).result
     return _restore_integer_signedness(result, authored_type)
 

--- a/ptodsl/ptodsl/_scalar_adaptation.py
+++ b/ptodsl/ptodsl/_scalar_adaptation.py
@@ -15,6 +15,7 @@ from ._types import (
     _restore_integer_signedness,
     _signless_integer_type,
     _strip_integer_signedness,
+    _parse_integer_value,
 )
 
 from ptoas.mlir.dialects import arith
@@ -180,15 +181,15 @@ def reconcile_typed_runtime_binary_operands(lhs, rhs):
     rhs_type = rhs.type
 
     if lhs_type == rhs_type:
-        return lhs, rhs, classify_runtime_scalar_type(lhs_type)
+        return lhs, rhs, classify_runtime_scalar_type(lhs_type), lhs_type
 
     if IndexType.isinstance(lhs_type) and IntegerType.isinstance(rhs_type):
         rhs = arith.IndexCastOp(IndexType.get(), _strip_integer_signedness(rhs)).result
-        return lhs, rhs, "index"
+        return lhs, rhs, "index", lhs_type
 
     if IntegerType.isinstance(lhs_type) and IndexType.isinstance(rhs_type):
         lhs = arith.IndexCastOp(IndexType.get(), _strip_integer_signedness(lhs)).result
-        return lhs, rhs, "index"
+        return lhs, rhs, "index", rhs_type
 
     if IntegerType.isinstance(lhs_type) and IntegerType.isinstance(rhs_type):
         lhs_width = IntegerType(lhs_type).width
@@ -200,11 +201,14 @@ def reconcile_typed_runtime_binary_operands(lhs, rhs):
         # restore the authored signedness only on the result.  This avoids
         # manufacturing a signed literal cast that can be reused with stale
         # type metadata by the tracer.
+        authored_type = lhs_type
+        if _integer_signedness(lhs_type) == "signless" and _integer_signedness(rhs_type) != "signless":
+            authored_type = rhs_type
         if _integer_signedness(lhs_type) == "signless" or _integer_signedness(rhs_type) == "signless":
             target_type = _signless_integer_type(target_type)
         lhs = coerce_integer_like(lhs, target_type)
         rhs = coerce_integer_like(rhs, target_type)
-        return lhs, rhs, "integer"
+        return lhs, rhs, "integer", authored_type
 
     raise TypeError(
         "runtime scalar operators require matching scalar types or an index/integer pair; "
@@ -266,7 +270,7 @@ def _materialize_runtime_literal(value, anchor_type):
     # stripping it again (the latter used to print malformed ``siN to iN``
     # casts for expressions such as ``num_tokens + 3``).
     signless_type = _signless_integer_type(anchor_type)
-    return arith.ConstantOp(signless_type, int(value)).result
+    return arith.ConstantOp(signless_type, _parse_integer_value(value, target_type=anchor_type)).result
 
 
 def _coerce_float_like(value, target_type):

--- a/ptodsl/ptodsl/_scalar_adaptation.py
+++ b/ptodsl/ptodsl/_scalar_adaptation.py
@@ -194,6 +194,14 @@ def reconcile_typed_runtime_binary_operands(lhs, rhs):
         lhs_width = IntegerType(lhs_type).width
         rhs_width = IntegerType(rhs_type).width
         target_type = lhs_type if lhs_width >= rhs_width else rhs_type
+        # Arithmetic operands are signless.  When a signed/unsigned runtime
+        # value is combined with a literal (which is intentionally emitted as
+        # signless), keep the common operand type signless through the op and
+        # restore the authored signedness only on the result.  This avoids
+        # manufacturing a signed literal cast that can be reused with stale
+        # type metadata by the tracer.
+        if _integer_signedness(lhs_type) == "signless" or _integer_signedness(rhs_type) == "signless":
+            target_type = _signless_integer_type(target_type)
         lhs = coerce_integer_like(lhs, target_type)
         rhs = coerce_integer_like(rhs, target_type)
         return lhs, rhs, "integer"
@@ -205,6 +213,12 @@ def reconcile_typed_runtime_binary_operands(lhs, rhs):
 
 
 def coerce_integer_like(value, target_type):
+    # Avoid a strip/restore round-trip when the authored integer type already
+    # matches the requested type.  Besides being redundant, the intermediate
+    # signless SSA value can be reused by the tracer with stale signedness and
+    # print an invalid cast (e.g. an i32 value declared as si32 source).
+    if value.type == target_type:
+        return value
     if IndexType.isinstance(value.type):
         signless_target = _signless_integer_type(target_type)
         adapted = arith.IndexCastOp(signless_target, value).result
@@ -246,7 +260,13 @@ def _materialize_runtime_literal(value, anchor_type):
     if kind == "index":
         return arith.ConstantOp(anchor_type, int(value)).result
 
-    return _materialize_integer_literal(anchor_type, value)
+    # Runtime arithmetic is lowered through builtin ``arith`` integer ops,
+    # whose operands are signless.  Materialize literals directly as signless
+    # constants instead of constructing a signed value and immediately
+    # stripping it again (the latter used to print malformed ``siN to iN``
+    # casts for expressions such as ``num_tokens + 3``).
+    signless_type = _signless_integer_type(anchor_type)
+    return arith.ConstantOp(signless_type, int(value)).result
 
 
 def _coerce_float_like(value, target_type):

--- a/ptodsl/ptodsl/_surface_values.py
+++ b/ptodsl/ptodsl/_surface_values.py
@@ -364,7 +364,7 @@ def _emit_vec_binary_op(op_name: str, lhs, rhs):
     rhs_raw = unwrap_surface_value(rhs)
     if not (VectorType.isinstance(lhs_raw.type) and VectorType.isinstance(rhs_raw.type)):
         raise TypeError("PTODSL VecValue arithmetic expects compatible vector operands")
-    lhs_raw, rhs_raw, kind = normalize_runtime_binary_operands(lhs_raw, rhs_raw)
+    lhs_raw, rhs_raw, kind, _ = normalize_runtime_binary_operands(lhs_raw, rhs_raw)
     if kind != "float":
         raise TypeError(f"PTODSL VecValue operator '{op_name}' currently supports only floating-point vectors")
     return VecValue(emit_runtime_binary_op(op_name, lhs_raw, rhs_raw))

--- a/ptodsl/tests/test_issue_1405_signed_runtime_arithmetic.py
+++ b/ptodsl/tests/test_issue_1405_signed_runtime_arithmetic.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Regression test for signed runtime values used in arithmetic expressions."""
+
+from ptodsl import pto, scalar
+
+
+@pto.jit(target="a5")
+def signed_runtime_arithmetic_probe(
+    out_ptr: pto.ptr(pto.si32, "gm"),
+    num_tokens: pto.si32,
+):
+    # This is the shape emitted by TileLang topk_gate: a signed runtime
+    # parameter is combined with Python literals and then used as an index.
+    waves = (num_tokens + 3) // 4
+    index = waves - 1
+    scalar.store(num_tokens + 1, out_ptr, index)
+
+
+def test_signed_runtime_arithmetic_roundtrip():
+    text = signed_runtime_arithmetic_probe.compile().mlir_text()
+    # Compilation itself performs the MLIR parse/verify round trip.  Keep the
+    # ABI signed while requiring signless arith operations in the generated IR.
+    assert "num_tokens" not in text
+    assert "func.func @signed_runtime_arithmetic_probe" in text
+    assert "arith.addi" in text
+    assert "arith.floordivsi" in text
+    assert "si32" in text
+    assert "i32" in text
+    # The source of every signless arithmetic constant must be i32 itself;
+    # the malformed form was `... %c3_i32 : si32 to i32`.
+    import re
+
+    assert not re.search(r"%c\w+ = builtin\.unrealized_conversion_cast .*: si32 to i32", text)

--- a/ptodsl/tests/test_issue_1405_signed_runtime_arithmetic.py
+++ b/ptodsl/tests/test_issue_1405_signed_runtime_arithmetic.py
@@ -39,3 +39,26 @@ def test_signed_runtime_arithmetic_roundtrip():
     import re
 
     assert not re.search(r"%c\w+ = builtin\.unrealized_conversion_cast .*: si32 to i32", text)
+
+
+@pto.jit(target="a5")
+def unsigned_runtime_arithmetic_probe(
+    out_ptr: pto.ptr(pto.ui32, "gm"),
+    value: pto.ui32,
+):
+    quotient = (value + "0x3") // 4
+    remainder = value % 4
+    is_small = value < 7
+    bounded_max = scalar.max(value, 7)
+    bounded_min = scalar.min(value, 7)
+    scalar.store(quotient + remainder + bounded_max + bounded_min, out_ptr, 0)
+    scalar.store(is_small, out_ptr, 1)
+
+
+def test_unsigned_runtime_arithmetic_preserves_unsigned_ops():
+    text = unsigned_runtime_arithmetic_probe.compile().mlir_text()
+    assert "arith.divui" in text
+    assert "arith.remui" in text
+    assert "arith.cmpi ult" in text
+    assert "arith.maxui" in text
+    assert "arith.minui" in text


### PR DESCRIPTION
Fix runtime integer arithmetic lowering after 5eb87c21. Integer literals are emitted signless, and mixed signed/signless operands are reconciled in signless arithmetic types. Explicit signed/unsigned scalar and VMI storage semantics remain unchanged. Regression: PTODSL jit compile suite and topk_gate E=256/384/512/72 K=8/9/8/6 num_sms=2.