### PR TITLE
fix(ptodsl): allow VMI vmula without a mask

### DIFF
--- a/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
+++ b/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
@@ -1075,7 +1075,7 @@ low, high = pto.vmi.vmull(a32, b32, mask)
 - `a` and `b` must be identical 32-bit integer VMI vectors.
 - `low` and `high` each have the same lane count and signedness as `a`.
 
-### `pto.vmi.vmula(acc, lhs, rhs, mask, *, pmode=None) -> VRegType`
+### `pto.vmi.vmula(acc, lhs, rhs, mask=None, *, pmode=None) -> VRegType`
 
 **Description**: Fused multiply-accumulate: `result = acc + (lhs * rhs)`.
 The accumulator is both the input and the result value.
@@ -1087,7 +1087,7 @@ The accumulator is both the input and the result value.
 | `acc` | `VRegType` | Accumulator vector |
 | `lhs` | `VRegType` | First multiply operand |
 | `rhs` | `VRegType` | Second multiply operand |
-| `mask` | VMI mask | **Required.** Predicate mask |
+| `mask` | VMI mask or `None` | Optional predicate mask. If omitted, all lanes are active. |
 | `pmode` | `str` or `None` | Optional predicate mode: `"merge"` keeps predicate-inactive lanes at their prior value; `"zero"` writes 0 |
 **Returns**:
 

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -1210,14 +1210,15 @@ class _VMINamespace:
         )
 
     @staticmethod
-    def vmula(acc, lhs, rhs, mask, *, pmode=None, loc=None, ip=None):
+    def vmula(acc, lhs, rhs, mask=None, *, pmode=None, loc=None, ip=None):
+        """Emit fused ``acc + lhs * rhs``; an omitted mask means all-active."""
         return _call_value(
             "vmula",
             _type_of(acc),
             _raw(acc),
             _raw(lhs),
             _raw(rhs),
-            _required_variadic_mask(mask, context="pto.vmi.vmula(...)"),
+            _variadic_mask(mask),
             pmode=pmode,
             loc=loc,
             ip=ip,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -3771,6 +3771,7 @@ def vmi_wrapper_dispatch_probe():
     parametric_relu = pto.vmi.vprelu(lhs, rhs, mask)
     low, high = pto.vmi.vmull(int_lhs, int_rhs, mask)
     multiply_accumulate = pto.vmi.vmula(lhs, lhs, rhs, mask)
+    multiply_accumulate_all_active = pto.vmi.vmula(lhs, lhs, rhs)
     widened = pto.vmi.vadd(low, high, mask)
     casted = pto.vmi.vcvt(shuffled, pto.f16)
     casted_r = pto.vmi.vcvt(shuffled, pto.f16, rounding="R", saturate="SAT")
@@ -3802,6 +3803,7 @@ def vmi_wrapper_dispatch_probe():
     _ = gatherb
     _ = hist
     _ = cumul
+    _ = multiply_accumulate_all_active
     _ = widened
     _ = casted
     _ = (casted_r, casted_a, casted_h, casted_z)
@@ -8356,6 +8358,15 @@ def main() -> None:
     expect(
         vmi_wrapper_dispatch_text.count("pto.vmi.vexpdif") == 2,
         "VMI wrapper dispatch should cover both f32 and f16 vexpdif forms",
+    )
+    expect(
+        re.search(
+            r"pto\.vmi\.vmula %[^,]+, %[^,]+, %[^,:]+ : !pto\.vmi\.vreg<64xf32>, "
+            r"!pto\.vmi\.vreg<64xf32>, !pto\.vmi\.vreg<64xf32> -> "
+            r"!pto\.vmi\.vreg<64xf32>",
+            vmi_wrapper_dispatch_text,
+        ) is not None,
+        "pto.vmi.vmula should emit the all-active form when its mask is omitted",
     )
     expect(
         "!pto.vmi.vreg<128xf32>" in vmi_wrapper_dispatch_text,


### PR DESCRIPTION
## Summary
- align `pto.vmi.vmula` with the optional-mask VMI IR contract
- omit the mask operand for the all-active form
- document the API and add a PTODSL JIT regression test

## Audit
Reviewed every VMI ODS op with a variadic mask. The existing PTODSL wrappers for binary and unary elementwise ops, plus `vstore`, already accept `mask=None`; `vmi.vmula` was the sole mismatch. Legacy `pto.vmula` remains unchanged because its non-VMI mask operand is required.

## Testing
- `ctest --test-dir build -R '^ptodsl_jit_compile$|jit_compile' --output-on-failure`\n- `git diff --check`