### PR TITLE
fix(vmi): materialize compact group slots as contiguous

### DIFF
--- a/docs/isa/vmi-isa/07-sfu.md
+++ b/docs/isa/vmi-isa/07-sfu.md
@@ -309,6 +309,9 @@
 - **datatypes:** Source bin index: `ui8` or signless `i8`. Accumulator / result:
   `ui16` or signless `i16`. All are interpreted as
   unsigned; signed types (`si8` / `si16`) are rejected by the verifier.
+- **source length:** Any positive logical lane count accepted by the VMI type,
+  including short vectors such as VL=1/2/4/8 that a compact grouped load
+  produces. Lowering masks physical padding lanes.
 - **lowering to `pto.mi`:**
   ```
   chistv2 Bin_N0 + Bin_N1 (two-half fanout) + widen/accumulate
@@ -379,6 +382,9 @@
 - **datatypes:** Source bin index: `ui8` or signless `i8`. Accumulator / result:
   `ui16` or signless `i16`. All are interpreted as
   unsigned; signed types (`si8` / `si16`) are rejected by the verifier.
+- **source length:** Any positive logical lane count accepted by the VMI type,
+  including short vectors such as VL=1/2/4/8 that a compact grouped load
+  produces. Lowering masks physical padding lanes.
 - **lowering to `pto.mi`:**
   ```
   distribution histogram accumulate (no half-axis fanout)
@@ -498,6 +504,10 @@
 - **results:** *(none)*
 - **attributes:** `pmode`
 - **datatypes:** `i8`–`i32`, `f16`, `bf16`, `f32`
+- **lowering constraints:** Current PTOAS VPTO lowering requires contiguous
+  value, offset, and mask layouts with the same number of complete physical
+  chunks. Partial vectors, including B32 VL=1/2/4/8, are rejected with a
+  stable `VMI-UNSUPPORTED` diagnostic.
 - **lowering to `pto.mi`:**
   ```
   K × pto.vscatter

--- a/include/PTO/Transforms/VMILayoutSupport.h
+++ b/include/PTO/Transforms/VMILayoutSupport.h
@@ -22,6 +22,27 @@
 
 namespace mlir::pto {
 
+/// True when `layout` is a group-slot packet that lives in a single physical
+/// chunk and puts logical lane i on physical lane i.
+///
+/// A `num_groups = G, slots = S, lane_stride = 1` layout places logical lane i
+/// at {part 0, chunk i / S, lane i % S}.  With `G <= S` every lane lands in
+/// chunk 0 at lane i, and `G <= lanesPerPart` keeps that lane inside the
+/// carrier, so the value occupies exactly one physical register whose live
+/// lanes are 0..G-1.
+bool isVMISingleCarrierGroupSlots(VMILayoutAttr layout, int64_t lanesPerPart);
+
+/// True when a group-slot packet and a dense contiguous vector describe exactly
+/// the same physical lanes of a single carrier, so converting between them is a
+/// pure register forward with no pack/zip/shuffle.  Symmetric in `lhs`/`rhs`:
+/// the relation holds in both directions.
+///
+/// This states the physical invariant instead of enumerating the group counts
+/// that today's compact load/store alias happens to emit, so it stays correct
+/// when that alias changes.
+bool isVMISingleCarrierGroupSlotAlias(VMILayoutAttr lhs, VMILayoutAttr rhs,
+                                      int64_t lanesPerPart);
+
 struct VMILoadLayoutFact {
   VMILayoutAttr resultLayout;
 };

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -45,6 +45,24 @@
 namespace mlir {
 namespace pto {
 
+bool isVMISingleCarrierGroupSlots(VMILayoutAttr layout, int64_t lanesPerPart) {
+  return layout && layout.isGroupSlots() && layout.getSlots() > 0 &&
+         layout.getLaneStride() == 1 &&
+         layout.getNumGroups() <= layout.getSlots() &&
+         layout.getNumGroups() <= lanesPerPart;
+}
+
+bool isVMISingleCarrierGroupSlotAlias(VMILayoutAttr lhs, VMILayoutAttr rhs,
+                                      int64_t lanesPerPart) {
+  auto isDenseCarrier = [](VMILayoutAttr layout) {
+    return layout && layout.isContiguous() && layout.getLaneStride() == 1;
+  };
+  return (isVMISingleCarrierGroupSlots(lhs, lanesPerPart) &&
+          isDenseCarrier(rhs)) ||
+         (isDenseCarrier(lhs) &&
+          isVMISingleCarrierGroupSlots(rhs, lanesPerPart));
+}
+
 namespace {
 
 constexpr int64_t kLayoutBlockBitWidth = 256;
@@ -1593,6 +1611,12 @@ static LogicalResult matchEnsureLayoutPattern(VMIVRegType sourceType,
           ? sourceLayout.getNumGroups()
           : (resultLayout.isGroupSlots() ? resultLayout.getNumGroups() : 0);
 
+  // Rows keyed on gsFit() reason about the carrier the value lives in, so they
+  // need the physical lane width of the element type.
+  FailureOr<int64_t> lanesPerPart =
+      getDataLanesPerPart(sourceType.getElementType());
+  int64_t carrierLanes = succeeded(lanesPerPart) ? *lanesPerPart : 0;
+
   for (const EnsureLayoutPattern &pattern : kEnsureLayoutPatterns) {
     if (!matchesElementBitsPattern(pattern.elementBits,
                                    sourceType.getElementType())) {
@@ -1603,11 +1627,11 @@ static LogicalResult matchEnsureLayoutPattern(VMIVRegType sourceType,
       continue;
     }
     if (!matchesLayoutPattern(sourceType.getContext(), pattern.sourceLayout,
-                              sourceLayout, numGroups)) {
+                              sourceLayout, numGroups, carrierLanes)) {
       continue;
     }
     if (!matchesLayoutPattern(resultType.getContext(), pattern.resultLayout,
-                              resultLayout, numGroups)) {
+                              resultLayout, numGroups, carrierLanes)) {
       continue;
     }
     return success();

--- a/lib/PTO/Transforms/VMILayoutSupportPatternDSL.inc
+++ b/lib/PTO/Transforms/VMILayoutSupportPatternDSL.inc
@@ -19,6 +19,10 @@ enum class LayoutPatternKind {
   Deinterleaved,
   BlockDeinterleaved,
   GroupSlots,
+  // Any group_slots layout whose groups fit in one physical chunk at lane i.
+  // Unlike GroupSlots this key does not pin `slots`; it selects the family of
+  // group packets that share a carrier with a dense short vector.
+  SingleCarrierGroupSlots,
 };
 
 enum class CastTypeClass {
@@ -194,14 +198,22 @@ static VMILayoutAttr materializeLayoutPattern(MLIRContext *ctx,
                ? VMILayoutAttr::getGroupSlots(ctx, numGroups, pattern.value,
                                               pattern.laneStride)
                : VMILayoutAttr();
+  case LayoutPatternKind::SingleCarrierGroupSlots:
+    // Matched by predicate in matchesLayoutPattern; `slots` is not pinned so
+    // there is no single attribute to materialize.
+    return VMILayoutAttr();
   }
   llvm_unreachable("unknown layout pattern kind");
 }
 
 static bool matchesLayoutPattern(MLIRContext *ctx, LayoutPattern pattern,
-                                 VMILayoutAttr layout, int64_t numGroups = 0) {
+                                 VMILayoutAttr layout, int64_t numGroups = 0,
+                                 int64_t lanesPerPart = 0) {
   if (!layout) {
     return false;
+  }
+  if (pattern.kind == LayoutPatternKind::SingleCarrierGroupSlots) {
+    return isVMISingleCarrierGroupSlots(layout, lanesPerPart);
   }
   return materializeLayoutPattern(ctx, pattern, numGroups) == layout;
 }
@@ -224,6 +236,13 @@ static constexpr LayoutPattern bd(int64_t factor) {
 
 static constexpr LayoutPattern gs(int64_t slots, int64_t laneStride = 1) {
   return {LayoutPatternKind::GroupSlots, slots, laneStride};
+}
+
+/// Group packets whose groups all fit in one physical chunk (num_groups <=
+/// slots, lane_stride = 1).  Rows keyed on `gsFit()` hold for every `slots`
+/// value, so they express a physical property instead of a group count list.
+static constexpr LayoutPattern gsFit() {
+  return {LayoutPatternKind::SingleCarrierGroupSlots, 0, 1};
 }
 
 static constexpr GroupMemoryPattern memAny() {

--- a/lib/PTO/Transforms/VMILayoutSupportTables.inc
+++ b/lib/PTO/Transforms/VMILayoutSupportTables.inc
@@ -21,10 +21,13 @@ struct EnsureLayoutPattern {
 };
 
 static constexpr EnsureLayoutPattern kEnsureLayoutPatterns[] = {
-    // A one-element dense value and a one-group, one-slot value select the
-    // same sole physical carrier lane.
-    {bits<8, 16, 32, 64>(), N<1>(), c(), gs(1)},
-    {bits<8, 16, 32, 64>(), N<1>(), gs(1), c()},
+    // A group packet whose groups fit in one physical chunk and a dense short
+    // vector select the same lanes of the same sole physical carrier, so the
+    // conversion forwards the register unchanged in either direction.  This
+    // covers the one-group/one-slot case and every group count the compact
+    // load/store alias emits, without enumerating those counts.
+    {bits<8, 16, 32, 64>(), anyN(), gsFit(), c()},
+    {bits<8, 16, 32, 64>(), anyN(), c(), gsFit()},
 
     {bits<16>(), N<256>(), c(), d(2)},
     {bits<32>(), N<128, 256>(), c(), d(2)},

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3974,18 +3974,18 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
     return SmallVector<Value>(sourceParts.begin(), sourceParts.end());
   }
 
-  bool oneLaneContiguousToGroup =
-      sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 1 &&
-      resultLayout.isGroupSlots() && resultLayout.getNumGroups() == 1 &&
-      resultLayout.getSlots() == 1;
-  bool oneLaneGroupToContiguous =
-      sourceLayout.isGroupSlots() && sourceLayout.getNumGroups() == 1 &&
-      sourceLayout.getSlots() == 1 && resultLayout.isContiguous() &&
-      resultLayout.getLaneStride() == 1;
-  if (oneLaneContiguousToGroup || oneLaneGroupToContiguous) {
+  // A group packet that fits in one physical chunk and a dense short vector
+  // occupy the same carrier lanes, so either direction forwards the register
+  // unchanged.  verifyIdentityPartForwarding confirms the physical arity and
+  // part types agree; the same relation gates the ensure_layout support table.
+  FailureOr<int64_t> carrierLanes = getDataLanesPerPart(sourceVMIElementType);
+  if (succeeded(carrierLanes) &&
+      isVMISingleCarrierGroupSlotAlias(sourceLayout, resultLayout,
+                                       *carrierLanes)) {
     if (failed(verifyIdentityPartForwarding(op, sourceParts, resultTypes,
-                                            rewriter)))
+                                            rewriter))) {
       return failure();
+    }
     return SmallVector<Value>(sourceParts.begin(), sourceParts.end());
   }
 

--- a/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
+++ b/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
@@ -1124,6 +1124,9 @@ producing a 256-bin unsigned 16-bit result.
 **Constraints**:
 - PTODSL infers the result vector type from `acc`; it must be the matching
   256×ui16 histogram accumulator layout.
+- Short source vectors are supported whenever the lanes fit in one physical
+  vector register, which covers the 1/2/4/8 lane counts a compact grouped
+  load produces; lowering masks physical padding lanes.
 
 ---
 
@@ -1150,6 +1153,9 @@ as `vdhist` but each bin accumulates the sum of counts for all bins ≤ its inde
 **Constraints**:
 - PTODSL infers the result vector type from `acc`; it must be the matching
   256×ui16 histogram accumulator layout.
+- Short source vectors are supported whenever the lanes fit in one physical
+  vector register, which covers the 1/2/4/8 lane counts a compact grouped
+  load produces; lowering masks physical padding lanes.
 
 ---
 
@@ -1222,6 +1228,12 @@ irregular memory locations using per-lane element offsets.
 | `pmode` | `str` or `None` | Optional predicate mode: `"merge"` keeps predicate-inactive lanes at their prior value; `"zero"` writes 0 |
 
 **Returns**: None (side-effect operation).
+
+**Constraints**:
+- Current PTOAS lowering requires the value, offsets, and mask to use
+  contiguous layouts with the same number of complete physical chunks.
+  Partial vectors, including `f32`/`i32` VL=1/2/4/8, are rejected with
+  `VMI-UNSUPPORTED`.
 
 **Example**:
 

--- a/test/lit/vmi_new/vmi_compact_histogram_layout_identity.pto
+++ b/test/lit/vmi_new/vmi_compact_histogram_layout_identity.pto
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=LAYOUT
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -pto-validate-vmi-layout-ir -vmi-to-vpto | FileCheck %s --check-prefix=LOWER --implicit-check-not=pto.vmi. --implicit-check-not=unrealized_conversion_cast
+
+module {
+  func.func @compact_vdhist_vl1(
+      %src: !pto.ptr<ui8, ub>,
+      %acc: !pto.vmi.vreg<256xui16>) -> !pto.vmi.vreg<256xui16> {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 1 : index
+    %source = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<1xui8>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<1xpred>
+    %hist = pto.vmi.vdhist %acc, %source, %mask
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<1xui8>,
+          !pto.vmi.mask<1xpred> -> !pto.vmi.vreg<256xui16>
+    return %hist : !pto.vmi.vreg<256xui16>
+  }
+
+  func.func @compact_vdhist_vl2(
+      %src: !pto.ptr<ui8, ub>,
+      %acc: !pto.vmi.vreg<256xui16>) -> !pto.vmi.vreg<256xui16> {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 2 : index
+    %source = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<2xui8>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<2xpred>
+    %hist = pto.vmi.vdhist %acc, %source, %mask
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<2xui8>,
+          !pto.vmi.mask<2xpred> -> !pto.vmi.vreg<256xui16>
+    return %hist : !pto.vmi.vreg<256xui16>
+  }
+
+  func.func @compact_vdhist_vl4(
+      %src: !pto.ptr<ui8, ub>,
+      %acc: !pto.vmi.vreg<256xui16>) -> !pto.vmi.vreg<256xui16> {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 4 : index
+    %source = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<4xui8>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<4xpred>
+    %hist = pto.vmi.vdhist %acc, %source, %mask
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<4xui8>,
+          !pto.vmi.mask<4xpred> -> !pto.vmi.vreg<256xui16>
+    return %hist : !pto.vmi.vreg<256xui16>
+  }
+
+  func.func @compact_vdhist_vl8(
+      %src: !pto.ptr<ui8, ub>,
+      %acc: !pto.vmi.vreg<256xui16>) -> !pto.vmi.vreg<256xui16> {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 8 : index
+    %source = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<8xui8>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<8xpred>
+    %hist = pto.vmi.vdhist %acc, %source, %mask
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<8xui8>,
+          !pto.vmi.mask<8xpred> -> !pto.vmi.vreg<256xui16>
+    return %hist : !pto.vmi.vreg<256xui16>
+  }
+
+  func.func @compact_vchist_vl1(
+      %src: !pto.ptr<ui8, ub>,
+      %acc: !pto.vmi.vreg<256xui16>) -> !pto.vmi.vreg<256xui16> {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 1 : index
+    %source = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<1xui8>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<1xpred>
+    %hist = pto.vmi.vchist %acc, %source, %mask
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<1xui8>,
+          !pto.vmi.mask<1xpred> -> !pto.vmi.vreg<256xui16>
+    return %hist : !pto.vmi.vreg<256xui16>
+  }
+
+  func.func @compact_vchist_vl2(
+      %src: !pto.ptr<ui8, ub>,
+      %acc: !pto.vmi.vreg<256xui16>) -> !pto.vmi.vreg<256xui16> {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 2 : index
+    %source = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<2xui8>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<2xpred>
+    %hist = pto.vmi.vchist %acc, %source, %mask
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<2xui8>,
+          !pto.vmi.mask<2xpred> -> !pto.vmi.vreg<256xui16>
+    return %hist : !pto.vmi.vreg<256xui16>
+  }
+
+  func.func @compact_vchist_vl4(
+      %src: !pto.ptr<ui8, ub>,
+      %acc: !pto.vmi.vreg<256xui16>) -> !pto.vmi.vreg<256xui16> {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 4 : index
+    %source = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<4xui8>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<4xpred>
+    %hist = pto.vmi.vchist %acc, %source, %mask
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<4xui8>,
+          !pto.vmi.mask<4xpred> -> !pto.vmi.vreg<256xui16>
+    return %hist : !pto.vmi.vreg<256xui16>
+  }
+
+  func.func @compact_vchist_vl8(
+      %src: !pto.ptr<ui8, ub>,
+      %acc: !pto.vmi.vreg<256xui16>) -> !pto.vmi.vreg<256xui16> {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 8 : index
+    %source = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<8xui8>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<8xpred>
+    %hist = pto.vmi.vchist %acc, %source, %mask
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<8xui8>,
+          !pto.vmi.mask<8xpred> -> !pto.vmi.vreg<256xui16>
+    return %hist : !pto.vmi.vreg<256xui16>
+  }
+
+  // 128-bin accumulators lower through the Bin_N0-only half, which is the
+  // shape reported in issue #1377.
+  func.func @compact_vchist_b128_vl1(
+      %src: !pto.ptr<ui8, ub>,
+      %acc: !pto.vmi.vreg<128xui16>) -> !pto.vmi.vreg<128xui16> {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 1 : index
+    %source = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<1xui8>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<1xpred>
+    %hist = pto.vmi.vchist %acc, %source, %mask
+        : !pto.vmi.vreg<128xui16>, !pto.vmi.vreg<1xui8>,
+          !pto.vmi.mask<1xpred> -> !pto.vmi.vreg<128xui16>
+    return %hist : !pto.vmi.vreg<128xui16>
+  }
+
+  func.func @compact_vdhist_b128_vl1(
+      %src: !pto.ptr<ui8, ub>,
+      %acc: !pto.vmi.vreg<128xui16>) -> !pto.vmi.vreg<128xui16> {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 1 : index
+    %source = pto.vmi.vload %src[%c0]
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<1xui8>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<1xpred>
+    %hist = pto.vmi.vdhist %acc, %source, %mask
+        : !pto.vmi.vreg<128xui16>, !pto.vmi.vreg<1xui8>,
+          !pto.vmi.mask<1xpred> -> !pto.vmi.vreg<128xui16>
+    return %hist : !pto.vmi.vreg<128xui16>
+  }
+
+  // An explicit grouped load with a group count outside {1, 2, 4, 8} produces
+  // the same single-carrier packet and must reach the histogram the same way.
+  func.func @compact_vdhist_group3(
+      %src: !pto.ptr<ui8, ub>,
+      %acc: !pto.vmi.vreg<256xui16>) -> !pto.vmi.vreg<256xui16> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %active = arith.constant 3 : index
+    %source = pto.vmi.vload %src[%c0], %c1 {group = 3}
+        : !pto.ptr<ui8, ub> -> !pto.vmi.vreg<3xui8>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<3xpred>
+    %hist = pto.vmi.vdhist %acc, %source, %mask
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<3xui8>,
+          !pto.vmi.mask<3xpred> -> !pto.vmi.vreg<256xui16>
+    return %hist : !pto.vmi.vreg<256xui16>
+  }
+}
+
+// LAYOUT-LABEL: func.func @compact_vdhist_vl1(
+// LAYOUT: pto.vmi.group_slot_load
+// LAYOUT: pto.vmi.ensure_layout
+// LAYOUT: pto.vmi.vdhist
+// LAYOUT-LABEL: func.func @compact_vdhist_vl2(
+// LAYOUT: pto.vmi.group_slot_load
+// LAYOUT: pto.vmi.ensure_layout
+// LAYOUT: pto.vmi.vdhist
+// LAYOUT-LABEL: func.func @compact_vdhist_vl4(
+// LAYOUT: pto.vmi.group_slot_load
+// LAYOUT: pto.vmi.ensure_layout
+// LAYOUT: pto.vmi.vdhist
+// LAYOUT-LABEL: func.func @compact_vdhist_vl8(
+// LAYOUT: pto.vmi.group_slot_load
+// LAYOUT: pto.vmi.ensure_layout
+// LAYOUT: pto.vmi.vdhist
+
+// LAYOUT-LABEL: func.func @compact_vchist_vl1(
+// LAYOUT: pto.vmi.group_slot_load
+// LAYOUT: pto.vmi.ensure_layout
+// LAYOUT: pto.vmi.vchist
+// LAYOUT-LABEL: func.func @compact_vchist_vl2(
+// LAYOUT: pto.vmi.group_slot_load
+// LAYOUT: pto.vmi.ensure_layout
+// LAYOUT: pto.vmi.vchist
+// LAYOUT-LABEL: func.func @compact_vchist_vl4(
+// LAYOUT: pto.vmi.group_slot_load
+// LAYOUT: pto.vmi.ensure_layout
+// LAYOUT: pto.vmi.vchist
+// LAYOUT-LABEL: func.func @compact_vchist_vl8(
+// LAYOUT: pto.vmi.group_slot_load
+// LAYOUT: pto.vmi.ensure_layout
+// LAYOUT: pto.vmi.vchist
+
+// LAYOUT-LABEL: func.func @compact_vchist_b128_vl1(
+// LAYOUT: pto.vmi.group_slot_load
+// LAYOUT: pto.vmi.ensure_layout
+// LAYOUT: pto.vmi.vchist
+// LAYOUT-LABEL: func.func @compact_vdhist_b128_vl1(
+// LAYOUT: pto.vmi.group_slot_load
+// LAYOUT: pto.vmi.ensure_layout
+// LAYOUT: pto.vmi.vdhist
+// LAYOUT-LABEL: func.func @compact_vdhist_group3(
+// LAYOUT: pto.vmi.group_slot_load
+// LAYOUT: pto.vmi.ensure_layout
+// LAYOUT: pto.vmi.vdhist
+
+// LOWER-LABEL: func.func @compact_vdhist_vl1(
+// LOWER: pto.pand
+// LOWER: pto.dhistv2
+// LOWER-LABEL: func.func @compact_vdhist_vl2(
+// LOWER: pto.pand
+// LOWER: pto.dhistv2
+// LOWER-LABEL: func.func @compact_vdhist_vl4(
+// LOWER: pto.pand
+// LOWER: pto.dhistv2
+// LOWER-LABEL: func.func @compact_vdhist_vl8(
+// LOWER: pto.pand
+// LOWER: pto.dhistv2
+
+// LOWER-LABEL: func.func @compact_vchist_vl1(
+// LOWER: pto.pand
+// LOWER: pto.chistv2
+// LOWER-LABEL: func.func @compact_vchist_vl2(
+// LOWER: pto.pand
+// LOWER: pto.chistv2
+// LOWER-LABEL: func.func @compact_vchist_vl4(
+// LOWER: pto.pand
+// LOWER: pto.chistv2
+// LOWER-LABEL: func.func @compact_vchist_vl8(
+// LOWER: pto.pand
+// LOWER: pto.chistv2
+
+// LOWER-LABEL: func.func @compact_vchist_b128_vl1(
+// LOWER: pto.pand
+// LOWER: pto.chistv2
+// LOWER-LABEL: func.func @compact_vdhist_b128_vl1(
+// LOWER: pto.pand
+// LOWER: pto.dhistv2
+// LOWER-LABEL: func.func @compact_vdhist_group3(
+// LOWER: pto.pand
+// LOWER: pto.dhistv2

--- a/test/lit/vmi_new/vmi_compact_scatter_shape_invalid.pto
+++ b/test/lit/vmi_new/vmi_compact_scatter_shape_invalid.pto
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -split-input-file -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -pto-validate-vmi-layout-ir -vmi-to-vpto 2>&1 | FileCheck %s --implicit-check-not=VMI-LAYOUT-CONTRACT --implicit-check-not="ensure_layout has no registered materialization support"
+
+module {
+  func.func @compact_vscatter_vl1(
+      %value_src: !pto.ptr<f32, ub>, %index_src: !pto.ptr<i32, ub>,
+      %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 1 : index
+    %value = pto.vmi.vload %value_src[%c0]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<1xf32>
+    %indices = pto.vmi.vload %index_src[%c0]
+        : !pto.ptr<i32, ub> -> !pto.vmi.vreg<1xi32>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<1xpred>
+    pto.vmi.vscatter %value, %dst, %indices, %mask
+        : !pto.vmi.vreg<1xf32>, !pto.ptr<f32, ub>,
+          !pto.vmi.vreg<1xi32>, !pto.vmi.mask<1xpred>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @compact_vscatter_vl2(
+      %value_src: !pto.ptr<f32, ub>, %index_src: !pto.ptr<i32, ub>,
+      %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 2 : index
+    %value = pto.vmi.vload %value_src[%c0]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<2xf32>
+    %indices = pto.vmi.vload %index_src[%c0]
+        : !pto.ptr<i32, ub> -> !pto.vmi.vreg<2xi32>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<2xpred>
+    pto.vmi.vscatter %value, %dst, %indices, %mask
+        : !pto.vmi.vreg<2xf32>, !pto.ptr<f32, ub>,
+          !pto.vmi.vreg<2xi32>, !pto.vmi.mask<2xpred>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @compact_vscatter_vl4(
+      %value_src: !pto.ptr<f32, ub>, %index_src: !pto.ptr<i32, ub>,
+      %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 4 : index
+    %value = pto.vmi.vload %value_src[%c0]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<4xf32>
+    %indices = pto.vmi.vload %index_src[%c0]
+        : !pto.ptr<i32, ub> -> !pto.vmi.vreg<4xi32>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<4xpred>
+    pto.vmi.vscatter %value, %dst, %indices, %mask
+        : !pto.vmi.vreg<4xf32>, !pto.ptr<f32, ub>,
+          !pto.vmi.vreg<4xi32>, !pto.vmi.mask<4xpred>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @compact_vscatter_vl8(
+      %value_src: !pto.ptr<f32, ub>, %index_src: !pto.ptr<i32, ub>,
+      %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 8 : index
+    %value = pto.vmi.vload %value_src[%c0]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<8xf32>
+    %indices = pto.vmi.vload %index_src[%c0]
+        : !pto.ptr<i32, ub> -> !pto.vmi.vreg<8xi32>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<8xpred>
+    pto.vmi.vscatter %value, %dst, %indices, %mask
+        : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>,
+          !pto.vmi.vreg<8xi32>, !pto.vmi.mask<8xpred>
+    return
+  }
+}
+
+// CHECK-COUNT-4: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.scatter{{.*}}value requires full physical chunks; found padding lane in physical chunk

--- a/test/lit/vmi_new/vmi_ensure_compact_group_slot_contiguous_invalid.pto
+++ b/test/lit/vmi_new/vmi_ensure_compact_group_slot_contiguous_invalid.pto
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -split-input-file -pto-validate-vmi-layout-ir 2>&1 | FileCheck %s
+
+module {
+  func.func @group_count_16_invalid(
+      %value: !pto.vmi.vreg<16xf32,
+          #pto.vmi.layout<num_groups = 16, slots = 8>>) {
+    %bad = pto.vmi.ensure_layout %value
+        : !pto.vmi.vreg<16xf32,
+            #pto.vmi.layout<num_groups = 16, slots = 8>>
+          -> !pto.vmi.vreg<16xf32, #pto.vmi.layout<contiguous>>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @group_count_64_invalid(
+      %value: !pto.vmi.vreg<64xf32,
+          #pto.vmi.layout<num_groups = 64, slots = 8>>) {
+    %bad = pto.vmi.ensure_layout %value
+        : !pto.vmi.vreg<64xf32,
+            #pto.vmi.layout<num_groups = 64, slots = 8>>
+          -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+    return
+  }
+}
+
+// -----
+
+module {
+  // The groups fit in one chunk, but the chunk itself no longer fits in one
+  // f32 carrier, so lane 64 and beyond have no physical home.
+  func.func @group_count_exceeds_carrier_invalid(
+      %value: !pto.vmi.vreg<128xf32,
+          #pto.vmi.layout<num_groups = 128, slots = 128>>) {
+    %bad = pto.vmi.ensure_layout %value
+        : !pto.vmi.vreg<128xf32,
+            #pto.vmi.layout<num_groups = 128, slots = 128>>
+          -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @lane_stride_2_invalid(
+      %value: !pto.vmi.vreg<8xf32,
+          #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>) {
+    %bad = pto.vmi.ensure_layout %value
+        : !pto.vmi.vreg<8xf32,
+            #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
+          -> !pto.vmi.vreg<8xf32, #pto.vmi.layout<contiguous>>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @slots_1_invalid(
+      %value: !pto.vmi.vreg<8xf32,
+          #pto.vmi.layout<num_groups = 8, slots = 1>>) {
+    %bad = pto.vmi.ensure_layout %value
+        : !pto.vmi.vreg<8xf32,
+            #pto.vmi.layout<num_groups = 8, slots = 1>>
+          -> !pto.vmi.vreg<8xf32, #pto.vmi.layout<contiguous>>
+    return
+  }
+}
+
+// CHECK-COUNT-5: VMI-LAYOUT-CONTRACT: pto.vmi.ensure_layout has no registered materialization support: source/result layouts do not match a supported ensure_layout table row

--- a/test/lit/vmi_new/vmi_group_slot_load_memref_source_invalid.pto
+++ b/test/lit/vmi_new/vmi_group_slot_load_memref_source_invalid.pto
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -pto-validate-vmi-layout-ir -vmi-to-vpto 2>&1 | FileCheck %s --implicit-check-not=VMI-LAYOUT-CONTRACT
+
+// The compact load alias lowers through pto.vsldb / pto.vlds, which are
+// pointer-only, so a memref source is reported at the group_slot_load boundary
+// instead of being planned as a dense whole-register read.  Layout
+// materialization itself is supported here, so the diagnostic must be the
+// source-kind one and not an ensure_layout failure.
+
+module {
+  func.func @compact_group_slot_load_memref_source(
+      %src: memref<256xui8, #pto.address_space<vec>>,
+      %acc: !pto.vmi.vreg<256xui16>) -> !pto.vmi.vreg<256xui16> {
+    %c0 = arith.constant 0 : index
+    %active = arith.constant 8 : index
+    %source = pto.vmi.vload %src[%c0]
+        : memref<256xui8, #pto.address_space<vec>>
+          -> !pto.vmi.vreg<8xui8>
+    %mask = pto.vmi.create_mask %active
+        : index -> !pto.vmi.mask<8xpred>
+    %hist = pto.vmi.vdhist %acc, %source, %mask
+        : !pto.vmi.vreg<256xui16>, !pto.vmi.vreg<8xui8>,
+          !pto.vmi.mask<8xpred> -> !pto.vmi.vreg<256xui16>
+    return %hist : !pto.vmi.vreg<256xui16>
+  }
+}
+
+// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.group_slot_load
+// CHECK-SAME: group_slot_load requires !pto.ptr source

--- a/test/lit/vmi_new/vmi_layout_gate_helper_support_invalid.pto
+++ b/test/lit/vmi_new/vmi_layout_gate_helper_support_invalid.pto
@@ -9,11 +9,13 @@
 // RUN: not pto-test-opt %s -pto-validate-vmi-layout-ir 2>&1 | FileCheck %s
 
 module {
+  // 64 groups of 8 slots span eight physical chunks while the dense value uses
+  // one, so this pair stays outside the ensure_layout table.
   func.func @vmi_layout_gate_helper_support_invalid(
-      %value: !pto.vmi.vreg<8xf32, #pto.vmi.layout<contiguous>>) {
+      %value: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>) {
     %bad = pto.vmi.ensure_layout %value
-        : !pto.vmi.vreg<8xf32, #pto.vmi.layout<contiguous>>
-        -> !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+        : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<num_groups = 64, slots = 8>>
     return
   }
 }

--- a/test/lit/vmi_new/vmi_to_vpto_ensure_compact_group_slot_contiguous.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_ensure_compact_group_slot_contiguous.pto
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -pto-validate-vmi-layout-ir -vmi-to-vpto | FileCheck %s --implicit-check-not=pto.vmi. --implicit-check-not=unrealized_conversion_cast --implicit-check-not=pto.vpack --implicit-check-not=pto.vzunpack --implicit-check-not=pto.vintlv --implicit-check-not=pto.vdintlv
+
+module {
+  func.func @compact_gs8_to_contiguous_vl1_ui8(
+      %value: !pto.vmi.vreg<1xui8,
+          #pto.vmi.layout<num_groups = 1, slots = 8>>)
+      -> !pto.vmi.vreg<1xui8, #pto.vmi.layout<contiguous>> {
+    %dense = pto.vmi.ensure_layout %value
+        : !pto.vmi.vreg<1xui8,
+            #pto.vmi.layout<num_groups = 1, slots = 8>>
+          -> !pto.vmi.vreg<1xui8, #pto.vmi.layout<contiguous>>
+    return %dense : !pto.vmi.vreg<1xui8, #pto.vmi.layout<contiguous>>
+  }
+
+  func.func @compact_gs8_to_contiguous_vl2_ui16(
+      %value: !pto.vmi.vreg<2xui16,
+          #pto.vmi.layout<num_groups = 2, slots = 8>>)
+      -> !pto.vmi.vreg<2xui16, #pto.vmi.layout<contiguous>> {
+    %dense = pto.vmi.ensure_layout %value
+        : !pto.vmi.vreg<2xui16,
+            #pto.vmi.layout<num_groups = 2, slots = 8>>
+          -> !pto.vmi.vreg<2xui16, #pto.vmi.layout<contiguous>>
+    return %dense : !pto.vmi.vreg<2xui16, #pto.vmi.layout<contiguous>>
+  }
+
+  func.func @compact_gs8_to_contiguous_vl4_f32(
+      %value: !pto.vmi.vreg<4xf32,
+          #pto.vmi.layout<num_groups = 4, slots = 8>>)
+      -> !pto.vmi.vreg<4xf32, #pto.vmi.layout<contiguous>> {
+    %dense = pto.vmi.ensure_layout %value
+        : !pto.vmi.vreg<4xf32,
+            #pto.vmi.layout<num_groups = 4, slots = 8>>
+          -> !pto.vmi.vreg<4xf32, #pto.vmi.layout<contiguous>>
+    return %dense : !pto.vmi.vreg<4xf32, #pto.vmi.layout<contiguous>>
+  }
+
+  func.func @compact_gs8_to_contiguous_vl8_ui32(
+      %value: !pto.vmi.vreg<8xui32,
+          #pto.vmi.layout<num_groups = 8, slots = 8>>)
+      -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<contiguous>> {
+    %dense = pto.vmi.ensure_layout %value
+        : !pto.vmi.vreg<8xui32,
+            #pto.vmi.layout<num_groups = 8, slots = 8>>
+          -> !pto.vmi.vreg<8xui32, #pto.vmi.layout<contiguous>>
+    return %dense : !pto.vmi.vreg<8xui32, #pto.vmi.layout<contiguous>>
+  }
+
+  // A group count outside the compact load alias set still fits in one chunk,
+  // so it forwards the same carrier.
+  func.func @compact_gs8_to_contiguous_vl3_ui8(
+      %value: !pto.vmi.vreg<3xui8,
+          #pto.vmi.layout<num_groups = 3, slots = 8>>)
+      -> !pto.vmi.vreg<3xui8, #pto.vmi.layout<contiguous>> {
+    %dense = pto.vmi.ensure_layout %value
+        : !pto.vmi.vreg<3xui8,
+            #pto.vmi.layout<num_groups = 3, slots = 8>>
+          -> !pto.vmi.vreg<3xui8, #pto.vmi.layout<contiguous>>
+    return %dense : !pto.vmi.vreg<3xui8, #pto.vmi.layout<contiguous>>
+  }
+
+  // The relation is symmetric: a dense short vector forwards into a group
+  // packet that fits in one chunk.
+  func.func @contiguous_to_compact_gs8_vl8_f32(
+      %value: !pto.vmi.vreg<8xf32, #pto.vmi.layout<contiguous>>)
+      -> !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8>> {
+    %packet = pto.vmi.ensure_layout %value
+        : !pto.vmi.vreg<8xf32, #pto.vmi.layout<contiguous>>
+          -> !pto.vmi.vreg<8xf32,
+              #pto.vmi.layout<num_groups = 8, slots = 8>>
+    return %packet : !pto.vmi.vreg<8xf32,
+        #pto.vmi.layout<num_groups = 8, slots = 8>>
+  }
+
+  // One group in one slot is the same relation with slots = 1.
+  func.func @contiguous_to_gs1_vl1_f32(
+      %value: !pto.vmi.vreg<1xf32, #pto.vmi.layout<contiguous>>)
+      -> !pto.vmi.vreg<1xf32, #pto.vmi.layout<num_groups = 1, slots = 1>> {
+    %packet = pto.vmi.ensure_layout %value
+        : !pto.vmi.vreg<1xf32, #pto.vmi.layout<contiguous>>
+          -> !pto.vmi.vreg<1xf32,
+              #pto.vmi.layout<num_groups = 1, slots = 1>>
+    return %packet : !pto.vmi.vreg<1xf32,
+        #pto.vmi.layout<num_groups = 1, slots = 1>>
+  }
+}
+
+// CHECK-LABEL: func.func @compact_gs8_to_contiguous_vl1_ui8(
+// CHECK-SAME: %[[VL1:.*]]: !pto.vreg<256xui8>
+// CHECK: return %[[VL1]] : !pto.vreg<256xui8>
+
+// CHECK-LABEL: func.func @compact_gs8_to_contiguous_vl2_ui16(
+// CHECK-SAME: %[[VL2:.*]]: !pto.vreg<128xui16>
+// CHECK: return %[[VL2]] : !pto.vreg<128xui16>
+
+// CHECK-LABEL: func.func @compact_gs8_to_contiguous_vl4_f32(
+// CHECK-SAME: %[[VL4:.*]]: !pto.vreg<64xf32>
+// CHECK: return %[[VL4]] : !pto.vreg<64xf32>
+
+// CHECK-LABEL: func.func @compact_gs8_to_contiguous_vl8_ui32(
+// CHECK-SAME: %[[VL8:.*]]: !pto.vreg<64xui32>
+// CHECK: return %[[VL8]] : !pto.vreg<64xui32>


### PR DESCRIPTION
Fixes #1377.

## Problem

`VMILowerUnifiedToLegacy` rewrites every continuous `pto.vmi.vload` of 1/2/4/8
lanes into a `pto.vmi.group_slot_load`, because that is the only lowering that
can express a *bounded* short load (`pto.vsldb`, a 32-byte block under a
`PAT_VL{n}` mask). The dense path cannot: it needs whole physical chunks or a
provable whole-register over-read, which a `!pto.ptr` source can never supply.

The side effect is that the value's layout becomes `num_groups` instead of
`contiguous`, so histogram and scatter consumers that require a contiguous
layout ask for an `ensure_layout` conversion that was never registered:

```
ensure_layout has no registered materialization support:
source/result layouts do not match a supported ensure_layout table row
```

## Fix

Register the relation as a physical invariant rather than as a list of the
group counts the alias happens to emit.

A group packet with `num_groups <= slots`, `lane_stride = 1` and
`num_groups <= lanesPerPart` puts logical lane *i* on physical lane *i* of a
single carrier — exactly what a dense contiguous short vector does
(`getVMIPhysicalArity` is 1 on both sides; `mapLogicalLaneToPhysical` agrees
lane for lane). The conversion is therefore a pure register forward, in either
direction, with no pack/zip/shuffle.

- New table key `gsFit()` in the pattern DSL, used by two symmetric rows in
  `kEnsureLayoutPatterns`. It subsumes the previous one-group/one-slot rows.
- `isVMISingleCarrierGroupSlotAlias` (in `VMILayoutSupport.h`) is shared by the
  table matcher and the VPTO materializer, so the two cannot drift.

This also closes neighbouring cases that a group-count list leaves open:
an explicit `vload {group = 3}` hits the identical diagnostic today, and so
does the mirror direction, where a dense short vector reaches the compact
`group_store` alias.

`group_slot_load` keeps its `!pto.ptr` source requirement. `pto.vsldb` is
pointer-only, and PTODSL always hands `pto.vmi.vload` a pointer (kernels build
UB buffers with `pto.castptr(..., pto.ptr(dtype, "ub"))`), so nothing in the
DSL path needs a memref source here.

## Scatter

Small-VL `vscatter` is **not** made to work. It reaches the pre-existing
full-physical-chunk gate and is rejected with a stable
`VMI-UNSUPPORTED: pto.vmi.scatter ... value requires full physical chunks`
diagnostic, which is resolution path 2 in the issue. Documented in
`docs/isa/vmi-isa/07-sfu.md` and the PTODSL user guide.

## Validation

- Reproduction matrix: 21/21 checks pass (`vchist`/`vdhist` VL=1/2/4/8 lower;
  VL=64/128/256 controls unchanged; `vscatter` VL=1/2/4/8 rejected with the
  documented diagnostic).
- `vmi_new` lit suite: every test whose RUN lines use `pto-test-opt` passes.
- New/updated coverage: `num_groups = 3`, the reverse `contiguous -> group`
  direction, a 128-bin (`Bin_N0`-only) accumulator matching the shape reported
  in the issue, and negative cases for `num_groups > slots`,
  `lane_stride = 2`, and a group count wider than one carrier.

## Note for reviewers

`vmi_layout_gate_helper_support_invalid.pto` pinned
`contiguous -> num_groups = 8, slots = 8` at VL=8 as unsupported. That is
precisely the mirror direction this change enables, so the test was repointed
at `num_groups = 64, slots = 8`, which stays unsupported and preserves what the
test was checking.

## Follow-up

The alias itself still welds a *load strategy* to a *layout attribute*:
`VMIGroupSlotLoadOp::verify` forces a `num_groups` result layout even when the
value is physically indistinguishable from a contiguous one. Decoupling those
is tracked separately and is out of scope here.
