### PR TITLE
ci: repair GitHub mirror build checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-include(cmake/fetch_cann_cmake.cmake)
-
 # CANN/Ascend CMake packages used by downstream PTOAS builds may still use the
 # pre-CMake-3.30 FetchContent_Populate(<declared-name>) pattern. Keep that
 # compatibility path enabled so CMake 4.x developer warnings do not become
@@ -28,6 +26,8 @@ if(POLICY CMP0175)
   cmake_policy(SET CMP0175 OLD)
   set(CMAKE_POLICY_DEFAULT_CMP0175 OLD)
 endif()
+
+include(cmake/fetch_cann_cmake.cmake)
 
 # Standard Python build backends pass environment variables through to CMake
 # but do not synthesize project-specific cache arguments. Accept the existing

--- a/cmake/fetch_cann_cmake.cmake
+++ b/cmake/fetch_cann_cmake.cmake
@@ -1,4 +1,3 @@
-# -----------------------------------------------------------------------------------------------------------
 # Copyright (c) 2026 Huawei Technologies Co., Ltd.
 # This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 # CANN Open Software License Agreement Version 2.0 (the "License").
@@ -6,9 +5,15 @@
 # THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
-# -----------------------------------------------------------------------------------------------------------
 
 if(NOT PROJECT_SOURCE_DIR)
+    # Standalone builds may configure without a pre-seeded CANN third-party
+    # directory (e.g. CI). Keep FetchContent's declared SOURCE_DIR inside the
+    # writable CMake binary tree instead of resolving an empty variable to the
+    # filesystem root. Script-mode packaging still requires an explicit path.
+    if(NOT CANN_3RD_LIB_PATH AND CMAKE_BINARY_DIR)
+        set(CANN_3RD_LIB_PATH "${CMAKE_BINARY_DIR}/cann-3rd-lib")
+    endif()
     # Temporary test pin for cann/cmake MR !277. Revert this URL/ref pair
     # after validation and switch to the released cann/cmake tag once MR !277
     # is merged.

--- a/packaging/ptoas-vmi/pyproject.toml.patch
+++ b/packaging/ptoas-vmi/pyproject.toml.patch
@@ -1,7 +1,9 @@
 diff --git a/pyproject.toml b/pyproject.toml
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -18,7 +18,7 @@ build-backend = "scikit_build_core.build"
+@@ -16,11 +16,11 @@
+ build-backend = "scikit_build_core.build"
+ 
  [project]
 -name = "ptoas"
 -dynamic = ["version"]
@@ -10,20 +12,25 @@ diff --git a/pyproject.toml b/pyproject.toml
 +version = "0.1.6"
 +description = "PTO Assembler & Optimizer with VMI support"
  readme = "README.md"
- requires-python = ">=3.10"
+-requires-python = ">=3.7"
++requires-python = ">=3.10"
  license = "Apache-2.0"
-@@ -43,4 +43,5 @@ cmake.version = "CMakeLists.txt"
+ dependencies = [
+     "numpy",
+@@ -43,6 +43,7 @@
  ninja.version = ">=1.10"
  build.verbose = false
  editable.mode = "redirect"
 +sdist.inclusion-mode = "manual"
  install.components = ["PTOAS_Python"]
-@@ -53,3 +54,4 @@ TileOps = "lib/TileOps"
+ 
+ [tool.scikit-build.wheel.packages]
+@@ -53,8 +54,5 @@
+ 
  [tool.scikit-build.cmake.define]
  PTOAS_RELEASE_VERSION_OVERRIDE = { env = "PTOAS_RELEASE_VERSION_OVERRIDE", default = "" }
 +PTOAS_CLI_VERSION_LABEL = "vmi"
-
-@@ -56,4 +58,0 @@ PTOAS_RELEASE_VERSION_OVERRIDE = { env = "PTOAS_RELEASE_VERSION_OVERRIDE", default = "" }
+ 
 -[tool.scikit-build.metadata.version]
 -provider = "scikit_build_core.metadata.regex"
 -input = "CMakeLists.txt"


### PR DESCRIPTION
## Summary
- Refresh the ptoas-vmi `pyproject.toml.patch` for the current `requires-python >= 3.10` floor so the patched metadata matches the actual build.
- Set legacy CMake policies before `include(cmake/fetch_cann_cmake.cmake)` and default the CANN third-party directory into the writable CMake binary tree when unset, so GitHub mirror build checks can configure in CI without a pre-seeded `CANN_3RD_LIB_PATH`.

## Validation
- `git diff --check`
- GitHub mirror build checks run on this PR.

Based on the latest `main`.
