### PR TITLE
feat(ptodsl): expose tile MGather

### DIFF
--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -4147,6 +4147,32 @@ def tscatter(src, dst, *, indexes=None, axis=None, mask_pattern=None):
     )
 
 
+def mgather(mem, idx, dst, coalesce, *, scratch=None, gather_oob=None):
+    """``pto.mgather`` from a GM tensor view into a destination tile."""
+    if not isinstance(coalesce, Attribute):
+        coalesce = _enum_attr(
+            "coalesce",
+            coalesce,
+            supported={"row", "elem"},
+            context="tile.mgather(..., coalesce=...)",
+        )
+    if gather_oob is not None and not isinstance(gather_oob, Attribute):
+        gather_oob = _enum_attr(
+            "gather_oob",
+            gather_oob,
+            supported={"undefined", "clamp", "wrap", "zero"},
+            context="tile.mgather(..., gather_oob=...)",
+        )
+    _pto.mgather(
+        unwrap_surface_value(mem),
+        unwrap_surface_value(idx),
+        unwrap_surface_value(dst),
+        coalesce,
+        scratch=None if scratch is None else unwrap_surface_value(scratch),
+        gather_oob=gather_oob,
+    )
+
+
 def tsel(mask, src0, src1, dst, *, tmp=None):
     """``pto.tsel ins(mask, src0, src1, tmp) outs(dst)`` with synthesized scratch when omitted."""
     resolved_tmp = tmp if tmp is not None else _resolve_selection_tmp(dst, tmp, context="tsel")

--- a/ptodsl/ptodsl/_tile_namespace.py
+++ b/ptodsl/ptodsl/_tile_namespace.py
@@ -181,6 +181,7 @@ class _TileNamespace:
     gather = staticmethod(_ops.tgather)
     gatherb = staticmethod(_ops.tgatherb)
     scatter = staticmethod(_ops.tscatter)
+    mgather = staticmethod(_ops.mgather)
 
     tri = staticmethod(_ops.ttri)
     histogram = staticmethod(_ops.tthistogram)

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -868,6 +868,15 @@ def host_vec_copy_emitc(
     pto.tile.store(o_tile, out)
 
 
+@pto.jit(target="a5", backend="emitc")
+def mgather_emitc_frontend_probe(table_ptr: pto.ptr(pto.f32, "gm")):
+    table_view = pto.make_tensor_view(table_ptr, shape=[32, 32], strides=[32, 1])
+    table = pto.partition_view(table_view, offsets=[0, 0], sizes=[32, 32])
+    indexes = pto.alloc_tile(shape=[1, 32], dtype=pto.i32)
+    destination = pto.alloc_tile(shape=[32, 32], dtype=pto.f32)
+    pto.tile.mgather(table, indexes, destination, coalesce="row", gather_oob="zero")
+
+
 @pto.jit(target="a5", entry=False, backend="vpto")
 def non_entry_metadata_probe(
     A_ptr: pto.ptr(pto.f32, "gm"),
@@ -5729,6 +5738,17 @@ def main() -> None:
     expect(
         '#pto.kernel_kind<' not in emitc_entry_text,
         "EmitC-only child modules should not carry VPTO kernel-kind metadata",
+    )
+    mgather_emitc_text = mgather_emitc_frontend_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(mgather_emitc_text, "emitc pto.tile.mgather specialization")
+    expect("pto.mgather" in mgather_emitc_text, "pto.tile.mgather should lower to pto.mgather")
+    expect(
+        "coalesce = #pto<coalesce row>" in mgather_emitc_text,
+        "pto.tile.mgather should preserve the explicit row coalesce attribute",
+    )
+    expect(
+        "gatherOob = #pto<gather_oob zero>" in mgather_emitc_text,
+        "pto.tile.mgather should preserve the non-default zero gather_oob attribute",
     )
     emitc_helper_text = (
         emitc_entry_calls_emitc_vector_kernel_module_metadata_probe.compile().mlir_text()

--- a/ptodsl/tests/test_ptoas_frontend_verify.py
+++ b/ptodsl/tests/test_ptoas_frontend_verify.py
@@ -238,6 +238,15 @@ def host_vec_copy(
     pto.tile.store(o_tile, out)
 
 
+@pto.jit(target="a5", backend="emitc")
+def mgather_emitc_frontend_probe(table_ptr: pto.ptr(pto.f32, "gm")):
+    table_view = pto.make_tensor_view(table_ptr, shape=[32, 32], strides=[32, 1])
+    table = pto.partition_view(table_view, offsets=[0, 0], sizes=[32, 32])
+    indexes = pto.alloc_tile(shape=[1, 32], dtype=pto.i32)
+    destination = pto.alloc_tile(shape=[32, 32], dtype=pto.f32)
+    pto.tile.mgather(table, indexes, destination, coalesce="row", gather_oob="zero")
+
+
 @pto.simt
 def simt_gm_memory_core_body(gm: pto.ptr(pto.i32, "gm")):
     tx = pto.get_tid_x()
@@ -385,6 +394,20 @@ def main() -> None:
     expect(
         "pto.tload" in simple_frontend_text and "pto.tstore" in simple_frontend_text,
         "host_vec_copy frontend verification output should keep the tile IO contract visible",
+    )
+
+    mgather_cpp_texts = run_ptoas_emitc(
+        ptoas_bin,
+        mgather_emitc_frontend_probe.compile().mlir_text(),
+        "mgather_emitc_frontend_probe PTODSL EmitC artifact",
+    )
+    expect(
+        len(mgather_cpp_texts) == 1,
+        "mgather PTODSL probe should materialize one EmitC module",
+    )
+    expect(
+        "MGATHER<pto::Coalesce::Row, pto::GatherOOB::Zero>" in mgather_cpp_texts[0],
+        "PTODSL mgather probe should preserve row coalescing and zero out-of-bounds handling in EmitC",
     )
 
     struct_text = struct_frontend_verify_probe.compile().mlir_text()

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -1215,6 +1215,35 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "unsupported tile mask pattern"):
             pto.tile.gather(src, dst, mask_pattern="PAT_ALL", axis="row")
 
+        coalesce_attr = object()
+        oob_attr = object()
+        with patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_ops, "_enum_attr", side_effect=[coalesce_attr, oob_attr]) as enum_attr, \
+             patch.object(_ops._pto, "mgather") as mgather_op:
+            pto.tile.mgather(src, idx, dst, "row", gather_oob="zero")
+        self.assertEqual(
+            enum_attr.call_args_list,
+            [
+                call(
+                    "coalesce",
+                    "row",
+                    supported={"row", "elem"},
+                    context="tile.mgather(..., coalesce=...)",
+                ),
+                call(
+                    "gather_oob",
+                    "zero",
+                    supported={"undefined", "clamp", "wrap", "zero"},
+                    context="tile.mgather(..., gather_oob=...)",
+                ),
+            ],
+        )
+        self.assertEqual(mgather_op.call_args.args, (src, idx, dst, coalesce_attr))
+        self.assertEqual(
+            mgather_op.call_args.kwargs,
+            {"scratch": None, "gather_oob": oob_attr},
+        )
+
     def test_tile_mov_accepts_acc_to_vec_mode(self):
         src = object()
         dst = object()


### PR DESCRIPTION
## Summary
- expose the existing `pto.mgather` IR operation as public `pto.tile.mgather`
- support explicit Row/Elem coalescing, all GatherOOB values, and optional GM scratch
- add wrapper dispatch and real compiler-level MLIR coverage
- verify the generated PTODSL kernel through the existing EmitC lowering to `MGATHER<Coalesce, GatherOOB>`

This PR is frontend-only and does not depend on the A2/A3 VPTO MGather lowering.

## Validation
- `test_vector_cube_ops.py`: 61 passed
- `ptodsl_jit_compile`: passed
- `ptodsl_ptoas_frontend_verify`: passed, including PTOAS EmitC generation
- Python syntax validation: passed
- changed-code compliance: 0 errors, 0 warnings