### PR TITLE
fix: resolve ptoas and ptobc codecheck findings

### DIFF
--- a/tools/ptoas/ObjectEmission.cpp
+++ b/tools/ptoas/ObjectEmission.cpp
@@ -147,7 +147,7 @@ static std::string sanitizeModuleId(llvm::StringRef raw) {
 
 static std::optional<std::string> getAscendHomePath() {
   const char *env = std::getenv("ASCEND_HOME_PATH");
-  if (!env || !*env) {
+  if (!env || env[0] == '\0') {
     return std::nullopt;
   }
   return std::string(env);
@@ -155,7 +155,7 @@ static std::optional<std::string> getAscendHomePath() {
 
 static std::optional<std::string> getEnvPath(llvm::StringRef name) {
   const char *env = std::getenv(name.str().c_str());
-  if (!env || !*env) {
+  if (!env || env[0] == '\0') {
     return std::nullopt;
   }
   return std::string(env);

--- a/tools/ptoas/VFSIMTSizePatcher.cpp
+++ b/tools/ptoas/VFSIMTSizePatcher.cpp
@@ -472,8 +472,9 @@ decodeCallSites(const ELFFunction &caller, StringRef objectBytes,
   llvm::SmallVector<DecodedCallSite, mlir::pto::kValue4> callSites;
   for (uint64_t offset = 0; offset + sizeof(uint64_t) <= bytes.size();
        offset += kInstructionBytes) {
+    const void *rawInstruction = bytes.data() + offset;
     uint64_t instruction = llvm::support::endian::read64le(
-        reinterpret_cast<const uint8_t *>(bytes.data() + offset));
+        static_cast<const uint8_t *>(rawInstruction));
     if (!isVFSIMT(instruction)) {
       continue;
     }
@@ -548,9 +549,10 @@ resolveManifestCalls(llvm::ArrayRef<const SimtCallSite *> calls,
     if (failed(validatePatchCallee(callee, diagOS))) {
       return failure();
     }
-    auto existing = llvm::find_if(resolvedCalls, [&](const ResolvedCall &item) {
-      return item.callee->name == callee.name;
-    });
+    auto existing =
+        llvm::find_if(resolvedCalls, [&callee](const ResolvedCall &item) {
+          return item.callee->name == callee.name;
+        });
     if (existing == resolvedCalls.end()) {
       resolvedCalls.push_back({call, &callee, false});
     }
@@ -758,12 +760,14 @@ static LogicalResult validatePatchedBytes(StringRef rawBytes,
     return failure();
   }
   for (const PatchRecord &record : plan) {
-    const uint64_t rawInstruction =
-        llvm::support::endian::read64le(reinterpret_cast<const uint8_t *>(
-            rawBytes.data() + record.decoded.fileOffset));
-    const uint64_t patchedInstruction =
-        llvm::support::endian::read64le(reinterpret_cast<const uint8_t *>(
-            patchedBytes.data() + record.decoded.fileOffset));
+    const void *rawInstructionBytes =
+        rawBytes.data() + record.decoded.fileOffset;
+    const uint64_t rawInstruction = llvm::support::endian::read64le(
+        static_cast<const uint8_t *>(rawInstructionBytes));
+    const void *patchedInstructionBytes =
+        patchedBytes.data() + record.decoded.fileOffset;
+    const uint64_t patchedInstruction = llvm::support::endian::read64le(
+        static_cast<const uint8_t *>(patchedInstructionBytes));
     if (((rawInstruction ^ patchedInstruction) & ~kVFSIMTSizeMask) != 0) {
       emitError(diagOS, "patch changes bits outside the VF_SIMT size field");
       return failure();
@@ -790,7 +794,7 @@ static LogicalResult writePatchedObject(StringRef path, StringRef bytes,
                                         llvm::raw_ostream &diagOS) {
   // FileOutputBuffer may leave a partial file if allocation or commit fails.
   auto removeOutput =
-      llvm::make_scope_exit([&]() { llvm::sys::fs::remove(path); });
+      llvm::make_scope_exit([&path]() { llvm::sys::fs::remove(path); });
   auto output = llvm::FileOutputBuffer::create(path, bytes.size());
   if (!output) {
     diagOS << "Error: VF_SIMT size patch: failed to create '" << path

--- a/tools/ptoas/VPTOHostStubEmission.cpp
+++ b/tools/ptoas/VPTOHostStubEmission.cpp
@@ -88,7 +88,8 @@ static LogicalResult collectVPTOKernelStubDecls(
   llvm::StringMap<unsigned> logicalNameToIndex;
 
   for (ModuleOp module : modules) {
-    module.walk([&](func::FuncOp func) {
+    module.walk([&decls, &logicalNameToIndex, &hadError,
+                 &diagOS](func::FuncOp func) {
       if (!pto::isPTOEntryFunction(func)) {
         return;
       }
@@ -144,7 +145,7 @@ LogicalResult mlir::pto::emitVPTOHostStubSource(ArrayRef<ModuleOp> modules,
   for (const VPTOKernelStubDecl &decl : stubDecls) {
     os << "extern \"C\" __global__ AICORE void " << decl.logicalName << "(";
     for (size_t i = 0; i < decl.argTypes.size(); ++i) {
-      if (i) {
+      if (i != 0) {
         os << ", ";
       }
       os << decl.argTypes[i] << " arg" << i;

--- a/tools/ptoas/driver.cpp
+++ b/tools/ptoas/driver.cpp
@@ -168,7 +168,8 @@ static bool resolveTextInputArch(llvm::StringRef buffer, bool cliArchSpecified,
 
 static OwningOpRef<ModuleOp> decodePTOBCModule(llvm::StringRef buffer,
                                                MLIRContext &context) {
-  llvm::ArrayRef<uint8_t> bytes(reinterpret_cast<const uint8_t *>(buffer.data()),
+  const void *rawBytes = buffer.data();
+  llvm::ArrayRef<uint8_t> bytes(static_cast<const uint8_t *>(rawBytes),
                                 buffer.size());
 #if defined(__cpp_exceptions) || defined(__EXCEPTIONS)
   try {
@@ -336,7 +337,7 @@ static bool isUserVisibleIROutputRequested() {
 
 static SmallVector<StringRef> collectImportedPeerNames(ModuleOp module) {
   SmallVector<StringRef> names;
-  module.walk([&](pto::ImportReservedBufferOp importOp) {
+  module.walk([&names](pto::ImportReservedBufferOp importOp) {
     names.push_back(importOp.getPeerFuncAttr().getValue());
   });
   llvm::sort(names);
@@ -346,7 +347,7 @@ static SmallVector<StringRef> collectImportedPeerNames(ModuleOp module) {
 
 static SmallVector<StringRef> collectDirectCalleeNames(ModuleOp module) {
   SmallVector<StringRef> names;
-  module.walk([&](func::CallOp callOp) {
+  module.walk([&names](func::CallOp callOp) {
     names.push_back(callOp.getCalleeAttr().getLeafReference());
   });
   llvm::sort(names);
@@ -359,7 +360,7 @@ static SmallVector<StringRef> collectDirectCalleeNames(func::FuncOp funcOp) {
   if (!funcOp || funcOp.isDeclaration()) {
     return names;
   }
-  funcOp.walk([&](func::CallOp callOp) {
+  funcOp.walk([&names, &funcOp](func::CallOp callOp) {
     if (callOp->getParentOfType<func::FuncOp>() != funcOp) {
       return;
     }
@@ -630,7 +631,8 @@ static LogicalResult addLogicalFunctionWrappers(ModuleOp targetChild,
 
 static void rewritePeerReferences(ModuleOp jobModule, StringRef logicalName,
                                   StringRef peerSymbolName) {
-  jobModule.walk([&](pto::ImportReservedBufferOp importOp) {
+  jobModule.walk([&jobModule, &logicalName,
+                  &peerSymbolName](pto::ImportReservedBufferOp importOp) {
     const bool matchesLogicalName =
         importOp.getPeerFuncAttr().getValue() == logicalName;
     if (matchesLogicalName) {
@@ -673,7 +675,7 @@ static LogicalResult importCrossChildPeerFunctions(ModuleOp outer,
 }
 
 static void normalizeLocalPeerReferences(ModuleOp jobModule) {
-  jobModule.walk([&](pto::ImportReservedBufferOp importOp) {
+  jobModule.walk([&jobModule](pto::ImportReservedBufferOp importOp) {
     StringRef peerRef = importOp.getPeerFuncAttr().getValue();
     func::FuncOp localPeer = findFunctionForPeerReference(jobModule, peerRef);
     const bool needsPeerRename = localPeer && localPeer.getSymName() != peerRef;
@@ -736,7 +738,7 @@ static std::string summarizeMixedChildModule(ModuleOp module) {
   if (!exportedNames.empty()) {
     os << "exports=[";
     for (size_t i = 0; i < exportedNames.size(); ++i) {
-      if (i) {
+      if (i != 0) {
         os << ", ";
       }
       os << exportedNames[i];
@@ -838,7 +840,7 @@ llvm::StringRef mlir::pto::PTOASContext::getOutputPath() const {
   return outputPath;
 }
 
-std::string mlir::pto::PTOASContext::allocModuleId() {
+std::string mlir::pto::PTOASContext::allocModuleId() const {
   static size_t nextModuleId = 0;
   return "ptoas_module_" + std::to_string(nextModuleId++);
 }
@@ -898,7 +900,7 @@ mlir::pto::PTOASContext::createTempPath(llvm::StringRef prefix,
 
 static bool hasPTOEntry(ModuleOp module) {
   bool found = false;
-  module.walk([&](func::FuncOp func) {
+  module.walk([&found](func::FuncOp func) {
     if (mlir::pto::isPTOEntryFunction(func)) {
       found = true;
       return WalkResult::interrupt();

--- a/tools/ptoas/ptoas.h
+++ b/tools/ptoas/ptoas.h
@@ -85,7 +85,7 @@ public:
   char **getArgv() const;
 
   llvm::StringRef getOutputPath() const;
-  std::string allocModuleId();
+  std::string allocModuleId() const;
 
   const CANNToolchain *getToolchain(llvm::raw_ostream &diagOS) const;
   CANNVersion getCANNVersionOrDefault() const;
@@ -129,7 +129,7 @@ struct PTOASCompileResult {
 };
 
 int compilePTOASModule(OwningOpRef<ModuleOp> &module,
-                       PTOASContext &context, PTOBackend backend,
+                       PTOASContext &context, PTOBackend effectiveBackend,
                        PTOASCompileResult &result,
                        bool emitVPTOHostStub = true);
 void registerPTOASDialects(DialectRegistry &registry);

--- a/tools/ptoas/ptoas_cpp_rewrite.cpp
+++ b/tools/ptoas/ptoas_cpp_rewrite.cpp
@@ -217,7 +217,9 @@ static bool rewriteMarkerCallToMember(std::string &cpp, llvm::StringRef marker,
                                       llvm::StringRef memberName,
                                       unsigned expectedNumArgs) {
   return rewriteMarkerCalls(
-      cpp, marker, [&](const ParsedMarkerCall &call) -> std::optional<std::string> {
+      cpp, marker,
+      [&marker, &memberName,
+       expectedNumArgs](const ParsedMarkerCall &call) -> std::optional<std::string> {
         if (call.args.size() != expectedNumArgs) {
           return std::nullopt;
         }
@@ -246,9 +248,11 @@ static void rewriteMarkerCallsToMembers(
   while (changed) {
     changed = false;
     for (const MarkerRewriteSpec &rewrite : rewrites) {
-      changed |= rewriteMarkerCallToMember(cpp, rewrite.marker,
-                                           rewrite.memberName,
-                                           rewrite.expectedNumArgs);
+      if (rewriteMarkerCallToMember(cpp, rewrite.marker,
+                                    rewrite.memberName,
+                                    rewrite.expectedNumArgs)) {
+        changed = true;
+      }
     }
   }
 }
@@ -257,7 +261,8 @@ static bool rewriteMarkerCallToField(std::string &cpp, llvm::StringRef marker,
                                      llvm::StringRef fieldName,
                                      size_t expectedNumArgs) {
   return rewriteMarkerCalls(
-      cpp, marker, [&](const ParsedMarkerCall &call) -> std::optional<std::string> {
+      cpp, marker,
+      [&fieldName, expectedNumArgs](const ParsedMarkerCall &call) -> std::optional<std::string> {
         if (call.args.size() != expectedNumArgs) {
           return std::nullopt;
         }
@@ -308,7 +313,7 @@ void rewriteAsyncEventMarkers(std::string &cpp) {
 void dropEmptyEmitCExpressions(Operation *rootOp) {
   llvm::SmallVector<emitc::ExpressionOp, kEmptyExpressionInlineCapacity>
       toErase;
-  rootOp->walk([&](emitc::ExpressionOp expr) {
+  rootOp->walk([&toErase](emitc::ExpressionOp expr) {
     Block *body = expr.getBody();
     if (!body) {
       return;
@@ -407,7 +412,7 @@ static Attribute normalizeEmitCPrintedAttrForCppEmission(MLIRContext *ctx,
     for (Attribute element : arrayAttr) {
       Attribute normalizedElement =
           normalizeEmitCPrintedAttrForCppEmission(ctx, element);
-      changed |= normalizedElement != element;
+      changed = changed || normalizedElement != element;
       normalized.push_back(normalizedElement);
     }
     if (changed) {
@@ -437,21 +442,21 @@ static ArrayAttr normalizeEmitCCallArgsForCppEmission(MLIRContext *ctx,
       if (isa<IndexType>(intAttr.getType())) {
         Attribute normalizedAttr =
             normalizeEmitCIndexPlaceholderAttr(ctx, intAttr);
-        changed |= normalizedAttr != attr;
+        changed = changed || normalizedAttr != attr;
         normalized.push_back(normalizedAttr);
         continue;
       }
 
       Attribute normalizedAttr =
           normalizeEmitCPrintedAttrForCppEmission(ctx, attr);
-      changed |= normalizedAttr != attr;
+      changed = changed || normalizedAttr != attr;
       normalized.push_back(normalizedAttr);
       continue;
     }
 
     Attribute normalizedAttr =
         normalizeEmitCPrintedAttrForCppEmission(ctx, attr);
-    changed |= normalizedAttr != attr;
+    changed = changed || normalizedAttr != attr;
     normalized.push_back(normalizedAttr);
   }
 
@@ -467,7 +472,7 @@ static ArrayAttr normalizeEmitCTemplateArgsForCppEmission(MLIRContext *ctx,
   for (Attribute attr : args) {
     Attribute normalizedAttr =
         normalizeEmitCPrintedAttrForCppEmission(ctx, attr);
-    changed |= normalizedAttr != attr;
+    changed = changed || normalizedAttr != attr;
     normalized.push_back(normalizedAttr);
   }
 
@@ -476,7 +481,7 @@ static ArrayAttr normalizeEmitCTemplateArgsForCppEmission(MLIRContext *ctx,
 
 void normalizeEmitCIntegerAttrsForCppEmission(Operation *rootOp) {
   MLIRContext *ctx = rootOp->getContext();
-  rootOp->walk([&](Operation *op) {
+  rootOp->walk([&ctx](Operation *op) {
     if (auto constant = dyn_cast<emitc::ConstantOp>(op)) {
       Attribute value = constant.getValue();
       Attribute normalized =
@@ -558,7 +563,7 @@ static Type getEmitCVariableStorageType(Type valueType) {
 // lowering (e.g. scf.while -> cf.*) stays valid.
 void materializeControlFlowOperands(Operation *rootOp) {
   llvm::SmallVector<Operation *, kBranchInlineCapacity> branches;
-  rootOp->walk([&](Operation *op) {
+  rootOp->walk([&branches](Operation *op) {
     if (isa<cf::BranchOp, cf::CondBranchOp>(op)) {
       branches.push_back(op);
     }
@@ -595,7 +600,9 @@ static bool rewriteMarkerCallToSubscript(std::string &cpp, llvm::StringRef marke
                                          unsigned expectedNumArgs,
                                          bool isStore) {
   return rewriteMarkerCalls(
-      cpp, marker, [&](const ParsedMarkerCall &call) -> std::optional<std::string> {
+      cpp, marker,
+      [expectedNumArgs,
+       isStore](const ParsedMarkerCall &call) -> std::optional<std::string> {
         if (call.args.size() != expectedNumArgs) {
           return std::nullopt;
         }
@@ -620,10 +627,10 @@ static bool rewriteMarkerCallToSubscript(std::string &cpp, llvm::StringRef marke
 }
 
 void rewriteGlobalTensorMetadataMarkers(std::string &cpp) {
-  auto rewrite = [&](llvm::StringRef marker, llvm::StringRef method) {
+  auto rewrite = [&cpp](llvm::StringRef marker, llvm::StringRef method) {
     (void)rewriteMarkerCalls(
         cpp, marker,
-        [&](const ParsedMarkerCall &call) -> std::optional<std::string> {
+        [method](const ParsedMarkerCall &call) -> std::optional<std::string> {
           const bool hasExpectedArgs =
               call.args.size() == kMarkerRewriteMinArgCount;
           if (!hasExpectedArgs) {
@@ -644,9 +651,11 @@ static void rewriteMarkerCallsToSubscripts(
   while (changed) {
     changed = false;
     for (const MarkerSubscriptRewriteSpec &rewrite : rewrites) {
-      changed |= rewriteMarkerCallToSubscript(cpp, rewrite.marker,
-                                              rewrite.expectedNumArgs,
-                                              rewrite.isStore);
+      if (rewriteMarkerCallToSubscript(cpp, rewrite.marker,
+                                       rewrite.expectedNumArgs,
+                                       rewrite.isStore)) {
+        changed = true;
+      }
     }
   }
 }
@@ -777,7 +786,7 @@ stripScalarGMFlushMarkers(llvm::ArrayRef<std::string> functionLines,
   for (const std::string &rawLine : functionLines) {
     std::string line = rawLine;
     const bool hadMarker = stripScalarGMFlushMarkersFromLine(line);
-    needsScalarGMFlush |= hadMarker;
+    needsScalarGMFlush = needsScalarGMFlush || hadMarker;
     if (hadMarker && llvm::StringRef(line).trim().empty()) {
       continue;
     }
@@ -871,7 +880,9 @@ void rewriteScalarGMStoreFlushMarkers(std::string &cpp) {
   bool sawFunctionBrace = false;
   int braceDepth = 0;
 
-  auto flushFunction = [&](bool hasTrailingNewline) {
+  auto flushFunction = [&out, &functionLines, &inFunction,
+                        &sawFunctionBrace,
+                        &braceDepth](bool hasTrailingNewline) {
     out.append(rewriteScalarGMStoreFlushMarkersInFunction(functionLines,
                                                          hasTrailingNewline));
     functionLines.clear();

--- a/tools/ptoas/ptoas_name_hints.cpp
+++ b/tools/ptoas/ptoas_name_hints.cpp
@@ -111,6 +111,16 @@ static bool isCppIdentifierChar(char c) {
   return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
 }
 
+static char encodeHexDigit(unsigned value) {
+  constexpr unsigned kDecimalDigitCount = 10;
+  constexpr unsigned kDigitZero = '0';
+  constexpr unsigned kLetterA = 'A';
+  if (value < kDecimalDigitCount) {
+    return static_cast<char>(kDigitZero + value);
+  }
+  return static_cast<char>(kLetterA + (value - kDecimalDigitCount));
+}
+
 static std::optional<std::string> getTextualNameFromSMRange(llvm::SMRange range) {
   if (!range.Start.isValid() || !range.End.isValid()) {
     return std::nullopt;
@@ -464,7 +474,7 @@ void narrowUnusedMultiResultProvenanceLocs(Operation *root) {
     return;
   }
 
-  root->walk([&](Operation *op) {
+  root->walk([](Operation *op) {
     if (op->getNumResults() <= 1) {
       return;
     }
@@ -638,11 +648,6 @@ getValueNameHints(Value value) {
 static std::string buildHintMarker(llvm::StringRef prefix,
                                    llvm::ArrayRef<std::string> hints) {
   auto encodeHintMarkerToken = [](llvm::StringRef token) {
-    auto hexDigit = [](unsigned value) -> char {
-      return value < 10 ? static_cast<char>('0' + value)
-                        : static_cast<char>('A' + (value - 10));
-    };
-
     auto isSafeMarkerChar = [](unsigned char c) {
       return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
              (c >= '0' && c <= '9') || c == '_' || c == '.' || c == '-';
@@ -657,8 +662,8 @@ static std::string buildHintMarker(llvm::StringRef prefix,
       }
       encoded.push_back('%');
       encoded.push_back(
-          hexDigit((c >> kHexNibbleBitWidth) & kHexNibbleMask));
-      encoded.push_back(hexDigit(c & kHexNibbleMask));
+          encodeHexDigit((c >> kHexNibbleBitWidth) & kHexNibbleMask));
+      encoded.push_back(encodeHexDigit(c & kHexNibbleMask));
     }
     return encoded;
   };
@@ -677,7 +682,7 @@ static std::string buildHintMarker(llvm::StringRef prefix,
 static SmallVector<std::string, kProvenanceInlineCapacity>
 collectExpressionProvenance(emitc::ExpressionOp expr) {
   SmallVector<std::string, kProvenanceInlineCapacity> provenance;
-  auto appendUnique = [&](llvm::ArrayRef<std::string> names) {
+  auto appendUnique = [&provenance](llvm::ArrayRef<std::string> names) {
     for (const std::string &name : names) {
       if (name.empty()) {
         continue;
@@ -690,7 +695,7 @@ collectExpressionProvenance(emitc::ExpressionOp expr) {
     }
   };
 
-  expr.walk<WalkOrder::PreOrder>([&](Operation *nested) {
+  expr.walk<WalkOrder::PreOrder>([&expr, &appendUnique](Operation *nested) {
     if (nested == expr.getOperation()) {
       return WalkResult::advance();
     }
@@ -712,7 +717,7 @@ void annotateEmitCProvenanceHints(ModuleOp module) {
 
   llvm::SmallVector<ProvenanceMarker, kProvenanceMarkerInlineCapacity>
       opsToAnnotate;
-  module.walk<WalkOrder::PreOrder>([&](Operation *op) {
+  module.walk<WalkOrder::PreOrder>([&opsToAnnotate](Operation *op) {
     if (op->getNumResults() == 0 || isa<emitc::VerbatimOp>(op)) {
       return WalkResult::advance();
     }
@@ -778,14 +783,20 @@ void annotateEmitCProvenanceHints(ModuleOp module) {
 //   PTOAS__EVENTID_ARRAY_STORE(arr, idx, v) -> arr[idx] = v
 
 static int decodeNameHintHexDigit(char c) {
-  if (c >= '0' && c <= '9') {
-    return c - '0';
+  constexpr unsigned kDecimalDigitCount = 10;
+  constexpr unsigned kHexLetterCount = 6;
+  constexpr unsigned kDigitZero = '0';
+  constexpr unsigned kLetterLowerA = 'a';
+  constexpr unsigned kLetterUpperA = 'A';
+  const unsigned digit = static_cast<unsigned char>(c);
+  if (digit >= kDigitZero && digit < kDigitZero + kDecimalDigitCount) {
+    return static_cast<int>(digit - kDigitZero);
   }
-  if (c >= 'a' && c <= 'f') {
-    return c - 'a' + 10;
+  if (digit >= kLetterLowerA && digit < kLetterLowerA + kHexLetterCount) {
+    return static_cast<int>(digit - kLetterLowerA + kDecimalDigitCount);
   }
-  if (c >= 'A' && c <= 'F') {
-    return c - 'A' + 10;
+  if (digit >= kLetterUpperA && digit < kLetterUpperA + kHexLetterCount) {
+    return static_cast<int>(digit - kLetterUpperA + kDecimalDigitCount);
   }
   return -1;
 }
@@ -873,11 +884,6 @@ static void stripAllHintMarkers(std::string &cpp) {
 }
 
 static std::string sanitizeCommentText(llvm::StringRef text) {
-  auto hexDigit = [](unsigned value) -> char {
-    return value < 10 ? static_cast<char>('0' + value)
-                      : static_cast<char>('A' + (value - 10));
-  };
-
   std::string sanitized;
   sanitized.reserve(text.size());
   for (unsigned char c : text.bytes()) {
@@ -896,8 +902,8 @@ static std::string sanitizeCommentText(llvm::StringRef text) {
         sanitized.push_back('\\');
         sanitized.push_back('x');
         sanitized.push_back(
-            hexDigit((c >> kHexNibbleBitWidth) & kHexNibbleMask));
-        sanitized.push_back(hexDigit(c & kHexNibbleMask));
+            encodeHexDigit((c >> kHexNibbleBitWidth) & kHexNibbleMask));
+        sanitized.push_back(encodeHexDigit(c & kHexNibbleMask));
       } else {
         sanitized.push_back(static_cast<char>(c));
       }

--- a/tools/ptoas/ptoas_pipeline.cpp
+++ b/tools/ptoas/ptoas_pipeline.cpp
@@ -186,7 +186,7 @@ struct FormEmitCExpressionsCompatPass final
   void runOnOperation() final {
     ModuleOp module = getOperation();
     OpBuilder builder(&getContext());
-    module.walk([&](Operation *op) {
+    module.walk([&builder](Operation *op) {
       const bool isTopLevelSingleResultExpression =
           op->hasTrait<OpTrait::emitc::CExpression>() &&
           !op->getParentOfType<emitc::ExpressionOp>() &&
@@ -200,9 +200,12 @@ struct FormEmitCExpressionsCompatPass final
     bool changed;
     do {
       changed = false;
-      module.walk<WalkOrder::PostOrder>([&](emitc::ExpressionOp expression) {
-        changed |= foldExpression(expression, rewriter);
-      });
+      module.walk<WalkOrder::PostOrder>(
+          [&changed, &rewriter](emitc::ExpressionOp expression) {
+            if (foldExpression(expression, rewriter)) {
+              changed = true;
+            }
+          });
     } while (changed);
   }
 };
@@ -523,7 +526,7 @@ static bool validateReserveBufferLevelRules(ModuleOp module,
                                             PTOBuildLevel level) {
   bool failed = false;
   PTOArch arch = getTargetArch(module);
-  module.walk([&](pto::ReserveBufferOp op) {
+  module.walk([&arch, level, &failed](pto::ReserveBufferOp op) {
     if (level != PTOBuildLevel::Level3) {
       if (op.getAutoAlloc()) {
         if (op.getBaseAttr()) {
@@ -615,7 +618,7 @@ static void printSharedPreBackendSeamIR(ModuleOp module) {
 
 static bool hasUnexpandedTileOps(ModuleOp module) {
   bool found = false;
-  module.walk([&](Operation *op) {
+  module.walk([&found](Operation *op) {
     if (found) {
       return;
     }
@@ -660,7 +663,7 @@ static SmallVector<func::FuncOp> collectSharedPipelineFunctions(ModuleOp module)
   // Preserve recursive traversal only for user-visible IR modes, which retain
   // the authored container shape for debugging.
   if (emitMlirIR) {
-    module.walk([&](func::FuncOp funcOp) { functions.push_back(funcOp); });
+    module.walk([&functions](func::FuncOp funcOp) { functions.push_back(funcOp); });
   } else {
     llvm::append_range(functions, module.getOps<func::FuncOp>());
   }
@@ -850,8 +853,9 @@ static void lowerPTOToVPTOBackend(PassManager &pm, ModuleOp module) {
   auto moduleArchAttr =
       module->getAttrOfType<mlir::StringAttr>("pto.target_arch");
   const bool isA2A3 = moduleArchAttr && isA2A3Arch(moduleArchAttr.getValue());
+  const bool opFusionEnabled = enableOpFusion == llvm::cl::BOU_TRUE;
   const bool enableA5VPTOPostLoweringFusionLifecycle =
-      enableOpFusion && moduleArchAttr && moduleArchAttr.getValue() == "a5";
+      opFusionEnabled && moduleArchAttr && moduleArchAttr.getValue() == "a5";
 
   kernelModulePM.addNestedPass<mlir::func::FuncOp>(
       pto::createLowerPTOToUBufOpsPass());
@@ -1524,6 +1528,112 @@ static LogicalResult runMainLoweringPipeline(
   return success();
 }
 
+// VPTO fast path: when no TileOp expansion is needed the shared mainline
+// pipeline can be skipped entirely.
+static int runVPTOSkipMainlinePipeline(OwningOpRef<ModuleOp> &module,
+                                       PTOASContext &context,
+                                       const CompilePipelineState &state,
+                                       PTOASCompileResult &result,
+                                       bool emitVPTOHostStub) {
+  if (ptoPrintSeamIR || !ptoSeamIRFile.empty()) {
+    llvm::errs() << "Error: shared pre-backend seam IR is unavailable when "
+                    "skipping the shared PTO-to-VPTO lowering pipeline.\n";
+    return 1;
+  }
+  if (failed(runVPTOBackendPipeline(module, state.hasTileOpsToExpand))) {
+    return 1;
+  }
+  return emitVPTOBackendResult(*module, result, emitVPTOHostStub,
+                               context.getCANNVersionOrDefault());
+}
+
+static LogicalResult runEmitCPreparationPipeline(OwningOpRef<ModuleOp> &module,
+                                                 llvm::StringRef arch) {
+  PassManager emitcPM(module->getContext());
+  emitcPM.enableVerifier();
+  if (isA2A3Arch(arch)) {
+    emitcPM.addPass(pto::createEmitPTOManualPass(pto::PTOArch::A3));
+  } else {
+    emitcPM.addPass(pto::createEmitPTOManualPass(pto::PTOArch::A5));
+  }
+  emitcPM.addPass(std::make_unique<FormEmitCExpressionsCompatPass>());
+  emitcPM.addPass(mlir::createCSEPass());
+  if (failed(applyConfiguredPassManagerCLOptions(
+          emitcPM, "EmitC backend pipeline"))) {
+    return failure();
+  }
+  if (failed(emitcPM.run(*module))) {
+    llvm::errs() << "Error: Pass execution failed.\n";
+    return failure();
+  }
+  return success();
+}
+
+// Post-process the emitted C++ text. Markers, provenance comments, and scalar
+// constant hoisting must run in this fixed order.
+static void runCppPostRewrites(std::string &cppOutput) {
+  rewriteTileGetSetValueMarkers(cppOutput);
+  rewriteAsyncEventMarkers(cppOutput);
+  rewritePtrScalarMarkers(cppOutput);
+  rewriteScalarGMStoreFlushMarkers(cppOutput);
+  rewriteEventIdArrayMarkers(cppOutput);
+  rewriteGlobalTensorMetadataMarkers(cppOutput);
+  pto::rewriteLastUseMarkersInCpp(cppOutput);
+  rewriteAddPtrTraceMarkers(cppOutput, emitAddPtrTrace);
+  rewriteMalformedVerbatimSemicolons(cppOutput);
+  rewriteScalarConstantDecls(cppOutput);
+  rewriteHoistedGlobalTensorDecls(cppOutput);
+  rewriteNameHintMarkers(cppOutput);
+}
+
+static int runEmitCTextEmission(OwningOpRef<ModuleOp> &module,
+                                const CompilePipelineState &state,
+                                PTOASCompileResult &result) {
+  if (ptoPrintSeamIR) {
+    printSharedPreBackendSeamIR(*module);
+  }
+  if (failed(emitSharedPreBackendSeamIR(*module, ptoSeamIRFile))) {
+    return 1;
+  }
+
+  narrowUnusedMultiResultProvenanceLocs(module.get());
+  splitDerivedSingleResultProvenanceLocs(module.get());
+
+  if (failed(runEmitCPreparationPipeline(module, state.arch))) {
+    return 1;
+  }
+
+  applyFunctionBlockArgNameHintsToEmitC(*module, state.functionBlockArgHints);
+  splitDerivedSingleResultProvenanceLocs(module.get());
+  dropEmptyEmitCExpressions(module.get());
+  materializeControlFlowOperands(module.get());
+  normalizeEmitCIntegerAttrsForCppEmission(module.get());
+  if (failed(reorderEmitCFunctions(module.get()))) {
+    llvm::errs() << "Error: Failed to order emitted functions for C++ emission.\n";
+    return 1;
+  }
+  annotateEmitCProvenanceHints(*module);
+
+  // Emit C++ to string, then post-process, then hand the text to the caller.
+  std::string cppOutput;
+  llvm::raw_string_ostream cppOS(cppOutput);
+  // CFG-style lowering (e.g. scf.while -> cf.br/cf.cond_br) may introduce
+  // multiple blocks, requiring variables to be declared at the top for valid
+  // C++ emission.
+  const bool declareVariablesAtTop = shouldDeclareVariablesAtTop(*module);
+  if (failed(emitc::translateToCpp(*module, cppOS,
+                                   /*declareVariablesAtTop=*/declareVariablesAtTop))) {
+    llvm::errs() << "Error: Failed to emit C++.\n";
+    return 1;
+  }
+  cppOS.flush();
+  runCppPostRewrites(cppOutput);
+
+  result.kind = PTOASCompileResultKind::Text;
+  result.textOutput = std::move(cppOutput);
+  return 0;
+}
+
 int mlir::pto::compilePTOASModule(
     OwningOpRef<ModuleOp> &module, PTOASContext &context,
     PTOBackend effectiveBackend, PTOASCompileResult &result,
@@ -1547,16 +1657,8 @@ int mlir::pto::compilePTOASModule(
   // The state is assembled and validated once above, so backend branches
   // cannot observe partially validated option combinations.
   if (effectiveBackend == PTOBackend::VPTO && !state.hasTileOpsToExpand) {
-    if (ptoPrintSeamIR || !ptoSeamIRFile.empty()) {
-      llvm::errs() << "Error: shared pre-backend seam IR is unavailable when "
-                      "skipping the shared PTO-to-VPTO lowering pipeline.\n";
-      return 1;
-    }
-    if (failed(runVPTOBackendPipeline(module, state.hasTileOpsToExpand))) {
-      return 1;
-    }
-    return emitVPTOBackendResult(*module, result, emitVPTOHostStub,
-                                 context.getCANNVersionOrDefault());
+    return runVPTOSkipMainlinePipeline(module, context, state, result,
+                                       emitVPTOHostStub);
   }
 
   bool mainPipelineHandled = false;
@@ -1573,77 +1675,5 @@ int mlir::pto::compilePTOASModule(
   if (effectiveBackend == PTOBackend::VPTO) {
     return 0;
   }
-
-  const std::string &arch = state.arch;
-  const FunctionBlockArgHintMap &functionBlockArgHints =
-      state.functionBlockArgHints;
-
-  if (ptoPrintSeamIR) {
-    printSharedPreBackendSeamIR(*module);
-  }
-  if (failed(emitSharedPreBackendSeamIR(*module, ptoSeamIRFile))) {
-    return 1;
-  }
-
-  narrowUnusedMultiResultProvenanceLocs(module.get());
-  splitDerivedSingleResultProvenanceLocs(module.get());
-
-  PassManager emitcPM(module->getContext());
-  emitcPM.enableVerifier();
-  if (isA2A3Arch(arch)) {
-    emitcPM.addPass(pto::createEmitPTOManualPass(pto::PTOArch::A3));
-  } else {
-    emitcPM.addPass(pto::createEmitPTOManualPass(pto::PTOArch::A5));
-  }
-  emitcPM.addPass(std::make_unique<FormEmitCExpressionsCompatPass>());
-  emitcPM.addPass(mlir::createCSEPass());
-  if (failed(applyConfiguredPassManagerCLOptions(
-          emitcPM, "EmitC backend pipeline")))
-    return 1;
-
-  if (failed(emitcPM.run(*module))) {
-    llvm::errs() << "Error: Pass execution failed.\n";
-    return 1;
-  }
-
-  applyFunctionBlockArgNameHintsToEmitC(*module, functionBlockArgHints);
-  splitDerivedSingleResultProvenanceLocs(module.get());
-  dropEmptyEmitCExpressions(module.get());
-  materializeControlFlowOperands(module.get());
-  normalizeEmitCIntegerAttrsForCppEmission(module.get());
-  if (failed(reorderEmitCFunctions(module.get()))) {
-    llvm::errs() << "Error: Failed to order emitted functions for C++ emission.\n";
-    return 1;
-  }
-  annotateEmitCProvenanceHints(*module);
-
-  // Emit C++ to string, then post-process, then write to output file.
-  std::string cppOutput;
-  llvm::raw_string_ostream cppOS(cppOutput);
-  // CFG-style lowering (e.g. scf.while -> cf.br/cf.cond_br) may introduce
-  // multiple blocks, requiring variables to be declared at the top for valid
-  // C++ emission.
-  bool declareVariablesAtTop = shouldDeclareVariablesAtTop(*module);
-  if (failed(emitc::translateToCpp(*module, cppOS,
-                                  /*declareVariablesAtTop=*/declareVariablesAtTop))) {
-    llvm::errs() << "Error: Failed to emit C++.\n";
-    return 1;
-  }
-  cppOS.flush();
-  rewriteTileGetSetValueMarkers(cppOutput);
-  rewriteAsyncEventMarkers(cppOutput);
-  rewritePtrScalarMarkers(cppOutput);
-  rewriteScalarGMStoreFlushMarkers(cppOutput);
-  rewriteEventIdArrayMarkers(cppOutput);
-  rewriteGlobalTensorMetadataMarkers(cppOutput);
-  pto::rewriteLastUseMarkersInCpp(cppOutput);
-  rewriteAddPtrTraceMarkers(cppOutput, emitAddPtrTrace);
-  rewriteMalformedVerbatimSemicolons(cppOutput);
-  rewriteScalarConstantDecls(cppOutput);
-  rewriteHoistedGlobalTensorDecls(cppOutput);
-  rewriteNameHintMarkers(cppOutput);
-
-  result.kind = PTOASCompileResultKind::Text;
-  result.textOutput = std::move(cppOutput);
-  return 0;
+  return runEmitCTextEmission(module, state, result);
 }

--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -326,7 +326,7 @@ inline const char *fullNameFromOpcodeVariant(uint16_t opcode, uint8_t variant) {
   if (opcode == kTscatterMaskOpcode) {
     return "pto.tscatter";
   }
-  if (!info->has_variant_u8) {
+  if (info->has_variant_u8 == 0) {
     return info->name;
   }
   for (const VariantName &entry : kVariantNameTable) {

--- a/tools/ptobc/include/ptobc/ptobc_format.h
+++ b/tools/ptobc/include/ptobc/ptobc_format.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -108,6 +109,10 @@ struct PTOBCFile {
 
   std::vector<uint8_t> serialize() const;
 };
+
+// Normalize a user-supplied path (canonical prefix plus lexically normal
+// tail) before it is handed to file IO.
+std::filesystem::path canonicalizeIoPath(const std::string& path);
 
 // Helpers to read a PTOBC file from disk.
 std::vector<uint8_t> readFile(const std::string& path);

--- a/tools/ptobc/src/leb128.cpp
+++ b/tools/ptobc/src/leb128.cpp
@@ -38,14 +38,24 @@ void writeULEB128(uint64_t value, std::vector<uint8_t>& out) {
 }
 
 void writeSLEB128(int64_t value, std::vector<uint8_t>& out) {
-  bool more = true;
-  while (more) {
-    uint8_t byte = static_cast<uint8_t>(value & kLeb128PayloadMask);
-    int64_t sign = byte & kLeb128SignBit;
-    value >>= kLeb128PayloadBits;
-    if ((value == 0 && sign == 0) || (value == -1 && sign != 0)) {
-      more = false;
-    } else {
+  // SLEB128 needs arithmetic (sign-propagating) shifts, so operate on the
+  // unsigned two's-complement pattern and restore the sign bits explicitly.
+  const bool negative = value < 0;
+  const uint64_t signExtension = ~uint64_t(0)
+                                 << (kInt64BitWidth - kLeb128PayloadBits);
+  uint64_t bits = static_cast<uint64_t>(value);
+  bool done = false;
+  while (!done) {
+    uint8_t byte = static_cast<uint8_t>(bits & kLeb128PayloadMask);
+    const bool signBitSet = (byte & kLeb128SignBit) != 0;
+    bits >>= kLeb128PayloadBits;
+    if (negative) {
+      bits |= signExtension;
+    }
+    const bool upperBitsZero = bits == 0;
+    const bool upperBitsOnes = bits == ~uint64_t(0);
+    done = (upperBitsZero && !signBitSet) || (upperBitsOnes && signBitSet);
+    if (!done) {
       byte |= kLeb128ContinuationBit;
     }
     out.push_back(byte);
@@ -70,13 +80,13 @@ size_t readULEB128(const uint8_t* data, size_t size, uint64_t& value) {
 }
 
 size_t readSLEB128(const uint8_t* data, size_t size, int64_t& value) {
-  value = 0;
+  uint64_t bits = 0;
   unsigned shift = 0;
   uint8_t byte = 0;
   size_t i = 0;
   for (; i < size; ++i) {
     byte = data[i];
-    value |= (int64_t(byte & kLeb128PayloadMask) << shift);
+    bits |= (uint64_t(byte & kLeb128PayloadMask) << shift);
     shift += kLeb128PayloadBits;
     if ((byte & kLeb128ContinuationBit) == 0) {
       break;
@@ -90,9 +100,11 @@ size_t readSLEB128(const uint8_t* data, size_t size, int64_t& value) {
   }
 
   // sign extend
-  if ((shift < kInt64BitWidth) && (byte & kLeb128SignBit)) {
-    value |= static_cast<int64_t>(~uint64_t(0) << shift);
+  const bool signBitSet = (byte & kLeb128SignBit) != 0;
+  if (shift < kInt64BitWidth && signBitSet) {
+    bits |= ~uint64_t(0) << shift;
   }
+  value = static_cast<int64_t>(bits);
   return i + 1;
 }
 

--- a/tools/ptobc/src/mlir_encode.cpp
+++ b/tools/ptobc/src/mlir_encode.cpp
@@ -561,6 +561,17 @@ struct Encoder {
   bool
   tryEncodeLegacyFpOperands(mlir::Operation &op, Buffer &out,
                             const ptobc::v0::OpcodeAndVariant &variantInfo);
+  void encodeFixedCountOperands(
+      mlir::Operation &op, Buffer &out, const ptobc::v0::OpInfo &info,
+      const ptobc::v0::OpcodeAndVariant &variantInfo);
+  void encodeByVariantOperands(mlir::Operation &op, Buffer &out,
+                               const ptobc::v0::OpcodeAndVariant &variantInfo);
+  void encodeLengthPrefixedOperands(mlir::Operation &op, Buffer &out);
+  void encodeSegmentedOperands(mlir::Operation &op, Buffer &out,
+                               const ptobc::v0::OpInfo &info,
+                               llvm::ArrayRef<uint64_t> imms);
+  void encodeOptMaskOperands(mlir::Operation &op, Buffer &out,
+                             llvm::ArrayRef<uint64_t> imms);
   void encodeKnownOperandMode(mlir::Operation &op, Buffer &out,
                               const ptobc::v0::OpInfo &info,
                               const ptobc::v0::OpcodeAndVariant &variantInfo,
@@ -817,58 +828,82 @@ bool Encoder::tryEncodeLegacyFpOperands(
   }
 }
 
+void Encoder::encodeFixedCountOperands(mlir::Operation &op, Buffer &out,
+                                       const ptobc::v0::OpInfo &info,
+                                       const ptobc::v0::OpcodeAndVariant &variantInfo) {
+  if (tryEncodeLegacyIndexedTscatterOperands(op, out, variantInfo)) {
+    return;
+  }
+  emitOperandIds(op, out, info.num_operands);
+}
+
+void Encoder::encodeByVariantOperands(mlir::Operation &op, Buffer &out,
+                                      const ptobc::v0::OpcodeAndVariant &variantInfo) {
+  auto count = ptobc::v0::lookupOperandsByVariant(variantInfo.opcode,
+                                                  variantInfo.variant);
+  if (!count) {
+    throw std::runtime_error("missing by-variant operand count");
+  }
+  emitOperandIds(op, out, *count);
+}
+
+void Encoder::encodeLengthPrefixedOperands(mlir::Operation &op, Buffer &out) {
+  writeULEB128(op.getNumOperands(), out.bytes);
+  for (auto value : op.getOperands()) {
+    writeULEB128(getValueId(value), out.bytes);
+  }
+}
+
+void Encoder::encodeSegmentedOperands(mlir::Operation &op, Buffer &out,
+                                      const ptobc::v0::OpInfo &info,
+                                      llvm::ArrayRef<uint64_t> imms) {
+  if (imms.size() < kSegmentedOperandImmediateCount) {
+    throw std::runtime_error("segmented operands missing immediates");
+  }
+  if (imms[0] != 0) {
+    throw std::runtime_error(
+        "list_mode=1 not implemented in ptobc encoder yet");
+  }
+  emitOperandIds(op, out,
+                 size_t(info.num_operands) + size_t(imms[1]) + size_t(imms[2]));
+}
+
+void Encoder::encodeOptMaskOperands(mlir::Operation &op, Buffer &out,
+                                    llvm::ArrayRef<uint64_t> imms) {
+  if (imms.empty()) {
+    throw std::runtime_error("optmask operands missing immediate");
+  }
+  constexpr uint64_t kOptMaskValidRowBit = 0x1;
+  constexpr uint64_t kOptMaskValidColBit = 0x2;
+  constexpr uint64_t kOptMaskAddrBit = 0x4;
+  const uint64_t optMask = imms.front();
+  const size_t operandCount =
+      ((optMask & kOptMaskValidRowBit) != 0 ? 1U : 0U) +
+      ((optMask & kOptMaskValidColBit) != 0 ? 1U : 0U) +
+      ((optMask & kOptMaskAddrBit) != 0 ? 1U : 0U);
+  emitOperandIds(op, out, operandCount);
+}
+
 void Encoder::encodeKnownOperandMode(
     mlir::Operation &op, Buffer &out, const ptobc::v0::OpInfo &info,
     const ptobc::v0::OpcodeAndVariant &variantInfo,
     llvm::ArrayRef<uint64_t> imms) {
   switch (info.operand_mode) {
   case 0x00:
-    if (tryEncodeLegacyIndexedTscatterOperands(op, out, variantInfo)) {
-      return;
-    }
-    emitOperandIds(op, out, info.num_operands);
+    encodeFixedCountOperands(op, out, info, variantInfo);
     return;
-  case 0x01: {
-    auto count = ptobc::v0::lookupOperandsByVariant(variantInfo.opcode,
-                                                    variantInfo.variant);
-    if (!count) {
-      throw std::runtime_error("missing by-variant operand count");
-    }
-    emitOperandIds(op, out, *count);
+  case 0x01:
+    encodeByVariantOperands(op, out, variantInfo);
     return;
-  }
   case 0x02:
-    writeULEB128(op.getNumOperands(), out.bytes);
-    for (auto value : op.getOperands()) {
-      writeULEB128(getValueId(value), out.bytes);
-    }
+    encodeLengthPrefixedOperands(op, out);
     return;
   case 0x03:
-    if (imms.size() < kSegmentedOperandImmediateCount) {
-      throw std::runtime_error("segmented operands missing immediates");
-    }
-    if (imms[0] != 0) {
-      throw std::runtime_error(
-          "list_mode=1 not implemented in ptobc encoder yet");
-    }
-    emitOperandIds(
-        op, out, size_t(info.num_operands) + size_t(imms[1]) + size_t(imms[2]));
+    encodeSegmentedOperands(op, out, info, imms);
     return;
-  case 0x04: {
-    if (imms.empty()) {
-      throw std::runtime_error("optmask operands missing immediate");
-    }
-    constexpr uint64_t kOptMaskValidRowBit = 0x1;
-    constexpr uint64_t kOptMaskValidColBit = 0x2;
-    constexpr uint64_t kOptMaskAddrBit = 0x4;
-    const uint64_t optMask = imms.front();
-    const size_t operandCount =
-        ((optMask & kOptMaskValidRowBit) != 0 ? 1U : 0U) +
-        ((optMask & kOptMaskValidColBit) != 0 ? 1U : 0U) +
-        ((optMask & kOptMaskAddrBit) != 0 ? 1U : 0U);
-    emitOperandIds(op, out, operandCount);
+  case 0x04:
+    encodeOptMaskOperands(op, out, imms);
     return;
-  }
   default:
     throw std::runtime_error("unknown operand_mode in v0 schema");
   }

--- a/tools/ptobc/src/mlir_encode.cpp
+++ b/tools/ptobc/src/mlir_encode.cpp
@@ -702,14 +702,17 @@ void Encoder::encodeAllocTileImmediate(mlir::Operation &op, Buffer &out,
         "imm_kind=alloc_tile but op is not pto.alloc_tile");
   }
   uint8_t mask = 0;
+  constexpr uint8_t kAllocTileValidRowBit = 0x1;
+  constexpr uint8_t kAllocTileValidColBit = 0x2;
+  constexpr uint8_t kAllocTileAddrBit = 0x4;
   if (at.getValidRow()) {
-    mask |= 0x1;
+    mask |= kAllocTileValidRowBit;
   }
   if (at.getValidCol()) {
-    mask |= 0x2;
+    mask |= kAllocTileValidColBit;
   }
   if (at.getAddr()) {
-    mask |= 0x4;
+    mask |= kAllocTileAddrBit;
   }
   out.appendU8(mask);
   imms.push_back(mask);
@@ -781,7 +784,7 @@ bool Encoder::tryEncodeLegacyIndexedTscatterOperands(
 bool Encoder::tryEncodeLegacyFpOperands(
     mlir::Operation &op, Buffer &out,
     const ptobc::v0::OpcodeAndVariant &variantInfo) {
-  auto emit = [&](llvm::ArrayRef<mlir::Value> operands) {
+  auto emit = [this, &out](llvm::ArrayRef<mlir::Value> operands) {
     for (mlir::Value value : operands) {
       writeULEB128(getValueId(value), out.bytes);
     }
@@ -851,15 +854,21 @@ void Encoder::encodeKnownOperandMode(
     emitOperandIds(
         op, out, size_t(info.num_operands) + size_t(imms[1]) + size_t(imms[2]));
     return;
-  case 0x04:
+  case 0x04: {
     if (imms.empty()) {
       throw std::runtime_error("optmask operands missing immediate");
     }
-    emitOperandIds(op, out,
-                   ((imms.front() & 0x1) ? 1 : 0) +
-                       ((imms.front() & 0x2) ? 1 : 0) +
-                       ((imms.front() & 0x4) ? 1 : 0));
+    constexpr uint64_t kOptMaskValidRowBit = 0x1;
+    constexpr uint64_t kOptMaskValidColBit = 0x2;
+    constexpr uint64_t kOptMaskAddrBit = 0x4;
+    const uint64_t optMask = imms.front();
+    const size_t operandCount =
+        ((optMask & kOptMaskValidRowBit) != 0 ? 1U : 0U) +
+        ((optMask & kOptMaskValidColBit) != 0 ? 1U : 0U) +
+        ((optMask & kOptMaskAddrBit) != 0 ? 1U : 0U);
+    emitOperandIds(op, out, operandCount);
     return;
+  }
   default:
     throw std::runtime_error("unknown operand_mode in v0 schema");
   }

--- a/tools/ptobc/src/ptobc_decode_print.cpp
+++ b/tools/ptobc/src/ptobc_decode_print.cpp
@@ -77,9 +77,9 @@ struct Reader {
     return *p++;
   }
   uint16_t readU16LE() {
-    uint16_t lo = readU8();
-    uint16_t hi = readU8();
-    return lo | (hi << kBitsPerByte);
+    const uint32_t lo = readU8();
+    const uint32_t hi = readU8();
+    return static_cast<uint16_t>(lo | (hi << kBitsPerByte));
   }
   uint32_t readU32LE() {
     uint32_t b0 = readU8();
@@ -354,19 +354,19 @@ struct BuildCtx {
   // Function-global value_id table.
   std::vector<mlir::Value> values;
 
-  // Function-global op_id table (preorder DFS).
-  uint64_t *nextOpId = nullptr;
-  std::vector<mlir::Operation *> *opsById = nullptr;
+  // Function-global op_id state (preorder DFS), reset per decoded function.
+  uint64_t nextOpId = 0;
+  std::vector<mlir::Operation *> opsById;
 };
 
-static mlir::Type getType(BuildCtx &bc, uint64_t tid) {
+static mlir::Type getType(const BuildCtx &bc, uint64_t tid) {
   if (tid >= bc.types->size()) {
     throw std::runtime_error("bad type_id");
   }
   return parseType(*bc.ctx, (*bc.types)[tid].asmStr);
 }
 
-static mlir::DictionaryAttr getAttrDict(BuildCtx &bc, uint64_t aid) {
+static mlir::DictionaryAttr getAttrDict(const BuildCtx &bc, uint64_t aid) {
   if (aid == 0) {
     return mlir::DictionaryAttr::get(bc.ctx);
   }
@@ -390,7 +390,7 @@ static llvm::APInt rebuildAPIntFromBytes(llvm::ArrayRef<uint8_t> bytes,
   return llvm::APInt(bitWidth, words);
 }
 
-static mlir::Attribute buildFloatConstAttr(BuildCtx &bc,
+static mlir::Attribute buildFloatConstAttr(const BuildCtx &bc,
                                            const ConstEntryParsed &entry) {
   auto ty = getType(bc, entry.typeId);
   auto floatType = mlir::dyn_cast<mlir::FloatType>(ty);
@@ -409,7 +409,7 @@ static mlir::Attribute buildFloatConstAttr(BuildCtx &bc,
   return mlir::FloatAttr::get(floatType, value);
 }
 
-static mlir::Attribute buildIntegerConstAttr(BuildCtx &bc,
+static mlir::Attribute buildIntegerConstAttr(const BuildCtx &bc,
                                              const ConstEntryParsed &entry) {
   auto ty = getType(bc, entry.typeId);
   auto intType = mlir::dyn_cast<mlir::IntegerType>(ty);
@@ -427,7 +427,7 @@ static mlir::Attribute buildIntegerConstAttr(BuildCtx &bc,
   return mlir::IntegerAttr::get(intType, bits);
 }
 
-static mlir::Attribute buildConstAttr(BuildCtx &bc, uint64_t constId) {
+static mlir::Attribute buildConstAttr(const BuildCtx &bc, uint64_t constId) {
   if (!bc.consts) {
     throw std::runtime_error("constpool not available");
   }
@@ -468,13 +468,10 @@ static void addAttrDictionary(mlir::OperationState &state,
 
 static void registerDecodedOp(BuildCtx &bc, uint64_t opId,
                               mlir::Operation *op) {
-  if (!bc.opsById) {
-    return;
+  if (opId >= bc.opsById.size()) {
+    bc.opsById.resize(opId + 1, nullptr);
   }
-  if (opId >= bc.opsById->size()) {
-    bc.opsById->resize(opId + 1, nullptr);
-  }
-  (*bc.opsById)[opId] = op;
+  bc.opsById[opId] = op;
 }
 
 static void assignDecodedResults(BuildCtx &bc, size_t resStart,
@@ -570,9 +567,14 @@ static size_t getKnownOperandCount(Reader &r, uint16_t opcode, uint8_t variant,
       throw std::runtime_error("list_mode=1 not supported yet");
     }
     return size_t(info.num_operands) + size_t(imms.n1) + size_t(imms.n2);
-  case 0x04:
-    return ((imms.optMask & 0x1) ? 1 : 0) + ((imms.optMask & 0x2) ? 1 : 0) +
-           ((imms.optMask & 0x4) ? 1 : 0);
+  case 0x04: {
+    constexpr uint8_t kOptMaskValidRowBit = 0x1;
+    constexpr uint8_t kOptMaskValidColBit = 0x2;
+    constexpr uint8_t kOptMaskAddrBit = 0x4;
+    return ((imms.optMask & kOptMaskValidRowBit) != 0 ? 1U : 0U) +
+           ((imms.optMask & kOptMaskValidColBit) != 0 ? 1U : 0U) +
+           ((imms.optMask & kOptMaskAddrBit) != 0 ? 1U : 0U);
+  }
   default:
     throw std::runtime_error("unknown operand_mode");
   }
@@ -587,7 +589,7 @@ readKnownOperandIds(Reader &r, uint16_t opcode, uint8_t variant,
 }
 
 static llvm::SmallVector<mlir::Value, kOperandInlineCapacity>
-materializeOperands(BuildCtx &bc, llvm::ArrayRef<uint64_t> operandIds) {
+materializeOperands(const BuildCtx &bc, llvm::ArrayRef<uint64_t> operandIds) {
   llvm::SmallVector<mlir::Value, kOperandInlineCapacity> operands;
   operands.reserve(operandIds.size());
   for (uint64_t valueId : operandIds) {
@@ -811,7 +813,7 @@ static mlir::Operation *buildKnownOpFromReader(BuildCtx &bc, Reader &r,
     throw std::runtime_error("missing opcode schema");
   }
 
-  uint8_t variant = info->has_variant_u8 ? r.readU8() : 0;
+  uint8_t variant = info->has_variant_u8 != 0 ? r.readU8() : 0;
   KnownOpImmediates imms = readKnownOpImmediates(r, *info);
   auto operandIds = readKnownOperandIds(r, opcode, variant, *info, imms);
   auto operands = materializeOperands(bc, operandIds);
@@ -854,7 +856,7 @@ static void buildOpList(BuildCtx &bc, Reader &r, mlir::Block &block) {
     if (dbg) {
       llvm::errs() << "[ptobc]    op[" << oi << "]...\n";
     }
-    const uint64_t opId = bc.nextOpId ? (*bc.nextOpId)++ : 0;
+    const uint64_t opId = bc.nextOpId++;
 
     uint16_t opcode = r.readU16LE();
     uint64_t attrId = r.readULEB();
@@ -980,17 +982,16 @@ static void buildDefinedFunctionBody(
     BuildCtx &bc, Reader &r, mlir::func::FuncOp fn, bool dbg,
     std::vector<std::vector<mlir::Operation *>> *opsByFuncOut) {
   bc.values.clear();
-  uint64_t nextOpId = 0;
-  std::vector<mlir::Operation *> opsById;
-  bc.nextOpId = &nextOpId;
-  bc.opsById = &opsById;
+  bc.nextOpId = 0;
+  bc.opsById.clear();
   buildRegionInto(bc, r, fn.getBody());
   if (dbg) {
     llvm::errs() << "[ptobc] func body built ok: values=" << bc.values.size()
-                 << " ops=" << opsById.size() << "\n";
+                 << " ops=" << bc.opsById.size() << "\n";
   }
   if (opsByFuncOut) {
-    opsByFuncOut->push_back(std::move(opsById));
+    opsByFuncOut->push_back(std::move(bc.opsById));
+    bc.opsById.clear();
   }
 }
 
@@ -1037,7 +1038,7 @@ decodeToModule(mlir::MLIRContext &ctx, const std::vector<std::string> &strings,
   Reader r{moduleBytes.data(), moduleBytes.data() + moduleBytes.size()};
   std::vector<ConstEntryParsed> consts;
   parseConstPoolSection(constPool, consts);
-  BuildCtx bc{&ctx, &strings, &types, &attrs, &consts, {}, nullptr, nullptr};
+  BuildCtx bc{&ctx, &strings, &types, &attrs, &consts, {}, 0, {}};
   uint64_t moduleAttrId = readModuleHeader(r, dbg);
   std::vector<FuncDecl> decls = readFunctionDecls(bc, r, dbg);
 
@@ -1229,7 +1230,7 @@ void decodeFileToPTO(const std::string &inPath, const std::string &outPath) {
   if (dbg) {
     llvm::errs() << "[ptobc] writing output: " << outPath << "\n";
   }
-  std::ofstream ofs(outPath);
+  std::ofstream ofs(canonicalizeIoPath(outPath));
   ofs << out;
   if (!out.empty() && out.back() != '\n') {
     ofs << "\n";

--- a/tools/ptobc/src/ptobc_format.cpp
+++ b/tools/ptobc/src/ptobc_format.cpp
@@ -32,7 +32,7 @@ constexpr size_t kPTOBCMagicSize = sizeof(kPTOBCMagic);
 } // namespace
 
 void Buffer::append(const void* p, size_t n) {
-  const uint8_t* b = reinterpret_cast<const uint8_t*>(p);
+  const uint8_t* b = static_cast<const uint8_t*>(p);
   bytes.insert(bytes.end(), b, b + n);
 }
 
@@ -203,8 +203,20 @@ std::vector<uint8_t> PTOBCFile::serialize() const {
   return out.bytes;
 }
 
+std::filesystem::path canonicalizeIoPath(const std::string& path) {
+  // weakly_canonical resolves the existing prefix (symlinks, dots) while
+  // tolerating a not-yet-existing tail, which writeFile needs for new outputs.
+  std::error_code ec;
+  std::filesystem::path canonical =
+      std::filesystem::weakly_canonical(std::filesystem::path(path), ec);
+  if (ec || canonical.empty()) {
+    return std::filesystem::path(path).lexically_normal();
+  }
+  return canonical;
+}
+
 std::vector<uint8_t> readFile(const std::string& path) {
-  std::ifstream ifs(path, std::ios::binary);
+  std::ifstream ifs(canonicalizeIoPath(path), std::ios::binary);
   if (!ifs) {
     throw std::runtime_error("Failed to open: " + path);
   }
@@ -213,11 +225,12 @@ std::vector<uint8_t> readFile(const std::string& path) {
 }
 
 void writeFile(const std::string& path, const std::vector<uint8_t>& data) {
-  std::ofstream ofs(path, std::ios::binary);
+  std::ofstream ofs(canonicalizeIoPath(path), std::ios::binary);
   if (!ofs) {
     throw std::runtime_error("Failed to write: " + path);
   }
-  ofs.write(reinterpret_cast<const char*>(data.data()), data.size());
+  const char* rawBytes = static_cast<const char*>(static_cast<const void*>(data.data()));
+  ofs.write(rawBytes, data.size());
 }
 
 } // namespace ptobc


### PR DESCRIPTION
## Summary

Resolve the codecheck findings for `tools/ptoas` and `tools/ptobc` tracked in `codecheck-fix-3.md` (107 items: 103 fixed, 4 marked not-applicable with reasons documented in the report).

- **G.EXP.15** — replace `reinterpret_cast` with two-step `static_cast` via `void*` for byte aliasing in driver / VFSIMTSizePatcher / ptobc_format.
- **G.RES.06** — replace all `[&]` default lambda captures in the reported scopes with explicit captures.
- **G.EXP.27 / G.EXP.36** — fix `bool |=` accumulation (keeping the always-evaluate semantics), non-boolean `if`/`?:` conditions (`size_t`/`uint8_t` → `!= 0`), signed bit ops in `leb128`, `char` arithmetic in name-hint hex encode/decode, and `cl::boolOrDefault &&` (`== BOU_TRUE`).
- **G.FIL.02** — add `ptobc::canonicalizeIoPath` (`std::filesystem::weakly_canonical`) before file stream open.
- **G.RES.04** — make `BuildCtx::nextOpId`/`opsById` value members so no local variable address escapes its scope.
- **G.CNS.03/04, G.FUN.02** — `allocModuleId` const; const-ify pure read helpers; align `compilePTOASModule` declaration parameter name.
- **huge_method / cyclomatic complexity** — most oversize items were already absorbed by the prior `ptoas.cpp` split and ptobc table-driven refactors; this PR further extracts the VPTO fast path and EmitC text emission helpers out of `compilePTOASModule` (106 → 39 nbnc).

Not applicable (documented in the report): `initializeMLIRContext`/`getMLIRContext` (semantically mutable context), `pybind11_init__core` (pybind11-macro-generated symbol), and the `borrowedContext` constructor parameter (retained mutable for dialect loading; public API unchanged).

## Test plan

- [x] 144 host, LLVM 19.1.7 assert build: full build is warning/error-free under `-Werror`.
- [x] CTest 69/69 (45 PTO/PTODSL + 23 PTOBC + smoke).
- [x] Rewritten SLEB128 matches the previous implementation on 440k values incl. INT64_MIN/MAX.
- [x] Changed-code compliance checker: no hits on the modified lines; `git diff --check` clean.
