### PR TITLE
improve VMI FP4 dequant support

### DIFF
--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -413,31 +413,7 @@ struct LayoutSolver {
       return {};
     }
 
-    VMILayoutAttr directLayout = fact->layout.resultLayout;
-    // A direct E2B packet fills exactly one physical part. When the
-    // contiguous form of this broadcast spans multiple physical chunks, the
-    // direct table can only offer a deinterleaved split layout. Prefer the
-    // generic contiguous lowering (group_slots -> contiguous) so consumers
-    // such as plain elementwise vmul can stay contiguous and avoid
-    // vldsx2/vintlv-style deinterleave materialization.
-    if (fact->kind == VMIGroupBroadcastLoadDirectKind::E2B &&
-        directLayout.isDeinterleaved()) {
-      VMILayoutAttr contiguous = getContiguousLayout();
-      auto contiguousType = VMIVRegType::get(
-          ctx, type.getElementCount(), type.getElementType(), contiguous);
-      FailureOr<int64_t> contiguousArity = getVMIPhysicalArity(contiguousType);
-      if (succeeded(contiguousArity) && *contiguousArity > 1) {
-        FailureOr<
-            SmallVector<VMIGroupBroadcastLayoutFact, mlir::pto::kValue4>>
-            contiguousFacts = supports.getGroupBroadcastLayoutFactsForLayout(
-                type, contiguousType, op.getNumGroupsAttr().getInt(),
-                VMIGroupBroadcastLayoutPort::Result, contiguous);
-        if (succeeded(contiguousFacts) && !contiguousFacts->empty()) {
-          return contiguous;
-        }
-      }
-    }
-    return directLayout;
+    return fact->layout.resultLayout;
   }
 
   VMILayoutAttr getPreferredGroupBroadcastSourceLayout(Value value,
@@ -952,20 +928,6 @@ struct LayoutSolver {
     return llvm::TypeSwitch<Operation *, std::optional<WalkResult>>(op)
         .Case<VMIDeinterleaveLoadOp>([this, op](auto load) {
           return addDeinterleaveLoadConstraint(load, op);
-        })
-        .Case<VMILoadOp>([this, op](auto load) {
-          auto type = cast<VMIVRegType>(load.getResult().getType());
-          FailureOr<int64_t> lanesPerPart =
-              getDataLanesPerPart(type.getElementType());
-          VMILayoutAttr layout = getContiguousLayout();
-          if (succeeded(lanesPerPart) &&
-              type.getElementCount() < *lanesPerPart &&
-              *lanesPerPart % type.getElementCount() == 0) {
-            int64_t laneStride = *lanesPerPart / type.getElementCount();
-            layout = VMILayoutAttr::getContiguous(ctx, laneStride);
-          }
-          return constraintResult(
-              setNaturalLayout(load.getResult(), layout, op));
         })
         .Case<VMIMaskedLoadOp, VMIExpandLoadOp>([this, op](auto load) {
           requestDataUse(load.getPassthruMutable(), getContiguousLayout());

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -412,7 +412,32 @@ struct LayoutSolver {
     if (failed(fact)) {
       return {};
     }
-    return fact->layout.resultLayout;
+
+    VMILayoutAttr directLayout = fact->layout.resultLayout;
+    // A direct E2B packet fills exactly one physical part. When the
+    // contiguous form of this broadcast spans multiple physical chunks, the
+    // direct table can only offer a deinterleaved split layout. Prefer the
+    // generic contiguous lowering (group_slots -> contiguous) so consumers
+    // such as plain elementwise vmul can stay contiguous and avoid
+    // vldsx2/vintlv-style deinterleave materialization.
+    if (fact->kind == VMIGroupBroadcastLoadDirectKind::E2B &&
+        directLayout.isDeinterleaved()) {
+      VMILayoutAttr contiguous = getContiguousLayout();
+      auto contiguousType = VMIVRegType::get(
+          ctx, type.getElementCount(), type.getElementType(), contiguous);
+      FailureOr<int64_t> contiguousArity = getVMIPhysicalArity(contiguousType);
+      if (succeeded(contiguousArity) && *contiguousArity > 1) {
+        FailureOr<
+            SmallVector<VMIGroupBroadcastLayoutFact, mlir::pto::kValue4>>
+            contiguousFacts = supports.getGroupBroadcastLayoutFactsForLayout(
+                type, contiguousType, op.getNumGroupsAttr().getInt(),
+                VMIGroupBroadcastLayoutPort::Result, contiguous);
+        if (succeeded(contiguousFacts) && !contiguousFacts->empty()) {
+          return contiguous;
+        }
+      }
+    }
+    return directLayout;
   }
 
   VMILayoutAttr getPreferredGroupBroadcastSourceLayout(Value value,
@@ -927,6 +952,20 @@ struct LayoutSolver {
     return llvm::TypeSwitch<Operation *, std::optional<WalkResult>>(op)
         .Case<VMIDeinterleaveLoadOp>([this, op](auto load) {
           return addDeinterleaveLoadConstraint(load, op);
+        })
+        .Case<VMILoadOp>([this, op](auto load) {
+          auto type = cast<VMIVRegType>(load.getResult().getType());
+          FailureOr<int64_t> lanesPerPart =
+              getDataLanesPerPart(type.getElementType());
+          VMILayoutAttr layout = getContiguousLayout();
+          if (succeeded(lanesPerPart) &&
+              type.getElementCount() < *lanesPerPart &&
+              *lanesPerPart % type.getElementCount() == 0) {
+            int64_t laneStride = *lanesPerPart / type.getElementCount();
+            layout = VMILayoutAttr::getContiguous(ctx, laneStride);
+          }
+          return constraintResult(
+              setNaturalLayout(load.getResult(), layout, op));
         })
         .Case<VMIMaskedLoadOp, VMIExpandLoadOp>([this, op](auto load) {
           requestDataUse(load.getPassthruMutable(), getContiguousLayout());

--- a/lib/PTO/Transforms/VMILayoutSupportPatternDSL.inc
+++ b/lib/PTO/Transforms/VMILayoutSupportPatternDSL.inc
@@ -28,6 +28,8 @@ enum class CastTypeClass {
   Float,
   // Both source and result are integer element types.
   Integer,
+  // Packed E2M1 pairs widened to the register-only BF16-pair carrier.
+  F4E2M1x2ToBF16x2,
 };
 
 struct LayoutPattern {
@@ -138,6 +140,9 @@ static bool matchesCastTypeClass(CastTypeClass typeClass, Type sourceType,
             pto::isPTOLowPrecisionType(resultType));
   case CastTypeClass::Integer:
     return isa<IntegerType>(sourceType) && isa<IntegerType>(resultType);
+  case CastTypeClass::F4E2M1x2ToBF16x2:
+    return isa<pto::F4E2M1x2Type>(sourceType) &&
+           pto::isPTOBF16x2Type(resultType);
   }
   llvm_unreachable("unknown cast type class");
 }

--- a/lib/PTO/Transforms/VMILayoutSupportTables.inc
+++ b/lib/PTO/Transforms/VMILayoutSupportTables.inc
@@ -183,6 +183,7 @@ static constexpr PreferredCastLayoutPattern kPreferredCastLayoutPatterns[] = {
     // compact lane-stride form is the natural cast layout.
     {bits<16>(), bits<32>(), 64, ls(2), c()},
     {bits<8>(), bits<32>(), 64, ls(4), c()},
+    {bits<8>(), bits<32>(), 128, ls(4), c()},
     {bits<32>(), bits<16>(), 64, c(), ls(2)},
     {bits<32>(), bits<8>(), 64, c(), ls(4)},
     {bits<32>(), bits<8>(), 128, d(2), ls(2)},

--- a/lib/PTO/Transforms/VMILayoutSupportTables.inc
+++ b/lib/PTO/Transforms/VMILayoutSupportTables.inc
@@ -183,7 +183,8 @@ static constexpr PreferredCastLayoutPattern kPreferredCastLayoutPatterns[] = {
     // compact lane-stride form is the natural cast layout.
     {bits<16>(), bits<32>(), 64, ls(2), c()},
     {bits<8>(), bits<32>(), 64, ls(4), c()},
-    {bits<8>(), bits<32>(), 128, ls(4), c()},
+    {bits<8>(), bits<32>(), 128, ls(4), c(),
+     CastTypeClass::F4E2M1x2ToBF16x2},
     {bits<32>(), bits<16>(), 64, c(), ls(2)},
     {bits<32>(), bits<8>(), 64, c(), ls(4)},
     {bits<32>(), bits<8>(), 128, d(2), ls(2)},

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8926,6 +8926,22 @@ struct OneToNVMIGroupBroadcastLoadOpPattern
               firstType, VPTOMemoryOpFamily::Load, e2bDist);
     }
 
+    // One E2B packet materializes exactly one physical part. A contiguous
+    // broadcast result that spans multiple physical chunks has no single
+    // reusable packet per part, so keep the direct-E2B path only for the
+    // one-packet-per-part shapes and let the generic group_slots ->
+    // contiguous broadcast fallback handle the rest.
+    if (canUseDirectE2B) {
+      VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
+      FailureOr<int64_t> contiguousChunksPerPart =
+          getDataChunksInPart(resultVMIType, 0);
+      if (resultLayout && resultLayout.isContiguous() &&
+          (failed(contiguousChunksPerPart) ||
+           *contiguousChunksPerPart != 1)) {
+        canUseDirectE2B = false;
+      }
+    }
+
     if (failed(directFact) ||
         directFact->kind != VMIGroupBroadcastLoadDirectKind::E2B ||
         !canUseDirectE2B) {
@@ -11306,15 +11322,28 @@ struct OneToNVMIExtFOpPattern : OneToNOpConversionPattern<VMIExtFOp> {
 
     ArrayRef<StringRef> parts;
     int64_t factor = 0;
-    if (sourceBits == 16 && resultTypes.size() == 2 * sourceParts.size()) {
+    if (sourceBits == 16) {
       static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
-      parts = kEvenOddParts;
-      factor = 2;
-    } else if (sourceBits == 8 &&
-               resultTypes.size() == 4 * sourceParts.size()) {
+      constexpr int64_t kMaxFactor = 2;
+      if (resultTypes.size() == 0 ||
+          resultTypes.size() % sourceParts.size() != 0 ||
+          resultTypes.size() > kMaxFactor * sourceParts.size()) {
+        return rewriter.notifyMatchFailure(
+            op, "unsupported physical extf source/result width relation");
+      }
+      factor = resultTypes.size() / sourceParts.size();
+      parts = ArrayRef<StringRef>(kEvenOddParts, factor);
+    } else if (sourceBits == 8) {
       static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
-      parts = kPacked4Parts;
-      factor = 4;
+      constexpr int64_t kMaxFactor = 4;
+      if (resultTypes.size() == 0 ||
+          resultTypes.size() % sourceParts.size() != 0 ||
+          resultTypes.size() > kMaxFactor * sourceParts.size()) {
+        return rewriter.notifyMatchFailure(
+            op, "unsupported physical extf source/result width relation");
+      }
+      factor = resultTypes.size() / sourceParts.size();
+      parts = ArrayRef<StringRef>(kPacked4Parts, factor);
     } else {
       return rewriter.notifyMatchFailure(
           op, "unsupported physical extf source/result width relation");
@@ -11327,15 +11356,15 @@ struct OneToNVMIExtFOpPattern : OneToNOpConversionPattern<VMIExtFOp> {
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
-    for (int64_t partIndex = 0; partIndex < factor; ++partIndex) {
-      for (auto [chunkIndex, sourcePart] : llvm::enumerate(sourceParts)) {
-        VRegType resultType =
-            resultVRegTypes[partIndex * sourceParts.size() + chunkIndex];
-        results.push_back(viewVcvtResult(
-            resultType, sourcePart, *mask, /*rnd=*/nullptr, /*sat=*/nullptr,
-            rewriter.getStringAttr(parts[partIndex])));
+      for (int64_t partIndex = 0; partIndex < factor; ++partIndex) {
+        for (auto [chunkIndex, sourcePart] : llvm::enumerate(sourceParts)) {
+          VRegType resultType =
+              resultVRegTypes[partIndex * sourceParts.size() + chunkIndex];
+          results.push_back(viewVcvtResult(
+              resultType, sourcePart, *mask, /*rnd=*/nullptr, /*sat=*/nullptr,
+              rewriter.getStringAttr(parts[partIndex])));
+        }
       }
-    }
 
     replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
     return success();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11324,26 +11324,41 @@ struct OneToNVMIExtFOpPattern : OneToNOpConversionPattern<VMIExtFOp> {
     int64_t factor = 0;
     if (sourceBits == 16) {
       static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
-      constexpr int64_t kMaxFactor = 2;
-      if (resultTypes.size() == 0 ||
-          resultTypes.size() % sourceParts.size() != 0 ||
-          resultTypes.size() > kMaxFactor * sourceParts.size()) {
+      if (resultTypes.size() != 2 * sourceParts.size()) {
         return rewriter.notifyMatchFailure(
             op, "unsupported physical extf source/result width relation");
       }
-      factor = resultTypes.size() / sourceParts.size();
-      parts = ArrayRef<StringRef>(kEvenOddParts, factor);
+      factor = 2;
+      parts = kEvenOddParts;
     } else if (sourceBits == 8) {
       static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
-      constexpr int64_t kMaxFactor = 4;
-      if (resultTypes.size() == 0 ||
-          resultTypes.size() % sourceParts.size() != 0 ||
-          resultTypes.size() > kMaxFactor * sourceParts.size()) {
+      static constexpr StringRef kPacked2Parts[] = {"P0", "P2"};
+      static constexpr StringRef kPacked1Parts[] = {"P0"};
+      bool isPackedE2M1 =
+          isa<pto::F4E2M1x2Type>(sourceVMIType.getElementType());
+      if (!isPackedE2M1 && resultTypes.size() != 4 * sourceParts.size()) {
         return rewriter.notifyMatchFailure(
             op, "unsupported physical extf source/result width relation");
       }
-      factor = resultTypes.size() / sourceParts.size();
-      parts = ArrayRef<StringRef>(kPacked4Parts, factor);
+      if (!isPackedE2M1) {
+        factor = 4;
+        parts = kPacked4Parts;
+      } else if (sourceLayout && sourceLayout.isContiguous() &&
+                 sourceLayout.getLaneStride() == 4) {
+        factor = 1;
+        parts = kPacked1Parts;
+      } else if (sourceLayout && sourceLayout.isContiguous() &&
+                 sourceLayout.getLaneStride() == 2) {
+        factor = 2;
+        parts = kPacked2Parts;
+      } else {
+        factor = 4;
+        parts = kPacked4Parts;
+      }
+      if (resultTypes.size() != factor * sourceParts.size()) {
+        return rewriter.notifyMatchFailure(
+            op, "FP4 extf physical arity does not match its source layout");
+      }
     } else {
       return rewriter.notifyMatchFailure(
           op, "unsupported physical extf source/result width relation");
@@ -11356,15 +11371,15 @@ struct OneToNVMIExtFOpPattern : OneToNOpConversionPattern<VMIExtFOp> {
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
-      for (int64_t partIndex = 0; partIndex < factor; ++partIndex) {
-        for (auto [chunkIndex, sourcePart] : llvm::enumerate(sourceParts)) {
-          VRegType resultType =
-              resultVRegTypes[partIndex * sourceParts.size() + chunkIndex];
-          results.push_back(viewVcvtResult(
-              resultType, sourcePart, *mask, /*rnd=*/nullptr, /*sat=*/nullptr,
-              rewriter.getStringAttr(parts[partIndex])));
-        }
+    for (int64_t partIndex = 0; partIndex < factor; ++partIndex) {
+      for (auto [chunkIndex, sourcePart] : llvm::enumerate(sourceParts)) {
+        VRegType resultType =
+            resultVRegTypes[partIndex * sourceParts.size() + chunkIndex];
+        results.push_back(viewVcvtResult(
+            resultType, sourcePart, *mask, /*rnd=*/nullptr, /*sat=*/nullptr,
+            rewriter.getStringAttr(parts[partIndex])));
       }
+    }
 
     replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
     return success();


### PR DESCRIPTION
Minor fixes on top of https://github.com/hw-native-sys/PTOAS/pull/1443

# Summary: keep the FP4 fix narrow and preserve existing VMI layouts

This branch starts at the PR1443 parent `209ac1ad8` and keeps only the
validated part of `578dec5de`: the scratch-free FP4 conversion contract.

The important change is scope. Preferred layout facts are now specific to
`f4E2M1x2 → bf16x2`; they are not a generic “8-bit to 32-bit” rule that can
silently change E4M3 or integer consumers. Physical FP4 conversion parts are
derived from the source layout, so contiguous lane-stride 4 uses P0, lane-
stride 2 uses P0/P2, and explicit packed/deinterleaved forms retain their
supported part mapping.

The lowering preserves the useful logical operation:

```text
vload(f4x2) → vcvt(bf16x2) → vinterpret_cast(bf16)
```

FP32 remains FP4→BF16 followed by BF16→FP32. The global `VMILoadOp` natural-
layout override from PR1443 is deliberately absent, so producer preferences do
not override channel split/merge or other consumer constraints. Direct E2B
scale broadcasts remain available when their native layout is consumable.

The full Python 3.11 PTOAS build passed 1,846 of 1,847 discovered lit tests;
the only non-pass is the existing unsupported platform test. The focused
regressions covering FP4 lane-stride mappings, BF16-pair conversion, group
broadcast behavior, and channel split/merge all pass.

The remaining cast-back slowdown is therefore not an unresolved FP4 value
layout bug. It is the separate noncanonical packed-scale problem: the VMI
compiler needs a typed vector extraction/materialization contract that can
consume packed UE8M0 bytes without scalarizing them or requiring host-padded
scale slots. The next PTOAS step is to add that contract, its layout support
facts, and lit coverage before re-running the complete device matrix.