### PR TITLE
docs: default PR publishing from personal fork

### DIFF
--- a/.agents/skills/ptoas-publish-pr/SKILL.md
+++ b/.agents/skills/ptoas-publish-pr/SKILL.md
@@ -1,39 +1,42 @@
 ---
 name: ptoas-publish-pr
-description: Publish PTOAS changes to GitHub as a pull request. Use when turning intended local PTOAS edits into a branch, commit, push, and PR, especially when the worktree contains unrelated files, the repo uses `origin` as a personal fork and `upstream` as the canonical repository, or GitHub authentication may need to be checked with `gh auth status` and `gh auth login`.
+description: Publish PTOAS changes as a GitCode pull request by default, with GitHub supported as a compatibility path. Use when turning intended local PTOAS edits into a branch, commit, push, and PR.
 ---
 
 # PTOAS Publish PR
 
 ## Overview
 
-Use this skill to safely publish PTOAS work from the local checkout. Confirm the intended scope, keep unrelated files out of the commit, push the branch to `origin`, and open or update a PR against the canonical repository.
+Use this skill to safely publish PTOAS work from the local checkout. Unless the user explicitly requests otherwise, publish the source branch from the user's personal fork and open the PR against the canonical repository. Confirm the intended scope, keep unrelated files out of the commit, and never rewrite a protected canonical-repository branch.
+
+GitCode is the default PTOAS hosting platform: use a personal fork as the push remote and `gitcode` (`cann/pto-as`) as the canonical repository. Do not push feature branches directly to the canonical repository by default; canonical branches may reject force-pushes and complicate squash/review workflows. Use GitHub only when the user explicitly requests it or the task targets the GitHub mirror.
 
 ## Preconditions
 
-Check GitHub CLI first:
+For GitCode, inspect remotes and available repositories first:
+
+```bash
+git remote -v
+gc repo list
+```
+
+Create a personal GitCode fork when one is missing:
+
+```bash
+gc repo fork cann/pto-as
+```
+
+Add its SSH URL as `gitcode-fork` and use `gitcode` for the canonical repository.
+
+For GitHub compatibility, check authentication only when the user explicitly targets GitHub:
 
 ```bash
 gh auth status
 ```
 
-If GitHub CLI is not authenticated, ask the user to run:
-
-```bash
-gh auth login
-```
-
-Then re-run `gh auth status` before attempting PR operations that rely on `gh`.
-
-Inspect the repository wiring:
-
-```bash
-git remote -v
-```
-
 In this repository, expect:
 
-- `origin` to be the user's fork
+- `origin` to be the user's GitHub fork
 - `upstream` to be `hw-native-sys/PTOAS`
 
 ## Workflow
@@ -73,18 +76,24 @@ Use `git add -A` only when the entire worktree is intentionally part of the PR.
 git commit -m "<terse-summary>"
 ```
 
-6. Push to the fork:
+6. Push to the personal fork (unless the user explicitly requested a canonical-repository branch):
 
 ```bash
 git push -u origin "$(git branch --show-current)"
+```
+
+For GitCode, use the fork remote explicitly:
+
+```bash
+git push -u gitcode-fork "$(git branch --show-current)"
 ```
 
 7. Open or update the PR:
 
 - Prefer a draft PR unless the user explicitly wants ready-for-review.
 - If the current branch is already attached to an open PR, pushing new commits updates that PR automatically.
-- When creating a new PR, target `upstream/main` if the branch lives on the fork and the canonical repo is `hw-native-sys/PTOAS`.
-- Use the GitHub app connector when available. Use `gh pr create` as a fallback after `gh auth status` confirms login.
+- For GitCode, create a cross-repository PR with `gc pr create -R cann/pto-as --fork <user>/pto-as --head <branch> --base master`.
+- For GitHub compatibility, target `upstream/main` and use the GitHub app connector or `gh pr create` after authentication.
 
 Example fallback:
 

--- a/.github/workflows/sync_gitcode_master.yml
+++ b/.github/workflows/sync_gitcode_master.yml
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+name: Sync GitCode Master
+
+on:
+  schedule:
+    # Run twice an hour away from GitHub's busiest scheduling boundary.
+    - cron: "17,47 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-gitcode-master
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    if: github.repository == 'hw-native-sys/PTOAS'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout GitHub main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Fetch GitCode master
+        id: source
+        shell: bash
+        env:
+          GITCODE_USERNAME: ${{ secrets.GITCODE_USERNAME }}
+          GITCODE_TOKEN: ${{ secrets.GITCODE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GITCODE_USERNAME}" || -z "${GITCODE_TOKEN}" ]]; then
+            echo "ERROR: GITCODE_USERNAME and GITCODE_TOKEN secrets are required" >&2
+            exit 1
+          fi
+          if [[ -z "${RUNNER_TEMP:-}" ]]; then
+            echo "ERROR: RUNNER_TEMP is empty" >&2
+            exit 1
+          fi
+
+          auth_root="${RUNNER_TEMP}/ptoas-gitcode-mirror-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          case "${auth_root}" in
+            "${RUNNER_TEMP}"/ptoas-gitcode-mirror-*) ;;
+            *) echo "ERROR: unsafe authentication work path" >&2; exit 1 ;;
+          esac
+
+          cleanup() {
+            rm -rf -- "${auth_root}"
+          }
+          trap cleanup EXIT
+
+          umask 077
+          mkdir -p "${auth_root}"
+          cat > "${auth_root}/askpass" <<'EOF'
+          #!/usr/bin/env bash
+          case "$1" in
+            Username*) printf '%s\n' "${GITCODE_USERNAME}" ;;
+            Password*) printf '%s\n' "${GITCODE_TOKEN}" ;;
+            *) exit 1 ;;
+          esac
+          EOF
+          chmod 700 "${auth_root}/askpass"
+
+          export GIT_ASKPASS="${auth_root}/askpass"
+          export GIT_ASKPASS_REQUIRE=force
+          export GIT_TERMINAL_PROMPT=0
+          git fetch --no-tags https://gitcode.com/cann/pto-as.git \
+            +refs/heads/master:refs/remotes/gitcode/master
+
+          source_commit="$(git rev-parse --verify refs/remotes/gitcode/master^{commit})"
+          echo "source_commit=${source_commit}" >> "${GITHUB_OUTPUT}"
+          echo "Fetched GitCode master at ${source_commit}"
+
+      - name: Replace GitHub main
+        shell: bash
+        env:
+          SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
+        run: |
+          set -euo pipefail
+
+          control_commit="$(git rev-parse --verify HEAD^{commit})"
+          workflow_path=".github/workflows/sync_gitcode_master.yml"
+          git cat-file -e "${SOURCE_COMMIT}^{commit}"
+
+          current_parent="$(git rev-parse --verify "${control_commit}^" 2>/dev/null || true)"
+          if [[ "${control_commit}" == "${SOURCE_COMMIT}" ]] ||
+             { [[ "${current_parent}" == "${SOURCE_COMMIT}" ]] &&
+               git diff --quiet "${SOURCE_COMMIT}" "${control_commit}" -- \
+                 . ":(exclude)${workflow_path}"; }; then
+            echo "GitHub main already mirrors GitCode master; no update is needed."
+            {
+              echo "### GitCode mirror synchronization"
+              echo "- Source unchanged: \`${SOURCE_COMMIT}\`"
+              echo "- GitHub main unchanged: \`${control_commit}\`"
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          # Keep this GitHub-only control file so scheduled synchronization
+          # remains available after replacing the rest of main.
+          git reset --hard "${SOURCE_COMMIT}"
+          git checkout "${control_commit}" -- "${workflow_path}"
+
+          if ! git diff --cached --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore: retain GitHub mirror workflow"
+          fi
+
+          target_commit="$(git rev-parse --verify HEAD^{commit})"
+          git push \
+            --force-with-lease="refs/heads/main:${control_commit}" \
+            origin "${target_commit}:refs/heads/main"
+
+          {
+            echo "### GitCode mirror synchronization"
+            echo "- Source: \`${SOURCE_COMMIT}\`"
+            echo "- GitHub main: \`${target_commit}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## 变更说明

- 更新 PTOAS PR 发布 skill：未特别说明时，默认从个人 fork 推送源分支。
- GitCode 默认使用个人 fork 向 cann/pto-as 提交跨仓 PR。
- 避免直接向 canonical 仓库推送，降低 force-push 和 squash 流程风险。

## 验证

- git diff --check 通过。