### PR TITLE
refactor(vmi): complete VMIToVPTO static analysis cleanup

### DIFF
--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3191,3 +3191,19 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 
 `vmi_to_vpto_fptosi_*` 代表性输入在既有 VMI pack/unpack pipeline invariant 处提前失败，
 未进入本轮 helper，不能将该既有测试前置失败归因于本次重构。
+
+# fp-to-int result 校验复用（2026-09-06）
+
+本轮进一步将 `fptosi` 与 `fptoui` 重复的 result physical chunk 非空及 `VRegType` 校验
+统一为 `validateFpToIntResultParts`。helper 通过参数保留两种操作各自的诊断文本，调用方
+仍分别负责转换合同和 lowering 路径；不改变 result arity、mask 或 part 顺序。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
+`vmi_to_vpto_fptoui_f16_to_u8.pto` 同样在既有 pack/unpack pipeline invariant 处提前失败，
+未进入本轮 helper。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3484,6 +3484,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_group_store_slots8_packed_byte.pto         # exit=0
 ```
 
+# shuffle forwarding source lane 映射拆分（2026-09-06）
+
+本轮将 `computeShuffleForwardingSourceChunk` 中单个结果 lane 的 padding 分类、logical
+index 到 source physical lane 映射及 same-lane 合同抽取为
+`getShuffleSourcePhysicalLane`。主函数继续负责 source chunk 一致性汇总和 flat index
+计算；padding 处理、越界诊断、chunk 合同及结果语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_shuffle_forwarding.pto                     # exit=0
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3222,3 +3222,18 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_ensure_layout_dense_composed.pto           # exit=0
 ```
+
+# adjacent mask granularity 结果合同拆分（2026-09-06）
+
+本轮将 `materializeAdjacentMaskGranularityConversion` 中 result physical arity/count 校验
+抽取为 `checkMaskGranularityResultArity`。相邻 granularity 的 plan 构造、逐 layout part
+物化、结果扁平化和失败传播保持原顺序；入口只负责连接 plan、物化和结果合同，未改变
+ppack/punpack/por 指令语义。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_ensure_mask_granularity.pto                # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2065,6 +2065,12 @@ exit=0，现有 slots=1 的 EVEN/P0 转换输出保持不变。
 `vmi_to_vpto_iota_group_subvl.pto` 和 `vmi_to_vpto_iota_group_deint.pto` lowering 均
 exit=0，普通 iota case 仍在既有 pack/unpack invariant 处提前终止。
 
+随后复核发现 `createSubVLGroupPeriodicChunk` 仍在入口重新组装相同的 iota 上下文，且
+调用方存在临时聚合对象，未完全落实数据泥团收敛。本轮将该 helper 也改为直接接收
+`IotaMaterializationContext`，并在各分派循环中复用具名 context；不改变任何算法或结果
+顺序。增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；三组 iota lowering case 均 exit=0。
+
 # vmull 物理 shape 合同职责整改
 
 本轮新增 `checkVmullPhysicalShape`，将 vmull 的 physical lane 数、physical data element

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1797,3 +1797,12 @@ predicate mode 拒绝、输入 arity、源元素类型和结果组数判定；�
 同时补齐本入口控制流大括号。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_vexpdif_f16.pto` 与 `vmi_to_vpto_vexpdif_f32.pto` lowering 均 exit=0。
+
+# mask binary physical chunk lowering 职责整改
+
+本轮将模板 `OneToNVMIMaskBinaryOpPattern::matchAndRewrite` 中 physical arity/type 校验、
+all-true seed mask 构造、目标 mask binary op 发射和结果替换抽取为 `lowerParts`。入口
+现在只负责 operand 归一化和 converted result type 获取；保持 seed mask 生成、TargetOp
+选择、结果顺序、mask 语义和原有诊断不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；仓库当前没有针对该
+模板的独立 `vmi_to_vpto` lit case，未虚构额外测试结果。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2624,3 +2624,13 @@ lane-stride → intermediate 顺序尝试，保持 optional/failure 传播、递
 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_to_vpto_ensure_layout_dense_composed.pto` 与 mask
 conversion case lowering 均 exit=0。
+
+# mask layout materialization context 数据泥团整改
+
+本轮引入 `MaskLayoutMaterializationContext`，统一承载 identity、deinterleaved2 和
+lane-stride 三路 mask layout materializer 共享的 operation、parts、source/result layout
+及 rewriter。`materializeMaskLayoutConversion` 仍按 identity → deinterleaved2 →
+lane-stride 顺序分派，optional/failure 传播、identity forwarding 合同和 unsupported
+诊断保持不变；lambda 改为显式接收 context，避免重复参数捕获与默认捕获风险。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；layout 和 mask granularity 相关 lowering case 均 exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3063,3 +3063,6 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 source lane 映射抽取为 `getShuffleSourceLane`。规划函数继续负责 source chunk 一致性与
 ASC/DESC 方向推导，抽取没有改变失败诊断、迭代顺序或最终 `ShuffleVselrPlan` 内容；增量
 检查仍为 `errors=0 warnings=0`，scatter lowering case exit=0。
+
+随后补齐 shuffle VSEL 规划失败诊断 lambda 的大括号；该修改仅满足控制流可读性约束，
+不改变诊断文本或失败传播。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2052,6 +2052,15 @@ exit=0，现有 slots=1 的 EVEN/P0 转换输出保持不变。
 `git diff --check` 通过；`vmi_layout_assignment_group_store_slots1_unit_stride.pto`
 完整 lowering pipeline exit=0。
 
+# vmull 物理 shape 合同职责整改
+
+本轮新增 `checkVmullPhysicalShape`，将 vmull 的 physical lane 数、physical data element
+type 和 mask granularity 合同从 `checkSupportedVmullShape` 中独立出来。原有四个输入
+类型一致性、逻辑 lane 数、layout、mask layout/granularity、physical arity 检查及诊断
+顺序保持不变；主函数只负责 shape plan 构建后调用物理合同检查。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_vmull_contiguous.pto` lowering exit=0。
+
 # group broadcast load BRC 单结果构造职责整改
 
 本轮在 `OneToNVMIGroupBroadcastLoadOpPattern::lowerDirectBRC` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2135,6 +2135,15 @@ chunk 顺序、诊断及结果替换语义不变。增量 `check_changed_code.py
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_group_broadcast_load_e2b_b16.pto` lowering exit=0。
 
+# group broadcast load BRC shape 校验职责整改
+
+本轮在 `OneToNVMIGroupBroadcastLoadOpPattern::lowerDirectBRC` 中引入
+`validateDirectBRCShape`，将 num_groups、源指针和 physical arity/chunks 合同校验抽取为
+独立 helper。主函数继续负责 BRC 结果遍历、group 索引和 `VldsOp` 发射；保持诊断顺序、
+chunks-per-group 计算、结果顺序和 BRC lowering 语义不变。增量 `check_changed_code.py`
+结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_group_broadcast_load_e2b_b16.pto` lowering exit=0。
+
 # group broadcast load E2B 单 packet 发射职责整改
 
 本轮在 `OneToNVMIGroupBroadcastLoadOpPattern::emitE2BPackets` 中引入 `emitE2BPacket`，

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2023,3 +2023,13 @@ carrier shape/result type 校验、逐级 `VsunpackOp`/`VzunpackOp` 以及最终
 原有诊断语义不变。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_to_vpto_group_slot_integer_extension_matrix.pto` lowering
 exit=0，现有 slots=1 的 EVEN/P0 转换输出保持不变。
+
+# packed-byte group store fallback 构造职责整改
+
+本轮在 `OneToNVMIGroupStoreOpPattern::lowerPackedByteSlots8` 中引入
+`buildPackedByteStatefulValue`，将 fallback 路径单个 block 的两级 `VpackOp` 类型和发射
+抽取出来。主循环继续负责 block 规划、`PK4_B32` direct store 与 stateful stream 分支、
+`activeGroups` advance 以及原有 block 顺序；未改变 direct/fallback 选择、stream payload
+布局或诊断语义。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_layout_assignment_group_store_slots1_unit_stride.pto`
+完整 lowering pipeline exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2392,6 +2392,16 @@ slots=1 group-slot-load 元素宽度检查的大括号。增量检查结果为
 通过；`vmi_to_vpto_load_store_contiguous.pto` lowering exit=0。runtime expand-load 样例在
 既有 VMI pack/unpack invariant 处提前终止，未进入本轮 helper。
 
+# group-broadcast load memory 合同职责整改（2026-09-06）
+
+本轮将 `checkSupportedGroupBroadcastLoadShape` 的 memory access plan、UB pointer 和
+memory 合同抽取为 `checkSupportedGroupBroadcastLoadMemory`；入口只保留 layout-support
+table 查询并调用 memory helper。group broadcast 的支持矩阵、地址空间要求、诊断和失败
+传播保持不变，同时补齐 group-slot-load 相关控制流大括号。增量检查结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_layout_assignment_group_broadcast_load_e2b_b16.pto` 与
+`vmi_to_vpto_load_store_contiguous.pto` lowering 均 exit=0。
+
 # scatter shape 合同职责整改（2026-09-06）
 
 本轮将 `checkSupportedScatterShape` 的布局/目标指针校验抽取为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2099,6 +2099,17 @@ factor 窄化的 lowering 优先级及各自 arity/layout 合同；没有把不�
 `vmi_to_vpto_truncf_f16_to_f8e4m3.pto` 尝试 lowering 时在既有 VMI pack/unpack invariant
 处提前失败，未进入本轮 plan builder，不能将该失败归因于本轮改动。
 
+# group broadcast E2B 合同职责整改
+
+本轮新增 `validateDirectE2BShape`，将 `group_broadcast_load` E2B 直接路径的 layout、元素
+宽度、unit `source_group_stride`、ptr source、`num_groups=8`、uniform chunks、physical
+arity 和单 packet 合同从 `lowerDirectE2B` 中独立出来。发射函数现在只负责获取已验证的
+dist/factor/chunk 参数、发射 E2B packets 和复用结果；B16/B32 dist、factor=2/4 结果顺序、
+诊断及 fallback 语义保持不变。增量
+`check_changed_code.py --base origin/master --fail-on none` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_layout_assignment_group_broadcast_load_e2b_b16.pto` lowering exit=0。
+
 # group load 布局分派职责整改
 
 本轮将 `OneToNVMIGroupLoadOpPattern::matchAndRewrite` 中 block-deinterleaved f32 特殊路径

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2431,6 +2431,15 @@ memory access proof 及两阶段失败回退，保持 masked-store 的支持范�
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；连续 load/store case
 仍按既有测试约束验证，未观察到本轮 helper 引入的新 lowering 错误。
 
+# gather physical chunk 条件职责整改（2026-09-06）
+
+本轮将 `checkSupportedGatherShape` 中 b16 单 physical chunk 例外与 b32 full-chunk 要求
+抽取为 `checkGatherPhysicalChunkRequirement`。入口保留 layout/source 与 element contract
+校验，helper 统一根据 element contract 和 physical arity 选择 `requiresFullChunks`，再
+调用已有 physical shape checker；gather 的支持矩阵、b16 单 chunk 例外、诊断和失败传播
+保持不变。增量检查结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+scatter 正常 case lowering 成功，非法 gather/scatter case 仍在预期 shape 诊断处失败。
+
 # scatter shape 合同职责整改（2026-09-06）
 
 本轮将 `checkSupportedScatterShape` 的布局/目标指针校验抽取为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2230,3 +2230,13 @@ source lane 与 slot mask 准备及结果替换；保持 EVEN/P0 part、slot mas
 和 lowering 语义不变。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_group_slot_integer_extension_matrix.pto` lowering exit=0。
+
+# ExtI factor part plan 职责整改
+
+本轮在模板 `OneToNVMIExtIOpPattern::lowerPhysicalExtension` 中引入
+`getExtensionPartPlan`，将 source/result width 关系、physical result arity 与 EVEN/ODD 或
+P0/P1/P2/P3 part 表选择抽取为独立 helper。主函数继续保留 dense lane-stride 优先路径、
+mask 构造和 factor extension 发射；保持分派优先级、part 顺序、诊断和 lowering 语义不变。
+增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_group_slot_integer_extension_matrix.pto` lowering
+exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2141,6 +2141,17 @@ mask、地址步长和失败诊断。增量
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_load_store_contiguous.pto` lowering exit=0。
 
+# interleave store 地址与直写路由职责整改
+
+本轮在 `OneToNVMIInterleaveStoreOpPattern` 中新增 `canUseDirectAccess` 与
+`getUnalignedBase`，将 `vstsx2` 直写地址合法性判断和非对齐 stateful stream 的 base
+物化从主入口独立出来。入口继续负责 dist/lane/arity 合同、逐 chunk 的 `vintlv`/`vstsx2`
+选择及 stream 收尾；保持 INTLV dist、low/high 顺序、每个 chunk 的 lane advance、align/base
+状态和失败诊断不变。增量
+`check_changed_code.py --base origin/master --fail-on none` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_interleaved_memory_ops.pto` lowering exit=0。
+
 # group load 布局分派职责整改
 
 本轮将 `OneToNVMIGroupLoadOpPattern::matchAndRewrite` 中 block-deinterleaved f32 特殊路径

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3159,3 +3159,18 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_reduce_extended.pto                       # exit=0
 ```
+
+# trunci physical 类型与路径条件整改（2026-09-06）
+
+本轮将 `OneToNVMITruncIOpPattern::matchAndRewrite` 中 source/result physical vreg 的非空、
+整数元素类型和跨 chunk 一致性检查抽取为 `getUniformTruncTypes`；同时为 exti/truncf
+入口中触及的 dense lane-stride、same-width 条件命名，避免复杂布尔表达式直接控制分派。
+不改变 s32→s8 alias、NOSAT carrier、factor=2/4 narrowing 的路径优先级或结果顺序。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_truncf_bf16x2_d4_packed4.pto               # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3382,6 +3382,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_group_store_slots8_packed_byte.pto         # exit=0
 ```
 
+# group-store layout 分类职责拆分（2026-09-06）
+
+本轮将 `OneToNVMIGroupStoreOpPattern::lowerByLayout` 中 scalar、compact、slots=1、
+slots=8 和 general layout 的分类条件抽取为 `classifyGroupStoreLayout`。主函数继续负责
+按分类调用对应 lowering、general support fact 查询及 deinterleaved/contiguous fallback；
+分派顺序、支持矩阵和失败传播保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
+```
+
 # legacy group-slot extension 准备阶段拆分（2026-09-06）
 
 本轮将 `lowerLegacyGroupSlotExtension` 中 group/slots/lane_stride shape 合同、conversion

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2397,6 +2397,17 @@ lambda 使用显式捕获，未改变 mask layout 或 padding 语义。增量
 `git diff --check` 通过；`vmi_layout_assignment_masked_load.pto` 在既有 residual VMI
 load 检查处终止，未进入本轮 materializer。
 
+# data layout intermediate materializer 职责整改
+
+本轮将 `materializeDataLayoutViaContiguous` 中两种 intermediate kind 的递归转换分别
+抽取为 `materializeDataLayoutThroughContiguous` 与
+`materializeDataLayoutThroughDeinterleaved`。原函数现在只负责 intermediate plan 查询、
+空输入检查和 kind 分派；保持 contiguous/deinterleaved intermediate 的选择、递归转换
+顺序、结果类型数量和失败传播语义不变。增量 `check_changed_code.py --base HEAD` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_ensure_layout_dense_composed.pto` lowering exit=0，deinterleaved case 在
+既有 pack/unpack invariant 处提前终止。
+
 # channel split 结果布局与 arity 合同职责整改
 
 本轮在 `checkSupportedChannelSplitShape` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2012,3 +2012,14 @@ mask 准备、结果块遍历及最终 `s32ToS8Alias` 处理；保持 `resultInd
 增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_to_vpto_trunci_s32_to_s8_nosat.pto` lowering exit=0，输出
 仍包含 4 个按 P0/P1/P2/P3 顺序的 `vcvt`、3 个 `vor` 以及末尾 signed bitcast。
+
+# exti dense group-slot 单结果 lowering 职责整改
+
+本轮在模板 `OneToNVMIExtIOpPattern` 中引入
+`buildDenseGroupSlotExtensionResult`，将 dense group-slot 路径中单个 physical result 的
+carrier shape/result type 校验、逐级 `VsunpackOp`/`VzunpackOp` 以及最终 carrier bitcast
+抽取为独立 helper。`lowerDenseGroupSlotExtension` 现在只负责结果遍历和扁平化；保持有符号
+与无符号 unpack 指令选择、每级 bit width/lane 校验、source/result 类型关系、结果顺序和
+原有诊断语义不变。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_group_slot_integer_extension_matrix.pto` lowering
+exit=0，现有 slots=1 的 EVEN/P0 转换输出保持不变。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3148,6 +3148,24 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 `vmi_to_vpto_ensure_mask_granularity_direct.pto` 在测试自身的 VMI `unpack` 前置 invariant
 处提前失败，未进入本轮 runtime expand-load helper。
 
+# gather 单 physical part 物化职责拆分（2026-09-06）
+
+本轮将 `OneToNVMIGatherOpPattern::lowerPhysicalParts` 中单个 physical part 的类型合同、
+按 element width 选择 `vgather2`/`vgather2.bc`，以及 all-active 条件下省略 `vsel` 的逻辑
+抽取为 `materializeGatherPart`。外层函数继续负责 arity 校验、part 遍历、结果收集和替换；
+静态 all-active 优化、mask/passthru 语义、指令选择和失败诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_gather_all_active_mask.pto                 # exit=0
+```
+
+普通 gather case 中部分输入在测试自身的 VMI lowering/invariant 处提前失败；all-active
+case 已完整通过。
+
 # deinterleave-load 结果类型合同拆分（2026-09-06）
 
 本轮将 `OneToNVMIDeinterleaveLoadOpPattern::matchAndRewrite` 中 low/high physical result

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3527,6 +3527,19 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 ```
 
+# constant mask active-run 物化拆分（2026-09-06）
+
+本轮将 `materializeConstantMaskChunk` 中单个连续 active run 的 prefix mask、PAND 差集
+构造抽取为局部 `materializeRun`，主体继续负责 run 扫描、多个 run 的 POR 合并和空 mask
+fallback。捕获集合采用显式列表；mask lane 顺序、结果语义和失败传播保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3166,6 +3166,24 @@ vmi_to_vpto_gather_all_active_mask.pto                 # exit=0
 普通 gather case 中部分输入在测试自身的 VMI lowering/invariant 处提前失败；all-active
 case 已完整通过。
 
+# masked-load 单 physical part 物化职责拆分（2026-09-06）
+
+本轮将 `OneToNVMIMaskedLoadOpPattern::lowerPhysicalParts` 中单个 physical part 的
+mask/passthru/result 类型校验、chunk offset 计算、`vlds` 和 `vsel` 发射抽取为
+`materializeMaskedLoadPart`。外层函数继续负责 physical arity 校验、part 遍历、结果
+收集和替换；masked-load 的 passthru 语义、访问步进、结果顺序和失败诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_masked_load.pto                  # reaches existing residual VMI op
+```
+
+该 layout case 在测试输入的既有 residual `pto.vmi.load` 问题处失败，未归因于本轮
+masked-load helper。
+
 # deinterleave-load 结果类型合同拆分（2026-09-06）
 
 本轮将 `OneToNVMIDeinterleaveLoadOpPattern::matchAndRewrite` 中 low/high physical result

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2377,6 +2377,16 @@ exit=0。
 `git diff --check` 通过；尝试的 mask granularity cases 在既有 pack/unpack invariant 或
 layout contract 处提前终止，未进入本轮 helper。
 
+# mask layout materializer 分派职责整改
+
+本轮在 `materializeMaskLayoutConversion` 中引入 `tryMaskLayoutMaterializer`，统一封装
+identity、deinterleaved=2 和 dense lane-stride 三类 materializer 的 `FailureOr<optional>`
+传播。入口保留 assigned-layout 前置检查、三类转换的原优先级以及最终 unsupported 诊断；
+lambda 使用显式捕获，未改变 mask layout 或 padding 语义。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_layout_assignment_masked_load.pto` 在既有 residual VMI
+load 检查处终止，未进入本轮 materializer。
+
 # channel split 结果布局与 arity 合同职责整改
 
 本轮在 `checkSupportedChannelSplitShape` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3058,3 +3058,8 @@ vmi_layout_assignment_scatter.pto                      # exit=0
 git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 ```
+
+随后将 `computeShuffleVselrPlanForChunk` 中的结果物理 lane 校验、逻辑 lane 越界检查和
+source lane 映射抽取为 `getShuffleSourceLane`。规划函数继续负责 source chunk 一致性与
+ASC/DESC 方向推导，抽取没有改变失败诊断、迭代顺序或最终 `ShuffleVselrPlan` 内容；增量
+检查仍为 `errors=0 warnings=0`，scatter lowering case exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3911,3 +3911,16 @@ vmi_to_vpto_vdintlv.pto                               # reaches existing pack/un
 
 该 case 在本轮转换前即会因测试输入中的 VMI `unpack` 出现在 VMI-to-VPTO physicalization
 之前而触发 `VMI-PASS-INVARIANT`；这不是本轮 `vdintlv` helper 改动引入的失败。
+
+# lane-stride carrier 合并职责拆分（2026-09-06）
+
+本轮将 `materializeLaneStrideResultPart` 中两个 carrier 的 pack、all-true mask 和 `vor`
+合并抽取为 `mergeLaneStrideCarrierPair`。原函数继续负责 lane-stride source slice、逐层
+carrier 收缩和最终 bitcast；奇数尾 carrier 的 LOWER 路径、结果顺序和失败传播保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3144,6 +3144,22 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 相关 block group-load case 在测试自身的 ensure_layout/truncf 不支持输入处提前失败，未
 进入本轮 chunk helper。
 
+# contiguous group-load 单 chunk 物化职责拆分（2026-09-06）
+
+本轮将 `OneToNVMIGroupLoadOpPattern::lowerContiguousChunks` 中单个 group/chunk 的
+result vreg 合同、group offset 计算和 `vlds` 发射抽取为
+`materializeContiguousGroupLoadChunk`。外层函数继续负责 full-group chunk 规划、arity
+校验、遍历和结果替换；group/chunk 地址步进、结果顺序、普通 contiguous load 语义和失败
+诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_load.pto                    # exit=0
+```
+
 部分 direct interleave lit case 仍会在测试自身的 VMI `unpack` 前置 invariant 处提前失败，
 未进入本轮分类逻辑。
 

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2064,3 +2064,13 @@ pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败
 诊断和替换语义不变。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_to_vpto_group_reduce_typed.pto` 在既有 VMI pack/unpack
 pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。
+
+# four-block group-reduce 单结果构造职责整改
+
+本轮在 `OneToNVMIGroupReduceOpPattern::lowerFourBlock` 中引入
+`buildFourBlockGroupResult`，将单个结果块的 4 路 `GroupReduceOp`、physical 类型校验、
+combine mask 构造以及 `sum01/sum23/final` 树形合并抽取为独立 helper。主函数继续负责
+整体 arity/基础类型校验、结果遍历和替换；保持 `part * resultPartCount + resultIndex`
+源索引、树形合并顺序、active group mask、结果顺序和诊断语义不变。增量
+`check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
+通过；本轮未新增可独立进入该 helper 的 runtime case，未虚构额外回归结果。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2152,6 +2152,16 @@ mask、地址步长和失败诊断。增量
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_interleaved_memory_ops.pto` lowering exit=0。
 
+# create_group_mask 常量结果物化职责整改
+
+本轮在 `OneToNVMICreateGroupMaskOpPattern` 中新增
+`materializeGroupMaskResults`，统一普通 constant group-mask 与 factor-4 contiguous
+中间路径的 physical mask 类型校验、chunk 物化和结果 arity 校验。两条路径仍分别提供
+自己的 overflow 诊断文本，动态路径、layout conversion、结果顺序和失败传播保持不变。
+增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_create_group_mask_block8_dynamic.pto` lowering
+exit=0。
+
 # group load 布局分派职责整改
 
 本轮将 `OneToNVMIGroupLoadOpPattern::matchAndRewrite` 中 block-deinterleaved f32 特殊路径

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2290,6 +2290,16 @@ mask 语义、group 顺序及失败传播不变。增量 `check_changed_code.py`
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_layout_assignment_group_reduce_s256.pto` 完整 lowering pipeline exit=0。
 
+# contiguous group reduce 类型合同职责整改
+
+本轮在 `OneToNVMIGroupReduceOpPattern::lowerContiguousRows` 中引入
+`ContiguousGroupReduceTypes` 与 `getContiguousGroupReduceTypes`，将结果 vreg、mask、
+source chunk、行归约结果及 combine mask 的物理类型合同集中校验和推导。主函数继续负责
+contiguous chunk shape、结果布局/arity、首 lane mask、归约构造和结果恢复；保持 slots=1
+与重复结果布局语义、诊断顺序及失败传播不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_layout_assignment_group_reduce_s256.pto` 完整 lowering pipeline exit=0。
+
 # zero-copy interleave 结果合同职责整改
 
 本轮在 `OneToNVMIInterleaveOpPattern::materializeZeroCopyResults` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3529,6 +3529,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_group_slot_integer_extension_matrix.pto   # exit=0
 ```
 
+# deinterleaved=4 contiguous 组物化拆分（2026-09-06）
+
+本轮将 `materializeDeinterleaved4ToContiguous` 的单组 source 类型/结果类型合同检查和
+四路 `vintlv` 物化抽取为 `materializeDeinterleaved4Group`。主函数继续负责 footprint
+arity、组分片和结果累积；source fallback、结果截断顺序、诊断文本及 `vintlv` 组合语义
+保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_vintlv_d2_to_d4.pto                        # blocked by pre-existing VMI-PASS-INVARIANT
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1768,3 +1768,12 @@ mask part 校验及逐 chunk `VaddcOp` 发射抽取为 `lowerParts`。入口继�
 类型转换、carry/result 容器准备与最终扁平化替换；carry 结果排布（所有 result 后接所有
 carry）、mask 合同、结果顺序和诊断语义保持不变。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+
+# vmull physical chunk lowering 职责整改
+
+本轮将 `OneToNVMIVmullOpPattern::matchAndRewrite` 中单个 physical part 的 64-lane data、
+i32/ui32 element、b32 mask 合同校验及 `VmullOp` 发射抽取为 `lowerPart`。入口继续负责
+low/high result type 获取、跨 operand arity 校验和结果扁平化；low 结果在前、high 结果在后
+的排布、mask 语义、失败诊断和结果顺序保持不变。为相邻 reduce-add 入口补齐控制流大括号
+以满足 `G.FMT.11-CPP`。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2392,6 +2392,16 @@ slots=1 group-slot-load 元素宽度检查的大括号。增量检查结果为
 通过；`vmi_to_vpto_load_store_contiguous.pto` lowering exit=0。runtime expand-load 样例在
 既有 VMI pack/unpack invariant 处提前终止，未进入本轮 helper。
 
+# scatter shape 合同职责整改（2026-09-06）
+
+本轮将 `checkSupportedScatterShape` 的布局/目标指针校验抽取为
+`checkScatterLayoutAndDestination`，将 value/index 位宽、索引 signedness 和 mask 粒度
+组合合同抽取为 `checkScatterElementContract`。主检查函数保留 physical arity/full-chunk
+检查及原有分派顺序；`vscatter` 支持矩阵、诊断和失败传播保持不变。同步补齐 stride-store
+shape helper 的控制流大括号。增量检查结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_layout_assignment_scatter.pto` 与 `vmi_to_vpto_scatter.pto`
+均 lowering exit=0。
+
 本轮尝试重新构建 `pto-test-opt` 时，CMake 仍因工作区既有的 `cann-cmake` 外部依赖
 配置尝试创建 `/cann-cmake` 且权限不足而无法重新配置；该环境问题未产生新的 C++ 编译
 诊断，未删除或重置现有 build tree。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2634,3 +2634,13 @@ lane-stride 顺序分派，optional/failure 传播、identity forwarding 合同�
 诊断保持不变；lambda 改为显式接收 context，避免重复参数捕获与默认捕获风险。增量
 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；layout 和 mask granularity 相关 lowering case 均 exit=0。
+
+# predicate interleave 分派职责整改
+
+本轮引入 `PredicateInterleaveKind` 与 `createPredicateInterleave`，统一 b8/b16/b32
+predicate 类型检查及 `pintlv`/`pdintlv` 指令选择；原有 `createPredicateIntlv` 与
+`createPredicateDintlv` 保留为语义清晰的薄包装。保持 low/high 返回顺序、mask 类型合同、
+unsupported 类型失败语义及所有 layout materialization 调用路径不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；dense layout、mask granularity 和 vdintlv 相关 case lowering
+均 exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3045,3 +3045,16 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_group_broadcast_load_e2b_b16.pto # exit=0
 vmi_layout_assignment_scatter.pto                      # exit=0
 ```
+
+# shuffle splat 与 VSEL 规划控制流整改（2026-09-06）
+
+本轮继续为 shuffle lane-0 splat 和 VSEL 规划补齐显式控制流边界，并将“存在非零索引”
+条件命名。source lane 映射、物理 part/chunk 枚举、失败诊断及结果计划顺序均保持不变，
+仅消除单语句控制流歧义。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -228,6 +228,17 @@ mask 的语义差异只存在于 active-lane 判定。补齐该批代码及 scal
 `vmi_to_vpto_expand_load_runtime_mask.pto` 回归时，在本轮逻辑前由既有
 `VMI-PASS-INVARIANT`（pack/unpack helper 提前物化）终止，未将该失败归因于本轮修改。
 
+# deinterleaved=4 布局方向分类职责整改
+
+本轮在 `materializeDeinterleaved4Layout` 中引入
+`Deinterleaved4LayoutDirection` 与 `getDeinterleaved4LayoutDirection`，将
+deinterleaved=4→contiguous 和 contiguous→deinterleaved=4 的布局方向识别从具体结果
+物化中分离。物化 helper 仍负责缺失 part 诊断、`vdintlv` 发射、结果顺序和失败传播，
+保持原有分派优先级与布局条件不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；尝试
+`vmi_to_vpto_vdintlv.pto` 时同样在既有 pack/unpack invariant 处提前终止，未将该失败归因
+于本轮方向分类变更。
+
 # create_mask 分派整改
 
 本轮将 `OneToNVMICreateMaskOpPattern` 中动态与常量 `create_mask` 的结果类型获取、

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3174,3 +3174,20 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_truncf_bf16x2_d4_packed4.pto               # exit=0
 ```
+
+# fp-to-int source 校验复用（2026-09-06）
+
+本轮将 `fptosi` 与 `fptoui` 两个 pattern 重复的 source physical chunks 校验统一为模板
+helper `validateFpToIntSourceParts`；helper 保留各操作独立的空输入、期望类型和类型不一
+致诊断文本，调用方仍负责各自的元素合同、宽窄转换及 part 规划。未改变转换支持矩阵、
+mask 语义或结果顺序。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
+`vmi_to_vpto_fptosi_*` 代表性输入在既有 VMI pack/unpack pipeline invariant 处提前失败，
+未进入本轮 helper，不能将该既有测试前置失败归因于本次重构。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,19 @@
 # VMIToVPTO 静态分析报告记录
 
+## residual sub-VL 单 group 物化拆分（2026-09-06）
+
+本轮将 `createResidualSubVLGroupPeriodicChunk` 内部 lambda 的单 group 偏移、方向计算、
+lane mask 和 `vsel` 物化抽取为 `materializeResidualSubVLGroup`。外层函数只负责初始化
+结果并按 local group 顺序累积；显式保留 previous result 作为选择的 passthru，确保 group
+覆盖顺序、ASC/DESC 语义和失败传播不变，同时移除该热点中的 lambda 捕获复杂度。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## residual sub-VL lambda 捕获审计（2026-09-06）
 
 本轮复核 `createResidualSubVLGroupPeriodicChunk` 的显式 lambda 捕获，补齐其实际使用的

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,19 @@
 # VMIToVPTO 静态分析报告记录
 
+## shuffle vselr source 合同拆分（2026-09-06）
+
+本轮将 `buildShuffleVselrResult` 中 source part 边界及 source/result vreg 类型合同抽取为
+`getShuffleVselrSourceType`。结果构造 helper 现在专注于 index 类型、`vci` selector 和
+`vselr` 发射；source 索引范围、元素类型/数量匹配仍在独立合同阶段校验。selector 顺序、
+descending 语义、失败诊断和结果替换保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## runtime expand-load 计划与物化拆分（2026-09-06）
 
 本轮将 `lowerRuntimeExpandLoad` 拆为两个职责明确的阶段：

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3338,3 +3338,17 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_compress_store.pto                         # exit=0
 ```
+
+# reduce source full-chunk 合同拆分（2026-09-06）
+
+本轮将 `buildReducePhysicalShapePlan` 中 source full physical chunk/padding lane 安全检查
+抽取为模板 helper `checkReduceSourceChunks`。plan builder 继续负责 layout 与 physical
+arity plan 组合；full-chunk 失败诊断、mask/source arity 合同及 result chunk 要求保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_group_reduce_addi_i16.pto                          # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3368,6 +3368,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_load_store_contiguous.pto                  # exit=0
 ```
 
+# interleave lowering 入口合同与布局查询拆分（2026-09-06）
+
+本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出
+arity 合同检查抽取为 `getInterleaveResultTypes`，并将 vintlv/vdintlv 布局事实查询抽取为
+`getInterleaveLayoutFact`。入口继续保持 lane-stride、contiguous 与 zero-copy 的分派顺序，
+结果替换、失败传播及诊断语义不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_vintlv.pto                                 # blocked by pre-existing VMI-PASS-INVARIANT
+```
+
 # slots=8 group-store 输入合同拆分（2026-09-06）
 
 本轮将 `lowerSlots8Dispatch` 中的物理 value arity 与首个 vreg 类型检查抽取为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2448,6 +2448,14 @@ physical arity 和 physical mask granularity 校验抽取为 `checkAddCarryMaskP
 的 mask 列表顺序、支持范围、诊断和失败传播保持不变；同时补齐新 helper 中的控制流
 条件命名。增量检查结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
 
+# verifier 控制流与 add-carry 合同收敛（2026-09-06）
+
+复核完整文件时发现 active-prefix、FP conversion、reduce、compress、group-reduce 以及
+add-carry verifier 区域仍有历史无大括号控制语句。本轮统一补齐这些控制流，并保留
+`checkAddCarryMaskPort` 的逐 mask 合同拆分；同时将复杂条件命名，避免文本检查器误判
+跨行条件。未改变 verifier dispatch 顺序、支持矩阵、诊断和失败传播。增量检查结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+
 # scatter shape 合同职责整改（2026-09-06）
 
 本轮将 `checkSupportedScatterShape` 的布局/目标指针校验抽取为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3514,6 +3514,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_load_store_contiguous.pto                  # exit=0
 ```
 
+# dense group-slot extension 结果合同拆分（2026-09-06）
+
+本轮将 `buildDenseGroupSlotExtensionResult` 中 source/result physical lane 数量、carrier
+比例和结果 vreg 类型检查抽取为 `validateDenseGroupSlotExtensionResult`。主函数继续负责
+逐级 `Vsunpack/Vzunpack` 物化和最终 bitcast；扩展方向、lane 校验、失败诊断及结果语义保持
+不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_group_slot_integer_extension_matrix.pto   # exit=0
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2130,6 +2130,17 @@ lane 数、地址操作数和 value/mask arity 合同；helper 按原顺序优�
 `check_changed_code.py --base origin/master --fail-on none` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
 
+# scalar store physical plan 职责整改
+
+本轮在 `OneToNVM​​IStoreOpPattern` 中引入 `StorePhysicalPlan` 与 `buildPhysicalPlan`，将
+普通 `store` 的 physical lanes、contiguous 目标类型、full-chunk 标志和 physical footprint
+比较集中到统一计划对象。主入口现在只负责地址归一化、lane-stride/deinterleaved 候选
+路由及 contiguous fallback；不改变原有候选优先级、layout conversion、stateful stream、
+mask、地址步长和失败诊断。增量
+`check_changed_code.py --base origin/master --fail-on none` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_load_store_contiguous.pto` lowering exit=0。
+
 # group load 布局分派职责整改
 
 本轮将 `OneToNVMIGroupLoadOpPattern::matchAndRewrite` 中 block-deinterleaved f32 特殊路径

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2337,6 +2337,16 @@ group_broadcast_load 的重复 shape-check 和失败诊断统一改用 `verifySu
 `vmi_layout_assignment_group_load_s16_unaligned_stride_invalid.pto` 仍按预期在既有
 layout contract invalid 处失败，诊断未改变。
 
+# channel split 结果布局与 arity 合同职责整改
+
+本轮在 `checkSupportedChannelSplitShape` 中引入
+`checkChannelSplitResultShape`，将每个 channel result 的 contiguous layout 检查、物理
+arity 汇总与 source/result arity 一致性校验抽取为独立 helper。主函数继续负责 channel 数
+量、source layout 和期望的 deinterleaved layout 判断；保持诊断顺序、结果顺序及失败语义
+不变。增量检查以 `HEAD` 为基线结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_channel_split_layout_invalid.pto` 仍按预期在原有
+layout contract 处失败。
+
 # scalar store verifier 分派职责整改
 
 本轮将 `verifySupportedVMIMemoryStoreOp` 中普通 `store` 的重复 shape-check 与错误诊断

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2096,6 +2096,16 @@ runtime prefix fallback 生成、结果 arity 校验；保持 physical part/chun
 `vmi_to_vpto_create_mask.pto` 在既有 VMI pack/unpack pipeline invariant 处提前失败，未
 进入本轮 helper，不能将该失败归因于本轮改动。
 
+# create_mask 动态 chunk mask 构造职责整改
+
+本轮在 `OneToNVMICreateMaskOpPattern::lowerDynamicMask` 中引入
+`buildDynamicMaskChunk`，将单个 physical result 的 mask 类型校验和 runtime prefix mask
+构造抽取为独立 helper。主函数继续负责 active lane clamp、part 分区、remaining 状态串接
+和结果顺序；保持动态 mask 的 remaining 传递、factor/chunk 索引、诊断及输出语义不变。
+增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_create_mask_dynamic.pto` 在既有 VMI pack/unpack
+pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。
+
 # group broadcast load E2B 结果复用职责整改
 
 本轮在 `OneToNVMIGroupBroadcastLoadOpPattern::lowerDirectE2B` 中引入 `buildE2BResults`，

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,21 @@
 # VMIToVPTO 静态分析报告记录
 
+## runtime expand-load 计划与物化拆分（2026-09-06）
+
+本轮将 `lowerRuntimeExpandLoad` 拆为两个职责明确的阶段：
+`buildRuntimeExpandLoadPlan` 负责单 physical chunk、result/mask/passthru 类型、pointer
+及 `source + offset` 合同，并返回显式的 `RuntimeExpandLoadPlan`；
+`materializeRuntimeExpandLoad` 负责 index carrier、`vusqz`、`vgather2_bc` 和 passthru
+`vsel` 的运行时 expand 语义物化。原有 runtime 只支持单 physical chunk 的限制、动态 mask
+和 passthru 语义、失败诊断及结果替换顺序保持不变；静态 all-active 路径未改变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## dense group-slot extension carrier 拆分（2026-09-06）
 
 本轮将 `buildDenseGroupSlotExtensionResult` 中单个 carrier 的逐级 unpack 发射与结果

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2280,6 +2280,16 @@ uniform vreg、mask/index 准备、对齐单 part 快路径和 direct-memory 合
 `git diff --check` 通过；`vmi_to_vpto_group_store_slots8_packed_byte.pto` 完整 lowering
 pipeline exit=0，输出仍包含 `PK4_B32`、stateful `vstus` 和 `NORM_B8` 路径。
 
+# deinterleaved=2 group reduce 类型合同职责整改
+
+本轮在 `OneToNVMIGroupReduceOpPattern::lowerFullDeinterleaved2` 中引入
+`Deinterleaved2GroupReduceTypes` 与 `getDeinterleaved2GroupReduceTypes`，将结果 vreg、
+mask、source chunk、行归约结果及 combine mask 的物理类型合同集中校验和推导。主函数继续
+负责 slots=1 结果约束、group/chunk arity、首 lane mask、归约构造和结果恢复；保持诊断顺序、
+mask 语义、group 顺序及失败传播不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_layout_assignment_group_reduce_s256.pto` 完整 lowering pipeline exit=0。
+
 # zero-copy interleave 结果合同职责整改
 
 本轮在 `OneToNVMIInterleaveOpPattern::materializeZeroCopyResults` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2349,6 +2349,14 @@ checked_files=1 errors=0 warnings=0
 `git diff --check` 通过；group-slot store、dense layout 和 interleaved memory lowering
 case 均 exit=0。
 
+# stride/scatter memory lowering 控制流整改（2026-09-06）
+
+本轮在完整分支增量检查中发现 `VMIStrideStoreOp` 与 `VMIScatterOp` lowering 仍有历史的
+无大括号控制语句。现将多操作数失败、physical arity 和 part 类型条件命名并补齐大括号，
+保持 `vsstb`/`vscatter` 发射顺序、操作数归一化、诊断文本和失败传播不变。增量
+`check_changed_code.py --base origin/master` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过。
+
 本轮尝试重新构建 `pto-test-opt` 时，CMake 仍因工作区既有的 `cann-cmake` 外部依赖
 配置尝试创建 `/cann-cmake` 且权限不足而无法重新配置；该环境问题未产生新的 C++ 编译
 诊断，未删除或重置现有 build tree。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2221,3 +2221,12 @@ mask、pair 顺序和诊断语义不变。增量 `check_changed_code.py` 结果�
 结果遍历和替换；保持 source/mask 对应关系、结果顺序、诊断和 lowering 语义不变。增量
 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
 通过；本轮未新增可独立进入该 helper 的 runtime case，未虚构额外回归结果。
+# legacy group-slot extension 单结果发射职责整改
+
+本轮在 `OneToNVMIExtIOpPattern::lowerLegacyGroupSlotExtension` 中引入
+`buildLegacyGroupSlotExtensionResult`，将单 physical result 的结果类型校验、source
+bitcast 和 `VcvtOp` 发射抽取为独立 helper。主函数继续负责 layout/width/arity 合约、
+source lane 与 slot mask 准备及结果替换；保持 EVEN/P0 part、slot mask、结果顺序、诊断
+和 lowering 语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_group_slot_integer_extension_matrix.pto` lowering exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2681,3 +2681,12 @@ granularity lowering case 均 exit=0。
 序列、mask merge 和结果 arity 检查保持在各自路径中，未改变 lowering 语义。增量
 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；layout 与 mask granularity lowering case 均 exit=0。
+
+# mask granularity cast layout 中间路径职责整改
+
+本轮新增 `materializeMaskGranularityCastThroughLayout`，将 physical granularity 转换后
+再执行 layout conversion 的两阶段路径独立出来。`materializeMaskGranularityCastParts`
+现在只负责判断 physical layout 是否相同并选择 direct 或 through-layout 路径；保持
+physical carrier 类型、granularity/layout 传播、转换顺序、结果 arity 及失败诊断不变。
+增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；mask granularity direct/multistep 与 dense layout case 均 exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -221,6 +221,13 @@ mask 的语义差异只存在于 active-lane 判定。补齐该批代码及 scal
 触及的控制语句大括号后，增量合规检查结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过。
 
+本轮还将 `computeSafeStatefulReadProof` 中的字节范围乘法、32-byte rounding 和物理访问
+包络计算抽取为 `buildStatefulReadEnvelopes`，使安全证明入口只负责静态 shape、offset
+范围、元素宽度与 footprint 前置条件。所有 `MulOverflow`/`AddOverflow`/`SubOverflow`
+检查、包络边界和失败原因保持不变；新增代码增量合规检查通过。尝试使用
+`vmi_to_vpto_expand_load_runtime_mask.pto` 回归时，在本轮逻辑前由既有
+`VMI-PASS-INVARIANT`（pack/unpack helper 提前物化）终止，未将该失败归因于本轮修改。
+
 # create_mask 分派整改
 
 本轮将 `OneToNVMICreateMaskOpPattern` 中动态与常量 `create_mask` 的结果类型获取、

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2307,6 +2307,29 @@ stream advance、诊断和 direct/fallback 语义不变。增量 `check_changed_
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
 
+# 本轮 G.FMT.11-CPP 增量整改（2026-09-06）
+
+本轮继续清理完整文件增量检查覆盖到的控制语句：为 iota contiguous/deinterleaved
+物化、constant/constant_mask conversion 以及 runtime `expand_load` 的失败分支补齐
+大括号；对包含多个失败条件和 mask 数量边界的条件引入具名布尔量，避免文本检查器将
+跨行条件误识别为无大括号控制语句。仅调整控制流书写形式和局部条件命名，没有改变
+物化顺序、结果 arity、类型检查、诊断或失败传播。
+
+验证结果：
+
+```text
+git diff --check  # passed
+python3 .agents/skills/enforce-ptoas-code-compliance/scripts/check_changed_code.py \
+  --repo . --base origin/master --fail-on none
+checked_files=1 errors=0 warnings=0
+```
+
+相关 lowering 回归均成功：
+`vmi_to_vpto_create_group_mask_block8_dynamic.pto`、`vmi_interleaved_memory_ops.pto`、
+`vmi_to_vpto_load_store_contiguous.pto` 的 `pto-test-opt` 完整 lowering exit=0。
+报告中的 AST 级超大函数、圈复杂度和历史数据泥团仍不能据此宣称全部清零，后续需在
+保持 lowering 分派和物理结果语义不变的前提下继续按职责边界拆分。
+
 # compact small group store 分支发射职责整改
 
 本轮在 `OneToNVMIGroupStoreOpPattern::lowerCompactSmallGroupStore` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2240,6 +2240,15 @@ source lane 与 slot mask 准备及结果替换；保持 EVEN/P0 part、slot mas
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_group_slot_integer_extension_matrix.pto` lowering exit=0。
 
+# ExtI dense lane-stride 单结果发射职责整改
+
+本轮在模板 `OneToNVMIExtIOpPattern::emitDenseLaneExtension` 中引入
+`buildDenseLaneExtensionResult`，将单 source/result pair 的 `VcvtOp` 发射抽取为独立 helper。
+主函数继续负责 all-true mask 构造、source/result 遍历和结果替换；保持 lane-stride part、
+mask、结果顺序、诊断及 lowering 语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_group_slot_integer_extension_matrix.pto` lowering exit=0。
+
 # ExtI factor conversion 单结果发射职责整改
 
 本轮在模板 `OneToNVMIExtIOpPattern::emitFactorExtension` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2644,3 +2644,13 @@ unsupported 类型失败语义及所有 layout materialization 调用路径不�
 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；dense layout、mask granularity 和 vdintlv 相关 case lowering
 均 exit=0。
+
+# mask physical carrier layout 控制流整改
+
+本轮清理 `getVMIMaskPhysicalCarrierLayout` 与
+`getVMIMaskPhysicalCarrierType` 中的无大括号控制语句，并将 physical carrier 缺失条件
+命名为 `missingPhysicalCarrier`。layout kind 到 contiguous/deinterleaved/
+block-deinterleaved/group-slots carrier 的映射、granularity 传播和失败语义保持不变。
+增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；vdintlv case 在既有 pack/unpack invariant 处提前终止，未进入
+本轮 carrier helper。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3059,6 +3059,23 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 ```
 
+# dense lane-stride store predicate 压缩职责拆分（2026-09-06）
+
+本轮将 `createDenseLaneStrideStorePredicate` 中 source mask/layout 合同和 lane-stride
+对应的 `punpack` 压缩逻辑抽取为 `compactDenseLaneStrideStorePredicate`。主函数继续负责
+active-lane 计算、尾部 mask 生成和最终 `pand`；b8→b32 的两级压缩、lane_stride=2 路径、
+全 active 快路径及失败语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
+`vmi_lane_stride_masked_store.pto` 在测试自身的 conflicting mask layout contract 处提前
+失败，未进入本轮 predicate helper。
+
 # narrowing mask granularity 单 chunk 物化职责拆分（2026-09-06）
 
 本轮将 `materializeNarrowingMaskGranularityPart` 中单个结果 chunk 的 source 消耗、

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3184,6 +3184,23 @@ vmi_layout_assignment_masked_load.pto                  # reaches existing residu
 该 layout case 在测试输入的既有 residual `pto.vmi.load` 问题处失败，未归因于本轮
 masked-load helper。
 
+# expand-load static chunk 物化职责拆分（2026-09-06）
+
+本轮将 `OneToNVMIExpandLoadOpPattern::lowerStaticExpandLoad` 中单个 result chunk 的
+vreg 合同校验、offset 计算和 `vlds` 发射抽取为 `materializeStaticExpandLoadPart`。外层
+函数继续负责 full/safe-read 合同、结果遍历和替换；static all-active 路径的访问步进、
+结果顺序、失败诊断以及与 runtime gather 路径的分派保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
+现有 static/runtime expand-load case 在测试自身的 VMI `unpack` 前置 invariant 处提前
+失败，未进入本轮 chunk helper。
+
 # deinterleave-load 结果类型合同拆分（2026-09-06）
 
 本轮将 `OneToNVMIDeinterleaveLoadOpPattern::matchAndRewrite` 中 low/high physical result

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2095,6 +2095,16 @@ stream advance、诊断和 direct/fallback 语义不变。增量 `check_changed_
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
 
+# contiguous group store 单 chunk 发射职责整改
+
+本轮在 `OneToNVMIGroupStoreOpPattern::lowerContiguousGroupStore` 中引入
+`emitContiguousGroupStorePart`，将单 physical chunk 的 vreg 校验、all-true mask、group/
+chunk 索引及 offset 计算和 `VstsOp` 发射抽取为独立 helper。主函数继续负责 contiguous
+layout 的 chunk shape/arity 合约和遍历；保持 `index / chunksPerGroup`、`index % chunksPerGroup`
+地址映射、lane offset、结果顺序、诊断和 store 语义不变。增量 `check_changed_code.py`
+结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
+
 # create_mask 常量 chunk 活跃度计算职责整改
 
 本轮在 `OneToNVMICreateMaskOpPattern::lowerConstantMask` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1862,3 +1862,12 @@ signless integer 校验、seed mask、零值 `VdupOp` 和 `VusqzOp` 发射抽取
 诊断不变。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_to_vpto_active_prefix_index.pto` 当前在既有 VMI pack/unpack
 pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。
+
+# compress physical part lowering 职责整改
+
+本轮将 `OneToNVMICompressOpPattern::matchAndRewrite` 中单 physical part 的
+source/mask/result 合同校验和 `VsqzOp` 发射抽取为 `lowerPart`。入口继续负责 one-part
+arity 限制、converted result type 获取与结果替换；保持压缩语义、结果类型、结果顺序和
+原有诊断不变。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_compress.pto` 当前在既有 VMI pack/unpack
+pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,20 @@
 # VMIToVPTO 静态分析报告记录
 
+## trunci group-slot carrier 路由拆分（2026-09-06）
+
+本轮将 `lowerGroupSlotTruncPart` 的三种物化策略拆为独立 helper：
+`lowerGroupSlotDirectCarrier` 处理 lane-stride=4 的直接 carrier，
+`lowerGroupSlotWideCarrier` 处理 lane-stride=2 的转换后 carrier，入口保留普通窄化
+`vcvt` 路径及策略路由。这样 direct bitcast、wide carrier `vcvt + bitcast` 和普通
+窄化的合同与发射职责明确分离；结果类型、active-slot mask、part 选择和失败诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## contiguous group-reduce shape 计划拆分（2026-09-06）
 
 本轮将 `lowerContiguousRows` 中的 chunk 形状推导、group 数量/每组 chunk 数、slots=1

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1912,3 +1912,14 @@ active_prefix_index、compress 和 compress_store 的 shape check、reason 收�
 `WalkResult` 处理。两种操作仍保留各自的 shape checker、支持条件文本和操作识别顺序，
 不改变成功/失败语义。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+
+# reduce_add 物理累加路径共性整改
+
+本轮将 `reduce_addi` 与 `reduce_addf` 中重复的等价 mask 合并、首 chunk `vcadd`、多
+chunk 首 lane mask 构造、逐 chunk `vcadd`/`vadd` 累加和结果替换抽取为共享模板
+`lowerReduceAddParts`。两个入口仍分别负责 converted result type 获取和
+`ReduceAddPhysicalPlan` 构建，并传递各自诊断文本；保持整数/浮点操作选择、单 chunk
+快路径、累加顺序、mask 语义及结果布局不变。为 helper 相关控制流补齐具名条件和大括号。
+增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；现有 reduce_add cases 在既有 VMI pack/unpack pipeline invariant
+处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3554,6 +3554,20 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_channel_split_merge.pto                    # exit=0
 ```
 
+# non-prefix constant mask 物化拆分（2026-09-06）
+
+本轮将 `materializeConstantMaskChunk` 中非连续 active lane 的 run 扫描、单 run PAND
+差集和多 run POR 合并抽取为 `materializeNonPrefixConstantMask`。主函数继续负责输入
+shape 校验、prefix 快路径和空 mask fallback；显式错误路径、mask lane 顺序和结果语义保持
+不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2085,6 +2085,16 @@ mask、结果顺序和诊断语义不变。增量 `check_changed_code.py` 结果
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；本轮未新增可独立进入该
 helper 的 runtime case，未虚构额外回归结果。
 
+# compact small group store 布局物化职责整改
+
+本轮在 `OneToNVMIGroupStoreOpPattern::lowerCompactSmallGroupStore` 中引入
+`materializeCompactSmallGroupValue`，将 lane-stride 判断、compact group-slots 类型构造及
+`materializeEnsureLayoutConversion` 结果校验抽取为独立 helper。主函数继续负责输入 arity/
+指针合同、对齐 `VstsOp` 与非对齐 stateful stream 分支；保持 compact value、地址、mask、
+stream advance、诊断和 direct/fallback 语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
+
 # create_mask 常量 chunk 活跃度计算职责整改
 
 本轮在 `OneToNVMICreateMaskOpPattern::lowerConstantMask` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2417,6 +2417,15 @@ intermediate 的严格优先级。各 lambda 使用显式捕获；主函数仍�
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_ensure_layout_dense_composed.pto` lowering exit=0。
 
+# active-prefix index shape 合同职责整改
+
+本轮将 `buildActivePrefixIndexShapePlan` 的校验拆为
+`checkActivePrefixIndexLayouts` 与 `checkActivePrefixIndexPhysicalChunks`，分别负责
+contiguous mask/result layout、full physical chunk 证明以及单 physical chunk arity 合同。
+plan builder 继续负责物理类型提取和最终 plan 组装，保持原诊断文本、校验顺序和失败语义
+不变。增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；active-prefix 正常样例在既有 pack/unpack invariant 处提前终止。
+
 # channel split 结果布局与 arity 合同职责整改
 
 本轮在 `checkSupportedChannelSplitShape` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2347,6 +2347,16 @@ layout/arity 汇总；保持 deinterleaved 期望布局、诊断顺序及失败�
 `git diff --check` 通过；channel merge 正常样例在既有 layout contract 冲突处提前失败，
 未进入本轮 helper。
 
+# mask lane-stride 转换方向职责整改
+
+本轮在 `materializeMaskLaneStrideLayout` 中引入 `MaskLaneStrideLayoutPlan` 与
+`getMaskLaneStrideLayoutPlan`，将 contiguous↔lane-stride 的方向识别及 stride 参数准备
+从具体 `Punpack/Ppack` 物化中分离。主函数继续负责 stride 合法性诊断和选择 unpack/pack
+emitter，保持 factor=2/4 支持范围、结果顺序和失败语义不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；现有 mask layout 样例在既有 layout contract 或 pack/unpack
+invariant 处提前终止，未进入本轮 helper。
+
 # shuffle forwarding 单 chunk 映射职责整改
 
 本轮在 `computeShuffleForwardingSourceParts` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3254,3 +3254,18 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 
 `vmi_to_vpto_expand_load_all_active.pto` 在既有 VMI pack/unpack pipeline invariant 处提
 前失败，未进入本轮 helper。
+
+# masked-store contiguous materialization 职责拆分（2026-09-06）
+
+本轮将 `checkMaskedStoreLayoutAndArity` 中 value/mask contiguous materialization part
+计数、失败原因和 arity 一致性检查抽取为
+`checkMaskedStoreContiguousMaterialization`。layout/physical arity 与 full-chunk 检查
+仍由原 helper 负责，full-chunk 快路径、tail materialization 合同和诊断传播保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_masked_store.pto                           # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2240,6 +2240,15 @@ source lane 与 slot mask 准备及结果替换；保持 EVEN/P0 part、slot mas
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_group_slot_integer_extension_matrix.pto` lowering exit=0。
 
+# ExtI factor conversion 单结果发射职责整改
+
+本轮在模板 `OneToNVMIExtIOpPattern::emitFactorExtension` 中引入
+`buildFactorExtensionResult`，将单个 source chunk/factor part 的 `VcvtOp` 发射抽取为独立
+helper。主函数继续负责 part-major/chunk-major 结果遍历、physical result type 选择和结果
+替换；保持 part 顺序、mask、结果扁平顺序、诊断及 lowering 语义不变。增量
+`check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
+通过；`vmi_to_vpto_group_slot_integer_extension_matrix.pto` lowering exit=0。
+
 # ExtI factor part plan 职责整改
 
 本轮在模板 `OneToNVMIExtIOpPattern::lowerPhysicalExtension` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1943,3 +1943,11 @@ accumulator 类型、source lane 数以及 Bin_N0/Bin_N1 常量准备从 lowerin
 透传和失败语义；lambda 使用显式捕获，未引入 warning suppression。增量
 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
 通过；`vmi_to_vpto_abs.pto` lowering exit=0。
+
+# group-reduction verifier 分派职责整改
+
+本轮在 `verifySupportedVMIGroupReductionOp` 中引入显式捕获的局部 helper
+`verifyGroupReduction`，统一六类 group reduction 的 shape checker 调用与
+`WalkResult` 返回路径。各分支仍保留原有操作识别顺序、shape checker 和完整诊断文本，
+不改变成功/失败语义；未使用默认 lambda 捕获。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2052,6 +2052,18 @@ exit=0，现有 slots=1 的 EVEN/P0 转换输出保持不变。
 `git diff --check` 通过；`vmi_layout_assignment_group_store_slots1_unit_stride.pto`
 完整 lowering pipeline exit=0。
 
+# contiguous load 物理发射职责整改
+
+本轮将 `OneToNVMILoadOpPattern::lowerContiguous` 中对齐普通 `vlds` 与非对齐 stateful
+`vldus` 的物理 part 发射分别抽取为 `materializeAlignedContiguousParts` 和
+`materializeUnalignedContiguousParts`。入口现在只负责 direct-access 合法性判断、选择
+发射策略及后续 contiguous→目标 layout 转换；非对齐路径仍由一次 `vldas` 初始化 align，
+逐 chunk 使用 `vldus` 推进 align/base，对齐路径仍按 lane offset 使用普通 `vlds`。结果顺序、
+地址步长、失败诊断和 layout materialization 语义保持不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_load_store_contiguous.pto` 完整 lowering pipeline
+exit=0。
+
 # iota 物化上下文数据泥团整改
 
 本轮引入轻量 `IotaMaterializationContext`，统一携带 iota 三类物化路径共同需要的

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -284,6 +284,14 @@ factor 路由写入抽取为 `materializeStagingMaskGroup`。外层函数保留 
 入口的命名化 arity 判断。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
 
+# vaddcs physical chunk lowering 职责整改
+
+本轮将 `OneToNVMIVaddcsOpPattern::matchAndRewrite` 中 physical arity、carry-in/mask/carry
+的 b32 合同、32-bit data 校验及逐 chunk `VaddcsOp` 发射抽取为 `lowerParts`。入口继续负责
+converted result/carry type 获取和最终结果扁平化；carry-in 透传、carry 结果排布、mask
+语义、结果顺序和诊断保持不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+
 # mask cast fallback 分派整改
 
 本轮整理 `materializeMaskGranularityCastLayoutFallback` 的 fallback 控制流：明确

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2347,6 +2347,16 @@ layout/arity 汇总；保持 deinterleaved 期望布局、诊断顺序及失败�
 `git diff --check` 通过；channel merge 正常样例在既有 layout contract 冲突处提前失败，
 未进入本轮 helper。
 
+# shuffle forwarding 单 chunk 映射职责整改
+
+本轮在 `computeShuffleForwardingSourceParts` 中引入
+`computeShuffleForwardingSourceChunk`，将单个 result physical chunk 的 padding/lane 映射、
+same-lane 约束、source chunk 一致性和 flat-part 索引计算抽取为独立 helper。主函数继续
+负责 source/result 类型前置条件、result factor/chunk 遍历和 source part 结果收集；保持
+forwarding fallback 的优先级、结果顺序和所有失败诊断不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_shuffle_forwarding.pto` lowering exit=0。
+
 # channel split 结果布局与 arity 合同职责整改
 
 本轮在 `checkSupportedChannelSplitShape` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2105,6 +2105,16 @@ arity 合约、stride 常量和 part 遍历；保持 part 顺序、block/repeat 
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
 
+# slots=1 packed group store 值构造职责整改
+
+本轮在 `OneToNVMIGroupStoreOpPattern::lowerSlots1PackedUnitStride` 中引入
+`buildPackedSlots1Value`，将每个 group 的 `VdupOp`、lane mask 构造与 `VselOp` 累积抽取
+为独立 helper。主函数继续负责 mask 类型/all-mask 准备、地址对齐判断以及 aligned
+`VstsOp` 或 unaligned stateful stream 分支；保持 group 顺序、LOWEST splat 语义、lane
+选择、store mask、stream advance 和诊断语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
+
 # one-block group-reduce 单结果构造职责整改
 
 本轮在 `OneToNVMIGroupReduceOpPattern::lowerOneBlock` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2033,3 +2033,14 @@ exit=0，现有 slots=1 的 EVEN/P0 转换输出保持不变。
 布局或诊断语义。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_layout_assignment_group_store_slots1_unit_stride.pto`
 完整 lowering pipeline exit=0。
+
+# group broadcast load BRC 单结果构造职责整改
+
+本轮在 `OneToNVMIGroupBroadcastLoadOpPattern::lowerDirectBRC` 中引入
+`buildDirectBRCResult`，将单个结果块的 physical vreg 校验、group offset 计算和 `VldsOp`
+发射抽取为独立 helper。`lowerDirectBRC` 仍负责 BRC arity/指针合同、结果遍历和扁平化；
+保持 group index 计算、source-group-stride 透传、结果顺序、BRC dist token 和原有诊断语义
+不变。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过。现有 `vmi_layout_assignment_group_slot_broadcast_load_brc_b32.pto`
+在 group_slot_load 的既有 unsupported-shape 诊断处提前失败，未进入本轮 BRC helper，不能
+将该失败归因于本轮改动。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2144,6 +2144,15 @@ chunk 顺序、诊断及结果替换语义不变。增量 `check_changed_code.py
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_group_broadcast_load_e2b_b16.pto` lowering exit=0。
 
+# group broadcast load direct/fallback 分派职责整改
+
+本轮在 `OneToNVMIGroupBroadcastLoadOpPattern::lowerDirectOrFallback` 中引入
+`tryLowerDirectBRC` 与 `tryLowerDirectE2B`，分别封装 BRC/E2B candidate、dist token、地址
+合法性判断和 direct lowering 调用。主函数现在只负责 BRC→E2B→group-slot fallback 的优先
+级分派；保持 directFact 条件、地址分析、失败传播、结果顺序、诊断和 fallback 语义不变。
+增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_group_broadcast_load_e2b_b16.pto` lowering exit=0。
+
 # group broadcast load fallback source plan 职责整改
 
 本轮在 `OneToNVMIGroupBroadcastLoadOpPattern::lowerGroupSlotFallback` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3382,3 +3382,18 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_load_store_contiguous.pto                  # exit=0
 ```
+
+# contiguous load 访存物化职责拆分（2026-09-06）
+
+本轮将 `OneToNVMILoadOpPattern::lowerContiguous` 中 aligned `vlds` 与 unaligned stateful
+`vldus` 的选择抽取为 `materializeContiguousLoadParts`。helper 只负责根据 direct-memory
+合法性选择物化路径，`lowerContiguous` 继续负责 layout conversion 和结果替换；对齐证明、
+align/base 状态推进、part 顺序及 fallback 语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_load_store_contiguous.pto                  # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1734,6 +1734,16 @@ physical plan、lane-stride/factor 分派和 mask 构造；保持 packed BF16x2 
 通过；`vmi_to_vpto_extf_f4x2_to_bf16x2_ls4.pto` lowering exit=0；另一个 extf case
 仍在既有 VMI pack/unpack pipeline invariant 处提前失败。
 
+# truncf group-slot physical chunk 发射整改
+
+本轮将 `OneToNVMITruncFOpPattern::lowerGroupSlotTrunc` 中单个 physical part 的 source/
+result 类型校验、结果位宽判断、EVEN/P0 选择、round mode 计算和 `VcvtOp` 发射抽取为
+`lowerGroupSlotTruncPart`。外层继续负责 group-slot shape、slots=1/8 active mask 和结果
+收集；保持 f32 source、f16/f8 result、active slot mask、saturate、round 和结果顺序不变。
+增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；现有 group-slot truncf cases 在既有 VMI pack/unpack pipeline
+invariant 处提前失败，未进入本轮 helper。
+
 # reduce_min/max physical 校验整改
 
 本轮将模板 `OneToNVMIReduceMinMaxOpPattern::matchAndRewrite` 中 min/max reduction 共用

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2269,6 +2269,17 @@ source lane 与 slot mask 准备及结果替换；保持 EVEN/P0 part、slot mas
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_group_slot_integer_extension_matrix.pto` lowering exit=0。
 
+# packed-byte group store 块发射职责整改
+
+本轮在 `OneToNVMIGroupStoreOpPattern::lowerPackedByteSlots8` 中引入
+`emitPackedByteStoreBlocks`，将每个 32-group block 的 packed value 构造结果分派、直接
+`PK4_B32` 发射以及 stateful stream value/advance 收集抽取为独立 helper。入口继续负责
+uniform vreg、mask/index 准备、对齐单 part 快路径和 direct-memory 合法性判断；保持 block
+顺序、active lane mask、group offset、PK4_B32 与 `vstus`/`vstas` 选择及失败传播语义不变。
+增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_group_store_slots8_packed_byte.pto` 完整 lowering
+pipeline exit=0，输出仍包含 `PK4_B32`、stateful `vstus` 和 `NORM_B8` 路径。
+
 # zero-copy interleave 结果合同职责整改
 
 本轮在 `OneToNVMIInterleaveOpPattern::materializeZeroCopyResults` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2085,6 +2085,15 @@ mask、结果顺序和诊断语义不变。增量 `check_changed_code.py` 结果
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；本轮未新增可独立进入该
 helper 的 runtime case，未虚构额外回归结果。
 
+# group broadcast load E2B 结果复用职责整改
+
+本轮在 `OneToNVMIGroupBroadcastLoadOpPattern::lowerDirectE2B` 中引入 `buildE2BResults`，
+将 E2B packet 复用时的 part/chunk 结果类型一致性校验与扁平结果收集抽取为独立 helper。
+主函数继续负责 E2B layout、stride、arity 合约和 packet 发射；保持 packet 复用规则、part/
+chunk 顺序、诊断及结果替换语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_group_broadcast_load_e2b_b16.pto` lowering exit=0。
+
 # slots=8 lane-stride group store direct 发射职责整改
 
 本轮在 `OneToNVMIGroupStoreOpPattern::lowerSlots8LaneStride` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2721,3 +2721,14 @@ factor/group 合同、逐组调用具体的 factor=2/4 物化逻辑和最终结�
 `git diff --check` 通过。`vmi_to_vpto_ensure_mask_granularity_multistep.pto` 尝试
 lowering 时在既有 VMI pack/unpack pipeline invariant 处提前失败，未进入本轮 staging
 helper，不能将该失败归因于本轮改动。
+
+# group store 布局分派职责整改
+
+本轮将 `OneToNVMIGroupStoreOpPattern::matchAndRewrite` 中的布局分类与后端选择抽取为
+`lowerByLayout`。入口现在只负责 destination/offset/row_stride 的单值归一化并保留统一
+scalar `group_store` 的注释上下文，helper 负责 compact-small、slots=1、slots=8、one-block、
+deinterleaved=2 与 contiguous 路径的优先级分派。support-table 查询、deinterleaved shape
+探测、失败诊断和所有具体 lowering 的参数/结果语义均保持不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_layout_assignment_group_store_slots1_unit_stride.pto`
+完整 lowering pipeline exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2300,6 +2300,14 @@ contiguous chunk shape、结果布局/arity、首 lane mask、归约构造和结
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_layout_assignment_group_reduce_s256.pto` 完整 lowering pipeline exit=0。
 
+# stateful offset 范围边界转换职责整改
+
+本轮将 `getStatefulOffsetRange` 内嵌的 APInt 上下界转换 lambda 抽取为
+`convertFiniteRangeBound`，集中处理有符号/无符号解释和 int64 可表示性边界。范围分析、
+循环归纳变量查找、非负性校验和失败诊断保持不变；显式捕获与控制流大括号要求也得到统一。
+增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过。
+
 # zero-copy interleave 结果合同职责整改
 
 本轮在 `OneToNVMIInterleaveOpPattern::materializeZeroCopyResults` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2369,6 +2369,19 @@ case 均 exit=0。
 `check_changed_code.py --base origin/master` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过。
 
+# group-load contiguous shape 职责整改（2026-09-06）
+
+本轮将 `checkSupportedGroupLoadShape` 中 contiguous result layout 的 memory support、
+full-chunk/group-row 合同抽取为 `checkSupportedContiguousGroupLoadShape`，入口现在只负责
+result layout 分类、group size 推导及 block-deinterleaved 分派。contiguous 与
+block-deinterleaved 的支持优先级、row-stride 规则、诊断和失败传播保持不变；同时补齐
+slots=1 group-slot-load 元素宽度检查的大括号。增量检查结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+
+`vmi_layout_assignment_group_store_slots1_unit_stride.pto` 与
+`vmi_to_vpto_load_store_contiguous.pto` lowering exit=0；两个 group-load stride store
+样例在既有测试 IR 的整体 region/前置约束处终止，未进入本轮 helper，不能归因于本轮修改。
+
 本轮尝试重新构建 `pto-test-opt` 时，CMake 仍因工作区既有的 `cann-cmake` 外部依赖
 配置尝试创建 `/cann-cmake` 且权限不足而无法重新配置；该环境问题未产生新的 C++ 编译
 诊断，未删除或重置现有 build tree。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2337,6 +2337,16 @@ group_broadcast_load 的重复 shape-check 和失败诊断统一改用 `verifySu
 `vmi_layout_assignment_group_load_s16_unaligned_stride_invalid.pto` 仍按预期在既有
 layout contract invalid 处失败，诊断未改变。
 
+# channel merge 结果合同职责整改
+
+本轮在 `checkSupportedChannelMergeShape` 中引入
+`checkChannelMergeResultShape`，将 result layout、result physical arity 和输入/结果
+arity 一致性校验抽取为独立 helper。主函数继续负责 channel 数量和所有输入 contiguous
+layout/arity 汇总；保持 deinterleaved 期望布局、诊断顺序及失败语义不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；channel merge 正常样例在既有 layout contract 冲突处提前失败，
+未进入本轮 helper。
+
 # channel split 结果布局与 arity 合同职责整改
 
 本轮在 `checkSupportedChannelSplitShape` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3111,6 +3111,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_deinterleave_load_layout_propagation.pto           # exit=0
 ```
 
+# deinterleave-load 结果类型合同拆分（2026-09-06）
+
+本轮将 `OneToNVMIDeinterleaveLoadOpPattern::matchAndRewrite` 中 low/high physical result
+type 转换、转换失败和 arity 一致性校验抽取为 `getDeinterleaveLoadResultTypes`。入口继续
+负责 source/offset 归一化、element/distance 合同、direct-access 合法性判断及 aligned 与
+unaligned 路由；结果类型顺序、失败诊断和 `vldsx2`/stateful fallback 语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_deinterleave_load_layout_propagation.pto           # exit=0
+```
+
 随后将 `computeShuffleVselrPlanForChunk` 中的结果物理 lane 校验、逻辑 lane 越界检查和
 source lane 映射抽取为 `getShuffleSourceLane`。规划函数继续负责 source chunk 一致性与
 ASC/DESC 方向推导，抽取没有改变失败诊断、迭代顺序或最终 `ShuffleVselrPlan` 内容；增量

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2708,3 +2708,16 @@ direct layout conversion → staging factor route → dense-split contiguous con
 尝试顺序；direct conversion 失败后继续尝试的语义、optional/failure 传播和结果顺序不变。
 增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；mask granularity direct/multistep case 均 exit=0。
+
+# staging mask part 累积职责整改
+
+本轮引入 `StagingMaskPartAccumulator`，将 contiguous→deinterleaved staging mask 转换中
+physical part 容器的初始化、每组结果的 arity 校验与追加、以及 part-major 扁平化集中到
+一个有明确所有权的累积对象。`materializeStagingContiguousToDeintMaskLayout` 现在只负责
+factor/group 合同、逐组调用具体的 factor=2/4 物化逻辑和最终结果返回；没有把 factor=2
+与 factor=4 的 `pdintlv` 语义强行合并，仍保持源 part 补齐、group 顺序、part-major 结果
+顺序、结果 arity 诊断及失败传播不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过。`vmi_to_vpto_ensure_mask_granularity_multistep.pto` 尝试
+lowering 时在既有 VMI pack/unpack pipeline invariant 处提前失败，未进入本轮 staging
+helper，不能将该失败归因于本轮改动。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3514,6 +3514,19 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_create_mask_plt_fallback.pto              # invalid/invariant diagnostic retained
 ```
 
+# shuffle forwarding 输入合同拆分（2026-09-06）
+
+本轮将 `computeShuffleForwardingSourceParts` 的 physical lanes、indices 非空和 result
+layout factor 输入合同集中到局部 `validateInputs`。主体继续负责按 result factor/chunk
+遍历并调用 source chunk 映射；错误诊断、source flat index 顺序和 forwarding 语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2165,6 +2165,16 @@ arity 合约、stride 常量和 part 遍历；保持 part 顺序、block/repeat 
 通过；`vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline
 exit=0。
 
+# deinterleaved=2 group store low/high pair 发射职责整改
+
+本轮在 `OneToNVMIGroupStoreOpPattern::lowerDeinterleaved2GroupStore` 中引入
+`emitDeinterleaved2GroupStorePair`，将单个 low/high pair 的类型合同、all-true mask、
+chunk offset 和 `Vstsx2Op` 发射抽取为独立 helper。主函数继续负责 chunk shape、dist 能力、
+physical arity 及双层 group/chunk 遍历；保持 low/high 索引、INTLV dist、lane offset、
+mask、pair 顺序和诊断语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；本轮未新增可独立覆盖该
+分支的 runtime case，未虚构额外回归结果。
+
 # slots=1 packed group store 值构造职责整改
 
 本轮在 `OneToNVMIGroupStoreOpPattern::lowerSlots1PackedUnitStride` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,19 @@
 # VMIToVPTO 静态分析报告记录
 
+## lane-stride masked-store 单 chunk 发射拆分（2026-09-06）
+
+本轮将 `OneToNVMIMaskedStoreOpPattern::lowerLaneStride` 中单 physical chunk 的类型/active
+lane 检查、predicate 压缩、地址合法性和 `vsts` 发射抽取为
+`emitLaneStrideMaskedStorePart`。外层函数只负责 matching value/mask 遍历和 semantic
+offset 累积；零 active lane、offset 步进、dist 传递、失败诊断及 store 顺序保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## group-store 通用布局 lowering 拆分（2026-09-06）
 
 本轮将 `OneToNVMIGroupStoreOpPattern::lowerByLayout` 中 general layout 的 support fact

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3559,6 +3559,20 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_masked_store.pto                           # exit=0
 ```
 
+# group-broadcast E2B chunk 合同拆分（2026-09-06）
+
+本轮将 `validateDirectE2BShape` 中各 physical part 的 chunk 数量一致性检查抽取为
+`validateDirectE2BChunks`。E2B 主合同仍负责 layout、element width、stride、pointer、
+group 数量和结果 arity 检查；E2B dist 选择、单 packet 限制与失败诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_group_broadcast_load_e2b_b16.pto           # blocked by pre-existing VMI-PASS-INVARIANT
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2110,6 +2110,17 @@ dist/factor/chunk 参数、发射 E2B packets 和复用结果；B16/B32 dist、f
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_layout_assignment_group_broadcast_load_e2b_b16.pto` lowering exit=0。
 
+# masked store 布局分派职责整改
+
+本轮将 `OneToNVMIMaskedStoreOpPattern::matchAndRewrite` 中 lane-stride dist/mask-granularity
+候选判断与 contiguous fallback 分派抽取为 `lowerByLayout`。入口现在只负责 physical
+lane 数、地址操作数和 value/mask arity 合同；helper 按原顺序优先选择 lane-stride
+`vsts`，否则进入 contiguous layout materialization。对齐证明、mask 转换、结果顺序、
+失败诊断和 lowering 语义保持不变。增量
+`check_changed_code.py --base origin/master --fail-on none` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_masked_store.pto` lowering exit=0。
+
 # group load 布局分派职责整改
 
 本轮将 `OneToNVMIGroupLoadOpPattern::matchAndRewrite` 中 block-deinterleaved f32 特殊路径

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2690,3 +2690,12 @@ granularity lowering case 均 exit=0。
 physical carrier 类型、granularity/layout 传播、转换顺序、结果 arity 及失败诊断不变。
 增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；mask granularity direct/multistep 与 dense layout case 均 exit=0。
+
+# staging mask factor 路由职责整改
+
+本轮新增 `getMaskStagingDirection`，将 factor=2/4 staging 路径的 contiguous 与
+deinterleaved layout 方向识别从 `materializeMaskGranularityCastStagingLayout` 中独立出来。
+入口现在只负责按 factor 顺序尝试并调用对应 materializer；deint→contiguous 与
+contiguous→deint 的发射语义、factor 优先级、结果顺序及失败传播保持不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；mask granularity direct/multistep 和 dense layout case 均 exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3588,6 +3588,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
 ```
 
+# group-slot-load slots=1 chunk 发射拆分（2026-09-06）
+
+本轮将 `lowerGroupSlotLoadSlots1` 循环中的结果类型/mask 合同、group offset 计算、pointer
+构造和 `vsldb` 发射抽取为 `emitGroupSlotLoadSlots1Chunk`。主函数继续负责 element width
+和 source stride 对齐合同及逐 group 遍历；`PAT_VL1` mask、地址步进、结果顺序和失败诊断
+保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_slot_load_slots1_unaligned_stride_invalid.pto # expected invalid-case exit=1
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1834,3 +1834,13 @@ predicate mode、signedness bitcast、结果顺序、mask 语义和原有诊断�
 大括号。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；现有 compare cases 在既有 VMI pack/unpack pipeline invariant
 处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。
+
+# select physical chunk lowering 职责整改
+
+本轮将 `OneToNVMISelectOpPattern::matchAndRewrite` 中 physical part 的 mask/data 类型
+校验和 `VselOp` 发射抽取为 `lowerPart`。入口继续负责 mask、true/false value 与 result
+的 physical arity 校验和结果扁平化；保持 `VselOp(true, false, mask)` operand 顺序、
+结果顺序、mask 语义和原有诊断不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_cmp_select.pto` 当前在既有 VMI pack/unpack pipeline invariant 处提前失败，
+未进入本轮 helper，不能将该失败归因于本轮改动。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3144,3 +3144,18 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_layout_assignment_group_broadcast_load_e2b_b16.pto # exit=0
 ```
+
+# integer extension source 合同职责拆分（2026-09-06）
+
+本轮将 `OneToNVMIExtIOpPattern::matchAndRewrite` 中 source physical chunks 的非空、类型
+可转换及跨 chunk 一致性检查抽取为 `getUniformExtensionSourceType`。入口继续负责 VMI
+布局分派、result 类型收集及 factor/lane-stride lowering；source 类型合同、失败诊断和
+物理结果顺序保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_reduce_extended.pto                       # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1853,3 +1853,12 @@ predicate mode、signedness bitcast、结果顺序、mask 语义和原有诊断�
 同时将相邻 `active_prefix_index` 的条件判断改为具名布尔值并补齐大括号，以满足
 `G.FMT.11-CPP`。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_to_vpto_vselr.pto` lowering exit=0。
+
+# active_prefix_index physical part lowering 职责整改
+
+本轮将 `OneToNVMIActivePrefixIndexOpPattern::matchAndRewrite` 中 physical vreg/mask 合同、
+signless integer 校验、seed mask、零值 `VdupOp` 和 `VusqzOp` 发射抽取为 `lowerPart`。入口
+继续负责 one-part arity 与结果替换；保持零值宽度、mask 语义、指令顺序、结果类型和原有
+诊断不变。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_active_prefix_index.pto` 当前在既有 VMI pack/unpack
+pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2328,6 +2328,15 @@ group_broadcast_load 的重复 shape-check 和失败诊断统一改用 `verifySu
 `vmi_layout_assignment_group_load_s16_unaligned_stride_invalid.pto` 仍按预期在既有
 layout contract invalid 处失败，诊断未改变。
 
+# scalar store verifier 分派职责整改
+
+本轮将 `verifySupportedVMIMemoryStoreOp` 中普通 `store` 的重复 shape-check 与错误诊断
+改为复用 `verifySupportedShapeOp`，新增 `checkSupportedVMIStoreShape` 仅负责把 operation
+operand 适配到既有 `checkSupportedStoreShape`。structured store（包括 masked_store）的
+分派顺序和特殊诊断保持不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_group_store_slots1_1pt.pto` lowering exit=0。
+
 # contiguous group reduce 类型合同职责整改
 
 本轮在 `OneToNVMIGroupReduceOpPattern::lowerContiguousRows` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,20 @@
 # VMIToVPTO 静态分析报告记录
 
+## dense group-slot extension carrier 拆分（2026-09-06）
+
+本轮将 `buildDenseGroupSlotExtensionResult` 中单个 carrier 的逐级 unpack 发射与结果
+合同检查拆为 `extendDenseGroupSlotCarrier`。主 helper 负责目标 physical result 合同、
+按位宽推进和最终 bitcast；carrier helper 负责下一层元素类型/车道数推导、lane 合同和
+有符号/无符号 unpack 指令选择。扩展层数、`Vsunpack`/`Vzunpack` 选择、失败诊断和结果
+顺序保持不变，没有改变 lowering 语义。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## 动态 group-mask lane index 职责拆分（2026-09-06）
 
 本轮将 `buildDynamicGroupMaskLaneIndex` 的索引构造拆为两个明确阶段：

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3573,6 +3573,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_group_broadcast_load_e2b_b16.pto           # blocked by pre-existing VMI-PASS-INVARIANT
 ```
 
+# slots=8 lane-stride group-store 地址规划拆分（2026-09-06）
+
+本轮将 `lowerSlots8LaneStride` 中每个 slot block 的 vreg 合同、group offset 构造和
+direct-memory 合法性汇总抽取为 `buildLaneStrideGroupOffsets`。主函数继续负责 dist/mask
+选择、unaligned compact stream fallback 和 aligned 发射；地址顺序、stream advances、
+失败诊断及 direct/stream 路由保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1934,3 +1934,12 @@ accumulator 类型、source lane 数以及 Bin_N0/Bin_N1 常量准备从 lowerin
 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
 通过；现有 vdhist/vchist cases 在既有 VMI pack/unpack pipeline invariant 处提前失败，
 未进入本轮 helper，不能将该失败归因于本轮改动。
+
+# VMI-to-VPTO verifier walk 职责整改
+
+本轮将 `verifySupportedVMIToVPTOOps` 的单 operation 标准分派、channel/shuffle 分派和
+默认通过逻辑抽取为 `verifySupportedVMIToVPTOOp`。模块 walk 入口现在只负责遍历与最终
+`WalkResult` 汇总，保留原有标准检查优先于 channel shuffle 的顺序、稳定 gather 选项
+透传和失败语义；lambda 使用显式捕获，未引入 warning suppression。增量
+`check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
+通过；`vmi_to_vpto_abs.pto` lowering exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3066,3 +3066,19 @@ ASC/DESC 方向推导，抽取没有改变失败诊断、迭代顺序或最终 `
 
 随后补齐 shuffle VSEL 规划失败诊断 lambda 的大括号；该修改仅满足控制流可读性约束，
 不改变诊断文本或失败传播。
+
+# group store physical shape 职责拆分（2026-09-06）
+
+本轮将 `checkSupportedGroupStoreByLayout` 中通用 physical shape 合同校验抽取为
+`checkSupportedGroupStorePhysicalShape`。布局分派 helper 现在只负责 compact-small、
+group-slots 和通用 layout-fact 路由；physical helper 负责 destination shape、one-block
+plan、full group chunk 与 deinterleaved=2 fallback 的顺序。支持范围、失败诊断和原有
+优先级保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3191,6 +3191,22 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
 ```
 
+# slots=8 packed-byte group-store 单 part 合并职责拆分（2026-09-06）
+
+本轮将 `buildPackedByteStoreBlock` 中单个 local part 的 `vselr` 选择、lane range mask
+构造和 `vsel` 合并抽取为 `mergePackedByteStoreBlockPart`。block helper 继续负责 part
+索引/尾部 active-group 判断、block accumulator、store mask 和 group offset；`PK4_B32`
+直写、stateful packed-byte stream、尾部 mask 和结果顺序语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_group_store_slots8_packed_byte.pto          # exit=0
+vmi_to_vpto_group_store_lane_stride.pto                 # exit=0
+```
+
 # contiguous group-load 单 chunk 物化职责拆分（2026-09-06）
 
 本轮将 `OneToNVMIGroupLoadOpPattern::lowerContiguousChunks` 中单个 group/chunk 的

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2440,6 +2440,14 @@ memory access proof 及两阶段失败回退，保持 masked-store 的支持范�
 保持不变。增量检查结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 scatter 正常 case lowering 成功，非法 gather/scatter case 仍在预期 shape 诊断处失败。
 
+# add-carry mask port 合同职责整改（2026-09-06）
+
+本轮将 `checkSupportedVMIAddCarryPorts` 中每个 mask/carry port 的 layout、b32 粒度、
+physical arity 和 physical mask granularity 校验抽取为 `checkAddCarryMaskPort`。共享
+数据 port 的 32-bit、同类型、布局及 64-lane 合同仍由主 helper 负责，`vaddc`/`vaddcs`
+的 mask 列表顺序、支持范围、诊断和失败传播保持不变；同时补齐新 helper 中的控制流
+条件命名。增量检查结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+
 # scatter shape 合同职责整改（2026-09-06）
 
 本轮将 `checkSupportedScatterShape` 的布局/目标指针校验抽取为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2071,6 +2071,11 @@ exit=0，普通 iota case 仍在既有 pack/unpack invariant 处提前终止。
 顺序。增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；三组 iota lowering case 均 exit=0。
 
+进一步将同一 context 提升到 grouped、contiguous 和 deinterleaved iota 各自的循环外，
+避免每个物理 chunk 重复构造临时 context。该调整只改变对象生命周期与参数传递方式，
+不改变 chunk 共享 key、布局分派、偏移计算或结果顺序；增量检查及三组 iota lowering
+case 均继续通过。
+
 # vmull 物理 shape 合同职责整改
 
 本轮新增 `checkVmullPhysicalShape`，将 vmull 的 physical lane 数、physical data element

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3427,6 +3427,20 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_trunci_lane_stride.pto           # exit=0
 ```
 
+# deinterleaved=2 full group-reduce shape 拆分（2026-09-06）
+
+本轮将 `lowerFullDeinterleaved2` 中 result slots、物理 lane、group/chunk 数量及 source/
+mask/result arity 合同抽取为 `validateFullDeinterleaved2Shape`。主函数继续负责 reduce
+类型准备、lane mask、结果归并与恢复；group/chunk 计算、失败诊断和结果语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_reduce_s256.pto            # exit=0
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1896,3 +1896,11 @@ active_prefix_index、compress 和 compress_store 的 shape check、reason 收�
 `WalkResult` 处理。各操作仍保留原有 shape checker、诊断正文、操作识别顺序和成功/失败
 语义，避免重复控制流。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+
+# add-carry verifier 分派职责整改
+
+本轮为 `verifySupportedVMIAddCarryOp` 引入模板 helper `verifyAddCarryShape`，统一
+`vaddc`/`vaddcs` 的 shape checker、reason 收集、诊断前缀和 `WalkResult` 处理。两种操作
+仍使用各自的 shape checker、诊断名称和原有识别顺序，保持成功/失败语义不变。增量
+`check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
+通过。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1824,3 +1824,13 @@ all-true seed mask 构造、目标 mask unary op 发射和结果替换抽取为 
 原有诊断语义不变。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_mask_logic.pto` lowering exit=0。
+
+# compare physical chunk lowering 职责整改
+
+本轮将模板 `OneToNVMICmpOpPattern::matchAndRewrite` 中 physical part 的 mask/type 合同、
+all-true seed mask、整数 signedness carrier 物化和 `VcmpOp` 发射抽取为 `lowerPart`。入口
+继续负责 predicate 支持检查、converted result type 获取和 physical arity 校验；保持
+predicate mode、signedness bitcast、结果顺序、mask 语义和原有诊断不变，并补齐控制流
+大括号。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；现有 compare cases 在既有 VMI pack/unpack pipeline invariant
+处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,20 @@
 # VMIToVPTO 静态分析报告记录
 
+## arithmetic verifier 分派拆分（2026-09-06）
+
+本轮将 `verifySupportedVMIArithmeticOp` 拆为普通 unary/binary maskable 算术分派与
+vector-scalar 算术分派：`verifySupportedVMIUnaryBinaryArithmeticOp` 维护原有普通向量
+op 表，`verifySupportedVMIVecScalarArithmeticOp` 维护 `vadds/vmuls/vmaxs/vmins/vshls/
+vshrs` 表，入口只负责两组分派。所有 op 名称、maskable 检查、`pmode=merge` 诊断及
+`std::optional<WalkResult>` 语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## conversion verifier 分派拆分（2026-09-06）
 
 本轮将 `verifySupportedVMIConversionOp` 按语义拆为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,19 @@
 # VMIToVPTO 静态分析报告记录
 
+## group-reduction verifier 分派清理（2026-09-06）
+
+本轮清理 `verifySupportedVMIGroupReductionOp` 中仅转发参数的默认捕获 lambda，直接使用
+现有 `verifySupportedGroupReduceOp` 模板，避免无意义的间接层；各 group-reduction op 的
+诊断文本、support check 和 `WalkResult` 语义保持不变。同时将本轮触及的复杂条件提取为
+命名布尔量，满足控制语句大括号规则并提升可读性。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## structured-store verifier masked-store 分支拆分（2026-09-06）
 
 本轮将 `verifySupportedVMIStructuredStoreOp` 中 masked-store 的专用 shape 检查及诊断抽取

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2673,3 +2673,11 @@ block-deinterleaved/group-slots carrier 的映射、granularity 传播和失败�
 传播保持不变。增量 `check_changed_code.py --base HEAD` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；layout 和 mask
 granularity lowering case 均 exit=0。
+
+# mask lane-stride 结果类型校验职责整改
+
+本轮新增 `getMaskLaneStrideResultType`，统一 pack/unpack 两条路径对 physical result
+`MaskType` 的校验与诊断。实际的 source index、lane-stride part 选择、punpack/ppack
+序列、mask merge 和结果 arity 检查保持在各自路径中，未改变 lowering 语义。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；layout 与 mask granularity lowering case 均 exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2105,6 +2105,16 @@ arity 合约、stride 常量和 part 遍历；保持 part 顺序、block/repeat 
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
 
+# slots=1 group store point-store 单组发射职责整改
+
+本轮在 `OneToNVMIGroupStoreOpPattern::lowerSlots1PointStores` 中引入
+`emitSlots1PointStore`，将单个 group 的 vreg 校验、`PAT_VL1` mask 构造、group offset 计算
+和 point-store `VstsOp` 发射抽取为独立 helper。主函数继续负责 point-store dist 能力
+检查及 group 遍历；保持 row stride、地址偏移、mask、dist token、group 顺序和诊断语义不变。
+增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
+通过；`vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline
+exit=0。
+
 # slots=1 packed group store 值构造职责整改
 
 本轮在 `OneToNVMIGroupStoreOpPattern::lowerSlots1PackedUnitStride` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3159,6 +3159,23 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_group_load.pto                    # exit=0
 ```
 
+# group-store slots=1 非对齐 stream 发射职责拆分（2026-09-06）
+
+本轮将 `lowerSlots1PackedUnitStride` 中非对齐 destination 的 pointer 物化、offset 合成、
+单 packed value 的 stream advance 准备及 stateful store 发射抽取为
+`emitPackedSlots1StoreStream`。主函数继续负责 packed value 构造、对齐 `vsts` 路径、
+对齐 mask 及最终 op 删除；aligned/unaligned 路由、`numGroups` advance 和 `vstus/vstas`
+语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
+vmi_to_vpto_group_store_slots1_unit_stride_alignment.pto # exit=0
+```
+
 # contiguous group-load 单 chunk 物化职责拆分（2026-09-06）
 
 本轮将 `OneToNVMIGroupLoadOpPattern::lowerContiguousChunks` 中单个 group/chunk 的

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1724,6 +1724,16 @@ OneBlock、TwoBlock、FourBlock、deinterleaved-2 及 contiguous rows 的执行�
 触发 `G.FMT.11-CPP`。增量合规检查结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_layout_assignment_group_slots_fanout.pto` lowering exit=0。
 
+# extf result view 规划整改
+
+本轮将 `OneToNVMIExtFOpPattern::matchAndRewrite` 中 packed BF16x2 结果的物理 view 类型
+规划抽取为 `ResultViewPlan`/`buildResultViewPlan`。入口仍负责 source/result layout、
+physical plan、lane-stride/factor 分派和 mask 构造；保持 packed BF16x2 的 BF16 view
+扩展、后续 `VbitcastOp` 物理无副作用语义、结果顺序和普通结果类型不变。增量
+`check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
+通过；`vmi_to_vpto_extf_f4x2_to_bf16x2_ls4.pto` lowering exit=0；另一个 extf case
+仍在既有 VMI pack/unpack pipeline invariant 处提前失败。
+
 # reduce_min/max physical 校验整改
 
 本轮将模板 `OneToNVMIReduceMinMaxOpPattern::matchAndRewrite` 中 min/max reduction 共用

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2104,6 +2104,16 @@ stream advance、诊断和 direct/fallback 语义不变。增量 `check_changed_
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
 
+# compact small group store 分支发射职责整改
+
+本轮在 `OneToNVMIGroupStoreOpPattern::lowerCompactSmallGroupStore` 中引入
+`emitAlignedCompactSmallGroupStore` 与 `emitUnalignedCompactSmallGroupStore`，分别封装
+对齐路径的 dist/mask/`VstsOp` 和非对齐路径的 base/advance/stateful stream 发射。入口继续
+负责输入合同、compact value 物化和对齐判断；保持地址、mask、stream advance、诊断以及
+aligned/unaligned 分支语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
+
 # packed-byte group store direct 发射职责整改
 
 本轮在 `OneToNVMIGroupStoreOpPattern::lowerPackedByteSlots8` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3130,6 +3130,21 @@ vmi_layout_assignment_intlv_lane_stride.pto            # exit=0
 部分 direct interleave lit case 仍会在测试自身的 VMI `unpack` 前置 invariant 处提前失败，
 未进入本轮分类逻辑。
 
+# lane-stride interleave 单 pair 物化职责拆分（2026-09-06）
+
+本轮将 `lowerLaneStrideInterleave` 中 carrier type 构造、lhs/rhs bitcast、目标
+interleave 发射和 low/high 结果 bitcast 抽取为 `materializeLaneStrideInterleavePair`。
+入口继续负责 one-part/stride/carrier 宽度合同和最终结果替换；lane-stride carrier 语义、
+目标 op 类型、结果顺序和失败诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_intlv_lane_stride.pto            # exit=0
+```
+
 # expand-load runtime 路径职责拆分（2026-09-06）
 
 本轮将 `OneToNVMIExpandLoadOpPattern::matchAndRewrite` 中 runtime expand-load 的物理

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3207,3 +3207,18 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 
 `vmi_to_vpto_fptoui_f16_to_u8.pto` 同样在既有 pack/unpack pipeline invariant 处提前失败，
 未进入本轮 helper。
+
+# data layout materializer 路由收敛（2026-09-06）
+
+本轮将 `materializeDataLayoutConversion` 中四路 materializer 的重复 optional/failure
+处理收敛到 `tryDataLayoutMaterializers`。helper 严格保持 simple → deinterleaved2 →
+lane-stride → via-contiguous 的尝试顺序；入口只负责 context 构造、最终结果转移和
+unsupported 诊断，不改变递归转换、结果 arity 或失败传播。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_ensure_layout_dense_composed.pto           # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -760,6 +760,63 @@ widen/narrow 分派；保持 unsigned conversion 的诊断、arity、EVEN/ODD pa
 顺序不变。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过。
 
+# 编译告警与死代码收敛整改（2026-09-07）
+
+本轮根据真实的 `VMIToVPTO.cpp` 单文件编译日志继续整改，而不是以增量文本检查结果代替
+完整验证。删除了已无调用方的 deinterleaved=4 旧物化 helper、mask staging 旧 helper，
+以及重构后遗留的未使用 `fail` lambda、局部变量和常量；将 `DenseMap` 成员采用明确的默认
+构造，避免显式构造函数告警；所有本轮触及的 `notifyMatchFailure` 调用均显式消费其
+`[[nodiscard]]` 返回值。上述改动不改变 lowering 分派、物理 part 顺序或失败诊断语义。
+
+验证结果：使用 build 目录中 `ninja -t commands` 导出的真实编译命令编译
+`VMIToVPTO.cpp`，编译器告警数为 0；`pto-test-opt` 对 interleave、contiguous load/store、
+group broadcast、group store、unit-stride group store 和 dynamic group mask 六个代表性
+case 均返回 exit=0；`check_changed_code.py` 为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过。完整内部静态报告的 AST 复杂度/方法规模历史基线仍需专用分析器
+重新扫描确认，不能由上述增量检查替代。
+
+报告明确点名的 `populateVMIConversionPatterns` 也已按职责拆为 structural/memory、
+arithmetic、reduction/conversion 三组注册 helper；公开入口仅按原顺序调用三组 helper。
+pattern 类型集合、构造参数和注册先后关系保持不变，入口方法不再超过报告配置的 50 行
+阈值。拆分后真实单文件编译继续保持 0 warning。
+
+本轮还将 `getContiguousMaterializationPartCount` 的输入/布局获取与布局计数逻辑拆开，
+并将嵌套条件改为命名布尔条件，避免文本规则误判控制语句。该修改只影响诊断前置校验，
+不改变 contiguous/deinterleaved 的 part count 结果。增量 checker、`git diff --check`、
+真实单文件编译和 group-store lowering 回归均通过。
+
+`computeShuffleVselrPlans` 也已拆成输入合同构造和 result part/chunk 遍历两个阶段：
+`ShuffleVselrInputPlan` 仅保存已验证的 source/result 类型、indices、physical lanes 与
+result factor，后续 helper 只负责逐 chunk 生成计划。每个 chunk 仍调用原有
+`computeShuffleVselrPlanForChunk`，因此 source chunk 约束、ASC/DESC 检查和 plan 顺序不变。
+`vmi_to_vpto_shuffle_forwarding.pto` 与 `vmi_to_vpto_shuffle_lane0_splat.pto` 回归通过，
+增量 checker 和真实单文件编译均为 0 warning。
+
+同一 shuffle 家族中的 `computeShuffleForwardingSourceParts` 已复用
+`ShuffleForwardingInputPlan`，将 indices 纳入该已验证输入对象，并把 result part/chunk
+遍历抽为独立 helper。每个 result chunk 仍调用原有 source chunk 映射函数，因此
+forwarding 的 source physical chunk 约束、失败诊断和输出顺序不变。
+`vmi_to_vpto_shuffle_forwarding.pto`、增量 checker、`git diff --check` 与真实单文件编译
+均通过且无 warning。
+
+复核发现原报告点名的 `lowerGroupSlotLoadParts` 已在当前树中收敛为 slots=8/slots=1
+两个既有 helper 的短分派，原始 134 行数据不再适用；未做形式化的继续切割。作为回归，按
+lit 文件的原始 pass pipeline 与 FileCheck 运行了 shuffle forwarding、lane0 splat、
+contiguous load/store、slots=1 unit-stride group store 和 dynamic group mask 五个 case，
+均通过。
+
+`OneToNVMITruncFOpPattern::matchAndRewrite` 的 non-group-slot 分支已抽为
+`lowerNonGroupSlotTrunc`。该 helper 保留原有 physical plan、same-width、dense lane-stride、
+Even/Odd、Packed4、lane-stride、arity 和 `vcvt` round/saturate 分派；入口仅负责 VMI 类型、
+结果类型转换以及 group-slot 快路径选择。真实单文件编译无 warning，
+`vmi_to_vpto_truncf_bf16x2_d2_multichunk.pto` 按其 `LOWER` FileCheck 规则通过。
+
+`OneToNVMIFPToSIOpPattern::matchAndRewrite` 按 three-way conversion strategy 拆为
+dense 1:1 widen、generic Even/Odd widen 和 narrow 三个 helper。每个 helper 保留原有
+mask 创建、physical arity、lane-stride、part 选择、rounding/saturate 与诊断约束；入口
+继续负责 conversion contract、physical type 校验和策略分派。真实单文件编译无 warning，
+`vmi_to_vpto_fptosi_f32_to_i32_default_sat.pto` 的 FileCheck 通过。
+
 本轮将 `OneToNVMIDeinterleaveLoadOpPattern` 的非对齐两轮 `vldus` 与 `vdintlv` 组合
 抽取为 `lowerUnaligned`。helper 显式维护 `streamBase/streamAlign` 的更新链，负责
 ptr 物化、offset 合成、每轮增量和 low/high 结果重排；direct `vldsx2` 路径保持独立。
@@ -3584,6 +3641,33 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
 ```
 
+# group-store routing 条件显式化（2026-09-07）
+
+本轮将 `checkSupportedGroupStorePhysicalShape` 与
+`checkSupportedGroupStoreByLayout` 的 one-block、contiguous-group-chunk 和 compact-small-
+group 路由条件提取为命名布尔值。该修改不改变 routing 顺序：compact group 优先，随后
+group-slots，再查询 layout fact 并依次尝试 one-block、contiguous group chunk 与
+deinterleaved fallback。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
+```
+
+# 非复杂度规则当前状态复核（2026-09-07）
+
+针对原报告中的 `G.RES.06-CPP`、`G.INC.12-CPP` 与 `warning_suppression` 做了当前源码
+复核：`VMIToVPTO.cpp` 的文件私有实现处于 anonymous namespace 内，且源码中未检出 lambda
+默认捕获 (`[&]`/`[=]`)、`#pragma diagnostic`、`NOLINT` 或 `-Wno-*` suppression。此前已删除
+历史 suppression；当前无须为这些规则再增加任何 suppression 或可见性包装。
+
+该结论来自当前工作树的文本检索，不能替代内部分析器对历史 `huge_method`、
+`huge_cyclomatic_complexity` 与 `Data Clumps` 指标的完整 AST 复扫。
+
 # slots=8 packed-byte group-store 单 part 合并职责拆分（2026-09-06）
 
 本轮将 `buildPackedByteStoreBlock` 中单个 local part 的 `vselr` 选择、lane range mask
@@ -4616,3 +4700,935 @@ carrier 收缩和最终 bitcast；奇数尾 carrier 的 LOWER 路径、结果顺
 git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 ```
+
+# FP-to-UI physical conversion 分派拆分（2026-09-07）
+
+本轮将 `OneToNVMIFPToUIOpPattern::matchAndRewrite` 中 widening 与 narrowing 的
+physical part 物化分别抽取为 `lowerWiden` 和 `lowerNarrow`。入口现在只保留 source/result
+type、conversion contract、rounding/saturate attribute 的收集，以及 same-width/widen/narrow
+分派。两个 helper 保持原有 physical arity、contiguous result lane stride、all-true mask、
+EVEN/ODD part 顺序和失败诊断；没有引入 warning suppression。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+issue_585_vcvt_round_z.pto (-vmi-lower-unified-to-legacy -vmi-to-vpto)
+                                                     # FileCheck VPTO, exit=0
+```
+
+上述增量检查只验证 changed-code 的基础规则；历史报告中的完整 AST 方法长度、复杂度与数据泥团
+指标仍需使用原始静态分析器重新扫描后确认，不能由该脚本推导为已清零。
+
+# Integer extension physical path 去重（2026-09-07）
+
+`OneToNVMIExtIOpPattern::matchAndRewrite` 原先在已有 `lowerPhysicalExtension` 后再次实现
+contiguous lane-stride alias、2x/4x part plan、mask 构造和 `vcvt` 发射。本轮删去该重复实现，
+让入口在完成 group-slot 分派和 physical type 收集后统一委派给 helper。helper 覆盖相同的
+direct lane-stride fast path 与 general factor path，因此 source/result arity、part 顺序、mask
+及失败诊断保持不变。
+
+复用后真实编译还发现 `getExtensionPartPlan` 的入参声明成了 `ArrayRef<Value>`，但它只读取
+physical part 数量且调用端传入 `ValueRange`；此前未被该 helper 路径实例化。已将接口改为
+`ValueRange`，使声明与调用端及实际需求一致。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_integer_casts.pto                          # exit=0
+vmi_to_vpto_group_slot_integer_extension_matrix.pto    # exit=0
+```
+
+# mask/materialization 控制流花括号整改（2026-09-07）
+
+本轮继续按 `G.FMT.11-CPP` 清理报告覆盖区域内的单语句控制流，为
+`checkSupportedMaskedLoadShape`、`createPowerOfTwoRemainder`、
+`materializePrefixMask` 与 `getActiveDataLanesInPhysicalChunk` 补齐花括号。
+这是纯控制流边界显式化：failure、full-chunk fast path、prefix fast path 和 active-lane
+累加的返回及执行顺序均保持不变。增量检查同时定位到 `getActiveDataLanesInPhysicalChunk`
+中三处同类遗留问题，已在本轮一并修正。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_constant_mask_nonprefix.pto                # exit=0
+vmi_to_vpto_iota_group_subvl.pto                       # exit=0
+vmi_to_vpto_masked_load.pto                            # exit=0
+```
+
+`vmi_to_vpto_iota_group_subvl.pto` 运行时的 unified-to-legacy remark 是测试输入中
+`vadds` 尚无 legacy equivalent 的既有提示；它不影响随后的 VPTO lowering 与 FileCheck
+结果。
+
+# type/invariant 遍历控制流花括号整改（2026-09-07）
+
+本轮继续落实 `G.FMT.11-CPP`，清理 `containsVMIType`、`hasVMIType`、
+`isLayoutAssignedVMIType`、`verifyLayoutAssignedVMITypeTree`、
+`verifyVMIToVPTOInputAttribute` 和 `verifyVMIToVPTOInputTypes` 中的 early-return、属性
+递归和 region/block/type 遍历控制流。没有改变遍历范围、短路返回或 layout invariant
+diagnostic。
+
+同时将 `hasVMIType(op->getOperandTypes()) || hasVMIType(op->getResultTypes())` 及 dynamic
+group-mask 的嵌套 `failed(...)` 条件拆为命名布尔值，规避增量检查器无法解析嵌套括号的
+假阳性；表达式仍只由无副作用的 type/layout 查询构成。`computeShuffleLane0SplatSourcePart`
+中实际缺失的一处花括号也已修正。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_layout_gate_valid.pto                              # exit=0
+vmi_layout_gate_helper_materialization_shape_invalid.pto # exit=0
+```
+
+# physical type/mask utility 控制流花括号整改（2026-09-07）
+
+本轮将 `materializeVPTOToVMI`、`materializeVMIToVPTO`、mask granularity 查询、converted
+result type 获取、physical footprint 校验、operand flattening，以及 all-true/mask-type
+创建 helper 中的单语句条件/循环补齐花括号。所有修改均为行为等价的控制流显式化；没有改变
+unsupported granularity 的 failure、footprint 比较或创建的 predicate 类型。
+
+`hasNoWiderFootprintThanContiguous` 的复合 `failed(...)` 条件也改为命名布尔量，避免增量
+检查器对嵌套调用的误判。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_constant_mask_nonprefix.pto                # exit=0
+```
+
+# memory/address 查询 helper 控制流整改（2026-09-07）
+
+本轮清理 `getConstantIndexValue`、`getStaticMemRefElementCount`、
+`getMemoryElementType`、`buildContiguousIdentityLaneAddressMap` 和
+`requireIdentityMemRefLayout` 中的单语句条件，并将复合 physical-shape/subview 条件提取
+为命名布尔值。保持常量 offset 识别、静态 memref overflow failure、地址 footprint 计算及
+非 identity/subview 诊断不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_load_store_contiguous.pto                  # exit=0（按原 RUN 行传入 layout/mask assignment）
+vmi_to_vpto_memory_footprint.pto                       # exit=0
+```
+
+首次手工运行 contiguous case 时遗漏了该测试 RUN 行要求的 assignment passes，得到的是
+layout-assigned invariant 诊断；补齐原 pipeline 后通过，未发现源码回归。
+
+# load/store/interleave support contract 控制流整改（2026-09-07）
+
+本轮为 contiguous/deinterleaved load、contiguous/interleave store 的 support contract
+补齐 early-return 与 layout/arity/physical-chunk 条件的花括号。复合 low/high input 与
+direct contiguous store 条件改为命名布尔值；layout support、dist token、full-chunk 与
+contiguous materialization 的原有优先级不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_load_store_contiguous.pto                  # exit=0
+vmi_interleaved_memory_ops.pto (ASSIGN)                # exit=0
+vmi_interleaved_memory_ops.pto (LOWER)                 # exit=0
+```
+
+# group chunk support contract 控制流整改（2026-09-07）
+
+本轮将 `getGroupSizeFromNumGroups`、`checkSupportedGroupChunkShape` 与
+`checkDeinterleaved2GroupStoreChunkShape` 的 group-size、layout、full-chunk、dist token
+及 per-part chunk 合同改为显式控制流。复合条件拆为命名布尔值，支持范围、诊断文本、输出的
+lanes/groupCount/chunksPerGroupPerPart 值及失败优先级均保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
+vmi_layout_assignment_group_load_s32_stride_broadcast_reduce.pto (ASSIGN) # exit=0
+vmi_layout_assignment_group_load_s32_stride_broadcast_reduce.pto (LOWERERR) # exit=0
+```
+
+# group-load layout 分派控制流整改（2026-09-07）
+
+本轮将 contiguous group-load 的 unit row-stride fast path 和 group-load 顶层的
+block-deinterleaved f32 分派条件提取为命名布尔值。该改动只显式化既有路由选择；
+contiguous→`checkSupportedContiguousGroupLoadShape`、block-deinterleaved f32→
+`checkSupportedBlockDeinterleavedGroupLoadShape` 与其余布局的拒绝诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_layout_assignment_group_load.pto                  # exit=0
+vmi_layout_gate_group_load_support_invalid.pto        # exit=0
+```
+
+# one-block group-store plan 控制流整改（2026-09-07）
+
+本轮将 `getOneBlockGroupStorePlan` 的 layout/block-class、VCG block shape、pointer
+destination、row-stride 对齐和 16-bit block-stride 控制字段验证改为显式控制流。复合合同
+均提取为命名布尔量；plan 中的 `groupSize`、`groupsPerPart`、`blockStride` 计算与失败
+诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
+```
+
+# prefix-mask 与 physical-part utility 控制流整改（2026-09-07）
+
+本轮为 `checkSupportedMaskableVReg`、`createPrefixMaskForActiveLanes`、
+`createPartitionActiveLanes`、`getPowerOfTwoLog2` 和 `getPrefixPattern` 中的 early-return、
+dynamic-mask failure、factor/bias 分支补齐花括号。`getPowerOfTwoLog2` 的位运算条件及
+其余复合条件改为命名布尔量，避免文本检查器对嵌套表达式产生误报。mask pattern、active
+lane clamp、partition 计算和失败传播保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_iota_group_subvl.pto                       # exit=0
+vmi_to_vpto_constant_mask_nonprefix.pto                # exit=0
+```
+
+# predicate construction 控制流花括号整改（2026-09-07）
+
+本轮继续整改 `G.FMT.11-CPP`，为 `createAllTrueMask`、`createPatternMask`、
+`createPrefixMask` 及 reduction predicate equivalence/combine helper 补齐控制流花括号。
+同时将含嵌套 type/operation 查询的复合条件提取为命名布尔值，以免 changed-code 检查器误把
+已带花括号的条件识别为违规。predicate granularity 选择、mask 等价判定、combine 顺序和
+failure 条件均保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_constant_mask_nonprefix.pto                # exit=0
+```
+
+# store tail-predicate 控制流整改（2026-09-07）
+
+本轮将 contiguous store 和 dense lane-stride store 的 tail-predicate 构造中所有
+early-return 补齐花括号，并将复合失败条件提取为命名布尔值。后者避免增量文本检查器在
+`failed(...)` 的内层右括号处误判控制语句，也直接表达了“tail mask 与 all-true mask
+必须同时可物化”的原有合同。active lane 查询、predicate compact、`pand` 的输入顺序及
+失败传播保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_memory_footprint.pto                       # exit=0
+vmi_to_vpto_load_store_contiguous.pto                  # exit=0
+```
+
+# slots=8 group-store 地址计划去重（2026-09-07）
+
+本轮将 slots=8 contiguous 与 lane-stride group-store 共同的 group-offset 构造及 direct
+memory legality 判定收敛为 `buildSlots8GroupOffsets`，将共同的每 slot-block stream advance
+计算收敛为 `buildSlots8StreamAdvances`。`dist` 仍是地址计划的显式输入，因而 contiguous
+normal-store 与 lane-stride store 的对齐证明范围不变；原先只透传而未使用的 `numGroups`
+参数被移除。同时删除 non-aligned ordinary store active-lane 失败分支中位于
+`notifyMatchFailure` 直接返回后的不可达 `return failure()`。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
+vmi_to_vpto_group_store_lane_stride.pto               # exit=0
+vmi_to_vpto_group_store_slots8_packed_byte.pto        # exit=0
+```
+
+# data-layout materializer 调度职责整理（2026-09-07）
+
+本轮继续处理报告中 `materializeDataLayoutConversion` 的历史复杂度热点。已有的
+`DataLayoutMaterializationContext` 保留不变；移除了只做转发的泛型 helper 与 lambda
+调度层，改为 simple、deinterleaved=2、lane-stride、via-contiguous 四个具名阶段。新建
+`DataLayoutMaterializationResult` 与 `didHandleDataLayoutMaterialization` 明确每阶段的
+短路合同：失败或已物化即返回，否则尝试下一种布局关系。阶段顺序、失败传播和 fallback
+覆盖范围保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_load_store_contiguous.pto                  # exit=0
+vmi_interleaved_memory_ops.pto (LOWER)                # exit=0
+```
+
+# mask-layout materializer 调度职责整理（2026-09-07）
+
+本轮将 `MaskLayoutMaterializationContext` 的 identity、deinterleaved=2 与
+lane-stride 三阶段调度从泛型转发 helper/lambda 改为具名调用。
+`MaskLayoutMaterializationResult` 与 `didHandleMaskLayoutMaterialization`
+统一表达原有短路规则：失败或已有物化结果即返回，否则继续下一种布局关系。各 materializer
+的调用顺序、参数、诊断和 fallback 范围保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+```
+
+当前 `build/tools/pto-test-opt` 对 `vmi_to_vpto_ensure_mask_layout.pto` 与
+`vmi_to_vpto_constant_mask_nonprefix.pto` 在本轮修改前的 layout-contract/precheck 阶段即
+失败，未到达 mask-layout materializer；因此未将其作为本轮功能回归证据，也未修改测试来
+规避该既有构建产物与工作树契约不同步的问题。
+
+# staging mask-layout 无效失败路径清理（2026-09-07）
+
+本轮清理 `materializeMaskGranularityCastStagingLayout` 的无效包装：staging materializer
+成功后原先把已有 `SmallVector<Value>` 包装进必定成功、必定含值的 `FailureOr<optional>`，
+再检查不可能触发的失败/空值路径。现在成功时直接返回 `optional` 结果；factor 选择、两种
+staging materializer 的调用、其真实失败传播与未命中时的空 optional fallback 保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+```
+
+# group chunk / dist-token 控制流整改（2026-09-07）
+
+本轮继续清理 `G.FMT.11-CPP`：为 contiguous group chunk 合同、mask lane-range 与
+group-slot selector 物化、load/store dist token、store mask granularity 以及 compare predicate
+映射补齐花括号。含 `layout.getLaneStride()` 等嵌套查询的条件提取为具名布尔值，避免文本检查器
+在内层右括号处误判。支持的 element width、dist token、mask granularity、compare mode 及
+失败返回保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_integer_casts.pto                          # exit=0
+```
+
+# ExtF physical lowering 分阶段（2026-09-07）
+
+本轮将 `OneToNVMIExtFOpPattern::matchAndRewrite` 的 physical lowering 决策提取为
+`lowerPhysicalExtF`。入口保留 VMI 类型、转换结果类型和 `ExtFPhysicalPlan` 构建；helper
+统一处理 bf16x2 view、all-true mask、dense lane-stride 以及 factor=2/4 路径选择。
+`pto.vcvt` 的 part、bf16x2 bitcast、arity 判断、诊断文本及失败顺序均保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_extf.pto                                  # exit=0
+vmi_to_vpto_extf_multichunk.pto                       # exit=0
+```
+
+`vmi_to_vpto_extf_f4x2_to_bf16x2_variants.pto` 在当前 `pto-test-opt` 中于
+`vmi-to-vpto` 前的 layout-assignment precheck 失败，且文件没有 `CHECK` 指令；没有将其
+用作本轮回归证据，也没有修改测试来掩盖该既有构建产物与工作树契约不同步问题。
+
+# Vexpdif f32/f16 lowering 职责拆分（2026-09-07）
+
+本轮按 `G.FUN.01-CPP` 将 `OneToNVMIVexpdifOpPattern::matchAndRewrite` 的 f32 与 f16
+physical lowering 分别收敛到 `lowerF32`、`lowerF16`；`lowerBySourceElementType` 只保留
+元素类型分派。入口继续负责 pmode、转换结果类型和输入 arity 合同。f32 的 `ODD` part、f16
+的 EVEN/ODD 再按 chunk 展开、结果扁平化顺序以及所有原诊断文本保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+```
+
+当前 `build/tools/pto-test-opt/pto-test-opt` 的时间戳早于本次对象文件，且
+`vmi_to_vpto_vexpdif_f16.pto`、`vmi_to_vpto_vexpdif_f32.pto` 都在
+layout-assignment precheck 阶段失败，未执行本轮 lowering。未把这些执行结果记作回归通过；
+仍需要能够链接当前 `PTOTransforms` 的测试工具后补齐该两条功能回归。
+
+# FPToSI physical conversion 分阶段（2026-09-07）
+
+本轮将 `OneToNVMIFPToSIOpPattern::matchAndRewrite` 的 conversion contract、source/result
+physical part 校验、rounding/saturate 获取及 same-width/widen/narrow 路由收敛到
+`lowerConversion`。入口仅负责读取 VMI 类型、converted result types 与 source parts。
+已有 `lowerSameWidthFpToInt`、`lowerWiden`、`lowerNarrow` 的调用顺序、layout fast path、
+诊断文本、part 选择与失败传播均保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+```
+
+当前 `pto-test-opt` 仍早于本次对象文件，故未将其执行结果作为本轮当前源码的 lit 回归证据。
+
+# SIToFP physical part 合同与 lowering 分阶段（2026-09-07）
+
+本轮将 `OneToNVMISIToFPOpPattern::matchAndRewrite` 的 physical source/result 收集、
+all-true mask 物化及宽度路由收敛到 `lowerPhysicalConversion`。其中
+`collectSourceType` 明确验证 source parts 非空、为 integer vreg 且类型一致；
+`collectResultTypes` 明确验证 physical result 列表非空并保持既有同构 vreg 合同，避免在
+空列表上访问 `front()`。原有 `si32 -> f32`、`si8 -> f16` lowering、part 顺序、诊断文本与
+失败传播保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+```
+
+# FPToUI physical conversion 分阶段（2026-09-07）
+
+本轮将 `OneToNVMIFPToUIOpPattern::matchAndRewrite` 中的 conversion contract、physical
+part 校验、rounding/saturate 获取以及 same-width/widen/narrow 路由收敛至
+`lowerConversion`。入口仅保留 VMI 类型、converted result types 和 source parts 读取。
+原有 `lowerSameWidthFpToInt`、`lowerWiden`、`lowerNarrow` 的调用条件、part 顺序、诊断及
+失败传播均保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+```
+
+# ConstantMask 计划消费与物化拆分（2026-09-07）
+
+本轮将 `OneToNVMIConstantMaskOpPattern::matchAndRewrite` 中逐 chunk 的结果容量、mask type、
+`materializeConstantMaskChunk` 及最终 arity 合同收敛到 `materializePhysicalMasks`。入口只负责
+converted result types、constant mask materialization plan 的计算和最终替换。物化顺序、
+所有 match failure 诊断、result arity 检查与扁平结果替换保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+```
+
+# Bitcast physical parts lowering 拆分（2026-09-07）
+
+本轮将 `OneToNVMIBitcastOpPattern::matchAndRewrite` 的 physical arity 检查、逐 part
+`VbitcastOp` 物化及结果替换收敛到 `lowerParts`。入口仅负责 converted result types 获取；
+bitcast type 合同、诊断文本、part 顺序和失败传播保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+```
+
+# ConstantMask/CreateMask 物化边界与控制流整改（2026-09-07）
+
+本轮将 `OneToNVMICreateMaskOpPattern` 中 constant-mask 的结果消费职责与既有 dynamic
+lowering 分支保持清晰边界，并为 concrete layout 条件补齐 `G.FMT.11-CPP` 花括号。前者的
+physical mask 物化仍由既有 `lowerConstantMask` 负责，后者的动态路径、active-lane 截断和
+layout factor 语义均未改变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+```
+
+# 全文件控制流花括号复核（2026-09-07）
+
+本轮对 `VMIToVPTO.cpp` 进行完整文本审计，并补齐剩余历史 `G.FMT.11-CPP` 控制流：包括
+input IR/type converter、static-mask 合同、safe-read/gather failure helper，以及
+cf/scf structural conversion 的 branch、case 与 result-type 遍历。复合表达式的内层右括号会
+触发文本检查器假阳性，已改为具名布尔值后保持同一判断语义。switch destination 更新、operand
+展开、type conversion、mask all-active 判断及 early-return 行为均未改变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 全文件控制流文本审计                     # no remaining recognisable unbraced if/for/while
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+```
+
+上述文本审计仅用于 `G.FMT.11-CPP` 复核，不替代内部 AST 分析器对 `huge_method`、
+`huge_cyclomatic_complexity` 与 Data Clumps 的完整复扫。
+
+# Constant splat 解析与 physical 发射拆分（2026-09-07）
+
+本轮将 `OneToNVMIConstantOpPattern::matchAndRewrite` 的 scalar 常量创建、physical vreg
+逐 part 发射及最终替换抽取为 `lowerSplat`。入口保留 dense-splat/typed-attribute 合同与
+有符号整数到 signless scalar 的归一化；`vdup` 顺序、all-true mask 构造、结果 arity 和
+失败诊断均保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
+# conversion carrier 合同控制流整改（2026-09-07）
+
+本轮为 pack/unpack physical arity、identity part forwarding、unsigned/signed carrier、
+`bitcastVReg`、`getVcaddResultType` 与 carrier pack/unpack helper 补齐控制流花括号。
+带 `.size()`、`.getType()`、`.getWidth()` 的合同改为命名布尔值，避免增量检查器将内层调用
+右括号误识别为控制语句结束。physical arity、signedness carrier、identity bitcast 和失败
+传播保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+```
+
+# group-broadcast direct-fact 只读合同（2026-09-07）
+
+本轮将 group-broadcast-load 的 direct lowering fact 在
+`tryLowerDirectBRC`、`tryLowerDirectE2B` 与 `lowerDirectOrFallback` 三层接口改为
+`const FailureOr<VMIGroupBroadcastLoadDirectFact> &`。该 fact 仅用于选择 BRC/E2B/fallback，
+不应暗示可被 callee 修改；候选条件、地址 legality、direct lowering 和 fallback 顺序保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_group_broadcast_load_e2b_b16.pto          # exit=0
+```
+
+# TruncI 非 group-slot lowering 职责拆分（2026-09-07）
+
+本轮将 `OneToNVMITruncIOpPattern::matchAndRewrite` 的非 group-slot 路径收敛到
+`lowerNonGroupSlotTrunc`：该 helper 负责统一物理类型、宽度和 arity 合同、dense
+lane-stride/NOSAT carrier、`s32 -> s8` 的无符号 bit-pattern carrier，以及 factor=2/4 的
+physical conversion 选择。重写入口现在仅负责转换结果类型、布局取得和 group-slot 分派。
+保留了原有的诊断文本、`s32 -> s8` bitcast 顺序、factor part 选择和失败/fallback 顺序。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+VMIToVPTO.cpp 单文件真实编译                           # exit=0, warning=0, error=0
+vmi_to_vpto_trunci_i32_to_ui16_default_sat.pto        # exit=0
+vmi_to_vpto_trunci_s32_to_s8_nosat.pto                # exit=0
+vmi_to_vpto_integer_casts.pto                          # exit=0
+```
+
+# 当前源码最终编译复核（2026-09-07）
+
+本轮针对最近的 `ConstantOp` 类型修正，重新执行了 `VMIToVPTO.cpp` 的真实单文件编译命令。
+编译器返回 `exit=0`，日志中无 `warning:` 或 `error:`。随后再次运行增量合规检查，结果仍为
+`checked_files=1 errors=0 warnings=0`，并通过 `git diff --check`。
+
+尝试运行 Ninja 目标时，构建系统先触发 CMake 自动重新配置；配置阶段因当前环境无法创建
+`/cann-cmake` 外部依赖目录而失败。这是构建环境权限/路径问题，不是当前源文件编译错误，
+因此本轮以直接复用已生成编译命令的单文件编译作为 C++ 编译证据。
+
+# 全文件控制流 AST 风格复核补漏（2026-09-07）
+
+在先前基于行级正则的花括号复核之外，本轮使用能跨多行条件、`if constexpr` 与 range-for
+语句的轻量语法扫描再次审计 `VMIToVPTO.cpp`。该扫描定位并修复了 6 处遗漏的单语句控制流：
+constant-mask prefix fast path、mask-granularity layout-fact failure、constant integer carrier
+归一化、group-reduce `if constexpr`、group-broadcast failure propagation，以及
+`scf.index_switch` case-region 内联循环。所有这些路径仅增加花括号，未改变条件、发射顺序、
+诊断或返回值。
+
+本轮复核结果：轻量语法扫描的 `unbraced if/for/while` 列表为空；`git diff --check` 通过；
+`check_changed_code.py --base origin/master` 为 `checked_files=1 errors=0 warnings=0`；
+`VMIToVPTO.cpp` 真实单文件编译 `exit=0`，且编译日志无 `warning:`/`error:`。
+
+该审计仍是针对 `G.FMT.11-CPP` 的结构检查，不能替代原内部工具对全文件
+`huge_method`、`huge_cyclomatic_complexity` 与 Data Clumps 的复扫。
+
+# Iota conversion pattern 输入与路由拆分（2026-09-07）
+
+本轮继续处理报告中 `matchAndRewrite()` 的方法规模问题。新增
+`IotaLoweringInput` 与 `getIotaLoweringInput`，集中完成 layout、physical lanes、base
+单值化和 converted result types 的输入合同；新增 `lowerAndReplaceIota`，统一处理
+group/contiguous/deinterleaved 路由及最终 flat replacement。`matchAndRewrite` 仅保留输入
+准备、结果容器初始化和 helper 调用，未改变任何 iota 的 chunk 共享、布局分派、指令顺序、
+诊断文本或失败传播。
+
+本轮验证：
+
+```text
+VMIToVPTO.cpp 真实单文件编译                       # exit=0, warning=0, error=0
+git diff --check                                  # passed
+check_changed_code.py --base origin/master        # checked_files=1 errors=0 warnings=0
+```
+
+代表性 iota lowering 复核中，`vmi_to_vpto_iota_group_subvl.pto`、
+`vmi_to_vpto_iota_group2.pto` 与 `vmi_to_vpto_iota_group1_tail.pto` 均可由现有
+`pto-test-opt` 执行完成；普通 `vmi_to_vpto_iota.pto` 在既有
+`VMI-PASS-INVARIANT`（pack/unpack helper 提前于 VMI physicalization）处终止，属于当前
+测试二进制与工作树 pipeline 不同步，未将其计入本轮回归通过证据。
+
+# 静态 full-read envelope 拆分（2026-09-07）
+
+本轮继续处理 `computeSafeFullReadProof` 的职责混合问题。新增
+`VMIStaticReadEnvelopes` 与 `buildStaticReadEnvelopes`，集中负责 offset、allocation、
+physical footprint 的字节乘法溢出检查及 readable/candidate interval 构造；proof 函数保留
+输入合同、地址映射、元素宽度校验和最终 envelope 包含关系判断。字节范围、溢出诊断、
+`VMIMemorySafeReadProof` 字段赋值与成功条件保持不变。
+
+本轮验证：
+
+```text
+VMIToVPTO.cpp 真实单文件编译                       # exit=0, warning=0, error=0
+git diff --check                                  # passed
+check_changed_code.py --base origin/master        # checked_files=1 errors=0 warnings=0
+```
+
+先前的轻量函数范围扫描未按 NLOC/CCN 的正式口径统计，不能用于判断历史
+`huge_method` 是否清零。后续以可复现的 Lizard 扫描和内部 AST 工具为准；该结论不会影响
+本轮已完成的职责拆分与编译验证。
+
+# Stateful read footprint 计算拆分（2026-09-07）
+
+本轮将 `computeSafeStatefulReadProof` 中 physical footprint 的 lanes/arity 合同与乘法
+溢出检查抽取为 `getPhysicalReadFootprintElements`。stateful proof 主体继续负责静态
+memref、offset range、32-byte remainder、envelope 构造及包含关系判断；错误文本、区间
+边界和 `VMIMemorySafeReadProof` 字段语义保持不变。
+
+本轮验证：
+
+```text
+VMIToVPTO.cpp 真实单文件编译                       # exit=0, warning=0, error=0
+git diff --check                                  # passed
+check_changed_code.py --base origin/master        # checked_files=1 errors=0 warnings=0
+```
+
+# TruncF physical narrowing plan 与路由拆分（2026-09-07）
+
+本轮按 conversion 族的统一范式继续处理 `OneToNVMITruncFOpPattern`：
+`TruncFNarrowingPlan`/`buildNarrowingPlan` 负责 width relation、part token、result lane
+stride 和 physical arity 合同；`tryLowerSameWidthTrunc` 与
+`tryLowerDenseLaneStrideTrunc` 分别消费各自的完整 fast path；
+`lowerNonGroupSlotTrunc` 只负责编排 group-slot 排除、fast path 尝试和 narrow fallback。
+这保留了 same-width、dense lane-stride、factor=2/4 的优先级、rounding/saturate 属性、
+packed bf16x2 view、诊断及 flat replacement 语义。
+
+本轮验证：
+
+```text
+VMIToVPTO.cpp 真实单文件编译                       # exit=0, warning=0, error=0
+vmi_to_vpto_truncf_bf16x2_d4_packed4.pto           # exit=0
+git diff --check                                  # passed
+check_changed_code.py --base origin/master        # checked_files=1 errors=0 warnings=0
+```
+
+Lizard（`--length 50 --CCN 20`）复扫后，TruncF 的
+`lowerNonGroupSlotTrunc` 已不再命中该工具的 NLOC/CCN 告警；TruncI 保留其不同的
+NOSAT carrier 与 `s32 -> s8` alias 语义，将在同一 conversion 族的下一阶段单独整理。
+
+# TruncI physical plan 与 alias plan 拆分（2026-09-07）
+
+本轮继续处理 TruncI 的独立 physical 语义。`TruncIPhysicalPlan`/`buildPhysicalPlan`
+集中负责 uniform type、width factor、dense lane-stride legality 和 saturate 属性；
+`TruncIAliasPlan`/`materializeS32ToS8Alias` 集中负责 `s32 -> s8` 的 ui32/ui8 bit-pattern
+carrier；`getFactorTruncParts` 集中负责 factor=2/4 与 physical arity 合同。
+`lowerNonGroupSlotTrunc` 现在只按 NOSAT carrier、dense conversion、factor conversion
+选择消费计划。原有 alias 重写顺序、`finalizeResults` 回转、NOSAT 直通、part token、诊断
+和失败传播保持不变。
+
+本轮验证：
+
+```text
+VMIToVPTO.cpp 真实单文件编译                       # exit=0, warning=0, error=0
+git diff --check                                  # passed
+check_changed_code.py --base origin/master        # checked_files=1 errors=0 warnings=0
+```
+
+Lizard（`--length 50 --CCN 20`）复扫后，TruncF/TruncI 的两个
+`lowerNonGroupSlotTrunc` 均已不再命中。三个已有 TruncI/整数转换 lit 输入均在旧
+`pto-test-opt` 的 pack/unpack physicalization invariant 前置处终止，未执行到本轮 helper，
+因此没有将它们标记为本轮功能回归通过。
+
+# ExtI 输入与 layout 路由拆分（2026-09-07）
+
+本轮完成 conversion 族 ExtI 的入口分层。`ExtensionLoweringInput`/
+`getLoweringInput` 集中完成 VMI/physical type、source parts、converted result types 和
+layout 的输入合同；`lowerGroupSlotByLayout` 保留 compact carrier unpack 与 legacy vcvt 的
+选择；`lowerNonGroupSlotByLayout` 负责统一 result vreg type 与 physical extension lowering。
+入口仅做输入获取和 group-slot 分派。dense group-slot 的 slots、lane stride、width factor、
+signedness，legacy fallback 的条件、指令发射、结果顺序和诊断均保持不变。
+
+本轮验证：
+
+```text
+VMIToVPTO.cpp 真实单文件编译                               # exit=0, warning=0, error=0
+vmi_to_vpto_reduce_extended.pto                             # exit=0
+vmi_to_vpto_group_slot_integer_extension_matrix.pto         # exit=0
+vmi_to_vpto_group_slot_integer_unpack.pto                   # exit=0
+git diff --check                                            # passed
+check_changed_code.py --base origin/master                  # checked_files=1 errors=0 warnings=0
+```
+
+Lizard（`--length 50 --CCN 20`）复扫后，`ExtI::matchAndRewrite` 已不再命中。
+
+# ExtF factor contract 与 physical lowering 拆分（2026-09-07）
+
+本轮将 ExtF 的物理 extension 路径按稳定合同划分。`ExtFFactorPlan`/
+`buildFactorPlan` 集中处理源/结果宽度 factor、physical arity 与结果 layout 的关系，
+`createSeedMask` 集中处理 seed mask 的 materialization；`lowerPhysicalExtF` 只消费已经
+验证的 factor plan 发射转换。没有将 float extension 与整数 extension 强行泛化：两者的
+signedness、旧指令 fallback 和 carrier 语义不同，只复用了相同的“先建合同，再分 layout
+路由，最后逐 part 发射”边界。
+
+本轮使用现有编译命令更新了 `VMIToVPTO.cpp` 对象文件，编译日志为空；由于该次 shell
+执行超时后未能可靠取得直接 exit status，未将它记为独立 `exit=0` 证据。后续的全文件真实
+单文件编译已覆盖包含该修改的当前源码并返回 `exit=0`、`warning=0`、`error=0`。
+Lizard（`--length 50 --CCN 20`）复扫后，`ExtF::lowerPhysicalExtF` 不再命中。
+
+# Memory/store shape contract 收敛（2026-09-07）
+
+本轮开始按 memory/store 语义族统一收敛 shape 合同，而不是逐个 lowering 入口压缩。
+普通 `vstore` 的 `checkSupportedStoreShape` 现在只编排 write access plan、maskable
+element、layout support 与 `checkStorePhysicalCoverage`；后者独立负责 dense lane-stride、
+full physical chunk、contiguous tail 与可 materialize deinterleaved tail 的覆盖判定。
+
+`deinterleaved=2` group-store 将原先 3 个裸 output 参数的几何计算收敛为
+`Deinterleaved2GroupStoreShape`。`getDeinterleaved2StoreLanes` 验证 layout、full chunk
+与 `vstsx2 INTLV` 指令能力；`getDeinterleaved2GroupStoreGeometry` 验证 group row、part
+chunk 对称性并产出 `lanesPerPart/groupCount/chunksPerGroupPerPart`。保留兼容现有调用点的
+`checkDeinterleaved2GroupStoreChunkShape` 仅负责适配结果，所有原诊断文本和失败顺序保持。
+
+本轮验证：
+
+```text
+VMIToVPTO.cpp 真实单文件编译                       # exit=0, warning=0, error=0
+vmi_to_vpto_group_store_vsstb.pto                   # exit=0
+vmi_to_vpto_load_store_contiguous.pto               # exit=0
+vmi_to_vpto_store_deint_invalid.pto                 # 预期失败，原 VMI-UNSUPPORTED 文本保持
+git diff --check                                     # passed
+check_changed_code.py --base origin/master           # checked_files=1 errors=0 warnings=0
+```
+
+Lizard（`--length 50 --CCN 20`）复扫后，
+`checkSupportedStoreShape` 与 `checkDeinterleaved2GroupStoreChunkShape` 均不再命中。
+
+# Expand-load runtime-mask 合同分层（2026-09-07）
+
+同一 memory 族中，`expand_load` 的 runtime-mask 路径原来在一个检查函数内混合了
+`vgather2_bc` 指针/32-bit/b32 ISA 前提、result/passthru/mask 的 one-part arity 合同，以及
+三者 full physical chunk 要求。本轮将后两类分别抽为
+`checkExpandLoadRuntimeArity` 与 `checkExpandLoadRuntimeFullChunks`，入口保留 source 指针、
+element/mask ISA 前提及原有 all-active fallback 诊断，并按原顺序调用各合同。
+
+本轮验证：
+
+```text
+VMIToVPTO.cpp 真实单文件编译                             # exit=0, warning=0, error=0
+vmi_to_vpto_expand_load_runtime_mask.pto                  # exit=0
+vmi_to_vpto_expand_load_all_active.pto                    # exit=0
+vmi_to_vpto_expand_load_partial_mask_invalid.pto          # 预期失败，one-chunk 诊断保持
+git diff --check                                           # passed
+```
+
+Lizard（`--length 50 --CCN 20`）复扫后，
+`checkSupportedExpandLoadRuntimePath` 不再命中。
+
+# Static/stateful read proof facts 收敛（2026-09-07）
+
+本轮继续按 memory access plan 的证明层整改。static full-read 与 stateful-read 原先都在 proof
+主体里重复检查 element byte-addressability；现统一为 `getByteAddressableElementSize`。
+`VMIStaticReadContract`/`getStaticReadContract` 收集 static memref element count、非负常量
+offset、contiguous identity lane map 和 element bytes；`VMIStatefulReadContract`/
+`getStatefulReadContract` 收集 allocation、有限 offset range、element bytes、fixed 32B
+remainder 和 physical footprint。两个 proof 主体只构造对应 envelope、写入 proof 并作最终
+包含关系判定。
+
+这不是把 proof 的失败处理藏在 context 内：所有 contract helper 仍通过原有 reason 文本返回，
+proof 保持 `proven/reason/envelope/laneAddressMap` 的写入时机和算术边界，因而不会改变
+aligned full read 与 unaligned stateful read 的合法性。
+
+本轮验证：
+
+```text
+VMIToVPTO.cpp 真实单文件编译                                      # exit=0, warning=0, error=0
+vmi_to_vpto_load_store_contiguous.pto                              # exit=0
+vmi_to_vpto_expand_load_all_active.pto                             # exit=0
+vmi_to_vpto_expand_load_all_active_negative_offset_invalid.pto     # 预期失败
+git diff --check                                                    # passed
+```
+
+Lizard（`--length 50 --CCN 20`）复扫后，`computeSafeFullReadProof` 和
+`computeSafeStatefulReadProof` 均不再命中。
+
+# Store lowering 输入计划与发射路由拆分（2026-09-07）
+
+本轮完成普通 store 与 interleave-store 两个 lowering 入口的同层职责收敛。
+`StoreLoweringInput`/`getLoweringInput` 统一承载 converted destination/offset、value parts、
+VMI value type 和已验证的 `StorePhysicalPlan`；`lowerByPhysicalPlan` 保持原有的
+lane-stride -> deinterleaved direct `vstsx2` -> materialize-contiguous -> aligned/stateful stream
+优先级。`InterleaveStoreLoweringInput` 同样集中 source operands、INTLV token、lane width 和
+low/high part arity；`lowerByAddressPlan` 则只根据 direct-vs-stream 地址计划逐 chunk 发射
+`vstsx2` 或 `vintlv + vstus` stream。
+
+两条路径没有被合并成一个泛型 store emitter：普通 store 的 value layout materialization、tail
+mask 与 deinterleaved fast path，和 interleave-store 的 pair packet 语义不同。此次仅收敛共同的
+输入合同和“计划后发射”的架构层，保留原指令选择、stream advances、erase 时机与失败诊断。
+
+本轮验证：
+
+```text
+VMIToVPTO.cpp 真实单文件编译                       # exit=0, warning=0, error=0
+vmi_to_vpto_load_store_contiguous.pto               # exit=0
+vmi_interleaved_memory_ops.pto                      # exit=0
+git diff --check                                     # passed
+check_changed_code.py --base origin/master           # checked_files=1 errors=0 warnings=0
+```
+
+Lizard（`--length 50 --CCN 20`）复扫后，`VMIStoreOp::matchAndRewrite` 与
+`VMIInterleaveStoreOp::matchAndRewrite` 均不再命中。
+
+# Deinterleave-load 输入与 address-plan 路由拆分（2026-09-07）
+
+`DeinterleaveLoadLoweringInput`/`getLoweringInput` 将 converted source/offset、low/high
+physical result types、DINTLV token、lane width 及 low VMI type 收敛为一份输入合同；
+`lowerByAddressPlan` 只判断 direct `vldsx2` 是否满足地址对齐证明，或改走保留 align state 的
+`vldus + vdintlv` 流。两种发射路径的 low/high 结果顺序、每轮 advance 及结果 replacement
+保持不变。
+
+本轮验证：
+
+```text
+vmi_to_vpto_load_deint.pto              # 依 RUN pipeline 加 -vmi-lower-unified-to-legacy，exit=0
+vmi_to_vpto_load_deint_multichunk.pto   # 同上，exit=0
+git diff --check                         # passed
+check_changed_code.py                    # checked_files=1 errors=0 warnings=0
+```
+
+# Group-broadcast selector context 与 slots=1 merge 拆分（2026-09-07）
+
+group broadcast 中，`GroupBroadcastSelectorMetadata`/
+`getGroupBroadcastSelectorMetadata` 负责 source slots/lane stride、selector kind/period 及
+power-of-two ramp 合同；`createGroupBroadcastSelectorContext` 只 materialize index carrier 和
+all-mask。slots=1 fallback 另将 physical-lane-to-source mapping 与
+`materializeSlots1GroupBroadcastMerge` 的 splat/mask/select 发射分离。该拆分保留 selector
+cache、shared ramp、layout-table 映射验证和 chunk 内 source merge 顺序。
+
+本轮验证：
+
+```text
+VMIToVPTO.cpp 真实单文件编译                                      # exit=0, warning=0, error=0
+vmi_layout_assignment_group_broadcast_load_e2b_b16.pto             # exit=0
+vmi_to_vpto_group_broadcast_load_e2b_b16_stride_invalid.pto        # 预期 VMI-UNSUPPORTED
+git diff --check                                                    # passed
+check_changed_code.py --base origin/master                          # checked_files=1 errors=0 warnings=0
+```
+
+Lizard（`--length 50 --CCN 20`）复扫后，`DeinterleaveLoadOp::matchAndRewrite`、
+`materializeSlots1GroupBroadcastChunk` 与 `createGroupBroadcastLoweringContext` 均不再命中。
+
+# Interleave lowering 分类计划拆分（2026-09-07）
+
+`classifyInterleaveLowering` 原先同时判断 lane-stride、unit-stride contiguous 和 zero-copy
+factor 关系。本轮将三个可判定事实分别收敛到
+`hasLaneStrideInterleaveLayout`、`hasUnitStrideContiguousInterleaveLayout` 和
+`getZeroCopyInterleavePlan`；分类函数只按优先级返回 `InterleaveLoweringPlan`。Vintlv 与
+Vdintlv 的 factor 方向、layout equality 和失败诊断保持不变。
+
+# FPToUI conversion 输入合同拆分（2026-09-07）
+
+`FPToUILoweringInput`/`getLoweringInput` 集中处理 conversion contract、source/result
+physical parts、rounding/saturate 属性；`lowerConversion` 只按 same-width、widen、narrow
+三种物理路径分派。FPToUI 继续使用自身的 `VMIFpToUiContract`，没有与 signed 或 float
+extension 语义强行泛型化。
+
+# Control-flow switch operand segment 拆分与 Vmull data-layout 合同拆分（2026-09-07）
+
+`OneToNCFSwitchOpPattern` 将 case operand segment flattening 抽为
+`collectSwitchOperandSegments`，destination 变化判定独立为 `switchDestinationsChanged`；
+switch flag、default/case operand 顺序和 block conversion 语义保持不变。
+
+`validateVmullLogicalShape` 则把四个 data vreg 与 mask 的 layout、lane_stride、factor 和
+mask granularity 合同抽为 `validateVmullDataLayout`，logical element/lane 合同仍由原函数
+负责。这样没有把 vmull 的校验简化成“字段总结”，而是明确分开逻辑类型与物理布局约束。
+
+本轮验证：
+
+```text
+VMIToVPTO.cpp 真实单文件编译                       # exit=0, warning=0, error=0
+vmi_interleaved_memory_ops.pto                     # exit=0
+vmi_vcvt_fptoui_lower_to_legacy.pto                # exit=0
+vmi_layout_assignment_cf_switch.pto                # exit=0
+vmi_layout_assignment_scf_index_switch.pto         # exit=0
+git diff --check                                    # passed
+check_changed_code.py --base origin/master          # checked_files=1 errors=0 warnings=0
+```
+
+Lizard（`--length 50 --CCN 20`）复扫结果为空：当前文件不再有超过本轮扫描阈值的函数。
+
+# 最终可复现审计边界（2026-09-07）
+
+当前源码审计结果如下：
+
+```text
+Lizard --length 50 --CCN 20 --warnings_only          # 0 个函数命中
+check_changed_code.py --base origin/master           # errors=0 warnings=0
+git diff --check                                     # passed
+VMIToVPTO.cpp 单文件真实编译                        # exit=0，无 warning/error
+```
+
+文件私有实现均位于 anonymous namespace；未检出默认 lambda capture、诊断 suppression、
+`NOLINT` 或 `-Wno-*`。报告列出的参数泥团已按语义族收敛为 typed context/plan，包括 data/mask
+layout materialization、iota、memory read proof、store/interleave-store、group broadcast、
+conversion 和 interleave/vmull 合同。
+
+需要保留的工具边界：原始 `Data Clumps`、内部 `huge_method`/`huge_cyclomatic_complexity`
+口径来自外部 AST 分析器，本环境未提供该分析器；Lizard 结果只能证明当前配置下的 NLOC/CCN
+趋势，不能冒充内部报告的完全等价复扫。后续门禁若提供原分析器，应以本文件当前源码重新
+运行并补充其原始 finding/location，而不是仅依据增量检查器结果判定。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2074,3 +2074,13 @@ combine mask 构造以及 `sum01/sum23/final` 树形合并抽取为独立 helper
 源索引、树形合并顺序、active group mask、结果顺序和诊断语义不变。增量
 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
 通过；本轮未新增可独立进入该 helper 的 runtime case，未虚构额外回归结果。
+
+# two-block group-reduce 单结果构造职责整改
+
+本轮在 `OneToNVMIGroupReduceOpPattern::lowerTwoBlock` 中引入
+`buildTwoBlockGroupResult`，将单个结果块的 low/high source 与 mask 索引、physical 类型
+校验、combine mask 构造以及两路 `GroupReduceOp`/`CombineOp` 发射抽取为独立 helper。主
+函数继续负责整体 arity/基础类型校验、结果遍历和替换；保持 block 分区索引、active group
+mask、结果顺序和诊断语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；本轮未新增可独立进入该
+helper 的 runtime case，未虚构额外回归结果。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3028,3 +3028,20 @@ deinterleaved=2 与 contiguous 路径的优先级分派。support-table 查询�
 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_layout_assignment_group_store_slots1_unit_stride.pto`
 完整 lowering pipeline exit=0。
+
+# verifier 与 shuffle 规划控制流整改（2026-09-06）
+
+本轮继续清理 verifier/shape-plan 与 shuffle 规划区域：为 reduce physical chunk 检查、
+Vdhist/Vchist/Vmull 及 add-carry 端口校验补齐选择语句大括号，并将 Vmull/add-carry 的
+关键失败条件命名，保持原有支持范围和诊断顺序不变；同时为 shuffle forwarding 规划的
+lanes-per-part、indices、layout factor 和 physical chunk 查询补齐大括号，避免单语句控制
+流在后续维护中产生歧义。未改变物理 lane 映射、chunk 顺序或 lowering 结果。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_broadcast_load_e2b_b16.pto # exit=0
+vmi_layout_assignment_scatter.pto                      # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3128,3 +3128,19 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_layout_assignment_scatter.pto                      # exit=0
 ```
+
+# group broadcast shape 合同分层整改（2026-09-06）
+
+本轮将 `buildGroupBroadcastShapePlan` 中 source/result 基础合同、num_groups、布局类型及
+layout-support 查询抽取为 `checkGroupBroadcastLogicalContract`。plan builder 现在只负责
+physical lanes、group size 和 result factor 推导；结果 chunk 合同仍由既有
+`checkGroupBroadcastResultShape` 负责。该拆分保持 group size 推导、布局优先级、失败诊断
+和 lowering 结果不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_broadcast_load_e2b_b16.pto # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1880,3 +1880,11 @@ pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败
 `POST_UPDATE` stream 语义、align 状态更新顺序、store base 计算、结果擦除和原有诊断不变。
 增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_to_vpto_compress_store.pto` lowering exit=0。
+
+# compare verifier 分派职责整改
+
+本轮将 `verifySupportedVMICompareOp` 中 cmpf/cmpi 重复的 physical mask 检查、predicate
+合法性结果处理和 WalkResult 分派抽取为 `verifySupportedCompareValue`。入口仅负责区分
+cmpf/cmpi、传递对应 op 名称和 predicate checker；保持原有检查顺序、错误诊断来源、
+predicate 支持集合及 `WalkResult` 语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2044,3 +2044,13 @@ exit=0，现有 slots=1 的 EVEN/P0 转换输出保持不变。
 `git diff --check` 通过。现有 `vmi_layout_assignment_group_slot_broadcast_load_brc_b32.pto`
 在 group_slot_load 的既有 unsupported-shape 诊断处提前失败，未进入本轮 BRC helper，不能
 将该失败归因于本轮改动。
+
+# group-reduce deinterleaved=2 结果恢复职责整改
+
+本轮在 `OneToNVMIGroupReduceOpPattern::lowerFullDeinterleaved2` 中引入
+`restoreDeinterleaved2GroupResults`，将 reduction 结果到目标 physical vreg 的逐组 bitcast
+与结果收集抽取为独立 helper。主 lowering 保留布局、lane/arity、mask、row reduction 和
+combine 的校验及发射职责；保持结果组顺序、目标类型、诊断和替换语义不变。
+增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_group_reduce_slots8.pto` 在既有 VMI pack/unpack
+pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,19 @@
 # VMIToVPTO 静态分析报告记录
 
+## advanced-load verifier 分派拆分（2026-09-06）
+
+本轮将 `verifySupportedVMIMemoryAdvancedLoadOp` 按语义拆为
+`verifySupportedVMIMaskedLoadOp`、`verifySupportedVMIGatherOp` 和
+`verifySupportedVMIExpandLoadOp`。入口只负责分派；masked-load 的 stable-gather 开关、
+gather/expand-load 的 support shape 检查、诊断文本和 `WalkResult` 语义均保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## group-reduction verifier 分派清理（2026-09-06）
 
 本轮清理 `verifySupportedVMIGroupReductionOp` 中仅转发参数的默认捕获 lambda，直接使用

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2085,6 +2085,15 @@ mask、结果顺序和诊断语义不变。增量 `check_changed_code.py` 结果
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；本轮未新增可独立进入该
 helper 的 runtime case，未虚构额外回归结果。
 
+# zero-copy interleave 结果重排职责整改
+
+本轮在 `OneToNVMIInterleaveOpPattern::materializeZeroCopyResults` 中引入
+`appendVintlvZeroCopyResults` 与 `appendVdintlvZeroCopyResults`，分别封装 vintlv/vdintlv
+布局的 slice 重排逻辑。主函数继续负责输入 group 合约、结果 arity/type 校验；保持两种
+布局的 group/chunk 顺序、offset 计算、结果类型检查和诊断语义不变。增量
+`check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
+通过；本轮尝试的占位文件不存在，未虚构 interleave runtime 回归结果。
+
 # compact small group store 布局物化职责整改
 
 本轮在 `OneToNVMIGroupStoreOpPattern::lowerCompactSmallGroupStore` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3176,6 +3176,21 @@ vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
 vmi_to_vpto_group_store_slots1_unit_stride_alignment.pto # exit=0
 ```
 
+# group-store slots=1 packed value 单 group 物化职责拆分（2026-09-06）
+
+本轮将 `buildPackedSlots1Value` 中单个 group 的 value 类型合同、LOWEST `vdup`、lane
+range mask 构造和 `vsel` 合并抽取为 `materializePackedSlots1Group`。外层 helper 继续负责
+首 group 初始化、group 遍历和 packed value 累积；group 顺序、lane mask 范围、packed
+value 语义及失败诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
+```
+
 # contiguous group-load 单 chunk 物化职责拆分（2026-09-06）
 
 本轮将 `OneToNVMIGroupLoadOpPattern::lowerContiguousChunks` 中单个 group/chunk 的

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3427,3 +3427,18 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_load_store_contiguous.pto                  # exit=0
 ```
+
+# interleave-store address plan 职责拆分（2026-09-06）
+
+本轮将 `OneToNVMIInterleaveStoreOpPattern::matchAndRewrite` 中 direct `vstsx2` 合法性判定
+与 unaligned stream base 构造抽取为 `InterleaveStoreAddressPlan`/`buildAddressPlan`。入口
+继续负责 operands、low/high arity、chunk 发射和 stream 提交；direct/stream 路由优先级、
+offset 语义、状态对象和失败传播保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_load_store_contiguous.pto                  # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3893,3 +3893,21 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_layout_assignment_group_broadcast_load_e2b_b16.pto # exit=0
 ```
+
+# contiguous-to-deinterleaved 转换职责拆分（2026-09-06）
+
+本轮将 `materializeContiguousToDeinterleaved2` 的输入 shape 合同和单个 source pair 的
+`vdintlv` 发射分别抽取为 `validateContiguousToDeinterleaved2Shape` 与
+`materializeContiguousToDeinterleaved2Group`。主函数只负责按 group 遍历、结果分区和物理
+结果收集；source 缺失、arity、类型检查、`vdintlv` 发射及失败传播语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_vdintlv.pto                               # reaches existing pack/unpack invariant
+```
+
+该 case 在本轮转换前即会因测试输入中的 VMI `unpack` 出现在 VMI-to-VPTO physicalization
+之前而触发 `VMI-PASS-INVARIANT`；这不是本轮 `vdintlv` helper 改动引入的失败。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3127,6 +3127,23 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_intlv_lane_stride.pto            # exit=0
 ```
 
+# block-deinterleaved group-load 单 chunk 物化职责拆分（2026-09-06）
+
+本轮将 `OneToNVMIGroupLoadOpPattern::lowerBlockDeinterleaved` 中单个 part/chunk 的
+result vreg 与 all-true mask 合同、block offset/base 构造和 `vsldb` 发射抽取为
+`materializeBlockDeinterleavedChunk`。外层函数继续负责 block arity、part/chunk 遍历和
+结果替换；block stride、8-group 访问步长、part 顺序和失败诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
+相关 block group-load case 在测试自身的 ensure_layout/truncf 不支持输入处提前失败，未
+进入本轮 chunk helper。
+
 部分 direct interleave lit case 仍会在测试自身的 VMI `unpack` 前置 invariant 处提前失败，
 未进入本轮分类逻辑。
 

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3082,3 +3082,18 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_layout_assignment_group_store_slots1_unit_stride.pto # exit=0
 ```
+
+# mask layout materializer 路由职责拆分（2026-09-06）
+
+本轮将 `materializeMaskLayoutConversion` 中 identity → deinterleaved=2 → lane-stride
+的顺序尝试抽取为 `tryMaskLayoutMaterializers`。入口现在只负责布局存在性检查、context
+构造和最终 unsupported 诊断；materializer 的 optional/failure 传播、优先级、结果顺序
+均保持不变，未改变任何 mask layout 指令生成。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_ensure_mask_granularity.pto                # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2000,3 +2000,15 @@ mask 语义、单结果布局和诊断不变。增量 `check_changed_code.py` �
 继续返回相同的 match failure 诊断。该改动仅收敛控制流，未改变 lowering 顺序或物理结果
 语义。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_layout_assignment_group_slots_fanout.pto` lowering exit=0。
+
+# trunci factor 结果块 lowering 职责整改
+
+本轮在 `OneToNVMITruncIOpPattern` 中引入 `buildFactorTruncResult`，将
+`lowerFactorTrunc` 内单个结果块的多路 `VcvtOp` 发射、源 physical part 索引校验以及按
+原顺序的 `VorOp` 合并抽取为独立 helper。`lowerFactorTrunc` 仍负责 source/result 类型和
+mask 准备、结果块遍历及最终 `s32ToS8Alias` 处理；保持 `resultIndex * factor + partIndex`
+索引关系、P0/P1/P2/P3 等 part 顺序、source/result mask、结果顺序、诊断和 fallback 语义
+不变。helper 额外在使用 source part 前验证索引范围，避免物理 arity 不一致时越界访问。
+增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_trunci_s32_to_s8_nosat.pto` lowering exit=0，输出
+仍包含 4 个按 P0/P1/P2/P3 顺序的 `vcvt`、3 个 `vor` 以及末尾 signed bitcast。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1961,3 +1961,12 @@ accumulator 类型、source lane 数以及 Bin_N0/Bin_N1 常量准备从 lowerin
 mask 语义、单结果布局和诊断不变。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_reduce_extended.pto` lowering exit=0。
+
+# group-reduce plan 分派控制流整改
+
+本轮将 `OneToNVM​​IGroupReduceOpPattern::lowerByPlan` 的多段 plan 条件改为带显式
+`default` 的 `switch` 分派。每个 `GroupReduceLoweringPlan` 仍调用原有对应 lowering，
+包括 OneBlock、TwoBlock、FourBlock、FullDeinterleaved2 和 ContiguousRows；非法枚举值
+继续返回相同的 match failure 诊断。该改动仅收敛控制流，未改变 lowering 顺序或物理结果
+语义。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_layout_assignment_group_slots_fanout.pto` lowering exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1904,3 +1904,11 @@ active_prefix_index、compress 和 compress_store 的 shape check、reason 收�
 仍使用各自的 shape checker、诊断名称和原有识别顺序，保持成功/失败语义不变。增量
 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
 通过。
+
+# special-unary verifier 分派职责整改
+
+本轮为 `verifySupportedVMISpecialUnaryOp` 引入模板 helper
+`verifySpecialUnaryShape`，统一 `relu`/`vselr` 的 shape checker、reason 收集、诊断前缀和
+`WalkResult` 处理。两种操作仍保留各自的 shape checker、支持条件文本和操作识别顺序，
+不改变成功/失败语义。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2699,3 +2699,12 @@ deinterleaved layout 方向识别从 `materializeMaskGranularityCastStagingLayou
 contiguous→deint 的发射语义、factor 优先级、结果顺序及失败传播保持不变。增量
 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；mask granularity direct/multistep 和 dense layout case 均 exit=0。
+
+# mask granularity fallback 路由职责整改
+
+本轮新增 `requiresMaskDenseSplitFallback`，将 dense-split contiguous fallback 的触发条件
+从 `materializeMaskGranularityCastLayoutFallback` 中独立出来。fallback 入口仍严格保持
+direct layout conversion → staging factor route → dense-split contiguous conversion 的
+尝试顺序；direct conversion 失败后继续尝试的语义、optional/failure 传播和结果顺序不变。
+增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；mask granularity direct/multistep case 均 exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1777,3 +1777,13 @@ low/high result type 获取、跨 operand arity 校验和结果扁平化；low �
 的排布、mask 语义、失败诊断和结果顺序保持不变。为相邻 reduce-add 入口补齐控制流大括号
 以满足 `G.FMT.11-CPP`。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+
+# fma physical chunk lowering 职责整改
+
+本轮将 `OneToNVMIFmaOpPattern::matchAndRewrite` 中单个 physical part 的 vreg 类型合同、
+all-true mask 构造及 `VmulaOp` 发射抽取为 `lowerPart`。入口继续负责 lhs/rhs/acc/result
+physical arity 检查与结果收集；保持 `VmulaOp(acc, lhs, rhs, mask)` operand 顺序、mask
+语义、结果顺序和诊断不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+`vmi_to_vpto_fma.pto` 当前在既有 VMI pack/unpack pipeline invariant 处提前失败，未进入
+本轮 helper，不能将该失败归因于本轮改动。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2087,6 +2087,18 @@ mask 和失败语义不变。增量
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_load_store_contiguous.pto` lowering exit=0。
 
+# truncf 物理计划职责整改
+
+本轮新增 `TruncFPhysicalPlan` 与 `buildPhysicalPlan`，将 `truncf` 主入口中的 source/result
+physical part 统一类型、源/结果 storage bit width、packed bf16x2 的 bf16 view 构造集中到
+一个 plan builder。主入口仍保留 group-slot 特殊路径、同宽转换、dense lane-stride 和
+factor 窄化的 lowering 优先级及各自 arity/layout 合同；没有把不同 conversion 语义强行
+合并。结果顺序、mask、round/saturate、诊断和失败传播保持不变。增量
+`check_changed_code.py --base origin/master --fail-on none` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+`vmi_to_vpto_truncf_f16_to_f8e4m3.pto` 尝试 lowering 时在既有 VMI pack/unpack invariant
+处提前失败，未进入本轮 plan builder，不能将该失败归因于本轮改动。
+
 # group load 布局分派职责整改
 
 本轮将 `OneToNVMIGroupLoadOpPattern::matchAndRewrite` 中 block-deinterleaved f32 特殊路径

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3397,6 +3397,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_group_slot_integer_extension_matrix.pto   # exit=0
 ```
 
+# group-slot truncation physical parts 拆分（2026-09-06）
+
+本轮将 `lowerGroupSlotTrunc` 中逐 physical part 的 source/result 类型合同、packed
+`Vcvt` 快路径和通用 `lowerGroupSlotTruncPart` 调用抽取为
+`lowerGroupSlotTruncParts`。主函数继续负责模式准备、active-slot mask 和结果收敛；
+packed/direct 分派、SAT 属性传递、诊断文本及结果顺序保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_trunci_lane_stride.pto           # exit=0
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3499,6 +3499,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_shuffle_forwarding.pto                     # exit=0
 ```
 
+# constant create-mask chunk 物化拆分（2026-09-06）
+
+本轮将 `lowerConstantMask` 中单个 physical chunk 的 mask result 类型校验、prefix pattern
+快路径和 runtime prefix fallback 抽取为 `materializeConstantMaskValue`。主函数继续负责
+layout factor 遍历、padding/active lane 计算、结果 arity 检查和结果累积；mask 语义与失败
+诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_create_mask_plt_fallback.pto              # invalid/invariant diagnostic retained
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2340,6 +2340,15 @@ checked_files=1 errors=0 warnings=0
 既有 `VMI-PASS-INVARIANT`（pack/unpack helper 提前物化）处终止，未进入该路径，不能将
 该失败归因于本修复。
 
+# group-slot lane-stride 合同职责整改（2026-09-06）
+
+本轮将 `materializeGroupSlotLaneStride` 的输入 arity、stride 范围及 carrier 位宽校验抽取
+为 `checkGroupSlotLaneStrideContract`。物化主体只负责逐 physical part 调用已有的单 part
+转换并收集结果；失败诊断、source/result 顺序、stride 语义和结果数量保持不变，同时补齐
+循环控制语句大括号。增量静态检查结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；group-slot store、dense layout 和 interleaved memory lowering
+case 均 exit=0。
+
 本轮尝试重新构建 `pto-test-opt` 时，CMake 仍因工作区既有的 `cann-cmake` 外部依赖
 配置尝试创建 `/cann-cmake` 且权限不足而无法重新配置；该环境问题未产生新的 C++ 编译
 诊断，未删除或重置现有 build tree。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3352,3 +3352,18 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_group_reduce_addi_i16.pto                          # exit=0
 ```
+
+# load lane-stride dist 选择职责拆分（2026-09-06）
+
+本轮将 `OneToNVMILoadOpPattern::matchAndRewrite` 中 lane-stride dist 查询、首个 physical
+result 类型检查和 direct-memory 合法性判断抽取为 `getLoadLaneStrideDist`。入口继续保持
+build plan → lane-stride → deinterleaved → contiguous 的 lowering 优先级，dist token 的
+生命周期、地址合同和结果顺序均不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_load_store_contiguous.pto                  # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3368,6 +3368,20 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_load_store_contiguous.pto                  # exit=0
 ```
 
+# packed-byte slots=8 selector 构造拆分（2026-09-06）
+
+本轮将 `lowerPackedByteSlots8` 中 packed-byte mask 类型、all-true mask、slot index
+向量构造抽取为 `buildPackedByteSelectors`。对齐单 part 快路径、`PK4_B32` direct 判定、
+block 合并和 stateful stream fallback 保持不变；失败诊断和 selector 类型保持一致。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_group_store_slots8_packed_byte.pto         # exit=0
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,19 @@
 # VMIToVPTO 静态分析报告记录
 
+## contiguous masked-store layout conversion 拆分（2026-09-06）
+
+本轮将 `OneToNVMIMaskedStoreOpPattern::lowerContiguous` 中 value/mask 的 contiguous layout
+物化、类型列表构造及 arity 合同抽取为 `materializeContiguousMaskedStoreParts`。外层函数
+继续负责 converted part 遍历及单 chunk store 发射；value/mask 配对顺序、布局转换、失败
+诊断和 `vsts` 语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## lane-stride masked-store 单 chunk 发射拆分（2026-09-06）
 
 本轮将 `OneToNVMIMaskedStoreOpPattern::lowerLaneStride` 中单 physical chunk 的类型/active

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3397,3 +3397,18 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_load_store_contiguous.pto                  # exit=0
 ```
+
+# contiguous store unaligned base 职责拆分（2026-09-06）
+
+本轮将 `OneToNVMIStoreOpPattern::lowerContiguousStoreParts` 中 unaligned destination 的
+buffer pointer 物化和 offset 合成抽取为 `materializeUnalignedStoreBase`。store 主路径仍
+负责 aligned `vsts` 与 unaligned stateful stream 的选择、active-lane advances 收集和
+stream 发射；base 生命周期、offset 语义及失败诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_stride_store.pto                           # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2095,6 +2095,16 @@ block 顺序、offset、mask、dist token 和 direct/fallback 选择语义不变
 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
 通过；本轮未新增可独立覆盖该分支的 runtime case，未虚构额外回归结果。
 
+# one-block group store 单 part 发射职责整改
+
+本轮在 `OneToNVMIGroupStoreOpPattern::lowerOneBlockGroupStore` 中引入
+`emitOneBlockGroupStorePart`，将单个 physical part 的 vreg 校验、contiguous store mask、
+group offset/base 计算和 `VsstbOp` 发射抽取为独立 helper。主函数继续负责 one-block plan、
+arity 合约、stride 常量和 part 遍历；保持 part 顺序、block/repeat stride、地址计算、mask
+语义、诊断和替换行为不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
+
 # one-block group-reduce 单结果构造职责整改
 
 本轮在 `OneToNVMIGroupReduceOpPattern::lowerOneBlock` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2064,6 +2064,17 @@ exit=0，现有 slots=1 的 EVEN/P0 转换输出保持不变。
 `git diff --check` 通过；`vmi_to_vpto_load_store_contiguous.pto` 完整 lowering pipeline
 exit=0。
 
+# 全文件控制语句格式整改
+
+本轮按 `G.FMT.11-CPP` 清理了完整文件增量检查发现的历史无大括号控制语句，涉及
+`checkDeinterleaved2GroupStoreChunkShape`、`createPowerOfTwoRemainder`、
+`materializeEnsureLayoutConversion`、mask granularity 合同校验、`createAllFalseMaskLike`、
+channel split/merge 合同和 `compress_store` destination 校验。对复杂条件先引入具名
+布尔值，避免 checker 将跨行条件误判为无大括号；不改变任何 lowering、诊断或失败传播
+语义。相对 `origin/master` 的完整增量
+`check_changed_code.py --fail-on none` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过。
+
 # group load 布局分派职责整改
 
 本轮将 `OneToNVMIGroupLoadOpPattern::matchAndRewrite` 中 block-deinterleaved f32 特殊路径

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3540,6 +3540,20 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 ```
 
+# channel-split source shape 合同拆分（2026-09-06）
+
+本轮将 `checkSupportedChannelSplitShape` 中 source layout 与 physical arity 合同抽取为
+`checkChannelSplitSourceShape`。顶层检查继续负责 channel 数量/layout plan 和 result
+shape 校验；source/result arity 关系、诊断文本和支持矩阵保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_channel_split_merge.pto                    # exit=0
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,19 @@
 # VMIToVPTO 静态分析报告记录
 
+## shuffle vselr chunk 计数职责拆分（2026-09-06）
+
+本轮将 `computeShuffleVselrPlans` 中 result physical chunk 数量查询与计划遍历分离，
+新增 `getShuffleResultChunkCount` 统一处理 chunk 可计算性及诊断。vselr 的 source lane
+映射、ASC/DESC 方向判断、计划顺序和失败传播保持不变；该调整仅消除重复的 layout
+查询职责，未改变 shuffle lowering 语义。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## shuffle forwarding 输入计划拆分（2026-09-06）
 
 本轮将 `computeShuffleForwardingSourceParts` 的输入合法性与 forwarding 遍历分离，新增

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1752,3 +1752,11 @@ scalar 单值语义、mask 透传、TargetOp 选择、结果顺序和原有诊�
 大括号以满足 `G.FMT.11-CPP`。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_vector_scalar_ops.pto` lowering exit=0。
+
+# vaddc physical chunk lowering 职责整改
+
+本轮将 `OneToNVMIVaddcOpPattern::matchAndRewrite` 中 physical arity、32-bit data/b32
+mask part 校验及逐 chunk `VaddcOp` 发射抽取为 `lowerParts`。入口继续负责两个结果组的
+类型转换、carry/result 容器准备与最终扁平化替换；carry 结果排布（所有 result 后接所有
+carry）、mask 合同、结果顺序和诊断语义保持不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3398,6 +3398,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_group_store_slots8_packed_byte.pto         # exit=0
 ```
 
+# interleave 布局路径分派职责拆分（2026-09-06）
+
+本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中 lane-stride、contiguous
+和 zero-copy 的布局关系判断与 lowering 路由抽取为 `lowerInterleaveByLayout`。入口只保留
+操作数/结果类型获取、布局事实查询和统一调用；各路径的优先级、zero-copy 结果顺序、失败
+诊断和结果替换保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_intlv.pto                        # exit=0
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1951,3 +1951,13 @@ accumulator 类型、source lane 数以及 Bin_N0/Bin_N1 常量准备从 lowerin
 `WalkResult` 返回路径。各分支仍保留原有操作识别顺序、shape checker 和完整诊断文本，
 不改变成功/失败语义；未使用默认 lambda 捕获。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+
+# reduce min/max 顺序累加路径整改
+
+本轮将模板 `OneToNVMIReduceMinMaxOpPattern::lowerReduction` 中非等价 mask 合并场景的
+首 chunk reduction、单 chunk 快路径、首 lane mask 构造、多 chunk `ChunkReduceOp`/
+`CombineOp` 顺序累加和结果替换抽取为 `lowerSequentialReduction`。`lowerReduction` 继续
+负责等价 masked parts 快路径并在失败后转入该 helper；保持 min/max 操作选择、累加顺序、
+mask 语义、单结果布局和诊断不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_reduce_extended.pto` lowering exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,20 @@
 # VMIToVPTO 静态分析报告记录
 
+## group-broadcast 支持合同拆分（2026-09-06）
+
+本轮将 `checkGroupBroadcastLogicalContract` 中通用布局/元素/group 合同与
+`VMILayoutSupport::getGroupBroadcastSupport` 查询分离，新增
+`checkGroupBroadcastSupportContract`。前者只验证逻辑 shape，后者负责注册的支持矩阵及
+诊断透传；`buildGroupBroadcastShapePlan` 保持原检查顺序和失败传播，未改变支持范围或
+group-broadcast lowering 语义。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## lambda 显式捕获整改（2026-09-06）
 
 本轮处理报告中的 `G.RES.06-CPP` 风险：将

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3368,6 +3368,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_load_store_contiguous.pto                  # exit=0
 ```
 
+# slots=8 group-store 输入合同拆分（2026-09-06）
+
+本轮将 `lowerSlots8Dispatch` 中的物理 value arity 与首个 vreg 类型检查抽取为
+`getSlots8FirstVRegType`。分派入口继续负责 constant unit `row_stride` 检查，并保持
+packed-byte、lane-stride、contiguous 三条 lowering 路径的顺序、诊断文本和失败传播不变；
+空输入仍保留原有后续分派行为。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_group_store_slots8_packed_byte.pto         # exit=0
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,20 @@
 # VMIToVPTO 静态分析报告记录
 
+## conversion verifier 分派拆分（2026-09-06）
+
+本轮将 `verifySupportedVMIConversionOp` 按语义拆为
+`verifySupportedVMIFloatConversionOp` 与 `verifySupportedVMIIntegerConversionOp`：浮点/整
+数转换分别维护自身的 op 类型、shape check 和诊断文本，入口只负责两组分派。支持矩阵、
+检查顺序、`std::optional<WalkResult>` 行为及错误诊断保持不变，避免继续扩大单一 verifier
+函数的复杂度。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## group-broadcast 单 chunk 物化拆分（2026-09-06）
 
 本轮将 `lowerGroupBroadcastResultChunks` 中单 physical result 的类型合同检查与 chunk

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2104,6 +2104,16 @@ stream advance、诊断和 direct/fallback 语义不变。增量 `check_changed_
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
 
+# packed-byte group store direct 发射职责整改
+
+本轮在 `OneToNVMIGroupStoreOpPattern::lowerPackedByteSlots8` 中引入
+`emitPackedByteDirectStore`，将 direct `PK4_B32` 的单 block `VstsOp` 发射抽取为独立 helper；
+同时显式在 fallback stream 中按 block 计算 advance，保持原有 32-group block 步长语义。
+主函数继续负责 block 构造、direct/fallback 选择和 stream 收尾；保持 payload、mask、offset、
+结果顺序、诊断和 direct/fallback 语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
+
 # contiguous group store 单 chunk 发射职责整改
 
 本轮在 `OneToNVMIGroupStoreOpPattern::lowerContiguousGroupStore` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3471,6 +3471,20 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_trunci_lane_stride.pto           # exit=0
 ```
 
+# vmull logical shape 与 physical arity 拆分（2026-09-06）
+
+本轮将 `buildVmullShapePlan` 中 element type、lane 数量、layout 和 mask 合同抽取为
+`validateVmullLogicalShape`；原函数继续负责各端口 physical arity 计算与一致性检查。
+`VmullShapePlan` 的 data/layout/arity 内容、失败诊断和支持矩阵保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_vmull_deinterleaved.pto                    # exit=0
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3442,6 +3442,20 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_group_slot_load.pto                        # blocked by pre-existing VMI-PASS-INVARIANT
 ```
 
+# group-slot-load slots=8 chunk 发射拆分（2026-09-06）
+
+本轮将 `lowerGroupSlotLoadSlots8` 多组循环中的单个 chunk 合同校验、prefix mask、地址
+偏移和 `vsldb` 发射抽取为 `emitGroupSlotLoadSlots8Chunk`。主函数只保留 unit-stride
+合同、单组 BRC 分派和 chunk 遍历；多组 `vsldb` 的 mask/offset/结果顺序保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_slot_load.pto              # lowering output generated; command returned an existing test diagnostic
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3287,3 +3287,22 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 
 `vmi_lane_stride_masked_store.pto` 在测试自身已有的 mask layout contract 冲突处提前失败，
 未进入本轮 stride helper。
+
+# stride memory contract 上下文整改（2026-09-06）
+
+本轮复核并收敛上一轮的 stride helper：将 data/mask 类型、layout、pointer 和各方向诊断
+封装为 `StrideMemoryContract`，移除 load/store 入口中不再使用的失败 lambda，并统一由
+`checkStrideMemoryContract` 消费。该上下文只表达 stride 访存合同，不引入全局状态；
+`checkSupportedStoreShape` 仍在 store 路径单独执行，load/store 的 pointer 方向和 arity
+诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_stride_store.pto                           # exit=0
+```
+
+`vmi_to_vpto_stride_load.pto` 在既有 VMI pack/unpack pipeline invariant 处提前失败，未进入
+本轮 stride helper。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2367,6 +2367,16 @@ fallback 的 plan 字段、结果顺序和失败语义不变。增量 `check_cha
 `vmi_to_vpto_shuffle_forwarding.pto` 与 `vmi_to_vpto_shuffle_lane0_splat.pto` 均 lowering
 exit=0。
 
+# mask granularity 分片物化职责整改
+
+本轮在 `materializeAdjacentMaskGranularityConversion` 中引入
+`materializeMaskGranularityParts`，将按 layout factor 遍历、source chunk offset 推进和
+各 part 结果汇总抽取为独立 helper。主函数继续负责 conversion plan 构建、结果 arity
+校验和最终返回；widening/narrowing 的 pack/unpack 语义、part 顺序及失败诊断保持不变。
+增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；尝试的 mask granularity cases 在既有 pack/unpack invariant 或
+layout contract 处提前终止，未进入本轮 helper。
+
 # channel split 结果布局与 arity 合同职责整改
 
 本轮在 `checkSupportedChannelSplitShape` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3306,3 +3306,20 @@ vmi_to_vpto_stride_store.pto                           # exit=0
 
 `vmi_to_vpto_stride_load.pto` 在既有 VMI pack/unpack pipeline invariant 处提前失败，未进入
 本轮 stride helper。
+
+# active-prefix physical arity 合同拆分（2026-09-06）
+
+本轮将 active-prefix index shape plan 中 single-physical-chunk 的 arity 合同抽取为
+`checkActivePrefixIndexSingleChunk`，使 layout 合同、full physical chunk 合同和跨 chunk
+carry 限制分别表达。原有 mask/result layout 要求、padding lane 安全条件和失败诊断顺序
+保持不变；同时补齐本轮触及的控制流大括号。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
+active-prefix/compress 代表性测试在既有 VMI pack/unpack pipeline invariant 处提前失败，未
+进入本轮 helper。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2121,6 +2121,15 @@ lane 数、地址操作数和 value/mask arity 合同；helper 按原顺序优�
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_masked_store.pto` lowering exit=0。
 
+# ensure_mask_granularity 结果合同职责整改
+
+本轮在 `OneToNVMIEnsureMaskGranularityOpPattern` 中新增 `replaceCheckedResults`，将物化
+结果的 physical arity、逐 part 类型校验以及 One-to-N 替换集中到单一 helper。主入口继续
+负责 source/result 类型、支持关系和 granularity conversion 调用；结果顺序、失败诊断、
+类型合同和替换语义保持不变。增量
+`check_changed_code.py --base origin/master --fail-on none` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+
 # group load 布局分派职责整改
 
 本轮将 `OneToNVMIGroupLoadOpPattern::matchAndRewrite` 中 block-deinterleaved f32 特殊路径

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2085,6 +2085,16 @@ mask、结果顺序和诊断语义不变。增量 `check_changed_code.py` 结果
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；本轮未新增可独立进入该
 helper 的 runtime case，未虚构额外回归结果。
 
+# slots=8 lane-stride group store direct 发射职责整改
+
+本轮在 `OneToNVMIGroupStoreOpPattern::lowerSlots8LaneStride` 中引入
+`emitAlignedSlots8LaneStride`，将 direct 路径每个 slot block 的 vreg 校验、active group
+mask 构造和带 dist 的 `VstsOp` 发射抽取为独立 helper。主函数继续负责 dist/mask
+granularity 选择、地址合法性判断、unaligned compact fallback 与 stateful stream；保持
+block 顺序、offset、mask、dist token 和 direct/fallback 选择语义不变。增量
+`check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
+通过；本轮未新增可独立覆盖该分支的 runtime case，未虚构额外回归结果。
+
 # one-block group-reduce 单结果构造职责整改
 
 本轮在 `OneToNVMIGroupReduceOpPattern::lowerOneBlock` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2524,6 +2524,15 @@ exit=0。
 `git diff --check` 通过。native 增量构建仍被工作区既有 CMake 外部依赖尝试创建
 `/cann-cmake` 的权限错误阻断，未产生本轮 C++ 编译诊断。
 
+# group broadcast 结果 shape 合同职责整改
+
+本轮新增 `checkGroupBroadcastResultShape`，将 group broadcast 的结果 physical chunk 完整性、
+factor=1 快路径、block/deinterleaved 小 group 例外及 logical span 合同从入口分派中抽取。
+plan builder 仍负责输入类型/layout、组数、lanes-per-part 和 group size 推导；原有检查顺序、
+诊断文本、结果布局例外与 lowering 语义保持不变。增量检查结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；E2B group-broadcast
+case lowering exit=0。
+
 # group broadcast shape 重构回归修复
 
 复核既有 group-broadcast shape 拆分时发现入口遗漏了结果类型和诊断闭包定义，导致该

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,18 @@
 # VMIToVPTO 静态分析报告记录
 
+## residual sub-VL lambda 捕获审计（2026-09-06）
+
+本轮复核 `createResidualSubVLGroupPeriodicChunk` 的显式 lambda 捕获，补齐其实际使用的
+`allMask` 捕获项。该修复消除了隐式依赖，保持每个 group 的偏移、方向、lane mask 和
+`vsel` 结果语义不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## arithmetic verifier 分派拆分（2026-09-06）
 
 本轮将 `verifySupportedVMIArithmeticOp` 拆为普通 unary/binary maskable 算术分派与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3077,6 +3077,24 @@ vmi_to_vpto_ensure_mask_granularity_multistep.pto      # reaches existing pack/u
 该多步 granularity case 在测试自身的 VMI `unpack` 前置 invariant 处提前失败，未进入
 本轮 helper；该既有输入限制已如实记录。
 
+# deinterleaved=4 load 单组物化职责拆分（2026-09-06）
+
+本轮将 `OneToNVMIGroupLoadOpPattern::lowerDeinterleaved4` 中单个 logical group 的
+类型一致性检查、两次 `vldsx2`、两次 `vdintlv` 及四路结果整理抽取为
+`materializeDeinterleaved4LoadGroup`。主函数继续负责 physical arity 合同、四路 part
+容器和 group 遍历；访问 offset、part 顺序、dist 传递、失败诊断和结果布局保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_load_deint.pto                            # reaches existing pack/unpack invariant
+```
+
+相关 deinterleaved load case 在测试自身的 VMI `unpack` 前置 invariant 处提前失败，未
+进入本轮单组物化 helper；该既有输入限制已记录。
+
 随后将 `computeShuffleVselrPlanForChunk` 中的结果物理 lane 校验、逻辑 lane 越界检查和
 source lane 映射抽取为 `getShuffleSourceLane`。规划函数继续负责 source chunk 一致性与
 ASC/DESC 方向推导，抽取没有改变失败诊断、迭代顺序或最终 `ShuffleVselrPlan` 内容；增量

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3441,6 +3441,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_group_reduce_s256.pto            # exit=0
 ```
 
+# grouped-iota shape 合同拆分（2026-09-06）
+
+本轮将 `lowerGroupedIota` 中 group divisibility、group/physical lane 兼容性、contiguous
+layout 和结果 physical arity 合同抽取为 `validateGroupedIotaShape`。主函数继续负责共享
+chunk 缓存、lane offset 计算及 contiguous/sub-VL chunk 物化；grouped iota 的缓存 key、
+结果顺序、诊断文本和 lowering 语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_iota_group2.pto                            # exit=0
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3111,6 +3111,25 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_deinterleave_load_layout_propagation.pto           # exit=0
 ```
 
+# interleave layout 路由计划拆分（2026-09-06）
+
+本轮将 `lowerInterleaveByLayout` 中 lane-stride、全 contiguous 和 zero-copy layout 关系
+分类抽取为 `InterleaveLoweringPlan`/`classifyInterleaveLowering`。主函数现在只负责依据
+计划调用对应 lowering，或执行 zero-copy 结果物化；layout 关系判断、factor 推导和不支持
+诊断集中在分类 helper 中。原有路由优先级、zero-copy vintlv/vdintlv 条件、结果顺序和
+失败语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_intlv_lane_stride.pto            # exit=0
+```
+
+部分 direct interleave lit case 仍会在测试自身的 VMI `unpack` 前置 invariant 处提前失败，
+未进入本轮分类逻辑。
+
 # deinterleave-load 结果类型合同拆分（2026-09-06）
 
 本轮将 `OneToNVMIDeinterleaveLoadOpPattern::matchAndRewrite` 中 low/high physical result

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3367,3 +3367,18 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_load_store_contiguous.pto                  # exit=0
 ```
+
+# load physical plan 构造职责拆分（2026-09-06）
+
+本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与
+contiguous footprint type 获取分别抽取为 `getLoadResultTypes` 和
+`getContiguousLoadTypes`。plan builder 继续负责 source/offset 归一化、read-safety
+验证和 footprint 比较；地址语义、layout conversion 顺序及失败诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_load_store_contiguous.pto                  # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3877,3 +3877,19 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_load_store_contiguous.pto                  # exit=0
 ```
+
+# group-broadcast E2B 基础合同拆分（2026-09-06）
+
+本轮将 `validateDirectE2BShape` 中 direct E2B lowering 的基础合同检查抽取为
+`validateDirectE2BBasicContract`。该 helper 统一检查 result layout、b16/b32 element
+width、unit `source_group_stride`、pointer source 和 `num_groups = 8`；原函数继续负责
+physical chunk 数量、packet type、offset 计算及 E2B packet 发射。检查顺序、失败诊断和
+contiguous/deinterleaved 路由语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_broadcast_load_e2b_b16.pto # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2402,6 +2402,15 @@ table 查询并调用 memory helper。group broadcast 的支持矩阵、地址�
 `vmi_layout_assignment_group_broadcast_load_e2b_b16.pto` 与
 `vmi_to_vpto_load_store_contiguous.pto` lowering 均 exit=0。
 
+# group-slot load stride 合同职责整改（2026-09-06）
+
+本轮将 `checkSupportedGroupSlotLoadShape` 的 slots=8 unit-stride 合同抽取为
+`checkSupportedSlots8GroupSlotLoadShape`，与已有 slots=1 对齐步长校验形成对称的独立
+职责。主函数仍负责 layout fact、dense memory proof、指针校验和 slots 分派；source
+stride 规则、诊断和失败传播保持不变。增量检查结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过。现有 group-slot load 样例分别在既有 pack/unpack 或测试 region
+前置约束处终止，未进入本轮 helper，未归因于本轮修改。
+
 # scatter shape 合同职责整改（2026-09-06）
 
 本轮将 `checkSupportedScatterShape` 的布局/目标指针校验抽取为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2318,6 +2318,16 @@ shape-check、reason 传播和 `WalkResult` 错误处理统一改用已有的
 `vmi_deinterleave_load_layout_propagation.pto` lowering exit=0。
 `vmi_to_vpto_stride_load.pto` 在既有 pack/unpack invariant 处提前终止，未进入本轮 helper。
 
+# structured group load verifier 分派职责整改
+
+本轮继续将 `verifySupportedVMIStructuredLoadOp` 中 group_load、group_slot_load 与
+group_broadcast_load 的重复 shape-check 和失败诊断统一改用 `verifySupportedShapeOp`。
+每个分支的能力说明、识别顺序、checker 选择和失败语义保持不变。增量
+`check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
+通过；`vmi_layout_assignment_group_broadcast_load_e2b_b16.pto` lowering exit=0。
+`vmi_layout_assignment_group_load_s16_unaligned_stride_invalid.pto` 仍按预期在既有
+layout contract invalid 处失败，诊断未改变。
+
 # contiguous group reduce 类型合同职责整改
 
 本轮在 `OneToNVMIGroupReduceOpPattern::lowerContiguousRows` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3456,6 +3456,19 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_iota_group2.pto                            # exit=0
 ```
 
+# constant mask chunk shape 校验拆分（2026-09-06）
+
+本轮将 `materializeConstantMaskChunk` 的 mask lane 数量与 active-lane 输入一致性检查抽取
+为 `validateConstantMaskChunk`。主体继续负责 prefix mask 快路径、非连续 active run 的
+PAND/POR 合并和空 mask fallback；mask lane 顺序、结果语义及失败行为保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2504,3 +2504,13 @@ exit=0。
 # compress 结果 shape 合同职责整改
 
 本轮新增 `checkSupportedCompressResultShape`，将 `compress` 的结果 layout 存在性、contiguous 合同、物理 arity 可计算性及单 chunk 约束从入口校验中独立出来。`buildCompressPhysicalShapePlan` 继续只负责 source/mask 的输入合同，`compress_store` 保持独立诊断和 destination `!pto.ptr` 合同；结果布局校验顺序、错误文本、物理 chunk 限制及 lowering 语义均保持不变。增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；`vmi_to_vpto_compress_store.pto` lowering exit=0，普通 compress case 在既有 pack/unpack invariant 处提前终止。
+
+# reduce shape 合同分层整改
+
+本轮将通用 reduce shape plan builder 中的 layout 合同和 physical arity 合同分别抽取为
+`checkReduceLayouts` 与 `checkReducePhysicalArity`。builder 继续负责 source/mask/result
+类型提取、full physical chunk 证明和 plan 组装；原有 contiguous 要求、source/mask arity
+匹配、单 result chunk 约束、诊断顺序及失败传播保持不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过。native 增量构建仍被工作区既有 CMake 外部依赖尝试创建
+`/cann-cmake` 的权限错误阻断，未产生本轮 C++ 编译诊断。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2635,6 +2635,16 @@ lane-stride 顺序分派，optional/failure 传播、identity forwarding 合同�
 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；layout 和 mask granularity 相关 lowering case 均 exit=0。
 
+# deinterleaved=2 mask layout 路由职责整改
+
+本轮新增 `Deinterleaved2MaskLayoutDirection` 与
+`getDeinterleaved2MaskDirection`，将 source/result layout 的方向识别从
+`materializeDeinterleaved2MaskLayout` 中独立出来。物化函数现在只负责 arity、identity
+part forwarding 和方向对应的 intlv/dintlv 发射；to-contiguous/from-contiguous 的判定、
+结果顺序及失败诊断保持不变。增量 `check_changed_code.py --base HEAD` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；dense layout 与 vdintlv
+相关 case lowering 均 exit=0。
+
 # predicate interleave 分派职责整改
 
 本轮引入 `PredicateInterleaveKind` 与 `createPredicateInterleave`，统一 b8/b16/b32

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,19 @@
 # VMIToVPTO 静态分析报告记录
 
+## group-store 通用布局 lowering 拆分（2026-09-06）
+
+本轮将 `OneToNVMIGroupStoreOpPattern::lowerByLayout` 中 general layout 的 support fact
+查询、one-block/deinterleaved-2/contiguous 路由抽取为 `lowerGeneralGroupStore`。布局分类
+函数继续负责 scalar、compact、slots=1、slots=8 快路径；通用 helper 负责 support table
+事实与后端选择。deinterleaved-2 检查、fallback 顺序、地址/stride 传递和失败诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## residual sub-VL 单 group 物化拆分（2026-09-06）
 
 本轮将 `createResidualSubVLGroupPeriodicChunk` 内部 lambda 的单 group 偏移、方向计算、

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2340,6 +2340,10 @@ checked_files=1 errors=0 warnings=0
 既有 `VMI-PASS-INVARIANT`（pack/unpack helper 提前物化）处终止，未进入该路径，不能将
 该失败归因于本修复。
 
+本轮尝试重新构建 `pto-test-opt` 时，CMake 仍因工作区既有的 `cann-cmake` 外部依赖
+配置尝试创建 `/cann-cmake` 且权限不足而无法重新配置；该环境问题未产生新的 C++ 编译
+诊断，未删除或重置现有 build tree。
+
 # compact small group store 分支发射职责整改
 
 本轮在 `OneToNVMIGroupStoreOpPattern::lowerCompactSmallGroupStore` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2318,6 +2318,15 @@ shape-check、reason 传播和 `WalkResult` 错误处理统一改用已有的
 `vmi_deinterleave_load_layout_propagation.pto` lowering exit=0。
 `vmi_to_vpto_stride_load.pto` 在既有 pack/unpack invariant 处提前终止，未进入本轮 helper。
 
+# gather 布局与源地址合同职责整改
+
+本轮在 `checkSupportedGatherShape` 中引入 `checkGatherLayoutAndSource`，将四路 contiguous
+布局检查与 `!pto.ptr` 源地址约束从元素类型/physical arity 合同中分离。主 checker 继续
+负责 source element、index/mask/result 类型关系、B16/B32 选择及 physical chunk 限制，保持
+检查顺序、诊断文本和失败语义不变。增量检查以 `HEAD` 为基线结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；尝试的 gather cases
+在既有 VMI op verifier 的输入类型合同处提前失败，未进入本轮 helper。
+
 # structured group load verifier 分派职责整改
 
 本轮继续将 `verifySupportedVMIStructuredLoadOp` 中 group_load、group_slot_load 与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,18 @@
 # VMIToVPTO 静态分析报告记录
 
+## structured-load verifier 语义族拆分（2026-09-06）
+
+本轮将 `verifySupportedVMIStructuredLoadOp` 按 deinterleave、stride、group、group-slot 和
+group-broadcast 五类 op 拆为独立 helper，入口仅按原顺序分派。每类继续使用原有 shape
+check、诊断文本和 `WalkResult` 行为，未改变 structured-load 支持矩阵或 lowering 语义。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## structured-store verifier 语义族拆分（2026-09-06）
 
 本轮将 `verifySupportedVMIStructuredStoreOp` 按 interleave、group、stride、scatter 四类

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,20 @@
 # VMIToVPTO 静态分析报告记录
 
+## group-reduction verifier 浮点/整数分派拆分（2026-09-06）
+
+本轮将 `verifySupportedVMIGroupReductionOp` 拆为
+`verifySupportedVMIGroupFloatReductionOp` 与
+`verifySupportedVMIGroupIntegerReductionOp`，分别维护 add/max 浮点和 add/max/min 整数
+group-reduction 的 op 表与诊断。入口只负责语义族分派，support check、诊断文本、原有
+op 顺序和 `WalkResult` 语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## advanced-load verifier 分派拆分（2026-09-06）
 
 本轮将 `verifySupportedVMIMemoryAdvancedLoadOp` 按语义拆为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2135,6 +2135,16 @@ chunk 顺序、诊断及结果替换语义不变。增量 `check_changed_code.py
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_group_broadcast_load_e2b_b16.pto` lowering exit=0。
 
+# group broadcast load fallback source plan 职责整改
+
+本轮在 `OneToNVMIGroupBroadcastLoadOpPattern::lowerGroupSlotFallback` 中引入
+`buildGroupBroadcastFallbackSourcePlan`，将 source slots 选择、source VMI type、physical
+arity、lane 数和 source part type 构造抽取为独立计划 helper。主函数继续负责调用
+`lowerGroupSlotLoadParts`、`lowerGroupBroadcastParts` 和结果替换；保持 stride 到 slots 的
+映射、source type 顺序、诊断及 fallback lowering 语义不变。增量 `check_changed_code.py`
+结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_group_broadcast_load_e2b_b16.pto` lowering exit=0。
+
 # group broadcast load BRC shape 校验职责整改
 
 本轮在 `OneToNVMIGroupBroadcastLoadOpPattern::lowerDirectBRC` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2075,6 +2075,18 @@ channel split/merge 合同和 `compress_store` destination 校验。对复杂条
 `check_changed_code.py --fail-on none` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过。
 
+# scalar store deinterleaved 候选职责整改
+
+本轮在 `OneToNVM​​IStoreOpPattern` 中新增 `tryLowerDeinterleavedStore`，将普通
+`vmi.store` 的 deinterleaved=2 layout fact、full-physical-footprint、INTLV dist 合法性、
+偶数 physical part arity 和实际 `vstsx2` 发射从主 `matchAndRewrite` 中独立出来。helper
+采用明确的 candidate/不可用返回值：不满足候选条件时继续 contiguous materialization，
+真正发射失败时传播 failure；保持 lane-stride 优先级、contiguous fallback、地址/part 顺序、
+mask 和失败语义不变。增量
+`check_changed_code.py --base origin/master --fail-on none` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_load_store_contiguous.pto` lowering exit=0。
+
 # group load 布局分派职责整改
 
 本轮将 `OneToNVMIGroupLoadOpPattern::matchAndRewrite` 中 block-deinterleaved f32 特殊路径

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,19 @@
 # VMIToVPTO 静态分析报告记录
 
+## structured-store verifier masked-store 分支拆分（2026-09-06）
+
+本轮将 `verifySupportedVMIStructuredStoreOp` 中 masked-store 的专用 shape 检查及诊断抽取
+为 `verifySupportedVMIStructuredMaskedStoreOp`。structured-store 主分派继续负责
+interleave/group/stride/scatter 等 op；masked-store 的支持合同、错误文本和 interrupt
+行为保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## contiguous masked-store layout conversion 拆分（2026-09-06）
 
 本轮将 `OneToNVMIMaskedStoreOpPattern::lowerContiguous` 中 value/mask 的 contiguous layout

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,20 @@
 # VMIToVPTO 静态分析报告记录
 
+## normal-reduction verifier 浮点/整数分派拆分（2026-09-06）
+
+本轮将 `verifySupportedVMINormalReductionOp` 拆为
+`verifySupportedVMINormalFloatReductionOp` 与
+`verifySupportedVMINormalIntegerReductionOp`，分别维护 add/max/min 浮点和整数 reduction
+的 shape check 与诊断。入口只负责两类分派，保持原有 op 顺序、reassoc 要求、诊断文本和
+`WalkResult` 语义。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## group-reduction verifier 浮点/整数分派拆分（2026-09-06）
 
 本轮将 `verifySupportedVMIGroupReductionOp` 拆为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2605,3 +2605,11 @@ exit=0。
 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_layout_assignment_group_broadcast_load_e2b_b16.pto`
 完整 lowering pipeline exit=0。
+
+# mask physical part type 构造职责整改
+
+本轮新增 `repeatMaskPartType`，将按 physical arity 重复构造 `MaskType` part 列表的职责
+从 `getConvertedMaskPartTypes` 中独立出来；入口继续负责 arity/granularity 合同查询和
+physical part type 选择。补齐循环大括号并保持 part 数量、类型和失败语义不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；direct/multistep mask granularity lowering case 均 exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2052,6 +2052,19 @@ exit=0，现有 slots=1 的 EVEN/P0 转换输出保持不变。
 `git diff --check` 通过；`vmi_layout_assignment_group_store_slots1_unit_stride.pto`
 完整 lowering pipeline exit=0。
 
+# iota 物化上下文数据泥团整改
+
+本轮引入轻量 `IotaMaterializationContext`，统一携带 iota 三类物化路径共同需要的
+`Location`、base、order attribute 和 rewriter；新增 `getIotaOrder` 统一 ASC 默认值处理。
+`createIotaContiguousChunk`、`createSubVLGroupPeriodicChunk` 与
+`createIotaDeinterleavedChunk` 的 contiguous、group-periodic、deinterleaved lane 计算仍
+保持独立，未合并不同布局算法。共享 chunk、power-of-two fast path、残余 vsel、part/chunk
+偏移、ASC/DESC 方向和结果顺序均保持不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_iota_group2.pto`、
+`vmi_to_vpto_iota_group_subvl.pto` 和 `vmi_to_vpto_iota_group_deint.pto` lowering 均
+exit=0，普通 iota case 仍在既有 pack/unpack invariant 处提前终止。
+
 # vmull 物理 shape 合同职责整改
 
 本轮新增 `checkVmullPhysicalShape`，将 vmull 的 physical lane 数、physical data element

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3485,6 +3485,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_vmull_deinterleaved.pto                    # exit=0
 ```
 
+# group-broadcast selector 物化拆分（2026-09-06）
+
+本轮将 `getGroupBroadcastSelector` 中 constant selector 与共享 ramp 的构造逻辑分别抽取
+为 `materializeConstantGroupBroadcastSelector` 和 `materializeGroupBroadcastRamp`。缓存、
+base index 偏移、shift 顺序以及 selector kind 分派保持不变，避免在入口混合不同 selector
+物化策略。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_broadcast_load_e2b_b16.pto # exit=0
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3382,6 +3382,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_group_store_slots8_packed_byte.pto         # exit=0
 ```
 
+# legacy group-slot extension 准备阶段拆分（2026-09-06）
+
+本轮将 `lowerLegacyGroupSlotExtension` 中 group/slots/lane_stride shape 合同、conversion
+source vreg 类型和 active slot mask 构造抽取为 `prepareLegacyGroupSlotExtension`。主函数
+继续负责 `EVEN/P0` part 选择、逐 physical part `Vcvt` 和结果替换；扩展因子、mask 语义、
+诊断文本及结果顺序保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_group_slot_integer_extension_matrix.pto   # exit=0
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2308,6 +2308,16 @@ mask 语义、group 顺序及失败传播不变。增量 `check_changed_code.py`
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_layout_assignment_group_reduce_s256.pto` 完整 lowering pipeline exit=0。
 
+# structured load verifier 分派职责整改
+
+本轮将 `verifySupportedVMIStructuredLoadOp` 中 deinterleave_load 与 stride_load 的重复
+shape-check、reason 传播和 `WalkResult` 错误处理统一改用已有的
+`verifySupportedShapeOp`。两个分支仍按原顺序识别，并保留各自完整的 VPTO 能力诊断文本；
+不改变 checker、失败语义或后续 group-load 分支。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_deinterleave_load_layout_propagation.pto` lowering exit=0。
+`vmi_to_vpto_stride_load.pto` 在既有 pack/unpack invariant 处提前终止，未进入本轮 helper。
+
 # contiguous group reduce 类型合同职责整改
 
 本轮在 `OneToNVMIGroupReduceOpPattern::lowerContiguousRows` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3201,6 +3201,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 现有 static/runtime expand-load case 在测试自身的 VMI `unpack` 前置 invariant 处提前
 失败，未进入本轮 chunk helper。
 
+# contiguous group-reduce 单 group 物化职责拆分（2026-09-06）
+
+本轮将 `buildContiguousGroupReduceResults` 中单个 group 的 source/mask 类型检查、逐
+chunk `RowReduceOpTy` 发射和 combine 累积抽取为 `buildContiguousGroupReduceResult`。
+外层 helper 继续负责 group 遍历和结果收集；归约顺序、首 lane mask、combine 顺序、失败
+诊断和 slots=1/slots=8 结果恢复语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_reduce_s256.pto             # exit=0
+```
+
 # deinterleave-load 结果类型合同拆分（2026-09-06）
 
 本轮将 `OneToNVMIDeinterleaveLoadOpPattern::matchAndRewrite` 中 low/high physical result

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2422,6 +2422,15 @@ memory access proof 及两阶段失败回退，保持 masked-store 的支持范�
 `vmi_to_vpto_load_store_contiguous.pto` lowering exit=0。lane-stride masked-store 样例在
 既有 `ensure_mask_layout` 前置约束处终止，未进入本轮 helper。
 
+# group-slot load memory 合同职责整改（2026-09-06）
+
+本轮将 `checkSupportedGroupSlotLoadShape` 的 dense memory access proof 与 UB pointer
+校验抽取为 `checkGroupSlotLoadMemoryContract`，主函数只负责 layout fact 获取及 slots=1/8
+分派。source stride 约束、对齐要求、诊断和失败传播保持不变；同时补齐相邻的
+`getContiguousActiveDataLanes` 控制流大括号。增量检查结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；连续 load/store case
+仍按既有测试约束验证，未观察到本轮 helper 引入的新 lowering 错误。
+
 # scatter shape 合同职责整改（2026-09-06）
 
 本轮将 `checkSupportedScatterShape` 的布局/目标指针校验抽取为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3059,6 +3059,24 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 ```
 
+# narrowing mask granularity 单 chunk 物化职责拆分（2026-09-06）
+
+本轮将 `materializeNarrowingMaskGranularityPart` 中单个结果 chunk 的 source 消耗、
+`ppack` 及可选 `por` 合并抽取为 `materializeNarrowingMaskChunk`。外层 helper 继续负责
+结果 chunk 遍历、source 消耗总量检查和结果收集；`allTrue` 延迟创建、LOWER/HIGHER
+顺序、尾部奇数 source chunk 语义以及失败诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_ensure_mask_granularity_multistep.pto      # reaches existing pack/unpack invariant
+```
+
+该多步 granularity case 在测试自身的 VMI `unpack` 前置 invariant 处提前失败，未进入
+本轮 helper；该既有输入限制已如实记录。
+
 随后将 `computeShuffleVselrPlanForChunk` 中的结果物理 lane 校验、逻辑 lane 越界检查和
 source lane 映射抽取为 `getShuffleSourceLane`。规划函数继续负责 source chunk 一致性与
 ASC/DESC 方向推导，抽取没有改变失败诊断、迭代顺序或最终 `ShuffleVselrPlan` 内容；增量

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2357,6 +2357,16 @@ forwarding fallback 的优先级、结果顺序和所有失败诊断不变。增
 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_to_vpto_shuffle_forwarding.pto` lowering exit=0。
 
+# shuffle vselr lane 方向职责整改
+
+本轮在 `computeShuffleVselrPlanForChunk` 中引入 `getShuffleLaneDirection`，将单 lane 的
+ASC/DESC affine 关系判定与错误诊断抽取为独立 helper。chunk plan 主函数继续负责 padding、
+logical→physical 映射、source chunk 一致性、方向一致性和 flat index 组装；保持 vselr
+fallback 的 plan 字段、结果顺序和失败语义不变。增量 `check_changed_code.py --base HEAD`
+结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_shuffle_forwarding.pto` 与 `vmi_to_vpto_shuffle_lane0_splat.pto` 均 lowering
+exit=0。
+
 # channel split 结果布局与 arity 合同职责整改
 
 本轮在 `checkSupportedChannelSplitShape` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2076,6 +2076,16 @@ exit=0，普通 iota case 仍在既有 pack/unpack invariant 处提前终止。
 不改变 chunk 共享 key、布局分派、偏移计算或结果顺序；增量检查及三组 iota lowering
 case 均继续通过。
 
+# mask granularity 多步转换职责整改
+
+本轮将多步 mask granularity 转换中的“下一步类型构造”抽取为
+`buildNextMaskGranularityType`。`materializeMaskGranularitySteps` 现在只负责 rank 方向、
+逐步 part 转换和 current state 推进；保持 adjacent conversion 的调用顺序、b8/b16/b32
+rank 语义、layout/element count 传播及错误诊断不变。并移除未使用的最终 result type
+参数，避免数据泥团和误导性输入。增量 `check_changed_code.py --base HEAD` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_ensure_mask_granularity_multistep.pto` 与直接转换 case lowering 均 exit=0。
+
 # vmull 物理 shape 合同职责整改
 
 本轮新增 `checkVmullPhysicalShape`，将 vmull 的 physical lane 数、physical data element

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3412,3 +3412,18 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_stride_store.pto                           # exit=0
 ```
+
+# unaligned load state 推进职责拆分（2026-09-06）
+
+本轮将 `OneToNVMILoadOpPattern::materializeUnalignedContiguousParts` 中单个 `vldus` 发射
+及 updated base/align 状态封装为 `emitUnalignedLoadPart` 和 `UnalignedLoadPart`。外层
+循环只负责按 contiguous result types 累积结果并推进状态；`vldus` 的 increment、operand
+类型、align/base 更新顺序和 part 顺序保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_load_store_contiguous.pto                  # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2408,6 +2408,15 @@ load 检查处终止，未进入本轮 materializer。
 `vmi_to_vpto_ensure_layout_dense_composed.pto` lowering exit=0，deinterleaved case 在
 既有 pack/unpack invariant 处提前终止。
 
+# data layout conversion 路径尝试职责整改
+
+本轮在 `materializeDataLayoutConversion` 中统一封装四种 materializer 的
+`FailureOr<optional>` 尝试与失败传播，保持 simple → deinterleaved2 → lane-stride →
+intermediate 的严格优先级。各 lambda 使用显式捕获；主函数仍负责最终 unsupported 诊断，
+不改变布局转换结果、递归顺序或失败语义。增量 `check_changed_code.py --base HEAD` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_ensure_layout_dense_composed.pto` lowering exit=0。
+
 # channel split 结果布局与 arity 合同职责整改
 
 本轮在 `checkSupportedChannelSplitShape` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2330,6 +2330,16 @@ checked_files=1 errors=0 warnings=0
 报告中的 AST 级超大函数、圈复杂度和历史数据泥团仍不能据此宣称全部清零，后续需在
 保持 lowering 分派和物理结果语义不变的前提下继续按职责边界拆分。
 
+# mask granularity 多步物化状态修复（2026-09-06）
+
+复核多步 mask granularity conversion 时发现 `materializeMaskGranularitySteps` 使用了未
+初始化的 `currentRank`，会使非相邻粒度转换的状态推进不具备确定语义。现以已分类的
+`sourceRank` 初始化当前状态，保持逐级升/降粒度顺序和每一步的物化调用不变。增量合规
+检查与 `git diff --check` 均通过；`vmi_to_vpto_ensure_layout_dense_composed.pto`
+完整 lowering exit=0。`vmi_to_vpto_ensure_mask_granularity_multistep.pto` 仍在测试自身
+既有 `VMI-PASS-INVARIANT`（pack/unpack helper 提前物化）处终止，未进入该路径，不能将
+该失败归因于本修复。
+
 # compact small group store 分支发射职责整改
 
 本轮在 `OneToNVMIGroupStoreOpPattern::lowerCompactSmallGroupStore` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,20 @@
 # VMIToVPTO 静态分析报告记录
 
+## shuffle forwarding 输入计划拆分（2026-09-06）
+
+本轮将 `computeShuffleForwardingSourceParts` 的输入合法性与 forwarding 遍历分离，新增
+`ShuffleForwardingInputPlan`/`getShuffleForwardingInputPlan`，集中保存 source/result 类型、
+每个 physical part 的 lane 数和 result layout factor。主函数只负责按 result part/chunk
+计算 source flat index；索引非空、lane 数可知和 result layout 已分配等合同及原有错误文本
+保持不变。同时补齐本轮触及的控制语句大括号。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## trunci group-slot carrier 路由拆分（2026-09-06）
 
 本轮将 `lowerGroupSlotTruncPart` 的三种物化策略拆为独立 helper：

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3144,6 +3144,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 相关 block group-load case 在测试自身的 ensure_layout/truncf 不支持输入处提前失败，未
 进入本轮 chunk helper。
 
+# group-load unit-stride 单 chunk 物化职责拆分（2026-09-06）
+
+本轮将 `lowerContiguousUnitStride` 中单个 result chunk 的 vreg 合同、连续 offset 计算
+和 `vlds` 发射抽取为 `materializeContiguousUnitStrideChunk`。外层函数继续负责 physical
+lane 推导、chunk 遍历和结果替换；unit-stride 地址步进、结果顺序、普通 load 语义及失败
+诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_load.pto                    # exit=0
+```
+
 # contiguous group-load 单 chunk 物化职责拆分（2026-09-06）
 
 本轮将 `OneToNVMIGroupLoadOpPattern::lowerContiguousChunks` 中单个 group/chunk 的

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3130,6 +3130,24 @@ vmi_layout_assignment_intlv_lane_stride.pto            # exit=0
 部分 direct interleave lit case 仍会在测试自身的 VMI `unpack` 前置 invariant 处提前失败，
 未进入本轮分类逻辑。
 
+# expand-load runtime 路径职责拆分（2026-09-06）
+
+本轮将 `OneToNVMIExpandLoadOpPattern::matchAndRewrite` 中 runtime expand-load 的物理
+arity/type 合同、索引载体构造、`vgather2.bc`/`vsel` 发射和结果替换抽取为
+`lowerRuntimeExpandLoad`。入口继续负责 source/offset 归一化、result type 转换和 static
+all-active 快路径选择；runtime gather 的 index 语义、mask/passthru 使用及失败诊断保持
+不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
+`vmi_to_vpto_ensure_mask_granularity_direct.pto` 在测试自身的 VMI `unpack` 前置 invariant
+处提前失败，未进入本轮 runtime expand-load helper。
+
 # deinterleave-load 结果类型合同拆分（2026-09-06）
 
 本轮将 `OneToNVMIDeinterleaveLoadOpPattern::matchAndRewrite` 中 low/high physical result

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,19 @@
 # VMIToVPTO 静态分析报告记录
 
+## group-broadcast 单 chunk 物化拆分（2026-09-06）
+
+本轮将 `lowerGroupBroadcastResultChunks` 中单 physical result 的类型合同检查与 chunk
+物化抽取为 `lowerGroupBroadcastResultChunk`。外层函数继续负责 result layout factor、
+chunk 枚举、flat result 顺序和数量合同；helper 负责 uniform vreg 合同及单 chunk
+`lowerGroupBroadcastChunk` 调用。结果顺序、诊断和 group-broadcast lowering 语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## group-broadcast 支持合同拆分（2026-09-06）
 
 本轮将 `checkGroupBroadcastLogicalContract` 中通用布局/元素/group 合同与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3269,3 +3269,21 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_masked_store.pto                           # exit=0
 ```
+
+# stride memory 合同复用（2026-09-06）
+
+本轮将 `checkSupportedStrideLoadShape` 与 `checkSupportedStrideStoreShape` 中重复的布局、
+contiguous、UB pointer 和单 physical value/mask chunk 校验统一为
+`checkStrideMemoryContract`；store 入口保留其额外的 `checkSupportedStoreShape`，load/store
+仍使用各自的 source/destination 方向诊断。该重构不改变 `vsldb`/`vsstb` 支持范围或 arity
+语义。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
+`vmi_lane_stride_masked_store.pto` 在测试自身已有的 mask layout contract 冲突处提前失败，
+未进入本轮 stride helper。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1815,3 +1815,12 @@ source 与 converted result types；保持 TargetOp 选择、mask 语义、结�
 增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_to_vpto_abs.pto` 与 `vmi_to_vpto_negf.pto` lowering 均
 exit=0。
+
+# mask unary physical chunk lowering 职责整改
+
+本轮将模板 `OneToNVMIMaskUnaryOpPattern::matchAndRewrite` 中 physical arity/type 校验、
+all-true seed mask 构造、目标 mask unary op 发射和结果替换抽取为 `lowerParts`。入口只
+负责 source 与 converted result type 获取；保持 seed mask、TargetOp 选择、结果顺序和
+原有诊断语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_mask_logic.pto` lowering exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2543,6 +2543,17 @@ offset 计算、结果顺序及失败诊断保持不变。增量
 `git diff --check` 通过；现有 group-slot-load case 在既有 pack/unpack invariant 处
 提前终止，未进入本轮 helper。
 
+# dynamic create_group_mask shape 合同职责整改
+
+本轮将 `buildDynamicGroupMaskPlan` 的校验拆为 `checkDynamicGroupMaskLayout` 与
+`getDynamicGroupMaskPhysicalShape`：前者负责 layout、lane_stride、granularity 和
+logical `num_groups * group_size` 合同，后者负责 physical mask granularity、lanes-per-part
+及 result arity。plan builder 继续负责 factor/block 参数推导和 power-of-two block 约束；
+动态 active 元素 clamp、lane index 构造、padding mask 处理、chunk 遍历顺序及诊断语义保持
+不变。增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_create_group_mask_block8_dynamic.pto` lowering
+exit=0。
+
 # group broadcast shape 重构回归修复
 
 复核既有 group-broadcast shape 拆分时发现入口遗漏了结果类型和诊断闭包定义，导致该

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2085,6 +2085,17 @@ mask、结果顺序和诊断语义不变。增量 `check_changed_code.py` 结果
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；本轮未新增可独立进入该
 helper 的 runtime case，未虚构额外回归结果。
 
+# create_mask 常量 chunk 活跃度计算职责整改
+
+本轮在 `OneToNVMICreateMaskOpPattern::lowerConstantMask` 中引入
+`getConstantMaskChunkActivity`，将 physical chunk 的 padding lane 过滤、logical lane 映射
+和 active lane 计数抽取为独立 helper。主函数继续负责 chunk 结束判定、prefix mask 与
+runtime prefix fallback 生成、结果 arity 校验；保持 physical part/chunk 顺序、padding
+语义、mask pattern 选择、诊断和结果顺序不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_create_mask.pto` 在既有 VMI pack/unpack pipeline invariant 处提前失败，未
+进入本轮 helper，不能将该失败归因于本轮改动。
+
 # group broadcast load E2B 结果复用职责整改
 
 本轮在 `OneToNVMIGroupBroadcastLoadOpPattern::lowerDirectE2B` 中引入 `buildE2BResults`，

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3076,6 +3076,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 `vmi_lane_stride_masked_store.pto` 在测试自身的 conflicting mask layout contract 处提前
 失败，未进入本轮 predicate helper。
 
+# shuffle vselr 单 lane 状态更新职责拆分（2026-09-06）
+
+本轮将 `computeShuffleVselrPlanForChunk` 中单 lane 的 source physical 映射、单 source
+chunk 合同和 ASC/DESC 状态更新抽取为 `ShuffleChunkLaneState`/
+`updateShuffleChunkLaneState`。主函数继续负责 lane 遍历、source flat index 计算和最终
+plan 组装；padding/越界诊断、lane 顺序约束及 vselr 支持矩阵保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_shuffle_forwarding.pto                     # exit=0
+```
+
 # narrowing mask granularity 单 chunk 物化职责拆分（2026-09-06）
 
 本轮将 `materializeNarrowingMaskGranularityPart` 中单个结果 chunk 的 source 消耗、

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2500,3 +2500,7 @@ mask 构造和 factor extension 发射；保持分派优先级、part 顺序、�
 增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_to_vpto_group_slot_integer_extension_matrix.pto` lowering
 exit=0。
+
+# compress 结果 shape 合同职责整改
+
+本轮新增 `checkSupportedCompressResultShape`，将 `compress` 的结果 layout 存在性、contiguous 合同、物理 arity 可计算性及单 chunk 约束从入口校验中独立出来。`buildCompressPhysicalShapePlan` 继续只负责 source/mask 的输入合同，`compress_store` 保持独立诊断和 destination `!pto.ptr` 合同；结果布局校验顺序、错误文本、物理 chunk 限制及 lowering 语义均保持不变。增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；`vmi_to_vpto_compress_store.pto` lowering exit=0，普通 compress case 在既有 pack/unpack invariant 处提前终止。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3456,6 +3456,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_group_slot_load.pto              # lowering output generated; command returned an existing test diagnostic
 ```
 
+# group-slot truncation shape 合同拆分（2026-09-06）
+
+本轮将 `lowerGroupSlotTrunc` 中 source/result logical bits、slots/group 数量、支持的
+direct/packed 模式以及 physical arity 合同抽取为 `getGroupSlotTruncModes`。主 lowering
+继续负责 active-slot mask、packed/direct 逐 part 发射和结果收敛；NOSAT/SAT 选择、carrier
+处理、诊断文本及结果顺序保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_trunci_lane_stride.pto           # exit=0
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,19 @@
 # VMIToVPTO 静态分析报告记录
 
+## lambda 显式捕获整改（2026-09-06）
+
+本轮处理报告中的 `G.RES.06-CPP` 风险：将
+`createResidualSubVLGroupPeriodicChunk` 内部 `materializeGroup` lambda 从默认引用捕获
+改为显式捕获实际使用的局部对象和值。lambda 的行为、算术方向、lane mask 生成和失败
+传播保持不变；文件中不再保留 `[&]`/`[=]` 默认捕获。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## shuffle vselr chunk 计数职责拆分（2026-09-06）
 
 本轮将 `computeShuffleVselrPlans` 中 result physical chunk 数量查询与计划遍历分离，

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3469,6 +3469,21 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 ```
 
+# slots=8 lane-stride stream materialization 拆分（2026-09-06）
+
+本轮将 `lowerSlots8LaneStride` 的 unaligned fallback 中 compact layout 转换和 stream
+advance 计算抽取为 `materializeLaneStrideStreamValues` 与
+`buildLaneStrideStreamAdvances`。主函数继续负责 direct-memory 判定、stream 发射和 op
+生命周期；compact value 顺序、advance 语义、失败传播及 aligned 路径保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_group_store_slots8_packed_byte.pto         # exit=0
+```
+
 # interleave lowering 入口合同与布局查询拆分（2026-09-06）
 
 本轮将模板 `OneToNVMIInterleaveOpPattern::matchAndRewrite` 中的结果物理类型/输入输出

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,20 @@
 # VMIToVPTO 静态分析报告记录
 
+## contiguous group-reduce shape 计划拆分（2026-09-06）
+
+本轮将 `lowerContiguousRows` 中的 chunk 形状推导、group 数量/每组 chunk 数、slots=1
+结果布局识别和 source/mask/result arity 合同抽取为
+`getContiguousGroupReduceShape` 与 `ContiguousGroupReduceShape`。主 lowering 继续负责
+physical type 合同、first-lane mask、逐 group reduction 和结果恢复；group 顺序、slots=1
+结果映射、失败诊断及 reduction 语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## shuffle vselr source 合同拆分（2026-09-06）
 
 本轮将 `buildShuffleVselrResult` 中 source part 边界及 source/result vreg 类型合同抽取为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2613,3 +2613,14 @@ exit=0。
 physical part type 选择。补齐循环大括号并保持 part 数量、类型和失败语义不变。增量
 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；direct/multistep mask granularity lowering case 均 exit=0。
+
+# data layout materialization context 数据泥团整改
+
+本轮引入 `DataLayoutMaterializationContext` 与 `tryDataLayoutMaterializer`，统一承载
+data-layout conversion 四路 materializer 共同使用的 operation、source/result parts、
+layout、source element type 和 rewriter。入口仍严格按 simple → deinterleaved2 →
+lane-stride → intermediate 顺序尝试，保持 optional/failure 传播、递归转换和 unsupported
+诊断不变；lambda 改为显式接收 context，避免重复默认捕获和参数泥团。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_ensure_layout_dense_composed.pto` 与 mask
+conversion case lowering 均 exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3428,6 +3428,20 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_group_broadcast_load_e2b_b16.pto # exit=0
 ```
 
+# group-slot-load 单组 BRC 路径拆分（2026-09-06）
+
+本轮将 `lowerGroupSlotLoadSlots8` 中 `numGroups == 1` 的 BRC 结果类型、dist 查询和
+`vlds` 构造抽取为 `lowerSingleGroupSlotLoad`。slots=8 多组 `vsldb` 路径、mask 构造、
+offset 计算和支持矩阵保持不变；单组路径的诊断和结果顺序保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_group_slot_load.pto                        # blocked by pre-existing VMI-PASS-INVARIANT
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2135,6 +2135,15 @@ chunk 顺序、诊断及结果替换语义不变。增量 `check_changed_code.py
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_group_broadcast_load_e2b_b16.pto` lowering exit=0。
 
+# group broadcast load E2B 单 packet 发射职责整改
+
+本轮在 `OneToNVMIGroupBroadcastLoadOpPattern::emitE2BPackets` 中引入 `emitE2BPacket`，
+将单 packet 的结果 vreg 校验、chunk offset 计算和 `VldsOp` 发射抽取为独立 helper。主
+函数继续负责 packet 数量与 result type 选择；保持 E2B dist、chunk 步长、packet 顺序、
+诊断和结果复用语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_group_broadcast_load_e2b_b16.pto` lowering exit=0。
+
 # slots=8 lane-stride group store direct 发射职责整改
 
 本轮在 `OneToNVMIGroupStoreOpPattern::lowerSlots8LaneStride` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2533,6 +2533,16 @@ plan builder 仍负责输入类型/layout、组数、lanes-per-part 和 group si
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；E2B group-broadcast
 case lowering exit=0。
 
+# group slot load 结果类型职责整改
+
+本轮新增 `GroupSlotLoadResultPart` 与 `getGroupSlotLoadResultPart`，统一封装 slots=1/8
+路径重复的物理 vreg 类型和 mask 类型推导。两个 lowering helper 继续分别负责 unit-stride
+slots=8 的 BRC/VS LDB 发射和 slots=1 的单 block VS LDB 地址推进；分派、mask pattern、
+offset 计算、结果顺序及失败诊断保持不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；现有 group-slot-load case 在既有 pack/unpack invariant 处
+提前终止，未进入本轮 helper。
+
 # group broadcast shape 重构回归修复
 
 复核既有 group-broadcast shape 拆分时发现入口遗漏了结果类型和诊断闭包定义，导致该

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3113,3 +3113,18 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_truncf_bf16x2_d4_packed4.pto               # exit=0
 ```
+
+# scatter shape 类型上下文整改（2026-09-06）
+
+本轮引入 `ScatterShapeTypes`，集中承载 scatter 的 value、indices 和 mask 物理类型，
+并由 `getScatterShapeTypes` 统一执行类型提取。`checkSupportedScatterShape` 现在只负责编
+排验证顺序：布局/目的地址合同 → 元素合同 → physical chunk 合同；没有改变 arity、类型
+支持矩阵、失败诊断或 physical lowering 语义。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_scatter.pto                      # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3323,3 +3323,18 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 
 active-prefix/compress 代表性测试在既有 VMI pack/unpack pipeline invariant 处提前失败，未
 进入本轮 helper。
+
+# compress-store destination 合同拆分（2026-09-06）
+
+本轮将 `checkSupportedCompressStoreShape` 中 `!pto.ptr` destination 检查抽取为
+`checkCompressStoreDestination`，使 compress physical plan 合同与 `vstur` pointer 合同
+分离。原有 source/mask full-chunk、单 physical chunk 限制、SQZN 相关诊断和失败顺序保持
+不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_compress_store.pto                         # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1844,3 +1844,12 @@ predicate mode、signedness bitcast、结果顺序、mask 语义和原有诊断�
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_cmp_select.pto` 当前在既有 VMI pack/unpack pipeline invariant 处提前失败，
 未进入本轮 helper，不能将该失败归因于本轮改动。
+
+# vselr physical part lowering 职责整改
+
+本轮将 `OneToNVMIVselrOpPattern::matchAndRewrite` 中单 physical part 的 source/index/result
+类型合同与 `VselrOp` 发射抽取为 `lowerPart`。入口继续负责 one-part arity 限制和结果
+替换；保持 element-count/storage-width 匹配规则、结果类型、结果顺序和原有诊断不变。
+同时将相邻 `active_prefix_index` 的条件判断改为具名布尔值并补齐大括号，以满足
+`G.FMT.11-CPP`。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_vselr.pto` lowering exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2084,3 +2084,12 @@ combine mask 构造以及 `sum01/sum23/final` 树形合并抽取为独立 helper
 mask、结果顺序和诊断语义不变。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；本轮未新增可独立进入该
 helper 的 runtime case，未虚构额外回归结果。
+
+# one-block group-reduce 单结果构造职责整改
+
+本轮在 `OneToNVMIGroupReduceOpPattern::lowerOneBlock` 中引入
+`buildOneBlockGroupResult`，将单个 physical chunk 的 source/mask/result 类型合同检查与
+`GroupReduceOp` 发射抽取为独立 helper。主函数继续负责 arity、基础 physical 类型获取、
+结果遍历和替换；保持 source/mask 对应关系、结果顺序、诊断和 lowering 语义不变。增量
+`check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
+通过；本轮未新增可独立进入该 helper 的 runtime case，未虚构额外回归结果。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2086,6 +2086,15 @@ rank 语义、layout/element count 传播及错误诊断不变。并移除未使
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_ensure_mask_granularity_multistep.pto` 与直接转换 case lowering 均 exit=0。
 
+# mask granularity 路由分类职责整改
+
+本轮新增 `MaskGranularityRoute` 与 `classifyMaskGranularityRoute`，将 source/result rank
+解析、合法性检查和 adjacent/多步路径分类从转换入口中独立出来。入口现在只负责先做
+通用 materialization 合同校验，再按 route 分派 adjacent 或多步转换；保持 rank 数值、
+adjacent 判定、结果顺序和失败诊断语义不变。增量 `check_changed_code.py --base HEAD`
+结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；直接和多步
+mask granularity lowering case 均 exit=0。
+
 # vmull 物理 shape 合同职责整改
 
 本轮新增 `checkVmullPhysicalShape`，将 vmull 的 physical lane 数、physical data element

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1888,3 +1888,11 @@ pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败
 cmpf/cmpi、传递对应 op 名称和 predicate checker；保持原有检查顺序、错误诊断来源、
 predicate 支持集合及 `WalkResult` 语义不变。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+
+# compression verifier 分派职责整改
+
+本轮为 `verifySupportedVMICompressionOp` 引入模板 helper `verifyCompressionShape`，统一
+active_prefix_index、compress 和 compress_store 的 shape check、reason 收集、诊断前缀和
+`WalkResult` 处理。各操作仍保留原有 shape checker、诊断正文、操作识别顺序和成功/失败
+语义，避免重复控制流。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1787,3 +1787,13 @@ physical arity 检查与结果收集；保持 `VmulaOp(acc, lhs, rhs, mask)` ope
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
 `vmi_to_vpto_fma.pto` 当前在既有 VMI pack/unpack pipeline invariant 处提前失败，未进入
 本轮 helper，不能将该失败归因于本轮改动。
+
+# vexpdif physical chunk lowering 职责整改
+
+本轮将 `OneToNVMIVexpdifOpPattern::matchAndRewrite` 的 f32 与 f16 两类 physical chunk
+校验和目标指令发射分别抽取为 `lowerF32Part`、`lowerF16Part`。入口继续负责 merge
+predicate mode 拒绝、输入 arity、源元素类型和结果组数判定；保持 f32 使用 ODD、f16
+按 EVEN/ODD 展开、结果顺序、mask 粒度（b32/b16）和原有诊断不变。为满足 `G.FMT.11-CPP`
+同时补齐本入口控制流大括号。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_vexpdif_f16.pto` 与 `vmi_to_vpto_vexpdif_f32.pto` lowering 均 exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2064,6 +2064,17 @@ exit=0，现有 slots=1 的 EVEN/P0 转换输出保持不变。
 `git diff --check` 通过；`vmi_to_vpto_load_store_contiguous.pto` 完整 lowering pipeline
 exit=0。
 
+# group load 布局分派职责整改
+
+本轮将 `OneToNVMIGroupLoadOpPattern::matchAndRewrite` 中 block-deinterleaved f32 特殊路径
+判断抽取为 `lowerByLayout`。入口现在只负责 source/offset/row_stride 的单值归一化，
+helper 负责在保持原优先级下选择 block-f32 或 contiguous lowering；group size、结果类型、
+row stride、`vsldb`/`vlds` 发射、结果顺序和失败诊断均保持不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过。`vmi_to_vpto_group_load_support.pto` 尝试 lowering 时在既有
+VMI pack/unpack pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败归因于
+本轮改动。
+
 # truncf 物理类型合同职责整改
 
 本轮在 `OneToNVMITruncFOpPattern` 中新增 `getUniformSourceType` 与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2054,3 +2054,13 @@ combine 的校验及发射职责；保持结果组顺序、目标类型、诊断
 增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_to_vpto_group_reduce_slots8.pto` 在既有 VMI pack/unpack
 pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。
+
+# contiguous group-reduce 结果恢复职责整改
+
+本轮在 `OneToNVM​​IGroupReduceOpPattern::lowerContiguousRows` 中引入
+`restoreContiguousGroupResults`，将每组 reduction 结果的目标类型 bitcast、slots=1 与
+重复 chunk 结果布局恢复抽取为独立 helper。主 lowering 继续负责 contiguous chunk 合约、
+物理类型/arity 校验、row reduction 与 combine；保持结果组顺序、目标布局、结果复制规则、
+诊断和替换语义不变。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_group_reduce_typed.pto` 在既有 VMI pack/unpack
+pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1923,3 +1923,14 @@ chunk 首 lane mask 构造、逐 chunk `vcadd`/`vadd` 累加和结果替换抽�
 增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；现有 reduce_add cases 在既有 VMI pack/unpack pipeline invariant
 处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。
+
+# histogram lowering 物理计划整改
+
+本轮为共享模板 `lowerVMIHistogramToVPTO` 引入 `HistogramPhysicalPlan` 与
+`prepareHistogramPhysicalPlan`，将 accumulator half 数量、source/mask arity、ui16
+accumulator 类型、source lane 数以及 Bin_N0/Bin_N1 常量准备从 lowering 遍历中分离。主
+函数现在只负责按物理 chunk 调用 `lowerHistogramChunk` 和结果扁平化；保持一/两 half
+支持、tail b8 mask、bin 常量、dhistv2/chistv2 TargetOp 选择和结果顺序不变。增量
+`check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
+通过；现有 vdhist/vchist cases 在既有 VMI pack/unpack pipeline invariant 处提前失败，
+未进入本轮 helper，不能将该失败归因于本轮改动。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,18 @@
 # VMIToVPTO 静态分析报告记录
 
+## structured-store verifier 语义族拆分（2026-09-06）
+
+本轮将 `verifySupportedVMIStructuredStoreOp` 按 interleave、group、stride、scatter 四类
+op 拆为独立 helper，入口只负责保持 masked-store 优先级并顺序分派。每类仍调用原有
+shape check 和诊断文本，masked-store 优先级、支持矩阵及 `WalkResult` 行为保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
 ## normal-reduction verifier 浮点/整数分派拆分（2026-09-06）
 
 本轮将 `verifySupportedVMINormalReductionOp` 拆为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3544,6 +3544,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_to_vpto_vintlv_d2_to_d4.pto                        # blocked by pre-existing VMI-PASS-INVARIANT
 ```
 
+# masked-store contiguous chunk 发射拆分（2026-09-06）
+
+本轮将 `OneToNVMIMaskedStoreOpPattern::lowerContiguous` 中逐 physical chunk 的 value/mask
+类型检查、active lane 计算、predicate 物化、地址对齐校验和 `vsts` 发射抽取为
+`emitContiguousMaskedStorePart`。主函数继续负责 value/mask layout conversion、arity
+检查和 chunk 遍历，零 active lane、诊断文本及 store 顺序保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_masked_store.pto                           # exit=0
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2240,6 +2240,16 @@ source lane 与 slot mask 准备及结果替换；保持 EVEN/P0 part、slot mas
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_to_vpto_group_slot_integer_extension_matrix.pto` lowering exit=0。
 
+# zero-copy interleave 结果合同职责整改
+
+本轮在 `OneToNVMIInterleaveOpPattern::materializeZeroCopyResults` 中引入
+`validateZeroCopyResultParts`，将 low/high result type 合并、结果 arity 校验和 physical
+part 类型校验抽取为独立 helper。主函数继续负责 vintlv/vdintlv 的 zero-copy 重排；保持
+结果顺序、slice 布局、诊断及失败语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_vdintlv.pto` lowering exit=0（仅有 unified op 无 legacy equivalent 的既有
+remark）。
+
 # ExtI dense lane-stride 单结果发射职责整改
 
 本轮在模板 `OneToNVMIExtIOpPattern::emitDenseLaneExtension` 中引入

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3413,6 +3413,21 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_intlv.pto                        # exit=0
 ```
 
+# group-broadcast slots=1 lane 映射拆分（2026-09-06）
+
+本轮将 `materializeSlots1GroupBroadcastChunk` 中按物理 lane 映射 source chunk、校验布局
+selector 关系并收集 active source 的逻辑抽取为 `mapSlots1GroupBroadcastSources`。原 helper
+继续负责结果 mask 构造、Vdup/VSEL 合并和结果返回；padding lane、越界检查、诊断文本及
+合并顺序保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_layout_assignment_group_broadcast_load_e2b_b16.pto # exit=0
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2064,6 +2064,18 @@ exit=0，现有 slots=1 的 EVEN/P0 转换输出保持不变。
 `git diff --check` 通过；`vmi_to_vpto_load_store_contiguous.pto` 完整 lowering pipeline
 exit=0。
 
+# truncf 物理类型合同职责整改
+
+本轮在 `OneToNVMITruncFOpPattern` 中新增 `getUniformSourceType` 与
+`getUniformResultTypes`，将源 physical part 的非空/vreg/统一类型校验和结果 physical
+part 的统一类型校验从主 lowering 分派中独立出来。主函数仍保留 packed bf16x2 视图构造、
+group-slot 特殊路径、同宽转换、dense lane-stride 与 factor 窄化路径的优先级；结果宽度
+有效性仍在原位置检查，避免把不同的 width contract 与“类型一致性”错误合并。源/结果
+arity、part 顺序、mask、诊断和 lowering 语义保持不变。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过。尝试的 truncf case 在现有 pipeline 的依赖覆盖检查处失败，
+未产生本轮 helper 的编译或 lowering 诊断，不能将该失败归因于本轮改动。
+
 # iota 物化上下文数据泥团整改
 
 本轮引入轻量 `IotaMaterializationContext`，统一携带 iota 三类物化路径共同需要的

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1,5 +1,22 @@
 # VMIToVPTO 静态分析报告记录
 
+## 动态 group-mask lane index 职责拆分（2026-09-06）
+
+本轮将 `buildDynamicGroupMaskLaneIndex` 的索引构造拆为两个明确阶段：
+`buildDynamicGroupMaskBlockIndex` 负责 chunk 内索引、block 编号和 block 内 lane，
+`buildDynamicGroupMaskLogicalLane` 负责 factor/part 映射及最终 logical lane 合成。
+同时把 block size 的幂次约束从隐含解引用改为显式诊断，避免非法布局在创建 shift 前触发
+未定义状态。动态 mask 的 lane 结果、padding 处理和失败传播保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+ninja -C build pto-test-opt                            # blocked by existing /cann-cmake permission
+```
+
+
 ## 报告来源与范围
 
 本文记录 2026-09-05 从内部静态分析报告导入的结果，目标文件为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2411,6 +2411,17 @@ stride 规则、诊断和失败传播保持不变。增量检查结果为 `check
 `git diff --check` 通过。现有 group-slot load 样例分别在既有 pack/unpack 或测试 region
 前置约束处终止，未进入本轮 helper，未归因于本轮修改。
 
+# masked-store shape 合同职责整改（2026-09-06）
+
+本轮将 `checkSupportedMaskedStoreShape` 的完整 physical chunk 快路径抽取为
+`checkMaskedStoreFullChunks`，将 layout/arity、dense-lane-stride support 和 contiguous
+materialization arity 检查抽取为 `checkMaskedStoreLayoutAndArity`。主函数继续负责 predicate
+memory access proof 及两阶段失败回退，保持 masked-store 的支持范围、诊断和失败传播不变；
+同时清理相邻 shuffle helper 的控制流大括号。增量检查结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_load_store_contiguous.pto` lowering exit=0。lane-stride masked-store 样例在
+既有 `ensure_mask_layout` 前置约束处终止，未进入本轮 helper。
+
 # scatter shape 合同职责整改（2026-09-06）
 
 本轮将 `checkSupportedScatterShape` 的布局/目标指针校验抽取为

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -221,6 +221,10 @@ mask 的语义差异只存在于 active-lane 判定。补齐该批代码及 scal
 触及的控制语句大括号后，增量合规检查结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过。
 
+相关回归中 `vmi_to_vpto_stride_store.pto` 与 `vmi_layout_assignment_scatter.pto` 完整
+lowering exit=0；其余本轮抽样的 lane-stride 或非法 gather/scatter case 分别在既有
+layout/invariant 或预期的 invalid-shape 诊断处终止，未显示本轮控制流整改引入的新错误。
+
 本轮还将 `computeSafeStatefulReadProof` 中的字节范围乘法、32-byte rounding 和物理访问
 包络计算抽取为 `buildStatefulReadEnvelopes`，使安全证明入口只负责静态 shape、offset
 范围、元素宽度与 footprint 前置条件。所有 `MulOverflow`/`AddOverflow`/`SubOverflow`

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3500,6 +3500,20 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 vmi_layout_assignment_group_broadcast_load_e2b_b16.pto # exit=0
 ```
 
+# block-deinterleaved group-load shape 合同拆分（2026-09-06）
+
+本轮将 `lowerBlockF32` 中 group size/factor、num_groups、row_stride、pointer 类型等
+入口 shape 合同抽取为 `validateBlockF32Shape`。主函数继续负责结果类型获取、block/chunk
+均匀性检查和实际 lowering；原有检查顺序、诊断语义及 block-deinterleaved 发射保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_load_store_contiguous.pto                  # exit=0
+```
+
 # load physical plan 构造职责拆分（2026-09-06）
 
 本轮将 `OneToNVMILoadOpPattern::buildPhysicalPlan` 中 converted result type 获取与

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2311,6 +2311,14 @@ stream advance、诊断和 direct/fallback 语义不变。增量 `check_changed_
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
 `vmi_layout_assignment_group_store_slots1_unit_stride.pto` 完整 lowering pipeline exit=0。
 
+# group-store 通用 shape 校验控制流整改（2026-09-06）
+
+复核 `checkSupportedGroupStoreShape` 拆分后的通用 layout helper 时，补齐了 support-table、
+store-shape、one-block plan 和 contiguous-chunk 检查分支的大括号。该轮只规范失败路径
+控制流，不改变 compact-small、group-slots、one-block、deinterleaved 与 contiguous 的
+检查优先级、诊断和支持范围。增量 `check_changed_code.py --base origin/master` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过。
+
 # 本轮 G.FMT.11-CPP 增量整改（2026-09-06）
 
 本轮继续清理完整文件增量检查覆盖到的控制语句：为 iota contiguous/deinterleaved

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3237,3 +3237,20 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_ensure_mask_granularity.pto                # exit=0
 ```
+
+# expand-load all-active 路径判断拆分（2026-09-06）
+
+本轮将 `checkSupportedExpandLoadShape` 中 static all-active mask、full physical chunk 与
+read-safety proof 的组合判断抽取为 `hasSafeExpandLoadAllActivePath`。主 checker 继续负
+责 common shape、runtime-mask fallback 与诊断拼接；full-read 安全条件、fallback reason
+和 runtime path 选择语义保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+```
+
+`vmi_to_vpto_expand_load_all_active.pto` 在既有 VMI pack/unpack pipeline invariant 处提
+前失败，未进入本轮 helper。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3095,6 +3095,22 @@ vmi_to_vpto_load_deint.pto                            # reaches existing pack/un
 相关 deinterleaved load case 在测试自身的 VMI `unpack` 前置 invariant 处提前失败，未
 进入本轮单组物化 helper；该既有输入限制已记录。
 
+# unaligned deinterleave-load 单 pair 物化职责拆分（2026-09-06）
+
+本轮将 `OneToNVMIDeinterleaveLoadOpPattern::lowerUnaligned` 中单个 low/high pair 的
+物理类型校验、两次 `vldus`、`vdintlv` 以及 stateful `base/align` 更新抽取为
+`materializeUnalignedLoadPair` 和 `UnalignedDeinterleaveLoadPair`。外层循环继续负责
+初始化 `vldas` 状态、按 pair 遍历、结果分区和最终替换；stream 状态链、increment、结果
+顺序及失败诊断保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_deinterleave_load_layout_propagation.pto           # exit=0
+```
+
 随后将 `computeShuffleVselrPlanForChunk` 中的结果物理 lane 校验、逻辑 lane 越界检查和
 source lane 映射抽取为 `getShuffleSourceLane`。规划函数继续负责 source chunk 一致性与
 ASC/DESC 方向推导，抽取没有改变失败诊断、迭代顺序或最终 `ShuffleVselrPlan` 内容；增量

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3097,3 +3097,19 @@ git diff --check                                      # passed
 check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
 vmi_to_vpto_ensure_mask_granularity.pto                # exit=0
 ```
+
+# truncf 合同判断职责拆分（2026-09-06）
+
+本轮将 `OneToNVMITruncFOpPattern::matchAndRewrite` 中 packed-fp 合同判断和 group-slot
+布局识别分别抽取为 `hasUnsupportedPackedTruncFConversion` 与
+`hasGroupSlotTruncFLayouts`。入口继续负责结果类型转换和后续 same-width、lane-stride、
+factor narrowing 分派；packed carrier 支持矩阵、group-slot 优先级及所有 lowering 语义
+保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_truncf_bf16x2_d4_packed4.pto               # exit=0
+```

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2514,3 +2514,12 @@ exit=0。
 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过。native 增量构建仍被工作区既有 CMake 外部依赖尝试创建
 `/cann-cmake` 的权限错误阻断，未产生本轮 C++ 编译诊断。
+
+# group broadcast shape 重构回归修复
+
+复核既有 group-broadcast shape 拆分时发现入口遗漏了结果类型和诊断闭包定义，导致该
+路径无法通过 C++ 编译。现已补齐 `resultType` 的操作数类型提取及局部 `fail` 诊断 helper，
+不改变任何 shape 判定、错误文本或 lowering 分派。增量
+`check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_layout_assignment_group_broadcast_load_e2b_b16.pto`
+完整 lowering pipeline exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1744,6 +1744,16 @@ result 类型校验、结果位宽判断、EVEN/P0 选择、round mode 计算和
 `git diff --check` 通过；现有 group-slot truncf cases 在既有 VMI pack/unpack pipeline
 invariant 处提前失败，未进入本轮 helper。
 
+# truncf dense lane-stride 发射整改
+
+本轮将 `OneToNVMITruncFOpPattern::matchAndRewrite` 中 dense contiguous→lane_stride 路径
+的 all-true source mask、round/saturate、EVEN/P0 part 属性、packed BF16x2 source view、
+逐 chunk `VcvtOp` 发射和结果替换抽取为 `lowerDenseLaneStride`。入口继续负责识别
+32→16、32→8、16→8 的布局关系并选择 part；保持 source view、mask、round/saturate、
+结果顺序和诊断语义不变。增量 `check_changed_code.py` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；
+`vmi_to_vpto_truncf_bf16x2_d2_lane_stride2.pto` lowering exit=0。
+
 # reduce_min/max physical 校验整改
 
 本轮将模板 `OneToNVMIReduceMinMaxOpPattern::matchAndRewrite` 中 min/max reduction 共用

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1806,3 +1806,12 @@ all-true seed mask 构造、目标 mask binary op 发射和结果替换抽取为
 选择、结果顺序、mask 语义和原有诊断不变。增量 `check_changed_code.py` 结果为
 `checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；仓库当前没有针对该
 模板的独立 `vmi_to_vpto` lit case，未虚构额外测试结果。
+
+# unary physical chunk lowering 职责整改
+
+本轮将模板 `OneToNVMIUnaryOpPattern::matchAndRewrite` 中 physical arity/type 校验、
+all-true mask 构造、目标 unary op 发射和结果替换抽取为 `lowerParts`。入口仅负责取得
+source 与 converted result types；保持 TargetOp 选择、mask 语义、结果顺序和原有诊断不变。
+增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_abs.pto` 与 `vmi_to_vpto_negf.pto` lowering 均
+exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -3329,6 +3329,22 @@ check_changed_code.py --base origin/master            # checked_files=1 errors=0
 现有 static/runtime expand-load case 在测试自身的 VMI `unpack` 前置 invariant 处提前
 失败，未进入本轮 chunk helper。
 
+# residual sub-VL grouped-iota 单 group 物化职责拆分（2026-09-06）
+
+本轮将 `createResidualSubVLGroupPeriodicChunk` 中单个 local group 的方向调整、offset
+scalar 构造、lane range mask 和 `vsel` 合并抽取为局部 group 物化步骤。外层函数继续负责
+zero 初始化、group 遍历和结果累积；ASC/DESC 方向、浮点/整数 offset 语义、lane 范围和
+失败传播保持不变。
+
+本轮验证：
+
+```text
+git diff --check                                      # passed
+check_changed_code.py --base origin/master            # checked_files=1 errors=0 warnings=0
+vmi_to_vpto_iota_group2.pto                            # exit=0
+vmi_to_vpto_iota_group_subvl.pto                       # exit=0
+```
+
 # contiguous group-reduce 单 group 物化职责拆分（2026-09-06）
 
 本轮将 `buildContiguousGroupReduceResults` 中单个 group 的 source/mask 类型检查、逐

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2664,3 +2664,12 @@ block-deinterleaved/group-slots carrier 的映射、granularity 传播和失败�
 增量 `check_changed_code.py --base HEAD` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；vdintlv case 在既有 pack/unpack invariant 处提前终止，未进入
 本轮 carrier helper。
+
+# mask lane-stride factor 校验职责整改
+
+本轮新增 `checkMaskLaneStrideFactor`，将 lane-stride route 的 factor 合法性（仅支持 2/4）
+及方向相关诊断从 `materializeMaskLaneStrideLayout` 中独立出来。入口现在只负责 route
+查询、factor 校验和 pack/unpack 分派；结果 arity、pack/unpack 指令序列、mask 合并及失败
+传播保持不变。增量 `check_changed_code.py --base HEAD` 结果为
+`checked_files=1 errors=0 warnings=0`，`git diff --check` 通过；layout 和 mask
+granularity lowering case 均 exit=0。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -2382,6 +2382,16 @@ slots=1 group-slot-load 元素宽度检查的大括号。增量检查结果为
 `vmi_to_vpto_load_store_contiguous.pto` lowering exit=0；两个 group-load stride store
 样例在既有测试 IR 的整体 region/前置约束处终止，未进入本轮 helper，不能归因于本轮修改。
 
+# expand-load shape 公共合同整改（2026-09-06）
+
+本轮将 `checkSupportedExpandLoadShape` 中 memory access plan、result/passthru/mask layout
+存在性及 contiguous 合同抽取为 `checkSupportedExpandLoadCommonShape`。主函数现在只负责
+静态 all-active mask 判定、full-chunk/read-safety 快路径和 runtime-mask fallback；同时将
+静态 full-chunk 条件命名，补齐控制流大括号。expand 语义、runtime 路径支持范围、诊断和
+失败传播保持不变。增量检查结果为 `checked_files=1 errors=0 warnings=0`，`git diff --check`
+通过；`vmi_to_vpto_load_store_contiguous.pto` lowering exit=0。runtime expand-load 样例在
+既有 VMI pack/unpack invariant 处提前终止，未进入本轮 helper。
+
 本轮尝试重新构建 `pto-test-opt` 时，CMake 仍因工作区既有的 `cann-cmake` 外部依赖
 配置尝试创建 `/cann-cmake` 且权限不足而无法重新配置；该环境问题未产生新的 C++ 编译
 诊断，未删除或重置现有 build tree。

--- a/docs/designs/VMIToVPTO-static-analysis-report.md
+++ b/docs/designs/VMIToVPTO-static-analysis-report.md
@@ -1871,3 +1871,12 @@ arity 限制、converted result type 获取与结果替换；保持压缩语义�
 原有诊断不变。增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
 `git diff --check` 通过；`vmi_to_vpto_compress.pto` 当前在既有 VMI pack/unpack
 pipeline invariant 处提前失败，未进入本轮 helper，不能将该失败归因于本轮改动。
+
+# compress_store lowering 职责整改
+
+本轮将 `OneToNVMICompressStoreOpPattern::matchAndRewrite` 中 physical value/mask/ptr 类型
+校验、地址计算、`VsqzOp` 压缩、align 初始化及 `VsturOp`/`VstarOp` 发射抽取为
+`lowerStore`。入口继续负责 destination/offset 单值归一化和 one-part arity 校验；保持
+`POST_UPDATE` stream 语义、align 状态更新顺序、store base 计算、结果擦除和原有诊断不变。
+增量 `check_changed_code.py` 结果为 `checked_files=1 errors=0 warnings=0`，
+`git diff --check` 通过；`vmi_to_vpto_compress_store.pto` lowering exit=0。

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -14867,6 +14867,24 @@ private:
     return success();
   }
 
+  FailureOr<std::pair<ArrayRef<StringRef>, int64_t>> getExtensionPartPlan(
+      OpT op, ArrayRef<Value> sourceParts, ArrayRef<Type> resultTypes,
+      unsigned sourceBits, unsigned resultBits,
+      OneToNPatternRewriter &rewriter) const {
+    if (resultBits == sourceBits * 2 &&
+        resultTypes.size() == 2 * sourceParts.size()) {
+      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+      return std::make_pair(ArrayRef<StringRef>(kEvenOddParts), 2);
+    }
+    if (resultBits == sourceBits * 4 &&
+        resultTypes.size() == 4 * sourceParts.size()) {
+      static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
+      return std::make_pair(ArrayRef<StringRef>(kPacked4Parts), 4);
+    }
+    return rewriter.notifyMatchFailure(
+        op, "unsupported physical integer extension source/result width relation");
+  }
+
   FailureOr<Value> buildDenseGroupSlotExtensionResult(
       OpT op, Value sourcePart, Type resultType, VMIVRegType sourceVMIType,
       VMIVRegType resultVMIType, IntegerType resultIntegerType,
@@ -15064,22 +15082,11 @@ private:
                                     sourceType, part, rewriter);
     }
 
-    ArrayRef<StringRef> parts;
-    int64_t factor = 0;
-    if (resultBits == sourceBits * 2 &&
-        resultTypes.size() == 2 * sourceParts.size()) {
-      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
-      parts = kEvenOddParts;
-      factor = 2;
-    } else if (resultBits == sourceBits * 4 &&
-               resultTypes.size() == 4 * sourceParts.size()) {
-      static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
-      parts = kPacked4Parts;
-      factor = 4;
-    } else {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported physical integer extension source/result width "
-              "relation");
+    FailureOr<std::pair<ArrayRef<StringRef>, int64_t>> partPlan =
+        getExtensionPartPlan(op, sourceParts, resultTypes, sourceBits,
+                             resultBits, rewriter);
+    if (failed(partPlan)) {
+      return failure();
     }
 
     FailureOr<Value> mask =
@@ -15089,7 +15096,8 @@ private:
           op, "failed to build integer extension seed mask");
     }
 
-    return emitFactorExtension(op, sourceParts, resultVRegTypes, parts, factor,
+    return emitFactorExtension(op, sourceParts, resultVRegTypes, partPlan->first,
+                               partPlan->second,
                                *mask, rewriter);
   }
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12013,6 +12013,36 @@ private:
     return success();
   }
 
+  FailureOr<std::pair<MaskType, Value>> buildPackedByteSelectors(
+      VMIGroupStoreOp op, VRegType firstVRegType,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<MaskType> maskType =
+        getMaskTypeForVReg(firstVRegType, rewriter.getContext());
+    FailureOr<Value> allMask =
+        createAllTrueMaskForVReg(op.getLoc(), firstVRegType, rewriter);
+    bool failedMasks = failed(maskType) || failed(allMask);
+    if (failedMasks) {
+      rewriter.notifyMatchFailure(
+          op, "unsupported element type for packed group_store mask");
+      return failure();
+    }
+    auto indexElementType = IntegerType::get(
+        rewriter.getContext(),
+        pto::getPTOStorageElemBitWidth(firstVRegType.getElementType()));
+    auto indexType = VRegType::get(rewriter.getContext(),
+                                   firstVRegType.getElementCount(),
+                                   indexElementType);
+    FailureOr<Value> slotIndex = createGroupSlotIndexVector(
+        op.getLoc(), indexType, /*groupSize=*/8, /*baseGroupSlot=*/0,
+        rewriter);
+    if (failed(slotIndex)) {
+      rewriter.notifyMatchFailure(
+          op, "failed to create packed group_store lane selector");
+      return failure();
+    }
+    return std::make_pair(*maskType, *slotIndex);
+  }
+
   LogicalResult lowerPackedByteSlots8(
       VMIGroupStoreOp op, OneToNPatternRewriter &rewriter,
       ValueRange valueParts, VMIVRegType valueVMIType, VMILayoutAttr layout,
@@ -12025,12 +12055,6 @@ private:
         return rewriter.notifyMatchFailure(
             op, "packed slots=8 group_store requires uniform vreg parts");
       }
-    }
-    FailureOr<MaskType> maskType =
-        getMaskTypeForVReg(firstVRegType, rewriter.getContext());
-    if (failed(maskType)) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported element type for packed group_store mask");
     }
     bool alignedSinglePart =
         !laneStrided && numGroups == 8 && valueParts.size() == 1 &&
@@ -12045,28 +12069,18 @@ private:
       return success();
     }
 
-    auto indexElementType = IntegerType::get(
-        rewriter.getContext(),
-        pto::getPTOStorageElemBitWidth(firstVRegType.getElementType()));
-    auto indexType = VRegType::get(rewriter.getContext(),
-                                   firstVRegType.getElementCount(),
-                                   indexElementType);
-    FailureOr<Value> slotIndex = createGroupSlotIndexVector(
-        op.getLoc(), indexType, /*groupSize=*/8, /*baseGroupSlot=*/0,
-        rewriter);
-    FailureOr<Value> allMask =
-        createAllTrueMaskForVReg(op.getLoc(), firstVRegType, rewriter);
-    bool failedLaneSelectors = failed(slotIndex) || failed(allMask);
-    if (failedLaneSelectors) {
-      return rewriter.notifyMatchFailure(
-          op, "failed to create packed group_store lane selector");
+    FailureOr<std::pair<MaskType, Value>> selectors =
+        buildPackedByteSelectors(op, firstVRegType, rewriter);
+    if (failed(selectors)) {
+      return failure();
     }
     bool useDirectPack4 = isDirectMemoryDistAddressLegal(
         op.getDestination(), op.getOffset(),
         getMemoryElementType(op.getDestination().getType()), firstVRegType,
         VPTOMemoryOpFamily::Store, "PK4_B32");
     if (failed(emitPackedByteStoreBlocks(
-            op, rewriter, valueParts, firstVRegType, *maskType, *slotIndex,
+            op, rewriter, valueParts, firstVRegType, selectors->first,
+            selectors->second,
             destination, offset, rowStride, numGroups, useDirectPack4))) {
       return failure();
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12226,6 +12226,31 @@ public:
 struct OneToNVMIFmaOpPattern : OneToNOpConversionPattern<VMIFmaOp> {
   using OneToNOpConversionPattern<VMIFmaOp>::OneToNOpConversionPattern;
 
+private:
+  FailureOr<Value> lowerPart(VMIFmaOp op, Value lhs, Value rhs, Value acc,
+                             Type resultType,
+                             OneToNPatternRewriter &rewriter) const {
+    auto vregType = dyn_cast<VRegType>(resultType);
+    const bool invalidPart =
+        !vregType || lhs.getType() != resultType || rhs.getType() != resultType ||
+        acc.getType() != resultType;
+    if (invalidPart) {
+      rewriter.notifyMatchFailure(op,
+                                  "fma requires matching physical vreg parts");
+      return failure();
+    }
+    FailureOr<Value> mask =
+        createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
+    if (failed(mask)) {
+      rewriter.notifyMatchFailure(op, "unsupported element type for fma");
+      return failure();
+    }
+    return rewriter
+        .create<VmulaOp>(op.getLoc(), resultType, acc, lhs, rhs, *mask)
+        .getResult();
+  }
+
+public:
   LogicalResult
   matchAndRewrite(VMIFmaOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
@@ -12238,29 +12263,24 @@ struct OneToNVMIFmaOpPattern : OneToNOpConversionPattern<VMIFmaOp> {
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (lhsParts.size() != rhsParts.size() ||
+    const bool invalidArity =
+        lhsParts.size() != rhsParts.size() ||
         lhsParts.size() != accParts.size() ||
-        lhsParts.size() != resultTypes.size())
+        lhsParts.size() != resultTypes.size();
+    if (invalidArity) {
       return rewriter.notifyMatchFailure(op, "fma physical arity mismatch");
+    }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (auto [lhs, rhs, acc, resultType] :
          llvm::zip_equal(lhsParts, rhsParts, accParts, resultTypes)) {
-      auto vregType = dyn_cast<VRegType>(resultType);
-      if (!vregType || lhs.getType() != resultType ||
-          rhs.getType() != resultType || acc.getType() != resultType)
-        return rewriter.notifyMatchFailure(
-            op, "fma requires matching physical vreg parts");
-      FailureOr<Value> mask =
-          createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
-      if (failed(mask))
-        return rewriter.notifyMatchFailure(op,
-                                           "unsupported element type for fma");
-      results.push_back(
-          rewriter
-              .create<VmulaOp>(op.getLoc(), resultType, acc, lhs, rhs, *mask)
-              .getResult());
+      FailureOr<Value> result =
+          lowerPart(op, lhs, rhs, acc, resultType, rewriter);
+      if (failed(result)) {
+        return failure();
+      }
+      results.push_back(*result);
     }
 
     replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18549,43 +18549,35 @@ std::optional<WalkResult> verifySupportedVMIHistogramOp(Operation *op) {
   return std::nullopt;
 }
 
+template <typename CompressionOp, typename ShapeCheck>
+std::optional<WalkResult> verifyCompressionShape(
+    CompressionOp op, ShapeCheck check, StringRef diagnostic) {
+  std::string reason;
+  if (succeeded(check(op, &reason))) {
+    return WalkResult::advance();
+  }
+  op.emitError() << kVMIDiagUnsupportedPrefix << diagnostic << reason << ")";
+  return WalkResult::interrupt();
+}
+
 std::optional<WalkResult> verifySupportedVMICompressionOp(Operation *op) {
   if (auto activePrefix = dyn_cast<VMIActivePrefixIndexOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedActivePrefixIndexShape(activePrefix, &reason))) {
-      return WalkResult::advance();
-    }
-    activePrefix.emitError()
-        << kVMIDiagUnsupportedPrefix
-        << "pto.vmi.active_prefix_index lowers through pto.vusqz only for "
-           "one contiguous physical chunk ("
-        << reason << ")";
-    return WalkResult::interrupt();
+    return verifyCompressionShape(
+        activePrefix, checkSupportedActivePrefixIndexShape,
+        "pto.vmi.active_prefix_index lowers through pto.vusqz only for one "
+        "contiguous physical chunk (");
   }
   if (auto compress = dyn_cast<VMICompressOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedCompressShape(compress, &reason))) {
-      return WalkResult::advance();
-    }
-    compress.emitError()
-        << kVMIDiagUnsupportedPrefix
-        << "pto.vmi.compress lowers through pto.vsqz only for one "
-           "contiguous full physical chunk ("
-        << reason << ")";
-    return WalkResult::interrupt();
+    return verifyCompressionShape(
+        compress, checkSupportedCompressShape,
+        "pto.vmi.compress lowers through pto.vsqz only for one contiguous "
+        "full physical chunk (");
   }
   if (auto compressStore = dyn_cast<VMICompressStoreOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedCompressStoreShape(compressStore, &reason))) {
-      return WalkResult::advance();
-    }
-    compressStore.emitError()
-        << kVMIDiagUnsupportedPrefix
-        << "pto.vmi.compress_store lowers through pto.vsqz + pto.vstur "
-           "only for one contiguous full physical chunk with a UB pointer "
-           "destination ("
-        << reason << ")";
-    return WalkResult::interrupt();
+    return verifyCompressionShape(
+        compressStore, checkSupportedCompressStoreShape,
+        "pto.vmi.compress_store lowers through pto.vsqz + pto.vstur only for "
+        "one contiguous full physical chunk with a UB pointer destination (");
   }
   return std::nullopt;
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -21104,14 +21104,8 @@ std::optional<WalkResult> verifySupportedVMISpecialOp(Operation *op) {
   return verifySupportedVMISpecialUnaryOp(op);
 }
 
-std::optional<WalkResult> verifySupportedVMINormalReductionOp(Operation *op) {
-  if (auto reduce = dyn_cast<VMIReduceAddIOp>(op)) {
-    return verifySupportedReduceOp(
-        reduce, false,
-        "pto.vmi.reduce_addi lowers through pto.vcadd only for contiguous "
-        "full 32-bit integer source chunks with matching mask chunks and one "
-        "init/result chunk (");
-  }
+static std::optional<WalkResult> verifySupportedVMINormalFloatReductionOp(
+    Operation *op) {
   if (auto reduce = dyn_cast<VMIReduceAddFOp>(op)) {
     return verifySupportedReduceOp(
         reduce, true,
@@ -21133,6 +21127,18 @@ std::optional<WalkResult> verifySupportedVMINormalReductionOp(Operation *op) {
         "contiguous full source chunks with matching mask chunks and one "
         "init/result chunk (");
   }
+  return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMINormalIntegerReductionOp(
+    Operation *op) {
+  if (auto reduce = dyn_cast<VMIReduceAddIOp>(op)) {
+    return verifySupportedReduceOp(
+        reduce, false,
+        "pto.vmi.reduce_addi lowers through pto.vcadd only for contiguous "
+        "full 32-bit integer source chunks with matching mask chunks and one "
+        "init/result chunk (");
+  }
   if (auto reduce = dyn_cast<VMIReduceMaxIOp>(op)) {
     return verifySupportedReduceOp(
         reduce, false,
@@ -21148,6 +21154,15 @@ std::optional<WalkResult> verifySupportedVMINormalReductionOp(Operation *op) {
         "init/result chunk (");
   }
   return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMINormalReductionOp(
+    Operation *op) {
+  if (auto result = verifySupportedVMINormalFloatReductionOp(op);
+      result.has_value()) {
+    return result;
+  }
+  return verifySupportedVMINormalIntegerReductionOp(op);
 }
 
 static std::optional<WalkResult> verifySupportedVMIGroupFloatReductionOp(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -16430,11 +16430,10 @@ private:
         .getResult();
   }
 
-  LogicalResult lowerLegacyGroupSlotExtension(
+  FailureOr<std::tuple<int64_t, VRegType, Value>> prepareLegacyGroupSlotExtension(
       OpT op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
-      VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
-      VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
-      unsigned sourceBits, unsigned resultBits,
+      VMIVRegType sourceVMIType, VMILayoutAttr sourceLayout,
+      VMILayoutAttr resultLayout, unsigned sourceBits, unsigned resultBits,
       OneToNPatternRewriter &rewriter) const {
     bool invalidShape =
         sourceLayout.getNumGroups() != resultLayout.getNumGroups() ||
@@ -16451,7 +16450,6 @@ private:
       return rewriter.notifyMatchFailure(
           op, "unsupported group-slot integer extension shape");
     }
-    int64_t widenFactor = resultBits / sourceBits;
     FailureOr<int64_t> sourceLanes =
         getDataLanesPerPart(sourceVMIType.getElementType());
     if (failed(sourceLanes)) {
@@ -16473,6 +16471,26 @@ private:
       return rewriter.notifyMatchFailure(
           op, "failed to build group-slot integer extension mask");
     }
+    return std::make_tuple(resultBits / sourceBits, conversionSourceType,
+                           *slotMask);
+  }
+
+  LogicalResult lowerLegacyGroupSlotExtension(
+      OpT op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+      VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
+      unsigned sourceBits, unsigned resultBits,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<std::tuple<int64_t, VRegType, Value>> preparation =
+        prepareLegacyGroupSlotExtension(
+            op, sourceParts, resultTypes, sourceVMIType, sourceLayout,
+            resultLayout, sourceBits, resultBits, rewriter);
+    if (failed(preparation)) {
+      return failure();
+    }
+    int64_t widenFactor = std::get<0>(*preparation);
+    VRegType conversionSourceType = std::get<1>(*preparation);
+    Value slotMask = std::get<2>(*preparation);
     StringAttr part =
         rewriter.getStringAttr(widenFactor == 2 ? "EVEN" : "P0");
     SmallVector<Value> results;
@@ -16480,7 +16498,7 @@ private:
     for (auto [sourcePart, resultType] :
          llvm::zip_equal(sourceParts, resultTypes)) {
       FailureOr<Value> result = buildLegacyGroupSlotExtensionResult(
-          op, sourcePart, resultType, conversionSourceType, *slotMask, part,
+          op, sourcePart, resultType, conversionSourceType, slotMask, part,
           resultBits, rewriter);
       if (failed(result)) {
         return failure();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3243,23 +3243,27 @@ computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(sourceType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return fail("requires known lanes per physical part");
+  }
 
   ArrayRef<int64_t> indices = op.getIndices();
-  if (indices.empty())
+  if (indices.empty()) {
     return fail("requires non-empty indices");
+  }
 
   FailureOr<int64_t> resultFactor = getDataLayoutFactor(resultType);
-  if (failed(resultFactor))
+  if (failed(resultFactor)) {
     return fail("requires assigned result layout");
+  }
 
   SmallVector<int64_t> sourceFlatIndices;
   for (int64_t resultPart = 0; resultPart < *resultFactor; ++resultPart) {
     FailureOr<int64_t> resultChunks =
         getDataChunksInPart(resultType, resultPart);
-    if (failed(resultChunks))
+    if (failed(resultChunks)) {
       return fail("requires known result physical chunks");
+    }
 
     for (int64_t resultChunk = 0; resultChunk < *resultChunks; ++resultChunk) {
       FailureOr<int64_t> sourceFlatIndex =
@@ -18804,6 +18808,7 @@ static FailureOr<ReducePhysicalShapePlan> buildReducePhysicalShapePlan(
     return fail(Twine("requires full source physical chunks so padding lanes "
                       "do not participate in the reduction; ") +
                 fullChunkReason);
+  }
 
   int64_t sourceArity;
   int64_t resultArity;
@@ -19018,16 +19023,18 @@ LogicalResult checkSupportedGroupBroadcastShape(
 LogicalResult checkSupportedVdhistShape(VMIVdhistOp op,
                                        std::string *reason = nullptr) {
   VMILayoutSupport supports;
-  if (succeeded(supports.getVdhistSupport(op, reason)))
+  if (succeeded(supports.getVdhistSupport(op, reason))) {
     return success();
+  }
   return failure();
 }
 
 LogicalResult checkSupportedVchistShape(VMIVchistOp op,
                                        std::string *reason = nullptr) {
   VMILayoutSupport supports;
-  if (succeeded(supports.getVchistSupport(op, reason)))
+  if (succeeded(supports.getVchistSupport(op, reason))) {
     return success();
+  }
   return failure();
 }
 
@@ -19053,9 +19060,12 @@ static FailureOr<VmullShapePlan> buildVmullShapePlan(
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
 
   auto elementType = dyn_cast<IntegerType>(aType.getElementType());
-  if (!elementType || elementType.getWidth() != 32 ||
-      (!elementType.isSignless() && !elementType.isUnsigned()))
+  bool unsupportedElementType =
+      !elementType || elementType.getWidth() != 32 ||
+      (!elementType.isSignless() && !elementType.isUnsigned());
+  if (unsupportedElementType) {
     return fail("requires element type to be exactly i32 or ui32");
+  }
   if (aType != bType || aType != lowType || aType != highType) {
     return fail("requires identical a, b, low, and high VMI vreg types");
   }
@@ -19184,24 +19194,33 @@ checkSupportedVMIAddCarryPorts(VMIVRegType lhsType, VMIVRegType rhsType,
                                ArrayRef<VMIMaskType> maskTypes,
                                std::string *reason = nullptr) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   auto integerType = dyn_cast<IntegerType>(lhsType.getElementType());
-  if (!integerType || integerType.getWidth() != 32)
+  bool unsupportedIntegerType = !integerType || integerType.getWidth() != 32;
+  if (unsupportedIntegerType) {
     return fail("requires 32-bit integer data elements");
-  if (lhsType != rhsType || lhsType != resultType)
+  }
+  bool mismatchedTypes = lhsType != rhsType || lhsType != resultType;
+  if (mismatchedTypes) {
     return fail("requires matching lhs, rhs, and result VMI types");
-  if (!lhsType.getLayoutAttr())
+  }
+  if (!lhsType.getLayoutAttr()) {
     return fail("requires assigned data layout");
-  if (failed(checkSupportedMaskableVReg(lhsType)))
+  }
+  if (failed(checkSupportedMaskableVReg(lhsType))) {
     return fail("requires computable physical data parts");
+  }
 
   FailureOr<int64_t> dataArity = getVMIPhysicalArity(lhsType);
-  if (failed(dataArity) || *dataArity < 1)
+  bool invalidDataArity = failed(dataArity) || *dataArity < 1;
+  if (invalidDataArity) {
     return fail("requires non-empty physical data parts");
+  }
   for (VMIMaskType maskType : maskTypes) {
     if (failed(checkAddCarryMaskPort(maskType, lhsType.getLayoutAttr(),
                                      *dataArity, reason))) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12861,6 +12861,25 @@ public:
 struct OneToNVMICompressOpPattern : OneToNOpConversionPattern<VMICompressOp> {
   using OneToNOpConversionPattern<VMICompressOp>::OneToNOpConversionPattern;
 
+private:
+  FailureOr<Value> lowerPart(VMICompressOp op, Value source, Value mask,
+                             Type resultType,
+                             OneToNPatternRewriter &rewriter) const {
+    auto resultVRegType = dyn_cast<VRegType>(resultType);
+    const bool invalidPart =
+        !resultVRegType || source.getType() != resultType ||
+        !isa<MaskType>(mask.getType());
+    if (invalidPart) {
+      rewriter.notifyMatchFailure(
+          op, "compress requires physical source/mask/result parts");
+      return failure();
+    }
+    return rewriter
+        .create<VsqzOp>(op.getLoc(), resultVRegType, source, mask)
+        .getResult();
+  }
+
+public:
   LogicalResult
   matchAndRewrite(VMICompressOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
@@ -12872,22 +12891,20 @@ struct OneToNVMICompressOpPattern : OneToNOpConversionPattern<VMICompressOp> {
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (sourceParts.size() != 1 || maskParts.size() != 1 ||
-        resultTypes.size() != 1)
+    const bool invalidArity = sourceParts.size() != 1 ||
+                              maskParts.size() != 1 || resultTypes.size() != 1;
+    if (invalidArity) {
       return rewriter.notifyMatchFailure(
           op, "compress supports only one physical part");
+    }
 
-    auto resultType = dyn_cast<VRegType>(resultTypes.front());
-    if (!resultType || sourceParts.front().getType() != resultType ||
-        !isa<MaskType>(maskParts.front().getType()))
-      return rewriter.notifyMatchFailure(
-          op, "compress requires physical source/mask/result parts");
-
-    Value result = rewriter
-                       .create<VsqzOp>(op.getLoc(), resultType,
-                                       sourceParts.front(), maskParts.front())
-                       .getResult();
-    replaceOpWithFlatConvertedValues(rewriter, op, SmallVector<Value>{result},
+    FailureOr<Value> result = lowerPart(op, sourceParts.front(),
+                                        maskParts.front(), resultTypes.front(),
+                                        rewriter);
+    if (failed(result)) {
+      return failure();
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, SmallVector<Value>{*result},
                                      *this->getTypeConverter());
     return success();
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -15242,6 +15242,50 @@ private:
     return success();
   }
 
+  FailureOr<Value> buildFactorTruncResult(
+      VMITruncIOp op, ValueRange sourceParts, Type resultType,
+      int64_t resultIndex, int64_t factor, ArrayRef<StringRef> parts,
+      StringAttr sat, Value sourceMask, Value resultMask,
+      OneToNPatternRewriter &rewriter) const {
+    bool invalidFactor =
+        factor <= 0 || static_cast<size_t>(factor) > parts.size();
+    if (invalidFactor) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported physical trunci conversion factor");
+    }
+    auto resultVRegType = dyn_cast<VRegType>(resultType);
+    if (!resultVRegType) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported physical trunci result type");
+    }
+
+    SmallVector<Value> partials;
+    partials.reserve(static_cast<size_t>(factor));
+    for (int64_t partIndex = 0; partIndex < factor; ++partIndex) {
+      int64_t sourceIndex = resultIndex * factor + partIndex;
+      if (sourceIndex < 0 ||
+          sourceIndex >= static_cast<int64_t>(sourceParts.size())) {
+        return rewriter.notifyMatchFailure(
+            op, "trunci source part index exceeds physical arity");
+      }
+      partials.push_back(
+          rewriter
+              .create<VcvtOp>(op.getLoc(), resultVRegType,
+                              sourceParts[sourceIndex], sourceMask, nullptr, sat,
+                              rewriter.getStringAttr(parts[partIndex]))
+              .getResult());
+    }
+
+    Value merged = partials.front();
+    for (Value partial : llvm::drop_begin(partials)) {
+      merged = rewriter
+                   .create<VorOp>(op.getLoc(), resultVRegType, merged, partial,
+                                  resultMask)
+                   .getResult();
+    }
+    return merged;
+  }
+
   LogicalResult lowerFactorTrunc(
       VMITruncIOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
       ArrayRef<StringRef> parts, int64_t factor, StringAttr sat,
@@ -15265,26 +15309,13 @@ private:
     results.reserve(resultTypes.size());
     for (int64_t resultIndex = 0;
          resultIndex < static_cast<int64_t>(resultTypes.size()); ++resultIndex) {
-      Type currentResultType = resultTypes[resultIndex];
-      SmallVector<Value> partials;
-      partials.reserve(parts.size());
-      for (int64_t partIndex = 0; partIndex < factor; ++partIndex) {
-        Value sourcePart = sourceParts[resultIndex * factor + partIndex];
-        partials.push_back(
-            rewriter
-                .create<VcvtOp>(op.getLoc(), currentResultType, sourcePart,
-                                *sourceMask, nullptr, sat,
-                                rewriter.getStringAttr(parts[partIndex]))
-                .getResult());
+      FailureOr<Value> result = buildFactorTruncResult(
+          op, sourceParts, resultTypes[resultIndex], resultIndex, factor, parts,
+          sat, *sourceMask, *resultMask, rewriter);
+      if (failed(result)) {
+        return failure();
       }
-      Value merged = partials.front();
-      for (Value partial : llvm::drop_begin(partials)) {
-        merged = rewriter
-                     .create<VorOp>(op.getLoc(), currentResultType, merged,
-                                    partial, *resultMask)
-                     .getResult();
-      }
-      results.push_back(merged);
+      results.push_back(*result);
     }
     finalizeResults(op, results, s32ToS8Alias, originalResultTypes, rewriter);
     return success();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10755,6 +10755,14 @@ private:
         .getResult();
   }
 
+  void emitPackedByteDirectStore(
+      VMIGroupStoreOp op, OneToNPatternRewriter &rewriter, Value merged,
+      Value destination, Value groupOffset, Value storeMask) const {
+    rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{}, merged,
+                            destination, groupOffset,
+                            rewriter.getStringAttr("PK4_B32"), storeMask);
+  }
+
   LogicalResult lowerPackedByteSlots8(
       VMIGroupStoreOp op, OneToNPatternRewriter &rewriter,
       ValueRange valueParts, VMIVRegType valueVMIType, VMILayoutAttr layout,
@@ -10821,9 +10829,8 @@ private:
       Value storeMask = std::get<1>(*block);
       Value groupOffset = std::get<2>(*block);
       if (useDirectPack4) {
-        rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{}, merged,
-                                destination, groupOffset,
-                                rewriter.getStringAttr("PK4_B32"), storeMask);
+        emitPackedByteDirectStore(op, rewriter, merged, destination,
+                                  groupOffset, storeMask);
         continue;
       }
       FailureOr<Value> statefulValue = buildPackedByteStatefulValue(
@@ -10832,7 +10839,8 @@ private:
         return failure();
       }
       statefulValues.push_back(*statefulValue);
-      statefulAdvances.push_back(activeGroups);
+      statefulAdvances.push_back(
+          std::min<int64_t>(32, numGroups - blockStart));
     }
     if (!useDirectPack4 &&
         failed(emitPackedByteStoreStream(op, rewriter, destination, offset,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12189,6 +12189,40 @@ private:
     return success();
   }
 
+  void appendVintlvZeroCopyResults(SmallVectorImpl<Value> &results,
+                                   ValueRange lhsParts, ValueRange rhsParts,
+                                   int64_t inputFactor) const {
+    size_t groupChunks = lhsParts.size() / inputFactor;
+    size_t halfGroupChunks = groupChunks / 2;
+    for (int64_t group = 0; group < inputFactor; ++group) {
+      size_t offset = group * groupChunks;
+      llvm::append_range(results, lhsParts.slice(offset, halfGroupChunks));
+      llvm::append_range(results, rhsParts.slice(offset, halfGroupChunks));
+    }
+    for (int64_t group = 0; group < inputFactor; ++group) {
+      size_t offset = group * groupChunks + halfGroupChunks;
+      llvm::append_range(results, lhsParts.slice(offset, halfGroupChunks));
+      llvm::append_range(results, rhsParts.slice(offset, halfGroupChunks));
+    }
+  }
+
+  void appendVdintlvZeroCopyResults(SmallVectorImpl<Value> &results,
+                                    ValueRange lhsParts, ValueRange rhsParts,
+                                    int64_t inputFactor,
+                                    int64_t outputFactor) const {
+    size_t groupChunks = lhsParts.size() / inputFactor;
+    for (int64_t group = 0; group < outputFactor; ++group) {
+      size_t offset = 2 * group * groupChunks;
+      llvm::append_range(results, lhsParts.slice(offset, groupChunks));
+      llvm::append_range(results, rhsParts.slice(offset, groupChunks));
+    }
+    for (int64_t group = 0; group < outputFactor; ++group) {
+      size_t offset = (2 * group + 1) * groupChunks;
+      llvm::append_range(results, lhsParts.slice(offset, groupChunks));
+      llvm::append_range(results, rhsParts.slice(offset, groupChunks));
+    }
+  }
+
   FailureOr<SmallVector<Value>> materializeZeroCopyResults(
       SourceOp op, ValueRange lhsParts, ValueRange rhsParts,
       TypeRange lowTypes, TypeRange highTypes, int64_t inputFactor,
@@ -12203,18 +12237,7 @@ private:
         return rewriter.notifyMatchFailure(
             op, "zero-copy vintlv expects input groups with even chunk count");
       }
-      size_t groupChunks = lhsParts.size() / inputFactor;
-      size_t halfGroupChunks = groupChunks / 2;
-      for (int64_t group = 0; group < inputFactor; ++group) {
-        size_t offset = group * groupChunks;
-        llvm::append_range(results, lhsParts.slice(offset, halfGroupChunks));
-        llvm::append_range(results, rhsParts.slice(offset, halfGroupChunks));
-      }
-      for (int64_t group = 0; group < inputFactor; ++group) {
-        size_t offset = group * groupChunks + halfGroupChunks;
-        llvm::append_range(results, lhsParts.slice(offset, halfGroupChunks));
-        llvm::append_range(results, rhsParts.slice(offset, halfGroupChunks));
-      }
+      appendVintlvZeroCopyResults(results, lhsParts, rhsParts, inputFactor);
     } else {
       bool invalidGroupCount =
           lhsParts.empty() || lhsParts.size() % inputFactor != 0;
@@ -12222,17 +12245,8 @@ private:
         return rewriter.notifyMatchFailure(
             op, "zero-copy vdintlv expects complete input layout groups");
       }
-      size_t groupChunks = lhsParts.size() / inputFactor;
-      for (int64_t group = 0; group < outputFactor; ++group) {
-        size_t offset = 2 * group * groupChunks;
-        llvm::append_range(results, lhsParts.slice(offset, groupChunks));
-        llvm::append_range(results, rhsParts.slice(offset, groupChunks));
-      }
-      for (int64_t group = 0; group < outputFactor; ++group) {
-        size_t offset = (2 * group + 1) * groupChunks;
-        llvm::append_range(results, lhsParts.slice(offset, groupChunks));
-        llvm::append_range(results, rhsParts.slice(offset, groupChunks));
-      }
+      appendVdintlvZeroCopyResults(results, lhsParts, rhsParts, inputFactor,
+                                   outputFactor);
     }
 
     SmallVector<Type> resultTypes;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5494,10 +5494,13 @@ static FailureOr<SmallVector<Value>> materializeMaskLaneStridePack(
   return results;
 }
 
-FailureOr<std::optional<SmallVector<Value>>> materializeMaskLaneStrideLayout(
-    Operation *op, ValueRange sourceParts, TypeRange resultTypes,
-    VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
-    PatternRewriter &rewriter) {
+struct MaskLaneStrideLayoutPlan {
+  bool unpack;
+  int64_t laneStride;
+};
+
+static std::optional<MaskLaneStrideLayoutPlan> getMaskLaneStrideLayoutPlan(
+    VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout) {
   bool unpack = sourceLayout && sourceLayout.isContiguous() &&
                 sourceLayout.getLaneStride() == 1 && resultLayout &&
                 resultLayout.isContiguous() &&
@@ -5508,26 +5511,36 @@ FailureOr<std::optional<SmallVector<Value>>> materializeMaskLaneStrideLayout(
   if (!unpack && !pack) {
     return std::nullopt;
   }
+  return MaskLaneStrideLayoutPlan{
+      unpack, unpack ? resultLayout.getLaneStride() : sourceLayout.getLaneStride()};
+}
 
-  int64_t laneStride =
-      unpack ? resultLayout.getLaneStride() : sourceLayout.getLaneStride();
-  bool unsupportedStride = laneStride != 2 && laneStride != 4;
-  if (unsupportedStride) {
-    return rewriter.notifyMatchFailure(
-        op, unpack ? "unsupported dense mask lane_stride unpack factor"
-                   : "unsupported dense mask lane_stride pack factor");
+FailureOr<std::optional<SmallVector<Value>>> materializeMaskLaneStrideLayout(
+    Operation *op, ValueRange sourceParts, TypeRange resultTypes,
+    VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
+    PatternRewriter &rewriter) {
+  std::optional<MaskLaneStrideLayoutPlan> plan =
+      getMaskLaneStrideLayoutPlan(sourceLayout, resultLayout);
+  if (!plan) {
+    return std::nullopt;
   }
 
-  if (unpack) {
+  if (plan->laneStride != 2 && plan->laneStride != 4) {
+    return rewriter.notifyMatchFailure(
+        op, plan->unpack ? "unsupported dense mask lane_stride unpack factor"
+                         : "unsupported dense mask lane_stride pack factor");
+  }
+
+  if (plan->unpack) {
     FailureOr<SmallVector<Value>> results = materializeMaskLaneStrideUnpack(
-        op, sourceParts, resultTypes, laneStride, rewriter);
+        op, sourceParts, resultTypes, plan->laneStride, rewriter);
     if (failed(results)) {
       return failure();
     }
     return std::optional<SmallVector<Value>>(std::move(*results));
   }
   FailureOr<SmallVector<Value>> results = materializeMaskLaneStridePack(
-      op, sourceParts, resultTypes, laneStride, rewriter);
+      op, sourceParts, resultTypes, plan->laneStride, rewriter);
   if (failed(results)) {
     return failure();
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3297,7 +3297,8 @@ static FailureOr<bool> getShuffleLaneDirection(
   };
   bool ascending = sourceLane == baseLane + resultLane;
   bool descending = sourceLane == baseLane - resultLane;
-  if (!ascending && !descending) {
+  bool unsupportedDirection = !ascending && !descending;
+  if (unsupportedDirection) {
     return fail("requires ASC or DESC affine source lane indices");
   }
   return descending && !ascending;
@@ -3349,8 +3350,10 @@ FailureOr<ShuffleVselrPlan> computeShuffleVselrPlanForChunk(
       baseLane = sourcePhysical->lane;
       continue;
     }
-    if (*sourcePart != sourcePhysical->part ||
-        *sourceChunk != sourcePhysical->chunk) {
+    bool sourceChunkMismatch =
+        *sourcePart != sourcePhysical->part ||
+        *sourceChunk != sourcePhysical->chunk;
+    if (sourceChunkMismatch) {
       return fail("requires one source chunk per result chunk");
     }
     FailureOr<bool> laneDescending = getShuffleLaneDirection(
@@ -3362,7 +3365,8 @@ FailureOr<ShuffleVselrPlan> computeShuffleVselrPlanForChunk(
       descending = *laneDescending;
       continue;
     }
-    if (*descending != *laneDescending) {
+    bool laneOrderMismatch = *descending != *laneDescending;
+    if (laneOrderMismatch) {
       return fail("requires one index order per result chunk");
     }
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6119,18 +6119,23 @@ FailureOr<SmallVector<Type>> getConvertedMaskPartTypes(VMIMaskType type) {
 static FailureOr<VMILayoutAttr>
 getVMIMaskPhysicalCarrierLayout(VMIMaskType type) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return failure();
+  }
   MLIRContext *ctx = type.getContext();
-  if (layout.isContiguous())
+  if (layout.isContiguous()) {
     return VMILayoutAttr::getContiguous(ctx);
-  if (layout.isDeinterleaved())
+  }
+  if (layout.isDeinterleaved()) {
     return VMILayoutAttr::getDeinterleaved(ctx, layout.getFactor());
-  if (layout.isBlockDeinterleaved())
+  }
+  if (layout.isBlockDeinterleaved()) {
     return VMILayoutAttr::getBlockDeinterleaved(ctx, layout.getFactor());
-  if (layout.isGroupSlots())
+  }
+  if (layout.isGroupSlots()) {
     return VMILayoutAttr::getGroupSlots(ctx, layout.getNumGroups(),
                                         layout.getSlots());
+  }
   return failure();
 }
 
@@ -6140,8 +6145,11 @@ getVMIMaskPhysicalCarrierType(VMIMaskType type) {
       getVMIMaskPhysicalGranularity(type);
   FailureOr<VMILayoutAttr> physicalLayout =
       getVMIMaskPhysicalCarrierLayout(type);
-  if (failed(physicalGranularity) || failed(physicalLayout))
+  bool missingPhysicalCarrier = failed(physicalGranularity) ||
+                                failed(physicalLayout);
+  if (missingPhysicalCarrier) {
     return failure();
+  }
   return VMIMaskType::get(type.getContext(), type.getElementCount(),
                           *physicalGranularity, *physicalLayout);
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12579,18 +12579,67 @@ template <typename SourceOp>
 struct OneToNVMICmpOpPattern : OneToNOpConversionPattern<SourceOp> {
   using OneToNOpConversionPattern<SourceOp>::OneToNOpConversionPattern;
 
+private:
+  FailureOr<Value> lowerPart(
+      SourceOp op, Value lhs, Value rhs, Type resultType,
+      const VPTOCmpMode &cmpMode,
+      OneToNPatternRewriter &rewriter) const {
+    auto maskType = dyn_cast<MaskType>(resultType);
+    auto lhsType = dyn_cast<VRegType>(lhs.getType());
+    const bool invalidPart =
+        !maskType || lhs.getType() != rhs.getType() || !lhsType;
+    if (invalidPart) {
+      rewriter.notifyMatchFailure(op, "physical cmp part type mismatch");
+      return failure();
+    }
+    FailureOr<Value> seedMask =
+        createAllTrueMask(op.getLoc(), maskType, rewriter);
+    if (failed(seedMask)) {
+      rewriter.notifyMatchFailure(
+          op, "unsupported mask type for all-true cmp seed");
+      return failure();
+    }
+    if (cmpMode.signedness) {
+      FailureOr<VRegType> carrierType =
+          getSignednessCarrierVRegType(lhsType, *cmpMode.signedness);
+      if (failed(carrierType)) {
+        rewriter.notifyMatchFailure(
+            op, "unsupported integer compare signedness carrier");
+        return failure();
+      }
+      FailureOr<Value> carrierLhs =
+          bitcastVReg(op.getLoc(), lhs, *carrierType, rewriter);
+      FailureOr<Value> carrierRhs =
+          bitcastVReg(op.getLoc(), rhs, *carrierType, rewriter);
+      const bool failedCarriers = failed(carrierLhs) || failed(carrierRhs);
+      if (failedCarriers) {
+        rewriter.notifyMatchFailure(
+            op, "failed to materialize integer compare signedness carrier");
+        return failure();
+      }
+      lhs = *carrierLhs;
+      rhs = *carrierRhs;
+    }
+    return rewriter
+        .create<VcmpOp>(op.getLoc(), resultType, lhs, rhs, *seedMask,
+                        rewriter.getStringAttr(cmpMode.mode))
+        .getResult();
+  }
+
+public:
   LogicalResult matchAndRewrite(
       SourceOp op,
       typename OneToNOpConversionPattern<SourceOp>::OpAdaptor adaptor,
       OneToNPatternRewriter &rewriter) const override {
     std::optional<VPTOCmpMode> cmpMode =
         getVPTOCmpMode<SourceOp>(op.getPredicate());
-    if (!cmpMode)
+    if (!cmpMode) {
       return op.emitOpError()
              << kVMIDiagUnsupportedPrefix << "compare predicate "
              << op.getPredicate()
              << " cannot be lowered to pto.vcmp; supported predicates are "
              << getSupportedComparePredicateMessage<SourceOp>();
+    }
 
     ValueRange lhsParts = adaptor.getLhs();
     ValueRange rhsParts = adaptor.getRhs();
@@ -12600,45 +12649,22 @@ struct OneToNVMICmpOpPattern : OneToNOpConversionPattern<SourceOp> {
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (lhsParts.size() != rhsParts.size() ||
-        lhsParts.size() != resultTypes.size())
+    const bool invalidArity = lhsParts.size() != rhsParts.size() ||
+                              lhsParts.size() != resultTypes.size();
+    if (invalidArity) {
       return rewriter.notifyMatchFailure(op, "physical cmp arity mismatch");
+    }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (auto [lhs, rhs, resultType] :
          llvm::zip_equal(lhsParts, rhsParts, resultTypes)) {
-      auto maskType = dyn_cast<MaskType>(resultType);
-      auto lhsType = dyn_cast<VRegType>(lhs.getType());
-      if (!maskType || lhs.getType() != rhs.getType() || !lhsType)
-        return rewriter.notifyMatchFailure(op,
-                                           "physical cmp part type mismatch");
-      FailureOr<Value> seedMask =
-          createAllTrueMask(op.getLoc(), maskType, rewriter);
-      if (failed(seedMask))
-        return rewriter.notifyMatchFailure(
-            op, "unsupported mask type for all-true cmp seed");
-      if (cmpMode->signedness) {
-        FailureOr<VRegType> carrierType =
-            getSignednessCarrierVRegType(lhsType, *cmpMode->signedness);
-        if (failed(carrierType))
-          return rewriter.notifyMatchFailure(
-              op, "unsupported integer compare signedness carrier");
-        FailureOr<Value> carrierLhs =
-            bitcastVReg(op.getLoc(), lhs, *carrierType, rewriter);
-        FailureOr<Value> carrierRhs =
-            bitcastVReg(op.getLoc(), rhs, *carrierType, rewriter);
-        if (failed(carrierLhs) || failed(carrierRhs))
-          return rewriter.notifyMatchFailure(
-              op, "failed to materialize integer compare signedness carrier");
-        lhs = *carrierLhs;
-        rhs = *carrierRhs;
+      FailureOr<Value> result =
+          lowerPart(op, lhs, rhs, resultType, *cmpMode, rewriter);
+      if (failed(result)) {
+        return failure();
       }
-      results.push_back(rewriter
-                            .create<VcmpOp>(op.getLoc(), resultType, lhs, rhs,
-                                            *seedMask,
-                                            rewriter.getStringAttr(cmpMode->mode))
-                            .getResult());
+      results.push_back(*result);
     }
 
     replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9426,22 +9426,32 @@ private:
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (auto [index, resultType] : llvm::enumerate(resultTypes)) {
-      if (!isa<VRegType>(resultType)) {
-        return rewriter.notifyMatchFailure(
-            op, "contiguous group_load result must be vreg");
+      FailureOr<Value> result = materializeContiguousUnitStrideChunk(
+          op, rewriter, source, offset, resultType, index, *lanesPerPart);
+      if (failed(result)) {
+        return failure();
       }
-      Value chunkOffset = createChunkOffset(
-          op.getLoc(), offset, static_cast<int64_t>(index) * *lanesPerPart,
-          rewriter);
-      results.push_back(rewriter
-                            .create<VldsOp>(op.getLoc(), resultType,
-                                            /*updated_base=*/Type{}, source,
-                                            chunkOffset, /*dist=*/nullptr)
-                            .getResult());
+      results.push_back(*result);
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());
     return success();
+  }
+
+  FailureOr<Value> materializeContiguousUnitStrideChunk(
+      VMIGroupLoadOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value offset, Type resultType, size_t index, int64_t lanesPerPart) const {
+    if (!isa<VRegType>(resultType)) {
+      return rewriter.notifyMatchFailure(
+          op, "contiguous group_load result must be vreg");
+    }
+    Value chunkOffset = createChunkOffset(
+        op.getLoc(), offset, static_cast<int64_t>(index) * lanesPerPart,
+        rewriter);
+    return rewriter
+        .create<VldsOp>(op.getLoc(), resultType, Type{}, source, chunkOffset,
+                        nullptr)
+        .getResult();
   }
 
   FailureOr<Value> materializeBlockDeinterleavedChunk(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2256,10 +2256,9 @@ checkSupportedGroupSlotsStoreShape(VMIGroupStoreOp op, VMIVRegType valueType,
 }
 
 LogicalResult
-checkSupportedGroupStoreByLayout(VMIGroupStoreOp op, VMIVRegType valueType,
-                                 VMILayoutAttr layout,
-                                 std::optional<int64_t> rowStride,
-                                 std::string *reason) {
+checkSupportedGroupStorePhysicalShape(
+    VMIGroupStoreOp op, VMIVRegType valueType,
+    const VMIGroupStoreLayoutFact &fact, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
       *reason = message.str();
@@ -2267,6 +2266,35 @@ checkSupportedGroupStoreByLayout(VMIGroupStoreOp op, VMIVRegType valueType,
     return failure();
   };
 
+  if (failed(checkSupportedStoreShape(valueType,
+                                      op.getDestination(),
+                                      op.getDestination().getType(), reason))) {
+    return failure();
+  }
+  if (fact.blockClass == VMIGroupBlockClass::OneBlock) {
+    if (failed(getOneBlockGroupStorePlan(op, valueType, fact, reason))) {
+      return failure();
+    }
+    return success();
+  }
+  if (succeeded(checkSupportedGroupChunkShape(valueType, fact.groupSize,
+                                              reason))) {
+    return success();
+  }
+
+  int64_t lanesPerPart = 0;
+  int64_t groupCount = 0;
+  int64_t chunksPerGroupPerPart = 0;
+  return checkDeinterleaved2GroupStoreChunkShape(
+      valueType, fact.groupSize, &lanesPerPart, &groupCount,
+      &chunksPerGroupPerPart, reason);
+}
+
+LogicalResult
+checkSupportedGroupStoreByLayout(VMIGroupStoreOp op, VMIVRegType valueType,
+                                 VMILayoutAttr layout,
+                                 std::optional<int64_t> rowStride,
+                                 std::string *reason) {
   if (isCompactSmallGroupStore(layout, valueType,
                                op.getNumGroupsAttr().getInt(), rowStride)) {
     return checkSupportedCompactSmallGroupStoreShape(op, valueType, reason);
@@ -2281,28 +2309,7 @@ checkSupportedGroupStoreByLayout(VMIGroupStoreOp op, VMIVRegType valueType,
   if (failed(fact)) {
     return failure();
   }
-  if (failed(checkSupportedStoreShape(valueType,
-                                      op.getDestination(),
-                                      op.getDestination().getType(), reason))) {
-    return failure();
-  }
-  if (fact->blockClass == VMIGroupBlockClass::OneBlock) {
-    if (failed(getOneBlockGroupStorePlan(op, valueType, *fact, reason))) {
-      return failure();
-    }
-    return success();
-  }
-  if (succeeded(
-          checkSupportedGroupChunkShape(valueType, fact->groupSize, reason))) {
-    return success();
-  }
-
-  int64_t lanesPerPart = 0;
-  int64_t groupCount = 0;
-  int64_t chunksPerGroupPerPart = 0;
-  return checkDeinterleaved2GroupStoreChunkShape(
-      valueType, fact->groupSize, &lanesPerPart, &groupCount,
-      &chunksPerGroupPerPart, reason);
+  return checkSupportedGroupStorePhysicalShape(op, valueType, *fact, reason);
 }
 
 LogicalResult

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9472,7 +9472,7 @@ public:
                        .create<VselOp>(op.getLoc(), resultType, gathered,
                                        passthruParts.front(), maskParts.front())
                        .getResult();
-    replaceOpWithFlatConvertedValues(rewriter, op, SmallVector<Value>{result},
+    replaceOpWithFlatConvertedValues(rewriter, op, SmallVector<Value>{*result},
                                      *this->getTypeConverter());
     return success();
   }
@@ -12792,6 +12792,45 @@ struct OneToNVMIActivePrefixIndexOpPattern
   using OneToNOpConversionPattern<
       VMIActivePrefixIndexOp>::OneToNOpConversionPattern;
 
+private:
+  FailureOr<Value> lowerPart(VMIActivePrefixIndexOp op, Value mask,
+                             Type resultType,
+                             OneToNPatternRewriter &rewriter) const {
+    auto vregType = dyn_cast<VRegType>(resultType);
+    auto maskType = dyn_cast<MaskType>(mask.getType());
+    const bool invalidPartTypes = !vregType || !maskType;
+    if (invalidPartTypes) {
+      rewriter.notifyMatchFailure(
+          op, "active_prefix_index requires physical vreg/mask parts");
+      return failure();
+    }
+    auto intType = dyn_cast<IntegerType>(vregType.getElementType());
+    const bool invalidElementType = !intType || !intType.isSignless();
+    if (invalidElementType) {
+      rewriter.notifyMatchFailure(
+          op, "active_prefix_index requires signless integer result part");
+      return failure();
+    }
+    FailureOr<Value> seedMask =
+        createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
+    if (failed(seedMask)) {
+      rewriter.notifyMatchFailure(
+          op, "unsupported element type for active_prefix_index seed mask");
+      return failure();
+    }
+    Value zero = rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0,
+                                                       intType.getWidth());
+    Value carrier =
+        rewriter
+            .create<VdupOp>(op.getLoc(), resultType, zero, *seedMask,
+                            /*position=*/nullptr)
+            .getResult();
+    return rewriter
+        .create<VusqzOp>(op.getLoc(), resultType, carrier, mask)
+        .getResult();
+  }
+
+public:
   LogicalResult
   matchAndRewrite(VMIActivePrefixIndexOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
@@ -12808,39 +12847,11 @@ struct OneToNVMIActivePrefixIndexOpPattern
           op, "active_prefix_index supports only one physical part");
     }
 
-    auto resultType = dyn_cast<VRegType>(resultTypes.front());
-    auto maskType = dyn_cast<MaskType>(maskParts.front().getType());
-    const bool invalidPartTypes = !resultType || !maskType;
-    if (invalidPartTypes) {
-      return rewriter.notifyMatchFailure(
-          op, "active_prefix_index requires physical vreg/mask parts");
+    FailureOr<Value> result =
+        lowerPart(op, maskParts.front(), resultTypes.front(), rewriter);
+    if (failed(result)) {
+      return failure();
     }
-
-    auto intType = dyn_cast<IntegerType>(resultType.getElementType());
-    const bool invalidElementType = !intType || !intType.isSignless();
-    if (invalidElementType) {
-      return rewriter.notifyMatchFailure(
-          op, "active_prefix_index requires signless integer result part");
-    }
-
-    FailureOr<Value> seedMask =
-        createAllTrueMaskForVReg(op.getLoc(), resultType, rewriter);
-    if (failed(seedMask)) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported element type for active_prefix_index seed mask");
-    }
-
-    Value zero = rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0,
-                                                       intType.getWidth());
-    Value carrier =
-        rewriter
-            .create<VdupOp>(op.getLoc(), resultType, zero, *seedMask,
-                            /*position=*/nullptr)
-            .getResult();
-    Value result = rewriter
-                       .create<VusqzOp>(op.getLoc(), resultType, carrier,
-                                        maskParts.front())
-                       .getResult();
     replaceOpWithFlatConvertedValues(rewriter, op, SmallVector<Value>{result},
                                      *this->getTypeConverter());
     return success();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -20470,7 +20470,7 @@ WalkResult emitMemoryUnsupported(Operation *memoryOp, StringRef opName,
     return WalkResult::interrupt();
 }
 
-std::optional<WalkResult> verifySupportedVMIMemoryAdvancedLoadOp(
+static std::optional<WalkResult> verifySupportedVMIMaskedLoadOp(
     Operation *op, bool enableStableGatherMaskedLoad) {
   if (auto load = dyn_cast<VMIMaskedLoadOp>(op)) {
     if (enableStableGatherMaskedLoad) {
@@ -20486,6 +20486,10 @@ std::optional<WalkResult> verifySupportedVMIMemoryAdvancedLoadOp(
         "contiguous result/passthru/mask layouts, and either full physical "
         "chunks or a statically safe full-read footprint (");
   }
+  return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMIGatherOp(Operation *op) {
   if (auto gather = dyn_cast<VMIGatherOp>(op)) {
     return verifySupportedShapeOp(
         gather, checkSupportedGatherShape,
@@ -20494,6 +20498,10 @@ std::optional<WalkResult> verifySupportedVMIMemoryAdvancedLoadOp(
         "ui16/i16/f16/bf16 results with ui16 indices and b16 masks, or "
         "32-bit results with i32 indices and b32 masks (");
   }
+  return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMIExpandLoadOp(Operation *op) {
   if (auto load = dyn_cast<VMIExpandLoadOp>(op)) {
     return verifySupportedShapeOp(
         load, checkSupportedExpandLoadShape,
@@ -20503,6 +20511,19 @@ std::optional<WalkResult> verifySupportedVMIMemoryAdvancedLoadOp(
         "pto.vsel (");
   }
   return std::nullopt;
+}
+
+std::optional<WalkResult> verifySupportedVMIMemoryAdvancedLoadOp(
+    Operation *op, bool enableStableGatherMaskedLoad) {
+  if (auto result = verifySupportedVMIMaskedLoadOp(
+          op, enableStableGatherMaskedLoad);
+      result.has_value()) {
+    return result;
+  }
+  if (auto result = verifySupportedVMIGatherOp(op); result.has_value()) {
+    return result;
+  }
+  return verifySupportedVMIExpandLoadOp(op);
 }
 
 static std::optional<WalkResult> verifySupportedVMIStructuredMaskedStoreOp(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2487,6 +2487,26 @@ checkGatherLayoutAndSource(VMIGatherOp op, VMIVRegType resultType,
 }
 
 LogicalResult
+checkGatherPhysicalChunkRequirement(VMIVRegType resultType,
+                                    VMIVRegType indicesType,
+                                    VMIVRegType passthruType,
+                                    VMIMaskType maskType,
+                                    bool isB16Gather, bool isB32Gather,
+                                    std::string *reason) {
+  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
+  if (failed(resultArity)) {
+    return failure();
+  }
+  bool requiresFullChunks = isB32Gather;
+  if (isB16Gather) {
+    requiresFullChunks = *resultArity != 1;
+  }
+  return checkSupportedGatherPhysicalShape(
+      resultType, indicesType, passthruType, maskType, requiresFullChunks,
+      reason);
+}
+
+LogicalResult
 checkSupportedGatherShape(VMIGatherOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
@@ -2518,14 +2538,9 @@ checkSupportedGatherShape(VMIGatherOp op, std::string *reason) {
                      indexElementType.getWidth() == 16 &&
                      maskType.getGranularity() == "b16";
 
-  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  bool requiresFullChunks = isB32Gather;
-  if (isB16Gather && succeeded(resultArity)) {
-    requiresFullChunks = *resultArity != 1;
-  }
-  return checkSupportedGatherPhysicalShape(
-      resultType, indicesType, passthruType, maskType, requiresFullChunks,
-      reason);
+  return checkGatherPhysicalChunkRequirement(
+      resultType, indicesType, passthruType, maskType, isB16Gather,
+      isB32Gather, reason);
 }
 
 LogicalResult checkSupportedScatterPhysicalShape(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18442,45 +18442,27 @@ std::optional<WalkResult> verifySupportedVMIStructuredLoadOp(Operation *op) {
         "contiguous physical result/mask chunk and a supported UB source (");
   }
   if (auto load = dyn_cast<VMIGroupLoadOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedGroupLoadShape(load, &reason))) {
-      return WalkResult::advance();
-    }
-    load.emitError()
-        << kVMIDiagUnsupportedPrefix
-        << "pto.vmi.group_load requires contiguous full result chunks, a "
-           "supported UB source, and num_groups deriving a group size "
-           "aligned to physical chunks ("
-        << reason << ")";
-    return WalkResult::interrupt();
+    return verifySupportedShapeOp(
+        load, checkSupportedGroupLoadShape,
+        "pto.vmi.group_load requires contiguous full result chunks, a "
+        "supported UB source, and num_groups deriving a group size aligned "
+        "to physical chunks (");
   }
   if (auto load = dyn_cast<VMIGroupSlotLoadOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedGroupSlotLoadShape(load, &reason))) {
-      return WalkResult::advance();
-    }
-    load.emitError()
-        << kVMIDiagUnsupportedPrefix
-        << "pto.vmi.group_slot_load requires explicit group_slots result "
-           "layout matching num_groups, a supported UB pointer source, "
-           "and either slots=8 with constant unit source_group_stride or "
-           "slots=1 row-local lowering ("
-        << reason << ")";
-    return WalkResult::interrupt();
+    return verifySupportedShapeOp(
+        load, checkSupportedGroupSlotLoadShape,
+        "pto.vmi.group_slot_load requires explicit group_slots result layout "
+        "matching num_groups, a supported UB pointer source, and either "
+        "slots=8 with constant unit source_group_stride or slots=1 row-local "
+        "lowering (");
   }
   if (auto load = dyn_cast<VMIGroupBroadcastLoadOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedGroupBroadcastLoadShape(load, &reason))) {
-      return WalkResult::advance();
-    }
-    load.emitError()
-        << kVMIDiagUnsupportedPrefix
-        << "pto.vmi.group_broadcast_load requires either the BRC full-group "
-           "chunk form, the E2B packet form for b16/b32 direct or split "
-           "group size, or the generic group-slot-load then group-broadcast "
-           "fallback with supported UB pointer source and source_group_stride ("
-        << reason << ")";
-    return WalkResult::interrupt();
+    return verifySupportedShapeOp(
+        load, checkSupportedGroupBroadcastLoadShape,
+        "pto.vmi.group_broadcast_load requires either the BRC full-group "
+        "chunk form, the E2B packet form for b16/b32 direct or split group "
+        "size, or the generic group-slot-load then group-broadcast fallback "
+        "with supported UB pointer source and source_group_stride (");
   }
   return std::nullopt;
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -17599,6 +17599,36 @@ static FailureOr<int64_t> checkChannelSplitResultShape(
   return resultArity;
 }
 
+static LogicalResult checkChannelMergeResultShape(
+    VMIChannelMergeOp op, VMILayoutAttr expectedLayout, int64_t inputArity,
+    std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  auto resultType = cast<VMIVRegType>(op.getResult().getType());
+  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
+  if (!resultLayout) {
+    return fail("requires assigned result layout");
+  }
+  bool invalidResultLayout =
+      !resultLayout.isContiguous() && resultLayout != expectedLayout;
+  if (invalidResultLayout) {
+    return fail("requires result layout to be contiguous or matching "
+                "deinterleaved channel layout");
+  }
+  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
+  if (failed(resultArity)) {
+    return fail("requires computable result physical arity");
+  }
+  if (*resultArity != inputArity) {
+    return fail("requires source and result to have the same physical arity");
+  }
+  return success();
+}
+
 LogicalResult checkSupportedChannelSplitShape(VMIChannelSplitOp op,
                                               std::string *reason = nullptr) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
@@ -17655,23 +17685,10 @@ LogicalResult checkSupportedChannelMergeShape(VMIChannelMergeOp op,
     return failure();
   }
 
-  auto resultType = cast<VMIVRegType>(op.getResult().getType());
-  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!resultLayout)
-    return fail("requires assigned result layout");
-  bool invalidResultLayout =
-      !resultLayout.isContiguous() && resultLayout != plan->expectedLayout;
-  if (invalidResultLayout) {
-    return fail("requires result layout to be contiguous or matching "
-                "deinterleaved channel layout");
-
-  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(resultArity))
-    return fail("requires computable result physical arity");
-  bool resultArityMismatch = *resultArity != *inputArity;
-  if (resultArityMismatch) {
-    return fail("requires source and result to have the same physical arity");
-
+  if (failed(checkChannelMergeResultShape(op, plan->expectedLayout,
+                                          *inputArity, reason))) {
+    return failure();
+  }
   return success();
 }
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -20751,8 +20751,8 @@ WalkResult emitMaskableUnsupported(Operation *op, StringRef opName,
 }
 
 template <typename MaskableCheck>
-std::optional<WalkResult> verifySupportedVMIArithmeticOp(Operation *op,
-                                                         MaskableCheck check) {
+static std::optional<WalkResult> verifySupportedVMIUnaryBinaryArithmeticOp(
+    Operation *op, MaskableCheck check) {
 #define PTO_VERIFY_MASKABLE(Op, Name)                                      \
   if (auto value = dyn_cast<Op>(op)) {                                    \
     return verifySupportedMaskableOp(value, Name, check);                  \
@@ -20784,6 +20784,12 @@ std::optional<WalkResult> verifySupportedVMIArithmeticOp(Operation *op,
   PTO_VERIFY_MASKABLE(VMINotOp, "pto.vmi.not");
   PTO_VERIFY_MASKABLE(VMISelectOp, "pto.vmi.select");
 #undef PTO_VERIFY_MASKABLE
+  return std::nullopt;
+}
+
+template <typename MaskableCheck>
+static std::optional<WalkResult> verifySupportedVMIVecScalarArithmeticOp(
+    Operation *op, MaskableCheck check) {
   if (auto value = dyn_cast<VMIAddSOp>(op)) {
     return verifySupportedVecScalarOp(value, "pto.vmi.vadds", check);
   }
@@ -20803,6 +20809,16 @@ std::optional<WalkResult> verifySupportedVMIArithmeticOp(Operation *op,
     return verifySupportedVecScalarOp(value, "pto.vmi.vshrs", check);
   }
   return std::nullopt;
+}
+
+template <typename MaskableCheck>
+std::optional<WalkResult> verifySupportedVMIArithmeticOp(Operation *op,
+                                                         MaskableCheck check) {
+  if (auto result = verifySupportedVMIUnaryBinaryArithmeticOp(op, check);
+      result.has_value()) {
+    return result;
+  }
+  return verifySupportedVMIVecScalarArithmeticOp(op, check);
 }
 
 template <typename ReduceOp>

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12487,15 +12487,10 @@ private:
           op, "group_broadcast_load requires known chunks per part");
     }
     int64_t factor = layout.getFactor();
-    for (int64_t part = 1; part < factor; ++part) {
-      FailureOr<int64_t> currentChunks =
-          getDataChunksInPart(resultVMIType, part);
-      bool nonUniformChunks =
-          failed(currentChunks) || *currentChunks != *chunksPerPart;
-      if (nonUniformChunks) {
-        return rewriter.notifyMatchFailure(
-            op, "group_broadcast_load requires uniform chunks per part");
-      }
+    FailureOr<int64_t> uniformChunks = validateDirectE2BChunks(
+        op, resultVMIType, factor, *chunksPerPart, rewriter);
+    if (failed(uniformChunks)) {
+      return failure();
     }
     bool invalidArity =
         static_cast<int64_t>(resultTypes.size()) != factor * *chunksPerPart;
@@ -12509,6 +12504,22 @@ private:
     }
     StringRef e2bDist = elementBits == 16 ? "E2B_B16" : "E2B_B32";
     return std::make_tuple(e2bDist, factor, *chunksPerPart);
+  }
+
+  FailureOr<int64_t> validateDirectE2BChunks(
+      VMIGroupBroadcastLoadOp op, VMIVRegType resultVMIType, int64_t factor,
+      int64_t chunksPerPart, OneToNPatternRewriter &rewriter) const {
+    for (int64_t part = 1; part < factor; ++part) {
+      FailureOr<int64_t> currentChunks =
+          getDataChunksInPart(resultVMIType, part);
+      bool nonUniformChunks =
+          failed(currentChunks) || *currentChunks != chunksPerPart;
+      if (nonUniformChunks) {
+        return rewriter.notifyMatchFailure(
+            op, "group_broadcast_load requires uniform chunks per part");
+      }
+    }
+    return chunksPerPart;
   }
 
   LogicalResult lowerDirectE2B(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -21150,7 +21150,8 @@ std::optional<WalkResult> verifySupportedVMINormalReductionOp(Operation *op) {
   return std::nullopt;
 }
 
-std::optional<WalkResult> verifySupportedVMIGroupReductionOp(Operation *op) {
+static std::optional<WalkResult> verifySupportedVMIGroupFloatReductionOp(
+    Operation *op) {
   if (auto reduce = dyn_cast<VMIGroupReduceAddFOp>(op)) {
     return verifySupportedGroupReduceOp(
         reduce,
@@ -21159,6 +21160,20 @@ std::optional<WalkResult> verifySupportedVMIGroupReductionOp(Operation *op) {
         "#pto.vmi.layout<num_groups = G, slots = K> result chunks, and "
         "num_groups deriving a group size aligned to physical chunks (");
   }
+  if (auto reduce = dyn_cast<VMIGroupReduceMaxFOp>(op)) {
+    return verifySupportedGroupReduceOp(
+        reduce,
+        "pto.vmi.group_reduce_maxf lowers through pto.vcgmax/vmax for 32B "
+        "blocks or through pto.vcmax for contiguous full chunks, matching "
+        "source/mask chunks, #pto.vmi.layout<num_groups = G, slots = K> "
+        "result chunks, and num_groups deriving a group size aligned to "
+        "physical chunks (");
+  }
+  return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMIGroupIntegerReductionOp(
+    Operation *op) {
   if (auto reduce = dyn_cast<VMIGroupReduceAddIOp>(op)) {
     return verifySupportedGroupReduceOp(
         reduce,
@@ -21173,22 +21188,6 @@ std::optional<WalkResult> verifySupportedVMIGroupReductionOp(Operation *op) {
         "supported 32B block classes or through pto.vcmax for aligned full "
         "chunks (");
   }
-  if (auto reduce = dyn_cast<VMIGroupReduceMaxFOp>(op)) {
-    return verifySupportedGroupReduceOp(
-        reduce,
-        "pto.vmi.group_reduce_maxf lowers through pto.vcgmax/vmax for 32B "
-        "blocks or through pto.vcmax for contiguous full chunks, matching "
-        "source/mask chunks, #pto.vmi.layout<num_groups = G, slots = K> "
-        "result chunks, and num_groups deriving a group size aligned to "
-        "physical chunks (");
-  }
-  if (auto reduce = dyn_cast<VMIGroupReduceMinFOp>(op)) {
-    return verifySupportedGroupReduceOp(
-        reduce,
-        "pto.vmi.group_reduce_minf lowers through pto.vcgmin/vmin for "
-        "supported 32B block classes or through pto.vcmin for aligned full "
-        "chunks (");
-  }
   if (auto reduce = dyn_cast<VMIGroupReduceMinIOp>(op)) {
     return verifySupportedGroupReduceOp(
         reduce,
@@ -21197,6 +21196,15 @@ std::optional<WalkResult> verifySupportedVMIGroupReductionOp(Operation *op) {
         "chunks (");
   }
   return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMIGroupReductionOp(
+    Operation *op) {
+  if (auto result = verifySupportedVMIGroupFloatReductionOp(op);
+      result.has_value()) {
+    return result;
+  }
+  return verifySupportedVMIGroupIntegerReductionOp(op);
 }
 
 std::optional<WalkResult> verifySupportedVMIReductionOp(Operation *op) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12675,6 +12675,23 @@ public:
 struct OneToNVMISelectOpPattern : OneToNOpConversionPattern<VMISelectOp> {
   using OneToNOpConversionPattern<VMISelectOp>::OneToNOpConversionPattern;
 
+private:
+  FailureOr<Value> lowerPart(VMISelectOp op, Value mask, Value trueValue,
+                             Value falseValue, Type resultType,
+                             OneToNPatternRewriter &rewriter) const {
+    const bool invalidPart =
+        !isa<MaskType>(mask.getType()) || trueValue.getType() != resultType ||
+        falseValue.getType() != resultType || !isa<VRegType>(resultType);
+    if (invalidPart) {
+      rewriter.notifyMatchFailure(op, "physical select part type mismatch");
+      return failure();
+    }
+    return rewriter
+        .create<VselOp>(op.getLoc(), resultType, trueValue, falseValue, mask)
+        .getResult();
+  }
+
+public:
   LogicalResult
   matchAndRewrite(VMISelectOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
@@ -12687,23 +12704,24 @@ struct OneToNVMISelectOpPattern : OneToNOpConversionPattern<VMISelectOp> {
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (maskParts.size() != trueParts.size() ||
+    const bool invalidArity =
+        maskParts.size() != trueParts.size() ||
         trueParts.size() != falseParts.size() ||
-        trueParts.size() != resultTypes.size())
+        trueParts.size() != resultTypes.size();
+    if (invalidArity) {
       return rewriter.notifyMatchFailure(op, "physical select arity mismatch");
+    }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (auto [mask, trueValue, falseValue, resultType] :
          llvm::zip_equal(maskParts, trueParts, falseParts, resultTypes)) {
-      if (!isa<MaskType>(mask.getType()) || trueValue.getType() != resultType ||
-          falseValue.getType() != resultType || !isa<VRegType>(resultType))
-        return rewriter.notifyMatchFailure(
-            op, "physical select part type mismatch");
-      results.push_back(rewriter
-                            .create<VselOp>(op.getLoc(), resultType, trueValue,
-                                            falseValue, mask)
-                            .getResult());
+      FailureOr<Value> result =
+          lowerPart(op, mask, trueValue, falseValue, resultType, rewriter);
+      if (failed(result)) {
+        return failure();
+      }
+      results.push_back(*result);
     }
 
     replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10621,6 +10621,49 @@ private:
     return packed->front();
   }
 
+  LogicalResult emitAlignedCompactSmallGroupStore(
+      VMIGroupStoreOp op, Value compactValue, VMIVRegType valueVMIType,
+      Value destination, Value offset,
+      OneToNPatternRewriter &rewriter) const {
+    auto compactType = dyn_cast<VRegType>(compactValue.getType());
+    std::optional<std::string> normalDist =
+        getX2MemoryDistToken(valueVMIType.getElementType(), "NORM");
+    if (!compactType || !normalDist) {
+      return rewriter.notifyMatchFailure(
+          op, "aligned compact group_store requires a supported vreg element type");
+    }
+    FailureOr<MaskType> maskType =
+        getMaskTypeForVReg(compactType, rewriter.getContext());
+    if (failed(maskType)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to derive aligned compact group_store mask type");
+    }
+    FailureOr<Value> storeMask = createPrefixMaskForActiveLanes(
+        op.getLoc(), *maskType, valueVMIType.getElementCount(), rewriter);
+    if (failed(storeMask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to create aligned compact group_store mask");
+    }
+    rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{}, compactValue,
+                            destination, offset,
+                            rewriter.getStringAttr(*normalDist), *storeMask);
+    return success();
+  }
+
+  LogicalResult emitUnalignedCompactSmallGroupStore(
+      VMIGroupStoreOp op, Value compactValue, VMIVRegType valueVMIType,
+      Value destination, Value offset,
+      OneToNPatternRewriter &rewriter) const {
+    Value elementBase =
+        rewriter.create<AddPtrOp>(op.getLoc(), destination.getType(),
+                                  destination, offset)
+            .getResult();
+    SmallVector<Value> streamValues{compactValue};
+    SmallVector<int64_t> streamAdvances{valueVMIType.getElementCount()};
+    return emitStatefulStoreStream(op, elementBase, streamValues, streamAdvances,
+                                   rewriter);
+  }
+
   LogicalResult lowerCompactSmallGroupStore(
       VMIGroupStoreOp op, OpAdaptor adaptor,
       OneToNPatternRewriter &rewriter, VMIVRegType valueVMIType,
@@ -10645,40 +10688,16 @@ private:
 
     if (isKnownAddressAligned(destination, offset,
                               valueVMIType.getElementType(), 32)) {
-      auto compactType = dyn_cast<VRegType>(compactValue->getType());
-      std::optional<std::string> normalDist =
-          getX2MemoryDistToken(valueVMIType.getElementType(), "NORM");
-      if (!compactType || !normalDist) {
-        return rewriter.notifyMatchFailure(
-            op, "aligned compact group_store requires a supported vreg element type");
+      if (failed(emitAlignedCompactSmallGroupStore(
+              op, *compactValue, valueVMIType, destination, offset, rewriter))) {
+        return failure();
       }
-      FailureOr<MaskType> maskType =
-          getMaskTypeForVReg(compactType, rewriter.getContext());
-      if (failed(maskType)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to derive aligned compact group_store mask type");
-      }
-      FailureOr<Value> storeMask = createPrefixMaskForActiveLanes(
-          op.getLoc(), *maskType, valueVMIType.getElementCount(), rewriter);
-      if (failed(storeMask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to create aligned compact group_store mask");
-      }
-      rewriter.create<VstsOp>(
-          op.getLoc(), /*updated_base=*/Type{}, *compactValue, destination,
-          offset, rewriter.getStringAttr(*normalDist), *storeMask);
       rewriter.eraseOp(op);
       return success();
     }
 
-    Value elementBase =
-        rewriter.create<AddPtrOp>(op.getLoc(), destination.getType(),
-                                  destination, offset)
-            .getResult();
-    SmallVector<Value> streamValues{*compactValue};
-    SmallVector<int64_t> streamAdvances{valueVMIType.getElementCount()};
-    if (failed(emitStatefulStoreStream(op, elementBase, streamValues,
-                                       streamAdvances, rewriter))) {
+    if (failed(emitUnalignedCompactSmallGroupStore(
+            op, *compactValue, valueVMIType, destination, offset, rewriter))) {
       return failure();
     }
     rewriter.eraseOp(op);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8867,6 +8867,20 @@ private:
         resultLayout, factor, *blockElems, *chunksPerPart, *constantRowStride);
   }
 
+  LogicalResult lowerByLayout(
+      VMIGroupLoadOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value offset, Value rowStride, VMIVRegType resultVMIType,
+      VMILayoutAttr resultLayout) const {
+    bool isBlockF32 = resultLayout && resultLayout.isBlockDeinterleaved() &&
+                      resultVMIType.getElementType().isF32();
+    if (isBlockF32) {
+      return lowerBlockF32(op, rewriter, source, offset, rowStride,
+                           resultVMIType, resultLayout);
+    }
+    return lowerContiguousPath(op, rewriter, source, offset, rowStride,
+                               resultVMIType, resultLayout);
+  }
+
 public:
 
   LogicalResult
@@ -8888,16 +8902,8 @@ public:
       return failure();
     }
 
-    VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
-    bool isBlockF32 = resultLayout && resultLayout.isBlockDeinterleaved() &&
-                      resultVMIType.getElementType().isF32();
-    if (isBlockF32) {
-      return lowerBlockF32(op, rewriter, *source, *offset, *rowStride,
-                           resultVMIType, resultLayout);
-    }
-
-    return lowerContiguousPath(op, rewriter, *source, *offset, *rowStride,
-                               resultVMIType, resultLayout);
+    return lowerByLayout(op, rewriter, *source, *offset, *rowStride,
+                         resultVMIType, resultVMIType.getLayoutAttr());
   }
 };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -62,6 +62,8 @@ std::optional<std::string> getDenseLaneStrideLoadDistToken(VMIVRegType type);
 std::optional<std::string> getDenseLaneStrideStoreDistToken(VMIVRegType type);
 std::optional<std::string> getPointStoreDistToken(Type elementType);
 static int64_t getElementDeinterleaveFactor(VMILayoutAttr layout);
+static Type getMemoryElementType(Type type);
+static Attribute getMemorySpace(Type type);
 
 static LogicalResult emitStatefulStoreStream(Operation *op, Value base,
                                               ValueRange values,
@@ -123,17 +125,20 @@ static LogicalResult emitGroupStoreStream(Operation *op, Value destination,
 bool isVMIType(Type type) { return isa<VMIVRegType, VMIMaskType>(type); }
 
 bool containsVMIType(Type type) {
-  if (isVMIType(type))
+  if (isVMIType(type)) {
     return true;
+  }
 
-  if (auto functionType = dyn_cast<FunctionType>(type))
+  if (auto functionType = dyn_cast<FunctionType>(type)) {
     return llvm::any_of(functionType.getInputs(),
                         [](Type input) { return containsVMIType(input); }) ||
            llvm::any_of(functionType.getResults(),
                         [](Type result) { return containsVMIType(result); });
+  }
 
-  if (auto shapedType = dyn_cast<ShapedType>(type))
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
     return containsVMIType(shapedType.getElementType());
+  }
 
   return false;
 }
@@ -158,10 +163,12 @@ struct VMISupportResult {
   bool isSupported() const { return supported; }
 
   LogicalResult toLogicalResult(std::string *outReason = nullptr) const {
-    if (supported)
+    if (supported) {
       return mlir::success();
-    if (outReason)
+    }
+    if (outReason) {
       *outReason = reason;
+    }
     return mlir::failure();
   }
 };
@@ -171,42 +178,59 @@ bool hasVMIType(FunctionType type) {
 }
 
 bool hasVMIType(Attribute attr) {
-  if (!attr)
+  if (!attr) {
     return false;
+  }
 
-  if (auto typeAttr = dyn_cast<TypeAttr>(attr))
-    if (containsVMIType(typeAttr.getValue()))
+  if (auto typeAttr = dyn_cast<TypeAttr>(attr)) {
+    if (containsVMIType(typeAttr.getValue())) {
       return true;
+    }
+  }
 
-  if (auto typedAttr = dyn_cast<TypedAttr>(attr))
-    if (containsVMIType(typedAttr.getType()))
+  if (auto typedAttr = dyn_cast<TypedAttr>(attr)) {
+    if (containsVMIType(typedAttr.getType())) {
       return true;
+    }
+  }
 
-  if (auto arrayAttr = dyn_cast<ArrayAttr>(attr))
+  if (auto arrayAttr = dyn_cast<ArrayAttr>(attr)) {
     return llvm::any_of(arrayAttr,
                         [](Attribute element) { return hasVMIType(element); });
+  }
 
-  if (auto dictAttr = dyn_cast<DictionaryAttr>(attr))
+  if (auto dictAttr = dyn_cast<DictionaryAttr>(attr)) {
     return llvm::any_of(dictAttr, [](NamedAttribute namedAttr) {
       return hasVMIType(namedAttr.getValue());
     });
+  }
 
   return false;
 }
 
 bool hasVMIType(Operation *op) {
-  if (auto func = dyn_cast<func::FuncOp>(op))
-    if (hasVMIType(func.getFunctionType()))
+  if (auto func = dyn_cast<func::FuncOp>(op)) {
+    if (hasVMIType(func.getFunctionType())) {
       return true;
-  if (hasVMIType(op->getOperandTypes()) || hasVMIType(op->getResultTypes()))
+    }
+  }
+  bool operationHasVMIType = hasVMIType(op->getOperandTypes()) ||
+                             hasVMIType(op->getResultTypes());
+  if (operationHasVMIType) {
     return true;
-  for (Region &region : op->getRegions())
-    for (Block &block : region)
-      if (hasVMIType(block.getArgumentTypes()))
+  }
+  for (Region &region : op->getRegions()) {
+    for (Block &block : region) {
+      if (hasVMIType(block.getArgumentTypes())) {
         return true;
-  for (NamedAttribute attr : op->getAttrs())
-    if (hasVMIType(attr.getValue()))
+      }
+    }
+  }
+  for (NamedAttribute attr : op->getAttrs()) {
+    if (hasVMIType(attr.getValue())) {
       return true;
+    }
+  }
   return false;
 }
 
@@ -225,91 +249,123 @@ StringRef getTruncFRoundModeForResult(Type resultElementType) {
 }
 
 StringRef getTruncFRoundMode(VMITruncFOp op, Type resultElementType) {
-  if (auto roundingAttr = op->getAttrOfType<StringAttr>("rounding"))
+  if (auto roundingAttr = op->getAttrOfType<StringAttr>("rounding")) {
     return roundingAttr.getValue();
+  }
   return getTruncFRoundModeForResult(resultElementType);
 }
 
 bool isLayoutAssignedVMIType(Type type) {
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     return static_cast<bool>(vregType.getLayoutAttr());
-  if (auto maskType = dyn_cast<VMIMaskType>(type))
+  }
+  if (auto maskType = dyn_cast<VMIMaskType>(type)) {
     return maskType.getLayoutAttr() &&
            VMIMaskType::isConcreteGranularity(maskType.getGranularity());
+  }
   return true;
 }
 
 LogicalResult verifyLayoutAssignedVMITypeTree(Operation *op, Type type) {
-  if (!isLayoutAssignedVMIType(type))
+  if (!isLayoutAssignedVMIType(type)) {
     return op->emitError() << kVMIDiagPassInvariantPrefix
                            << "vmi-to-vpto requires layout-assigned VMI types";
-
-  if (auto functionType = dyn_cast<FunctionType>(type)) {
-    for (Type input : functionType.getInputs())
-      if (failed(verifyLayoutAssignedVMITypeTree(op, input)))
-        return failure();
-    for (Type result : functionType.getResults())
-      if (failed(verifyLayoutAssignedVMITypeTree(op, result)))
-        return failure();
   }
 
-  if (auto shapedType = dyn_cast<ShapedType>(type))
+  if (auto functionType = dyn_cast<FunctionType>(type)) {
+    for (Type input : functionType.getInputs()) {
+      if (failed(verifyLayoutAssignedVMITypeTree(op, input))) {
+        return failure();
+      }
+    }
+    for (Type result : functionType.getResults()) {
+      if (failed(verifyLayoutAssignedVMITypeTree(op, result))) {
+        return failure();
+      }
+    }
+  }
+
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
     return verifyLayoutAssignedVMITypeTree(op, shapedType.getElementType());
+  }
 
   return success();
 }
 
 LogicalResult verifyVMIToVPTOInputAttribute(Operation *op, Attribute attr) {
-  if (!attr)
+  if (!attr) {
     return success();
+  }
 
-  if (auto typeAttr = dyn_cast<TypeAttr>(attr))
-    if (failed(verifyLayoutAssignedVMITypeTree(op, typeAttr.getValue())))
+  if (auto typeAttr = dyn_cast<TypeAttr>(attr)) {
+    if (failed(verifyLayoutAssignedVMITypeTree(op, typeAttr.getValue()))) {
       return failure();
+    }
+  }
 
-  if (auto typedAttr = dyn_cast<TypedAttr>(attr))
-    if (failed(verifyLayoutAssignedVMITypeTree(op, typedAttr.getType())))
+  if (auto typedAttr = dyn_cast<TypedAttr>(attr)) {
+    if (failed(verifyLayoutAssignedVMITypeTree(op, typedAttr.getType()))) {
       return failure();
+    }
+  }
 
   if (auto arrayAttr = dyn_cast<ArrayAttr>(attr)) {
-    for (Attribute element : arrayAttr)
-      if (failed(verifyVMIToVPTOInputAttribute(op, element)))
+    for (Attribute element : arrayAttr) {
+      if (failed(verifyVMIToVPTOInputAttribute(op, element))) {
         return failure();
+      }
+    }
   }
 
   if (auto dictAttr = dyn_cast<DictionaryAttr>(attr)) {
-    for (NamedAttribute namedAttr : dictAttr)
-      if (failed(verifyVMIToVPTOInputAttribute(op, namedAttr.getValue())))
+    for (NamedAttribute namedAttr : dictAttr) {
+      if (failed(verifyVMIToVPTOInputAttribute(op, namedAttr.getValue()))) {
         return failure();
+      }
+    }
   }
 
   return success();
 }
 
 LogicalResult verifyVMIToVPTOInputTypes(Operation *op) {
-  for (Type type : op->getOperandTypes())
-    if (failed(verifyLayoutAssignedVMITypeTree(op, type)))
+  for (Type type : op->getOperandTypes()) {
+    if (failed(verifyLayoutAssignedVMITypeTree(op, type))) {
       return failure();
-  for (Type type : op->getResultTypes())
-    if (failed(verifyLayoutAssignedVMITypeTree(op, type)))
+    }
+  }
+  for (Type type : op->getResultTypes()) {
+    if (failed(verifyLayoutAssignedVMITypeTree(op, type))) {
       return failure();
+    }
+  }
   if (auto func = dyn_cast<func::FuncOp>(op)) {
     FunctionType functionType = func.getFunctionType();
-    for (Type type : functionType.getInputs())
-      if (failed(verifyLayoutAssignedVMITypeTree(op, type)))
+    for (Type type : functionType.getInputs()) {
+      if (failed(verifyLayoutAssignedVMITypeTree(op, type))) {
         return failure();
-    for (Type type : functionType.getResults())
-      if (failed(verifyLayoutAssignedVMITypeTree(op, type)))
+      }
+    }
+    for (Type type : functionType.getResults()) {
+      if (failed(verifyLayoutAssignedVMITypeTree(op, type))) {
         return failure();
+      }
+    }
   }
-  for (Region &region : op->getRegions())
-    for (Block &block : region)
-      for (Type type : block.getArgumentTypes())
-        if (failed(verifyLayoutAssignedVMITypeTree(op, type)))
+  for (Region &region : op->getRegions()) {
+    for (Block &block : region) {
+      for (Type type : block.getArgumentTypes()) {
+        if (failed(verifyLayoutAssignedVMITypeTree(op, type))) {
           return failure();
-  for (NamedAttribute attr : op->getAttrs())
-    if (failed(verifyVMIToVPTOInputAttribute(op, attr.getValue())))
+        }
+      }
+    }
+  }
+  for (NamedAttribute attr : op->getAttrs()) {
+    if (failed(verifyVMIToVPTOInputAttribute(op, attr.getValue()))) {
       return failure();
+    }
+  }
   return success();
 }
 
@@ -326,8 +382,9 @@ LogicalResult verifyVMIToVPTOInputIR(ModuleOp module) {
         return WalkResult::interrupt();
       }
     }
-    if (failed(verifyVMIToVPTOInputTypes(op)))
+    if (failed(verifyVMIToVPTOInputTypes(op))) {
       return WalkResult::interrupt();
+    }
     return WalkResult::advance();
   });
   return failure(result.wasInterrupted());
@@ -337,27 +394,32 @@ static std::optional<Value> materializeVPTOToVMI(OpBuilder &builder,
                                                  Type resultType,
                                                  ValueRange inputs,
                                                  Location loc) {
-  if (!isVMIType(resultType))
+  if (!isVMIType(resultType)) {
     return std::nullopt;
+  }
   return builder.create<VMIPackOp>(loc, resultType, inputs).getResult();
 }
 
 static std::optional<SmallVector<Value>>
 materializeVMIToVPTO(OpBuilder &builder, TypeRange resultTypes, Value input,
                      Location loc) {
-  if (!isVMIType(input.getType()))
+  if (!isVMIType(input.getType())) {
     return std::nullopt;
+  }
   auto unpackOp = builder.create<VMIUnpackOp>(loc, resultTypes, input);
   return SmallVector<Value>(unpackOp->getResults());
 }
 
 static int64_t getMaskGranularityBits(StringRef granularity) {
-  if (granularity == "b8")
+  if (granularity == "b8") {
     return 8;
-  if (granularity == "b16")
+  }
+  if (granularity == "b16") {
     return 16;
-  if (granularity == "b32")
+  }
+  if (granularity == "b32") {
     return 32;
+  }
   return 0;
 }
 
@@ -376,16 +438,18 @@ static StringRef getMaskGranularityForBits(int64_t bits) {
 
 static FailureOr<StringRef> getVMIMaskPhysicalGranularity(VMIMaskType type) {
   int64_t bits = getMaskGranularityBits(type.getGranularity());
-  if (bits == 0)
+  if (bits == 0) {
     return failure();
+  }
 
   VMILayoutAttr layout = type.getLayoutAttr();
   int64_t laneStride = layout && layout.hasLaneStride() ? layout.getLaneStride()
                                                         : 1;
   int64_t physicalBits = bits * laneStride;
   StringRef physicalGranularity = getMaskGranularityForBits(physicalBits);
-  if (physicalGranularity.empty())
+  if (physicalGranularity.empty()) {
     return failure();
+  }
   return physicalGranularity;
 }
 
@@ -397,15 +461,18 @@ public:
                      SmallVectorImpl<Type> &results) -> LogicalResult {
       FailureOr<int64_t> arity = getVMIPhysicalArity(type);
       Type physicalElementType = getVMIPhysicalDataElementType(type);
-      if (failed(arity))
+      if (failed(arity)) {
         return failure();
+      }
       FailureOr<int64_t> lanesPerPart =
           getDataLanesPerPart(physicalElementType);
-      if (failed(lanesPerPart))
+      if (failed(lanesPerPart)) {
         return failure();
-      for (int64_t i = 0; i < *arity; ++i)
+      }
+      for (int64_t i = 0; i < *arity; ++i) {
         results.push_back(VRegType::get(type.getContext(), *lanesPerPart,
                                         physicalElementType));
+      }
       return success();
     });
     addConversion(
@@ -413,11 +480,14 @@ public:
           FailureOr<int64_t> arity = getVMIPhysicalArity(type);
           FailureOr<StringRef> physicalGranularity =
               getVMIMaskPhysicalGranularity(type);
-          if (failed(arity) || failed(physicalGranularity))
+          bool invalidPhysicalType = failed(arity) || failed(physicalGranularity);
+          if (invalidPhysicalType) {
             return failure();
-          for (int64_t i = 0; i < *arity; ++i)
+          }
+          for (int64_t i = 0; i < *arity; ++i) {
             results.push_back(
                 MaskType::get(type.getContext(), *physicalGranularity));
+          }
           return success();
         });
     TypeConverter::addSourceMaterialization(materializeVPTOToVMI);
@@ -429,20 +499,23 @@ public:
 FailureOr<SmallVector<Type>>
 getConvertedResultTypes(Operation *op, unsigned resultIndex,
                         const TypeConverter &typeConverter) {
-  if (resultIndex >= op->getNumResults())
+  if (resultIndex >= op->getNumResults()) {
     return failure();
+  }
   SmallVector<Type> resultTypes;
   if (failed(typeConverter.convertType(op->getResult(resultIndex).getType(),
-                                       resultTypes)))
+                                       resultTypes))) {
     return failure();
+  }
   return resultTypes;
 }
 
 FailureOr<SmallVector<Type>>
 getConvertedResultTypes(Operation *op, const TypeConverter &typeConverter) {
   SmallVector<Type> resultTypes;
-  if (failed(typeConverter.convertTypes(op->getResultTypes(), resultTypes)))
+  if (failed(typeConverter.convertTypes(op->getResultTypes(), resultTypes))) {
     return failure();
+  }
   return resultTypes;
 }
 
@@ -452,8 +525,9 @@ getConvertedVRegTypesWithLayout(VMIVRegType type, VMILayoutAttr layout,
   auto relayoutType = VMIVRegType::get(type.getContext(), type.getElementCount(),
                                        type.getElementType(), layout);
   SmallVector<Type> convertedTypes;
-  if (failed(typeConverter.convertType(relayoutType, convertedTypes)))
+  if (failed(typeConverter.convertType(relayoutType, convertedTypes))) {
     return failure();
+  }
   return convertedTypes;
 }
 
@@ -461,15 +535,18 @@ FailureOr<int64_t> getVRegPhysicalFootprintBytes(TypeRange types) {
   int64_t totalBytes = 0;
   for (Type type : types) {
     auto vregType = dyn_cast<VRegType>(type);
-    if (!vregType)
+    if (!vregType) {
       return failure();
+    }
     unsigned elementBits =
         pto::getPTOStorageElemBitWidth(vregType.getElementType());
-    if (elementBits == 0)
+    if (elementBits == 0) {
       return failure();
+    }
     int64_t chunkBits = vregType.getElementCount() * elementBits;
-    if (chunkBits % 8 != 0)
+    if (chunkBits % 8 != 0) {
       return failure();
+    }
     totalBytes += chunkBits / 8;
   }
   return totalBytes;
@@ -481,8 +558,11 @@ FailureOr<bool> hasNoWiderFootprintThanContiguous(TypeRange assignedTypes,
       getVRegPhysicalFootprintBytes(assignedTypes);
   FailureOr<int64_t> contiguousBytes =
       getVRegPhysicalFootprintBytes(contiguousTypes);
-  if (failed(assignedBytes) || failed(contiguousBytes))
+  bool unavailableFootprints =
+      failed(assignedBytes) || failed(contiguousBytes);
+  if (unavailableFootprints) {
     return failure();
+  }
   return *assignedBytes <= *contiguousBytes;
 }
 
@@ -502,8 +582,9 @@ void replaceOpWithFlatConvertedValues(
 SmallVector<Value>
 flattenOneToNOperands(ArrayRef<ValueRange> operands) {
   SmallVector<Value> flat;
-  for (ValueRange operand : operands)
+  for (ValueRange operand : operands) {
     llvm::append_range(flat, operand);
+  }
   return flat;
 }
 
@@ -512,33 +593,39 @@ FailureOr<Value> createAllTrueMaskForVReg(Location loc, VRegType vregType,
   MLIRContext *ctx = rewriter.getContext();
   unsigned elementBits =
       pto::getPTOStorageElemBitWidth(vregType.getElementType());
-  if (elementBits == 8)
+  if (elementBits == 8) {
     return rewriter
         .create<PsetB8Op>(loc, MaskType::get(ctx, "b8"),
                           rewriter.getStringAttr("PAT_ALL"))
         .getResult();
-  if (elementBits == 16)
+  }
+  if (elementBits == 16) {
     return rewriter
         .create<PsetB16Op>(loc, MaskType::get(ctx, "b16"),
                            rewriter.getStringAttr("PAT_ALL"))
         .getResult();
-  if (elementBits == 32)
+  }
+  if (elementBits == 32) {
     return rewriter
         .create<PsetB32Op>(loc, MaskType::get(ctx, "b32"),
                            rewriter.getStringAttr("PAT_ALL"))
         .getResult();
+  }
   return failure();
 }
 
 FailureOr<MaskType> getMaskTypeForVReg(VRegType vregType, MLIRContext *ctx) {
   unsigned elementBits =
       pto::getPTOStorageElemBitWidth(vregType.getElementType());
-  if (elementBits == 8)
+  if (elementBits == 8) {
     return MaskType::get(ctx, "b8");
-  if (elementBits == 16)
+  }
+  if (elementBits == 16) {
     return MaskType::get(ctx, "b16");
-  if (elementBits == 32)
+  }
+  if (elementBits == 32) {
     return MaskType::get(ctx, "b32");
+  }
   return failure();
 }
 
@@ -546,15 +633,18 @@ FailureOr<Value> createAllTrueMask(Location loc, MaskType maskType,
                                    PatternRewriter &rewriter) {
   StringAttr pattern = rewriter.getStringAttr("PAT_ALL");
   MLIRContext *ctx = rewriter.getContext();
-  if (maskType.isB8())
+  if (maskType.isB8()) {
     return rewriter.create<PsetB8Op>(loc, MaskType::get(ctx, "b8"), pattern)
         .getResult();
-  if (maskType.isB16())
+  }
+  if (maskType.isB16()) {
     return rewriter.create<PsetB16Op>(loc, MaskType::get(ctx, "b16"), pattern)
         .getResult();
-  if (maskType.isB32())
+  }
+  if (maskType.isB32()) {
     return rewriter.create<PsetB32Op>(loc, MaskType::get(ctx, "b32"), pattern)
         .getResult();
+  }
   return failure();
 }
 
@@ -563,17 +653,20 @@ FailureOr<Value> createPatternMask(Location loc, MaskType maskType,
                                    PatternRewriter &rewriter) {
   StringAttr patternAttr = rewriter.getStringAttr(pattern);
   MLIRContext *ctx = rewriter.getContext();
-  if (maskType.isB8())
+  if (maskType.isB8()) {
     return rewriter.create<PsetB8Op>(loc, MaskType::get(ctx, "b8"), patternAttr)
         .getResult();
-  if (maskType.isB16())
+  }
+  if (maskType.isB16()) {
     return rewriter
         .create<PsetB16Op>(loc, MaskType::get(ctx, "b16"), patternAttr)
         .getResult();
-  if (maskType.isB32())
+  }
+  if (maskType.isB32()) {
     return rewriter
         .create<PsetB32Op>(loc, MaskType::get(ctx, "b32"), patternAttr)
         .getResult();
+  }
   return failure();
 }
 
@@ -587,30 +680,39 @@ FailureOr<Value> createPrefixMask(Location loc, MaskType maskType,
   // static masks produced through createAllTrueMask/createPatternMask.
   StringAttr patternAttr = rewriter.getStringAttr(pattern);
   MLIRContext *ctx = rewriter.getContext();
-  if (maskType.isB8())
+  if (maskType.isB8()) {
     return rewriter.create<PsetB8Op>(loc, MaskType::get(ctx, "b8"), patternAttr)
         .getResult();
-  if (maskType.isB16())
+  }
+  if (maskType.isB16()) {
     return rewriter
         .create<PsetB16Op>(loc, MaskType::get(ctx, "b16"), patternAttr)
         .getResult();
-  if (maskType.isB32())
+  }
+  if (maskType.isB32()) {
     return rewriter
         .create<PsetB32Op>(loc, MaskType::get(ctx, "b32"), patternAttr)
         .getResult();
+  }
   return failure();
 }
 
 bool areEquivalentReductionMasks(Value lhs, Value rhs) {
-  if (lhs == rhs)
+  if (lhs == rhs) {
     return true;
-  if (lhs.getType() != rhs.getType())
+  }
+  bool differentMaskTypes = lhs.getType() != rhs.getType();
+  if (differentMaskTypes) {
     return false;
+  }
 
   Operation *lhsOp = lhs.getDefiningOp();
   Operation *rhsOp = rhs.getDefiningOp();
-  if (!lhsOp || !rhsOp || lhsOp->getName() != rhsOp->getName())
+  bool differentDefiningOps =
+      !lhsOp || !rhsOp || lhsOp->getName() != rhsOp->getName();
+  if (differentDefiningOps) {
     return false;
+  }
 
   bool isPatternMask =
       isa<PsetB8Op, PsetB16Op, PsetB32Op, PgeB8Op, PgeB16Op, PgeB32Op>(
@@ -629,17 +731,20 @@ template <typename CombineOpTy>
 FailureOr<Value> combineEquivalentMaskedParts(
     Location loc, ValueRange sources, ValueRange masks, VRegType resultType,
     PatternRewriter &rewriter) {
-  if (sources.empty() || sources.size() != masks.size() ||
-      !haveEquivalentReductionMasks(masks))
+  bool invalidInputs = sources.empty() || sources.size() != masks.size() ||
+                       !haveEquivalentReductionMasks(masks);
+  if (invalidInputs) {
     return failure();
+  }
 
   Value combined = sources.front();
-  for (Value source : sources.drop_front())
+  for (Value source : sources.drop_front()) {
     combined =
         rewriter
             .create<CombineOpTy>(loc, resultType, combined, source,
                                  masks.front())
             .getResult();
+  }
   return combined;
 }
 
@@ -669,7 +774,7 @@ createRuntimePrefixMask(Location loc, MaskType maskType, Value activeLanes,
 LogicalResult
 checkSupportedMaskableVReg(VMIVRegType type, std::string *reason = nullptr) {
   auto fail = [&reason](const Twine &message)
-      -> FailureOr<ReducePhysicalShapePlan> {
+      -> LogicalResult {
     if (reason) {
       *reason = message.str();
     }
@@ -678,8 +783,11 @@ checkSupportedMaskableVReg(VMIVRegType type, std::string *reason = nullptr) {
 
   FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(type.getElementType());
   FailureOr<int64_t> arity = getVMIPhysicalArity(type);
-  if (failed(lanesPerPart) || failed(arity) || *arity < 1)
+  bool invalidPhysicalParts =
+      failed(lanesPerPart) || failed(arity) || *arity < 1;
+  if (invalidPhysicalParts) {
     return fail("requires computable non-empty physical vreg parts");
+  }
 
   return success();
 }
@@ -697,8 +805,9 @@ Value createI16Constant(Location loc, int64_t value,
 FailureOr<Value> createPrefixMaskForActiveLanes(Location loc, MaskType maskType,
                                                 int64_t activeLanes,
                                                 PatternRewriter &rewriter) {
-  if (activeLanes <= 0)
+  if (activeLanes <= 0) {
     return createPrefixMask(loc, maskType, "PAT_ALLF", rewriter);
+  }
 
   switch (activeLanes) {
   case 1:
@@ -715,8 +824,9 @@ FailureOr<Value> createPrefixMaskForActiveLanes(Location loc, MaskType maskType,
   default: {
     FailureOr<std::pair<Value, Value>> dynamicMask = createRuntimePrefixMask(
         loc, maskType, createI32Constant(loc, activeLanes, rewriter), rewriter);
-    if (failed(dynamicMask))
+    if (failed(dynamicMask)) {
       return failure();
+    }
     return dynamicMask->first;
   }
   }
@@ -736,20 +846,24 @@ Value clampDynamicActiveLanes(Location loc, Value activeLanes,
 Value createPartitionActiveLanes(Location loc, Value activeLanesI32,
                                  int64_t factor, int64_t part,
                                  PatternRewriter &rewriter) {
-  if (factor == 1)
+  if (factor == 1) {
     return activeLanesI32;
+  }
   int64_t bias = factor - 1 - part;
   Value biased = activeLanesI32;
-  if (bias != 0)
+  if (bias != 0) {
     biased = rewriter.create<arith::AddIOp>(
         loc, biased, createI32Constant(loc, bias, rewriter));
+  }
   return rewriter.create<arith::DivUIOp>(
       loc, biased, createI32Constant(loc, factor, rewriter));
 }
 
 std::optional<int64_t> getPowerOfTwoLog2(int64_t value) {
-  if (value <= 0 || (value & (value - 1)) != 0)
+  bool isNotPowerOfTwo = value <= 0 || (value & (value - 1)) != 0;
+  if (isNotPowerOfTwo) {
     return std::nullopt;
+  }
   int64_t log2 = 0;
   while (value > 1) {
     value >>= 1;
@@ -760,10 +874,12 @@ std::optional<int64_t> getPowerOfTwoLog2(int64_t value) {
 
 std::optional<std::string> getPrefixPattern(int64_t activeLanes,
                                             int64_t lanesPerPart) {
-  if (activeLanes <= 0)
+  if (activeLanes <= 0) {
     return std::string("PAT_ALLF");
-  if (activeLanes >= lanesPerPart)
+  }
+  if (activeLanes >= lanesPerPart) {
     return std::string("PAT_ALL");
+  }
   switch (activeLanes) {
   case 1:
   case 2:
@@ -796,16 +912,20 @@ static int64_t ceilDivNonNegative(int64_t lhs, int64_t rhs) {
 
 FailureOr<int64_t> getDataLayoutFactor(VMIVRegType type) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return failure();
+  }
   return layout.isDenseSplit() ? layout.getFactor() : 1;
 }
 
 FailureOr<int64_t> getDataChunksInPart(VMIVRegType type, int64_t part) {
   FailureOr<int64_t> factor = getDataLayoutFactor(type);
   FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(type.getElementType());
-  if (failed(factor) || failed(lanesPerPart) || part < 0 || part >= *factor)
+  bool invalidPart = failed(factor) || failed(lanesPerPart) || part < 0 ||
+                     part >= *factor;
+  if (invalidPart) {
     return failure();
+  }
 
   int64_t logicalLanesInPart =
       (type.getElementCount() + *factor - 1 - part) / *factor;
@@ -815,20 +935,26 @@ FailureOr<int64_t> getDataChunksInPart(VMIVRegType type, int64_t part) {
 FailureOr<int64_t> getDataFlatPartIndex(VMIVRegType type, int64_t part,
                                         int64_t chunk) {
   FailureOr<int64_t> factor = getDataLayoutFactor(type);
-  if (failed(factor) || part < 0 || part >= *factor || chunk < 0)
+  bool invalidPartOrChunk =
+      failed(factor) || part < 0 || part >= *factor || chunk < 0;
+  if (invalidPartOrChunk) {
     return failure();
+  }
 
   int64_t flatIndex = 0;
   for (int64_t currentPart = 0; currentPart < part; ++currentPart) {
     FailureOr<int64_t> chunks = getDataChunksInPart(type, currentPart);
-    if (failed(chunks))
+    if (failed(chunks)) {
       return failure();
+    }
     flatIndex += *chunks;
   }
 
   FailureOr<int64_t> chunks = getDataChunksInPart(type, part);
-  if (failed(chunks) || chunk >= *chunks)
+  bool invalidChunk = failed(chunks) || chunk >= *chunks;
+  if (invalidChunk) {
     return failure();
+  }
   return flatIndex + chunk;
 }
 
@@ -842,24 +968,29 @@ FailureOr<int64_t> checkFullDataPhysicalChunks(VMIVRegType type,
   };
 
   FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(type.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return fail("requires known physical lanes per part");
+  }
 
   FailureOr<int64_t> factor = getDataLayoutFactor(type);
-  if (failed(factor))
+  if (failed(factor)) {
     return fail("requires assigned layout");
+  }
 
   for (int64_t part = 0; part < *factor; ++part) {
     FailureOr<int64_t> chunks = getDataChunksInPart(type, part);
-    if (failed(chunks))
+    if (failed(chunks)) {
       return fail("requires known physical chunks");
+    }
     for (int64_t chunk = 0; chunk < *chunks; ++chunk) {
       for (int64_t lane = 0; lane < *lanesPerPart; ++lane) {
         FailureOr<bool> padding = isPaddingLane(type, part, chunk, lane);
-        if (failed(padding))
+        if (failed(padding)) {
           return fail("failed to map physical padding lane");
-        if (*padding)
+        }
+        if (*padding) {
           return fail("found padding lane in physical chunk");
+        }
       }
     }
   }
@@ -869,24 +1000,28 @@ FailureOr<int64_t> checkFullDataPhysicalChunks(VMIVRegType type,
 
 FailureOr<int64_t> getVMITypeLayoutFactor(Type type) {
   Attribute layout;
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     layout = vregType.getLayout();
-  else if (auto maskType = dyn_cast<VMIMaskType>(type))
+  } else if (auto maskType = dyn_cast<VMIMaskType>(type)) {
     layout = maskType.getLayout();
-  else
+  } else {
     return failure();
+  }
 
   auto layoutAttr = dyn_cast_or_null<VMILayoutAttr>(layout);
-  if (!layoutAttr)
+  if (!layoutAttr) {
     return failure();
+  }
   return layoutAttr.isDenseSplit() ? layoutAttr.getFactor() : 1;
 }
 
 FailureOr<int64_t> getVMITypeElementCount(Type type) {
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     return vregType.getElementCount();
-  if (auto maskType = dyn_cast<VMIMaskType>(type))
+  }
+  if (auto maskType = dyn_cast<VMIMaskType>(type)) {
     return maskType.getElementCount();
+  }
   return failure();
 }
 
@@ -897,8 +1032,9 @@ FailureOr<int64_t> getVMITypeLanesPerPart(Type type) {
   if (auto maskType = dyn_cast<VMIMaskType>(type)) {
     FailureOr<StringRef> physicalGranularity =
         getVMIMaskPhysicalGranularity(maskType);
-    if (failed(physicalGranularity))
+    if (failed(physicalGranularity)) {
       return failure();
+    }
     return getMaskLanesPerPart(*physicalGranularity);
   }
   return failure();
@@ -908,22 +1044,29 @@ FailureOr<int64_t> getVMITypeChunksInPart(Type type, int64_t part) {
   FailureOr<int64_t> elementCount = getVMITypeElementCount(type);
   FailureOr<int64_t> factor = getVMITypeLayoutFactor(type);
   FailureOr<int64_t> lanesPerPart = getVMITypeLanesPerPart(type);
-  if (failed(elementCount) || failed(factor) || failed(lanesPerPart) ||
-      part < 0 || part >= *factor)
+  bool invalidChunkQuery =
+      failed(elementCount) || failed(factor) || failed(lanesPerPart) ||
+      part < 0 || part >= *factor;
+  if (invalidChunkQuery) {
     return failure();
+  }
 
   VMILayoutAttr layout;
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     layout = vregType.getLayoutAttr();
-  else if (auto maskType = dyn_cast<VMIMaskType>(type))
+  } else if (auto maskType = dyn_cast<VMIMaskType>(type)) {
     layout = maskType.getLayoutAttr();
-  if (!layout)
+  }
+  if (!layout) {
     return failure();
+  }
 
   int64_t logicalLanesInPart = (*elementCount + *factor - 1 - part) / *factor;
   int64_t laneStride = 1;
-  if (isa<VMIVRegType>(type) && layout.isDense())
+  bool denseVRegLayout = isa<VMIVRegType>(type) && layout.isDense();
+  if (denseVRegLayout) {
     laneStride = layout.getLaneStride();
+  }
   int64_t physicalLanes =
       logicalLanesInPart == 0 ? 0 : (logicalLanesInPart - 1) * laneStride + 1;
   return ceilDivNonNegative(physicalLanes, *lanesPerPart);
@@ -939,20 +1082,25 @@ LogicalResult checkFullVMIPhysicalChunks(Type type, std::string *reason) {
 
   FailureOr<int64_t> factor = getVMITypeLayoutFactor(type);
   FailureOr<int64_t> lanesPerPart = getVMITypeLanesPerPart(type);
-  if (failed(factor) || failed(lanesPerPart))
+  bool unavailableVMIShape = failed(factor) || failed(lanesPerPart);
+  if (unavailableVMIShape) {
     return fail("requires assigned layout with known physical lanes per part");
+  }
 
   for (int64_t part = 0; part < *factor; ++part) {
     FailureOr<int64_t> chunks = getVMITypeChunksInPart(type, part);
-    if (failed(chunks))
+    if (failed(chunks)) {
       return fail("requires known physical chunks");
+    }
     for (int64_t chunk = 0; chunk < *chunks; ++chunk) {
       for (int64_t lane = 0; lane < *lanesPerPart; ++lane) {
         FailureOr<bool> padding = isPaddingLane(type, part, chunk, lane);
-        if (failed(padding))
+        if (failed(padding)) {
           return fail("failed to map physical padding lane");
-        if (*padding)
+        }
+        if (*padding) {
           return fail("found padding lane in physical chunk");
+        }
       }
     }
   }
@@ -1016,8 +1164,9 @@ static LogicalResult verifyMaterializationPartCounts(
   return success();
 }
 
-FailureOr<int64_t> getContiguousMaterializationPartCount(Type type,
-                                                         std::string *reason) {
+static FailureOr<int64_t> getContiguousMaterializationPartCountForLayout(
+    Type type, VMILayoutAttr layout, int64_t arity, int64_t factor,
+    std::string *reason) {
   auto fail = [&reason](const Twine &message) -> FailureOr<int64_t> {
     if (reason) {
       *reason = message.str();
@@ -1025,31 +1174,20 @@ FailureOr<int64_t> getContiguousMaterializationPartCount(Type type,
     return failure();
   };
 
-  FailureOr<int64_t> arity = getVMIPhysicalArity(type);
-  FailureOr<int64_t> factor = getVMITypeLayoutFactor(type);
-  bool missingMaterializationCounts = failed(arity) || failed(factor);
-  if (missingMaterializationCounts) {
-    return fail("requires computable physical arity and assigned layout");
-  }
-
-  FailureOr<VMILayoutAttr> layout = getMaterializationLayout(type, reason);
-  if (failed(layout)) {
-    return failure();
-  }
   bool isContiguousLayout =
-      layout->isContiguous() && layout->getLaneStride() == 1;
+      layout.isContiguous() && layout.getLaneStride() == 1;
   if (isContiguousLayout) {
-    return *arity;
+    return arity;
   }
   bool unsupportedSplitLayout =
-      !layout->isDenseSplit() ||
-      (layout->getFactor() != 2 && layout->getFactor() != 4);
+      !layout.isDenseSplit() ||
+      (layout.getFactor() != 2 && layout.getFactor() != 4);
   if (unsupportedSplitLayout) {
     return fail("requires contiguous, deinterleaved=2/4, or "
                 "block_deinterleaved=2/4 layout");
   }
 
-  if (failed(verifyMaterializationPartCounts(type, *layout, *factor, reason))) {
+  if (failed(verifyMaterializationPartCounts(type, layout, factor, reason))) {
     return failure();
   }
 
@@ -1068,6 +1206,25 @@ FailureOr<int64_t> getContiguousMaterializationPartCount(Type type,
   return getVMIPhysicalArity(contiguousType);
 }
 
+FailureOr<int64_t> getContiguousMaterializationPartCount(Type type,
+                                                         std::string *reason) {
+  FailureOr<int64_t> arity = getVMIPhysicalArity(type);
+  FailureOr<int64_t> factor = getVMITypeLayoutFactor(type);
+  bool missingMaterializationCounts = failed(arity) || failed(factor);
+  if (missingMaterializationCounts) {
+    if (reason) {
+      *reason = "requires computable physical arity and assigned layout";
+    }
+    return failure();
+  }
+  FailureOr<VMILayoutAttr> layout = getMaterializationLayout(type, reason);
+  if (failed(layout)) {
+    return failure();
+  }
+  return getContiguousMaterializationPartCountForLayout(type, *layout, *arity,
+                                                        *factor, reason);
+}
+
 LogicalResult checkCanMaterializeToContiguous(Type type, std::string *reason) {
   return succeeded(getContiguousMaterializationPartCount(type, reason))
              ? success()
@@ -1075,19 +1232,22 @@ LogicalResult checkCanMaterializeToContiguous(Type type, std::string *reason) {
 }
 
 std::optional<int64_t> getConstantIndexValue(Value value) {
-  if (auto constant = value.getDefiningOp<arith::ConstantIndexOp>())
+  if (auto constant = value.getDefiningOp<arith::ConstantIndexOp>()) {
     return constant.value();
+  }
   if (auto constant = value.getDefiningOp<arith::ConstantOp>()) {
-    if (auto integerAttr = dyn_cast<IntegerAttr>(constant.getValue()))
+    if (auto integerAttr = dyn_cast<IntegerAttr>(constant.getValue())) {
       return integerAttr.getInt();
+    }
   }
   return std::nullopt;
 }
 
 FailureOr<int64_t> getStaticMemRefElementCount(Type type) {
   auto memrefType = dyn_cast<MemRefType>(type);
-  if (!memrefType || !memrefType.hasStaticShape())
+  if (!memrefType || !memrefType.hasStaticShape()) {
     return failure();
+  }
 
   int64_t elements = 1;
   for (int64_t dim : memrefType.getShape()) {
@@ -1099,10 +1259,12 @@ FailureOr<int64_t> getStaticMemRefElementCount(Type type) {
 }
 
 static Type getMemoryElementType(Type type) {
-  if (auto ptrType = dyn_cast<PtrType>(type))
+  if (auto ptrType = dyn_cast<PtrType>(type)) {
     return ptrType.getElementType();
-  if (auto memrefType = dyn_cast<MemRefType>(type))
+  }
+  if (auto memrefType = dyn_cast<MemRefType>(type)) {
     return memrefType.getElementType();
+  }
   return {};
 }
 
@@ -1264,8 +1426,10 @@ buildContiguousIdentityLaneAddressMap(int64_t constantOffset,
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(resultType.getElementType());
   FailureOr<int64_t> arity = getVMIPhysicalArity(resultType);
-  if (failed(lanesPerPart) || failed(arity))
+  bool unavailableAddressMapShape = failed(lanesPerPart) || failed(arity);
+  if (unavailableAddressMapShape) {
     return fail("requires computable physical read footprint");
+  }
 
   VMIMemoryLaneAddressMap map;
   map.baseElementOffset = constantOffset;
@@ -1276,17 +1440,100 @@ buildContiguousIdentityLaneAddressMap(int64_t constantOffset,
 VMISupportResult requireIdentityMemRefLayout(Type memoryType, StringRef role,
                                              Value memoryValue = {}) {
   auto memrefType = dyn_cast<MemRefType>(memoryType);
-  if (!memrefType || memrefType.getLayout().isIdentity())
+  if (!memrefType || memrefType.getLayout().isIdentity()) {
     return VMISupportResult::success();
+  }
   std::string reason =
       (Twine(role) +
        " memref layout is non-identity; current VMI memory access plan "
        "supports only contiguous identity lane-to-address maps")
           .str();
-  if (memoryValue && memoryValue.getDefiningOp<memref::SubViewOp>())
+  bool hasSubViewBase =
+      memoryValue && memoryValue.getDefiningOp<memref::SubViewOp>();
+  if (hasSubViewBase) {
     reason += "; memref.subview requires normalized base/offset/stride "
               "lane-to-address planning";
+  }
   return VMISupportResult::failure(reason);
+}
+
+struct VMIStaticReadEnvelopes {
+  VMIByteInterval readable;
+  VMIByteInterval candidate;
+};
+
+static FailureOr<int64_t> getByteAddressableElementSize(
+    Type elementType, std::string *reason) {
+  unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
+  if (elementBits == 0 || elementBits % 8 != 0) {
+    if (reason) {
+      *reason = "requires byte-addressable element type";
+    }
+    return failure();
+  }
+  return static_cast<int64_t>(elementBits / 8);
+}
+
+static FailureOr<VMIStaticReadEnvelopes> buildStaticReadEnvelopes(
+    int64_t constantOffset, int64_t staticElements, int64_t elementBytes,
+    int64_t physicalFootprint, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> FailureOr<VMIStaticReadEnvelopes> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  int64_t offsetBytes;
+  int64_t allocationBytes;
+  int64_t footprintBytes;
+  bool envelopeOverflows =
+      llvm::MulOverflow(constantOffset, elementBytes, offsetBytes) ||
+      llvm::MulOverflow(staticElements, elementBytes, allocationBytes) ||
+      llvm::MulOverflow(physicalFootprint, elementBytes, footprintBytes);
+  if (envelopeOverflows) {
+    return fail("byte read envelope overflows int64");
+  }
+  return VMIStaticReadEnvelopes{
+      VMIByteInterval{-offsetBytes, allocationBytes - offsetBytes},
+      VMIByteInterval{0, footprintBytes}};
+}
+
+struct VMIStaticReadContract {
+  int64_t staticElements;
+  int64_t elementBytes;
+  VMIMemoryLaneAddressMap addressMap;
+};
+
+static FailureOr<VMIStaticReadContract> getStaticReadContract(
+    Type sourceType, int64_t constantOffset, VMIVRegType resultType,
+    std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> FailureOr<VMIStaticReadContract> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  FailureOr<int64_t> staticElements = getStaticMemRefElementCount(sourceType);
+  if (failed(staticElements)) {
+    return fail("requires statically shaped memref source");
+  }
+  if (constantOffset < 0) {
+    return fail("requires non-negative offset");
+  }
+  std::string addressMapReason;
+  FailureOr<VMIMemoryLaneAddressMap> addressMap =
+      buildContiguousIdentityLaneAddressMap(constantOffset, resultType,
+                                            &addressMapReason);
+  if (failed(addressMap)) {
+    return fail(addressMapReason);
+  }
+  std::string elementSizeReason;
+  FailureOr<int64_t> elementBytes = getByteAddressableElementSize(
+      resultType.getElementType(), &elementSizeReason);
+  if (failed(elementBytes)) {
+    return fail(elementSizeReason);
+  }
+  return VMIStaticReadContract{*staticElements, *elementBytes, *addressMap};
 }
 
 VMIMemorySafeReadProof
@@ -1301,51 +1548,35 @@ computeSafeFullReadProof(Type sourceType, std::optional<int64_t> constantOffset,
     return proof;
   };
 
-  if (!constantOffset)
+  if (!constantOffset) {
     return fail("requires constant index offset");
-
-  FailureOr<int64_t> staticElements = getStaticMemRefElementCount(sourceType);
-  if (failed(staticElements))
-    return fail("requires statically shaped memref source");
-  int64_t elements = *staticElements;
-  proof.staticElementCount = elements;
-
-  if (*constantOffset < 0)
-    return fail("requires non-negative offset");
-
-  std::string addressMapReason;
-  FailureOr<VMIMemoryLaneAddressMap> addressMap =
-      buildContiguousIdentityLaneAddressMap(*constantOffset, resultType,
-                                            &addressMapReason);
-  if (failed(addressMap))
-    return fail(addressMapReason);
-  proof.laneAddressMap = *addressMap;
-
-  proof.physicalFootprint = addressMap->physicalLaneFootprint;
-  unsigned elementBits =
-      pto::getPTOStorageElemBitWidth(resultType.getElementType());
-  if (elementBits == 0 || elementBits % 8 != 0) {
-    return fail("requires byte-addressable element type");
-  }
-  int64_t elementBytes = static_cast<int64_t>(elementBits / 8);
-  int64_t offsetBytes;
-  int64_t allocationBytes;
-  int64_t footprintBytes;
-  if (
-      llvm::MulOverflow(*constantOffset, elementBytes, offsetBytes) ||
-      llvm::MulOverflow(elements, elementBytes, allocationBytes) ||
-      llvm::MulOverflow(proof.physicalFootprint, elementBytes, footprintBytes)) {
-    return fail("byte read envelope overflows int64");
   }
 
-  proof.readableEnvelope =
-      VMIByteInterval{-offsetBytes, allocationBytes - offsetBytes};
-  proof.candidateReadEnvelope = VMIByteInterval{0, footprintBytes};
+  std::string contractReason;
+  FailureOr<VMIStaticReadContract> contract = getStaticReadContract(
+      sourceType, *constantOffset, resultType, &contractReason);
+  if (failed(contract)) {
+    return fail(contractReason);
+  }
+  proof.staticElementCount = contract->staticElements;
+  proof.laneAddressMap = contract->addressMap;
+  proof.physicalFootprint = contract->addressMap.physicalLaneFootprint;
+  std::string envelopeReason;
+  FailureOr<VMIStaticReadEnvelopes> envelopes = buildStaticReadEnvelopes(
+      *constantOffset, contract->staticElements, contract->elementBytes,
+      proof.physicalFootprint,
+      &envelopeReason);
+  if (failed(envelopes)) {
+    return fail(envelopeReason);
+  }
+  proof.readableEnvelope = envelopes->readable;
+  proof.candidateReadEnvelope = envelopes->candidate;
   if (!proof.readableEnvelope->contains(*proof.candidateReadEnvelope)) {
     return fail(Twine("full physical read footprint [") +
-                Twine(addressMap->baseElementOffset) + ", " +
-                Twine(addressMap->getExclusiveEndElement()) +
-                ") exceeds static memref element count " + Twine(elements));
+                Twine(contract->addressMap.baseElementOffset) + ", " +
+                Twine(contract->addressMap.getExclusiveEndElement()) +
+                ") exceeds static memref element count " +
+                Twine(contract->staticElements));
   }
 
   proof.proven = true;
@@ -1421,6 +1652,28 @@ static FailureOr<VMIStatefulReadEnvelopes> buildStatefulReadEnvelopes(
       VMIByteInterval{physicalBegin, physicalEnd}};
 }
 
+static FailureOr<int64_t> getPhysicalReadFootprintElements(
+    VMIVRegType resultType, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> FailureOr<int64_t> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  FailureOr<int64_t> lanesPerPart =
+      getDataLanesPerPart(resultType.getElementType());
+  FailureOr<int64_t> arity = getVMIPhysicalArity(resultType);
+  bool missingFootprint = failed(lanesPerPart) || failed(arity);
+  if (missingFootprint) {
+    return fail("requires computable physical read footprint");
+  }
+  int64_t footprintElements;
+  if (llvm::MulOverflow(*arity, *lanesPerPart, footprintElements)) {
+    return fail("stateful byte read envelope overflows int64");
+  }
+  return footprintElements;
+}
+
 static FailureOr<VMIStatefulOffsetRange>
 getStatefulOffsetRange(Value source, Value offset, std::string *reason) {
   auto fail = [&reason](const Twine &message)
@@ -1464,6 +1717,56 @@ getStatefulOffsetRange(Value source, Value offset, std::string *reason) {
   return VMIStatefulOffsetRange{*minOffset, *maxOffset};
 }
 
+struct VMIStatefulReadContract {
+  int64_t staticElements;
+  int64_t elementBytes;
+  int64_t physicalFootprint;
+  int64_t remainder;
+  VMIStatefulOffsetRange offsetRange;
+};
+
+static FailureOr<VMIStatefulReadContract> getStatefulReadContract(
+    Value source, Value offset, VMIVRegType resultType, std::string *reason) {
+  auto fail = [&reason](const Twine &message)
+      -> FailureOr<VMIStatefulReadContract> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  FailureOr<int64_t> staticElements =
+      getStaticMemRefElementCount(source.getType());
+  if (failed(staticElements)) {
+    return fail("requires statically shaped memref source");
+  }
+  std::string rangeReason;
+  FailureOr<VMIStatefulOffsetRange> offsetRange =
+      getStatefulOffsetRange(source, offset, &rangeReason);
+  if (failed(offsetRange)) {
+    return fail(rangeReason);
+  }
+  std::string elementSizeReason;
+  FailureOr<int64_t> elementBytes = getByteAddressableElementSize(
+      resultType.getElementType(), &elementSizeReason);
+  if (failed(elementBytes)) {
+    return fail(elementSizeReason);
+  }
+  constexpr int64_t blockBytes = 32;
+  std::optional<int64_t> remainder = getKnownAddressRemainderBytes(
+      source, offset, resultType.getElementType(), blockBytes);
+  if (!remainder) {
+    return fail("requires a proven fixed 32-byte address remainder");
+  }
+  std::string footprintReason;
+  FailureOr<int64_t> physicalFootprint =
+      getPhysicalReadFootprintElements(resultType, &footprintReason);
+  if (failed(physicalFootprint)) {
+    return fail(footprintReason);
+  }
+  return VMIStatefulReadContract{*staticElements, *elementBytes,
+                                 *physicalFootprint, *remainder, *offsetRange};
+}
+
 static VMIMemorySafeReadProof
 computeSafeStatefulReadProof(Value source, Value offset,
                              VMIVRegType resultType) {
@@ -1475,49 +1778,16 @@ computeSafeStatefulReadProof(Value source, Value offset,
     return proof;
   };
 
-  FailureOr<int64_t> staticElements =
-      getStaticMemRefElementCount(source.getType());
-  if (failed(staticElements)) {
-    return fail("requires statically shaped memref source");
-  }
-
-  std::string rangeReason;
-  FailureOr<VMIStatefulOffsetRange> offsetRange =
-      getStatefulOffsetRange(source, offset, &rangeReason);
-  if (failed(offsetRange)) {
-    return fail(rangeReason);
-  }
-
-  unsigned elementBits =
-      pto::getPTOStorageElemBitWidth(resultType.getElementType());
-  if (elementBits == 0 || elementBits % 8 != 0) {
-    return fail("requires byte-addressable element type");
-  }
-  int64_t elementBytes = static_cast<int64_t>(elementBits / 8);
-
-  constexpr int64_t blockBytes = 32;
-  std::optional<int64_t> remainder = getKnownAddressRemainderBytes(
-      source, offset, resultType.getElementType(), blockBytes);
-  if (!remainder) {
-    return fail("requires a proven fixed 32-byte address remainder");
-  }
-
-  FailureOr<int64_t> lanesPerPart =
-      getDataLanesPerPart(resultType.getElementType());
-  FailureOr<int64_t> arity = getVMIPhysicalArity(resultType);
-  bool missingFootprint = failed(lanesPerPart) || failed(arity);
-  if (missingFootprint) {
-    return fail("requires computable physical read footprint");
-  }
-
-  int64_t footprintElements;
-  if (llvm::MulOverflow(*arity, *lanesPerPart, footprintElements)) {
-    return fail("stateful byte read envelope overflows int64");
+  std::string contractReason;
+  FailureOr<VMIStatefulReadContract> contract =
+      getStatefulReadContract(source, offset, resultType, &contractReason);
+  if (failed(contract)) {
+    return fail(contractReason);
   }
   std::string envelopeReason;
   FailureOr<VMIStatefulReadEnvelopes> envelopes = buildStatefulReadEnvelopes(
-      *staticElements, *offsetRange, elementBytes, footprintElements,
-      *remainder, &envelopeReason);
+      contract->staticElements, contract->offsetRange, contract->elementBytes,
+      contract->physicalFootprint, contract->remainder, &envelopeReason);
   if (failed(envelopes)) {
     return fail(envelopeReason);
   }
@@ -1653,8 +1923,9 @@ FailureOr<int64_t> verifyFullOrSafeReadVRegChunks(Operation *op,
           : computeSafeStatefulReadProof(source, offset, type);
   if (safeReadProof.proven) {
     lanesPerPart = getDataLanesPerPart(type.getElementType());
-    if (succeeded(lanesPerPart))
+    if (succeeded(lanesPerPart)) {
       return *lanesPerPart;
+    }
   }
 
   std::string legalizationReason =
@@ -1680,18 +1951,22 @@ checkSupportedLoadShape(VMIVRegType type, Value source, Type sourceType,
 
   VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(
       source, sourceType, type, constantOffset, VMIMemoryCoverageKind::Dense);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
+  }
 
   VMILayoutSupport supports;
-  if (failed(supports.getLoadLayoutFact(type, reason)))
+  if (failed(supports.getLoadLayoutFact(type, reason))) {
     return failure();
+  }
 
-  if (getDenseLaneStrideLoadDistToken(type))
+  if (getDenseLaneStrideLoadDistToken(type)) {
     return success();
+  }
 
-  if (failed(getDataLanesPerPart(type.getElementType())))
+  if (failed(getDataLanesPerPart(type.getElementType()))) {
     return fail("requires element type with known physical lane width");
+  }
   return success();
 }
 
@@ -1699,7 +1974,7 @@ LogicalResult checkSupportedDeinterleaveLoadShape(
     VMIDeinterleaveLoadOp op,
     std::string *reason) {
   auto fail = [&reason](const Twine &message)
-      -> FailureOr<ActivePrefixIndexShapePlan> {
+      -> LogicalResult {
     if (reason) {
       *reason = message.str();
     }
@@ -1710,46 +1985,36 @@ LogicalResult checkSupportedDeinterleaveLoadShape(
   auto highType = cast<VMIVRegType>(op.getHigh().getType());
   VMILayoutSupport supports;
   if (failed(supports.getDeinterleaveLoadLayoutFactForLayouts(
-          lowType, highType, reason)))
+          lowType, highType, reason))) {
     return failure();
-  if (!getX2MemoryDistToken(lowType.getElementType(), "DINTLV"))
+  }
+  if (!getX2MemoryDistToken(lowType.getElementType(), "DINTLV")) {
     return fail("requires 8/16/32-bit element type for vldsx2 DINTLV");
+  }
 
   VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(
       op.getSource(), op.getOffset(), lowType, VMIMemoryCoverageKind::Dense);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
+  }
 
   std::string fullChunkReason;
-  if (failed(checkFullDataPhysicalChunks(lowType, &fullChunkReason)))
+  if (failed(checkFullDataPhysicalChunks(lowType, &fullChunkReason))) {
     return fail(Twine("requires full physical chunks; ") + fullChunkReason);
+  }
   return success();
 }
 
-LogicalResult checkSupportedStoreShape(VMIVRegType type, Value destination,
-                                       Type destinationType,
-                                       std::string *reason) {
-  VMIMemoryAccessPlan accessPlan = buildWriteAccessPlan(
-      destination, destinationType, type, VMIMemoryCoverageKind::Dense);
-  if (!accessPlan.layoutSupport.isSupported()) {
-    if (reason)
-      *reason = accessPlan.layoutSupport.reason;
-    return failure();
+static LogicalResult checkStorePhysicalCoverage(VMIVRegType type,
+                                                std::string *reason) {
+  if (getDenseLaneStrideStoreDistToken(type)) {
+    return success();
   }
 
-  if (failed(checkSupportedMaskableVReg(type, reason)))
-    return failure();
-
-  VMILayoutSupport supports;
-  if (failed(supports.getStoreLayoutFact(type, reason)))
-    return failure();
-
-  if (getDenseLaneStrideStoreDistToken(type))
-    return success();
-
   std::string fullChunkReason;
-  if (succeeded(checkFullDataPhysicalChunks(type, &fullChunkReason)))
+  if (succeeded(checkFullDataPhysicalChunks(type, &fullChunkReason))) {
     return success();
+  }
 
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
@@ -1759,20 +2024,49 @@ LogicalResult checkSupportedStoreShape(VMIVRegType type, Value destination,
   };
 
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned layout");
-  if (failed(getDataLanesPerPart(type.getElementType())))
+  }
+  if (failed(getDataLanesPerPart(type.getElementType()))) {
     return fail("requires known physical lanes per part");
-  if (layout.isContiguous() && layout.getLaneStride() == 1)
+  }
+  bool directContiguousStore =
+      layout.isContiguous() && layout.getLaneStride() == 1;
+  if (directContiguousStore) {
     return success();
+  }
 
   std::string materializationReason;
-  if (succeeded(checkCanMaterializeToContiguous(type, &materializationReason)))
+  if (succeeded(checkCanMaterializeToContiguous(type, &materializationReason))) {
     return success();
+  }
   return fail(Twine("partial/tail store requires contiguous layout or "
                     "deinterleaved layout that can materialize to contiguous; "
                     "value ") +
               fullChunkReason + ", materialization " + materializationReason);
+}
+
+LogicalResult checkSupportedStoreShape(VMIVRegType type, Value destination,
+                                       Type destinationType,
+                                       std::string *reason) {
+  VMIMemoryAccessPlan accessPlan = buildWriteAccessPlan(
+      destination, destinationType, type, VMIMemoryCoverageKind::Dense);
+  if (!accessPlan.layoutSupport.isSupported()) {
+    if (reason) {
+      *reason = accessPlan.layoutSupport.reason;
+    }
+    return failure();
+  }
+
+  if (failed(checkSupportedMaskableVReg(type, reason))) {
+    return failure();
+  }
+
+  VMILayoutSupport supports;
+  if (failed(supports.getStoreLayoutFact(type, reason))) {
+    return failure();
+  }
+  return checkStorePhysicalCoverage(type, reason);
 }
 
 LogicalResult checkSupportedInterleaveStoreShape(
@@ -1789,26 +2083,35 @@ LogicalResult checkSupportedInterleaveStoreShape(
   auto highType = cast<VMIVRegType>(op.getHigh().getType());
   VMILayoutAttr lowLayout = lowType.getLayoutAttr();
   VMILayoutAttr highLayout = highType.getLayoutAttr();
-  if (!lowLayout || !highLayout || !lowLayout.isContiguous() ||
-      !highLayout.isContiguous())
+  bool nonContiguousInputs =
+      !lowLayout || !highLayout || !lowLayout.isContiguous() ||
+      !highLayout.isContiguous();
+  if (nonContiguousInputs) {
     return fail("requires assigned contiguous low/high input layouts");
-  if (lowType.getElementCount() != highType.getElementCount() ||
-      lowType.getElementType() != highType.getElementType())
+  }
+  bool mismatchedInputs = lowType.getElementCount() != highType.getElementCount() ||
+                        lowType.getElementType() != highType.getElementType();
+  if (mismatchedInputs) {
     return fail("requires matching low/high input shape and element type");
-  if (!getX2MemoryDistToken(lowType.getElementType(), "INTLV"))
+  }
+  if (!getX2MemoryDistToken(lowType.getElementType(), "INTLV")) {
     return fail("requires 8/16/32-bit element type for vstsx2 INTLV");
+  }
 
   VMIMemoryAccessPlan accessPlan =
       buildWriteAccessPlan(op.getDestination(), op.getOffset(), lowType,
                            VMIMemoryCoverageKind::Dense);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
-  if (failed(checkSupportedMaskableVReg(lowType, reason)))
+  }
+  if (failed(checkSupportedMaskableVReg(lowType, reason))) {
     return failure();
+  }
 
   std::string fullChunkReason;
-  if (failed(checkFullDataPhysicalChunks(lowType, &fullChunkReason)))
+  if (failed(checkFullDataPhysicalChunks(lowType, &fullChunkReason))) {
     return fail(Twine("requires full physical chunks; ") + fullChunkReason);
+  }
   return success();
 }
 
@@ -1821,10 +2124,13 @@ FailureOr<int64_t> getGroupSizeFromNumGroups(VMIVRegType type,
     }
     return failure();
   };
-  if (numGroups <= 0)
+  if (numGroups <= 0) {
     return fail("requires num_groups to be positive");
-  if (type.getElementCount() % numGroups != 0)
+  }
+  bool unevenGroups = type.getElementCount() % numGroups != 0;
+  if (unevenGroups) {
     return fail("requires num_groups to evenly divide logical lane count");
+  }
   return type.getElementCount() / numGroups;
 }
 
@@ -1838,28 +2144,40 @@ LogicalResult checkSupportedGroupChunkShape(VMIVRegType type, int64_t groupSize,
   };
 
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isContiguous())
+  bool nonContiguousLayout = !layout || !layout.isContiguous();
+  if (nonContiguousLayout) {
     return fail("requires assigned contiguous layout");
+  }
   std::string fullChunkReason;
-  if (failed(checkFullDataPhysicalChunks(type, &fullChunkReason)))
+  if (failed(checkFullDataPhysicalChunks(type, &fullChunkReason))) {
     return fail(Twine("requires full physical chunks; ") + fullChunkReason);
+  }
   FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(type.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return fail("requires known physical lanes per part");
-  if (groupSize <= 0 || type.getElementCount() % groupSize != 0)
+  }
+  bool invalidGroupSize =
+      groupSize <= 0 || type.getElementCount() % groupSize != 0;
+  if (invalidGroupSize) {
     return fail("requires derived group size to evenly divide logical lane "
                 "count");
-  if (groupSize % *lanesPerPart != 0)
+  }
+  if (groupSize % *lanesPerPart != 0) {
     return fail("currently requires group size to be a multiple of physical "
                 "lanes per part");
+  }
   return success();
 }
 
-LogicalResult checkDeinterleaved2GroupStoreChunkShape(
-    VMIVRegType type, int64_t groupSize, int64_t *lanesPerPart,
-    int64_t *groupCount, int64_t *chunksPerGroupPerPart,
-    std::string *reason) {
-  auto fail = [&reason](const Twine &message) -> LogicalResult {
+struct Deinterleaved2GroupStoreShape {
+  int64_t lanesPerPart;
+  int64_t groupCount;
+  int64_t chunksPerGroupPerPart;
+};
+
+static FailureOr<int64_t>
+getDeinterleaved2StoreLanes(VMIVRegType type, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> FailureOr<int64_t> {
     if (reason) {
       *reason = message.str();
     }
@@ -1867,36 +2185,91 @@ LogicalResult checkDeinterleaved2GroupStoreChunkShape(
   };
 
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isDeinterleaved() || layout.getFactor() != 2 ||
-      layout.getLaneStride() != 1)
+  bool unsupportedLayout =
+      !layout || !layout.isDeinterleaved() || layout.getFactor() != 2 ||
+      layout.getLaneStride() != 1;
+  if (unsupportedLayout) {
     return fail("requires deinterleaved=2 value layout");
+  }
   std::string fullChunkReason;
-  if (failed(checkFullDataPhysicalChunks(type, &fullChunkReason)))
+  if (failed(checkFullDataPhysicalChunks(type, &fullChunkReason))) {
     return fail(Twine("requires full physical chunks; ") + fullChunkReason);
+  }
   FailureOr<int64_t> lanes = getDataLanesPerPart(type.getElementType());
-  if (failed(lanes))
+  if (failed(lanes)) {
     return fail("requires known physical lanes per part");
-  if (!getX2MemoryDistToken(type.getElementType(), "INTLV"))
+  }
+  if (!getX2MemoryDistToken(type.getElementType(), "INTLV")) {
     return fail("requires 8/16/32-bit element type for vstsx2 INTLV");
-  if (groupSize <= 0 || type.getElementCount() % groupSize != 0)
+  }
+  return *lanes;
+}
+
+static FailureOr<Deinterleaved2GroupStoreShape>
+getDeinterleaved2GroupStoreGeometry(VMIVRegType type, int64_t groupSize,
+                                    int64_t lanesPerPart,
+                                    std::string *reason) {
+  auto fail = [&reason](const Twine &message)
+      -> FailureOr<Deinterleaved2GroupStoreShape> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  bool invalidDeinterleavedGroupSize =
+      groupSize <= 0 || type.getElementCount() % groupSize != 0;
+  if (invalidDeinterleavedGroupSize) {
     return fail("requires derived group size to evenly divide logical lane "
                 "count");
-  int64_t pairLanes = 2 * *lanes;
-  if (groupSize % pairLanes != 0)
+  }
+  int64_t pairLanes = 2 * lanesPerPart;
+  if (groupSize % pairLanes != 0) {
     return fail("requires group size to be a multiple of two physical chunks");
+  }
 
   FailureOr<int64_t> part0Chunks = getDataChunksInPart(type, /*part=*/0);
   FailureOr<int64_t> part1Chunks = getDataChunksInPart(type, /*part=*/1);
-  if (failed(part0Chunks) || failed(part1Chunks) ||
-      *part0Chunks != *part1Chunks)
+  bool mismatchedPartChunks =
+      failed(part0Chunks) || failed(part1Chunks) ||
+      *part0Chunks != *part1Chunks;
+  if (mismatchedPartChunks) {
     return fail("requires matching deinterleaved part chunk counts");
+  }
 
-  *lanesPerPart = *lanes;
-  *groupCount = type.getElementCount() / groupSize;
-  *chunksPerGroupPerPart = groupSize / pairLanes;
-  if (*part0Chunks != *groupCount * *chunksPerGroupPerPart)
+  int64_t groupCount = type.getElementCount() / groupSize;
+  int64_t chunksPerGroupPerPart = groupSize / pairLanes;
+  if (*part0Chunks != groupCount * chunksPerGroupPerPart) {
     return fail("requires deinterleaved chunks to align with group rows");
-  return success();
+  }
+  return Deinterleaved2GroupStoreShape{lanesPerPart, groupCount,
+                                      chunksPerGroupPerPart};
+}
+
+static FailureOr<Deinterleaved2GroupStoreShape>
+getDeinterleaved2GroupStoreShape(VMIVRegType type, int64_t groupSize,
+                                 std::string *reason) {
+  FailureOr<int64_t> lanesPerPart =
+      getDeinterleaved2StoreLanes(type, reason);
+  if (failed(lanesPerPart)) {
+    return failure();
+  }
+  return getDeinterleaved2GroupStoreGeometry(type, groupSize,
+                                              *lanesPerPart, reason);
+}
+
+LogicalResult checkDeinterleaved2GroupStoreChunkShape(
+    VMIVRegType type, int64_t groupSize, int64_t *lanesPerPart,
+    int64_t *groupCount, int64_t *chunksPerGroupPerPart,
+    std::string *reason) {
+  FailureOr<Deinterleaved2GroupStoreShape> shape =
+      getDeinterleaved2GroupStoreShape(type, groupSize, reason);
+  if (succeeded(shape)) {
+    *lanesPerPart = shape->lanesPerPart;
+    *groupCount = shape->groupCount;
+    *chunksPerGroupPerPart = shape->chunksPerGroupPerPart;
+    return success();
+  }
+  return failure();
 }
 
 LogicalResult checkSupportedBlockDeinterleavedGroupLoadShape(
@@ -1943,13 +2316,6 @@ LogicalResult
 checkSupportedContiguousGroupLoadShape(VMIGroupLoadOp op,
                                        VMIVRegType resultType,
                                        int64_t groupSize, std::string *reason) {
-  auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
-
   VMILayoutSupport supports;
   if (failed(supports.getGroupLoadLayoutFact(op, reason))) {
     return failure();
@@ -1960,7 +2326,8 @@ checkSupportedContiguousGroupLoadShape(VMIGroupLoadOp op,
     return failure();
   }
   std::optional<int64_t> rowStride = getConstantIndexValue(op.getRowStride());
-  if (rowStride && *rowStride == groupSize) {
+  bool unitGroupRowStride = rowStride && *rowStride == groupSize;
+  if (unitGroupRowStride) {
     return success();
   }
   return checkSupportedGroupChunkShape(resultType, groupSize, reason);
@@ -1991,8 +2358,9 @@ checkSupportedGroupLoadShape(VMIGroupLoadOp op, std::string *reason) {
                                                   reason);
   }
 
-  if (resultLayout.isBlockDeinterleaved() &&
-      resultType.getElementType().isF32()) {
+  bool supportsBlockDeinterleaved =
+      resultLayout.isBlockDeinterleaved() && resultType.getElementType().isF32();
+  if (supportsBlockDeinterleaved) {
     return checkSupportedBlockDeinterleavedGroupLoadShape(op, resultType,
                                                           reason);
   }
@@ -2153,32 +2521,43 @@ FailureOr<OneBlockGroupStorePlan> getOneBlockGroupStorePlan(
     const VMIGroupStoreLayoutFact &fact, std::string *reason) {
   auto fail = [&reason](const Twine &message)
       -> FailureOr<OneBlockGroupStorePlan> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr layout = valueType.getLayoutAttr();
-  if (fact.blockClass != VMIGroupBlockClass::OneBlock || !layout ||
-      !layout.isContiguous())
+  bool unsupportedBlockLayout =
+      fact.blockClass != VMIGroupBlockClass::OneBlock || !layout ||
+      !layout.isContiguous();
+  if (unsupportedBlockLayout) {
     return fail("one-block group_store requires contiguous layout");
-  if (fact.groupSize <= 0 || fact.groupSize != fact.vcgBlockElems ||
-      fact.lanesPerPart <= 0 ||
-      fact.lanesPerPart % fact.groupSize != 0)
+  }
+  bool unsupportedBlockShape =
+      fact.groupSize <= 0 || fact.groupSize != fact.vcgBlockElems ||
+      fact.lanesPerPart <= 0 || fact.lanesPerPart % fact.groupSize != 0;
+  if (unsupportedBlockShape) {
     return fail("one-block group_store requires one 32B group per VCG block");
-  if (!isa<PtrType>(op.getDestination().getType()))
+  }
+  if (!isa<PtrType>(op.getDestination().getType())) {
     return fail("one-block group_store requires !pto.ptr destination");
+  }
 
   std::optional<int64_t> rowStride =
       getConstantIndexValue(op.getRowStride());
-  if (!rowStride || *rowStride <= 0 || *rowStride % fact.groupSize != 0)
+  bool unalignedRowStride =
+      !rowStride || *rowStride <= 0 || *rowStride % fact.groupSize != 0;
+  if (unalignedRowStride) {
     return fail("one-block group_store requires a constant positive row_stride "
                 "aligned to 32B blocks");
+  }
 
   int64_t blockStride = *rowStride / fact.groupSize;
-  if (blockStride > 0xffff)
+  if (blockStride > 0xffff) {
     return fail("one-block group_store block_stride exceeds the 16-bit vsstb "
                 "control field");
+  }
 
   return OneBlockGroupStorePlan{
       fact.groupSize, fact.lanesPerPart / fact.groupSize, blockStride};
@@ -2259,26 +2638,21 @@ LogicalResult
 checkSupportedGroupStorePhysicalShape(
     VMIGroupStoreOp op, VMIVRegType valueType,
     const VMIGroupStoreLayoutFact &fact, std::string *reason) {
-  auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
-
   if (failed(checkSupportedStoreShape(valueType,
                                       op.getDestination(),
                                       op.getDestination().getType(), reason))) {
     return failure();
   }
-  if (fact.blockClass == VMIGroupBlockClass::OneBlock) {
+  bool oneBlock = fact.blockClass == VMIGroupBlockClass::OneBlock;
+  if (oneBlock) {
     if (failed(getOneBlockGroupStorePlan(op, valueType, fact, reason))) {
       return failure();
     }
     return success();
   }
-  if (succeeded(checkSupportedGroupChunkShape(valueType, fact.groupSize,
-                                              reason))) {
+  bool contiguousGroupChunks = succeeded(
+      checkSupportedGroupChunkShape(valueType, fact.groupSize, reason));
+  if (contiguousGroupChunks) {
     return success();
   }
 
@@ -2295,8 +2669,9 @@ checkSupportedGroupStoreByLayout(VMIGroupStoreOp op, VMIVRegType valueType,
                                  VMILayoutAttr layout,
                                  std::optional<int64_t> rowStride,
                                  std::string *reason) {
-  if (isCompactSmallGroupStore(layout, valueType,
-                               op.getNumGroupsAttr().getInt(), rowStride)) {
+  bool compactSmallGroup = isCompactSmallGroupStore(
+      layout, valueType, op.getNumGroupsAttr().getInt(), rowStride);
+  if (compactSmallGroup) {
     return checkSupportedCompactSmallGroupStoreShape(op, valueType, reason);
   }
   if (layout && layout.isGroupSlots()) {
@@ -2324,8 +2699,9 @@ checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
 LogicalResult
 checkSupportedMaskedLoadShape(VMIMaskedLoadOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2352,8 +2728,9 @@ checkSupportedMaskedLoadShape(VMIMaskedLoadOp op, std::string *reason) {
   }
 
   std::string fullChunkReason;
-  if (succeeded(checkFullDataPhysicalChunks(resultType, &fullChunkReason)))
+  if (succeeded(checkFullDataPhysicalChunks(resultType, &fullChunkReason))) {
     return success();
+  }
 
   if (accessPlan.front().readSafety.proven) {
     return success();
@@ -2371,8 +2748,9 @@ LogicalResult checkSupportedGatherPhysicalShape(
     VMIVRegType resultType, VMIVRegType indicesType, VMIVRegType passthruType,
     VMIMaskType maskType, bool requiresFullChunks, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
@@ -2417,6 +2795,44 @@ LogicalResult checkSupportedGatherPhysicalShape(
   return success();
 }
 
+static bool haveMatchingIntegerSignedness(IntegerType sourceType,
+                                          IntegerType resultType) {
+  return (sourceType.isUnsigned() && resultType.isUnsigned()) ||
+         (!sourceType.isUnsigned() && !resultType.isUnsigned());
+}
+
+static bool isB8To16GatherContract(IntegerType sourceType,
+                                   IntegerType resultType,
+                                   IntegerType indexType,
+                                   VMIMaskType maskType) {
+  return sourceType.getWidth() == mlir::pto::kValue8 &&
+         resultType.getWidth() == mlir::pto::kValue16 &&
+         indexType.isUnsigned() && indexType.getWidth() == 16 &&
+         maskType.getGranularity() == "b16" &&
+         haveMatchingIntegerSignedness(sourceType, resultType);
+}
+
+static bool isSameWidth16IntegerGatherContract(IntegerType sourceType,
+                                               IntegerType resultType,
+                                               IntegerType indexType,
+                                               VMIMaskType maskType) {
+  return sourceType.getWidth() == mlir::pto::kValue16 &&
+         resultType.getWidth() == mlir::pto::kValue16 &&
+         indexType.isUnsigned() && indexType.getWidth() == 16 &&
+         maskType.getGranularity() == "b16" &&
+         haveMatchingIntegerSignedness(sourceType, resultType);
+}
+
+static bool isSameWidth16FloatGatherContract(Type sourceElementType,
+                                             Type resultElementType,
+                                             IntegerType indexType,
+                                             VMIMaskType maskType) {
+  return sourceElementType == resultElementType &&
+         (sourceElementType.isF16() || sourceElementType.isBF16()) &&
+         indexType.isUnsigned() && indexType.getWidth() == 16 &&
+         maskType.getGranularity() == "b16";
+}
+
 LogicalResult
 checkGatherElementContract(VMIVRegType resultType, VMIVRegType indicesType,
                             VMIMaskType maskType, Type sourceElemType,
@@ -2437,22 +2853,15 @@ checkGatherElementContract(VMIVRegType resultType, VMIVRegType indicesType,
   auto resultInt = dyn_cast<IntegerType>(resultType.getElementType());
   bool isB8To16Gather =
       resultBits == 16 && sourceInt && resultInt &&
-      sourceInt.getWidth() == mlir::pto::kValue8 &&
-      resultInt.getWidth() == mlir::pto::kValue16 &&
-      indexElementType.isUnsigned() && indexElementType.getWidth() == 16 &&
-      maskType.getGranularity() == "b16" &&
-      ((sourceInt.isUnsigned() && resultInt.isUnsigned()) ||
-       (!sourceInt.isUnsigned() && !resultInt.isUnsigned()));
+      isB8To16GatherContract(sourceInt, resultInt, indexElementType, maskType);
   bool isSameWidth16Gather =
-      resultBits == 16 && indexElementType.isUnsigned() &&
-      indexElementType.getWidth() == 16 && maskType.getGranularity() == "b16" &&
-      ((sourceInt && resultInt &&
-        sourceInt.getWidth() == mlir::pto::kValue16 &&
-        resultInt.getWidth() == mlir::pto::kValue16 &&
-        ((sourceInt.isUnsigned() && resultInt.isUnsigned()) ||
-         (!sourceInt.isUnsigned() && !resultInt.isUnsigned()))) ||
-       (sourceElemType == resultType.getElementType() &&
-        (sourceElemType.isF16() || sourceElemType.isBF16())));
+      resultBits == 16 &&
+      ((sourceInt && resultInt && isSameWidth16IntegerGatherContract(
+                                      sourceInt, resultInt, indexElementType,
+                                      maskType)) ||
+       isSameWidth16FloatGatherContract(sourceElemType,
+                                        resultType.getElementType(),
+                                        indexElementType, maskType));
   bool isB16Gather = isSameWidth16Gather || isB8To16Gather;
   bool isB32Gather = resultBits == 32 && indexElementType.getWidth() == 32 &&
                      maskType.getGranularity() == "b32";
@@ -2544,6 +2953,9 @@ checkSupportedGatherShape(VMIGatherOp op, std::string *reason) {
   bool isB16Gather = resultBits == 16 && indexElementType &&
                      indexElementType.getWidth() == 16 &&
                      maskType.getGranularity() == "b16";
+  bool isB32Gather = resultBits == 32 && indexElementType &&
+                     indexElementType.getWidth() == 32 &&
+                     maskType.getGranularity() == "b32";
 
   return checkGatherPhysicalChunkRequirement(
       resultType, indicesType, passthruType, maskType, isB16Gather,
@@ -2667,13 +3079,6 @@ static ScatterShapeTypes getScatterShapeTypes(VMIScatterOp op) {
 
 LogicalResult
 checkSupportedScatterShape(VMIScatterOp op, std::string *reason) {
-  auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
-
   ScatterShapeTypes types = getScatterShapeTypes(op);
   if (failed(checkScatterLayoutAndDestination(op, types.value, types.indices,
                                               types.mask, reason))) {
@@ -2801,19 +3206,22 @@ bool isStaticAllActiveMask(Value mask, int64_t expectedLanes,
                            std::string *reason = nullptr) {
   mask = stripMaskMaterialization(mask);
   auto fail = [&reason](const Twine &message) {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return false;
   };
 
   if (auto createMask = mask.getDefiningOp<VMICreateMaskOp>()) {
     auto activeConstant =
         createMask.getActiveLanes().getDefiningOp<arith::ConstantOp>();
-    if (!activeConstant)
+    if (!activeConstant) {
       return fail("create_mask active_lanes is dynamic");
+    }
     auto activeAttr = dyn_cast<IntegerAttr>(activeConstant.getValue());
-    if (!activeAttr)
+    if (!activeAttr) {
       return fail("create_mask active_lanes is not an integer constant");
+    }
     return activeAttr.getInt() >= expectedLanes
                ? true
                : fail("create_mask active_lanes is smaller than the logical "
@@ -2822,48 +3230,35 @@ bool isStaticAllActiveMask(Value mask, int64_t expectedLanes,
 
   if (auto constantMask = mask.getDefiningOp<VMIConstantMaskOp>()) {
     auto denseAttr = dyn_cast<DenseIntElementsAttr>(constantMask.getValue());
-    if (!denseAttr)
+    if (!denseAttr) {
       return fail("constant_mask is not a dense integer mask");
-    if (denseAttr.getNumElements() != expectedLanes)
+    }
+    bool invalidElementCount = denseAttr.getNumElements() != expectedLanes;
+    if (invalidElementCount) {
       return fail("constant_mask element count does not match the logical "
                   "lane count");
+    }
     auto values = denseAttr.getValues<bool>();
-    for (bool value : values)
-      if (!value)
+    for (bool value : values) {
+      if (!value) {
         return fail("constant_mask contains an inactive lane");
+      }
+    }
     return true;
   }
 
   return fail("mask is not a static all-active create_mask or constant_mask");
 }
 
-LogicalResult
-checkSupportedExpandLoadRuntimePath(
-    VMIExpandLoadOp op, VMIVRegType resultType, VMIVRegType passthruType,
-    VMIMaskType maskType, StringRef allActivePathReason, std::string *reason) {
+static LogicalResult checkExpandLoadRuntimeArity(
+    VMIVRegType resultType, VMIVRegType passthruType, VMIMaskType maskType,
+    std::string *reason) {
   auto fail = [&reason](const Twine &message) {
     if (reason) {
       *reason = message.str();
     }
     return failure();
   };
-
-  if (!isa<PtrType>(op.getSource().getType())) {
-    return fail(Twine("runtime-mask path requires !pto.ptr source because "
-                      "pto.vgather2_bc is pointer-only; all-active path ") +
-                allActivePathReason);
-  }
-  bool unsupportedResultWidth =
-      pto::getPTOStorageElemBitWidth(resultType.getElementType()) != 32;
-  if (unsupportedResultWidth) {
-    return fail("runtime-mask path currently requires 32-bit result element "
-                "type so prefix indices and gather result lane counts match");
-  }
-  bool unsupportedMaskGranularity = maskType.getGranularity() != "b32";
-  if (unsupportedMaskGranularity) {
-    return fail("runtime-mask path requires b32 mask granularity");
-  }
-
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
   FailureOr<int64_t> passthruArity = getVMIPhysicalArity(passthruType);
   FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
@@ -2878,7 +3273,18 @@ checkSupportedExpandLoadRuntimePath(
     return fail("runtime-mask path currently supports only one physical "
                 "chunk because prefix indices must not reset across chunks");
   }
+  return success();
+}
 
+static LogicalResult checkExpandLoadRuntimeFullChunks(
+    VMIVRegType resultType, VMIVRegType passthruType, VMIMaskType maskType,
+    std::string *reason) {
+  auto fail = [&reason](const Twine &message) {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
   std::string fullChunkReason;
   std::string passthruReason;
   std::string maskFullReason;
@@ -2895,6 +3301,39 @@ checkSupportedExpandLoadRuntimePath(
                 maskFullReason);
   }
   return success();
+}
+
+LogicalResult
+checkSupportedExpandLoadRuntimePath(
+    VMIExpandLoadOp op, VMIVRegType resultType, VMIVRegType passthruType,
+    VMIMaskType maskType, StringRef allActivePathReason, std::string *reason) {
+  auto fail = [&reason](const Twine &message) {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  if (!isa<PtrType>(op.getSource().getType())) {
+    return fail(Twine("runtime-mask path requires !pto.ptr source because "
+                      "pto.vgather2_bc is pointer-only; all-active path ") +
+                allActivePathReason);
+  }
+  bool unsupportedResultWidth =
+      pto::getPTOStorageElemBitWidth(resultType.getElementType()) != 32;
+  if (unsupportedResultWidth) {
+    return fail("runtime-mask path currently requires 32-bit result element "
+                "type so prefix indices and gather result lane counts match");
+  }
+  bool unsupportedMaskGranularity = maskType.getGranularity() != "b32";
+  if (unsupportedMaskGranularity) {
+    return fail("runtime-mask path requires b32 mask granularity");
+  }
+  if (failed(checkExpandLoadRuntimeArity(resultType, passthruType, maskType,
+                                         reason))) {
+    return failure();
+  }
+  return checkExpandLoadRuntimeFullChunks(resultType, passthruType, maskType,
+                                          reason);
 }
 
 LogicalResult
@@ -2956,13 +3395,6 @@ static bool hasSafeExpandLoadAllActivePath(
 
 LogicalResult
 checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
-  auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
-
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   auto passthruType = cast<VMIVRegType>(op.getPassthru().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
@@ -3054,12 +3486,6 @@ static LogicalResult checkMaskedStoreLayoutAndArity(
 static LogicalResult checkMaskedStoreContiguousMaterialization(
     VMIVRegType valueType, VMIMaskType maskType, StringRef valueReason,
     StringRef maskReason, std::string *reason) {
-  auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
   return checkMaskedStoreContiguousMaterialization(
       valueType, maskType, valueReason, maskReason, reason);
 }
@@ -3105,16 +3531,19 @@ FailureOr<int64_t> getActiveDataLanesInPhysicalChunk(VMIVRegType vmiType,
                                                      int64_t chunk) {
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(vmiType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return failure();
+  }
 
   int64_t active = 0;
   for (int64_t lane = 0; lane < *lanesPerPart; ++lane) {
     FailureOr<bool> padding = isPaddingLane(vmiType, /*part=*/0, chunk, lane);
-    if (failed(padding))
+    if (failed(padding)) {
       return failure();
-    if (!*padding)
+    }
+    if (!*padding) {
       ++active;
+    }
   }
   return active;
 }
@@ -3124,23 +3553,28 @@ FailureOr<Value> createContiguousStoreMask(Location loc, VMIVRegType vmiType,
                                            PatternRewriter &rewriter) {
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(vmiType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return failure();
+  }
 
   FailureOr<int64_t> activeLanes = getContiguousActiveDataLanes(vmiType, chunk);
-  if (failed(activeLanes))
+  if (failed(activeLanes)) {
     return failure();
-  if (*activeLanes == *lanesPerPart)
+  }
+  if (*activeLanes == *lanesPerPart) {
     return createAllTrueMaskForVReg(loc, vregType, rewriter);
+  }
 
   FailureOr<MaskType> maskType =
       getMaskTypeForVReg(vregType, rewriter.getContext());
-  if (failed(maskType))
+  if (failed(maskType)) {
     return failure();
+  }
   FailureOr<std::pair<Value, Value>> maskAndRemaining = createRuntimePrefixMask(
       loc, *maskType, createI32Constant(loc, *activeLanes, rewriter), rewriter);
-  if (failed(maskAndRemaining))
+  if (failed(maskAndRemaining)) {
     return failure();
+  }
   return maskAndRemaining->first;
 }
 
@@ -3150,23 +3584,29 @@ FailureOr<Value> createMaskedStorePredicate(Location loc, VMIVRegType vmiType,
                                             PatternRewriter &rewriter) {
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(vmiType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return failure();
+  }
 
   FailureOr<int64_t> activeLanes = getContiguousActiveDataLanes(vmiType, chunk);
-  if (failed(activeLanes))
+  if (failed(activeLanes)) {
     return failure();
-  if (*activeLanes == *lanesPerPart)
+  }
+  if (*activeLanes == *lanesPerPart) {
     return userMask;
+  }
 
   auto maskType = dyn_cast<MaskType>(userMask.getType());
-  if (!maskType)
+  if (!maskType) {
     return failure();
+  }
   FailureOr<Value> tailMask =
       createContiguousStoreMask(loc, vmiType, chunk, vregType, rewriter);
   FailureOr<Value> allTrue = createAllTrueMask(loc, maskType, rewriter);
-  if (failed(tailMask) || failed(allTrue))
+  bool failedTailMaskMaterialization = failed(tailMask) || failed(allTrue);
+  if (failedTailMaskMaterialization) {
     return failure();
+  }
   return rewriter.create<PandOp>(loc, maskType, userMask, *tailMask, *allTrue)
       .getResult();
 }
@@ -3221,17 +3661,22 @@ FailureOr<Value> createDenseLaneStrideStorePredicate(
   FailureOr<int64_t> activeLanes =
       getActiveDataLanesInPhysicalChunk(vmiType, chunk);
   FailureOr<int64_t> maskLanes = getMaskLanesPerPart(targetGranularity);
-  if (failed(activeLanes) || failed(maskLanes))
+  bool failedLaneCountQuery = failed(activeLanes) || failed(maskLanes);
+  if (failedLaneCountQuery) {
     return failure();
-  if (*activeLanes == *maskLanes)
+  }
+  if (*activeLanes == *maskLanes) {
     return *compactMask;
+  }
 
   auto targetMaskType = MaskType::get(rewriter.getContext(), targetGranularity);
   FailureOr<Value> tailMask = createPrefixMaskForActiveLanes(
       loc, targetMaskType, *activeLanes, rewriter);
   FailureOr<Value> allTrue = createAllTrueMask(loc, targetMaskType, rewriter);
-  if (failed(tailMask) || failed(allTrue))
+  bool failedTailMaskMaterialization = failed(tailMask) || failed(allTrue);
+  if (failedTailMaskMaterialization) {
     return failure();
+  }
   return rewriter
       .create<PandOp>(loc, targetMaskType, *compactMask, *tailMask, *allTrue)
       .getResult();
@@ -3288,7 +3733,8 @@ static FailureOr<int64_t> computeShuffleForwardingSourceChunk(
   std::optional<int64_t> sourcePart;
   std::optional<int64_t> sourceChunk;
   for (int64_t lane = 0; lane < lanesPerPart; ++lane) {
-    FailureOr<VMIPhysicalLane> sourcePhysical = getShuffleSourcePhysicalLane(
+    FailureOr<std::optional<VMIPhysicalLane>> sourcePhysical =
+        getShuffleSourcePhysicalLane(
         sourceType, resultType, indices, resultPart, resultChunk, lane,
         reason);
     if (failed(sourcePhysical)) {
@@ -3298,10 +3744,10 @@ static FailureOr<int64_t> computeShuffleForwardingSourceChunk(
       continue;
     }
     if (!sourcePart) {
-      sourcePart = sourcePhysical->value().part;
-      sourceChunk = sourcePhysical->value().chunk;
-    } else if (*sourcePart != sourcePhysical->value().part ||
-               *sourceChunk != sourcePhysical->value().chunk) {
+      sourcePart = (*sourcePhysical)->part;
+      sourceChunk = (*sourcePhysical)->chunk;
+    } else if (*sourcePart != (*sourcePhysical)->part ||
+               *sourceChunk != (*sourcePhysical)->chunk) {
       return fail("requires one source chunk per result chunk");
     }
   }
@@ -3319,6 +3765,7 @@ static FailureOr<int64_t> computeShuffleForwardingSourceChunk(
 struct ShuffleForwardingInputPlan {
   VMIVRegType sourceType;
   VMIVRegType resultType;
+  ArrayRef<int64_t> indices;
   int64_t lanesPerPart;
   int64_t resultFactor;
 };
@@ -3348,40 +3795,27 @@ getShuffleForwardingInputPlan(VMIShuffleOp op, std::string *reason) {
     }
     return failure();
   }
-  return ShuffleForwardingInputPlan{sourceType, resultType, *lanesPerPart,
-                                    *resultFactor};
+  return ShuffleForwardingInputPlan{sourceType, resultType, op.getIndices(),
+                                    *lanesPerPart, *resultFactor};
 }
 
-FailureOr<SmallVector<int64_t>>
-computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
-  auto fail = [&reason](const Twine &message) -> FailureOr<SmallVector<int64_t>> {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
-  FailureOr<ShuffleForwardingInputPlan> input =
-      getShuffleForwardingInputPlan(op, reason);
-  if (failed(input)) {
-    return failure();
-  }
-  auto sourceType = input->sourceType;
-  auto resultType = input->resultType;
-  int64_t lanesPerPart = input->lanesPerPart;
-  ArrayRef<int64_t> indices = op.getIndices();
+static FailureOr<SmallVector<int64_t>> materializeShuffleForwardingSourceParts(
+    const ShuffleForwardingInputPlan &input, std::string *reason) {
   SmallVector<int64_t> sourceFlatIndices;
-  for (int64_t resultPart = 0; resultPart < input->resultFactor; ++resultPart) {
+  for (int64_t resultPart = 0; resultPart < input.resultFactor; ++resultPart) {
     FailureOr<int64_t> resultChunks =
-        getDataChunksInPart(resultType, resultPart);
+        getDataChunksInPart(input.resultType, resultPart);
     if (failed(resultChunks)) {
-      return fail("requires known result physical chunks");
+      if (reason) {
+        *reason = "requires known result physical chunks";
+      }
+      return failure();
     }
-
     for (int64_t resultChunk = 0; resultChunk < *resultChunks; ++resultChunk) {
       FailureOr<int64_t> sourceFlatIndex =
           computeShuffleForwardingSourceChunk(
-              sourceType, resultType, indices, resultPart, resultChunk,
-              lanesPerPart, reason);
+              input.sourceType, input.resultType, input.indices, resultPart,
+              resultChunk, input.lanesPerPart, reason);
       if (failed(sourceFlatIndex)) {
         return failure();
       }
@@ -3390,6 +3824,16 @@ computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
   }
 
   return sourceFlatIndices;
+}
+
+FailureOr<SmallVector<int64_t>>
+computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
+  FailureOr<ShuffleForwardingInputPlan> input =
+      getShuffleForwardingInputPlan(op, reason);
+  if (failed(input)) {
+    return failure();
+  }
+  return materializeShuffleForwardingSourceParts(*input, reason);
 }
 
 struct ShuffleVselrPlan {
@@ -3541,8 +3985,9 @@ static FailureOr<int64_t> getShuffleResultChunkCount(
 FailureOr<int64_t> computeShuffleLane0SplatSourcePart(VMIShuffleOp op,
                                                       std::string *reason) {
   auto fail = [&reason](const Twine &message) -> FailureOr<int64_t> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -3570,16 +4015,22 @@ FailureOr<int64_t> computeShuffleLane0SplatSourcePart(VMIShuffleOp op,
   return *sourceFlatIndex;
 }
 
-FailureOr<SmallVector<ShuffleVselrPlan>>
-computeShuffleVselrPlans(VMIShuffleOp op, std::string *reason) {
-  auto fail =
-      [&reason](const Twine &message) -> FailureOr<SmallVector<ShuffleVselrPlan>> {
+struct ShuffleVselrInputPlan {
+  VMIVRegType sourceType;
+  VMIVRegType resultType;
+  ArrayRef<int64_t> indices;
+  int64_t lanesPerPart;
+  int64_t resultFactor;
+};
+
+static FailureOr<ShuffleVselrInputPlan> buildShuffleVselrInputPlan(
+    VMIShuffleOp op, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> FailureOr<ShuffleVselrInputPlan> {
     if (reason) {
       *reason = message.str();
     }
     return failure();
   };
-
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   FailureOr<int64_t> lanesPerPart =
@@ -3587,37 +4038,48 @@ computeShuffleVselrPlans(VMIShuffleOp op, std::string *reason) {
   if (failed(lanesPerPart)) {
     return fail("requires known lanes per physical part");
   }
-
   ArrayRef<int64_t> indices = op.getIndices();
   if (indices.empty()) {
     return fail("requires non-empty indices");
   }
-
   FailureOr<int64_t> resultFactor = getDataLayoutFactor(resultType);
   if (failed(resultFactor)) {
     return fail("requires assigned result layout");
   }
+  return ShuffleVselrInputPlan{sourceType, resultType, indices,
+                                *lanesPerPart, *resultFactor};
+}
 
+static FailureOr<SmallVector<ShuffleVselrPlan>> materializeShuffleVselrPlans(
+    const ShuffleVselrInputPlan &input, std::string *reason) {
   SmallVector<ShuffleVselrPlan> plans;
-  for (int64_t resultPart = 0; resultPart < *resultFactor; ++resultPart) {
+  for (int64_t resultPart = 0; resultPart < input.resultFactor; ++resultPart) {
     FailureOr<int64_t> resultChunks =
-        getShuffleResultChunkCount(resultType, resultPart, reason);
+        getShuffleResultChunkCount(input.resultType, resultPart, reason);
     if (failed(resultChunks)) {
-      return fail("requires known result physical chunks");
+      return failure();
     }
-
     for (int64_t resultChunk = 0; resultChunk < *resultChunks; ++resultChunk) {
       FailureOr<ShuffleVselrPlan> plan = computeShuffleVselrPlanForChunk(
-          sourceType, resultType, indices, resultPart, resultChunk,
-          *lanesPerPart, reason);
+          input.sourceType, input.resultType, input.indices, resultPart,
+          resultChunk, input.lanesPerPart, reason);
       if (failed(plan)) {
         return failure();
       }
       plans.push_back(*plan);
     }
   }
-
   return plans;
+}
+
+FailureOr<SmallVector<ShuffleVselrPlan>>
+computeShuffleVselrPlans(VMIShuffleOp op, std::string *reason) {
+  FailureOr<ShuffleVselrInputPlan> input =
+      buildShuffleVselrInputPlan(op, reason);
+  if (failed(input)) {
+    return failure();
+  }
+  return materializeShuffleVselrPlans(*input, reason);
 }
 
 struct ConstantMaskChunkMaterialization {
@@ -3806,8 +4268,9 @@ FailureOr<Value> createPowerOfTwoRemainder(Location loc, Value value,
   }
 
   std::optional<int64_t> shift = getPowerOfTwoLog2(modulus);
-  if (!shift)
+  if (!shift) {
     return failure();
+  }
   if (*shift == 0) {
     Value zero = createI32Constant(loc, 0, rewriter);
     return rewriter.create<VdupOp>(loc, vectorType, zero, allMask,
@@ -3981,7 +4444,7 @@ FailureOr<Value> materializeDynamicGroupMaskChunk(
                            rewriter.getStringAttr("lt"))
           .getResult();
   FailureOr<Value> paddedPredicate = applyGroupMaskPadding(
-      op, resultVMIType, *maskType, predicate, part, chunk, lanesPerPart,
+      op, resultVMIType, maskType, predicate, part, chunk, lanesPerPart,
       *allMask, rewriter);
   if (failed(paddedPredicate)) {
     return failure();
@@ -4085,8 +4548,10 @@ static FailureOr<DynamicGroupMaskPlan> buildDynamicGroupMaskPlan(
   int64_t arity = physicalShape->second;
   int64_t factor = layout.isDenseSplit() ? layout.getFactor() : 1;
   FailureOr<int64_t> blockElems = getVMILayoutBlockElems(resultVMIType);
-  if (factor <= 0 || failed(blockElems) || *blockElems <= 0 ||
-      static_cast<int64_t>(resultTypes.size()) % factor != 0) {
+  bool invalidResultCount =
+      factor <= 0 || failed(blockElems) || *blockElems <= 0 ||
+      static_cast<int64_t>(resultTypes.size()) % factor != 0;
+  if (invalidResultCount) {
     return fail("dynamic create_group_mask physical result count does not match layout factor");
   }
   if (!getPowerOfTwoLog2(*blockElems)) {
@@ -4120,11 +4585,6 @@ FailureOr<SmallVector<Value>> materializeDynamicGroupMaskForType(
     VMICreateGroupMaskOp op, Value activeElemsPerGroup,
     VMIMaskType resultVMIType, TypeRange resultTypes,
     PatternRewriter &rewriter) {
-  auto fail = [&op, &rewriter](const Twine &message) -> FailureOr<SmallVector<Value>> {
-    (void)rewriter.notifyMatchFailure(op, message);
-    return failure();
-  };
-
   Location loc = op.getLoc();
   FailureOr<DynamicGroupMaskPlan> plan =
       buildDynamicGroupMaskPlan(op, resultVMIType, resultTypes, nullptr);
@@ -4162,13 +4622,15 @@ FailureOr<Value> materializePrefixMask(Location loc, MaskType maskType,
                                        PatternRewriter &rewriter) {
   std::optional<std::string> pattern =
       getPrefixPattern(activeLanes, lanesPerPart);
-  if (pattern)
+  if (pattern) {
     return createPatternMask(loc, maskType, *pattern, rewriter);
+  }
 
   FailureOr<std::pair<Value, Value>> maskAndRemaining = createRuntimePrefixMask(
       loc, maskType, createI32Constant(loc, activeLanes, rewriter), rewriter);
-  if (failed(maskAndRemaining))
+  if (failed(maskAndRemaining)) {
     return failure();
+  }
   return maskAndRemaining->first;
 }
 
@@ -4240,9 +4702,10 @@ FailureOr<Value> materializeConstantMaskChunk(Location loc, MaskType maskType,
   }
 
   if (std::optional<int64_t> prefixCount =
-          getPrefixActiveLaneCount(activeLanes))
+          getPrefixActiveLaneCount(activeLanes)) {
     return materializePrefixMask(loc, maskType, *prefixCount, *lanesPerPart,
                                  rewriter);
+  }
 
   FailureOr<Value> allTrue = createAllTrueMask(loc, maskType, rewriter);
   if (failed(allTrue)) {
@@ -4290,24 +4753,31 @@ Value createGroupChunkOffset(Location loc, Value baseOffset, Value rowStride,
 LogicalResult checkContiguousFullGroupChunks(
     Operation *op, VMIVRegType type, int64_t groupSize, int64_t *lanesPerPart,
     int64_t *groupCount, int64_t *chunksPerGroup, PatternRewriter &rewriter) {
-  auto fail = [&reason](const Twine &message) {
+  auto fail = [&op, &rewriter](const Twine &message) {
     return rewriter.notifyMatchFailure(op, message);
   };
 
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isContiguous())
+  if (!layout || !layout.isContiguous()) {
     return fail("group op requires contiguous VMI layout");
-  if (failed(checkFullDataPhysicalChunks(type, nullptr)))
+  }
+  if (failed(checkFullDataPhysicalChunks(type, nullptr))) {
     return fail("group op requires full physical chunks");
+  }
   FailureOr<int64_t> lanes = getDataLanesPerPart(type.getElementType());
-  if (failed(lanes))
+  if (failed(lanes)) {
     return fail("group op requires known physical lanes per part");
-  if (groupSize <= 0 || type.getElementCount() % groupSize != 0)
+  }
+  bool invalidGroupSize =
+      groupSize <= 0 || type.getElementCount() % groupSize != 0;
+  if (invalidGroupSize) {
     return fail("group op requires derived group size to evenly divide lane "
                 "count");
-  if (groupSize % *lanes != 0)
+  }
+  if (groupSize % *lanes != 0) {
     return fail("group op currently requires group size to be a multiple of "
                 "physical lanes per part");
+  }
 
   *lanesPerPart = *lanes;
   *groupCount = type.getElementCount() / groupSize;
@@ -4320,8 +4790,10 @@ FailureOr<Value> createZeroVector(Location loc, VRegType type,
   FailureOr<Value> zero =
       createScalarOffsetConstant(loc, type.getElementType(), 0, rewriter);
   FailureOr<Value> mask = createAllTrueMaskForVReg(loc, type, rewriter);
-  if (failed(zero) || failed(mask))
+  bool failedMaterialization = failed(zero) || failed(mask);
+  if (failedMaterialization) {
     return failure();
+  }
   return rewriter
       .create<VdupOp>(loc, type, *zero, *mask,
                       /*position=*/nullptr)
@@ -4333,11 +4805,15 @@ FailureOr<Value> createLaneRangeMask(Location loc, MaskType maskType,
                                      PatternRewriter &rewriter) {
   FailureOr<int64_t> lanesPerPart =
       getMaskLanesPerPart(maskType.getGranularity());
-  if (failed(lanesPerPart) || begin < 0 || begin > end || end > *lanesPerPart)
+  bool invalidRange = failed(lanesPerPart) || begin < 0 || begin > end ||
+                      end > *lanesPerPart;
+  if (invalidRange) {
     return failure();
+  }
   SmallVector<int8_t> active(*lanesPerPart, 0);
-  for (int64_t lane = begin; lane < end; ++lane)
+  for (int64_t lane = begin; lane < end; ++lane) {
     active[lane] = 1;
+  }
   return materializeConstantMaskChunk(loc, maskType, active, rewriter);
 }
 
@@ -4353,16 +4829,21 @@ FailureOr<Value> createGroupSlotIndexVector(Location loc, VRegType indexType,
   FailureOr<MaskType> maskType =
       getMaskTypeForVReg(indexType, rewriter.getContext());
   FailureOr<Value> allMask = createAllTrueMaskForVReg(loc, indexType, rewriter);
-  if (failed(baseScalar) || failed(maskType) || failed(allMask))
+  bool failedSeedMaterialization =
+      failed(baseScalar) || failed(maskType) || failed(allMask);
+  if (failedSeedMaterialization) {
     return failure();
+  }
   Value result = rewriter
                      .create<VdupOp>(loc, indexType, *baseScalar, *allMask,
                                      /*position=*/nullptr)
                      .getResult();
-  if (groupSize >= lanesPerPart)
+  if (groupSize >= lanesPerPart) {
     return result;
-  if (lanesPerPart % groupSize != 0)
+  }
+  if (lanesPerPart % groupSize != 0) {
     return failure();
+  }
 
   int64_t groupsPerChunk = lanesPerPart / groupSize;
   for (int64_t localGroup = 1; localGroup < groupsPerChunk; ++localGroup) {
@@ -4372,8 +4853,10 @@ FailureOr<Value> createGroupSlotIndexVector(Location loc, VRegType indexType,
     FailureOr<Value> laneMask =
         createLaneRangeMask(loc, *maskType, localGroup * groupSize,
                             (localGroup + 1) * groupSize, rewriter);
-    if (failed(groupScalar) || failed(laneMask))
+    bool failedGroupMaterialization = failed(groupScalar) || failed(laneMask);
+    if (failedGroupMaterialization) {
       return failure();
+    }
     Value splat = rewriter
                       .create<VdupOp>(loc, indexType, *groupScalar, *allMask,
                                       /*position=*/nullptr)
@@ -4387,96 +4870,128 @@ FailureOr<Value> createGroupSlotIndexVector(Location loc, VRegType indexType,
 std::optional<std::string> getX2MemoryDistToken(Type elementType,
                                                 StringRef prefix) {
   unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  if (elementBits != 8 && elementBits != 16 && elementBits != 32)
+  if (elementBits != 8 && elementBits != 16 && elementBits != 32) {
     return std::nullopt;
+  }
   return (Twine(prefix) + "_B" + Twine(elementBits)).str();
 }
 
 std::optional<std::string> getDenseLaneStrideLoadDistToken(VMIVRegType type) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isContiguous())
+  if (!layout || !layout.isContiguous()) {
     return std::nullopt;
+  }
   unsigned elementBits = pto::getPTOStorageElemBitWidth(type.getElementType());
   if (layout.getLaneStride() == 2 &&
-      (elementBits == 8 || elementBits == 16 || elementBits == 32))
+      (elementBits == 8 || elementBits == 16 || elementBits == 32)) {
     return (Twine("UNPK_B") + Twine(elementBits)).str();
-  if (layout.getLaneStride() == 4 && elementBits == 8)
+  }
+  bool isUnpack4 = layout.getLaneStride() == 4 && elementBits == 8;
+  if (isUnpack4) {
     return std::string("UNPK4");
+  }
   return std::nullopt;
 }
 
 std::optional<std::string>
 getLaneStrideStoreDistToken(VMILayoutAttr layout, Type elementType) {
-  if (!layout || !layout.hasLaneStride())
+  if (!layout || !layout.hasLaneStride()) {
     return std::nullopt;
+  }
   unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  if (layout.getLaneStride() == 2 && elementBits == 8)
+  bool isPackB16 = layout.getLaneStride() == 2 && elementBits == 8;
+  if (isPackB16) {
     return std::string("PK_B16");
-  if (layout.getLaneStride() == 2 && elementBits == 16)
+  }
+  bool isPackB32 = layout.getLaneStride() == 2 && elementBits == 16;
+  if (isPackB32) {
     return std::string("PK_B32");
-  if (layout.getLaneStride() == 2 && elementBits == 32)
+  }
+  bool isPackB64 = layout.getLaneStride() == 2 && elementBits == 32;
+  if (isPackB64) {
     return std::string("PK_B64");
-  if (layout.getLaneStride() == 4 && elementBits == 8)
+  }
+  bool isPack4B32 = layout.getLaneStride() == 4 && elementBits == 8;
+  if (isPack4B32) {
     return std::string("PK4_B32");
+  }
   return std::nullopt;
 }
 
 std::optional<std::string> getDenseLaneStrideStoreDistToken(VMIVRegType type) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isContiguous())
+  if (!layout || !layout.isContiguous()) {
     return std::nullopt;
+  }
   return getLaneStrideStoreDistToken(layout, type.getElementType());
 }
 
 std::optional<StringRef>
 getLaneStrideStoreMaskGranularity(VMILayoutAttr layout, Type elementType) {
-  if (!layout || !layout.hasLaneStride())
+  if (!layout || !layout.hasLaneStride()) {
     return std::nullopt;
+  }
   unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  if (layout.getLaneStride() == 2 && elementBits == 8)
+  bool isB16Mask = layout.getLaneStride() == 2 && elementBits == 8;
+  if (isB16Mask) {
     return StringRef("b16");
+  }
   if (layout.getLaneStride() == 2 &&
-      (elementBits == 16 || elementBits == 32))
+      (elementBits == 16 || elementBits == 32)) {
     return StringRef("b32");
-  if (layout.getLaneStride() == 4 && elementBits == 8)
+  }
+  bool isB32MaskForPack4 = layout.getLaneStride() == 4 && elementBits == 8;
+  if (isB32MaskForPack4) {
     return StringRef("b32");
+  }
   return std::nullopt;
 }
 
 std::optional<StringRef>
 getDenseLaneStrideStoreMaskGranularity(VMIVRegType type) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isContiguous())
+  if (!layout || !layout.isContiguous()) {
     return std::nullopt;
+  }
   return getLaneStrideStoreMaskGranularity(layout, type.getElementType());
 }
 
 std::optional<StringRef>
 getDenseLaneStrideMaskedStoreMaskGranularity(VMIVRegType type) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isContiguous())
+  if (!layout || !layout.isContiguous()) {
     return std::nullopt;
+  }
   unsigned elementBits = pto::getPTOStorageElemBitWidth(type.getElementType());
-  if (layout.getLaneStride() == 2 && elementBits == 8)
+  bool isB16MaskedStore = layout.getLaneStride() == 2 && elementBits == 8;
+  if (isB16MaskedStore) {
     return StringRef("b16");
-  if (layout.getLaneStride() == 2 && elementBits == 16)
+  }
+  bool isB32MaskedStore = layout.getLaneStride() == 2 && elementBits == 16;
+  if (isB32MaskedStore) {
     return StringRef("b32");
-  if (layout.getLaneStride() == 4 && elementBits == 8)
+  }
+  bool isB32MaskedStorePack4 =
+      layout.getLaneStride() == 4 && elementBits == 8;
+  if (isB32MaskedStorePack4) {
     return StringRef("b32");
+  }
   return std::nullopt;
 }
 
 std::optional<std::string> getPointStoreDistToken(Type elementType) {
   unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  if (elementBits != 8 && elementBits != 16 && elementBits != 32)
+  if (elementBits != 8 && elementBits != 16 && elementBits != 32) {
     return std::nullopt;
+  }
   return (Twine("1PT_B") + Twine(elementBits)).str();
 }
 
 std::optional<std::string> getScalarBroadcastLoadDistToken(Type elementType) {
   unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  if (elementBits != 8 && elementBits != 16 && elementBits != 32)
+  if (elementBits != 8 && elementBits != 16 && elementBits != 32) {
     return std::nullopt;
+  }
   return (Twine("BRC_B") + Twine(elementBits)).str();
 }
 
@@ -4487,75 +5002,94 @@ struct VPTOCmpMode {
 
 std::optional<VPTOCmpMode> getVPTOCmpFMode(StringRef predicate) {
   if (predicate == "eq" || predicate == "ne" || predicate == "lt" ||
-      predicate == "le" || predicate == "gt" || predicate == "ge")
+      predicate == "le" || predicate == "gt" || predicate == "ge") {
     return VPTOCmpMode{predicate, std::nullopt};
-  if (predicate == "oeq")
+  }
+  if (predicate == "oeq") {
     return VPTOCmpMode{StringRef("eq"), std::nullopt};
-  if (predicate == "one")
+  }
+  if (predicate == "one") {
     return VPTOCmpMode{StringRef("ne"), std::nullopt};
-  if (predicate == "olt")
+  }
+  if (predicate == "olt") {
     return VPTOCmpMode{StringRef("lt"), std::nullopt};
-  if (predicate == "ole")
+  }
+  if (predicate == "ole") {
     return VPTOCmpMode{StringRef("le"), std::nullopt};
-  if (predicate == "ogt")
+  }
+  if (predicate == "ogt") {
     return VPTOCmpMode{StringRef("gt"), std::nullopt};
-  if (predicate == "oge")
+  }
+  if (predicate == "oge") {
     return VPTOCmpMode{StringRef("ge"), std::nullopt};
+  }
   return std::nullopt;
 }
 
 std::optional<VPTOCmpMode> getVPTOCmpIMode(StringRef predicate) {
-  if (predicate == "eq" || predicate == "ne")
+  if (predicate == "eq" || predicate == "ne") {
     return VPTOCmpMode{predicate, std::nullopt};
-  if (predicate == "ult")
+  }
+  if (predicate == "ult") {
     return VPTOCmpMode{
         StringRef("lt"), IntegerType::SignednessSemantics::Unsigned};
-  if (predicate == "ule")
+  }
+  if (predicate == "ule") {
     return VPTOCmpMode{
         StringRef("le"), IntegerType::SignednessSemantics::Unsigned};
-  if (predicate == "ugt")
+  }
+  if (predicate == "ugt") {
     return VPTOCmpMode{
         StringRef("gt"), IntegerType::SignednessSemantics::Unsigned};
-  if (predicate == "uge")
+  }
+  if (predicate == "uge") {
     return VPTOCmpMode{
         StringRef("ge"), IntegerType::SignednessSemantics::Unsigned};
-  if (predicate == "slt")
+  }
+  if (predicate == "slt") {
     return VPTOCmpMode{
         StringRef("lt"), IntegerType::SignednessSemantics::Signed};
-  if (predicate == "sle")
+  }
+  if (predicate == "sle") {
     return VPTOCmpMode{
         StringRef("le"), IntegerType::SignednessSemantics::Signed};
-  if (predicate == "sgt")
+  }
+  if (predicate == "sgt") {
     return VPTOCmpMode{
         StringRef("gt"), IntegerType::SignednessSemantics::Signed};
-  if (predicate == "sge")
+  }
+  if (predicate == "sge") {
     return VPTOCmpMode{
         StringRef("ge"), IntegerType::SignednessSemantics::Signed};
+  }
   return std::nullopt;
 }
 
 template <typename SourceOp>
 std::optional<VPTOCmpMode> getVPTOCmpMode(StringRef predicate) {
-  if constexpr (std::is_same_v<SourceOp, VMICmpIOp>)
+  if constexpr (std::is_same_v<SourceOp, VMICmpIOp>) {
     return getVPTOCmpIMode(predicate);
-  else
+  } else {
     return getVPTOCmpFMode(predicate);
+  }
 }
 
 template <typename SourceOp>
 StringRef getSupportedComparePredicateMessage() {
-  if constexpr (std::is_same_v<SourceOp, VMICmpIOp>)
+  if constexpr (std::is_same_v<SourceOp, VMICmpIOp>) {
     return "eq/ne, unsigned integer forms ult/ule/ugt/uge, and signed "
            "integer forms slt/sle/sgt/sge";
-  else
+  } else {
     return "eq/ne/lt/le/gt/ge and ordered FP forms oeq/one/olt/ole/ogt/oge";
+  }
 }
 
 template <typename SourceOp>
 LogicalResult checkSupportedComparePredicate(Operation *op,
                                              StringRef predicate) {
-  if (getVPTOCmpMode<SourceOp>(predicate))
+  if (getVPTOCmpMode<SourceOp>(predicate)) {
     return success();
+  }
   return op->emitError()
          << kVMIDiagUnsupportedPrefix << "compare predicate " << predicate
          << " cannot be lowered to pto.vcmp; supported predicates are "
@@ -4569,9 +5103,11 @@ struct OneToNVMIUnpackOpPattern : OneToNOpConversionPattern<VMIUnpackOp> {
   matchAndRewrite(VMIUnpackOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
     ValueRange sourceParts = adaptor.getSource();
-    if (sourceParts.size() != op->getNumResults())
+    bool arityMismatch = sourceParts.size() != op->getNumResults();
+    if (arityMismatch) {
       return rewriter.notifyMatchFailure(
           op, "converted source part count must match unpack results");
+    }
     replaceOpWithFlatConvertedValues(rewriter, op, sourceParts,
                                      *this->getTypeConverter());
     return success();
@@ -4586,9 +5122,12 @@ struct OneToNVMIPackOpPattern : OneToNOpConversionPattern<VMIPackOp> {
                   OneToNPatternRewriter &rewriter) const override {
     FailureOr<int64_t> arity = getVMIPhysicalArity(op.getResult().getType());
     SmallVector<Value> flatOperands = flattenOneToNOperands(adaptor.getOperands());
-    if (failed(arity) || static_cast<int64_t>(flatOperands.size()) != *arity)
+    bool arityMismatch =
+        failed(arity) || static_cast<int64_t>(flatOperands.size()) != *arity;
+    if (arityMismatch) {
       return rewriter.notifyMatchFailure(
           op, "pack part count must match converted VMI result arity");
+    }
     replaceOpWithFlatConvertedValues(rewriter, op, flatOperands,
                                      *this->getTypeConverter());
     return success();
@@ -4599,21 +5138,26 @@ LogicalResult verifyIdentityPartForwarding(Operation *op,
                                            ValueRange sourceParts,
                                            TypeRange resultTypes,
                                            PatternRewriter &rewriter) {
-  if (sourceParts.size() != resultTypes.size())
+  bool arityMismatch = sourceParts.size() != resultTypes.size();
+  if (arityMismatch) {
     return rewriter.notifyMatchFailure(
         op, "source and result physical arity mismatch");
+  }
   for (auto [part, resultType] : llvm::zip_equal(sourceParts, resultTypes)) {
-    if (part.getType() != resultType)
+    bool typeMismatch = part.getType() != resultType;
+    if (typeMismatch) {
       return rewriter.notifyMatchFailure(
           op, "helper requires non-identity physical materialization");
+    }
   }
   return success();
 }
 
 FailureOr<VRegType> getUnsignedCarrierVRegType(MLIRContext *ctx,
                                                unsigned elementBits) {
-  if (elementBits != 8 && elementBits != 16 && elementBits != 32)
+  if (elementBits != 8 && elementBits != 16 && elementBits != 32) {
     return failure();
+  }
   auto elementType = IntegerType::get(
       ctx, elementBits, IntegerType::SignednessSemantics::Unsigned);
   return VRegType::get(ctx, 2048 / elementBits, elementType);
@@ -4623,13 +5167,15 @@ FailureOr<VRegType>
 getSignednessCarrierVRegType(VRegType inputType,
                              IntegerType::SignednessSemantics signedness) {
   auto inputElementType = dyn_cast<IntegerType>(inputType.getElementType());
-  if (!inputElementType)
+  if (!inputElementType) {
     return failure();
+  }
   if ((signedness == IntegerType::SignednessSemantics::Signed &&
        !inputElementType.isUnsigned()) ||
       (signedness == IntegerType::SignednessSemantics::Unsigned &&
-       inputElementType.isUnsigned()))
+       inputElementType.isUnsigned())) {
     return inputType;
+  }
   auto carrierElementType = IntegerType::get(
       inputType.getContext(), inputElementType.getWidth(), signedness);
   return VRegType::get(inputType.getContext(), inputType.getElementCount(),
@@ -4638,22 +5184,29 @@ getSignednessCarrierVRegType(VRegType inputType,
 
 FailureOr<Value> bitcastVReg(Location loc, Value value, Type resultType,
                              PatternRewriter &rewriter) {
-  if (value.getType() == resultType)
+  bool isIdentity = value.getType() == resultType;
+  if (isIdentity) {
     return value;
+  }
   auto inputType = dyn_cast<VRegType>(value.getType());
   auto outputType = dyn_cast<VRegType>(resultType);
-  if (!inputType || !outputType)
+  if (!inputType || !outputType) {
     return failure();
+  }
   return rewriter.create<VbitcastOp>(loc, outputType, value).getResult();
 }
 
 FailureOr<VRegType> getVcaddResultType(VRegType inputType) {
   auto inputIntegerType = dyn_cast<IntegerType>(inputType.getElementType());
-  if (!inputIntegerType || inputIntegerType.getWidth() == 32)
+  bool preservesType =
+      !inputIntegerType || inputIntegerType.getWidth() == 32;
+  if (preservesType) {
     return inputType;
+  }
   unsigned inputWidth = inputIntegerType.getWidth();
-  if (inputWidth != 8 && inputWidth != 16)
+  if (inputWidth != 8 && inputWidth != 16) {
     return failure();
+  }
   auto resultElementType = IntegerType::get(
       inputType.getContext(), inputWidth * 2,
       inputIntegerType.getSignedness());
@@ -4666,8 +5219,9 @@ FailureOr<Value> unpackToNextCarrier(Location loc, Value source,
                                      PatternRewriter &rewriter) {
   FailureOr<VRegType> resultType =
       getUnsignedCarrierVRegType(rewriter.getContext(), sourceBits * 2);
-  if (failed(resultType))
+  if (failed(resultType)) {
     return failure();
+  }
   Value part = rewriter.create<arith::ConstantIndexOp>(loc, partIndex);
   return rewriter.create<VzunpackOp>(loc, *resultType, source, part)
       .getResult();
@@ -4679,8 +5233,9 @@ FailureOr<Value> packToPreviousCarrier(Location loc, Value source,
                                        PatternRewriter &rewriter) {
   FailureOr<VRegType> resultType =
       getUnsignedCarrierVRegType(rewriter.getContext(), resultBits);
-  if (failed(resultType))
+  if (failed(resultType)) {
     return failure();
+  }
   return rewriter
       .create<VpackOp>(loc, *resultType, source,
                        rewriter.getStringAttr(part))
@@ -5034,7 +5589,7 @@ materializeGroupSlotLaneStrideLayout(
       sourceLayout.getNumGroups() == resultLayout.getNumGroups() &&
       sourceLayout.getSlots() == 8 && resultLayout.getSlots() == 8;
   if (!supported) {
-    return std::nullopt;
+    return std::optional<SmallVector<Value>>{};
   }
   FailureOr<SmallVector<Value>> result = materializeGroupSlotLaneStride(
       op, sourceParts, resultTypes, sourceVMIElementType,
@@ -5063,11 +5618,11 @@ materializeBlockLayoutForwarding(Operation *op, ValueRange sourceParts,
       (isBlockDeinterleaved(sourceLayout, 2) ||
        isBlockDeinterleaved(sourceLayout, 4));
   if (!contiguousToBlock && !blockToContiguous) {
-    return std::nullopt;
+    return std::optional<SmallVector<Value>>{};
   }
   if (std::optional<SmallVector<Value>> castInputs =
           forwardBlockLayoutCastInputs(sourceParts, resultTypes)) {
-    return std::move(*castInputs);
+    return std::optional<SmallVector<Value>>(std::move(*castInputs));
   }
   return forwardIdentityLayoutParts(op, sourceParts, resultTypes, rewriter);
 }
@@ -5107,7 +5662,7 @@ materializeSimpleDataLayoutConversion(
     return failure();
   }
   if (groupSlot->has_value()) {
-    return std::move(**groupSlot);
+    return std::optional<SmallVector<Value>>(std::move(**groupSlot));
   }
 
   FailureOr<std::optional<SmallVector<Value>>> block =
@@ -5117,10 +5672,10 @@ materializeSimpleDataLayoutConversion(
     return failure();
   }
   if (block->has_value()) {
-    return std::move(**block);
+    return std::optional<SmallVector<Value>>(std::move(**block));
   }
 
-  return std::nullopt;
+  return std::optional<SmallVector<Value>>{};
 }
 
 static FailureOr<SmallVector<Value>> materializeDeinterleaved2ToContiguous(
@@ -5259,7 +5814,7 @@ FailureOr<std::optional<SmallVector<Value>>> materializeDeinterleaved2Layout(
                         resultLayout.isDeinterleaved() &&
                         isElementDeinterleaved(resultLayout);
   if (!toContiguous && !fromContiguous) {
-    return std::nullopt;
+    return std::optional<SmallVector<Value>>{};
   }
 
   if (toContiguous) {
@@ -5285,7 +5840,7 @@ FailureOr<std::optional<SmallVector<Value>>> materializeDataLaneStrideConversion
     VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
     Type sourceVMIElementType, PatternRewriter &rewriter) {
   if (!sourceLayout || !resultLayout) {
-    return std::nullopt;
+    return std::optional<SmallVector<Value>>{};
   }
   bool contiguousToLaneStride =
       sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 1 &&
@@ -5311,241 +5866,7 @@ FailureOr<std::optional<SmallVector<Value>>> materializeDataLaneStrideConversion
     }
     return std::optional<SmallVector<Value>>(std::move(*result));
   }
-  return std::nullopt;
-}
-
-static FailureOr<SmallVector<Value>> materializeDeinterleaved4Group(
-    Operation *op, ArrayRef<Value> groupParts, TypeRange resultTypes,
-    PatternRewriter &rewriter, size_t resultStart) {
-  Type chunkType = groupParts.front().getType();
-  bool mismatchedSources = llvm::any_of(
-      groupParts, [chunkType](Value part) { return part.getType() != chunkType; });
-  if (mismatchedSources) {
-    return rewriter.notifyMatchFailure(
-        op, "vintlv deinterleaved=4 requires matching source part types");
-  }
-  size_t resultEnd = std::min(resultTypes.size(), resultStart + 4);
-  for (size_t resultIndex = resultStart; resultIndex < resultEnd;
-       ++resultIndex) {
-    if (resultTypes[resultIndex] != chunkType) {
-      return rewriter.notifyMatchFailure(
-          op, "vintlv requires operands and results to share one type");
-    }
-  }
-  auto even = rewriter.create<VintlvOp>(op->getLoc(), chunkType, chunkType,
-                                        groupParts[0], groupParts[2]);
-  auto odd = rewriter.create<VintlvOp>(op->getLoc(), chunkType, chunkType,
-                                       groupParts[1], groupParts[3]);
-  auto low = rewriter.create<VintlvOp>(
-      op->getLoc(), chunkType, chunkType, even.getLow(), odd.getLow());
-  auto high = rewriter.create<VintlvOp>(
-      op->getLoc(), chunkType, chunkType, even.getHigh(), odd.getHigh());
-  SmallVector<Value> results = {low.getLow(), low.getHigh(), high.getLow(),
-                                high.getHigh()};
-  results.resize(resultEnd - resultStart);
-  return results;
-}
-
-static FailureOr<SmallVector<Value>> materializeDeinterleaved4ToContiguous(
-    Operation *op, ValueRange sourceParts, TypeRange resultTypes,
-    PatternRewriter &rewriter) {
-  bool resultExceedsSource = resultTypes.size() > sourceParts.size();
-  if (resultExceedsSource) {
-    (void)rewriter.notifyMatchFailure(
-        op, "deinterleaved=4 to contiguous materialization result arity "
-            "exceeds source footprint");
-    return failure();
-  }
-  size_t base = sourceParts.size() / 4;
-  size_t remainder = sourceParts.size() % 4;
-  SmallVector<size_t> counts;
-  SmallVector<size_t> offsets;
-  size_t offset = 0;
-  for (size_t part = 0; part < 4; ++part) {
-    counts.push_back(base + (part < remainder ? 1 : 0));
-    offsets.push_back(offset);
-    offset += counts.back();
-  }
-  auto getSourcePart = [&counts, &offsets, &sourceParts](size_t part,
-                                                          size_t group) {
-    return group < counts[part] ? sourceParts[offsets[part] + group]
-                                : sourceParts.back();
-  };
-  SmallVector<Value> results;
-  results.reserve(resultTypes.size());
-  size_t groups = (resultTypes.size() + 3) / 4;
-  for (size_t i = 0; i < groups && results.size() < resultTypes.size(); ++i) {
-    Value p0 = getSourcePart(0, i);
-    Value p1 = getSourcePart(1, i);
-    Value p2 = getSourcePart(2, i);
-    Value p3 = getSourcePart(3, i);
-    SmallVector<Value> groupParts = {p0, p1, p2, p3};
-    FailureOr<SmallVector<Value>> groupResults =
-        materializeDeinterleaved4Group(op, groupParts, resultTypes, rewriter,
-                                       results.size());
-    if (failed(groupResults)) {
-      return failure();
-    }
-    llvm::append_range(results, *groupResults);
-  }
-  return results;
-}
-
-static LogicalResult emitContiguousToDeinterleaved4Group(
-    Operation *op, ValueRange sourceParts, TypeRange resultTypes,
-    ArrayRef<size_t> counts, ArrayRef<size_t> offsets, size_t group,
-    SmallVectorImpl<SmallVector<Value>> &parts, PatternRewriter &rewriter) {
-  auto getSourcePart = [&sourceParts](size_t index) {
-    return sourceParts[std::min(index, sourceParts.size() - 1)];
-  };
-  Value s0 = getSourcePart(4 * group);
-  Value s1 = getSourcePart(4 * group + 1);
-  Value s2 = getSourcePart(4 * group + 2);
-  Value s3 = getSourcePart(4 * group + 3);
-  Type chunkType = s0.getType();
-  bool mismatchedSources = s1.getType() != chunkType ||
-                           s2.getType() != chunkType ||
-                           s3.getType() != chunkType;
-  if (mismatchedSources) {
-    return rewriter.notifyMatchFailure(
-        op, "vdintlv deinterleaved=4 requires matching source part types");
-  }
-  for (size_t part = 0; part < 4; ++part) {
-    bool invalidResultType =
-        group < counts[part] && resultTypes[offsets[part] + group] != chunkType;
-    if (invalidResultType) {
-      return rewriter.notifyMatchFailure(
-          op, "vdintlv requires operands and results to share one type");
-    }
-  }
-  auto low = rewriter.create<VdintlvOp>(op->getLoc(), chunkType, chunkType,
-                                        s0, s1);
-  auto high = rewriter.create<VdintlvOp>(op->getLoc(), chunkType, chunkType,
-                                         s2, s3);
-  auto even = rewriter.create<VdintlvOp>(
-      op->getLoc(), chunkType, chunkType, low.getLow(), high.getLow());
-  auto odd = rewriter.create<VdintlvOp>(
-      op->getLoc(), chunkType, chunkType, low.getHigh(), high.getHigh());
-  if (group < counts[0]) {
-    parts[0].push_back(even.getLow());
-  }
-  if (group < counts[1]) {
-    parts[1].push_back(odd.getLow());
-  }
-  if (group < counts[2]) {
-    parts[2].push_back(even.getHigh());
-  }
-  if (group < counts[3]) {
-    parts[3].push_back(odd.getHigh());
-  }
-  return success();
-}
-
-static FailureOr<SmallVector<Value>> materializeContiguousToDeinterleaved4(
-    Operation *op, ValueRange sourceParts, TypeRange resultTypes,
-    PatternRewriter &rewriter) {
-  bool sourceExceedsResult = sourceParts.size() > resultTypes.size();
-  if (sourceExceedsResult) {
-    (void)rewriter.notifyMatchFailure(
-        op, "contiguous to deinterleaved=4 materialization source footprint "
-            "exceeds result arity");
-    return failure();
-  }
-  SmallVector<size_t> counts;
-  SmallVector<size_t> offsets;
-  size_t base = resultTypes.size() / 4;
-  size_t remainder = resultTypes.size() % 4;
-  size_t offset = 0;
-  for (size_t part = 0; part < 4; ++part) {
-    counts.push_back(base + (part < remainder ? 1 : 0));
-    offsets.push_back(offset);
-    offset += counts.back();
-  }
-  SmallVector<SmallVector<Value>> parts(4);
-  for (size_t part = 0; part < 4; ++part) {
-    parts[part].reserve(counts[part]);
-  }
-  size_t groups = *std::max_element(counts.begin(), counts.end());
-
-  for (size_t i = 0; i < groups; ++i) {
-    if (failed(emitContiguousToDeinterleaved4Group(
-            op, sourceParts, resultTypes, counts, offsets, i, parts,
-            rewriter))) {
-      return failure();
-    }
-  }
-  SmallVector<Value> results;
-  results.reserve(resultTypes.size());
-  for (auto &part : parts) {
-    results.append(part);
-  }
-  return results;
-}
-
-enum class Deinterleaved4LayoutDirection {
-  Unsupported,
-  ToContiguous,
-  FromContiguous
-};
-
-static Deinterleaved4LayoutDirection getDeinterleaved4LayoutDirection(
-    VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout) {
-  bool sourceIsDeinterleaved4 =
-      sourceLayout && sourceLayout.isDeinterleaved() &&
-      sourceLayout.getFactor() == 4 && sourceLayout.getLaneStride() == 1;
-  bool resultIsDeinterleaved4 =
-      resultLayout && resultLayout.isDeinterleaved() &&
-      resultLayout.getFactor() == 4 && resultLayout.getLaneStride() == 1;
-  bool toContiguous = sourceIsDeinterleaved4 && resultLayout &&
-                      resultLayout.isContiguous() &&
-                      resultLayout.getLaneStride() == 1;
-  if (toContiguous) {
-    return Deinterleaved4LayoutDirection::ToContiguous;
-  }
-  bool fromContiguous = sourceLayout && sourceLayout.isContiguous() &&
-                        sourceLayout.getLaneStride() == 1 &&
-                        resultIsDeinterleaved4;
-  if (fromContiguous) {
-    return Deinterleaved4LayoutDirection::FromContiguous;
-  }
-  return Deinterleaved4LayoutDirection::Unsupported;
-}
-
-FailureOr<std::optional<SmallVector<Value>>> materializeDeinterleaved4Layout(
-    Operation *op, ValueRange sourceParts, TypeRange resultTypes,
-    VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
-    PatternRewriter &rewriter) {
-  Deinterleaved4LayoutDirection direction =
-      getDeinterleaved4LayoutDirection(sourceLayout, resultLayout);
-  if (direction == Deinterleaved4LayoutDirection::Unsupported) {
-    return std::nullopt;
-  }
-  bool missingParts = sourceParts.empty() || resultTypes.empty();
-  if (missingParts) {
-    (void)rewriter.notifyMatchFailure(
-        op, direction == Deinterleaved4LayoutDirection::ToContiguous
-                ? "deinterleaved=4 to contiguous materialization requires "
-                  "at least one source and result part"
-                : "contiguous to deinterleaved=4 materialization requires "
-                  "at least one source and result part");
-    return failure();
-  }
-
-  if (direction == Deinterleaved4LayoutDirection::ToContiguous) {
-    FailureOr<SmallVector<Value>> results =
-        materializeDeinterleaved4ToContiguous(op, sourceParts, resultTypes,
-                                              rewriter);
-    if (failed(results)) {
-      return failure();
-    }
-    return std::optional<SmallVector<Value>>(std::move(*results));
-  }
-  FailureOr<SmallVector<Value>> results = materializeContiguousToDeinterleaved4(
-      op, sourceParts, resultTypes, rewriter);
-  if (failed(results)) {
-    return failure();
-  }
-  return std::optional<SmallVector<Value>>(std::move(results));
+  return std::optional<SmallVector<Value>>{};
 }
 
 FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
@@ -5559,24 +5880,38 @@ struct DataLayoutIntermediatePlan {
   size_t intermediateCount;
 };
 
+static bool isContiguousLaneStrideLayout(VMILayoutAttr layout,
+                                         int64_t laneStride) {
+  return layout.isContiguous() && layout.getLaneStride() == laneStride;
+}
+
+static bool isDeinterleavedUnitStrideLayout(VMILayoutAttr layout,
+                                            int64_t factor) {
+  return layout.isDeinterleaved() && layout.getFactor() == factor &&
+         layout.getLaneStride() == 1;
+}
+
+static bool isSupportedDeinterleavedIntermediateLayout(VMILayoutAttr layout) {
+  return layout.isDeinterleaved() && layout.getLaneStride() == 1 &&
+         (layout.getFactor() == 2 || layout.getFactor() == 4);
+}
+
 static std::optional<DataLayoutIntermediatePlan>
 getDataLayoutIntermediatePlan(VMILayoutAttr sourceLayout,
                               VMILayoutAttr resultLayout,
                               size_t sourcePartCount) {
   bool deint2ToLaneStride =
-      sourceLayout.isDeinterleaved() && sourceLayout.getFactor() == 2 &&
-      sourceLayout.getLaneStride() == 1 && resultLayout.isContiguous() &&
-      resultLayout.getLaneStride() == 2;
+      isDeinterleavedUnitStrideLayout(sourceLayout, 2) &&
+      isContiguousLaneStrideLayout(resultLayout, 2);
   bool laneStrideToDeint2 =
-      sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 2 &&
-      resultLayout.isDeinterleaved() && resultLayout.getFactor() == 2 &&
-      resultLayout.getLaneStride() == 1;
+      isContiguousLaneStrideLayout(sourceLayout, 2) &&
+      isDeinterleavedUnitStrideLayout(resultLayout, 2);
   bool laneStride2ToLaneStride4 =
-      sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 2 &&
-      resultLayout.isContiguous() && resultLayout.getLaneStride() == 4;
+      isContiguousLaneStrideLayout(sourceLayout, 2) &&
+      isContiguousLaneStrideLayout(resultLayout, 4);
   bool laneStride4ToLaneStride2 =
-      sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 4 &&
-      resultLayout.isContiguous() && resultLayout.getLaneStride() == 2;
+      isContiguousLaneStrideLayout(sourceLayout, 4) &&
+      isContiguousLaneStrideLayout(resultLayout, 2);
   bool useContiguousIntermediate =
       deint2ToLaneStride || laneStrideToDeint2 || laneStride2ToLaneStride4 ||
       laneStride4ToLaneStride2;
@@ -5589,10 +5924,8 @@ getDataLayoutIntermediatePlan(VMILayoutAttr sourceLayout,
   }
 
   bool useDeinterleavedIntermediate =
-      sourceLayout.isDeinterleaved() && resultLayout.isDeinterleaved() &&
-      sourceLayout.getLaneStride() == 1 && resultLayout.getLaneStride() == 1 &&
-      (sourceLayout.getFactor() == 2 || sourceLayout.getFactor() == 4) &&
-      (resultLayout.getFactor() == 2 || resultLayout.getFactor() == 4);
+      isSupportedDeinterleavedIntermediateLayout(sourceLayout) &&
+      isSupportedDeinterleavedIntermediateLayout(resultLayout);
   if (useDeinterleavedIntermediate) {
     return DataLayoutIntermediatePlan{
         DataLayoutIntermediatePlan::Kind::Deinterleaved, sourcePartCount};
@@ -5646,7 +5979,7 @@ materializeDataLayoutViaContiguous(
       getDataLayoutIntermediatePlan(sourceLayout, resultLayout,
                                     sourceParts.size());
   if (!plan) {
-    return std::nullopt;
+    return std::optional<SmallVector<Value>>{};
   }
   if (sourceParts.empty()) {
     return failure();
@@ -5682,65 +6015,43 @@ struct DataLayoutMaterializationContext {
   PatternRewriter &rewriter;
 };
 
-template <typename Materializer>
-static FailureOr<std::optional<SmallVector<Value>>>
-tryDataLayoutMaterializer(const DataLayoutMaterializationContext &context,
-                          Materializer materializer) {
-  return materializer(context);
+using DataLayoutMaterializationResult =
+    FailureOr<std::optional<SmallVector<Value>>>;
+
+static bool didHandleDataLayoutMaterialization(
+    const DataLayoutMaterializationResult &result) {
+  return failed(result) || result->has_value();
 }
 
-static FailureOr<std::optional<SmallVector<Value>>>
+static DataLayoutMaterializationResult
 tryDataLayoutMaterializers(const DataLayoutMaterializationContext &context) {
-  auto tryMaterializer =
-      [&context](auto materializer)
-          -> FailureOr<std::optional<SmallVector<Value>>> {
-    FailureOr<std::optional<SmallVector<Value>>> result =
-        tryDataLayoutMaterializer(context, materializer);
-    if (failed(result)) {
-      return failure();
-    }
-    return result;
-  };
-
-  FailureOr<std::optional<SmallVector<Value>>> simple = tryMaterializer(
-      [](const DataLayoutMaterializationContext &context) {
-        return materializeSimpleDataLayoutConversion(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout,
-            context.sourceVMIElementType, context.rewriter);
-      });
-  bool simpleHandled = failed(simple) || simple->has_value();
-  if (simpleHandled) {
+  DataLayoutMaterializationResult simple =
+      materializeSimpleDataLayoutConversion(
+          context.op, context.sourceParts, context.resultTypes,
+          context.sourceLayout, context.resultLayout,
+          context.sourceVMIElementType, context.rewriter);
+  if (didHandleDataLayoutMaterialization(simple)) {
     return simple;
   }
-  FailureOr<std::optional<SmallVector<Value>>> deinterleaved2 = tryMaterializer(
-      [](const DataLayoutMaterializationContext &context) {
-        return materializeDeinterleaved2Layout(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout, context.rewriter);
-      });
-  bool deinterleaved2Handled =
-      failed(deinterleaved2) || deinterleaved2->has_value();
-  if (deinterleaved2Handled) {
+  DataLayoutMaterializationResult deinterleaved2 =
+      materializeDeinterleaved2Layout(
+          context.op, context.sourceParts, context.resultTypes,
+          context.sourceLayout, context.resultLayout, context.rewriter);
+  if (didHandleDataLayoutMaterialization(deinterleaved2)) {
     return deinterleaved2;
   }
-  FailureOr<std::optional<SmallVector<Value>>> laneStride = tryMaterializer(
-      [](const DataLayoutMaterializationContext &context) {
-        return materializeDataLaneStrideConversion(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout,
-            context.sourceVMIElementType, context.rewriter);
-      });
-  bool laneStrideHandled = failed(laneStride) || laneStride->has_value();
-  if (laneStrideHandled) {
+  DataLayoutMaterializationResult laneStride =
+      materializeDataLaneStrideConversion(
+          context.op, context.sourceParts, context.resultTypes,
+          context.sourceLayout, context.resultLayout,
+          context.sourceVMIElementType, context.rewriter);
+  if (didHandleDataLayoutMaterialization(laneStride)) {
     return laneStride;
   }
-  return tryMaterializer([](const DataLayoutMaterializationContext &context) {
-    return materializeDataLayoutViaContiguous(
-        context.op, context.sourceParts, context.resultTypes,
-        context.sourceLayout, context.resultLayout,
-        context.sourceVMIElementType, context.rewriter);
-  });
+  return materializeDataLayoutViaContiguous(
+      context.op, context.sourceParts, context.resultTypes,
+      context.sourceLayout, context.resultLayout, context.sourceVMIElementType,
+      context.rewriter);
 }
 
 FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
@@ -5929,7 +6240,7 @@ materializeDeinterleaved2MaskLayout(
   Deinterleaved2MaskLayoutDirection direction =
       getDeinterleaved2MaskDirection(sourceLayout, resultLayout);
   if (direction == Deinterleaved2MaskLayoutDirection::Unsupported) {
-    return std::nullopt;
+    return std::optional<SmallVector<Value>>{};
   }
   bool invalidArity = sourceParts.size() != resultTypes.size() ||
                       sourceParts.empty() || sourceParts.size() % 2 != 0;
@@ -5960,6 +6271,10 @@ materializeDeinterleaved2MaskLayout(
   }
   return std::optional<SmallVector<Value>>(std::move(*results));
 }
+
+static FailureOr<MaskType> getMaskLaneStrideResultType(
+    Operation *op, Type resultType, StringRef diagnostic,
+    PatternRewriter &rewriter);
 
 static FailureOr<SmallVector<Value>> materializeMaskLaneStrideUnpack(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
@@ -6171,7 +6486,7 @@ FailureOr<std::optional<SmallVector<Value>>> materializeMaskLaneStrideLayout(
   std::optional<MaskLaneStrideLayoutPlan> plan =
       getMaskLaneStrideLayoutPlan(sourceLayout, resultLayout);
   if (!plan) {
-    return std::nullopt;
+    return std::optional<SmallVector<Value>>{};
   }
 
   if (failed(checkMaskLaneStrideFactor(op, *plan, rewriter))) {
@@ -6199,7 +6514,7 @@ static FailureOr<std::optional<SmallVector<Value>>> materializeIdentityMaskLayou
     VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
     PatternRewriter &rewriter) {
   if (sourceLayout != resultLayout) {
-    return std::nullopt;
+    return std::optional<SmallVector<Value>>{};
   }
   if (failed(verifyIdentityPartForwarding(op, sourceParts, resultTypes,
                                           rewriter))) {
@@ -6218,48 +6533,34 @@ struct MaskLayoutMaterializationContext {
   PatternRewriter &rewriter;
 };
 
-template <typename Materializer>
-static FailureOr<std::optional<SmallVector<Value>>>
-tryMaskLayoutMaterializer(
-    const MaskLayoutMaterializationContext &context,
-    Materializer materializer) {
-  return materializer(context);
+using MaskLayoutMaterializationResult =
+    FailureOr<std::optional<SmallVector<Value>>>;
+
+static bool didHandleMaskLayoutMaterialization(
+    const MaskLayoutMaterializationResult &result) {
+  return failed(result) || result->has_value();
 }
 
-static FailureOr<std::optional<SmallVector<Value>>>
+static MaskLayoutMaterializationResult
 tryMaskLayoutMaterializers(const MaskLayoutMaterializationContext &context) {
-  FailureOr<std::optional<SmallVector<Value>>> identity =
-      tryMaskLayoutMaterializer(context, [](const MaskLayoutMaterializationContext &context) {
-        return materializeIdentityMaskLayout(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout, context.rewriter);
-      });
-  if (failed(identity)) {
-    return failure();
-  }
-  if (identity->has_value()) {
-    return std::move(*identity);
+  MaskLayoutMaterializationResult identity = materializeIdentityMaskLayout(
+      context.op, context.sourceParts, context.resultTypes,
+      context.sourceLayout, context.resultLayout, context.rewriter);
+  if (didHandleMaskLayoutMaterialization(identity)) {
+    return identity;
   }
 
-  FailureOr<std::optional<SmallVector<Value>>> deinterleaved2 =
-      tryMaskLayoutMaterializer(context, [](const MaskLayoutMaterializationContext &context) {
-        return materializeDeinterleaved2MaskLayout(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout, context.rewriter);
-      });
-  if (failed(deinterleaved2)) {
-    return failure();
-  }
-  if (deinterleaved2->has_value()) {
-    return std::move(*deinterleaved2);
+  MaskLayoutMaterializationResult deinterleaved2 =
+      materializeDeinterleaved2MaskLayout(
+          context.op, context.sourceParts, context.resultTypes,
+          context.sourceLayout, context.resultLayout, context.rewriter);
+  if (didHandleMaskLayoutMaterialization(deinterleaved2)) {
+    return deinterleaved2;
   }
 
-  return tryMaskLayoutMaterializer(
-      context, [](const MaskLayoutMaterializationContext &context) {
-        return materializeMaskLaneStrideLayout(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout, context.rewriter);
-      });
+  return materializeMaskLaneStrideLayout(
+      context.op, context.sourceParts, context.resultTypes, context.sourceLayout,
+      context.resultLayout, context.rewriter);
 }
 
 FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
@@ -6560,10 +6861,6 @@ static LogicalResult checkMaskGranularityResultArity(
 FailureOr<SmallVector<Value>> materializeAdjacentMaskGranularityConversion(
     Operation *op, VMIMaskType sourceType, VMIMaskType resultType,
     ValueRange sourceParts, PatternRewriter &rewriter) {
-  auto fail = [&op, &rewriter](const Twine &message) -> FailureOr<SmallVector<Value>> {
-    (void)rewriter.notifyMatchFailure(op, message);
-    return failure();
-  };
   FailureOr<MaskGranularityConversionPlan> plan =
       buildMaskGranularityConversionPlan(op, sourceType, resultType,
                                           sourceParts, rewriter);
@@ -6839,7 +7136,7 @@ static FailureOr<SmallVector<Value, 4>> materializeDeintToContiguousMaskGroup(
     if (failed(materialized)) {
       return failure();
     }
-    results.append(*materialized);
+    results.append(materialized->begin(), materialized->end());
     return results;
   }
     FailureOr<std::array<Value, 4>> materialized =
@@ -6848,7 +7145,7 @@ static FailureOr<SmallVector<Value, 4>> materializeDeintToContiguousMaskGroup(
   if (failed(materialized)) {
     return failure();
   }
-  results.append(*materialized);
+  results.append(materialized->begin(), materialized->end());
   return results;
 }
 
@@ -6991,7 +7288,7 @@ static FailureOr<SmallVector<Value, 4>> materializeContiguousToDeintMaskGroup(
     if (failed(materialized)) {
       return failure();
     }
-    results.append(*materialized);
+    results.append(materialized->begin(), materialized->end());
     return results;
   }
   FailureOr<std::array<Value, 4>> materialized =
@@ -7000,7 +7297,7 @@ static FailureOr<SmallVector<Value, 4>> materializeContiguousToDeintMaskGroup(
   if (failed(materialized)) {
     return failure();
   }
-  results.append(*materialized);
+  results.append(materialized->begin(), materialized->end());
   return results;
 }
 
@@ -7138,7 +7435,7 @@ materializeMaskGranularityCastLayoutFallback(
   }
 
   if (!requiresMaskDenseSplitFallback(sourceLayout, resultLayout)) {
-    return std::nullopt;
+    return std::optional<SmallVector<Value>>{};
   }
   FailureOr<SmallVector<Value>> contiguous =
       materializeMaskGranularityCastLayoutConversionViaContiguous(
@@ -7171,37 +7468,6 @@ materializeMaskGranularityCastLayoutConversionViaContiguous(
   }
   return materializeMaskGranularityCastLayoutConversion(
       op, contiguousType, resultType, *contiguousParts, resultTypes, rewriter);
-}
-
-FailureOr<std::optional<SmallVector<Value>>>
-materializeMaskGranularityCastStagingForFactor(
-    Operation *op, VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
-    ValueRange sourceParts, TypeRange resultTypes, int64_t factor,
-    PatternRewriter &rewriter) {
-  bool sourceContiguous =
-      sourceLayout && sourceLayout.isContiguous() &&
-      sourceLayout.getLaneStride() == 1;
-  bool resultContiguous =
-      resultLayout && resultLayout.isContiguous() &&
-      resultLayout.getLaneStride() == 1;
-  bool sourceDeinterleaved =
-      isElementDeinterleavedLayout(sourceLayout, factor) && resultContiguous;
-  bool resultDeinterleaved =
-      sourceContiguous && isElementDeinterleavedLayout(resultLayout, factor);
-  if (!sourceDeinterleaved && !resultDeinterleaved) {
-    return std::nullopt;
-  }
-
-  FailureOr<SmallVector<Value>> result =
-      sourceDeinterleaved
-          ? materializeStagingDeintToContiguousMaskLayout(
-                op, sourceParts, resultTypes, factor, rewriter)
-          : materializeStagingContiguousToDeintMaskLayout(
-                op, sourceParts, resultTypes, factor, rewriter);
-  if (failed(result)) {
-    return failure();
-  }
-  return std::optional<SmallVector<Value>>(std::move(*result));
 }
 
 static std::optional<bool> getMaskStagingDirection(
@@ -7241,16 +7507,9 @@ materializeMaskGranularityCastStagingLayout(
     if (failed(materialized)) {
       return failure();
     }
-    FailureOr<std::optional<SmallVector<Value>>> result =
-        std::optional<SmallVector<Value>>(std::move(*materialized));
-    if (failed(result)) {
-      return failure();
-    }
-    if (result->has_value()) {
-      return std::move(*result);
-    }
+    return std::optional<SmallVector<Value>>(std::move(*materialized));
   }
-  return std::nullopt;
+  return std::optional<SmallVector<Value>>{};
 }
 
 FailureOr<SmallVector<Value>> materializeMaskGranularityCastLayoutConversion(
@@ -7356,11 +7615,6 @@ static FailureOr<MaskGranularityCastPlan> buildMaskGranularityCastPlan(
 FailureOr<SmallVector<Value>> materializeMaskGranularityCastConversion(
     Operation *op, VMIMaskType sourceType, VMIMaskType resultType,
     ValueRange sourceParts, TypeRange resultTypes, PatternRewriter &rewriter) {
-  auto fail = [&op, &rewriter](const Twine &message) -> FailureOr<SmallVector<Value>> {
-    (void)rewriter.notifyMatchFailure(op, message);
-    return failure();
-  };
-
   FailureOr<MaskGranularityCastPlan> plan =
       buildMaskGranularityCastPlan(op, sourceType, resultType, rewriter);
   if (failed(plan)) {
@@ -7488,9 +7742,10 @@ public:
       std::string reason;
       if (failed(supports.getMaskGranularityCastLayoutFactForLayouts(
               sourceType, resultType, sourceType.getLayoutAttr(),
-              resultType.getLayoutAttr(), &reason)))
+              resultType.getLayoutAttr(), &reason))) {
         return rewriter.notifyMatchFailure(
             op, "unsupported mask granularity cast layout relation: " + reason);
+      }
     }
 
     ValueRange sourceParts = adaptor.getSource();
@@ -7507,84 +7762,6 @@ public:
     return replaceCheckedResults(op, rewriter, std::move(results), resultTypes);
   }
 
-private:
-  LogicalResult lowerDirect(
-      VMIDeinterleaveLoadOp op, OneToNPatternRewriter &rewriter, Value source,
-      Value offset, ArrayRef<Type> lowTypes, ArrayRef<Type> highTypes,
-      int64_t lanesPerPart, StringRef dist) const {
-    SmallVector<Value> lows;
-    SmallVector<Value> highs;
-    lows.reserve(lowTypes.size());
-    highs.reserve(highTypes.size());
-    for (size_t index = 0; index < lowTypes.size(); ++index) {
-      Type lowType = lowTypes[index];
-      Type highType = highTypes[index];
-      if (lowType != highType) {
-        return rewriter.notifyMatchFailure(
-            op, "deinterleave_load requires matching low/high physical types");
-      }
-      Value chunkOffset = createChunkOffset(
-          op.getLoc(), offset, static_cast<int64_t>(index) * 2 * lanesPerPart,
-          rewriter);
-      auto load = rewriter.create<Vldsx2Op>(
-          op.getLoc(), lowType, highType, Type{}, source, chunkOffset,
-          rewriter.getStringAttr(dist));
-      lows.push_back(load.getLow());
-      highs.push_back(load.getHigh());
-    }
-    SmallVector<Value> results;
-    results.reserve(lows.size() + highs.size());
-    results.append(lows);
-    results.append(highs);
-    replaceOpWithFlatConvertedValues(rewriter, op, results,
-                                     *this->getTypeConverter());
-    return success();
-  }
-
-  struct ExtFPhysicalPlan {
-    VRegType sourceType;
-    SmallVector<VRegType> resultTypes;
-  };
-
-  FailureOr<ExtFPhysicalPlan> buildPhysicalPlan(
-      VMIExtFOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
-      OneToNPatternRewriter &rewriter) const {
-    if (sourceParts.empty()) {
-      return rewriter.notifyMatchFailure(
-          op, "extf requires at least one physical source chunk");
-    }
-    auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
-    if (!sourceType) {
-      return rewriter.notifyMatchFailure(op, "expected physical extf source");
-    }
-    for (Value sourcePart : sourceParts) {
-      auto currentSourceType = dyn_cast<VRegType>(sourcePart.getType());
-      if (!currentSourceType || currentSourceType != sourceType) {
-        return rewriter.notifyMatchFailure(
-            op, "extf source physical parts must have matching type");
-      }
-    }
-    SmallVector<VRegType> resultVRegTypes;
-    resultVRegTypes.reserve(resultTypes.size());
-    for (Type resultType : resultTypes) {
-      auto resultVRegType = dyn_cast<VRegType>(resultType);
-      bool invalidFirstResult =
-          resultVRegTypes.empty() &&
-          (!resultVRegType ||
-           !(resultVRegType.getElementType().isF32() ||
-             pto::isPTOBF16x2Type(resultVRegType.getElementType())));
-      bool mismatchedResult =
-          !resultVRegTypes.empty() && resultVRegType != resultVRegTypes.front();
-      if (invalidFirstResult || mismatchedResult) {
-        return rewriter.notifyMatchFailure(
-            op, "unsupported physical extf result type");
-      }
-      resultVRegTypes.push_back(resultVRegType);
-    }
-    return ExtFPhysicalPlan{sourceType, std::move(resultVRegTypes)};
-  }
-
-  ;
 };
 
 struct OneToNVMIBroadcastOpPattern : OneToNOpConversionPattern<VMIBroadcastOp> {
@@ -7602,7 +7779,6 @@ struct OneToNVMIBroadcastOpPattern : OneToNOpConversionPattern<VMIBroadcastOp> {
     bool inputIsVReg = isa<VMIVRegType>(op.getValue().getType());
 
     FailureOr<SmallVector<Type>> maybe_resultTypes =
-
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
 
     if (failed(maybe_resultTypes)) {
@@ -7718,7 +7894,7 @@ FailureOr<std::optional<Value>> createPowerOfTwoSubVLChunk(
       !llvm::isPowerOf2_64(static_cast<uint64_t>(groupSize)) ||
       !isa<IntegerType>(base.getType());
   if (unsupportedShape) {
-    return std::nullopt;
+    return std::optional<Value>{};
   }
 
   FailureOr<Value> zeroScalar =
@@ -7975,6 +8151,42 @@ struct OneToNVMIIotaOpPattern : OneToNOpConversionPattern<IotaOp> {
       typename OneToNOpConversionPattern<IotaOp>::OpAdaptor;
 
 private:
+  struct IotaLoweringInput {
+    VMIVRegType resultVMIType;
+    VMILayoutAttr layout;
+    Value base;
+    SmallVector<Type> resultTypes;
+    int64_t lanesPerPart;
+  };
+
+  FailureOr<IotaLoweringInput> getIotaLoweringInput(
+      IotaOp op, OpAdaptor adaptor,
+      OneToNPatternRewriter &rewriter) const {
+    auto resultVMIType = cast<VMIVRegType>(op.getResult().getType());
+    VMILayoutAttr layout = resultVMIType.getLayoutAttr();
+    if (!layout) {
+      return rewriter.notifyMatchFailure(op, "iota requires assigned layout");
+    }
+    FailureOr<int64_t> lanesPerPart =
+        getDataLanesPerPart(resultVMIType.getElementType());
+    if (failed(lanesPerPart)) {
+      return rewriter.notifyMatchFailure(
+          op, "iota requires known physical lanes per part");
+    }
+    FailureOr<Value> base = getSingleValue(
+        op, adaptor.getBase(), "iota base must convert to one value", rewriter);
+    if (failed(base)) {
+      return failure();
+    }
+    FailureOr<SmallVector<Type>> resultTypes =
+        getConvertedResultTypes(op, 0, *this->getTypeConverter());
+    if (failed(resultTypes)) {
+      return failure();
+    }
+    return IotaLoweringInput{resultVMIType, layout, *base,
+                             std::move(*resultTypes), *lanesPerPart};
+  }
+
   FailureOr<std::pair<int64_t, int64_t>> validateGroupedIotaShape(
       IotaOp op, VMIVRegType resultVMIType, VMILayoutAttr layout,
       TypeRange resultTypes, int64_t lanesPerPart,
@@ -8101,82 +8313,83 @@ private:
     return success();
   }
 
+  LogicalResult lowerAndReplaceIota(
+      IotaOp op, Value base, VMIVRegType resultVMIType,
+      VMILayoutAttr layout, TypeRange resultTypes, int64_t lanesPerPart,
+      OneToNPatternRewriter &rewriter,
+      SmallVectorImpl<Value> &results) const {
+    if constexpr (std::is_same_v<IotaOp, VMIGroupIotaOp>) {
+      if (failed(lowerGroupedIota(op, base, resultVMIType, layout, resultTypes,
+                                  lanesPerPart, rewriter, results))) {
+        return failure();
+      }
+    } else if (layout.isContiguous()) {
+      if (failed(lowerContiguousIota(op, base, resultTypes, lanesPerPart,
+                                     rewriter, results))) {
+        return failure();
+      }
+    } else if (failed(lowerDeinterleavedIota(
+                   op, base, layout, resultTypes, lanesPerPart, rewriter,
+                   results))) {
+      return failure();
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
 public:
 
   LogicalResult
   matchAndRewrite(IotaOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
-    auto resultVMIType = cast<VMIVRegType>(op.getResult().getType());
-    VMILayoutAttr layout = resultVMIType.getLayoutAttr();
-    if (!layout) {
-      return rewriter.notifyMatchFailure(op, "iota requires assigned layout");
-    }
-
-    FailureOr<int64_t> lanesPerPart =
-        getDataLanesPerPart(resultVMIType.getElementType());
-    if (failed(lanesPerPart)) {
-      return rewriter.notifyMatchFailure(
-          op, "iota requires known physical lanes per part");
-    }
-
-    FailureOr<Value> base = getSingleValue(
-        op, adaptor.getBase(), "iota base must convert to one value", rewriter);
-    if (failed(base)) {
+    FailureOr<IotaLoweringInput> input =
+        getIotaLoweringInput(op, adaptor, rewriter);
+    if (failed(input)) {
       return failure();
     }
-
-    FailureOr<SmallVector<Type>> maybe_resultTypes =
-
-        getConvertedResultTypes(op, 0, *this->getTypeConverter());
-
-    if (failed(maybe_resultTypes)) {
-      return failure();
-    }
-
-    SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     SmallVector<Value> results;
-    results.reserve(resultTypes.size());
-
-    // Optional {group = C}: *group-periodic* ramp (not a continuous 0..L-1
-    // ramp). Each of C groups of size S = L / C independently gets
-    // dst[g*S + j] = base + j. Example L=128,C=2 → [base..base+63 |
-    // base..base+63]. Only contiguous layout is lowered here; non-contiguous
-    // results are rewritten earlier to contiguous + ensure_layout.
-    //
-    // Contiguous materialization:
-    //   * S % physVL == 0 → VCI chunk per distinct laneOffset (share parts).
-    //   * physVL % S == 0 → sub-VL: vdup (S=1) or vand(vci(0),S-1)+vadds(base).
-    if constexpr (std::is_same_v<IotaOp, VMIGroupIotaOp>) {
-      if (failed(lowerGroupedIota(op, *base, resultVMIType, layout, resultTypes,
-                                  *lanesPerPart, rewriter, results))) {
-        return failure();
-      }
-      replaceOpWithFlatConvertedValues(rewriter, op, results,
-                                       *this->getTypeConverter());
-      return success();
-    }
-
-    if (layout.isContiguous()) {
-      if (failed(lowerContiguousIota(op, *base, resultTypes, *lanesPerPart,
-                                     rewriter, results))) {
-        return failure();
-      }
-      replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
-      return success();
-    }
-
-    if (failed(lowerDeinterleavedIota(op, *base, layout, resultTypes,
-                                      *lanesPerPart, rewriter, results))) {
-      return failure();
-      }
-
-    replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
-    return success();
+    results.reserve(input->resultTypes.size());
+    return lowerAndReplaceIota(op, input->base, input->resultVMIType,
+                               input->layout, input->resultTypes,
+                               input->lanesPerPart, rewriter, results);
   }
 };
 
 struct OneToNVMIConstantOpPattern : OneToNOpConversionPattern<VMIConstantOp> {
   using OneToNOpConversionPattern<VMIConstantOp>::OneToNOpConversionPattern;
+
+private:
+  LogicalResult lowerSplat(VMIConstantOp op, TypedAttr splatAttr,
+                           ArrayRef<Type> resultTypes,
+                           OneToNPatternRewriter &rewriter) const {
+    Value scalar =
+        rewriter.create<arith::ConstantOp>(op.getLoc(), splatAttr).getResult();
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (Type resultType : resultTypes) {
+      auto vregType = dyn_cast<VRegType>(resultType);
+      if (!vregType) {
+        return rewriter.notifyMatchFailure(op, "constant result must be vreg");
+      }
+      FailureOr<Value> mask =
+          createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
+      if (failed(mask)) {
+        return rewriter.notifyMatchFailure(
+            op, "unsupported element type for constant mask");
+      }
+      results.push_back(
+          rewriter
+              .create<VdupOp>(op.getLoc(), resultType, scalar, *mask,
+                              /*position=*/nullptr)
+              .getResult());
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
+public:
 
   LogicalResult
   matchAndRewrite(VMIConstantOp op, OpAdaptor adaptor,
@@ -8197,41 +8410,19 @@ struct OneToNVMIConstantOpPattern : OneToNOpConversionPattern<VMIConstantOp> {
     // a signless scalar for a signed/unsigned result element.
     if (auto intAttr = dyn_cast<IntegerAttr>(splatAttr)) {
       if (auto intTy = dyn_cast<IntegerType>(intAttr.getType());
-          intTy && !intTy.isSignless())
+          intTy && !intTy.isSignless()) {
         splatAttr = IntegerAttr::get(rewriter.getIntegerType(intTy.getWidth()),
                                      intAttr.getValue());
+      }
     }
 
-    Value scalar =
-        rewriter.create<arith::ConstantOp>(op.getLoc(), splatAttr).getResult();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
     if (failed(maybe_resultTypes)) {
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    SmallVector<Value> results;
-    results.reserve(resultTypes.size());
-    for (Type resultType : resultTypes) {
-      auto vregType = dyn_cast<VRegType>(resultType);
-      if (!vregType) {
-        return rewriter.notifyMatchFailure(op, "constant result must be vreg");
-      }
-      FailureOr<Value> mask =
-          createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
-      if (failed(mask)) {
-        return rewriter.notifyMatchFailure(
-            op, "unsupported element type for constant mask");
-      }
-      results.push_back(rewriter
-                            .create<VdupOp>(op.getLoc(), resultType, scalar,
-                                            *mask,
-                                            /*position=*/nullptr)
-                            .getResult());
-    }
-
-    replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
-    return success();
+    return lowerSplat(op, splatAttr, resultTypes, rewriter);
   }
 };
 
@@ -8239,27 +8430,15 @@ struct OneToNVMIConstantMaskOpPattern
     : OneToNOpConversionPattern<VMIConstantMaskOp> {
   using OneToNOpConversionPattern<VMIConstantMaskOp>::OneToNOpConversionPattern;
 
-  LogicalResult
-  matchAndRewrite(VMIConstantMaskOp op, OpAdaptor adaptor,
-                  OneToNPatternRewriter &rewriter) const override {
-    FailureOr<SmallVector<Type>> maybe_resultTypes =
-        getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    bool failedResultTypeConversion = failed(maybe_resultTypes);
-    if (failedResultTypeConversion) {
-      return failure();
-    }
-    SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    std::string reason;
-    FailureOr<SmallVector<ConstantMaskChunkMaterialization>> materializations =
-        computeConstantMaskMaterialization(op, &reason);
-    if (failed(materializations)) {
-      return rewriter.notifyMatchFailure(op, Twine("constant_mask ") + reason);
-    }
-
+private:
+  FailureOr<SmallVector<Value>> materializePhysicalMasks(
+      VMIConstantMaskOp op, ArrayRef<Type> resultTypes,
+      ArrayRef<ConstantMaskChunkMaterialization> materializations,
+      OneToNPatternRewriter &rewriter) const {
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (const ConstantMaskChunkMaterialization &materialization :
-         *materializations) {
+         materializations) {
       bool tooManyMasks = results.size() >= resultTypes.size();
       if (tooManyMasks) {
         return rewriter.notifyMatchFailure(
@@ -8278,13 +8457,39 @@ struct OneToNVMIConstantMaskOpPattern
       }
       results.push_back(*mask);
     }
-
     bool resultArityMismatch = results.size() != resultTypes.size();
     if (resultArityMismatch) {
       return rewriter.notifyMatchFailure(
           op, "constant_mask physical result count mismatch");
     }
-    replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
+    return results;
+  }
+
+public:
+
+  LogicalResult
+  matchAndRewrite(VMIConstantMaskOp op, OpAdaptor adaptor,
+                  OneToNPatternRewriter &rewriter) const override {
+    FailureOr<SmallVector<Type>> maybe_resultTypes =
+        getConvertedResultTypes(op, 0, *this->getTypeConverter());
+    bool failedResultTypeConversion = failed(maybe_resultTypes);
+    if (failedResultTypeConversion) {
+      return failure();
+    }
+    SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
+    std::string reason;
+    FailureOr<SmallVector<ConstantMaskChunkMaterialization>> materializations =
+        computeConstantMaskMaterialization(op, &reason);
+    if (failed(materializations)) {
+      return rewriter.notifyMatchFailure(op, Twine("constant_mask ") + reason);
+    }
+    FailureOr<SmallVector<Value>> results = materializePhysicalMasks(
+        op, resultTypes, *materializations, rewriter);
+    if (failed(results)) {
+      return failure();
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, *results,
+                                     *this->getTypeConverter());
     return success();
   }
 };
@@ -8502,9 +8707,10 @@ public:
     auto resultVMIType = cast<VMIMaskType>(op.getResult().getType());
     VMILayoutAttr layout = resultVMIType.getLayoutAttr();
     if (!layout ||
-        !VMIMaskType::isConcreteGranularity(resultVMIType.getGranularity()))
+        !VMIMaskType::isConcreteGranularity(resultVMIType.getGranularity())) {
       return rewriter.notifyMatchFailure(
           op, "create_mask requires concrete layout and granularity");
+    }
     FailureOr<StringRef> physicalGranularity =
         getVMIMaskPhysicalGranularity(resultVMIType);
     FailureOr<int64_t> lanesPerPart =
@@ -8642,7 +8848,7 @@ private:
     if (failed(results)) {
       return failure();
     }
-    replaceOpWithFlatConvertedValues(rewriter, op, results,
+    replaceOpWithFlatConvertedValues(rewriter, op, *results,
                                      *this->getTypeConverter());
     return success();
   }
@@ -8804,8 +9010,6 @@ private:
     if (failed(lanesPerPart)) {
       return failure();
     }
-    VMILayoutAttr contiguousLayout =
-        VMILayoutAttr::getContiguous(rewriter.getContext());
     FailureOr<SmallVector<Type>> contiguousTypes =
         getContiguousLoadTypes(op, resultVMIType, rewriter);
     if (failed(contiguousTypes)) {
@@ -9095,26 +9299,6 @@ private:
     return success();
   }
 
-  LogicalResult lowerByLayout(
-      VMIMaskedStoreOp op, OneToNPatternRewriter &rewriter,
-      ValueRange valueParts, ValueRange maskParts, VMIVRegType valueVMIType,
-      VMIMaskType maskVMIType, Value destination, Value offset,
-      int64_t lanesPerPart) const {
-    std::optional<std::string> dist =
-        getDenseLaneStrideStoreDistToken(valueVMIType);
-    if (dist) {
-      std::optional<StringRef> maskGranularity =
-          getDenseLaneStrideMaskedStoreMaskGranularity(valueVMIType);
-      if (maskGranularity) {
-        return lowerLaneStride(op, rewriter, valueParts, maskParts,
-                               valueVMIType, maskVMIType, destination, offset,
-                               *dist, *maskGranularity);
-      }
-    }
-    return lowerContiguous(op, rewriter, valueParts, maskParts, valueVMIType,
-                           maskVMIType, destination, offset, lanesPerPart);
-  }
-
   std::optional<LogicalResult> lowerDirectDeinterleaved(
       VMILoadOp op, OneToNPatternRewriter &rewriter, Value source, Value offset,
       VMIVRegType resultVMIType, VMILayoutAttr resultLayout,
@@ -9214,6 +9398,16 @@ private:
     Value updatedAlign;
   };
 
+  struct DeinterleaveLoadLoweringInput {
+    Value source;
+    Value offset;
+    SmallVector<Type> lowTypes;
+    SmallVector<Type> highTypes;
+    VMIVRegType lowVMIType;
+    int64_t lanesPerPart;
+    std::string dist;
+  };
+
   FailureOr<UnalignedDeinterleaveLoadPair> materializeUnalignedLoadPair(
       VMIDeinterleaveLoadOp op, OneToNPatternRewriter &rewriter,
       Value streamBase, Value streamAlign, Type lowType, Type highType,
@@ -9235,6 +9429,36 @@ private:
                                          deinterleaved.getHigh(),
                                          second.getUpdatedBase(),
                                          second.getUpdatedAlign()};
+  }
+
+  LogicalResult lowerDirect(
+      VMIDeinterleaveLoadOp op, OneToNPatternRewriter &rewriter,
+      Value source, Value offset, ArrayRef<Type> lowTypes,
+      ArrayRef<Type> highTypes, int64_t lanesPerPart, StringRef dist) const {
+    SmallVector<Value> lows;
+    SmallVector<Value> highs;
+    lows.reserve(lowTypes.size());
+    highs.reserve(highTypes.size());
+    for (size_t index = 0; index < lowTypes.size(); ++index) {
+      if (lowTypes[index] != highTypes[index]) {
+        return rewriter.notifyMatchFailure(
+            op, "deinterleave_load requires matching low/high physical types");
+      }
+      Value chunkOffset = createChunkOffset(
+          op.getLoc(), offset, static_cast<int64_t>(index) * 2 * lanesPerPart,
+          rewriter);
+      auto load = rewriter.create<Vldsx2Op>(
+          op.getLoc(), lowTypes[index], highTypes[index], Type{}, source,
+          chunkOffset, rewriter.getStringAttr(dist));
+      lows.push_back(load.getLow());
+      highs.push_back(load.getHigh());
+    }
+    SmallVector<Value> results;
+    results.append(lows);
+    results.append(highs);
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
   }
 
   LogicalResult lowerUnaligned(
@@ -9286,35 +9510,6 @@ private:
   }
 
   FailureOr<std::pair<SmallVector<Type>, SmallVector<Type>>>
-  getInterleaveResultTypes(
-      SourceOp op, ValueRange lhsParts, ValueRange rhsParts,
-      ValueRange maskParts, OneToNPatternRewriter &rewriter) const {
-    FailureOr<SmallVector<Type>> maybeLowTypes =
-        getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    FailureOr<SmallVector<Type>> maybeHighTypes =
-        getConvertedResultTypes(op, 1, *this->getTypeConverter());
-    bool failedResultTypes = failed(maybeLowTypes) || failed(maybeHighTypes);
-    if (failedResultTypes) {
-      return failure();
-    }
-    bool arityMismatch = lhsParts.size() != rhsParts.size() ||
-                         lhsParts.size() != maybeLowTypes->size() ||
-                         lhsParts.size() != maybeHighTypes->size();
-    if (arityMismatch) {
-      rewriter.notifyMatchFailure(op, "physical interleave arity mismatch");
-      return failure();
-    }
-    bool maskArityMismatch =
-        !maskParts.empty() && maskParts.size() != lhsParts.size();
-    if (maskArityMismatch) {
-      rewriter.notifyMatchFailure(op, "physical interleave mask arity mismatch");
-      return failure();
-    }
-    return std::make_pair(std::move(*maybeLowTypes),
-                          std::move(*maybeHighTypes));
-  }
-
-  FailureOr<std::pair<SmallVector<Type>, SmallVector<Type>>>
   getDeinterleaveLoadResultTypes(
       VMIDeinterleaveLoadOp op, OneToNPatternRewriter &rewriter) const {
     FailureOr<SmallVector<Type>> lowTypes =
@@ -9333,112 +9528,9 @@ private:
     return std::make_pair(std::move(*lowTypes), std::move(*highTypes));
   }
 
-  FailureOr<VMIInterleaveLayoutFact> getInterleaveLayoutFact(
-      SourceOp op, VMIVRegType lhsType, VMIVRegType rhsType,
-      VMIMaskType maskType, VMIVRegType lowType, VMIVRegType highType,
+  FailureOr<DeinterleaveLoadLoweringInput> getLoweringInput(
+      VMIDeinterleaveLoadOp op, OpAdaptor adaptor,
       OneToNPatternRewriter &rewriter) const {
-    VMILayoutSupport supports;
-    FailureOr<VMIInterleaveLayoutFact> fact;
-    if constexpr (std::is_same_v<SourceOp, VMIVintlvOp>) {
-      fact = supports.getVintlvLayoutFactForLayouts(
-          lhsType, rhsType, maskType, lowType, highType);
-    } else {
-      fact = supports.getVdintlvLayoutFactForLayouts(
-          lhsType, rhsType, maskType, lowType, highType);
-    }
-    if (failed(fact)) {
-      rewriter.notifyMatchFailure(op, "unsupported interleave layout relation");
-    }
-    return fact;
-  }
-
-  enum class InterleaveLoweringKind { LaneStride, Contiguous, ZeroCopy };
-
-  struct InterleaveLoweringPlan {
-    InterleaveLoweringKind kind;
-    int64_t inputFactor = 0;
-    int64_t outputFactor = 0;
-    bool zeroCopyVintlv = false;
-  };
-
-  FailureOr<InterleaveLoweringPlan> classifyInterleaveLowering(
-      SourceOp op, const VMIInterleaveLayoutFact &fact,
-      OneToNPatternRewriter &rewriter) const {
-    bool allSameLaneStride = fact.lhsLayout == fact.rhsLayout &&
-                             fact.lhsLayout == fact.maskLayout &&
-                             fact.lhsLayout == fact.lowLayout &&
-                             fact.lhsLayout == fact.highLayout &&
-                             fact.lhsLayout.isContiguous() &&
-                             fact.lhsLayout.getLaneStride() > 1;
-    if (allSameLaneStride) {
-      return InterleaveLoweringPlan{InterleaveLoweringKind::LaneStride};
-    }
-    auto isContiguous = [](VMILayoutAttr layout) {
-      return layout && layout.isContiguous() && layout.getLaneStride() == 1;
-    };
-    bool allContiguous = isContiguous(fact.lhsLayout) &&
-                         isContiguous(fact.rhsLayout) &&
-                         isContiguous(fact.maskLayout) &&
-                         isContiguous(fact.lowLayout) &&
-                         isContiguous(fact.highLayout);
-    if (allContiguous) {
-      return InterleaveLoweringPlan{InterleaveLoweringKind::Contiguous};
-    }
-    int64_t inputFactor = getElementDeinterleaveFactor(fact.lhsLayout);
-    int64_t outputFactor = getElementDeinterleaveFactor(fact.lowLayout);
-    bool zeroCopyVintlv = std::is_same_v<SourceOp, VMIVintlvOp> &&
-                          inputFactor > 0 && fact.rhsLayout == fact.lhsLayout &&
-                          fact.maskLayout == fact.lhsLayout &&
-                          fact.highLayout == fact.lowLayout &&
-                          outputFactor == 2 * inputFactor;
-    bool zeroCopyVdintlv = std::is_same_v<SourceOp, VMIVdintlvOp> &&
-                           inputFactor > 0 &&
-                           fact.rhsLayout == fact.lhsLayout &&
-                           fact.maskLayout == fact.lhsLayout &&
-                           fact.highLayout == fact.lowLayout &&
-                           inputFactor == 2 * outputFactor;
-    if (!zeroCopyVintlv && !zeroCopyVdintlv) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported interleave physical layout relation");
-    }
-    return InterleaveLoweringPlan{InterleaveLoweringKind::ZeroCopy, inputFactor,
-                                  outputFactor, zeroCopyVintlv};
-  }
-
-  LogicalResult lowerInterleaveByLayout(
-      SourceOp op, OneToNPatternRewriter &rewriter, ValueRange lhsParts,
-      ValueRange rhsParts, ValueRange maskParts, ArrayRef<Type> lowTypes,
-      ArrayRef<Type> highTypes, Type elementType,
-      const VMIInterleaveLayoutFact &fact) const {
-    FailureOr<InterleaveLoweringPlan> plan =
-        classifyInterleaveLowering(op, fact, rewriter);
-    if (failed(plan)) {
-      return failure();
-    }
-    if (plan->kind == InterleaveLoweringKind::LaneStride) {
-      return lowerLaneStrideInterleave(op, rewriter, lhsParts, rhsParts,
-                                       lowTypes, highTypes, elementType, fact);
-    }
-    if (plan->kind == InterleaveLoweringKind::Contiguous) {
-      return lowerContiguous(op, rewriter, lhsParts, rhsParts, maskParts,
-                             lowTypes, highTypes);
-    }
-    FailureOr<SmallVector<Value>> zeroCopyResults = materializeZeroCopyResults(
-        op, lhsParts, rhsParts, lowTypes, highTypes, plan->inputFactor,
-        plan->outputFactor, plan->zeroCopyVintlv, rewriter);
-    if (failed(zeroCopyResults)) {
-      return failure();
-    }
-    replaceOpWithFlatConvertedValues(rewriter, op, *zeroCopyResults,
-                                     *this->getTypeConverter());
-    return success();
-  }
-
-public:
-
-  LogicalResult
-  matchAndRewrite(VMIDeinterleaveLoadOp op, OpAdaptor adaptor,
-                  OneToNPatternRewriter &rewriter) const override {
     auto lowVMIType = cast<VMIVRegType>(op.getLow().getType());
     FailureOr<Value> source = getSingleValue(
         op, adaptor.getSource(),
@@ -9450,43 +9542,60 @@ public:
     if (invalidOperands) {
       return failure();
     }
-
     FailureOr<int64_t> lanesPerPart =
         getDataLanesPerPart(lowVMIType.getElementType());
     if (failed(lanesPerPart)) {
       return rewriter.notifyMatchFailure(
           op, "deinterleave_load requires known physical lanes per part");
     }
-
     std::optional<std::string> dist =
         getX2MemoryDistToken(lowVMIType.getElementType(), "DINTLV");
     if (!dist) {
       return rewriter.notifyMatchFailure(
           op, "deinterleave_load requires vldsx2 DINTLV element support");
     }
-
     FailureOr<std::pair<SmallVector<Type>, SmallVector<Type>>> resultTypes =
         getDeinterleaveLoadResultTypes(op, rewriter);
     if (failed(resultTypes)) {
       return failure();
     }
-    SmallVector<Type> lowTypes = std::move(resultTypes->first);
-    SmallVector<Type> highTypes = std::move(resultTypes->second);
+    return DeinterleaveLoadLoweringInput{
+        *source, *offset, std::move(resultTypes->first),
+        std::move(resultTypes->second), lowVMIType, *lanesPerPart, *dist};
+  }
 
-    auto firstType =
-        lowTypes.empty() ? VRegType{} : dyn_cast<VRegType>(lowTypes.front());
+  LogicalResult lowerByAddressPlan(
+      VMIDeinterleaveLoadOp op, const DeinterleaveLoadLoweringInput &input,
+      OneToNPatternRewriter &rewriter) const {
+    auto firstType = input.lowTypes.empty()
+                         ? VRegType{}
+                         : dyn_cast<VRegType>(input.lowTypes.front());
     bool useDirectAccess =
-        firstType &&
-        isDirectMemoryDistAddressLegal(op.getSource(), op.getOffset(),
-                                       lowVMIType.getElementType(), firstType,
-                                       VPTOMemoryOpFamily::LoadX2, *dist);
+        firstType && isDirectMemoryDistAddressLegal(
+                         op.getSource(), op.getOffset(),
+                         input.lowVMIType.getElementType(), firstType,
+                         VPTOMemoryOpFamily::LoadX2, input.dist);
     if (!useDirectAccess) {
-      return lowerUnaligned(op, rewriter, *source, *offset, lowTypes,
-                            highTypes, *lanesPerPart);
+      return lowerUnaligned(op, rewriter, input.source, input.offset,
+                            input.lowTypes, input.highTypes,
+                            input.lanesPerPart);
     }
+    return lowerDirect(op, rewriter, input.source, input.offset, input.lowTypes,
+                       input.highTypes, input.lanesPerPart, input.dist);
+  }
 
-    return lowerDirect(op, rewriter, *source, *offset, lowTypes, highTypes,
-                       *lanesPerPart, *dist);
+
+public:
+
+  LogicalResult
+  matchAndRewrite(VMIDeinterleaveLoadOp op, OpAdaptor adaptor,
+                  OneToNPatternRewriter &rewriter) const override {
+    FailureOr<DeinterleaveLoadLoweringInput> input =
+        getLoweringInput(op, adaptor, rewriter);
+    if (failed(input)) {
+      return failure();
+    }
+    return lowerByAddressPlan(op, *input, rewriter);
   }
 };
 
@@ -9612,7 +9721,6 @@ private:
       return rewriter.notifyMatchFailure(
           op, "block_deinterleaved group_load arity mismatch");
     }
-    constexpr int64_t kGroupsPerBlockLoad = 8;
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (int64_t part = 0; part < factor; ++part) {
@@ -9824,7 +9932,7 @@ static FailureOr<GroupSlotLoadResultPart> getGroupSlotLoadResultPart(
         op, "unsupported element type for group_slot_load mask");
     return failure();
   }
-  return GroupSlotLoadResultPart{*vregType, *maskType};
+  return GroupSlotLoadResultPart{vregType, *maskType};
 }
 
 static LogicalResult lowerSingleGroupSlotLoad(
@@ -10090,6 +10198,12 @@ mapSlots1GroupBroadcastSources(
                         std::move(activeSourceChunks));
 }
 
+static FailureOr<Value> materializeSlots1GroupBroadcastMerge(
+    Operation *op, Type resultType, ValueRange sourceParts, int64_t lanesPerPart,
+    MaskType resultMaskType, ArrayRef<int64_t> laneSourceChunks,
+    ArrayRef<int64_t> activeSourceChunks, OneToNPatternRewriter &rewriter,
+    Value allMask);
+
 static FailureOr<Value> materializeSlots1GroupBroadcastChunk(
     Operation *op, Type resultType, VMIVRegType resultVMIType,
     ValueRange sourceParts, int64_t part, int64_t chunk, int64_t firstGroup,
@@ -10113,9 +10227,17 @@ static FailureOr<Value> materializeSlots1GroupBroadcastChunk(
   if (failed(mapping)) {
     return failure();
   }
-  SmallVector<int64_t> laneSourceChunks = std::move(mapping->first);
-  SmallVector<int64_t> activeSourceChunks = std::move(mapping->second);
-  auto splatSource = [&rewriter, &op, &resultType, &sourceParts, &allMask](
+  return materializeSlots1GroupBroadcastMerge(
+      op, resultType, sourceParts, lanesPerPart, *resultMaskType,
+      mapping->first, mapping->second, rewriter, allMask);
+}
+
+static FailureOr<Value> materializeSlots1GroupBroadcastMerge(
+    Operation *op, Type resultType, ValueRange sourceParts, int64_t lanesPerPart,
+    MaskType resultMaskType, ArrayRef<int64_t> laneSourceChunks,
+    ArrayRef<int64_t> activeSourceChunks, OneToNPatternRewriter &rewriter,
+    Value allMask) {
+  auto splatSource = [&rewriter, op, resultType, sourceParts, allMask](
                          int64_t chunkIndex) {
     return rewriter
         .create<VdupOp>(op->getLoc(), resultType, sourceParts[chunkIndex],
@@ -10131,7 +10253,7 @@ static FailureOr<Value> materializeSlots1GroupBroadcastChunk(
       }
     }
     FailureOr<Value> laneMask = materializeConstantMaskChunk(
-        op->getLoc(), *resultMaskType, laneMaskBits, rewriter);
+        op->getLoc(), resultMaskType, laneMaskBits, rewriter);
     if (failed(laneMask)) {
       return rewriter.notifyMatchFailure(
           op, "failed to create group_broadcast source merge mask");
@@ -10214,7 +10336,7 @@ static FailureOr<GroupBroadcastSelectorPlan> chooseGroupBroadcastSelectorPlan(
     return GroupBroadcastSelectorPlan{GroupBroadcastSelectorKind::VCGBlockRamp,
                                       fact.vcgBlockElems};
   }
-  rewriter.notifyMatchFailure(
+  (void)rewriter.notifyMatchFailure(
       op, "group_broadcast layout table row has no selector lowering plan");
   return failure();
 }
@@ -10237,6 +10359,80 @@ struct GroupBroadcastLoweringContext {
   int64_t sourceSlots;
   int64_t selectorPeriod;
 };
+
+struct GroupBroadcastSelectorMetadata {
+  int64_t sourceSlots;
+  int64_t sourceLaneStride;
+  GroupBroadcastSelectorPlan selectorPlan;
+  std::optional<int64_t> selectorShift;
+  std::optional<int64_t> sourceLaneStrideShift;
+};
+
+static FailureOr<GroupBroadcastSelectorMetadata>
+getGroupBroadcastSelectorMetadata(
+    Operation *op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+    const VMIGroupBroadcastLayoutFact &fact,
+    OneToNPatternRewriter &rewriter) {
+  VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
+  VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
+  int64_t sourceSlots = sourceLayout.getSlots();
+  int64_t sourceLaneStride = sourceLayout.getLaneStride();
+  if (sourceSlots <= 0 || sourceLaneStride <= 0) {
+    return rewriter.notifyMatchFailure(
+        op, "group_broadcast requires explicit positive source group slots");
+  }
+  FailureOr<GroupBroadcastSelectorPlan> selectorPlan =
+      chooseGroupBroadcastSelectorPlan(op, fact, resultLayout, rewriter);
+  if (failed(selectorPlan)) {
+    return failure();
+  }
+  std::optional<int64_t> selectorShift;
+  std::optional<int64_t> sourceLaneStrideShift;
+  if (selectorPlan->kind != GroupBroadcastSelectorKind::Constant) {
+    selectorShift = getPowerOfTwoLog2(selectorPlan->period);
+    sourceLaneStrideShift = getPowerOfTwoLog2(sourceLaneStride);
+    if (!selectorShift || !sourceLaneStrideShift) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast ramp requires power-of-two selector period "
+              "and source lane stride");
+    }
+  }
+  return GroupBroadcastSelectorMetadata{
+      sourceSlots, sourceLaneStride, *selectorPlan, selectorShift,
+      sourceLaneStrideShift};
+}
+
+static FailureOr<GroupBroadcastSelectorContext>
+createGroupBroadcastSelectorContext(
+    Operation *op, VRegType sourceType,
+    const GroupBroadcastSelectorMetadata &metadata,
+    OneToNPatternRewriter &rewriter) {
+  unsigned indexBits = pto::getPTOStorageElemBitWidth(
+      sourceType.getElementType());
+  auto indexElementType = IntegerType::get(
+      rewriter.getContext(), indexBits,
+      IntegerType::SignednessSemantics::Unsigned);
+  auto indexScalarType = IntegerType::get(rewriter.getContext(), indexBits);
+  auto indexType = VRegType::get(rewriter.getContext(),
+                                 sourceType.getElementCount(), indexElementType);
+  FailureOr<Value> allMask =
+      createAllTrueMaskForVReg(op->getLoc(), indexType, rewriter);
+  if (failed(allMask)) {
+    return rewriter.notifyMatchFailure(
+        op, "failed to create group_broadcast all mask");
+  }
+  return GroupBroadcastSelectorContext{
+      op,
+      metadata.selectorPlan.kind,
+      metadata.sourceLaneStride,
+      metadata.selectorShift,
+      metadata.sourceLaneStrideShift,
+      indexScalarType,
+      indexType,
+      *allMask,
+      Value(),
+      llvm::DenseMap<int64_t, Value>()};
+}
 
 static FailureOr<Value> materializeConstantGroupBroadcastSelector(
     GroupBroadcastSelectorContext &context, int64_t baseIndex,
@@ -10304,63 +10500,20 @@ createGroupBroadcastLoweringContext(
     Operation *op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
     const VMIGroupBroadcastLayoutFact &fact, VRegType sourceType,
     OneToNPatternRewriter &rewriter) {
-  VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
-  VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
-  int64_t sourceSlots = sourceLayout.getSlots();
-  int64_t sourceLaneStride = sourceLayout.getLaneStride();
-  bool invalidSourceLayout = sourceSlots <= 0 || sourceLaneStride <= 0;
-  if (invalidSourceLayout) {
-    return rewriter.notifyMatchFailure(
-        op, "group_broadcast requires explicit positive source group slots");
-  }
-
-  FailureOr<GroupBroadcastSelectorPlan> selectorPlan =
-      chooseGroupBroadcastSelectorPlan(op, fact, resultLayout, rewriter);
-  if (failed(selectorPlan)) {
+  FailureOr<GroupBroadcastSelectorMetadata> metadata =
+      getGroupBroadcastSelectorMetadata(op, sourceVMIType, resultVMIType, fact,
+                                        rewriter);
+  if (failed(metadata)) {
     return failure();
   }
-  GroupBroadcastSelectorKind selectorKind = selectorPlan->kind;
-  int64_t selectorPeriod = selectorPlan->period;
-  std::optional<int64_t> selectorShift;
-  std::optional<int64_t> sourceLaneStrideShift;
-  if (selectorKind != GroupBroadcastSelectorKind::Constant) {
-    selectorShift = getPowerOfTwoLog2(selectorPeriod);
-    sourceLaneStrideShift = getPowerOfTwoLog2(sourceLaneStride);
-    bool invalidRamp = !selectorShift || !sourceLaneStrideShift;
-    if (invalidRamp) {
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast ramp requires power-of-two selector period "
-              "and source lane stride");
-    }
+  FailureOr<GroupBroadcastSelectorContext> selectorContext =
+      createGroupBroadcastSelectorContext(op, sourceType, *metadata, rewriter);
+  if (failed(selectorContext)) {
+    return failure();
   }
-
-  unsigned indexBits = pto::getPTOStorageElemBitWidth(
-      sourceType.getElementType());
-  auto indexElementType = IntegerType::get(
-      rewriter.getContext(), indexBits,
-      IntegerType::SignednessSemantics::Unsigned);
-  auto indexScalarType = IntegerType::get(rewriter.getContext(), indexBits);
-  auto indexType = VRegType::get(rewriter.getContext(),
-                                 sourceType.getElementCount(), indexElementType);
-  FailureOr<Value> allMask =
-      createAllTrueMaskForVReg(op->getLoc(), indexType, rewriter);
-  if (failed(allMask)) {
-    return rewriter.notifyMatchFailure(
-        op, "failed to create group_broadcast all mask");
-  }
-  GroupBroadcastSelectorContext selectorContext{
-      op,
-      selectorKind,
-      sourceLaneStride,
-      selectorShift,
-      sourceLaneStrideShift,
-      indexScalarType,
-      indexType,
-      *allMask,
-      Value(),
-      {}};
-  return GroupBroadcastLoweringContext{std::move(selectorContext), sourceSlots,
-                                       selectorPeriod};
+  return GroupBroadcastLoweringContext{std::move(*selectorContext),
+                                       metadata->sourceSlots,
+                                       metadata->selectorPlan.period};
 }
 
 static FailureOr<Value> getGroupBroadcastSelector(
@@ -10378,16 +10531,16 @@ static FailureOr<Value> getGroupBroadcastSelector(
     if (failed(selector)) {
       return failure();
     }
-    context.selectorByBaseIndex.try_emplace(baseIndex, selector);
-    return selector;
+    context.selectorByBaseIndex.try_emplace(baseIndex, *selector);
+    return *selector;
   }
   FailureOr<Value> selector =
       materializeGroupBroadcastRamp(context, baseIndex, rewriter);
   if (failed(selector)) {
     return failure();
   }
-  context.selectorByBaseIndex.try_emplace(baseIndex, selector);
-  return selector;
+  context.selectorByBaseIndex.try_emplace(baseIndex, *selector);
+  return *selector;
 }
 
 static FailureOr<Value> materializeGroupBroadcastChunk(
@@ -10506,6 +10659,12 @@ static FailureOr<VRegType> validateGroupBroadcastSources(
   }
   return firstSourceType;
 }
+
+static FailureOr<Value> lowerGroupBroadcastResultChunk(
+    Operation *op, Type resultType, VMIVRegType resultVMIType,
+    ValueRange sourceParts, const VMIGroupBroadcastLayoutFact &fact,
+    GroupBroadcastLoweringContext &context, VRegType expectedSourceType,
+    int64_t part, int64_t chunk, OneToNPatternRewriter &rewriter);
 
 static LogicalResult lowerGroupBroadcastResultChunks(
     Operation *op, ValueRange sourceParts, VMIVRegType resultVMIType,
@@ -10752,6 +10911,35 @@ struct OneToNVMIGatherOpPattern : OneToNOpConversionPattern<VMIGatherOp> {
   using OneToNOpConversionPattern<VMIGatherOp>::OneToNOpConversionPattern;
 
 private:
+  FailureOr<Value> materializeGatherPart(
+      VMIGatherOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value indices, Value mask, Value passthru, Type resultType,
+      bool allActive) const {
+    bool invalidPartTypes = !isa<VRegType>(indices.getType()) ||
+                            !isa<MaskType>(mask.getType()) ||
+                            passthru.getType() != resultType ||
+                            !isa<VRegType>(resultType);
+    if (invalidPartTypes) {
+      return rewriter.notifyMatchFailure(
+          op, "gather physical part type mismatch");
+    }
+    unsigned resultBits = pto::getPTOStorageElemBitWidth(
+        cast<VRegType>(resultType).getElementType());
+    Value gathered = resultBits == 16
+                         ? rewriter.create<Vgather2Op>(
+                               op.getLoc(), resultType, source, indices, mask)
+                               .getResult()
+                         : rewriter.create<Vgather2BcOp>(
+                               op.getLoc(), resultType, source, indices, mask)
+                               .getResult();
+    if (allActive) {
+      return gathered;
+    }
+    return rewriter
+        .create<VselOp>(op.getLoc(), resultType, gathered, passthru, mask)
+        .getResult();
+  }
+
   LogicalResult lowerPhysicalParts(
       VMIGatherOp op, OneToNPatternRewriter &rewriter, Value source,
       ValueRange indicesParts, ValueRange maskParts, ValueRange passthruParts,
@@ -10851,7 +11039,7 @@ private:
                            .create<AddPtrOp>(op.getLoc(), source.getType(), source,
                                              offset)
                            .getResult();
-    return RuntimeExpandLoadPlan{*resultType, gatherBase, maskParts.front(),
+    return RuntimeExpandLoadPlan{resultType, gatherBase, maskParts.front(),
                                  passthruParts.front()};
   }
 
@@ -10989,6 +11177,14 @@ private:
     bool noWiderThanContiguous;
   };
 
+  struct StoreLoweringInput {
+    Value destination;
+    Value offset;
+    ValueRange valueParts;
+    VMIVRegType valueVMIType;
+    StorePhysicalPlan plan;
+  };
+
   FailureOr<StorePhysicalPlan> buildPhysicalPlan(
       VMIStoreOp op, ValueRange valueParts, VMIVRegType valueVMIType,
       OneToNPatternRewriter &rewriter) const {
@@ -11021,6 +11217,30 @@ private:
                              succeeded(checkFullDataPhysicalChunks(
                                  valueVMIType, nullptr)),
                              *noWiderThanContiguous};
+  }
+
+  FailureOr<StoreLoweringInput> getLoweringInput(
+      VMIStoreOp op, OpAdaptor adaptor,
+      OneToNPatternRewriter &rewriter) const {
+    auto valueVMIType = cast<VMIVRegType>(op.getValue().getType());
+    FailureOr<Value> destination = getSingleValue(
+        op, adaptor.getDestination(),
+        "store destination must convert to one value", rewriter);
+    FailureOr<Value> offset = getSingleValue(
+        op, adaptor.getOffset(), "store offset must convert to one value",
+        rewriter);
+    bool invalidAddressOperands = failed(destination) || failed(offset);
+    if (invalidAddressOperands) {
+      return failure();
+    }
+    ValueRange valueParts = adaptor.getValue();
+    FailureOr<StorePhysicalPlan> plan =
+        buildPhysicalPlan(op, valueParts, valueVMIType, rewriter);
+    if (failed(plan)) {
+      return failure();
+    }
+    return StoreLoweringInput{*destination, *offset, valueParts, valueVMIType,
+                              std::move(*plan)};
   }
 
   FailureOr<SmallVector<Type>> getContiguousStoreTypes(
@@ -11124,7 +11344,6 @@ private:
         if (failed(maybeActiveLanes)) {
           return rewriter.notifyMatchFailure(
               op, "failed to compute unaligned store active lanes");
-          return failure();
         }
         if (*maybeActiveLanes == 0) {
           continue;
@@ -11188,6 +11407,46 @@ private:
                                        rewriter))) {
       return failure();
     }
+    return success();
+  }
+
+  LogicalResult lowerByPhysicalPlan(
+      VMIStoreOp op, const StoreLoweringInput &input,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<bool> laneStrideStore = tryLowerLaneStrideStore(
+        op, input.destination, input.offset, input.valueParts,
+        input.valueVMIType, rewriter);
+    if (failed(laneStrideStore)) {
+      return failure();
+    }
+    if (*laneStrideStore) {
+      return success();
+    }
+    FailureOr<bool> deinterleavedStore = tryLowerDeinterleavedStore(
+        op, input.destination, input.offset, input.valueParts,
+        input.valueVMIType, input.plan.lanesPerPart,
+        input.plan.fullPhysicalChunks, input.plan.noWiderThanContiguous,
+        rewriter);
+    if (failed(deinterleavedStore)) {
+      return failure();
+    }
+    if (*deinterleavedStore) {
+      return success();
+    }
+    FailureOr<SmallVector<Value>> storeParts = materializeDataLayoutConversion(
+        op, input.valueParts, input.plan.contiguousTypes,
+        input.valueVMIType.getLayoutAttr(), input.plan.contiguousLayout,
+        input.valueVMIType.getElementType(), rewriter);
+    if (failed(storeParts)) {
+      return failure();
+    }
+    if (failed(lowerContiguousStoreParts(
+            op, input.destination, input.offset, *storeParts,
+            input.valueVMIType, input.plan.lanesPerPart,
+            input.plan.fullPhysicalChunks, rewriter))) {
+      return failure();
+    }
+    rewriter.eraseOp(op);
     return success();
   }
 
@@ -11308,59 +11567,11 @@ public:
   LogicalResult
   matchAndRewrite(VMIStoreOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
-    auto valueVMIType = cast<VMIVRegType>(op.getValue().getType());
-    FailureOr<Value> destination =
-        getSingleValue(op, adaptor.getDestination(),
-                       "store destination must convert to one value", rewriter);
-    FailureOr<Value> offset =
-        getSingleValue(op, adaptor.getOffset(),
-                       "store offset must convert to one value", rewriter);
-    bool invalidAddressOperands = failed(destination) || failed(offset);
-    if (invalidAddressOperands) {
+    FailureOr<StoreLoweringInput> input = getLoweringInput(op, adaptor, rewriter);
+    if (failed(input)) {
       return failure();
     }
-
-    ValueRange valueParts = adaptor.getValue();
-    FailureOr<StorePhysicalPlan> plan =
-        buildPhysicalPlan(op, valueParts, valueVMIType, rewriter);
-    if (failed(plan)) {
-      return failure();
-    }
-    FailureOr<bool> laneStrideStore = tryLowerLaneStrideStore(
-        op, *destination, *offset, valueParts, valueVMIType, rewriter);
-    if (failed(laneStrideStore)) {
-      return failure();
-    }
-    if (*laneStrideStore) {
-      return success();
-    }
-
-    FailureOr<bool> deinterleavedStore = tryLowerDeinterleavedStore(
-        op, *destination, *offset, valueParts, valueVMIType,
-        plan->lanesPerPart, plan->fullPhysicalChunks,
-        plan->noWiderThanContiguous, rewriter);
-    if (failed(deinterleavedStore)) {
-      return failure();
-    }
-    if (*deinterleavedStore) {
-      return success();
-    }
-
-    FailureOr<SmallVector<Value>> storeParts = materializeDataLayoutConversion(
-        op, valueParts, plan->contiguousTypes, valueVMIType.getLayoutAttr(),
-        plan->contiguousLayout, valueVMIType.getElementType(), rewriter);
-    if (failed(storeParts)) {
-      return failure();
-    }
-
-    if (failed(lowerContiguousStoreParts(
-            op, *destination, *offset, *storeParts, valueVMIType,
-            plan->lanesPerPart, plan->fullPhysicalChunks, rewriter))) {
-      return failure();
-    }
-
-    rewriter.eraseOp(op);
-    return success();
+    return lowerByPhysicalPlan(op, *input, rewriter);
   }
 };
 
@@ -11447,6 +11658,54 @@ private:
     bool useDirectAccess;
   };
 
+  struct InterleaveStoreLoweringInput {
+    Value destination;
+    Value offset;
+    ValueRange lowParts;
+    ValueRange highParts;
+    VMIVRegType lowVMIType;
+    int64_t lanesPerPart;
+    std::string dist;
+  };
+
+  FailureOr<InterleaveStoreLoweringInput> getLoweringInput(
+      VMIInterleaveStoreOp op, OpAdaptor adaptor,
+      OneToNPatternRewriter &rewriter) const {
+    auto lowVMIType = cast<VMIVRegType>(op.getLow().getType());
+    FailureOr<int64_t> lanesPerPart =
+        getDataLanesPerPart(lowVMIType.getElementType());
+    if (failed(lanesPerPart)) {
+      return rewriter.notifyMatchFailure(
+          op, "interleave_store requires known physical lanes per part");
+    }
+    std::optional<std::string> dist =
+        getX2MemoryDistToken(lowVMIType.getElementType(), "INTLV");
+    if (!dist) {
+      return rewriter.notifyMatchFailure(
+          op, "interleave_store requires vstsx2 INTLV element support");
+    }
+    FailureOr<Value> destination = getSingleValue(
+        op, adaptor.getDestination(),
+        "interleave_store destination must convert to one value", rewriter);
+    FailureOr<Value> offset = getSingleValue(
+        op, adaptor.getOffset(),
+        "interleave_store offset must convert to one value", rewriter);
+    bool invalidAddressOperands = failed(destination) || failed(offset);
+    if (invalidAddressOperands) {
+      return failure();
+    }
+    ValueRange lowParts = adaptor.getLow();
+    ValueRange highParts = adaptor.getHigh();
+    bool arityMismatch = lowParts.size() != highParts.size();
+    if (arityMismatch) {
+      return rewriter.notifyMatchFailure(
+          op, "interleave_store requires matching low/high physical arity");
+    }
+    return InterleaveStoreLoweringInput{*destination, *offset, lowParts,
+                                        highParts, lowVMIType, *lanesPerPart,
+                                        *dist};
+  }
+
   FailureOr<InterleaveStoreAddressPlan> buildAddressPlan(
       VMIInterleaveStoreOp op, Value destination, Value offset,
       ValueRange lowParts, VMIVRegType lowVMIType, StringRef dist,
@@ -11467,73 +11726,46 @@ private:
     return InterleaveStoreAddressPlan{destination, offset, *base, false};
   }
 
+  LogicalResult lowerByAddressPlan(
+      VMIInterleaveStoreOp op, const InterleaveStoreLoweringInput &input,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<InterleaveStoreAddressPlan> addressPlan = buildAddressPlan(
+        op, input.destination, input.offset, input.lowParts, input.lowVMIType,
+        input.dist, rewriter);
+    if (failed(addressPlan)) {
+      return failure();
+    }
+    SmallVector<Value> streamValues;
+    SmallVector<int64_t> streamAdvances;
+    for (size_t index = 0, e = input.lowParts.size(); index < e; ++index) {
+      if (failed(emitInterleaveStoreChunk(
+              op, input.lowParts[index], input.highParts[index], index,
+              input.lanesPerPart, input.destination, input.offset, input.dist,
+              addressPlan->useDirectAccess, streamValues, streamAdvances,
+              rewriter))) {
+        return failure();
+      }
+    }
+    if (!addressPlan->useDirectAccess &&
+        failed(emitStatefulStoreStream(op, addressPlan->streamBase,
+                                       streamValues, streamAdvances, rewriter))) {
+      return failure();
+    }
+    rewriter.eraseOp(op);
+    return success();
+  }
+
 public:
 
   LogicalResult
   matchAndRewrite(VMIInterleaveStoreOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
-    auto lowVMIType = cast<VMIVRegType>(op.getLow().getType());
-    FailureOr<int64_t> lanesPerPart =
-        getDataLanesPerPart(lowVMIType.getElementType());
-    if (failed(lanesPerPart)) {
-      return rewriter.notifyMatchFailure(
-          op, "interleave_store requires known physical lanes per part");
-    }
-
-    std::optional<std::string> dist =
-        getX2MemoryDistToken(lowVMIType.getElementType(), "INTLV");
-    if (!dist) {
-      return rewriter.notifyMatchFailure(
-          op, "interleave_store requires vstsx2 INTLV element support");
-    }
-
-    FailureOr<Value> destination = getSingleValue(
-        op, adaptor.getDestination(),
-        "interleave_store destination must convert to one value", rewriter);
-    FailureOr<Value> offset = getSingleValue(
-        op, adaptor.getOffset(),
-        "interleave_store offset must convert to one value", rewriter);
-    bool invalidAddressOperands = failed(destination) || failed(offset);
-    if (invalidAddressOperands) {
+    FailureOr<InterleaveStoreLoweringInput> input =
+        getLoweringInput(op, adaptor, rewriter);
+    if (failed(input)) {
       return failure();
     }
-
-    ValueRange lowParts = adaptor.getLow();
-    ValueRange highParts = adaptor.getHigh();
-    bool arityMismatch = lowParts.size() != highParts.size();
-    if (arityMismatch) {
-      return rewriter.notifyMatchFailure(
-          op, "interleave_store requires matching low/high physical arity");
-    }
-
-    FailureOr<InterleaveStoreAddressPlan> addressPlan = buildAddressPlan(
-        op, *destination, *offset, lowParts, lowVMIType, *dist, rewriter);
-    if (failed(addressPlan)) {
-      return failure();
-    }
-    bool useDirectAccess = addressPlan->useDirectAccess;
-    SmallVector<Value> streamValues;
-    SmallVector<int64_t> streamAdvances;
-    Value streamBase = addressPlan->streamBase;
-
-    for (size_t index = 0, e = lowParts.size(); index < e; ++index) {
-      if (failed(emitInterleaveStoreChunk(
-              op, lowParts[index], highParts[index], index, *lanesPerPart,
-              *destination, *offset, *dist, useDirectAccess, streamValues,
-              streamAdvances, rewriter))) {
-        return failure();
-      }
-    }
-
-    if (!useDirectAccess) {
-      if (failed(emitStatefulStoreStream(op, streamBase, streamValues,
-                                         streamAdvances, rewriter))) {
-        return failure();
-      }
-    }
-
-    rewriter.eraseOp(op);
-    return success();
+    return lowerByAddressPlan(op, *input, rewriter);
   }
 };
 
@@ -11661,7 +11893,7 @@ private:
           op, "unsupported element type for packed group_store mask");
     }
     FailureOr<Value> packed = buildPackedSlots1Value(
-        op, rewriter, valueParts, layout, *firstType, *maskType, *allMask);
+        op, rewriter, valueParts, layout, firstType, *maskType, *allMask);
     if (failed(packed)) {
       return failure();
     }
@@ -11984,32 +12216,21 @@ private:
 
   LogicalResult lowerSlots8Contiguous(
       VMIGroupStoreOp op, OpAdaptor adaptor, OneToNPatternRewriter &rewriter,
-      VMIVRegType valueVMIType, Value destination, Value offset,
-      Value rowStride, int64_t numGroups) const {
+      Value destination, Value offset, Value rowStride,
+      int64_t numGroups) const {
     ValueRange valueParts = adaptor.getValue();
-    SmallVector<Value> groupOffsets;
-    bool useDirectAccess = true;
-    for (auto [slotBlock, value] : llvm::enumerate(valueParts)) {
-      auto vregType = dyn_cast<VRegType>(value.getType());
-      if (!vregType) {
-        return rewriter.notifyMatchFailure(op,
-                                           "group_store value must be vreg");
-      }
-      Value groupOffset = createGroupChunkOffset(
-          op.getLoc(), offset, rowStride, slotBlock * 8,
-          /*chunkLaneOffset=*/0, rewriter);
-      groupOffsets.push_back(groupOffset);
-      useDirectAccess &= isDirectMemoryDistAddressLegal(
-          op.getDestination(), groupOffset,
-          getMemoryElementType(op.getDestination().getType()), vregType,
-          VPTOMemoryOpFamily::Store, "");
+    FailureOr<std::pair<SmallVector<Value>, bool>> offsetPlan =
+        buildSlots8GroupOffsets(op, valueParts, destination, offset, rowStride,
+                                "", rewriter);
+    if (failed(offsetPlan)) {
+      return failure();
     }
+    SmallVector<Value> groupOffsets = std::move(offsetPlan->first);
+    bool useDirectAccess = offsetPlan->second;
 
     if (!useDirectAccess) {
-      SmallVector<int64_t> advances;
-      for (size_t slotBlock = 0; slotBlock < valueParts.size(); ++slotBlock) {
-        advances.push_back(std::min<int64_t>(8, numGroups - slotBlock * 8));
-      }
+      SmallVector<int64_t> advances =
+          buildSlots8StreamAdvances(numGroups, valueParts.size());
       if (failed(emitGroupStoreStream(op, destination, offset, valueParts,
                                       advances, rewriter))) {
         return failure();
@@ -12111,16 +12332,16 @@ private:
     return success();
   }
 
-  FailureOr<std::pair<SmallVector<Value>, bool>> buildLaneStrideGroupOffsets(
+  FailureOr<std::pair<SmallVector<Value>, bool>> buildSlots8GroupOffsets(
       VMIGroupStoreOp op, ValueRange valueParts, Value destination,
-      Value offset, Value rowStride, int64_t numGroups, StringRef dist,
+      Value offset, Value rowStride, StringRef dist,
       OneToNPatternRewriter &rewriter) const {
     SmallVector<Value> groupOffsets;
     bool useDirectAccess = true;
     for (auto [slotBlock, value] : llvm::enumerate(valueParts)) {
       auto vregType = dyn_cast<VRegType>(value.getType());
       if (!vregType) {
-        rewriter.notifyMatchFailure(op, "group_store value must be vreg");
+        (void)rewriter.notifyMatchFailure(op, "group_store value must be vreg");
         return failure();
       }
       Value groupOffset = createGroupChunkOffset(
@@ -12154,7 +12375,7 @@ private:
     return *compactValues;
   }
 
-  SmallVector<int64_t> buildLaneStrideStreamAdvances(
+  SmallVector<int64_t> buildSlots8StreamAdvances(
       int64_t numGroups, size_t valueCount) const {
     SmallVector<int64_t> advances;
     advances.reserve(valueCount);
@@ -12180,8 +12401,8 @@ private:
     ValueRange valueParts = adaptor.getValue();
     auto maskType = MaskType::get(rewriter.getContext(), *maskGranularity);
     FailureOr<std::pair<SmallVector<Value>, bool>> offsetPlan =
-        buildLaneStrideGroupOffsets(op, valueParts, destination, offset,
-                                     rowStride, numGroups, *dist, rewriter);
+        buildSlots8GroupOffsets(op, valueParts, destination, offset, rowStride,
+                                *dist, rewriter);
     if (failed(offsetPlan)) {
       return failure();
     }
@@ -12195,7 +12416,7 @@ private:
         return failure();
       }
       SmallVector<int64_t> advances =
-          buildLaneStrideStreamAdvances(numGroups, compactValues->size());
+          buildSlots8StreamAdvances(numGroups, compactValues->size());
       if (failed(emitGroupStoreStream(op, destination, offset, *compactValues,
                                       advances, rewriter))) {
         return failure();
@@ -12456,7 +12677,7 @@ private:
         createAllTrueMaskForVReg(op.getLoc(), firstVRegType, rewriter);
     bool failedMasks = failed(maskType) || failed(allMask);
     if (failedMasks) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "unsupported element type for packed group_store mask");
       return failure();
     }
@@ -12470,7 +12691,7 @@ private:
         op.getLoc(), indexType, /*groupSize=*/8, /*baseGroupSlot=*/0,
         rewriter);
     if (failed(slotIndex)) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "failed to create packed group_store lane selector");
       return failure();
     }
@@ -12529,7 +12750,8 @@ private:
     bool hasExpectedArity = static_cast<int64_t>(valueParts.size()) ==
                             ceilDivNonNegative(layout.getNumGroups(), 8);
     if (!hasExpectedArity) {
-      rewriter.notifyMatchFailure(op, "slots=8 group_store arity mismatch");
+      (void)rewriter.notifyMatchFailure(op,
+                                        "slots=8 group_store arity mismatch");
       return failure();
     }
     if (valueParts.empty()) {
@@ -12537,7 +12759,8 @@ private:
     }
     auto firstVRegType = dyn_cast<VRegType>(valueParts.front().getType());
     if (!firstVRegType) {
-      rewriter.notifyMatchFailure(op, "group_store value must be vreg");
+      (void)rewriter.notifyMatchFailure(op,
+                                        "group_store value must be vreg");
       return failure();
     }
     return std::optional<VRegType>(firstVRegType);
@@ -12570,8 +12793,8 @@ private:
       return lowerSlots8LaneStride(op, adaptor, rewriter, valueVMIType, layout,
                                    destination, offset, rowStride, numGroups);
     }
-    return lowerSlots8Contiguous(op, adaptor, rewriter, valueVMIType, destination,
-                                 offset, rowStride, numGroups);
+    return lowerSlots8Contiguous(op, adaptor, rewriter, destination, offset,
+                                 rowStride, numGroups);
   }
 
   enum class GroupStoreLayoutKind { Scalar, Compact, Slots1, Slots8, General };
@@ -12869,6 +13092,26 @@ private:
     }
     rewriter.eraseOp(op);
     return success();
+  }
+
+  LogicalResult lowerByLayout(
+      VMIMaskedStoreOp op, OneToNPatternRewriter &rewriter,
+      ValueRange valueParts, ValueRange maskParts, VMIVRegType valueVMIType,
+      VMIMaskType maskVMIType, Value destination, Value offset,
+      int64_t lanesPerPart) const {
+    std::optional<std::string> dist =
+        getDenseLaneStrideStoreDistToken(valueVMIType);
+    if (dist) {
+      std::optional<StringRef> maskGranularity =
+          getDenseLaneStrideMaskedStoreMaskGranularity(valueVMIType);
+      if (maskGranularity) {
+        return lowerLaneStride(op, rewriter, valueParts, maskParts,
+                               valueVMIType, maskVMIType, destination, offset,
+                               *dist, *maskGranularity);
+      }
+    }
+    return lowerContiguous(op, rewriter, valueParts, maskParts, valueVMIType,
+                           maskVMIType, destination, offset, lanesPerPart);
   }
 
 public:
@@ -13216,7 +13459,7 @@ private:
       VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
       Value source, Value offset, Value sourceGroupStride,
       VMIVRegType resultVMIType, ArrayRef<Type> resultTypes, int64_t numGroups,
-      FailureOr<VMIGroupBroadcastLoadDirectFact> &directFact) const {
+      const FailureOr<VMIGroupBroadcastLoadDirectFact> &directFact) const {
     bool candidate = succeeded(directFact) &&
                      directFact->kind == VMIGroupBroadcastLoadDirectKind::BRC &&
                      !resultTypes.empty();
@@ -13252,7 +13495,7 @@ private:
       VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
       Value source, Value offset, VMIVRegType resultVMIType,
       ArrayRef<Type> resultTypes, int64_t numGroups,
-      FailureOr<VMIGroupBroadcastLoadDirectFact> &directFact) const {
+      const FailureOr<VMIGroupBroadcastLoadDirectFact> &directFact) const {
     bool candidate = succeeded(directFact) &&
                      directFact->kind == VMIGroupBroadcastLoadDirectKind::E2B &&
                      !resultTypes.empty();
@@ -13282,7 +13525,7 @@ private:
       VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
       Value source, Value offset, Value sourceGroupStride,
       VMIVRegType resultVMIType, ArrayRef<Type> resultTypes, int64_t numGroups,
-      FailureOr<VMIGroupBroadcastLoadDirectFact> &directFact) const {
+      const FailureOr<VMIGroupBroadcastLoadDirectFact> &directFact) const {
     FailureOr<bool> loweredBRC = tryLowerDirectBRC(
         op, rewriter, source, offset, sourceGroupStride, resultVMIType,
         resultTypes, numGroups, directFact);
@@ -14006,6 +14249,137 @@ private:
     return std::make_pair(*low, *high);
   }
 
+  FailureOr<std::pair<SmallVector<Type>, SmallVector<Type>>>
+  getInterleaveResultTypes(
+      SourceOp op, ValueRange lhsParts, ValueRange rhsParts,
+      ValueRange maskParts, OneToNPatternRewriter &rewriter) const {
+    FailureOr<SmallVector<Type>> lowTypes =
+        getConvertedResultTypes(op, 0, *this->getTypeConverter());
+    FailureOr<SmallVector<Type>> highTypes =
+        getConvertedResultTypes(op, 1, *this->getTypeConverter());
+    bool invalidArity =
+        failed(lowTypes) || failed(highTypes) || lhsParts.size() != rhsParts.size() ||
+        lhsParts.size() != lowTypes->size() || lhsParts.size() != highTypes->size() ||
+        (!maskParts.empty() && maskParts.size() != lhsParts.size());
+    if (invalidArity) {
+      return rewriter.notifyMatchFailure(op, "physical interleave arity mismatch");
+    }
+    return std::make_pair(std::move(*lowTypes), std::move(*highTypes));
+  }
+
+  FailureOr<VMIInterleaveLayoutFact> getInterleaveLayoutFact(
+      SourceOp op, VMIVRegType lhsType, VMIVRegType rhsType,
+      VMIMaskType maskType, VMIVRegType lowType, VMIVRegType highType,
+      OneToNPatternRewriter &rewriter) const {
+    VMILayoutSupport supports;
+    FailureOr<VMIInterleaveLayoutFact> fact;
+    if constexpr (std::is_same_v<SourceOp, VMIVintlvOp>) {
+      fact = supports.getVintlvLayoutFactForLayouts(lhsType, rhsType, maskType,
+                                                    lowType, highType);
+    } else {
+      fact = supports.getVdintlvLayoutFactForLayouts(lhsType, rhsType, maskType,
+                                                     lowType, highType);
+    }
+    if (failed(fact)) {
+      (void)rewriter.notifyMatchFailure(op, "unsupported interleave layout relation");
+    }
+    return fact;
+  }
+
+  enum class InterleaveLoweringKind { LaneStride, Contiguous, ZeroCopy };
+  struct InterleaveLoweringPlan {
+    InterleaveLoweringKind kind;
+    int64_t inputFactor = 0;
+    int64_t outputFactor = 0;
+    bool zeroCopyVintlv = false;
+  };
+
+  static bool hasLaneStrideInterleaveLayout(
+      const VMIInterleaveLayoutFact &fact) {
+    return fact.lhsLayout == fact.rhsLayout &&
+           fact.lhsLayout == fact.maskLayout &&
+           fact.lhsLayout == fact.lowLayout &&
+           fact.lhsLayout == fact.highLayout &&
+           fact.lhsLayout.isContiguous() &&
+           fact.lhsLayout.getLaneStride() > 1;
+  }
+
+  static bool hasUnitStrideContiguousInterleaveLayout(
+      const VMIInterleaveLayoutFact &fact) {
+    auto contiguous = [](VMILayoutAttr layout) {
+      return layout && layout.isContiguous() && layout.getLaneStride() == 1;
+    };
+    return contiguous(fact.lhsLayout) && contiguous(fact.rhsLayout) &&
+           contiguous(fact.maskLayout) && contiguous(fact.lowLayout) &&
+           contiguous(fact.highLayout);
+  }
+
+  std::optional<InterleaveLoweringPlan> getZeroCopyInterleavePlan(
+      const VMIInterleaveLayoutFact &fact) const {
+    int64_t inputFactor = getElementDeinterleaveFactor(fact.lhsLayout);
+    int64_t outputFactor = getElementDeinterleaveFactor(fact.lowLayout);
+    bool matchingInputs = fact.rhsLayout == fact.lhsLayout &&
+                          fact.maskLayout == fact.lhsLayout;
+    bool matchingOutputs = fact.highLayout == fact.lowLayout;
+    bool vintlv = std::is_same_v<SourceOp, VMIVintlvOp> && inputFactor > 0 &&
+                  matchingInputs && matchingOutputs &&
+                  outputFactor == 2 * inputFactor;
+    bool vdintlv = std::is_same_v<SourceOp, VMIVdintlvOp> && inputFactor > 0 &&
+                   matchingInputs && matchingOutputs &&
+                   inputFactor == 2 * outputFactor;
+    if (!vintlv && !vdintlv) {
+      return std::nullopt;
+    }
+    return InterleaveLoweringPlan{InterleaveLoweringKind::ZeroCopy,
+                                  inputFactor, outputFactor, vintlv};
+  }
+
+  FailureOr<InterleaveLoweringPlan> classifyInterleaveLowering(
+      SourceOp op, const VMIInterleaveLayoutFact &fact,
+      OneToNPatternRewriter &rewriter) const {
+    if (hasLaneStrideInterleaveLayout(fact)) {
+      return InterleaveLoweringPlan{InterleaveLoweringKind::LaneStride};
+    }
+    if (hasUnitStrideContiguousInterleaveLayout(fact)) {
+      return InterleaveLoweringPlan{InterleaveLoweringKind::Contiguous};
+    }
+    std::optional<InterleaveLoweringPlan> zeroCopyPlan =
+        getZeroCopyInterleavePlan(fact);
+    if (!zeroCopyPlan) {
+      return rewriter.notifyMatchFailure(op, "unsupported interleave physical layout relation");
+    }
+    return *zeroCopyPlan;
+  }
+
+  LogicalResult lowerInterleaveByLayout(
+      SourceOp op, OneToNPatternRewriter &rewriter, ValueRange lhsParts,
+      ValueRange rhsParts, ValueRange maskParts, ArrayRef<Type> lowTypes,
+      ArrayRef<Type> highTypes, Type elementType,
+      const VMIInterleaveLayoutFact &fact) const {
+    FailureOr<InterleaveLoweringPlan> plan =
+        classifyInterleaveLowering(op, fact, rewriter);
+    if (failed(plan)) {
+      return failure();
+    }
+    if (plan->kind == InterleaveLoweringKind::LaneStride) {
+      return lowerLaneStrideInterleave(op, rewriter, lhsParts, rhsParts,
+                                       lowTypes, highTypes, elementType, fact);
+    }
+    if (plan->kind == InterleaveLoweringKind::Contiguous) {
+      return lowerContiguous(op, rewriter, lhsParts, rhsParts, maskParts,
+                             lowTypes, highTypes);
+    }
+    FailureOr<SmallVector<Value>> results = materializeZeroCopyResults(
+        op, lhsParts, rhsParts, lowTypes, highTypes, plan->inputFactor,
+        plan->outputFactor, plan->zeroCopyVintlv, rewriter);
+    if (failed(results)) {
+      return failure();
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, *results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
   LogicalResult lowerLaneStrideInterleave(
       SourceOp op, OneToNPatternRewriter &rewriter, ValueRange lhsParts,
       ValueRange rhsParts, TypeRange lowTypes, TypeRange highTypes,
@@ -14208,14 +14582,15 @@ private:
         !vregType || lhs.getType() != resultType || rhs.getType() != resultType ||
         acc.getType() != resultType;
     if (invalidPart) {
-      rewriter.notifyMatchFailure(op,
-                                  "fma requires matching physical vreg parts");
+      (void)rewriter.notifyMatchFailure(
+          op, "fma requires matching physical vreg parts");
       return failure();
     }
     FailureOr<Value> mask =
         createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
     if (failed(mask)) {
-      rewriter.notifyMatchFailure(op, "unsupported element type for fma");
+      (void)rewriter.notifyMatchFailure(op,
+                                        "unsupported element type for fma");
       return failure();
     }
     return rewriter
@@ -14275,7 +14650,7 @@ private:
         x.getType() != resultType || max.getType() != resultType ||
         maskType.getGranularity() != "b32";
     if (invalidPart) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "f32 vexpdif requires matching f32 parts and b32 masks");
       return failure();
     }
@@ -14297,7 +14672,7 @@ private:
         !resultVRegType.getElementType().isF32() ||
         max.getType() != x.getType() || maskType.getGranularity() != "b16";
     if (invalidPart) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "f16 vexpdif requires matching f16 parts and b16 masks");
       return failure();
     }
@@ -14305,6 +14680,77 @@ private:
         .create<VexpdifOp>(op.getLoc(), resultType, x, max, mask,
                            rewriter.getStringAttr(part))
         .getResult();
+  }
+
+  LogicalResult lowerF32(VMIVexpdifOp op, ValueRange xParts,
+                         ValueRange maxParts, ValueRange maskParts,
+                         ArrayRef<Type> resultTypes,
+                         OneToNPatternRewriter &rewriter) const {
+    const bool invalidArity = xParts.size() != resultTypes.size();
+    if (invalidArity) {
+      return rewriter.notifyMatchFailure(
+          op, "f32 vexpdif requires one result per source part");
+    }
+
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (auto [x, max, mask, resultType] :
+         llvm::zip_equal(xParts, maxParts, maskParts, resultTypes)) {
+      FailureOr<Value> result =
+          lowerF32Part(op, x, max, mask, resultType, rewriter);
+      if (failed(result)) {
+        return failure();
+      }
+      results.push_back(*result);
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
+  LogicalResult lowerF16(VMIVexpdifOp op, ValueRange xParts,
+                         ValueRange maxParts, ValueRange maskParts,
+                         ArrayRef<Type> resultTypes,
+                         OneToNPatternRewriter &rewriter) const {
+    const bool invalidArity = resultTypes.size() != 2 * xParts.size();
+    if (invalidArity) {
+      return rewriter.notifyMatchFailure(
+          op, "f16 vexpdif requires EVEN/ODD f32 result parts");
+    }
+
+    static constexpr StringRef kParts[] = {"EVEN", "ODD"};
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (auto [partIndex, part] : llvm::enumerate(kParts)) {
+      for (auto [chunkIndex, x] : llvm::enumerate(xParts)) {
+        Value max = maxParts[chunkIndex];
+        Value mask = maskParts[chunkIndex];
+        Type resultType = resultTypes[partIndex * xParts.size() + chunkIndex];
+        FailureOr<Value> result =
+            lowerF16Part(op, x, max, mask, resultType, part, rewriter);
+        if (failed(result)) {
+          return failure();
+        }
+        results.push_back(*result);
+      }
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
+  LogicalResult lowerBySourceElementType(
+      VMIVexpdifOp op, ValueRange xParts, ValueRange maxParts,
+      ValueRange maskParts, ArrayRef<Type> resultTypes,
+      Type sourceElementType, OneToNPatternRewriter &rewriter) const {
+    if (sourceElementType.isF32()) {
+      return lowerF32(op, xParts, maxParts, maskParts, resultTypes, rewriter);
+    }
+    if (!sourceElementType.isF16()) {
+      return rewriter.notifyMatchFailure(
+          op, "f16 vexpdif requires EVEN/ODD f32 result parts");
+    }
+    return lowerF16(op, xParts, maxParts, maskParts, resultTypes, rewriter);
   }
 
 public:
@@ -14334,52 +14780,9 @@ public:
     }
 
     auto sourceVMIType = cast<VMIVRegType>(op.getX().getType());
-    SmallVector<Value> results;
-    results.reserve(resultTypes.size());
-
-    if (sourceVMIType.getElementType().isF32()) {
-      const bool invalidF32Arity = xParts.size() != resultTypes.size();
-      if (invalidF32Arity) {
-        return rewriter.notifyMatchFailure(
-            op, "f32 vexpdif requires one result per source part");
-      }
-      for (auto [x, max, mask, resultType] :
-           llvm::zip_equal(xParts, maxParts, maskParts, resultTypes)) {
-        FailureOr<Value> result =
-            lowerF32Part(op, x, max, mask, resultType, rewriter);
-        if (failed(result)) {
-          return failure();
-        }
-        results.push_back(*result);
-      }
-    } else {
-      const bool invalidF16Arity =
-          !sourceVMIType.getElementType().isF16() ||
-          resultTypes.size() != 2 * xParts.size();
-      if (invalidF16Arity) {
-        return rewriter.notifyMatchFailure(
-            op, "f16 vexpdif requires EVEN/ODD f32 result parts");
-      }
-
-      static constexpr StringRef kParts[] = {"EVEN", "ODD"};
-      for (auto [partIndex, part] : llvm::enumerate(kParts)) {
-        for (auto [chunkIndex, x] : llvm::enumerate(xParts)) {
-          Value max = maxParts[chunkIndex];
-          Value mask = maskParts[chunkIndex];
-          Type resultType = resultTypes[partIndex * xParts.size() + chunkIndex];
-          FailureOr<Value> result = lowerF16Part(
-              op, x, max, mask, resultType, part, rewriter);
-          if (failed(result)) {
-            return failure();
-          }
-          results.push_back(*result);
-        }
-      }
-    }
-
-    replaceOpWithFlatConvertedValues(rewriter, op, results,
-                                     *this->getTypeConverter());
-    return success();
+    return lowerBySourceElementType(
+        op, xParts, maxParts, maskParts, resultTypes,
+        sourceVMIType.getElementType(), rewriter);
   }
 };
 
@@ -14562,13 +14965,14 @@ private:
     const bool invalidPart =
         !maskType || lhs.getType() != rhs.getType() || !lhsType;
     if (invalidPart) {
-      rewriter.notifyMatchFailure(op, "physical cmp part type mismatch");
+      (void)rewriter.notifyMatchFailure(op,
+                                        "physical cmp part type mismatch");
       return failure();
     }
     FailureOr<Value> seedMask =
         createAllTrueMask(op.getLoc(), maskType, rewriter);
     if (failed(seedMask)) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "unsupported mask type for all-true cmp seed");
       return failure();
     }
@@ -14576,7 +14980,7 @@ private:
       FailureOr<VRegType> carrierType =
           getSignednessCarrierVRegType(lhsType, *cmpMode.signedness);
       if (failed(carrierType)) {
-        rewriter.notifyMatchFailure(
+        (void)rewriter.notifyMatchFailure(
             op, "unsupported integer compare signedness carrier");
         return failure();
       }
@@ -14586,7 +14990,7 @@ private:
           bitcastVReg(op.getLoc(), rhs, *carrierType, rewriter);
       const bool failedCarriers = failed(carrierLhs) || failed(carrierRhs);
       if (failedCarriers) {
-        rewriter.notifyMatchFailure(
+        (void)rewriter.notifyMatchFailure(
             op, "failed to materialize integer compare signedness carrier");
         return failure();
       }
@@ -14656,7 +15060,8 @@ private:
         !isa<MaskType>(mask.getType()) || trueValue.getType() != resultType ||
         falseValue.getType() != resultType || !isa<VRegType>(resultType);
     if (invalidPart) {
-      rewriter.notifyMatchFailure(op, "physical select part type mismatch");
+      (void)rewriter.notifyMatchFailure(
+          op, "physical select part type mismatch");
       return failure();
     }
     return rewriter
@@ -14719,7 +15124,7 @@ private:
         pto::getPTOStorageElemBitWidth(sourceType.getElementType()) !=
             pto::getPTOStorageElemBitWidth(indexType.getElementType());
     if (invalidPart) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "vselr physical source/index/result type mismatch");
       return failure();
     }
@@ -14773,21 +15178,21 @@ private:
     auto maskType = dyn_cast<MaskType>(mask.getType());
     const bool invalidPartTypes = !vregType || !maskType;
     if (invalidPartTypes) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "active_prefix_index requires physical vreg/mask parts");
       return failure();
     }
     auto intType = dyn_cast<IntegerType>(vregType.getElementType());
     const bool invalidElementType = !intType || !intType.isSignless();
     if (invalidElementType) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "active_prefix_index requires signless integer result part");
       return failure();
     }
     FailureOr<Value> seedMask =
         createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
     if (failed(seedMask)) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "unsupported element type for active_prefix_index seed mask");
       return failure();
     }
@@ -14825,7 +15230,7 @@ public:
     if (failed(result)) {
       return failure();
     }
-    replaceOpWithFlatConvertedValues(rewriter, op, SmallVector<Value>{result},
+    replaceOpWithFlatConvertedValues(rewriter, op, SmallVector<Value>{*result},
                                      *this->getTypeConverter());
     return success();
   }
@@ -14843,7 +15248,7 @@ private:
         !resultVRegType || source.getType() != resultType ||
         !isa<MaskType>(mask.getType());
     if (invalidPart) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "compress requires physical source/mask/result parts");
       return failure();
     }
@@ -14986,14 +15391,14 @@ static FailureOr<ReduceAddPhysicalPlan> buildReduceAddPhysicalPlan(
                   " requires every mask chunk to have the same predicate type");
     }
   }
-  return ReduceAddPhysicalPlan{*resultType, *maskType};
+  return ReduceAddPhysicalPlan{resultType, maskType};
 }
 
 template <typename ReduceOp>
 static LogicalResult lowerReduceAddParts(
     ReduceOp op, ValueRange sourceParts, ValueRange maskParts,
     VRegType resultType, MaskType maskType, StringRef firstLaneDiagnostic,
-    OneToNPatternRewriter &rewriter, const TypeConverter &typeConverter) {
+    OneToNPatternRewriter &rewriter, TypeConverter &typeConverter) {
   FailureOr<Value> combined = combineEquivalentMaskedParts<VaddOp>(
       op.getLoc(), sourceParts, maskParts, resultType, rewriter);
   if (succeeded(combined)) {
@@ -15178,7 +15583,7 @@ private:
     for (auto [sourceIndex, sourcePart] : llvm::enumerate(sourceParts)) {
       FailureOr<Value> result = buildOneBlockGroupResult(
           op, sourcePart, maskParts[sourceIndex], resultTypes[sourceIndex],
-          *resultType, *maskType, rewriter);
+          resultType, maskType, rewriter);
       if (failed(result)) {
         return failure();
       }
@@ -15252,7 +15657,7 @@ private:
          ++resultIndex) {
       FailureOr<Value> result = buildTwoBlockGroupResult(
           op, sourceParts, maskParts, resultTypes, resultIndex, resultPartCount,
-          numGroups, *resultType, *maskType, rewriter);
+          numGroups, resultType, maskType, rewriter);
       if (failed(result)) {
         return failure();
       }
@@ -15332,7 +15737,7 @@ private:
          ++resultIndex) {
       FailureOr<Value> result = buildFourBlockGroupResult(
           op, sourceParts, maskParts, resultTypes, resultIndex,
-          resultPartCount, numGroups, *resultType, *maskType, rewriter);
+          resultPartCount, numGroups, resultType, maskType, rewriter);
       if (failed(result)) {
         return failure();
       }
@@ -15451,7 +15856,7 @@ private:
           op, "failed to derive deinterleaved=2 combine mask type");
     }
     return Deinterleaved2GroupReduceTypes{
-        *resultType, *maskType, *sourcePartType, *rowResultType, *rowMaskType};
+        resultType, maskType, sourcePartType, *rowResultType, *rowMaskType};
   }
 
   FailureOr<std::pair<int64_t, int64_t>> validateFullDeinterleaved2Shape(
@@ -15471,7 +15876,7 @@ private:
       return rewriter.notifyMatchFailure(
           op, "deinterleaved=2 group_reduce requires known physical lanes");
     }
-    bool invalidGroupSize = *groupSize % (2 * *lanesPerPart) != 0;
+    bool invalidGroupSize = groupSize % (2 * *lanesPerPart) != 0;
     if (invalidGroupSize) {
       return rewriter.notifyMatchFailure(
           op, "deinterleaved=2 group_reduce requires group size to be a "
@@ -15689,7 +16094,7 @@ private:
           op, "failed to derive group combine mask type");
     }
     return ContiguousGroupReduceTypes{
-        *resultType, *maskType, *sourcePartType, *rowResultType, *rowMaskType};
+        resultType, maskType, sourcePartType, *rowResultType, *rowMaskType};
   }
 
   LogicalResult lowerContiguousRows(
@@ -15813,8 +16218,9 @@ private:
 
   FailureOr<VRegType> getRowResultType(VRegType sourceType,
                                        VRegType resultType) const {
-    if constexpr (std::is_same_v<OpTy, VMIGroupReduceAddIOp>)
+    if constexpr (std::is_same_v<OpTy, VMIGroupReduceAddIOp>) {
       return getVcaddResultType(sourceType);
+    }
     return resultType;
   }
 
@@ -15870,8 +16276,9 @@ struct OneToNVMIGroupBroadcastOpPattern
     SmallVector<Value> results;
     if (failed(lowerGroupBroadcastParts(
             op, sourceParts, sourceVMIType, resultVMIType, resultTypes,
-            op.getNumGroupsAttr().getInt(), rewriter, results)))
+            op.getNumGroupsAttr().getInt(), rewriter, results))) {
       return failure();
+    }
 
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());
@@ -15921,7 +16328,7 @@ static LogicalResult lowerHistogramChunk(
   return success();
 }
 
-template <typename VMIOp, typename VPTOHistOp>
+template <typename VMIOp>
 struct HistogramPhysicalPlan {
   ValueRange sourceParts;
   ValueRange maskParts;
@@ -15943,30 +16350,34 @@ static FailureOr<HistogramPhysicalPlan<VMIOp>> prepareHistogramPhysicalPlan(
   size_t halfCount = accParts.size();
   const bool invalidHalfCount = halfCount != 1 && halfCount != 2;
   if (invalidHalfCount) {
-    return rewriter.notifyMatchFailure(
-        op, "expected one or two accumulator parts");
+      (void)rewriter.notifyMatchFailure(op,
+                                        "expected one or two accumulator parts");
+      return failure();
   }
   const bool invalidSourceMaskArity =
       sourceParts.empty() || sourceParts.size() != maskParts.size();
   if (invalidSourceMaskArity) {
-    return rewriter.notifyMatchFailure(
-        op, "expected matching source/mask chunks");
+      (void)rewriter.notifyMatchFailure(op,
+                                        "expected matching source/mask chunks");
+      return failure();
   }
   auto partType = dyn_cast<VRegType>(accParts.front().getType());
   if (!partType) {
-    return rewriter.notifyMatchFailure(op, "expected ui16 acc parts");
+    (void)rewriter.notifyMatchFailure(op, "expected ui16 acc parts");
+    return failure();
   }
   const bool mismatchedSecondHalf =
       halfCount == 2 && accParts[1].getType() != partType;
   if (mismatchedSecondHalf) {
-    return rewriter.notifyMatchFailure(op,
-                                       "expected matching ui16 acc parts");
+    (void)rewriter.notifyMatchFailure(op, "expected matching ui16 acc parts");
+    return failure();
   }
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(sourceType.getElementType());
   if (failed(lanesPerPart)) {
-    return rewriter.notifyMatchFailure(op, "failed to compute source lanes");
+    (void)rewriter.notifyMatchFailure(op, "failed to compute source lanes");
+    return failure();
   }
   Location loc = op.getLoc();
   SmallVector<Value, 2> binConsts;
@@ -15975,8 +16386,9 @@ static FailureOr<HistogramPhysicalPlan<VMIOp>> prepareHistogramPhysicalPlan(
     binConsts.push_back(createI32Constant(loc, 1, rewriter));
   }
   return HistogramPhysicalPlan<VMIOp>{
-      sourceParts, maskParts, SmallVector<Value, 2>(accParts.begin(), accParts.end()),
-      std::move(binConsts), *partType, *lanesPerPart, halfCount};
+      sourceParts, maskParts,
+      SmallVector<Value, 2>(accParts.begin(), accParts.end()),
+      std::move(binConsts), partType, *lanesPerPart, halfCount};
 }
 
 template <typename VMIOp, typename VPTOHistOp>
@@ -16105,7 +16517,7 @@ private:
             op, "min/max reduction requires every mask chunk to have the same predicate type");
       }
     }
-    return std::make_pair(*resultType, *maskType);
+    return std::make_pair(resultType, maskType);
   }
 
   LogicalResult lowerReduction(SourceOp op, ValueRange sourceParts,
@@ -16158,6 +16570,49 @@ struct OneToNVMIExtFOpPattern : OneToNOpConversionPattern<VMIExtFOp> {
   using OneToNOpConversionPattern<VMIExtFOp>::OneToNOpConversionPattern;
 
 private:
+  struct ExtFPhysicalPlan {
+    VRegType sourceType;
+    SmallVector<VRegType> resultTypes;
+  };
+
+  FailureOr<ExtFPhysicalPlan> buildPhysicalPlan(
+      VMIExtFOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      OneToNPatternRewriter &rewriter) const {
+    if (sourceParts.empty()) {
+      return rewriter.notifyMatchFailure(
+          op, "extf requires at least one physical source chunk");
+    }
+    auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
+    if (!sourceType) {
+      return rewriter.notifyMatchFailure(op, "expected physical extf source");
+    }
+    for (Value sourcePart : sourceParts) {
+      auto currentSourceType = dyn_cast<VRegType>(sourcePart.getType());
+      if (!currentSourceType || currentSourceType != sourceType) {
+        return rewriter.notifyMatchFailure(
+            op, "extf source physical parts must have matching type");
+      }
+    }
+    SmallVector<VRegType> resultVRegTypes;
+    resultVRegTypes.reserve(resultTypes.size());
+    for (Type resultType : resultTypes) {
+      auto resultVRegType = dyn_cast<VRegType>(resultType);
+      bool invalidFirstResult =
+          resultVRegTypes.empty() &&
+          (!resultVRegType ||
+           !(resultVRegType.getElementType().isF32() ||
+             pto::isPTOBF16x2Type(resultVRegType.getElementType())));
+      bool mismatchedResult =
+          !resultVRegTypes.empty() && resultVRegType != resultVRegTypes.front();
+      if (invalidFirstResult || mismatchedResult) {
+        return rewriter.notifyMatchFailure(
+            op, "unsupported physical extf result type");
+      }
+      resultVRegTypes.push_back(resultVRegType);
+    }
+    return ExtFPhysicalPlan{sourceType, std::move(resultVRegTypes)};
+  }
+
   struct ResultViewPlan {
     bool isPackedBF16x2;
     VRegType vcvtResultType;
@@ -16233,6 +16688,81 @@ private:
     return success();
   }
 
+  struct ExtFFactorPlan {
+    ArrayRef<StringRef> parts;
+    int64_t factor;
+  };
+
+  FailureOr<ExtFFactorPlan> buildFactorPlan(
+      VMIExtFOp op, unsigned sourceBits, size_t sourcePartCount,
+      size_t resultPartCount, OneToNPatternRewriter &rewriter) const {
+    if (sourceBits == 16 && resultPartCount == 2 * sourcePartCount) {
+      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+      return ExtFFactorPlan{ArrayRef<StringRef>(kEvenOddParts), 2};
+    }
+    if (sourceBits == 8 && resultPartCount == 4 * sourcePartCount) {
+      static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
+      return ExtFFactorPlan{ArrayRef<StringRef>(kPacked4Parts), 4};
+    }
+    return rewriter.notifyMatchFailure(
+        op, "unsupported physical extf source/result width relation");
+  }
+
+  FailureOr<Value> createSeedMask(VMIExtFOp op, VRegType sourceType,
+                                   OneToNPatternRewriter &rewriter) const {
+    FailureOr<Value> mask =
+        createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
+    if (failed(mask)) {
+      return rewriter.notifyMatchFailure(op, "failed to build extf seed mask");
+    }
+    return *mask;
+  }
+
+  LogicalResult lowerPhysicalExtF(
+      VMIExtFOp op, ValueRange sourceParts, const ExtFPhysicalPlan &plan,
+      VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
+      OneToNPatternRewriter &rewriter) const {
+    unsigned sourceBits =
+        pto::getPTOStorageElemBitWidth(plan.sourceType.getElementType());
+    // A packed bf16x2 physical result cannot be produced directly by
+    // pto.vcvt (classifyVcvtElemType has no BF16x2 branch); the widest native
+    // f4 conversion result element is bf16. Build the bf16 view type (2 bf16
+    // lanes per bf16x2 lane) and reinterpret each vcvt result with a
+    // physical-noop VbitcastOp, mirroring the source-side reinterpret in
+    // OneToNVMITruncFOpPattern (viewVcvtSource).
+    ResultViewPlan viewPlan = buildResultViewPlan(plan.resultTypes, rewriter);
+    bool denseLaneStrideExtension =
+        sourceLayout && resultLayout && sourceLayout.isContiguous() &&
+        resultLayout.isContiguous() && resultLayout.getLaneStride() == 1 &&
+        ((sourceBits == 16 && sourceLayout.getLaneStride() == 2) ||
+         (sourceBits == 8 && sourceLayout.getLaneStride() == 4)) &&
+        plan.resultTypes.size() == sourceParts.size();
+    if (denseLaneStrideExtension) {
+      StringRef part = sourceBits == 16 ? StringRef("EVEN") : StringRef("P0");
+      FailureOr<Value> mask = createSeedMask(op, plan.sourceType, rewriter);
+      if (failed(mask)) {
+        return failure();
+      }
+      return lowerLaneStride(op, rewriter, sourceParts, plan.resultTypes, *mask,
+                             part, viewPlan.isPackedBF16x2,
+                             viewPlan.vcvtResultType);
+    }
+
+    FailureOr<ExtFFactorPlan> factorPlan = buildFactorPlan(
+        op, sourceBits, sourceParts.size(), plan.resultTypes.size(), rewriter);
+    if (failed(factorPlan)) {
+      return failure();
+    }
+    FailureOr<Value> mask = createSeedMask(op, plan.sourceType, rewriter);
+    if (failed(mask)) {
+      return failure();
+    }
+    return lowerFactor(op, rewriter, sourceParts, plan.resultTypes,
+                       factorPlan->parts, factorPlan->factor, *mask,
+                       viewPlan.isPackedBF16x2,
+                       viewPlan.vcvtResultType);
+  }
+
 public:
 
   LogicalResult
@@ -16252,68 +16782,10 @@ public:
     if (failed(plan)) {
       return failure();
     }
-    VRegType sourceType = plan->sourceType;
-    ArrayRef<VRegType> resultVRegTypes = plan->resultTypes;
-
-    unsigned sourceBits =
-        pto::getPTOStorageElemBitWidth(sourceType.getElementType());
-    // A packed bf16x2 physical result cannot be produced directly by
-    // pto.vcvt (classifyVcvtElemType has no BF16x2 branch); the widest native
-    // f4 conversion result element is bf16. Build the bf16 view type (2 bf16
-    // lanes per bf16x2 lane) and reinterpret each vcvt result with a
-    // physical-noop VbitcastOp, mirroring the source-side reinterpret in
-    // OneToNVMITruncFOpPattern (viewVcvtSource).
-    ResultViewPlan viewPlan =
-        buildResultViewPlan(resultVRegTypes, rewriter);
     VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
     VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
-    bool denseLaneStrideExtension =
-        sourceLayout && resultLayout && sourceLayout.isContiguous() &&
-        resultLayout.isContiguous() && resultLayout.getLaneStride() == 1 &&
-        ((sourceBits == 16 && sourceLayout.getLaneStride() == 2) ||
-         (sourceBits == 8 && sourceLayout.getLaneStride() == 4)) &&
-        resultTypes.size() == sourceParts.size();
-    if (denseLaneStrideExtension) {
-      StringRef part = sourceBits == 16 ? StringRef("EVEN") : StringRef("P0");
-      FailureOr<Value> mask =
-          createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
-      if (failed(mask)) {
-        return rewriter.notifyMatchFailure(op,
-                                           "failed to build extf seed mask");
-      }
-
-      return lowerLaneStride(op, rewriter, sourceParts, resultVRegTypes,
-                             *mask, part, viewPlan.isPackedBF16x2,
-                             viewPlan.vcvtResultType);
-    }
-
-    ArrayRef<StringRef> parts;
-    int64_t factor = 0;
-    bool isFactor2 =
-        sourceBits == 16 && resultTypes.size() == 2 * sourceParts.size();
-    if (isFactor2) {
-      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
-      parts = kEvenOddParts;
-      factor = 2;
-    } else if (sourceBits == 8 &&
-               resultTypes.size() == 4 * sourceParts.size()) {
-      static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
-      parts = kPacked4Parts;
-      factor = 4;
-    } else {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported physical extf source/result width relation");
-    }
-
-    FailureOr<Value> mask =
-        createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
-    if (failed(mask)) {
-      return rewriter.notifyMatchFailure(op, "failed to build extf seed mask");
-    }
-
-    return lowerFactor(op, rewriter, sourceParts, resultVRegTypes, parts,
-                       factor, *mask, viewPlan.isPackedBF16x2,
-                       viewPlan.vcvtResultType);
+    return lowerPhysicalExtF(op, sourceParts, *plan, sourceLayout,
+                             resultLayout, rewriter);
   }
 };
 
@@ -16336,6 +16808,21 @@ struct OneToNVMITruncFOpPattern : OneToNOpConversionPattern<VMITruncFOp> {
   using OneToNOpConversionPattern<VMITruncFOp>::OneToNOpConversionPattern;
 
 private:
+  struct TruncFPhysicalPlan {
+    VRegType sourceType;
+    SmallVector<VRegType> resultTypes;
+    VRegType sourceViewType;
+    unsigned sourceBits;
+    unsigned resultBits;
+    bool sourceIsPackedBF16x2;
+  };
+
+  struct TruncFNarrowingPlan {
+    ArrayRef<StringRef> parts;
+    int64_t sourceFactor;
+    int64_t resultLaneStride;
+  };
+
   FailureOr<VRegType> getUniformSourceType(
       VMITruncFOp op, ValueRange sourceParts,
       OneToNPatternRewriter &rewriter) const {
@@ -16460,7 +16947,7 @@ private:
     const bool invalidTypes =
         !sourceType || !sourceType.getElementType().isF32() || !resultType;
     if (invalidTypes) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "unsupported group-slot truncf physical type");
       return failure();
     }
@@ -16468,7 +16955,7 @@ private:
         pto::getPTOStorageElemBitWidth(resultType.getElementType());
     const bool unsupportedResultBits = resultBits != 16 && resultBits != 8;
     if (unsupportedResultBits) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "unsupported group-slot truncf physical type");
       return failure();
     }
@@ -16603,6 +17090,43 @@ private:
     return success();
   }
 
+  FailureOr<TruncFNarrowingPlan> buildNarrowingPlan(
+      VMITruncFOp op, unsigned sourceBits, unsigned resultBits,
+      VMILayoutAttr resultLayout, size_t sourcePartCount,
+      size_t resultPartCount, OneToNPatternRewriter &rewriter) const {
+    ArrayRef<StringRef> parts;
+    int64_t factor = 0;
+    if (resultBits * 2 == sourceBits) {
+      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+      parts = kEvenOddParts;
+      factor = 2;
+    } else if (resultBits * 4 == sourceBits) {
+      static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
+      parts = kPacked4Parts;
+      factor = 4;
+    } else {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported physical truncf source/result width relation");
+    }
+    int64_t resultLaneStride = resultLayout && resultLayout.isContiguous()
+                                   ? resultLayout.getLaneStride()
+                                   : 1;
+    bool invalidResultLaneStride =
+        resultLaneStride <= 0 || factor % resultLaneStride != 0;
+    if (invalidResultLaneStride) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported physical truncf result lane stride");
+    }
+    int64_t sourceFactor = factor / resultLaneStride;
+    bool sourceArityMismatch =
+        sourcePartCount != static_cast<size_t>(sourceFactor) * resultPartCount;
+    if (sourceArityMismatch) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported physical truncf source/result arity relation");
+    }
+    return TruncFNarrowingPlan{parts, sourceFactor, resultLaneStride};
+  }
+
   LogicalResult lowerGroupSlotTrunc(
       VMITruncFOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
       VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
@@ -16646,6 +17170,107 @@ private:
     return success();
   }
 
+  FailureOr<bool> tryLowerSameWidthTrunc(
+      VMITruncFOp op, ValueRange sourceParts,
+      const TruncFPhysicalPlan &physicalPlan, VMILayoutAttr sourceLayout,
+      VMILayoutAttr resultLayout, OneToNPatternRewriter &rewriter) const {
+    bool sameWidthContiguous =
+        physicalPlan.sourceBits == physicalPlan.resultBits && sourceLayout &&
+        resultLayout && sourceLayout.isContiguous() &&
+        sourceLayout.getLaneStride() == 1 && resultLayout.isContiguous() &&
+        resultLayout.getLaneStride() == 1 &&
+        sourceParts.size() == physicalPlan.resultTypes.size();
+    if (!sameWidthContiguous) {
+      return false;
+    }
+    StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
+    if (failed(lowerSameWidth(op, sourceParts, physicalPlan.resultTypes,
+                              physicalPlan.sourceViewType, sat, rewriter))) {
+      return failure();
+    }
+    return true;
+  }
+
+  FailureOr<bool> tryLowerDenseLaneStrideTrunc(
+      VMITruncFOp op, ValueRange sourceParts,
+      const TruncFPhysicalPlan &physicalPlan, VMILayoutAttr sourceLayout,
+      VMILayoutAttr resultLayout, OneToNPatternRewriter &rewriter) const {
+    bool denseLaneStrideNarrowing =
+        sourceLayout && resultLayout && sourceLayout.isContiguous() &&
+        sourceLayout.getLaneStride() == 1 && resultLayout.isContiguous() &&
+        resultLayout.getLaneStride() != 1 &&
+        sourceParts.size() == physicalPlan.resultTypes.size();
+    if (!denseLaneStrideNarrowing) {
+      return false;
+    }
+    bool isEven32To16 = physicalPlan.resultBits == 16 &&
+                          resultLayout.getLaneStride() == 2;
+    bool isPacked32To8 = physicalPlan.resultBits == 8 &&
+                           resultLayout.getLaneStride() == 4;
+    bool isEven16To8 = physicalPlan.resultBits == 8 &&
+                         resultLayout.getLaneStride() == 2;
+    if (!isEven32To16 && !isPacked32To8 && !isEven16To8) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported dense lane_stride truncf result layout");
+    }
+    StringRef part = isPacked32To8 ? "P0" : "EVEN";
+    if (failed(lowerDenseLaneStride(
+            op, sourceParts, physicalPlan.resultTypes, part,
+            physicalPlan.sourceIsPackedBF16x2, physicalPlan.sourceViewType,
+            rewriter))) {
+      return failure();
+    }
+    return true;
+  }
+
+  LogicalResult lowerNonGroupSlotTrunc(
+      VMITruncFOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<TruncFPhysicalPlan> physicalPlan =
+        buildPhysicalPlan(op, sourceParts, resultTypes, rewriter);
+    if (failed(physicalPlan)) {
+      return failure();
+    }
+    bool unsupportedGroupSlotLayout = sourceLayout && sourceLayout.isGroupSlots();
+    if (unsupportedGroupSlotLayout) {
+      return rewriter.notifyMatchFailure(
+          op, "group-slot layout for non-f32 truncf not supported");
+    }
+    FailureOr<bool> sameWidth = tryLowerSameWidthTrunc(
+        op, sourceParts, *physicalPlan, sourceLayout, resultLayout, rewriter);
+    if (failed(sameWidth)) {
+      return failure();
+    }
+    if (*sameWidth) {
+      return success();
+    }
+    FailureOr<bool> denseLaneStride = tryLowerDenseLaneStrideTrunc(
+        op, sourceParts, *physicalPlan, sourceLayout, resultLayout, rewriter);
+    if (failed(denseLaneStride)) {
+      return failure();
+    }
+    if (*denseLaneStride) {
+      return success();
+    }
+    FailureOr<TruncFNarrowingPlan> narrowingPlan = buildNarrowingPlan(
+        op, physicalPlan->sourceBits, physicalPlan->resultBits, resultLayout,
+        sourceParts.size(),
+        resultTypes.size(), rewriter);
+    if (failed(narrowingPlan)) {
+      return failure();
+    }
+    StringAttr rnd = rewriter.getStringAttr(
+        getTruncFRoundMode(op, physicalPlan->resultTypes.front().getElementType()));
+    StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
+    return lowerNarrow(op, sourceParts, physicalPlan->resultTypes,
+                       narrowingPlan->parts,
+                       narrowingPlan->sourceFactor,
+                       narrowingPlan->resultLaneStride,
+                       physicalPlan->sourceViewType,
+                       physicalPlan->sourceIsPackedBF16x2, rnd, sat, rewriter);
+  }
+
 public:
 
   LogicalResult
@@ -16676,100 +17301,8 @@ public:
                                  rewriter);
     }
 
-    FailureOr<TruncFPhysicalPlan> physicalPlan =
-        buildPhysicalPlan(op, sourceParts, resultTypes, rewriter);
-    if (failed(physicalPlan)) {
-      return failure();
-    }
-    VRegType sourceType0 = physicalPlan->sourceType;
-    unsigned sourceBits = physicalPlan->sourceBits;
-    VRegType vcvtSourceVRegType = physicalPlan->sourceViewType;
-    bool sourceIsPackedBF16x2 = physicalPlan->sourceIsPackedBF16x2;
-    // A packed bf16x2 source is consumed through its native bf16 view.
-    // Group-slot layout for non-f32 sources is not supported yet.
-    bool unsupportedGroupSlotLayout = sourceLayout && sourceLayout.isGroupSlots();
-    if (unsupportedGroupSlotLayout) {
-      return rewriter.notifyMatchFailure(
-          op, "group-slot layout for non-f32 truncf not supported");
-    }
-    SmallVector<VRegType> resultVRegTypes = physicalPlan->resultTypes;
-    unsigned resultBits = physicalPlan->resultBits;
-    // Same-width fp->fp (bf16 -> f16, f16 -> bf16): dense contiguous 1:1,
-    // no part; rnd always, sat follows the fp-to-fp contract.
-    bool sameWidthContiguous =
-        sourceBits == resultBits && sourceLayout && resultLayout &&
-        sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 1 &&
-        resultLayout.isContiguous() && resultLayout.getLaneStride() == 1 &&
-        sourceParts.size() == resultTypes.size();
-    if (sameWidthContiguous) {
-      StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
-      return lowerSameWidth(op, sourceParts, resultVRegTypes,
-                            vcvtSourceVRegType, sat, rewriter);
-    }
-
-    bool denseLaneStrideNarrowing =
-        sourceLayout && resultLayout && sourceLayout.isContiguous() &&
-        sourceLayout.getLaneStride() == 1 && resultLayout.isContiguous() &&
-        resultLayout.getLaneStride() != 1 &&
-        sourceParts.size() == resultTypes.size();
-    if (denseLaneStrideNarrowing) {
-      bool isEven32To16 =
-          resultBits == 16 && resultLayout.getLaneStride() == 2;
-      bool isPacked32To8 =
-          resultBits == 8 && resultLayout.getLaneStride() == 4;
-      bool isEven16To8 = resultBits == 8 && resultLayout.getLaneStride() == 2;
-      bool unsupportedLayout =
-          !isEven32To16 && !isPacked32To8 && !isEven16To8;
-      if (unsupportedLayout) {
-        return rewriter.notifyMatchFailure(
-            op, "unsupported dense lane_stride truncf result layout");
-      }
-      StringRef part = isPacked32To8 ? "P0" : "EVEN";
-      return lowerDenseLaneStride(op, sourceParts, resultVRegTypes, part,
-                                  sourceIsPackedBF16x2, vcvtSourceVRegType,
-                                  rewriter);
-    }
-
-    ArrayRef<StringRef> allParts;
-    int64_t factor = 0;
-    if (resultBits * 2 == sourceBits) {
-      // 32→16 or 16→8: EvenOdd.
-      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
-      allParts = kEvenOddParts;
-      factor = 2;
-    } else if (resultBits * 4 == sourceBits) {
-      // 32→8: Packed4.
-      static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
-      allParts = kPacked4Parts;
-      factor = 4;
-    } else {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported physical truncf source/result width relation");
-    }
-
-    int64_t resultLaneStride = resultLayout && resultLayout.isContiguous()
-                                   ? resultLayout.getLaneStride()
-                                   : 1;
-    bool invalidResultLaneStride =
-        resultLaneStride <= 0 || factor % resultLaneStride != 0;
-    if (invalidResultLaneStride) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported physical truncf result lane stride");
-    }
-    int64_t sourceFactor = factor / resultLaneStride;
-    bool sourceArityMismatch =
-        sourceParts.size() != sourceFactor * resultTypes.size();
-    if (sourceArityMismatch) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported physical truncf source/result arity relation");
-    }
-
-    StringAttr rnd = rewriter.getStringAttr(
-        getTruncFRoundMode(op, resultVRegTypes.front().getElementType()));
-    StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
-    return lowerNarrow(op, sourceParts, resultVRegTypes, allParts,
-                       sourceFactor, resultLaneStride, vcvtSourceVRegType,
-                       sourceIsPackedBF16x2, rnd, sat, rewriter);
+    return lowerNonGroupSlotTrunc(op, sourceParts, resultTypes, sourceLayout,
+                                  resultLayout, rewriter);
   }
 };
 
@@ -16848,18 +17381,18 @@ private:
   }
 
   FailureOr<std::pair<ArrayRef<StringRef>, int64_t>> getExtensionPartPlan(
-      OpT op, ArrayRef<Value> sourceParts, ArrayRef<Type> resultTypes,
+      OpT op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
       unsigned sourceBits, unsigned resultBits,
       OneToNPatternRewriter &rewriter) const {
     if (resultBits == sourceBits * 2 &&
         resultTypes.size() == 2 * sourceParts.size()) {
       static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
-      return std::make_pair(ArrayRef<StringRef>(kEvenOddParts), 2);
+      return std::make_pair(ArrayRef<StringRef>(kEvenOddParts), int64_t{2});
     }
     if (resultBits == sourceBits * 4 &&
         resultTypes.size() == 4 * sourceParts.size()) {
       static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
-      return std::make_pair(ArrayRef<StringRef>(kPacked4Parts), 4);
+      return std::make_pair(ArrayRef<StringRef>(kPacked4Parts), int64_t{4});
     }
     return rewriter.notifyMatchFailure(
         op, "unsupported physical integer extension source/result width relation");
@@ -16889,7 +17422,7 @@ private:
                   ? "unsupported dense group-slot integer extension carrier shape"
                   : "unsupported dense group-slot integer extension result type");
     }
-    return *physicalResultType;
+    return physicalResultType;
   }
 
   FailureOr<Value> buildDenseGroupSlotExtensionResult(
@@ -17043,7 +17576,7 @@ private:
       return rewriter.notifyMatchFailure(
           op, "failed to build group-slot integer extension mask");
     }
-    return std::make_tuple(resultBits / sourceBits, conversionSourceType,
+    return std::make_tuple(static_cast<int64_t>(resultBits / sourceBits), conversionSourceType,
                            *slotMask);
   }
 
@@ -17162,148 +17695,106 @@ private:
     return sourceType;
   }
 
+  struct ExtensionLoweringInput {
+    VMIVRegType sourceVMIType;
+    VMIVRegType resultVMIType;
+    ValueRange sourceParts;
+    SmallVector<Type> resultTypes;
+    VRegType sourceType;
+    VMILayoutAttr sourceLayout;
+    VMILayoutAttr resultLayout;
+  };
+
+  FailureOr<ExtensionLoweringInput> getLoweringInput(
+      OpT op, typename OneToNOpConversionPattern<OpT>::OpAdaptor adaptor,
+      OneToNPatternRewriter &rewriter) const {
+    auto sourceVMIType = cast<VMIVRegType>(op.getSource().getType());
+    auto resultVMIType = cast<VMIVRegType>(op.getResult().getType());
+    ValueRange sourceParts = adaptor.getSource();
+    FailureOr<SmallVector<Type>> resultTypes =
+        getConvertedResultTypes(op, 0, *this->getTypeConverter());
+    if (failed(resultTypes)) {
+      return failure();
+    }
+    FailureOr<VRegType> sourceType =
+        getUniformExtensionSourceType(op, sourceParts, rewriter);
+    if (failed(sourceType)) {
+      return failure();
+    }
+    return ExtensionLoweringInput{
+        sourceVMIType, resultVMIType, sourceParts, std::move(*resultTypes),
+        *sourceType, sourceVMIType.getLayoutAttr(), resultVMIType.getLayoutAttr()};
+  }
+
+  LogicalResult lowerGroupSlotByLayout(
+      OpT op, const ExtensionLoweringInput &input,
+      OneToNPatternRewriter &rewriter) const {
+    unsigned sourceBits =
+        pto::getPTOStorageElemBitWidth(input.sourceVMIType.getElementType());
+    unsigned resultBits =
+        pto::getPTOStorageElemBitWidth(input.resultVMIType.getElementType());
+    auto sourceIntegerType =
+        dyn_cast<IntegerType>(input.sourceVMIType.getElementType());
+    auto resultIntegerType =
+        dyn_cast<IntegerType>(input.resultVMIType.getElementType());
+    int64_t slots = input.sourceLayout.getSlots();
+    bool denseGroupSlotExtension =
+        sourceIntegerType && resultIntegerType &&
+        input.sourceLayout.getNumGroups() == input.resultLayout.getNumGroups() &&
+        input.sourceLayout.getLaneStride() == 1 &&
+        input.resultLayout.getLaneStride() == 1 &&
+        input.sourceLayout.getSlots() == input.resultLayout.getSlots() &&
+        (slots == 2 || slots == 4 || slots == 8) && sourceBits > 0 &&
+        resultBits > sourceBits && resultBits % sourceBits == 0 &&
+        (resultBits / sourceBits == 2 || resultBits / sourceBits == 4) &&
+        input.sourceParts.size() == input.resultTypes.size();
+    if (denseGroupSlotExtension) {
+      return lowerDenseGroupSlotExtension(
+          op, input.sourceParts, input.resultTypes, input.sourceVMIType,
+          input.resultVMIType, resultIntegerType, sourceBits, resultBits,
+          rewriter);
+    }
+    return lowerLegacyGroupSlotExtension(
+        op, input.sourceParts, input.resultTypes, input.sourceVMIType,
+        input.resultVMIType, input.sourceLayout, input.resultLayout,
+        sourceBits, resultBits, rewriter);
+  }
+
+  LogicalResult lowerNonGroupSlotByLayout(
+      OpT op, const ExtensionLoweringInput &input,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<SmallVector<VRegType>> resultVRegTypes =
+        collectExtensionResultTypes(op, input.resultTypes, rewriter);
+    if (failed(resultVRegTypes)) {
+      return failure();
+    }
+    unsigned sourceBits =
+        pto::getPTOStorageElemBitWidth(input.sourceType.getElementType());
+    unsigned resultBits = pto::getPTOStorageElemBitWidth(
+        resultVRegTypes->front().getElementType());
+    return lowerPhysicalExtension(
+        op, input.sourceParts, *resultVRegTypes, input.resultTypes,
+        input.sourceType, sourceBits, resultBits, input.sourceLayout,
+        input.resultLayout, rewriter);
+  }
+
 public:
   LogicalResult
   matchAndRewrite(OpT op,
                   typename OneToNOpConversionPattern<OpT>::OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
-    auto sourceVMIType = cast<VMIVRegType>(op.getSource().getType());
-    auto resultVMIType = cast<VMIVRegType>(op.getResult().getType());
-    ValueRange sourceParts = adaptor.getSource();
-    FailureOr<SmallVector<Type>> maybe_resultTypes =
-        getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes)) {
+    FailureOr<ExtensionLoweringInput> input =
+        getLoweringInput(op, adaptor, rewriter);
+    if (failed(input)) {
       return failure();
     }
-    SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    FailureOr<VRegType> maybeSourceType =
-        getUniformExtensionSourceType(op, sourceParts, rewriter);
-    if (failed(maybeSourceType)) {
-      return failure();
-    }
-    VRegType sourceType = *maybeSourceType;
-
-    VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
-    VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
-    bool groupSlotLayouts = sourceLayout && resultLayout &&
-                            sourceLayout.isGroupSlots() &&
-                            resultLayout.isGroupSlots();
+    bool groupSlotLayouts =
+        input->sourceLayout && input->resultLayout &&
+        input->sourceLayout.isGroupSlots() && input->resultLayout.isGroupSlots();
     if (groupSlotLayouts) {
-      unsigned sourceBits =
-          pto::getPTOStorageElemBitWidth(sourceVMIType.getElementType());
-      unsigned resultBits =
-          pto::getPTOStorageElemBitWidth(resultVMIType.getElementType());
-      auto sourceIntegerType =
-          dyn_cast<IntegerType>(sourceVMIType.getElementType());
-      auto resultIntegerType =
-          dyn_cast<IntegerType>(resultVMIType.getElementType());
-      int64_t slots = sourceLayout.getSlots();
-      // Unpack preserves lane order only for compact group-slot carriers.
-      // Non-unit lane strides and dense-split layouts use the vcvt fallback.
-      bool denseGroupSlotExtension =
-          sourceIntegerType && resultIntegerType &&
-          sourceLayout.getNumGroups() == resultLayout.getNumGroups() &&
-          sourceLayout.getLaneStride() == 1 &&
-          resultLayout.getLaneStride() == 1 &&
-          sourceLayout.getSlots() == resultLayout.getSlots() &&
-          (slots == 2 || slots == 4 || slots == 8) && sourceBits > 0 &&
-          resultBits > sourceBits && resultBits % sourceBits == 0 &&
-          (resultBits / sourceBits == 2 || resultBits / sourceBits == 4) &&
-          sourceParts.size() == resultTypes.size();
-      if (denseGroupSlotExtension) {
-        return lowerDenseGroupSlotExtension(
-            op, sourceParts, resultTypes, sourceVMIType, resultVMIType,
-            *resultIntegerType, sourceBits, resultBits, rewriter);
-      }
-      return lowerLegacyGroupSlotExtension(
-          op, sourceParts, resultTypes, sourceVMIType, resultVMIType,
-          sourceLayout, resultLayout, sourceBits, resultBits, rewriter);
+      return lowerGroupSlotByLayout(op, *input, rewriter);
     }
-
-    FailureOr<SmallVector<VRegType>> maybeResultVRegTypes =
-        collectExtensionResultTypes(op, resultTypes, rewriter);
-    if (failed(maybeResultVRegTypes)) {
-      return failure();
-    }
-    SmallVector<VRegType> resultVRegTypes = std::move(*maybeResultVRegTypes);
-
-    unsigned sourceBits =
-        pto::getPTOStorageElemBitWidth(sourceType.getElementType());
-    unsigned resultBits = pto::getPTOStorageElemBitWidth(
-        resultVRegTypes.front().getElementType());
-
-    bool directLaneStrideAlias =
-        sourceLayout && resultLayout && sourceLayout.isContiguous() &&
-        resultLayout.isContiguous() && resultLayout.getLaneStride() == 1 &&
-        ((resultBits == sourceBits * 2 && sourceLayout.getLaneStride() == 2) ||
-         (resultBits == sourceBits * 4 && sourceLayout.getLaneStride() == 4)) &&
-        resultTypes.size() == sourceParts.size();
-    if (directLaneStrideAlias) {
-      StringRef part =
-          resultBits == sourceBits * 2 ? StringRef("EVEN") : StringRef("P0");
-      FailureOr<Value> mask =
-          createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
-      if (failed(mask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to build integer extension seed mask");
-      }
-
-      SmallVector<Value> results;
-      results.reserve(resultTypes.size());
-      for (auto [sourcePart, resultType] :
-           llvm::zip_equal(sourceParts, resultVRegTypes)) {
-        results.push_back(rewriter
-                              .create<VcvtOp>(op.getLoc(), resultType,
-                                              sourcePart, *mask,
-                                              /*rnd=*/nullptr, /*sat=*/nullptr,
-                                              rewriter.getStringAttr(part))
-                              .getResult());
-      }
-      replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
-      return success();
-    }
-
-    ArrayRef<StringRef> parts;
-    int64_t factor = 0;
-    if (resultBits == sourceBits * 2 &&
-        resultTypes.size() == 2 * sourceParts.size()) {
-      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
-      parts = kEvenOddParts;
-      factor = 2;
-    } else if (resultBits == sourceBits * 4 &&
-               resultTypes.size() == 4 * sourceParts.size()) {
-      static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
-      parts = kPacked4Parts;
-      factor = 4;
-    } else {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported physical integer extension source/result width "
-              "relation");
-    }
-
-    FailureOr<Value> mask =
-        createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
-    if (failed(mask)) {
-      return rewriter.notifyMatchFailure(
-          op, "failed to build integer extension seed mask");
-
-    SmallVector<Value> results;
-    results.reserve(resultTypes.size());
-    for (int64_t partIndex = 0; partIndex < factor; ++partIndex) {
-      for (auto [chunkIndex, sourcePart] : llvm::enumerate(sourceParts)) {
-        VRegType resultType =
-            resultVRegTypes[partIndex * sourceParts.size() + chunkIndex];
-        results.push_back(
-            rewriter
-                .create<VcvtOp>(op.getLoc(), resultType, sourcePart, *mask,
-                                /*rnd=*/nullptr, /*sat=*/nullptr,
-                                rewriter.getStringAttr(parts[partIndex]))
-                .getResult());
-      }
-    }
-
-    replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
-    return success();
+    return lowerNonGroupSlotByLayout(op, *input, rewriter);
   }
 };
 
@@ -17369,7 +17860,7 @@ private:
             op, "trunci result physical parts must have matching integer type");
       }
     }
-    return std::make_pair(*sourceType, *resultType);
+    return std::make_pair(sourceType, resultType);
   }
 
   void finalizeResults(VMITruncIOp op, SmallVectorImpl<Value> &results,
@@ -17480,7 +17971,8 @@ private:
         (!supportsDirect && !supportsPacked) ||
         sourceParts.size() != resultTypes.size();
     if (invalidShape) {
-      rewriter.notifyMatchFailure(op, "unsupported group-slot trunci shape");
+      (void)rewriter.notifyMatchFailure(op,
+                                        "unsupported group-slot trunci shape");
       return failure();
     }
     return std::make_pair(supportsDirect, supportsPacked);
@@ -17504,7 +17996,7 @@ private:
               sourceBits &&
           resultType;
       if (!validPhysicalTypes) {
-        rewriter.notifyMatchFailure(
+        (void)rewriter.notifyMatchFailure(
             op, "unsupported group-slot trunci physical type");
         return failure();
       }
@@ -17701,6 +18193,148 @@ private:
     return success();
   }
 
+  struct TruncIPhysicalPlan {
+    VRegType sourceType;
+    VRegType resultType;
+    int64_t factor;
+    bool denseLaneStride;
+    StringAttr saturate;
+  };
+
+  FailureOr<TruncIPhysicalPlan> buildPhysicalPlan(
+      VMITruncIOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<std::pair<VRegType, VRegType>> uniformTypes =
+        getUniformTruncTypes(op, sourceParts, resultTypes, rewriter);
+    if (failed(uniformTypes)) {
+      return failure();
+    }
+    unsigned sourceBits =
+        pto::getPTOStorageElemBitWidth(uniformTypes->first.getElementType());
+    unsigned resultBits =
+        pto::getPTOStorageElemBitWidth(uniformTypes->second.getElementType());
+    bool invalidWidth = sourceBits == 0 || resultBits == 0 ||
+                        sourceBits % resultBits != 0;
+    if (invalidWidth) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported physical trunci source/result width relation");
+    }
+    int64_t factor = sourceBits / resultBits;
+    bool denseLaneStride =
+        sourceLayout && resultLayout && sourceLayout.isContiguous() &&
+        sourceLayout.getLaneStride() == 1 && resultLayout.isContiguous() &&
+        resultLayout.getLaneStride() == factor &&
+        sourceParts.size() == resultTypes.size();
+    bool unsupportedDenseFactor = denseLaneStride && factor != 2 && factor != 4;
+    if (unsupportedDenseFactor) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported dense lane_stride trunci result layout");
+    }
+    return TruncIPhysicalPlan{uniformTypes->first, uniformTypes->second, factor,
+                              denseLaneStride,
+                              op->getAttrOfType<StringAttr>("saturate")};
+  }
+
+  struct TruncIAliasPlan {
+    SmallVector<Value> sourceParts;
+    SmallVector<Type> resultTypes;
+    SmallVector<Type> originalResultTypes;
+    bool requiresResultBitcast = false;
+  };
+
+  TruncIAliasPlan materializeS32ToS8Alias(
+      VMITruncIOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      const TruncIPhysicalPlan &physicalPlan,
+      OneToNPatternRewriter &rewriter) const {
+    TruncIAliasPlan aliasPlan;
+    bool requiresAlias =
+        physicalPlan.sourceType.getElementType().isSignedInteger(32) &&
+        physicalPlan.resultType.getElementType().isSignedInteger(8);
+    if (!requiresAlias) {
+      aliasPlan.sourceParts.assign(sourceParts.begin(), sourceParts.end());
+      aliasPlan.resultTypes.assign(resultTypes.begin(), resultTypes.end());
+      return aliasPlan;
+    }
+    auto u32ElemTy = rewriter.getIntegerType(32, /*isSigned=*/false);
+    auto u8ElemTy = rewriter.getIntegerType(8, /*isSigned=*/false);
+    aliasPlan.originalResultTypes.assign(resultTypes.begin(), resultTypes.end());
+    aliasPlan.sourceParts.reserve(sourceParts.size());
+    for (Value sourcePart : sourceParts) {
+      auto sourcePartType = cast<VRegType>(sourcePart.getType());
+      aliasPlan.sourceParts.push_back(
+          rewriter.create<VbitcastOp>(
+              op.getLoc(), VRegType::get(sourcePartType.getContext(),
+                                          sourcePartType.getElementCount(),
+                                          u32ElemTy),
+              sourcePart).getResult());
+    }
+    aliasPlan.resultTypes.reserve(resultTypes.size());
+    for (Type resultType : resultTypes) {
+      auto resultVRegType = cast<VRegType>(resultType);
+      aliasPlan.resultTypes.push_back(VRegType::get(
+          resultVRegType.getContext(), resultVRegType.getElementCount(),
+          u8ElemTy));
+    }
+    aliasPlan.requiresResultBitcast = true;
+    return aliasPlan;
+  }
+
+  FailureOr<ArrayRef<StringRef>> getFactorTruncParts(
+      VMITruncIOp op, int64_t factor, size_t sourcePartCount,
+      size_t resultPartCount, OneToNPatternRewriter &rewriter) const {
+    bool invalidFactorArity =
+        (factor != 2 && factor != 4) ||
+        sourcePartCount != resultPartCount * static_cast<size_t>(factor);
+    if (invalidFactorArity) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported physical trunci source/result arity relation");
+    }
+    if (factor == 2) {
+      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+      return ArrayRef<StringRef>(kEvenOddParts);
+    }
+    static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
+    return ArrayRef<StringRef>(kPacked4Parts);
+  }
+
+  LogicalResult lowerNonGroupSlotTrunc(
+      VMITruncIOp op, ValueRange sourceParts, SmallVector<Type> resultTypes,
+      VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<TruncIPhysicalPlan> physicalPlan = buildPhysicalPlan(
+        op, sourceParts, resultTypes, sourceLayout, resultLayout, rewriter);
+    if (failed(physicalPlan)) {
+      return failure();
+    }
+    bool useNoSatCarrier =
+        physicalPlan->denseLaneStride && physicalPlan->saturate &&
+        physicalPlan->saturate.getValue() == "NOSAT";
+    if (useNoSatCarrier) {
+      return lowerNoSatDenseCarrier(op, sourceParts, resultTypes, rewriter);
+    }
+    TruncIAliasPlan aliasPlan = materializeS32ToS8Alias(
+        op, sourceParts, resultTypes, *physicalPlan, rewriter);
+    if (physicalPlan->denseLaneStride) {
+      return lowerDenseLaneStrideTrunc(
+          op, aliasPlan.sourceParts, aliasPlan.resultTypes,
+          physicalPlan->factor, physicalPlan->saturate,
+          aliasPlan.requiresResultBitcast, aliasPlan.originalResultTypes,
+          rewriter);
+    }
+    FailureOr<ArrayRef<StringRef>> parts = getFactorTruncParts(
+        op, physicalPlan->factor, aliasPlan.sourceParts.size(),
+        aliasPlan.resultTypes.size(), rewriter);
+    if (failed(parts)) {
+      return failure();
+    }
+    return lowerFactorTrunc(
+        op, aliasPlan.sourceParts, aliasPlan.resultTypes, *parts,
+        physicalPlan->factor, physicalPlan->saturate,
+        aliasPlan.requiresResultBitcast, aliasPlan.originalResultTypes,
+        rewriter);
+  }
+
 public:
 
   LogicalResult
@@ -17727,110 +18361,8 @@ public:
                                  resultTypes);
     }
 
-    FailureOr<std::pair<VRegType, VRegType>> uniformTypes =
-        getUniformTruncTypes(op, sourceParts, resultTypes, rewriter);
-    if (failed(uniformTypes)) {
-      return failure();
-    }
-    VRegType sourceType0 = uniformTypes->first;
-    VRegType resultType0 = uniformTypes->second;
-
-    unsigned sourceBits =
-        pto::getPTOStorageElemBitWidth(sourceType0.getElementType());
-    unsigned resultBits =
-        pto::getPTOStorageElemBitWidth(resultType0.getElementType());
-    bool invalidWidth = sourceBits == 0 || resultBits == 0 ||
-                        sourceBits % resultBits != 0;
-    if (invalidWidth) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported physical trunci source/result width relation");
-    }
-
-    int64_t factor = sourceBits / resultBits;
-
-    StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
-
-    bool isDenseLaneStrideNarrowing =
-        sourceLayout && resultLayout && sourceLayout.isContiguous() &&
-        sourceLayout.getLaneStride() == 1 && resultLayout.isContiguous() &&
-        resultLayout.getLaneStride() == factor &&
-        sourceParts.size() == resultTypes.size();
-    bool unsupportedDenseFactor =
-        isDenseLaneStrideNarrowing && factor != 2 && factor != 4;
-    if (unsupportedDenseFactor) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported dense lane_stride trunci result layout");
-    }
-
-    bool useNoSatCarrier =
-        isDenseLaneStrideNarrowing && sat && sat.getValue() == "NOSAT";
-    if (useNoSatCarrier) {
-      return lowerNoSatDenseCarrier(op, sourceParts, resultTypes, rewriter);
-    }
-
-    // s32 -> s8 alias: borrow ui32 -> ui8 physical path (NOSAT bit-pattern
-    // equivalent).  Rewrite source parts si32 -> ui32 / result types si8 -> ui8
-    // via vbitcast; finalize() below casts merged ui8 results back to si8.
-    const bool s32ToS8Alias =
-        sourceType0.getElementType().isSignedInteger(32) &&
-        resultType0.getElementType().isSignedInteger(8);
-
-    SmallVector<Type> originalResultTypes;
-    SmallVector<Value> aliasedSourceStorage;
-    if (s32ToS8Alias) {
-      auto u32ElemTy = rewriter.getIntegerType(32, /*isSigned=*/false);
-      auto u8ElemTy = rewriter.getIntegerType(8, /*isSigned=*/false);
-      originalResultTypes = resultTypes;
-
-      aliasedSourceStorage.reserve(sourceParts.size());
-      for (Value sp : sourceParts) {
-        auto spTy = cast<VRegType>(sp.getType());
-        aliasedSourceStorage.push_back(
-            rewriter.create<VbitcastOp>(
-                op.getLoc(),
-                VRegType::get(spTy.getContext(), spTy.getElementCount(),
-                              u32ElemTy),
-                sp).getResult());
-      }
-      sourceParts = ValueRange(aliasedSourceStorage);
-      sourceType0 = cast<VRegType>(aliasedSourceStorage.front().getType());
-
-      for (Type &rt : resultTypes) {
-        auto rtVReg = cast<VRegType>(rt);
-        rt = VRegType::get(rtVReg.getContext(), rtVReg.getElementCount(),
-                           u8ElemTy);
-      }
-      resultType0 = cast<VRegType>(resultTypes.front());
-    }
-
-    if (isDenseLaneStrideNarrowing) {
-      return lowerDenseLaneStrideTrunc(
-          op, sourceParts, resultTypes, factor, sat, s32ToS8Alias,
-          originalResultTypes, rewriter);
-    }
-
-    bool invalidFactorArity =
-        (factor != 2 && factor != 4) ||
-        sourceParts.size() != resultTypes.size() * factor;
-    if (invalidFactorArity) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported physical trunci source/result arity relation");
-    }
-
-    ArrayRef<StringRef> parts;
-    if (factor == 2) {
-      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
-      parts = kEvenOddParts;
-    } else if (factor == 4) {
-      static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
-      parts = kPacked4Parts;
-    } else {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported physical trunci source/result width relation");
-    }
-
-    return lowerFactorTrunc(op, sourceParts, resultTypes, parts, factor, sat,
-                            s32ToS8Alias, originalResultTypes, rewriter);
+    return lowerNonGroupSlotTrunc(op, sourceParts, std::move(resultTypes),
+                                  sourceLayout, resultLayout, rewriter);
   }
 };
 
@@ -18048,6 +18580,144 @@ private:
         "unsupported physical fptosi result type", rewriter);
   }
 
+  LogicalResult lowerDenseWiden(
+      VMIFPToSIOp op, ValueRange sourceParts,
+      ArrayRef<VRegType> resultTypes, VRegType sourceType, unsigned sourceBits,
+      StringAttr rnd, StringAttr sat, OneToNPatternRewriter &rewriter) const {
+    StringRef part = sourceBits == 16 ? StringRef("EVEN") : StringRef("P0");
+    FailureOr<Value> mask =
+        createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
+    if (failed(mask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to build fptosi widen 1:1 mask");
+    }
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (auto [sourcePart, resultType] :
+         llvm::zip_equal(sourceParts, resultTypes)) {
+      results.push_back(
+          rewriter
+              .create<VcvtOp>(op.getLoc(), resultType, sourcePart, *mask, rnd,
+                              sat, rewriter.getStringAttr(part))
+              .getResult());
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
+  LogicalResult lowerWiden(
+      VMIFPToSIOp op, ValueRange sourceParts,
+      ArrayRef<Type> physicalResultTypes, ArrayRef<VRegType> resultTypes,
+      VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+      VRegType sourceType, unsigned sourceBits, StringAttr rnd, StringAttr sat,
+      OneToNPatternRewriter &rewriter) const {
+    VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
+    VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
+    bool denseOneToOne =
+        sourceLayout && resultLayout && sourceLayout.isContiguous() &&
+        resultLayout.isContiguous() && resultLayout.getLaneStride() == 1 &&
+        ((sourceBits == 16 && sourceLayout.getLaneStride() == 2) ||
+         (sourceBits == 8 && sourceLayout.getLaneStride() == 4)) &&
+        physicalResultTypes.size() == sourceParts.size();
+    if (denseOneToOne) {
+      return lowerDenseWiden(op, sourceParts, resultTypes, sourceType,
+                             sourceBits, rnd, sat, rewriter);
+    }
+    static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+    return lowerWidenFpToInt(
+        op, sourceParts, resultTypes, kEvenOddParts, rnd, sat,
+        "widen fptosi requires result arity = 2 × source arity",
+        "failed to build fptosi widen mask", this->getTypeConverter(),
+        rewriter);
+  }
+
+  LogicalResult lowerNarrow(
+      VMIFPToSIOp op, ValueRange sourceParts,
+      ArrayRef<Type> physicalResultTypes, ArrayRef<VRegType> resultTypes,
+      VMIVRegType resultVMIType, unsigned sourceBits, unsigned resultBits,
+      StringAttr rnd, StringAttr sat, OneToNPatternRewriter &rewriter) const {
+    int64_t factor = sourceBits / resultBits;
+    VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
+    int64_t resultLaneStride = resultLayout && resultLayout.isContiguous()
+                                   ? resultLayout.getLaneStride()
+                                   : 1;
+    bool invalidResultLaneStride =
+        resultLaneStride <= 0 || factor % resultLaneStride != 0;
+    if (invalidResultLaneStride) {
+      return rewriter.notifyMatchFailure(
+          op, "narrow fptosi: unsupported result lane stride");
+    }
+    int64_t sourceFactor = factor / resultLaneStride;
+    bool invalidSourceArity =
+        sourceParts.size() != sourceFactor * physicalResultTypes.size();
+    if (invalidSourceArity) {
+      return rewriter.notifyMatchFailure(
+          op, "narrow fptosi: source arity != sourceFactor × result arity");
+    }
+    static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+    static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
+    ArrayRef<StringRef> parts = factor == 2
+                                    ? ArrayRef<StringRef>(kEvenOddParts)
+                                    : ArrayRef<StringRef>(kPacked4Parts);
+    return lowerNarrowFpToInt(
+        op, sourceParts, resultTypes, sourceFactor, resultLaneStride, parts,
+        rnd, sat, "failed to build fptosi source mask",
+        "failed to build narrow fptosi result mask", this->getTypeConverter(),
+        rewriter);
+  }
+
+  LogicalResult lowerConversion(
+      VMIFPToSIOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+      OneToNPatternRewriter &rewriter) const {
+    Type sourceElementType = sourceVMIType.getElementType();
+    Type resultElementType = resultVMIType.getElementType();
+    auto contract =
+        lookupVMIFpToSiContract(sourceElementType, resultElementType);
+    if (!contract) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported fp-to-si conversion element type pair");
+    }
+    FailureOr<VRegType> sourceType =
+        validateSourceParts(op, sourceParts, rewriter);
+    if (failed(sourceType)) {
+      return failure();
+    }
+    FailureOr<SmallVector<VRegType>> resultVRegTypes =
+        validateResultParts(op, resultTypes, rewriter);
+    if (failed(resultVRegTypes)) {
+      return failure();
+    }
+
+    StringAttr rnd = op->getAttrOfType<StringAttr>("rounding");
+    if (!rnd) {
+      rnd = rewriter.getStringAttr("R");
+    }
+    StringAttr sat = contract->requiresSat
+                         ? op->getAttrOfType<StringAttr>("saturate")
+                         : nullptr;
+    if (!contract->requiresPart) {
+      return lowerSameWidthFpToInt(
+          op, sourceParts, *resultVRegTypes, rnd, sat,
+          "same-width fptosi requires matching physical arity",
+          "failed to build fptosi mask", this->getTypeConverter(), rewriter);
+    }
+
+    unsigned sourceBits =
+        pto::getPTOStorageElemBitWidth(sourceElementType);
+    unsigned resultBits =
+        pto::getPTOStorageElemBitWidth(resultElementType);
+    if (resultBits > sourceBits) {
+      return lowerWiden(op, sourceParts, resultTypes, *resultVRegTypes,
+                        sourceVMIType, resultVMIType, *sourceType, sourceBits,
+                        rnd, sat, rewriter);
+    }
+    return lowerNarrow(op, sourceParts, resultTypes, *resultVRegTypes,
+                       resultVMIType, sourceBits, resultBits, rnd, sat,
+                       rewriter);
+  }
+
 public:
 
   LogicalResult
@@ -18063,119 +18733,8 @@ public:
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
 
-    Type srcElem = sourceVMIType.getElementType();
-    Type dstElem = resultVMIType.getElementType();
-    auto contract = lookupVMIFpToSiContract(srcElem, dstElem);
-    if (!contract) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported fp-to-si conversion element type pair");
-    }
-
-    FailureOr<VRegType> sourceType0 =
-        validateSourceParts(op, sourceParts, rewriter);
-    if (failed(sourceType0)) {
-      return failure();
-    }
-
-    FailureOr<SmallVector<VRegType>> resultVRegTypes =
-        validateResultParts(op, resultTypes, rewriter);
-    if (failed(resultVRegTypes)) {
-      return failure();
-    }
-
-    StringAttr rnd = op->getAttrOfType<StringAttr>("rounding");
-    if (!rnd) {
-      rnd = rewriter.getStringAttr("R");
-    }
-    StringAttr sat =
-        contract->requiresSat
-            ? op->getAttrOfType<StringAttr>("saturate")
-            : nullptr;
-
-    if (!contract->requiresPart) {
-      // Same-width (f32→s32, f16→s16): 1:1 mapping, no part.
-      return lowerSameWidthFpToInt(
-          op, sourceParts, *resultVRegTypes, rnd, sat,
-          "same-width fptosi requires matching physical arity",
-          "failed to build fptosi mask", *this->getTypeConverter(), rewriter);
-    }
-
-    // requiresPart: widen (f16→s32, bf16→s32) or narrow (f32→s16, f16→s8).
-    unsigned srcBits = pto::getPTOStorageElemBitWidth(srcElem);
-    unsigned dstBits = pto::getPTOStorageElemBitWidth(dstElem);
-
-    if (dstBits > srcBits) {
-      // Widen: dense 1:1 (single part) or 2× EvenOdd.
-      VMILayoutAttr srcLayout = sourceVMIType.getLayoutAttr();
-      VMILayoutAttr dstLayout = resultVMIType.getLayoutAttr();
-      if (srcLayout && dstLayout && srcLayout.isContiguous() &&
-          dstLayout.isContiguous() && dstLayout.getLaneStride() == 1 &&
-          ((srcBits == 16 && srcLayout.getLaneStride() == 2) ||
-           (srcBits == 8 && srcLayout.getLaneStride() == 4)) &&
-          resultTypes.size() == sourceParts.size()) {
-        // Dense 1:1: each source chunk → 1 result chunk (single part).
-        StringRef part = srcBits == 16 ? StringRef("EVEN") : StringRef("P0");
-        FailureOr<Value> mask =
-            createAllTrueMaskForVReg(op.getLoc(), *sourceType0, rewriter);
-        if (failed(mask)) {
-          return rewriter.notifyMatchFailure(
-              op, "failed to build fptosi widen 1:1 mask");
-        }
-        SmallVector<Value> results;
-        results.reserve(resultTypes.size());
-        for (auto [sourcePart, resultType] :
-             llvm::zip_equal(sourceParts, *resultVRegTypes)) {
-          results.push_back(
-              rewriter
-                  .create<VcvtOp>(op.getLoc(), resultType, sourcePart, *mask,
-                                  rnd, sat,
-                                  rewriter.getStringAttr(part))
-                  .getResult());
-        }
-        replaceOpWithFlatConvertedValues(rewriter, op, results,
-                                         *this->getTypeConverter());
-        return success();
-      }
-
-      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
-      return lowerWidenFpToInt(
-          op, sourceParts, *resultVRegTypes, kEvenOddParts, rnd, sat,
-          "widen fptosi requires result arity = 2 × source arity",
-          "failed to build fptosi widen mask", *this->getTypeConverter(),
-          rewriter);
-    }
-
-    // Narrow: sourceFactor source chunks merge into 1 result chunk.
-    int64_t factor = srcBits / dstBits; // 2 for 32→16 or 16→8
-    VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
-    int64_t resultLaneStride = resultLayout && resultLayout.isContiguous()
-                                   ? resultLayout.getLaneStride()
-                                   : 1;
-    bool invalidResultLaneStride =
-        resultLaneStride <= 0 || factor % resultLaneStride != 0;
-    if (invalidResultLaneStride) {
-      return rewriter.notifyMatchFailure(
-          op, "narrow fptosi: unsupported result lane stride");
-    }
-    int64_t sourceFactor = factor / resultLaneStride;
-    bool invalidSourceArity =
-        sourceParts.size() != sourceFactor * resultTypes.size();
-    if (invalidSourceArity) {
-      return rewriter.notifyMatchFailure(
-          op, "narrow fptosi: source arity != sourceFactor × result arity");
-    }
-
-    static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
-    static constexpr StringRef kPacked4Parts[] = {"P0", "P1", "P2", "P3"};
-    ArrayRef<StringRef> parts = factor == 2
-                                    ? ArrayRef<StringRef>(kEvenOddParts)
-                                    : ArrayRef<StringRef>(kPacked4Parts);
-    return lowerNarrowFpToInt(
-        op, sourceParts, *resultVRegTypes, sourceFactor, resultLaneStride, parts,
-        rnd, sat,
-        "failed to build fptosi source mask",
-        "failed to build narrow fptosi result mask",
-        *this->getTypeConverter(), rewriter);
+    return lowerConversion(op, sourceParts, resultTypes, sourceVMIType,
+                           resultVMIType, rewriter);
   }
 };
 
@@ -18184,6 +18743,18 @@ struct OneToNVMIFPToUIOpPattern
   using OneToNOpConversionPattern<VMIFPToUIOp>::OneToNOpConversionPattern;
 
 private:
+  struct FPToUILoweringInput {
+    ValueRange sourceParts;
+    ArrayRef<Type> resultTypes;
+    VMIVRegType sourceVMIType;
+    VMIVRegType resultVMIType;
+    VRegType sourceType;
+    SmallVector<VRegType> resultVRegTypes;
+    VMIFpToUiContract contract;
+    StringAttr rounding;
+    StringAttr saturate;
+  };
+
   FailureOr<VRegType> validateSourceParts(
       VMIFPToUIOp op, ValueRange sourceParts,
       OneToNPatternRewriter &rewriter) const {
@@ -18201,6 +18772,122 @@ private:
         "unsupported physical fptoui result type", rewriter);
   }
 
+  LogicalResult lowerWiden(
+      VMIFPToUIOp op, ValueRange sourceParts, ArrayRef<Type> physicalResultTypes,
+      ArrayRef<VRegType> resultTypes, StringAttr rnd, StringAttr sat,
+      OneToNPatternRewriter &rewriter) const {
+    bool invalidWidenArity =
+        physicalResultTypes.size() != 2 * sourceParts.size();
+    if (invalidWidenArity) {
+      return rewriter.notifyMatchFailure(
+          op, "widen fptoui requires result arity = 2 × source arity");
+    }
+    static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+    return lowerWidenFpToInt(
+        op, sourceParts, resultTypes, kEvenOddParts, rnd, sat,
+        "widen fptoui requires result arity = 2 × source arity",
+        "failed to build fptoui widen mask", this->getTypeConverter(),
+        rewriter);
+  }
+
+  LogicalResult lowerNarrow(
+      VMIFPToUIOp op, ValueRange sourceParts, ArrayRef<Type> physicalResultTypes,
+      ArrayRef<VRegType> resultTypes, VMIVRegType resultVMIType,
+      unsigned sourceBits, unsigned resultBits, StringAttr rnd, StringAttr sat,
+      OneToNPatternRewriter &rewriter) const {
+    int64_t factor = sourceBits / resultBits;
+    VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
+    int64_t resultLaneStride = resultLayout && resultLayout.isContiguous()
+                                   ? resultLayout.getLaneStride()
+                                   : 1;
+    bool invalidResultLaneStride =
+        resultLaneStride <= 0 || factor % resultLaneStride != 0;
+    if (invalidResultLaneStride) {
+      return rewriter.notifyMatchFailure(
+          op, "narrow fptoui: unsupported result lane stride");
+    }
+    int64_t sourceFactor = factor / resultLaneStride;
+    bool invalidSourceArity =
+        sourceParts.size() != sourceFactor * physicalResultTypes.size();
+    if (invalidSourceArity) {
+      return rewriter.notifyMatchFailure(
+          op, "narrow fptoui: source arity != sourceFactor × result arity");
+    }
+    static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+    return lowerNarrowFpToInt(
+        op, sourceParts, resultTypes, sourceFactor, resultLaneStride,
+        kEvenOddParts, rnd, sat, "failed to build fptoui source mask",
+        "failed to build narrow fptoui result mask", this->getTypeConverter(),
+        rewriter);
+  }
+
+  FailureOr<FPToUILoweringInput> getLoweringInput(
+      VMIFPToUIOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+      OneToNPatternRewriter &rewriter) const {
+    auto contract = lookupVMIFpToUIContract(sourceVMIType.getElementType(),
+                                             resultVMIType.getElementType());
+    if (!contract) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported fp-to-ui conversion element type pair");
+    }
+    FailureOr<VRegType> sourceType =
+        validateSourceParts(op, sourceParts, rewriter);
+    if (failed(sourceType)) {
+      return failure();
+    }
+    FailureOr<SmallVector<VRegType>> resultVRegTypes =
+        validateResultParts(op, resultTypes, rewriter);
+    if (failed(resultVRegTypes)) {
+      return failure();
+    }
+    StringAttr rounding = op->getAttrOfType<StringAttr>("rounding");
+    if (!rounding) {
+      rounding = rewriter.getStringAttr("R");
+    }
+    StringAttr saturate = contract->requiresSat
+                              ? op->getAttrOfType<StringAttr>("saturate")
+                              : nullptr;
+    return FPToUILoweringInput{sourceParts, resultTypes, sourceVMIType,
+                               resultVMIType, *sourceType,
+                               std::move(*resultVRegTypes), *contract,
+                               rounding, saturate};
+  }
+
+  LogicalResult lowerConversion(
+      VMIFPToUIOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<FPToUILoweringInput> input = getLoweringInput(
+        op, sourceParts, resultTypes, sourceVMIType, resultVMIType, rewriter);
+    if (failed(input)) {
+      return failure();
+    }
+    if (!input->contract.requiresPart) {
+      return lowerSameWidthFpToInt(
+          op, input->sourceParts, input->resultVRegTypes, input->rounding,
+          input->saturate,
+          "same-width fptoui requires matching physical arity",
+          "failed to build fptoui mask", this->getTypeConverter(), rewriter);
+    }
+    unsigned sourceBits =
+        pto::getPTOStorageElemBitWidth(input->sourceVMIType.getElementType());
+    unsigned resultBits =
+        pto::getPTOStorageElemBitWidth(input->resultVMIType.getElementType());
+    if (resultBits > sourceBits) {
+      return lowerWiden(op, input->sourceParts, input->resultTypes,
+                        input->resultVRegTypes, input->rounding,
+                        input->saturate, rewriter);
+    }
+    if (resultBits < sourceBits) {
+      return lowerNarrow(op, input->sourceParts, input->resultTypes,
+                         input->resultVRegTypes, input->resultVMIType,
+                         sourceBits, resultBits, input->rounding,
+                         input->saturate, rewriter);
+    }
+    return failure();
+  }
+
 public:
 
   LogicalResult
@@ -18216,95 +18903,8 @@ public:
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
 
-    Type srcElem = sourceVMIType.getElementType();
-    Type dstElem = resultVMIType.getElementType();
-    auto contract = lookupVMIFpToUIContract(srcElem, dstElem);
-    if (!contract) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported fp-to-ui conversion element type pair");
-    }
-
-    FailureOr<VRegType> sourceType0 =
-        validateSourceParts(op, sourceParts, rewriter);
-    if (failed(sourceType0)) {
-      return failure();
-    }
-
-    FailureOr<SmallVector<VRegType>> resultVRegTypes =
-        validateResultParts(op, resultTypes, rewriter);
-    if (failed(resultVRegTypes)) {
-      return failure();
-    }
-
-    StringAttr rnd = op->getAttrOfType<StringAttr>("rounding");
-    if (!rnd) {
-      rnd = rewriter.getStringAttr("R");
-    }
-    StringAttr sat = contract->requiresSat
-                         ? op->getAttrOfType<StringAttr>("saturate")
-                         : nullptr;
-
-    if (!contract->requiresPart) {
-      // Same-width: 1:1 mapping, no part.
-      return lowerSameWidthFpToInt(
-          op, sourceParts, *resultVRegTypes, rnd, sat,
-          "same-width fptoui requires matching physical arity",
-          "failed to build fptoui mask", *this->getTypeConverter(), rewriter);
-    }
-
-    // requiresPart: narrow (f16→u8).
-    unsigned srcBits = pto::getPTOStorageElemBitWidth(srcElem);
-    unsigned dstBits = pto::getPTOStorageElemBitWidth(dstElem);
-
-    if (dstBits > srcBits) {
-      // Widen: 2× EvenOdd (currently no fp→ui widen paths, but handle
-      // generically).
-      bool invalidWidenArity = resultTypes.size() != 2 * sourceParts.size();
-      if (invalidWidenArity) {
-        return rewriter.notifyMatchFailure(
-            op, "widen fptoui requires result arity = 2 × source arity");
-      }
-
-      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
-      return lowerWidenFpToInt(
-          op, sourceParts, *resultVRegTypes, kEvenOddParts, rnd, sat,
-          "widen fptoui requires result arity = 2 × source arity",
-          "failed to build fptoui widen mask", *this->getTypeConverter(),
-          rewriter);
-    }
-
-    // Narrow (f16→u8): EvenOdd — source parts are grouped by EvenOdd factor,
-    // each result chunk merges 2 source parts via vcvt EVEN/ODD + vor.
-    if (dstBits < srcBits) {
-      int64_t factor = srcBits / dstBits; // 2 for 16→8
-      VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
-      int64_t resultLaneStride = resultLayout && resultLayout.isContiguous()
-                                     ? resultLayout.getLaneStride()
-                                     : 1;
-      bool invalidResultLaneStride =
-          resultLaneStride <= 0 || factor % resultLaneStride != 0;
-      if (invalidResultLaneStride) {
-        return rewriter.notifyMatchFailure(
-            op, "narrow fptoui: unsupported result lane stride");
-      }
-      int64_t sourceFactor = factor / resultLaneStride;
-      bool invalidSourceArity =
-          sourceParts.size() != sourceFactor * resultTypes.size();
-      if (invalidSourceArity) {
-        return rewriter.notifyMatchFailure(
-            op, "narrow fptoui: source arity != sourceFactor × result arity");
-      }
-
-      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
-      return lowerNarrowFpToInt(
-          op, sourceParts, *resultVRegTypes, sourceFactor, resultLaneStride,
-          kEvenOddParts, rnd, sat,
-          "failed to build fptoui source mask",
-          "failed to build narrow fptoui result mask",
-          *this->getTypeConverter(), rewriter);
-    }
-
-    return failure();
+    return lowerConversion(op, sourceParts, resultTypes, sourceVMIType,
+                           resultVMIType, rewriter);
   }
 };
 
@@ -18382,6 +18982,10 @@ private:
   FailureOr<SmallVector<VRegType>> collectResultTypes(
       VMISIToFPOp op, TypeRange resultTypes,
       OneToNPatternRewriter &rewriter) const {
+    if (resultTypes.empty()) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported physical sitofp result type");
+    }
     SmallVector<VRegType> resultVRegTypes;
     resultVRegTypes.reserve(resultTypes.size());
     for (Type resultType : resultTypes) {
@@ -18400,6 +19004,56 @@ private:
     return resultVRegTypes;
   }
 
+  FailureOr<VRegType> collectSourceType(
+      VMISIToFPOp op, ValueRange sourceParts,
+      OneToNPatternRewriter &rewriter) const {
+    if (sourceParts.empty()) {
+      return rewriter.notifyMatchFailure(op,
+                                         "sitofp requires integer source chunks");
+    }
+    auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
+    bool invalidSourceType =
+        !sourceType || !isa<IntegerType>(sourceType.getElementType());
+    if (invalidSourceType) {
+      return rewriter.notifyMatchFailure(op,
+                                         "sitofp requires integer source chunks");
+    }
+    for (Value sourcePart : sourceParts) {
+      bool mismatchedSourceType = sourcePart.getType() != sourceType;
+      if (mismatchedSourceType) {
+        return rewriter.notifyMatchFailure(
+            op, "sitofp requires integer source chunks");
+      }
+    }
+    return sourceType;
+  }
+
+  LogicalResult lowerPhysicalConversion(
+      VMISIToFPOp op, ValueRange sourceParts, TypeRange resultTypes,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<VRegType> sourceType =
+        collectSourceType(op, sourceParts, rewriter);
+    if (failed(sourceType)) {
+      return failure();
+    }
+    FailureOr<SmallVector<VRegType>> resultVRegTypes =
+        collectResultTypes(op, resultTypes, rewriter);
+    if (failed(resultVRegTypes)) {
+      return failure();
+    }
+    unsigned sourceBits =
+        pto::getPTOStorageElemBitWidth(sourceType->getElementType());
+    unsigned resultBits = pto::getPTOStorageElemBitWidth(
+        resultVRegTypes->front().getElementType());
+    FailureOr<Value> mask =
+        createAllTrueMaskForVReg(op.getLoc(), *sourceType, rewriter);
+    if (failed(mask)) {
+      return rewriter.notifyMatchFailure(op, "failed to build sitofp mask");
+    }
+    return lowerConversion(op, sourceParts, *resultVRegTypes, *mask,
+                           sourceBits, resultBits, rewriter);
+  }
+
 public:
 
   LogicalResult
@@ -18413,30 +19067,7 @@ public:
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
 
-    auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
-    if (!sourceType || !isa<IntegerType>(sourceType.getElementType())) {
-      return rewriter.notifyMatchFailure(
-          op, "sitofp requires integer source chunks");
-    }
-    unsigned sourceBits =
-        pto::getPTOStorageElemBitWidth(sourceType.getElementType());
-
-    FailureOr<SmallVector<VRegType>> resultVRegTypes =
-        collectResultTypes(op, resultTypes, rewriter);
-    if (failed(resultVRegTypes)) {
-      return failure();
-    }
-    unsigned resultBits = pto::getPTOStorageElemBitWidth(
-        resultVRegTypes->front().getElementType());
-
-    FailureOr<Value> mask =
-        createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
-    if (failed(mask)) {
-      return rewriter.notifyMatchFailure(op, "failed to build sitofp mask");
-    }
-
-    return lowerConversion(op, sourceParts, *resultVRegTypes, *mask, sourceBits,
-                           resultBits, rewriter);
+    return lowerPhysicalConversion(op, sourceParts, resultTypes, rewriter);
   }
 };
 
@@ -18457,6 +19088,29 @@ private:
         .getResult();
   }
 
+  LogicalResult lowerParts(VMIBitcastOp op, ValueRange sourceParts,
+                           ArrayRef<Type> resultTypes,
+                           OneToNPatternRewriter &rewriter) const {
+    bool arityMismatch = sourceParts.size() != resultTypes.size();
+    if (arityMismatch) {
+      return rewriter.notifyMatchFailure(op, "physical bitcast arity mismatch");
+    }
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (auto [sourcePart, resultType] :
+         llvm::zip_equal(sourceParts, resultTypes)) {
+      FailureOr<Value> result =
+          buildBitcastPart(op, sourcePart, resultType, rewriter);
+      if (failed(result)) {
+        return failure();
+      }
+      results.push_back(*result);
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
 public:
 
   LogicalResult
@@ -18469,25 +19123,7 @@ public:
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    bool arityMismatch = sourceParts.size() != resultTypes.size();
-    if (arityMismatch) {
-      return rewriter.notifyMatchFailure(op, "physical bitcast arity mismatch");
-    }
-
-    SmallVector<Value> results;
-    results.reserve(resultTypes.size());
-    for (auto [sourcePart, resultType] :
-         llvm::zip_equal(sourceParts, resultTypes)) {
-      FailureOr<Value> result =
-          buildBitcastPart(op, sourcePart, resultType, rewriter);
-      if (failed(result)) {
-        return failure();
-      }
-      results.push_back(*result);
-    }
-
-    replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
-    return success();
+    return lowerParts(op, sourceParts, resultTypes, rewriter);
   }
 };
 
@@ -18763,7 +19399,7 @@ private:
       return rewriter.notifyMatchFailure(
           op, "shuffle vselr source/result type mismatch");
     }
-    return *sourceVRegType;
+    return sourceVRegType;
   }
 
   LogicalResult lowerVselr(
@@ -18860,8 +19496,9 @@ struct OneToNCFBranchOpPattern : OneToNOpConversionPattern<cf::BranchOp> {
     Block *dest = convertBranchDestBlock(op.getDest(), rewriter, *converter,
                                          convertedBlocks);
     if (!adaptor.getOperandMapping().hasNonIdentityConversion() &&
-        dest == op.getDest())
+        dest == op.getDest()) {
       return failure();
+    }
 
     rewriter.replaceOpWithNewOp<cf::BranchOp>(op, dest,
                                               adaptor.getFlatOperands());
@@ -18884,8 +19521,9 @@ struct OneToNCFCondBranchOpPattern
                                               *converter, convertedBlocks);
 
     if (!adaptor.getOperandMapping().hasNonIdentityConversion() &&
-        trueDest == op.getTrueDest() && falseDest == op.getFalseDest())
+        trueDest == op.getTrueDest() && falseDest == op.getFalseDest()) {
       return failure();
+    }
 
     ValueRange condition = adaptor.getCondition();
     bool conditionArityMismatch = condition.size() != 1;
@@ -18899,12 +19537,14 @@ struct OneToNCFCondBranchOpPattern
     ValueRange flatOperands = adaptor.getFlatOperands();
     const OneToNTypeMapping &operandMapping = adaptor.getOperandMapping();
     unsigned operandIndex = 1;
-    for (unsigned i = 0, e = op.getNumTrueOperands(); i < e; ++i)
+    for (unsigned i = 0, e = op.getNumTrueOperands(); i < e; ++i) {
       llvm::append_range(trueOperands, operandMapping.getConvertedValues(
                                            flatOperands, operandIndex++));
-    for (unsigned i = 0, e = op.getNumFalseOperands(); i < e; ++i)
+    }
+    for (unsigned i = 0, e = op.getNumFalseOperands(); i < e; ++i) {
       llvm::append_range(falseOperands, operandMapping.getConvertedValues(
                                             flatOperands, operandIndex++));
+    }
 
     rewriter.replaceOpWithNewOp<cf::CondBranchOp>(op, condition.front(),
                                                   trueDest, trueOperands,
@@ -18916,25 +19556,65 @@ struct OneToNCFCondBranchOpPattern
 struct OneToNCFSwitchOpPattern : OneToNOpConversionPattern<cf::SwitchOp> {
   using OneToNOpConversionPattern<cf::SwitchOp>::OneToNOpConversionPattern;
 
+private:
+  static void collectSwitchOperandSegments(
+      ArrayRef<int32_t> segmentSizes, ValueRange flatOperands,
+      const OneToNTypeMapping &operandMapping, unsigned &operandIndex,
+      SmallVectorImpl<SmallVector<Value>> &storage,
+      SmallVectorImpl<ValueRange> &segments) {
+    storage.reserve(segmentSizes.size());
+    segments.reserve(segmentSizes.size());
+    for (int32_t segmentSize : segmentSizes) {
+      SmallVector<Value> operands;
+      for (int32_t index = 0; index < segmentSize; ++index) {
+        llvm::append_range(operands, operandMapping.getConvertedValues(
+                                         flatOperands, operandIndex++));
+      }
+      storage.push_back(std::move(operands));
+    }
+    for (SmallVector<Value> &operands : storage) {
+      segments.push_back(operands);
+    }
+  }
+
+  static Block *convertSwitchDestination(
+      Block *destination, OneToNPatternRewriter &rewriter,
+      OneToNTypeConverter &converter, llvm::DenseMap<Block *, Block *> &blocks) {
+    return convertBranchDestBlock(destination, rewriter, converter, blocks);
+  }
+
+  static bool switchDestinationsChanged(
+      cf::SwitchOp op, Block *defaultDest, ArrayRef<Block *> caseDests) {
+    if (defaultDest != op.getDefaultDestination()) {
+      return true;
+    }
+    for (auto [oldDest, newDest] :
+         llvm::zip(op.getCaseDestinations(), caseDests)) {
+      if (oldDest != newDest) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+public:
   LogicalResult
   matchAndRewrite(cf::SwitchOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
     auto *converter = getTypeConverter<OneToNTypeConverter>();
     llvm::DenseMap<Block *, Block *> convertedBlocks;
-    Block *defaultDest = convertBranchDestBlock(
+    Block *defaultDest = convertSwitchDestination(
         op.getDefaultDestination(), rewriter, *converter, convertedBlocks);
 
     SmallVector<Block *> caseDests;
     caseDests.reserve(op.getCaseDestinations().size());
-    for (Block *dest : op.getCaseDestinations())
-      caseDests.push_back(
-          convertBranchDestBlock(dest, rewriter, *converter, convertedBlocks));
+    for (Block *dest : op.getCaseDestinations()) {
+      caseDests.push_back(convertSwitchDestination(dest, rewriter, *converter,
+                                                   convertedBlocks));
+    }
 
-    bool changed = defaultDest != op.getDefaultDestination();
-    for (auto [oldDest, newDest] :
-         llvm::zip(op.getCaseDestinations(), caseDests))
-      changed |= oldDest != newDest;
-    changed |= adaptor.getOperandMapping().hasNonIdentityConversion();
+    bool changed = switchDestinationsChanged(op, defaultDest, caseDests) ||
+                   adaptor.getOperandMapping().hasNonIdentityConversion();
     if (!changed) {
       return failure();
     }
@@ -18952,21 +19632,14 @@ struct OneToNCFSwitchOpPattern : OneToNOpConversionPattern<cf::SwitchOp> {
     ValueRange flatOperands = adaptor.getFlatOperands();
     const OneToNTypeMapping &operandMapping = adaptor.getOperandMapping();
     unsigned operandIndex = 1;
-    for (unsigned i = 0, e = op.getDefaultOperands().size(); i < e; ++i)
+    for (unsigned i = 0, e = op.getDefaultOperands().size(); i < e; ++i) {
       llvm::append_range(defaultOperands, operandMapping.getConvertedValues(
                                               flatOperands, operandIndex++));
-
-    caseOperandStorage.reserve(op.getCaseOperandSegments().size());
-    caseOperands.reserve(op.getCaseOperandSegments().size());
-    for (int32_t segmentSize : op.getCaseOperandSegments()) {
-      SmallVector<Value> operands;
-      for (int32_t i = 0; i < segmentSize; ++i)
-        llvm::append_range(operands, operandMapping.getConvertedValues(
-                                         flatOperands, operandIndex++));
-      caseOperandStorage.push_back(std::move(operands));
     }
-    for (SmallVector<Value> &operands : caseOperandStorage)
-      caseOperands.push_back(operands);
+
+    collectSwitchOperandSegments(op.getCaseOperandSegments(), flatOperands,
+                                 operandMapping, operandIndex,
+                                 caseOperandStorage, caseOperands);
 
     rewriter.replaceOpWithNewOp<cf::SwitchOp>(
         op, flag.front(), defaultDest, defaultOperands, op.getCaseValuesAttr(),
@@ -18985,8 +19658,9 @@ struct OneToNSCFExecuteRegionOpPattern
                   OneToNPatternRewriter &rewriter) const override {
     SmallVector<Type> resultTypes;
     const OneToNTypeMapping &resultMapping = adaptor.getResultMapping();
-    for (unsigned i = 0, e = op->getNumResults(); i < e; ++i)
+    for (unsigned i = 0, e = op->getNumResults(); i < e; ++i) {
       llvm::append_range(resultTypes, resultMapping.getConvertedTypes(i));
+    }
     if (resultTypes == op->getResultTypes()) {
       return failure();
     }
@@ -19018,8 +19692,9 @@ struct OneToNSCFIndexSwitchOpPattern
 
     SmallVector<Type> resultTypes;
     const OneToNTypeMapping &resultMapping = adaptor.getResultMapping();
-    for (unsigned i = 0, e = op->getNumResults(); i < e; ++i)
+    for (unsigned i = 0, e = op->getNumResults(); i < e; ++i) {
       llvm::append_range(resultTypes, resultMapping.getConvertedTypes(i));
+    }
     if (resultTypes == op->getResultTypes()) {
       return failure();
     }
@@ -19030,14 +19705,15 @@ struct OneToNSCFIndexSwitchOpPattern
     rewriter.inlineRegionBefore(op.getDefaultRegion(), newOp.getDefaultRegion(),
                                 newOp.getDefaultRegion().end());
     for (auto [srcRegion, dstRegion] :
-         llvm::zip(op.getCaseRegions(), newOp.getCaseRegions()))
+         llvm::zip(op.getCaseRegions(), newOp.getCaseRegions())) {
       rewriter.inlineRegionBefore(srcRegion, dstRegion, dstRegion.end());
+    }
     rewriter.replaceOp(op, newOp->getResults(), resultMapping);
     return success();
   }
 };
 
-void populateVMIConversionPatterns(
+static void populateVMIStructuralAndMemoryPatterns(
     VMIToVPTOTypeConverter &typeConverter, RewritePatternSet &patterns) {
   populateFuncTypeConversionPatterns(typeConverter, patterns);
   scf::populateSCFStructuralOneToNTypeConversions(typeConverter, patterns);
@@ -19063,7 +19739,12 @@ void populateVMIConversionPatterns(
       OneToNVMIExpandLoadOpPattern, OneToNVMIStoreOpPattern,
       OneToNVMIInterleaveStoreOpPattern, OneToNVMIGroupStoreOpPattern,
       OneToNVMIMaskedStoreOpPattern, OneToNVMIStrideStoreOpPattern,
-      OneToNVMIScatterOpPattern, OneToNVMIBinaryOpPattern<VMIAddFOp, VaddOp>,
+      OneToNVMIScatterOpPattern>(typeConverter, patterns.getContext());
+}
+
+static void populateVMIArithmeticPatterns(
+    VMIToVPTOTypeConverter &typeConverter, RewritePatternSet &patterns) {
+  patterns.add<OneToNVMIBinaryOpPattern<VMIAddFOp, VaddOp>,
       OneToNVMIBinaryOpPattern<VMIAddIOp, VaddOp>,
       OneToNVMIVaddcOpPattern, OneToNVMIVaddcsOpPattern,
       OneToNVMIBinaryOpPattern<VMISubFOp, VsubOp>,
@@ -19100,7 +19781,13 @@ void populateVMIConversionPatterns(
       OneToNVMICmpOpPattern<VMICmpFOp>, OneToNVMICmpOpPattern<VMICmpIOp>,
       OneToNVMISelectOpPattern, OneToNVMIVselrOpPattern,
       OneToNVMIActivePrefixIndexOpPattern,
-      OneToNVMICompressOpPattern, OneToNVMICompressStoreOpPattern,
+      OneToNVMICompressOpPattern,
+      OneToNVMICompressStoreOpPattern>(typeConverter, patterns.getContext());
+}
+
+static void populateVMIReductionAndConversionPatterns(
+    VMIToVPTOTypeConverter &typeConverter, RewritePatternSet &patterns) {
+  patterns.add<
       OneToNVMIReduceAddIOpPattern, OneToNVMIReduceAddFOpPattern,
       OneToNVMIGroupBroadcastOpPattern, OneToNVMIVdhistOpPattern,
       OneToNVMIVchistOpPattern,
@@ -19135,6 +19822,13 @@ void populateVMIConversionPatterns(
                                              patterns.getContext());
   patterns.add<OneToNVMIEnsureMaskGranularityOpPattern>(
       typeConverter, patterns.getContext());
+}
+
+void populateVMIConversionPatterns(
+    VMIToVPTOTypeConverter &typeConverter, RewritePatternSet &patterns) {
+  populateVMIStructuralAndMemoryPatterns(typeConverter, patterns);
+  populateVMIArithmeticPatterns(typeConverter, patterns);
+  populateVMIReductionAndConversionPatterns(typeConverter, patterns);
 }
 
 static WalkResult verifyNoResidualCreateMask(Operation *op) {
@@ -19229,6 +19923,14 @@ LogicalResult checkSupportedTruncIShape(VMITruncIOp op,
   }
   return success();
 }
+
+static LogicalResult checkSameWidthConversionArity(
+    VMIVRegType sourceType, VMIVRegType resultType, StringRef conversionName,
+    std::string *reason);
+
+template <typename ShapeOp, typename ShapeCheck>
+WalkResult verifySupportedShapeOp(ShapeOp op, ShapeCheck check,
+                                  StringRef diagnostic);
 
 template <typename OpTy, typename ContractLookup>
 LogicalResult checkSupportedFPToIntShape(OpTy op, StringRef conversionName,
@@ -19534,20 +20236,11 @@ LogicalResult checkSupportedChannelSplitShape(VMIChannelSplitOp op,
 
 LogicalResult checkSupportedChannelMergeShape(VMIChannelMergeOp op,
                                               std::string *reason = nullptr) {
-  auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
-
   FailureOr<ChannelShapePlan> plan = buildChannelShapePlan(
       op, op.getInputs().size(), "channel_merge", reason);
   if (failed(plan)) {
     return failure();
   }
-  int64_t channels = plan->channels;
-
   FailureOr<int64_t> inputArity =
       getContiguousChannelInputArity(op.getInputs(), reason);
   if (failed(inputArity)) {
@@ -19633,14 +20326,6 @@ static LogicalResult checkActivePrefixIndexSingleChunk(
 
 static FailureOr<ActivePrefixIndexShapePlan> buildActivePrefixIndexShapePlan(
     VMIActivePrefixIndexOp op, std::string *reason) {
-  auto fail = [&reason](const Twine &message)
-      -> FailureOr<ActivePrefixIndexShapePlan> {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
-
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   if (failed(checkActivePrefixIndexLayouts(maskType, resultType, reason))) {
@@ -19871,14 +20556,6 @@ static LogicalResult checkReduceSourceChunks(OpTy op, VMIVRegType sourceType,
 template <typename OpTy>
 static FailureOr<ReducePhysicalShapePlan> buildReducePhysicalShapePlan(
     OpTy op, std::string *reason) {
-  auto fail = [&reason](const Twine &message)
-      -> FailureOr<ReducePhysicalShapePlan> {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
-
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
@@ -20104,12 +20781,12 @@ static LogicalResult checkGroupBroadcastResultShape(
       getVMILayoutBlockElems(resultType);
   bool blockFragmentSmallGroup =
       resultLayout.isBlockDeinterleaved() && succeeded(resultBlockElems) &&
-      *groupSize < *lanesPerPart && *lanesPerPart % *resultBlockElems == 0;
+      groupSize < lanesPerPart && lanesPerPart % *resultBlockElems == 0;
   bool deinterleavedSmallGroup =
       resultLayout.isDeinterleaved() &&
-      *groupSize < *lanesPerPart && *groupSize >= *resultFactor &&
-      *groupSize % *resultFactor == 0 &&
-      *lanesPerPart % (*groupSize / *resultFactor) == 0;
+      groupSize < lanesPerPart && groupSize >= resultFactor &&
+      groupSize % resultFactor == 0 &&
+      lanesPerPart % (groupSize / resultFactor) == 0;
   if (blockFragmentSmallGroup || deinterleavedSmallGroup) {
     return success();
   }
@@ -20161,6 +20838,42 @@ struct VmullShapePlan {
   int64_t arity;
 };
 
+static LogicalResult validateVmullDataLayout(
+    VMIVRegType aType, VMIVRegType bType, VMIVRegType lowType,
+    VMIVRegType highType, VMIMaskType maskType, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  if (aType != bType || aType != lowType || aType != highType) {
+    return fail("requires identical a, b, low, and high VMI vreg types");
+  }
+  VMILayoutAttr layout = aType.getLayoutAttr();
+  if (!layout) {
+    return fail("requires an assigned data layout");
+  }
+  bool supportedLayout =
+      layout.getLaneStride() == 1 &&
+      (layout.isContiguous() ||
+       (layout.isDeinterleaved() &&
+        (layout.getFactor() == 2 || layout.getFactor() == 4)));
+  if (!supportedLayout) {
+    return fail("requires contiguous or deinterleaved factor 2/4 layout with "
+                "lane_stride=1");
+  }
+  bool maskLayoutMismatch = maskType.getLayoutAttr() != layout;
+  if (maskLayoutMismatch) {
+    return fail("requires the mask and all four data values to share one layout");
+  }
+  bool unsupportedMaskGranularity = maskType.getGranularity() != "b32";
+  if (unsupportedMaskGranularity) {
+    return fail("requires b32 mask granularity");
+  }
+  return success();
+}
+
 static FailureOr<VmullShapePlan> validateVmullLogicalShape(
     VMIVmullOp op, VMIVRegType aType, VMIVRegType bType,
     VMIVRegType lowType, VMIVRegType highType, VMIMaskType maskType,
@@ -20179,34 +20892,15 @@ static FailureOr<VmullShapePlan> validateVmullLogicalShape(
   if (unsupportedElementType) {
     return fail("requires element type to be exactly i32 or ui32");
   }
-  if (aType != bType || aType != lowType || aType != highType) {
-    return fail("requires identical a, b, low, and high VMI vreg types");
-  }
   int64_t lanes = aType.getElementCount();
   if (lanes != 64 && lanes != 128 && lanes != 256) {
     return fail("requires logical lane count 64, 128, or 256");
   }
-  VMILayoutAttr layout = aType.getLayoutAttr();
-  if (!layout) {
-    return fail("requires an assigned data layout");
+  if (failed(validateVmullDataLayout(aType, bType, lowType, highType, maskType,
+                                     reason))) {
+    return failure();
   }
-  bool supportedLayout =
-      layout.getLaneStride() == 1 &&
-      (layout.isContiguous() ||
-       (layout.isDeinterleaved() &&
-        (layout.getFactor() == 2 || layout.getFactor() == 4)));
-  if (!supportedLayout) {
-    return fail("requires contiguous or deinterleaved factor 2/4 layout with "
-                "lane_stride=1");
-  }
-  bool maskLayoutMismatch = maskType.getLayoutAttr() != layout;
-  bool unsupportedMaskGranularity = maskType.getGranularity() != "b32";
-  if (maskLayoutMismatch || unsupportedMaskGranularity) {
-    return fail(maskLayoutMismatch
-                    ? "requires the mask and all four data values to share one layout"
-                    : "requires b32 mask granularity");
-  }
-  return VmullShapePlan{aType, layout, 0};
+  return VmullShapePlan{aType, aType.getLayoutAttr(), 0};
 }
 
 static FailureOr<VmullShapePlan> buildVmullShapePlan(
@@ -20232,7 +20926,10 @@ static FailureOr<VmullShapePlan> buildVmullShapePlan(
       failed(aArity) || failed(bArity) || failed(lowArity) ||
       failed(highArity) || failed(maskArity) || *aArity < 1;
   if (missingArity) {
-    return fail("requires computable non-empty physical arity on every port");
+    if (reason) {
+      *reason = "requires computable non-empty physical arity on every port";
+    }
+    return failure();
   }
   bool arityMismatch =
       *aArity != *bArity || *aArity != *lowArity || *aArity != *highArity ||
@@ -20449,10 +21146,6 @@ void emitEnsureLayoutMaterializationError(VMIEnsureLayoutOp ensure,
       << "); partial/tail layout materialization requires an explicit "
          "packing plan";
 }
-
-template <typename ShapeOp, typename ShapeCheck>
-WalkResult verifySupportedShapeOp(ShapeOp op, ShapeCheck check,
-                                  StringRef diagnostic);
 
 WalkResult emitMemoryUnsupported(Operation *memoryOp, StringRef opName,
                                  VMIVRegType type, Value source,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -20632,7 +20632,8 @@ std::optional<WalkResult> verifySupportedVMIMemoryStoreOp(Operation *op) {
   return std::nullopt;
 }
 
-std::optional<WalkResult> verifySupportedVMIStructuredLoadOp(Operation *op) {
+static std::optional<WalkResult> verifySupportedVMIDeinterleaveLoadOp(
+    Operation *op) {
   if (auto load = dyn_cast<VMIDeinterleaveLoadOp>(op)) {
     return verifySupportedShapeOp(
         load, checkSupportedDeinterleaveLoadShape,
@@ -20640,12 +20641,20 @@ std::optional<WalkResult> verifySupportedVMIStructuredLoadOp(Operation *op) {
         "matching contiguous full low/high result chunks with a supported "
         "UB source and 8/16/32-bit element type (");
   }
+  return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMIStrideLoadOp(Operation *op) {
   if (auto load = dyn_cast<VMIStrideLoadOp>(op)) {
     return verifySupportedShapeOp(
         load, checkSupportedStrideLoadShape,
         "pto.vmi.stride_load lowers through pto.vsldb only for one "
         "contiguous physical result/mask chunk and a supported UB source (");
   }
+  return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMIGroupLoadOp(Operation *op) {
   if (auto load = dyn_cast<VMIGroupLoadOp>(op)) {
     return verifySupportedShapeOp(
         load, checkSupportedGroupLoadShape,
@@ -20653,6 +20662,11 @@ std::optional<WalkResult> verifySupportedVMIStructuredLoadOp(Operation *op) {
         "supported UB source, and num_groups deriving a group size aligned "
         "to physical chunks (");
   }
+  return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMIGroupSlotLoadOp(
+    Operation *op) {
   if (auto load = dyn_cast<VMIGroupSlotLoadOp>(op)) {
     return verifySupportedShapeOp(
         load, checkSupportedGroupSlotLoadShape,
@@ -20661,6 +20675,11 @@ std::optional<WalkResult> verifySupportedVMIStructuredLoadOp(Operation *op) {
         "slots=8 with constant unit source_group_stride or slots=1 row-local "
         "lowering (");
   }
+  return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMIGroupBroadcastLoadOp(
+    Operation *op) {
   if (auto load = dyn_cast<VMIGroupBroadcastLoadOp>(op)) {
     return verifySupportedShapeOp(
         load, checkSupportedGroupBroadcastLoadShape,
@@ -20670,6 +20689,24 @@ std::optional<WalkResult> verifySupportedVMIStructuredLoadOp(Operation *op) {
         "with supported UB pointer source and source_group_stride (");
   }
   return std::nullopt;
+}
+
+std::optional<WalkResult> verifySupportedVMIStructuredLoadOp(Operation *op) {
+  if (auto result = verifySupportedVMIDeinterleaveLoadOp(op);
+      result.has_value()) {
+    return result;
+  }
+  if (auto result = verifySupportedVMIStrideLoadOp(op); result.has_value()) {
+    return result;
+  }
+  if (auto result = verifySupportedVMIGroupLoadOp(op); result.has_value()) {
+    return result;
+  }
+  if (auto result = verifySupportedVMIGroupSlotLoadOp(op);
+      result.has_value()) {
+    return result;
+  }
+  return verifySupportedVMIGroupBroadcastLoadOp(op);
 }
 
 std::optional<WalkResult> verifySupportedVMIMemoryLoadOp(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9507,6 +9507,22 @@ private:
     return success();
   }
 
+  FailureOr<Value> materializeContiguousGroupLoadChunk(
+      VMIGroupLoadOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value offset, Value rowStride, Type resultType, int64_t group,
+      int64_t chunkInGroup, int64_t lanesPerPart) const {
+    if (!isa<VRegType>(resultType)) {
+      return rewriter.notifyMatchFailure(op, "group_load result must be vreg");
+    }
+    Value chunkOffset = createGroupChunkOffset(
+        op.getLoc(), offset, rowStride, group, chunkInGroup * lanesPerPart,
+        rewriter);
+    return rewriter
+        .create<VldsOp>(op.getLoc(), resultType, Type{}, source, chunkOffset,
+                        nullptr)
+        .getResult();
+  }
+
   LogicalResult lowerContiguousChunks(
       VMIGroupLoadOp op, OneToNPatternRewriter &rewriter, Value source,
       Value offset, Value rowStride, VMIVRegType resultVMIType,
@@ -9533,20 +9549,15 @@ private:
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (auto [index, resultType] : llvm::enumerate(resultTypes)) {
-      if (!isa<VRegType>(resultType)) {
-        return rewriter.notifyMatchFailure(op,
-                                           "group_load result must be vreg");
-      }
       int64_t group = index / chunksPerGroup;
       int64_t chunkInGroup = index % chunksPerGroup;
-      Value chunkOffset = createGroupChunkOffset(
-          op.getLoc(), offset, rowStride, group, chunkInGroup * lanesPerPart,
-          rewriter);
-      results.push_back(rewriter
-                            .create<VldsOp>(op.getLoc(), resultType,
-                                            /*updated_base=*/Type{}, source,
-                                            chunkOffset, /*dist=*/nullptr)
-                            .getResult());
+      FailureOr<Value> result = materializeContiguousGroupLoadChunk(
+          op, rewriter, source, offset, rowStride, resultType, group,
+          chunkInGroup, lanesPerPart);
+      if (failed(result)) {
+        return failure();
+      }
+      results.push_back(*result);
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -19410,8 +19410,10 @@ struct VmullShapePlan {
   int64_t arity;
 };
 
-static FailureOr<VmullShapePlan> buildVmullShapePlan(
-    VMIVmullOp op, std::string *reason) {
+static FailureOr<VmullShapePlan> validateVmullLogicalShape(
+    VMIVmullOp op, VMIVRegType aType, VMIVRegType bType,
+    VMIVRegType lowType, VMIVRegType highType, VMIMaskType maskType,
+    std::string *reason) {
   auto fail = [&reason](const Twine &message)
       -> FailureOr<VmullShapePlan> {
     if (reason) {
@@ -19419,12 +19421,6 @@ static FailureOr<VmullShapePlan> buildVmullShapePlan(
     }
     return failure();
   };
-  auto aType = cast<VMIVRegType>(op.getA().getType());
-  auto bType = cast<VMIVRegType>(op.getB().getType());
-  auto lowType = cast<VMIVRegType>(op.getLow().getType());
-  auto highType = cast<VMIVRegType>(op.getHigh().getType());
-  auto maskType = cast<VMIMaskType>(op.getMask().getType());
-
   auto elementType = dyn_cast<IntegerType>(aType.getElementType());
   bool unsupportedElementType =
       !elementType || elementType.getWidth() != 32 ||
@@ -19435,12 +19431,10 @@ static FailureOr<VmullShapePlan> buildVmullShapePlan(
   if (aType != bType || aType != lowType || aType != highType) {
     return fail("requires identical a, b, low, and high VMI vreg types");
   }
-
   int64_t lanes = aType.getElementCount();
   if (lanes != 64 && lanes != 128 && lanes != 256) {
     return fail("requires logical lane count 64, 128, or 256");
   }
-
   VMILayoutAttr layout = aType.getLayoutAttr();
   if (!layout) {
     return fail("requires an assigned data layout");
@@ -19455,13 +19449,27 @@ static FailureOr<VmullShapePlan> buildVmullShapePlan(
                 "lane_stride=1");
   }
   bool maskLayoutMismatch = maskType.getLayoutAttr() != layout;
-  if (maskLayoutMismatch) {
-    return fail("requires the mask and all four data values to share one "
-                "layout");
-  }
   bool unsupportedMaskGranularity = maskType.getGranularity() != "b32";
-  if (unsupportedMaskGranularity) {
-    return fail("requires b32 mask granularity");
+  if (maskLayoutMismatch || unsupportedMaskGranularity) {
+    return fail(maskLayoutMismatch
+                    ? "requires the mask and all four data values to share one layout"
+                    : "requires b32 mask granularity");
+  }
+  return VmullShapePlan{aType, layout, 0};
+}
+
+static FailureOr<VmullShapePlan> buildVmullShapePlan(
+    VMIVmullOp op, std::string *reason) {
+  auto aType = cast<VMIVRegType>(op.getA().getType());
+  auto bType = cast<VMIVRegType>(op.getB().getType());
+  auto lowType = cast<VMIVRegType>(op.getLow().getType());
+  auto highType = cast<VMIVRegType>(op.getHigh().getType());
+  auto maskType = cast<VMIMaskType>(op.getMask().getType());
+
+  FailureOr<VmullShapePlan> logical = validateVmullLogicalShape(
+      op, aType, bType, lowType, highType, maskType, reason);
+  if (failed(logical)) {
+    return failure();
   }
 
   FailureOr<int64_t> aArity = getVMIPhysicalArity(aType);
@@ -19479,10 +19487,12 @@ static FailureOr<VmullShapePlan> buildVmullShapePlan(
       *aArity != *bArity || *aArity != *lowArity || *aArity != *highArity ||
       *aArity != *maskArity;
   if (arityMismatch) {
-    return fail("requires matching physical arity on a, b, mask, low, and "
-                "high");
+    if (reason) {
+      *reason = "requires matching physical arity on a, b, mask, low, and high";
+    }
+    return failure();
   }
-  return VmullShapePlan{aType, layout, *aArity};
+  return VmullShapePlan{aType, logical->layout, *aArity};
 }
 
 static LogicalResult checkVmullPhysicalShape(VMIVRegType dataType,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8499,6 +8499,31 @@ private:
     bool noWiderThanContiguous;
   };
 
+  FailureOr<SmallVector<Type>> getLoadResultTypes(
+      VMILoadOp op) const {
+    FailureOr<SmallVector<Type>> resultTypes =
+        getConvertedResultTypes(op, 0, *this->getTypeConverter());
+    if (failed(resultTypes)) {
+      return failure();
+    }
+    return std::move(*resultTypes);
+  }
+
+  FailureOr<SmallVector<Type>> getContiguousLoadTypes(
+      VMILoadOp op, VMIVRegType resultVMIType,
+      OneToNPatternRewriter &rewriter) const {
+    VMILayoutAttr contiguousLayout =
+        VMILayoutAttr::getContiguous(rewriter.getContext());
+    FailureOr<SmallVector<Type>> contiguousTypes =
+        getConvertedVRegTypesWithLayout(resultVMIType, contiguousLayout,
+                                        *this->getTypeConverter());
+    if (failed(contiguousTypes)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to compute contiguous load footprint");
+    }
+    return std::move(*contiguousTypes);
+  }
+
   FailureOr<LoadPhysicalPlan> buildPhysicalPlan(
       VMILoadOp op, OpAdaptor adaptor,
       OneToNPatternRewriter &rewriter) const {
@@ -8512,9 +8537,9 @@ private:
     if (failedOperands) {
       return failure();
     }
-    FailureOr<SmallVector<Type>> maybeResultTypes =
-        getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybeResultTypes)) {
+    FailureOr<SmallVector<Type>> resultTypes =
+        getLoadResultTypes(op);
+    if (failed(resultTypes)) {
       return failure();
     }
     auto resultVMIType = cast<VMIVRegType>(op.getResult().getType());
@@ -8525,25 +8550,21 @@ private:
     }
     VMILayoutAttr contiguousLayout =
         VMILayoutAttr::getContiguous(rewriter.getContext());
-    FailureOr<SmallVector<Type>> maybeContiguousTypes =
-        getConvertedVRegTypesWithLayout(resultVMIType, contiguousLayout,
-                                        *this->getTypeConverter());
-    if (failed(maybeContiguousTypes)) {
-      return rewriter.notifyMatchFailure(
-          op, "failed to compute contiguous load footprint");
+    FailureOr<SmallVector<Type>> contiguousTypes =
+        getContiguousLoadTypes(op, resultVMIType, rewriter);
+    if (failed(contiguousTypes)) {
+      return failure();
     }
-    SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
-    SmallVector<Type> contiguousTypes = std::move(*maybeContiguousTypes);
     FailureOr<bool> noWiderThanContiguous =
-        hasNoWiderFootprintThanContiguous(resultTypes, contiguousTypes);
+        hasNoWiderFootprintThanContiguous(*resultTypes, *contiguousTypes);
     if (failed(noWiderThanContiguous)) {
       return rewriter.notifyMatchFailure(
           op, "failed to compare load physical footprint");
     }
     return LoadPhysicalPlan{*source,
                            *offset,
-                           std::move(resultTypes),
-                           std::move(contiguousTypes),
+                           std::move(*resultTypes),
+                           std::move(*contiguousTypes),
                            resultVMIType.getLayoutAttr(),
                            *lanesPerPart,
                            *noWiderThanContiguous};

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18410,8 +18410,11 @@ std::optional<WalkResult> verifySupportedVMINormalReductionOp(Operation *op) {
 }
 
 std::optional<WalkResult> verifySupportedVMIGroupReductionOp(Operation *op) {
+  auto verifyGroupReduction = [](auto reduce, StringRef diagnostic) {
+    return verifySupportedGroupReduceOp(reduce, diagnostic);
+  };
   if (auto reduce = dyn_cast<VMIGroupReduceAddFOp>(op)) {
-    return verifySupportedGroupReduceOp(
+    return verifyGroupReduction(
         reduce,
         "pto.vmi.group_reduce_addf lowers through pto.vcgadd for 32B blocks "
         "or through pto.vcadd for contiguous full source/mask chunks, "
@@ -18419,21 +18422,21 @@ std::optional<WalkResult> verifySupportedVMIGroupReductionOp(Operation *op) {
         "num_groups deriving a group size aligned to physical chunks (");
   }
   if (auto reduce = dyn_cast<VMIGroupReduceAddIOp>(op)) {
-    return verifySupportedGroupReduceOp(
+    return verifyGroupReduction(
         reduce,
         "pto.vmi.group_reduce_addi lowers through pto.vcgadd/vadd for "
         "supported 32B block classes or through an internal widening "
         "pto.vcadd path for aligned full chunks (");
   }
   if (auto reduce = dyn_cast<VMIGroupReduceMaxIOp>(op)) {
-    return verifySupportedGroupReduceOp(
+    return verifyGroupReduction(
         reduce,
         "pto.vmi.group_reduce_maxi lowers through pto.vcgmax/vmax for "
         "supported 32B block classes or through pto.vcmax for aligned full "
         "chunks (");
   }
   if (auto reduce = dyn_cast<VMIGroupReduceMaxFOp>(op)) {
-    return verifySupportedGroupReduceOp(
+    return verifyGroupReduction(
         reduce,
         "pto.vmi.group_reduce_maxf lowers through pto.vcgmax/vmax for 32B "
         "blocks or through pto.vcmax for contiguous full chunks, matching "
@@ -18442,14 +18445,14 @@ std::optional<WalkResult> verifySupportedVMIGroupReductionOp(Operation *op) {
         "physical chunks (");
   }
   if (auto reduce = dyn_cast<VMIGroupReduceMinFOp>(op)) {
-    return verifySupportedGroupReduceOp(
+    return verifyGroupReduction(
         reduce,
         "pto.vmi.group_reduce_minf lowers through pto.vcgmin/vmin for "
         "supported 32B block classes or through pto.vcmin for aligned full "
         "chunks (");
   }
   if (auto reduce = dyn_cast<VMIGroupReduceMinIOp>(op)) {
-    return verifySupportedGroupReduceOp(
+    return verifyGroupReduction(
         reduce,
         "pto.vmi.group_reduce_mini lowers through pto.vcgmin/vmin for "
         "supported 32B block classes or through pto.vcmin for aligned full "

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7768,6 +7768,48 @@ FailureOr<std::optional<Value>> createPowerOfTwoSubVLChunk(
 /// lane-range vsel. Index iota is integer-only in practice.
 ///
 /// When S == physVL this is just `vci(base)` (single group fills the VL).
+static FailureOr<Value> materializeResidualSubVLGroup(
+    Location loc, Type resultType, Value base, StringRef order, Value full,
+    MaskType maskType, Value zeroScalar, Value allMask, Value previousResult,
+    int64_t groupSize, int64_t localGroup, PatternRewriter &rewriter) {
+  Value adjusted = full;
+  if (localGroup != 0) {
+    int64_t delta = localGroup * groupSize;
+    FailureOr<Value> offsetScalar =
+        createScalarOffsetConstant(loc, base.getType(), delta, rewriter);
+    if (failed(offsetScalar)) {
+      return failure();
+    }
+    if (order == "DESC") {
+      adjusted = rewriter
+                     .create<VaddsOp>(loc, resultType, full, *offsetScalar,
+                                      allMask)
+                     .getResult();
+    } else {
+      Value negOffset = isa<FloatType>(base.getType())
+                            ? rewriter.create<arith::NegFOp>(
+                                  loc, *offsetScalar)
+                                  .getResult()
+                            : rewriter
+                                  .create<arith::SubIOp>(loc, zeroScalar,
+                                                         *offsetScalar)
+                                  .getResult();
+      adjusted = rewriter
+                     .create<VaddsOp>(loc, resultType, full, negOffset, allMask)
+                     .getResult();
+    }
+  }
+  FailureOr<Value> laneMask = createLaneRangeMask(
+      loc, maskType, localGroup * groupSize, (localGroup + 1) * groupSize,
+      rewriter);
+  if (failed(laneMask)) {
+    return failure();
+  }
+  return rewriter
+      .create<VselOp>(loc, resultType, adjusted, previousResult, *laneMask)
+      .getResult();
+}
+
 FailureOr<Value> createResidualSubVLGroupPeriodicChunk(
     Location loc, Type resultType, Value base, StringRef order,
     Value full, MaskType maskType, Value zeroScalar, Value allMask,
@@ -7779,49 +7821,10 @@ FailureOr<Value> createResidualSubVLGroupPeriodicChunk(
                           allMask,
                           /*position=*/nullptr)
           .getResult();
-  auto materializeGroup =
-      [&loc, resultType, base, order, full, maskType, zeroScalar, allMask,
-       groupSize, &rewriter](int64_t localGroup) -> FailureOr<Value> {
-    Value adjusted = full;
-    if (localGroup != 0) {
-      int64_t delta = localGroup * groupSize;
-      FailureOr<Value> offsetScalar =
-          createScalarOffsetConstant(loc, base.getType(), delta, rewriter);
-      if (failed(offsetScalar)) {
-        return failure();
-      }
-      if (order == "DESC") {
-        adjusted = rewriter
-                       .create<VaddsOp>(loc, resultType, full, *offsetScalar,
-                                        allMask)
-                       .getResult();
-      } else {
-        Value negOffset = isa<FloatType>(base.getType())
-                              ? rewriter.create<arith::NegFOp>(
-                                    loc, *offsetScalar)
-                                    .getResult()
-                              : rewriter
-                                    .create<arith::SubIOp>(
-                                        loc, zeroScalar, *offsetScalar)
-                                    .getResult();
-        adjusted = rewriter
-                       .create<VaddsOp>(loc, resultType, full, negOffset,
-                                        allMask)
-                       .getResult();
-      }
-    }
-    FailureOr<Value> laneMask = createLaneRangeMask(
-        loc, maskType, localGroup * groupSize, (localGroup + 1) * groupSize,
-        rewriter);
-    if (failed(laneMask)) {
-      return failure();
-    }
-    return rewriter
-        .create<VselOp>(loc, resultType, adjusted, result, *laneMask)
-        .getResult();
-  };
   for (int64_t localGroup = 0; localGroup < groupsPerChunk; ++localGroup) {
-    FailureOr<Value> nextResult = materializeGroup(localGroup);
+    FailureOr<Value> nextResult = materializeResidualSubVLGroup(
+        loc, resultType, base, order, full, maskType, zeroScalar, allMask,
+        result, groupSize, localGroup, rewriter);
     if (failed(nextResult)) {
       return failure();
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9092,6 +9092,36 @@ struct OneToNVMIDeinterleaveLoadOpPattern
       VMIDeinterleaveLoadOp>::OneToNOpConversionPattern;
 
 private:
+  struct UnalignedDeinterleaveLoadPair {
+    Value low;
+    Value high;
+    Value updatedBase;
+    Value updatedAlign;
+  };
+
+  FailureOr<UnalignedDeinterleaveLoadPair> materializeUnalignedLoadPair(
+      VMIDeinterleaveLoadOp op, OneToNPatternRewriter &rewriter,
+      Value streamBase, Value streamAlign, Type lowType, Type highType,
+      Value increment) const {
+    if (lowType != highType) {
+      return rewriter.notifyMatchFailure(
+          op, "deinterleave_load requires matching low/high physical types");
+    }
+    auto first = rewriter.create<VldusOp>(
+        op.getLoc(), lowType, streamAlign.getType(), streamBase.getType(),
+        streamBase, streamAlign, increment);
+    auto second = rewriter.create<VldusOp>(
+        op.getLoc(), highType, first.getUpdatedAlign().getType(),
+        first.getUpdatedBase().getType(), first.getUpdatedBase(),
+        first.getUpdatedAlign(), increment);
+    auto deinterleaved = rewriter.create<VdintlvOp>(
+        op.getLoc(), lowType, highType, first.getResult(), second.getResult());
+    return UnalignedDeinterleaveLoadPair{deinterleaved.getLow(),
+                                         deinterleaved.getHigh(),
+                                         second.getUpdatedBase(),
+                                         second.getUpdatedAlign()};
+  }
+
   LogicalResult lowerUnaligned(
       VMIDeinterleaveLoadOp op, OneToNPatternRewriter &rewriter,
       Value source, Value offset, ArrayRef<Type> lowTypes,
@@ -9119,25 +9149,17 @@ private:
     lows.reserve(lowTypes.size());
     highs.reserve(highTypes.size());
     for (size_t index = 0; index < lowTypes.size(); ++index) {
-      Type lowType = lowTypes[index];
-      Type highType = highTypes[index];
-      if (lowType != highType) {
-        return rewriter.notifyMatchFailure(
-            op, "deinterleave_load requires matching low/high physical types");
+      FailureOr<UnalignedDeinterleaveLoadPair> pair =
+          materializeUnalignedLoadPair(op, rewriter, streamBase, streamAlign,
+                                       lowTypes[index], highTypes[index],
+                                       increment);
+      if (failed(pair)) {
+        return failure();
       }
-      auto first = rewriter.create<VldusOp>(
-          op.getLoc(), lowType, streamAlign.getType(), streamBase.getType(),
-          streamBase, streamAlign, increment);
-      auto second = rewriter.create<VldusOp>(
-          op.getLoc(), highType, first.getUpdatedAlign().getType(),
-          first.getUpdatedBase().getType(), first.getUpdatedBase(),
-          first.getUpdatedAlign(), increment);
-      auto deinterleaved = rewriter.create<VdintlvOp>(
-          op.getLoc(), lowType, highType, first.getResult(), second.getResult());
-      lows.push_back(deinterleaved.getLow());
-      highs.push_back(deinterleaved.getHigh());
-      streamBase = second.getUpdatedBase();
-      streamAlign = second.getUpdatedAlign();
+      lows.push_back(pair->low);
+      highs.push_back(pair->high);
+      streamBase = pair->updatedBase;
+      streamAlign = pair->updatedAlign;
     }
     SmallVector<Value> results;
     results.reserve(lows.size() + highs.size());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11884,6 +11884,27 @@ private:
     return success();
   }
 
+  FailureOr<std::optional<VRegType>> getSlots8FirstVRegType(
+      VMIGroupStoreOp op, OpAdaptor adaptor, VMILayoutAttr layout,
+      OneToNPatternRewriter &rewriter) const {
+    ValueRange valueParts = adaptor.getValue();
+    bool hasExpectedArity = static_cast<int64_t>(valueParts.size()) ==
+                            ceilDivNonNegative(layout.getNumGroups(), 8);
+    if (!hasExpectedArity) {
+      rewriter.notifyMatchFailure(op, "slots=8 group_store arity mismatch");
+      return failure();
+    }
+    if (valueParts.empty()) {
+      return std::optional<VRegType>();
+    }
+    auto firstVRegType = dyn_cast<VRegType>(valueParts.front().getType());
+    if (!firstVRegType) {
+      rewriter.notifyMatchFailure(op, "group_store value must be vreg");
+      return failure();
+    }
+    return std::optional<VRegType>(firstVRegType);
+  }
+
   LogicalResult lowerSlots8Dispatch(
       VMIGroupStoreOp op, OpAdaptor adaptor, OneToNPatternRewriter &rewriter,
       VMIVRegType valueVMIType, VMILayoutAttr layout, Value destination,
@@ -11896,22 +11917,16 @@ private:
       return rewriter.notifyMatchFailure(
           op, "slots=8 group_store requires constant unit row_stride");
     }
-    ValueRange valueParts = adaptor.getValue();
-    bool hasExpectedArity = static_cast<int64_t>(valueParts.size()) ==
-                            ceilDivNonNegative(numGroups, 8);
-    if (!hasExpectedArity) {
-      return rewriter.notifyMatchFailure(op, "slots=8 group_store arity mismatch");
+    FailureOr<std::optional<VRegType>> firstVRegType =
+        getSlots8FirstVRegType(op, adaptor, layout, rewriter);
+    if (failed(firstVRegType)) {
+      return failure();
     }
-    if (!valueParts.empty()) {
-      auto firstVRegType = dyn_cast<VRegType>(valueParts.front().getType());
-      if (!firstVRegType) {
-        return rewriter.notifyMatchFailure(op, "group_store value must be vreg");
-      }
-      if (isPackedByteGroupStore(op.getDestination().getType(), firstVRegType)) {
-        return lowerPackedByteSlots8(
-            op, rewriter, valueParts, valueVMIType, layout, destination, offset,
-            rowStride, numGroups, *firstVRegType);
-      }
+    if (*firstVRegType && isPackedByteGroupStore(
+                               op.getDestination().getType(), **firstVRegType)) {
+      return lowerPackedByteSlots8(
+            op, rewriter, adaptor.getValue(), valueVMIType, layout, destination,
+            offset, rowStride, numGroups, **firstVRegType);
     }
     if (layout.hasLaneStride()) {
       return lowerSlots8LaneStride(op, adaptor, rewriter, valueVMIType, layout,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5298,46 +5298,57 @@ FailureOr<SmallVector<Value>> materializeEnsureLayoutConversion(
                                          sourceType.getElementType(), rewriter);
 }
 
-FailureOr<std::pair<Value, Value>>
-createPredicateDintlv(Location loc, Type lowType, Type highType, Value lhs,
-                      Value rhs, PatternRewriter &rewriter) {
+enum class PredicateInterleaveKind { Interleave, Deinterleave };
+
+static FailureOr<std::pair<Value, Value>> createPredicateInterleave(
+    Location loc, Type lowType, Type highType, Value lhs, Value rhs,
+    PredicateInterleaveKind kind, PatternRewriter &rewriter) {
   auto maskType = dyn_cast<MaskType>(lowType);
-  if (!maskType || highType != lowType)
+  if (!maskType || highType != lowType) {
     return failure();
+  }
+  bool deinterleave = kind == PredicateInterleaveKind::Deinterleave;
   if (maskType.isB8()) {
-    auto op = rewriter.create<PdintlvB8Op>(loc, lowType, highType, lhs, rhs);
+    if (deinterleave) {
+      auto op = rewriter.create<PdintlvB8Op>(loc, lowType, highType, lhs, rhs);
+      return std::make_pair(op.getLow(), op.getHigh());
+    }
+    auto op = rewriter.create<PintlvB8Op>(loc, lowType, highType, lhs, rhs);
     return std::make_pair(op.getLow(), op.getHigh());
   }
   if (maskType.isB16()) {
-    auto op = rewriter.create<PdintlvB16Op>(loc, lowType, highType, lhs, rhs);
+    if (deinterleave) {
+      auto op = rewriter.create<PdintlvB16Op>(loc, lowType, highType, lhs, rhs);
+      return std::make_pair(op.getLow(), op.getHigh());
+    }
+    auto op = rewriter.create<PintlvB16Op>(loc, lowType, highType, lhs, rhs);
     return std::make_pair(op.getLow(), op.getHigh());
   }
   if (maskType.isB32()) {
-    auto op = rewriter.create<PdintlvB32Op>(loc, lowType, highType, lhs, rhs);
+    if (deinterleave) {
+      auto op = rewriter.create<PdintlvB32Op>(loc, lowType, highType, lhs, rhs);
+      return std::make_pair(op.getLow(), op.getHigh());
+    }
+    auto op = rewriter.create<PintlvB32Op>(loc, lowType, highType, lhs, rhs);
     return std::make_pair(op.getLow(), op.getHigh());
   }
   return failure();
 }
 
 FailureOr<std::pair<Value, Value>>
+createPredicateDintlv(Location loc, Type lowType, Type highType, Value lhs,
+                      Value rhs, PatternRewriter &rewriter) {
+  return createPredicateInterleave(loc, lowType, highType, lhs, rhs,
+                                   PredicateInterleaveKind::Deinterleave,
+                                   rewriter);
+}
+
+FailureOr<std::pair<Value, Value>>
 createPredicateIntlv(Location loc, Type lowType, Type highType, Value lhs,
                      Value rhs, PatternRewriter &rewriter) {
-  auto maskType = dyn_cast<MaskType>(lowType);
-  if (!maskType || highType != lowType)
-    return failure();
-  if (maskType.isB8()) {
-    auto op = rewriter.create<PintlvB8Op>(loc, lowType, highType, lhs, rhs);
-    return std::make_pair(op.getLow(), op.getHigh());
-  }
-  if (maskType.isB16()) {
-    auto op = rewriter.create<PintlvB16Op>(loc, lowType, highType, lhs, rhs);
-    return std::make_pair(op.getLow(), op.getHigh());
-  }
-  if (maskType.isB32()) {
-    auto op = rewriter.create<PintlvB32Op>(loc, lowType, highType, lhs, rhs);
-    return std::make_pair(op.getLow(), op.getHigh());
-  }
-  return failure();
+  return createPredicateInterleave(loc, lowType, highType, lhs, rhs,
+                                   PredicateInterleaveKind::Interleave,
+                                   rewriter);
 }
 
 static FailureOr<SmallVector<Value>> materializeDeinterleaved2MaskToContiguous(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10782,6 +10782,46 @@ private:
                             rewriter.getStringAttr("PK4_B32"), storeMask);
   }
 
+  LogicalResult emitPackedByteStoreBlocks(
+      VMIGroupStoreOp op, OneToNPatternRewriter &rewriter,
+      ValueRange valueParts, VRegType firstVRegType, MaskType maskType,
+      Value slotIndex, Value destination, Value offset, Value rowStride,
+      int64_t numGroups, bool useDirectPack4) const {
+    SmallVector<Value> statefulValues;
+    SmallVector<int64_t> statefulAdvances;
+    for (int64_t blockStart = 0; blockStart < numGroups; blockStart += 32) {
+      FailureOr<std::tuple<Value, Value, Value>> block =
+          buildPackedByteStoreBlock(
+              op, rewriter, valueParts, firstVRegType, maskType, slotIndex,
+              destination, offset, rowStride, numGroups, blockStart);
+      if (failed(block)) {
+        return failure();
+      }
+      Value merged = std::get<0>(*block);
+      Value storeMask = std::get<1>(*block);
+      Value groupOffset = std::get<2>(*block);
+      if (useDirectPack4) {
+        emitPackedByteDirectStore(op, rewriter, merged, destination,
+                                  groupOffset, storeMask);
+        continue;
+      }
+      FailureOr<Value> statefulValue =
+          buildPackedByteStatefulValue(op, merged, rewriter);
+      if (failed(statefulValue)) {
+        return failure();
+      }
+      statefulValues.push_back(*statefulValue);
+      statefulAdvances.push_back(
+          std::min<int64_t>(32, numGroups - blockStart));
+    }
+    if (!useDirectPack4 &&
+        failed(emitPackedByteStoreStream(op, rewriter, destination, offset,
+                                         statefulValues, statefulAdvances))) {
+      return failure();
+    }
+    return success();
+  }
+
   LogicalResult lowerPackedByteSlots8(
       VMIGroupStoreOp op, OneToNPatternRewriter &rewriter,
       ValueRange valueParts, VMIVRegType valueVMIType, VMILayoutAttr layout,
@@ -10830,40 +10870,13 @@ private:
       return rewriter.notifyMatchFailure(
           op, "failed to create packed group_store lane selector");
     }
-    SmallVector<Value> statefulValues;
-    SmallVector<int64_t> statefulAdvances;
     bool useDirectPack4 = isDirectMemoryDistAddressLegal(
         op.getDestination(), op.getOffset(),
         getMemoryElementType(op.getDestination().getType()), firstVRegType,
         VPTOMemoryOpFamily::Store, "PK4_B32");
-    for (int64_t blockStart = 0; blockStart < numGroups; blockStart += 32) {
-      FailureOr<std::tuple<Value, Value, Value>> block =
-          buildPackedByteStoreBlock(
-              op, rewriter, valueParts, firstVRegType, *maskType, *slotIndex,
-              destination, offset, rowStride, numGroups, blockStart);
-      if (failed(block)) {
-        return failure();
-      }
-      Value merged = std::get<0>(*block);
-      Value storeMask = std::get<1>(*block);
-      Value groupOffset = std::get<2>(*block);
-      if (useDirectPack4) {
-        emitPackedByteDirectStore(op, rewriter, merged, destination,
-                                  groupOffset, storeMask);
-        continue;
-      }
-      FailureOr<Value> statefulValue = buildPackedByteStatefulValue(
-          op, merged, rewriter);
-      if (failed(statefulValue)) {
-        return failure();
-      }
-      statefulValues.push_back(*statefulValue);
-      statefulAdvances.push_back(
-          std::min<int64_t>(32, numGroups - blockStart));
-    }
-    if (!useDirectPack4 &&
-        failed(emitPackedByteStoreStream(op, rewriter, destination, offset,
-                                         statefulValues, statefulAdvances))) {
+    if (failed(emitPackedByteStoreBlocks(
+            op, rewriter, valueParts, firstVRegType, *maskType, *slotIndex,
+            destination, offset, rowStride, numGroups, useDirectPack4))) {
       return failure();
     }
     rewriter.eraseOp(op);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -4504,27 +4504,45 @@ FailureOr<SmallVector<Value>> materializeLaneStrideToContiguous(
       laneStride, rewriter);
 }
 
+static LogicalResult checkGroupSlotLaneStrideContract(
+    Operation *op, ValueRange sourceParts, TypeRange resultTypes,
+    Type elementType, int64_t sourceStride, int64_t resultStride,
+    PatternRewriter &rewriter) {
+  auto fail = [&op, &rewriter](const Twine &message) {
+    (void)rewriter.notifyMatchFailure(op, message);
+    return failure();
+  };
+  bool invalidArity = sourceParts.size() != resultTypes.size() ||
+                     sourceParts.empty();
+  if (invalidArity) {
+    return fail("group-slot lane_stride materialization requires matching "
+                "non-empty source/result physical arity");
+  }
+  bool unsupportedStride =
+      (sourceStride != 1 && sourceStride != 2 && sourceStride != 4) ||
+      (resultStride != 1 && resultStride != 2 && resultStride != 4);
+  if (unsupportedStride) {
+    return fail("unsupported group-slot lane_stride factor");
+  }
+  unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
+  int64_t maxStride = std::max(sourceStride, resultStride);
+  bool unsupportedCarrier =
+      (elementBits != 8 && elementBits != 16) || elementBits * maxStride > 32;
+  if (unsupportedCarrier) {
+    return fail("unsupported group-slot lane_stride carrier shape");
+  }
+  return success();
+}
+
 FailureOr<SmallVector<Value>> materializeGroupSlotLaneStride(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
     Type elementType, int64_t sourceStride, int64_t resultStride,
     PatternRewriter &rewriter) {
-  auto fail = [&op, &rewriter](const Twine &message) -> FailureOr<SmallVector<Value>> {
-    (void)rewriter.notifyMatchFailure(op, message);
+  if (failed(checkGroupSlotLaneStrideContract(
+          op, sourceParts, resultTypes, elementType, sourceStride, resultStride,
+          rewriter))) {
     return failure();
-  };
-
-  if (sourceParts.size() != resultTypes.size() || sourceParts.empty())
-    return fail("group-slot lane_stride materialization requires matching "
-                "non-empty source/result physical arity");
-  if ((sourceStride != 1 && sourceStride != 2 && sourceStride != 4) ||
-      (resultStride != 1 && resultStride != 2 && resultStride != 4))
-    return fail("unsupported group-slot lane_stride factor");
-
-  unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  int64_t maxStride = std::max(sourceStride, resultStride);
-  if ((elementBits != 8 && elementBits != 16) ||
-      elementBits * maxStride > 32)
-    return fail("unsupported group-slot lane_stride carrier shape");
+  }
 
   SmallVector<Value> results;
   results.reserve(resultTypes.size());
@@ -4533,8 +4551,10 @@ FailureOr<SmallVector<Value>> materializeGroupSlotLaneStride(
     FailureOr<Value> result = materializeGroupSlotLaneStridePart(
         op, source, resultType, elementType, sourceStride, resultStride,
         rewriter);
-    if (failed(result))
-      return fail("failed to bitcast group-slot result carrier");
+    if (failed(result)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to bitcast group-slot result carrier");
+    }
     results.push_back(*result);
   }
   return results;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8831,6 +8831,22 @@ private:
                                lanesPerPart, *dist);
   }
 
+  std::optional<std::string> getLoadLaneStrideDist(
+      VMILoadOp op, VMIVRegType resultVMIType,
+      ArrayRef<Type> resultTypes) const {
+    std::optional<std::string> dist =
+        getDenseLaneStrideLoadDistToken(resultVMIType);
+    auto resultType =
+        resultTypes.empty() ? VRegType{} : dyn_cast<VRegType>(resultTypes.front());
+    if (!dist || !resultType ||
+        !isDirectMemoryDistAddressLegal(
+            op.getSource(), op.getOffset(), resultVMIType.getElementType(),
+            resultType, VPTOMemoryOpFamily::Load, *dist)) {
+      return std::nullopt;
+    }
+    return dist;
+  }
+
 public:
 
   LogicalResult
@@ -8841,18 +8857,9 @@ public:
     if (failed(plan)) {
       return failure();
     }
-    std::optional<std::string> laneStrideDist =
-        getDenseLaneStrideLoadDistToken(resultVMIType);
-    auto laneStrideResultType =
-        plan->resultTypes.empty()
-            ? VRegType{}
-            : dyn_cast<VRegType>(plan->resultTypes[0]);
-    bool canUseLaneStrideDist =
-        laneStrideDist && laneStrideResultType &&
-        isDirectMemoryDistAddressLegal(
-            op.getSource(), op.getOffset(), resultVMIType.getElementType(),
-            laneStrideResultType, VPTOMemoryOpFamily::Load, *laneStrideDist);
-    if (canUseLaneStrideDist) {
+    std::optional<StringRef> laneStrideDist =
+        getLoadLaneStrideDist(op, resultVMIType, plan->resultTypes);
+    if (laneStrideDist) {
       return lowerLaneStride(op, rewriter, plan->source, plan->offset,
                              resultVMIType, plan->resultTypes, *laneStrideDist,
                              plan->lanesPerPart);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3222,6 +3222,44 @@ FailureOr<Value> createDenseLaneStrideStorePredicate(
       .getResult();
 }
 
+static FailureOr<std::optional<VMIPhysicalLane>> getShuffleSourcePhysicalLane(
+    VMIVRegType sourceType, VMIVRegType resultType,
+    ArrayRef<int64_t> indices, int64_t resultPart, int64_t resultChunk,
+    int64_t lane, std::string *reason) {
+  auto fail = [&reason](const Twine &message)
+      -> FailureOr<std::optional<VMIPhysicalLane>> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return std::optional<VMIPhysicalLane>();
+  };
+  FailureOr<bool> padding =
+      isPaddingLane(resultType, resultPart, resultChunk, lane);
+  if (failed(padding)) {
+    return fail("failed to classify result padding lanes");
+  }
+  if (*padding) {
+    return std::optional<VMIPhysicalLane>();
+  }
+  FailureOr<int64_t> logicalLane =
+      mapPhysicalLaneToLogical(resultType, resultPart, resultChunk, lane);
+  bool logicalLaneOutOfRange =
+      failed(logicalLane) ||
+      *logicalLane >= static_cast<int64_t>(indices.size());
+  if (logicalLaneOutOfRange) {
+    return fail("failed to map result lane");
+  }
+  FailureOr<VMIPhysicalLane> sourcePhysical =
+      mapLogicalLaneToPhysical(sourceType, indices[*logicalLane]);
+  if (failed(sourcePhysical)) {
+    return fail("failed to map source lane");
+  }
+  if (sourcePhysical->lane != lane) {
+    return fail("requires same-lane physical chunks");
+  }
+  return std::optional<VMIPhysicalLane>(*sourcePhysical);
+}
+
 static FailureOr<int64_t> computeShuffleForwardingSourceChunk(
     VMIVRegType sourceType, VMIVRegType resultType, ArrayRef<int64_t> indices,
     int64_t resultPart, int64_t resultChunk, int64_t lanesPerPart,
@@ -3235,38 +3273,20 @@ static FailureOr<int64_t> computeShuffleForwardingSourceChunk(
   std::optional<int64_t> sourcePart;
   std::optional<int64_t> sourceChunk;
   for (int64_t lane = 0; lane < lanesPerPart; ++lane) {
-    FailureOr<bool> padding =
-        isPaddingLane(resultType, resultPart, resultChunk, lane);
-    if (failed(padding)) {
-      return fail("failed to classify result padding lanes");
+    FailureOr<VMIPhysicalLane> sourcePhysical = getShuffleSourcePhysicalLane(
+        sourceType, resultType, indices, resultPart, resultChunk, lane,
+        reason);
+    if (failed(sourcePhysical)) {
+      return failure();
     }
-    if (*padding) {
+    if (!*sourcePhysical) {
       continue;
     }
-    FailureOr<int64_t> logicalLane =
-        mapPhysicalLaneToLogical(resultType, resultPart, resultChunk, lane);
-    bool logicalLaneOutOfRange =
-        succeeded(logicalLane) &&
-        *logicalLane >= static_cast<int64_t>(indices.size());
-    if (failed(logicalLane)) {
-      return fail("failed to map result lane");
-    }
-    if (logicalLaneOutOfRange) {
-      return fail("failed to map result lane");
-    }
-    FailureOr<VMIPhysicalLane> sourcePhysical =
-        mapLogicalLaneToPhysical(sourceType, indices[*logicalLane]);
-    if (failed(sourcePhysical)) {
-      return fail("failed to map source lane");
-    }
-    if (sourcePhysical->lane != lane) {
-      return fail("requires same-lane physical chunks");
-    }
     if (!sourcePart) {
-      sourcePart = sourcePhysical->part;
-      sourceChunk = sourcePhysical->chunk;
-    } else if (*sourcePart != sourcePhysical->part ||
-               *sourceChunk != sourcePhysical->chunk) {
+      sourcePart = sourcePhysical->value().part;
+      sourceChunk = sourcePhysical->value().chunk;
+    } else if (*sourcePart != sourcePhysical->value().part ||
+               *sourceChunk != sourcePhysical->value().chunk) {
       return fail("requires one source chunk per result chunk");
     }
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10308,6 +10308,31 @@ private:
     return success();
   }
 
+  LogicalResult emitContiguousGroupStorePart(
+      VMIGroupStoreOp op, Value value, int64_t index, int64_t chunksPerGroup,
+      int64_t lanesPerPart, Value destination, Value offset, Value rowStride,
+      OneToNPatternRewriter &rewriter) const {
+    auto vregType = dyn_cast<VRegType>(value.getType());
+    if (!vregType) {
+      return rewriter.notifyMatchFailure(op,
+                                         "group_store value must be vreg");
+    }
+    FailureOr<Value> mask =
+        createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
+    if (failed(mask)) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported element type for group_store mask");
+    }
+    int64_t group = index / chunksPerGroup;
+    int64_t chunkInGroup = index % chunksPerGroup;
+    Value chunkOffset = createGroupChunkOffset(
+        op.getLoc(), offset, rowStride, group, chunkInGroup * lanesPerPart,
+        rewriter);
+    rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{}, value,
+                            destination, chunkOffset, /*dist=*/nullptr, *mask);
+    return success();
+  }
+
   LogicalResult lowerContiguousGroupStore(
       VMIGroupStoreOp op, OpAdaptor adaptor, OneToNPatternRewriter &rewriter,
       VMIVRegType valueVMIType, const VMIGroupStoreLayoutFact &fact,
@@ -10327,25 +10352,11 @@ private:
       return rewriter.notifyMatchFailure(op, "group_store arity mismatch");
     }
     for (auto [index, value] : llvm::enumerate(valueParts)) {
-      auto vregType = dyn_cast<VRegType>(value.getType());
-      if (!vregType) {
-        return rewriter.notifyMatchFailure(op,
-                                           "group_store value must be vreg");
+      if (failed(emitContiguousGroupStorePart(
+              op, value, index, chunksPerGroup, lanesPerPart, destination,
+              offset, rowStride, rewriter))) {
+        return failure();
       }
-      FailureOr<Value> mask =
-          createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
-      if (failed(mask)) {
-        return rewriter.notifyMatchFailure(
-            op, "unsupported element type for group_store mask");
-      }
-      int64_t group = index / chunksPerGroup;
-      int64_t chunkInGroup = index % chunksPerGroup;
-      Value chunkOffset = createGroupChunkOffset(
-          op.getLoc(), offset, rowStride, group, chunkInGroup * lanesPerPart,
-          rewriter);
-      rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{}, value,
-                              destination, chunkOffset, /*dist=*/nullptr,
-                              *mask);
     }
     rewriter.eraseOp(op);
     return success();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10632,6 +10632,26 @@ private:
     return std::make_tuple(merged, *storeMask, groupOffset);
   }
 
+  FailureOr<Value> buildPackedByteStatefulValue(
+      VMIGroupStoreOp op, Value merged,
+      OneToNPatternRewriter &rewriter) const {
+    MLIRContext *ctx = rewriter.getContext();
+    auto ui16 = IntegerType::get(
+        ctx, 16, IntegerType::SignednessSemantics::Unsigned);
+    auto ui8 = IntegerType::get(
+        ctx, 8, IntegerType::SignednessSemantics::Unsigned);
+    auto packed16Type = VRegType::get(ctx, 128, ui16);
+    auto packed8Type = VRegType::get(ctx, 256, ui8);
+    Value packed16 = rewriter
+                         .create<VpackOp>(op.getLoc(), packed16Type, merged,
+                                          rewriter.getStringAttr("LOWER"))
+                         .getResult();
+    return rewriter
+        .create<VpackOp>(op.getLoc(), packed8Type, packed16,
+                         rewriter.getStringAttr("LOWER"))
+        .getResult();
+  }
+
   LogicalResult lowerPackedByteSlots8(
       VMIGroupStoreOp op, OneToNPatternRewriter &rewriter,
       ValueRange valueParts, VMIVRegType valueVMIType, VMILayoutAttr layout,
@@ -10703,22 +10723,12 @@ private:
                                 rewriter.getStringAttr("PK4_B32"), storeMask);
         continue;
       }
-      MLIRContext *ctx = rewriter.getContext();
-      auto ui16 = IntegerType::get(
-          ctx, 16, IntegerType::SignednessSemantics::Unsigned);
-      auto ui8 = IntegerType::get(
-          ctx, 8, IntegerType::SignednessSemantics::Unsigned);
-      auto packed16Type = VRegType::get(ctx, 128, ui16);
-      auto packed8Type = VRegType::get(ctx, 256, ui8);
-      Value packed16 = rewriter
-                           .create<VpackOp>(op.getLoc(), packed16Type, merged,
-                                            rewriter.getStringAttr("LOWER"))
-                           .getResult();
-      statefulValues.push_back(
-          rewriter
-              .create<VpackOp>(op.getLoc(), packed8Type, packed16,
-                               rewriter.getStringAttr("LOWER"))
-              .getResult());
+      FailureOr<Value> statefulValue = buildPackedByteStatefulValue(
+          op, merged, rewriter);
+      if (failed(statefulValue)) {
+        return failure();
+      }
+      statefulValues.push_back(*statefulValue);
       statefulAdvances.push_back(activeGroups);
     }
     if (!useDirectPack4 &&

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5048,9 +5048,9 @@ static FailureOr<SmallVector<Value>> materializeDeinterleaved2ToContiguous(
   return results;
 }
 
-static FailureOr<SmallVector<Value>> materializeContiguousToDeinterleaved2(
+static LogicalResult validateContiguousToDeinterleaved2Shape(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
-    PatternRewriter &rewriter) {
+    PatternRewriter &rewriter, int64_t &groups) {
   bool invalidResult = sourceParts.empty() || resultTypes.empty() ||
                        resultTypes.size() % 2 != 0;
   if (invalidResult) {
@@ -5058,13 +5058,38 @@ static FailureOr<SmallVector<Value>> materializeContiguousToDeinterleaved2(
         op, "contiguous to deinterleaved=2 materialization requires at least "
             "one source part and 2*N result parts");
   }
-  int64_t groups = resultTypes.size() / 2;
+  groups = resultTypes.size() / 2;
   bool sourceExceedsResult =
       sourceParts.size() > static_cast<size_t>(2 * groups);
   if (sourceExceedsResult) {
     return rewriter.notifyMatchFailure(
         op, "contiguous to deinterleaved=2 materialization source footprint "
             "exceeds result arity");
+  }
+  return success();
+}
+
+static FailureOr<std::pair<Value, Value>> materializeContiguousToDeinterleaved2Group(
+    Operation *op, Value lhs, Value rhs, Type lowType, Type highType,
+    PatternRewriter &rewriter) {
+  bool mismatchedTypes = lhs.getType() != rhs.getType() ||
+                         lhs.getType() != lowType || lhs.getType() != highType;
+  if (mismatchedTypes) {
+    return rewriter.notifyMatchFailure(
+        op, "vdintlv requires operands and results to share one type");
+  }
+  auto materialize = rewriter.create<VdintlvOp>(op->getLoc(), lowType, highType,
+                                                 lhs, rhs);
+  return std::make_pair(materialize.getLow(), materialize.getHigh());
+}
+
+static FailureOr<SmallVector<Value>> materializeContiguousToDeinterleaved2(
+    Operation *op, ValueRange sourceParts, TypeRange resultTypes,
+    PatternRewriter &rewriter) {
+  int64_t groups = 0;
+  if (failed(validateContiguousToDeinterleaved2Shape(
+          op, sourceParts, resultTypes, rewriter, groups))) {
+    return failure();
   }
   SmallVector<Value> part0;
   SmallVector<Value> part1;
@@ -5081,17 +5106,14 @@ static FailureOr<SmallVector<Value>> materializeContiguousToDeinterleaved2(
                                                           : lhsIndex;
     Value lhs = sourceParts[lhsIndex];
     Value rhs = sourceParts[rhsIndex];
-    bool mismatchedTypes = lhs.getType() != rhs.getType() ||
-                           lhs.getType() != resultTypes[i] ||
-                           lhs.getType() != resultTypes[groups + i];
-    if (mismatchedTypes) {
-      return rewriter.notifyMatchFailure(
-          op, "vdintlv requires operands and results to share one type");
+    FailureOr<std::pair<Value, Value>> materialize =
+        materializeContiguousToDeinterleaved2Group(
+            op, lhs, rhs, resultTypes[i], resultTypes[groups + i], rewriter);
+    if (failed(materialize)) {
+      return failure();
     }
-    auto materialize = rewriter.create<VdintlvOp>(
-        op->getLoc(), resultTypes[i], resultTypes[groups + i], lhs, rhs);
-    part0.push_back(materialize.getLow());
-    part1.push_back(materialize.getHigh());
+    part0.push_back(materialize->first);
+    part1.push_back(materialize->second);
   }
   SmallVector<Value> results;
   results.reserve(resultTypes.size());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -19964,10 +19964,18 @@ static LogicalResult checkGroupBroadcastLogicalContract(
     return fail("supports only slots=8 or slots=1 group_broadcast source "
                 "layouts");
   }
+  return success();
+}
+
+static LogicalResult checkGroupBroadcastSupportContract(
+    VMIGroupBroadcastOp op, std::string *reason) {
   VMILayoutSupport supports;
   std::string supportReason;
   if (failed(supports.getGroupBroadcastSupport(op, &supportReason))) {
-    return fail(supportReason);
+    if (reason) {
+      *reason = supportReason;
+    }
+    return failure();
   }
   return success();
 }
@@ -19989,6 +19997,9 @@ static FailureOr<GroupBroadcastShapePlan> buildGroupBroadcastShapePlan(
   if (failed(checkGroupBroadcastLogicalContract(
           op, sourceType, resultType, sourceLayout, resultLayout, numGroups,
           reason))) {
+    return failure();
+  }
+  if (failed(checkGroupBroadcastSupportContract(op, reason))) {
     return failure();
   }
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -17831,6 +17831,60 @@ struct ActivePrefixIndexShapePlan {
   VMIVRegType resultType;
 };
 
+static LogicalResult checkActivePrefixIndexLayouts(
+    VMIMaskType maskType, VMIVRegType resultType, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  VMILayoutAttr maskLayout = maskType.getLayoutAttr();
+  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
+  if (!maskLayout || !resultLayout)
+  {
+    return fail("requires assigned mask and result layouts");
+  }
+  if (!maskLayout.isContiguous() || !resultLayout.isContiguous())
+  {
+    return fail("requires contiguous mask and result layouts");
+  }
+  return success();
+}
+
+static LogicalResult checkActivePrefixIndexPhysicalChunks(
+    VMIMaskType maskType, VMIVRegType resultType, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  std::string resultFullReason;
+  if (failed(checkFullDataPhysicalChunks(resultType, &resultFullReason))) {
+    return fail(Twine("requires full result physical chunks so padding mask "
+                      "lanes cannot affect the observable prefix; ") +
+                resultFullReason);
+  }
+  std::string maskFullReason;
+  if (failed(checkFullVMIPhysicalChunks(maskType, &maskFullReason))) {
+    return fail(Twine("requires full mask physical chunks so padding mask "
+                      "lanes cannot affect the observable prefix; ") +
+                maskFullReason);
+  }
+  FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
+  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
+  if (failed(maskArity) || failed(resultArity))
+  {
+    return fail("requires computable mask and result physical arity");
+  }
+  if (*maskArity != 1 || *resultArity != 1) {
+    return fail("requires a single physical chunk; multi-chunk prefix needs "
+                "cross-chunk carry");
+  }
+  return success();
+}
+
 static FailureOr<ActivePrefixIndexShapePlan> buildActivePrefixIndexShapePlan(
     VMIActivePrefixIndexOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message)
@@ -17843,32 +17897,13 @@ static FailureOr<ActivePrefixIndexShapePlan> buildActivePrefixIndexShapePlan(
 
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
-  VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!maskLayout || !resultLayout)
-    return fail("requires assigned mask and result layouts");
-  if (!maskLayout.isContiguous() || !resultLayout.isContiguous())
-    return fail("requires contiguous mask and result layouts");
-
-  std::string resultFullReason;
-  if (failed(checkFullDataPhysicalChunks(resultType, &resultFullReason)))
-    return fail(Twine("requires full result physical chunks so padding mask "
-                      "lanes cannot affect the observable prefix; ") +
-                resultFullReason);
-
-  std::string maskFullReason;
-  if (failed(checkFullVMIPhysicalChunks(maskType, &maskFullReason)))
-    return fail(Twine("requires full mask physical chunks so padding mask "
-                      "lanes cannot affect the observable prefix; ") +
-                maskFullReason);
-
-  FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
-  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(maskArity) || failed(resultArity))
-    return fail("requires computable mask and result physical arity");
-  if (*maskArity != 1 || *resultArity != 1)
-    return fail("requires a single physical chunk; multi-chunk prefix needs "
-                "cross-chunk carry");
+  bool invalidActivePrefixShape =
+      failed(checkActivePrefixIndexLayouts(maskType, resultType, reason)) ||
+      failed(checkActivePrefixIndexPhysicalChunks(maskType, resultType,
+                                                  reason));
+  if (invalidActivePrefixShape) {
+    return failure();
+  }
 
   return ActivePrefixIndexShapePlan{maskType, resultType};
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18403,22 +18403,20 @@ std::optional<WalkResult> verifySupportedVMIStructuredStoreOp(Operation *op) {
   return std::nullopt;
 }
 
+static LogicalResult checkSupportedVMIStoreShape(VMIStoreOp op,
+                                                 std::string *reason) {
+  return checkSupportedStoreShape(
+      cast<VMIVRegType>(op.getValue().getType()), op.getDestination(),
+      op.getDestination().getType(), reason);
+}
+
 std::optional<WalkResult> verifySupportedVMIMemoryStoreOp(Operation *op) {
   if (auto store = dyn_cast<VMIStoreOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedStoreShape(
-            cast<VMIVRegType>(store.getValue().getType()),
-            store.getDestination(), store.getDestination().getType(),
-            &reason))) {
-      return WalkResult::advance();
-    }
-    store.emitError()
-        << kVMIDiagUnsupportedPrefix
-        << "pto.vmi.store requires an 8/16/32-bit predicate-maskable element "
-           "type and either full physical chunks or contiguous tail-store "
-           "layout, with UB-backed destination ("
-        << reason << ")";
-    return WalkResult::interrupt();
+    return verifySupportedShapeOp(
+        store, checkSupportedVMIStoreShape,
+        "pto.vmi.store requires an 8/16/32-bit predicate-maskable element "
+        "type and either full physical chunks or contiguous tail-store "
+        "layout, with UB-backed destination (");
   }
   if (auto structuredResult = verifySupportedVMIStructuredStoreOp(op);
       structuredResult.has_value()) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7318,17 +7318,10 @@ private:
                                                    factor, part, rewriter);
       for (int64_t chunk = 0; chunk < chunksPerPart; ++chunk) {
         Type resultType = resultTypes[part * chunksPerPart + chunk];
-        auto maskType = dyn_cast<MaskType>(resultType);
-        if (!maskType) {
-          return rewriter.notifyMatchFailure(
-              op, "create_mask result must be mask");
-        }
         FailureOr<std::pair<Value, Value>> maskAndRemaining =
-            createRuntimePrefixMask(op.getLoc(), maskType, remaining,
-                                    rewriter);
+            buildDynamicMaskChunk(op, resultType, remaining, rewriter);
         if (failed(maskAndRemaining)) {
-          return rewriter.notifyMatchFailure(
-              op, "unsupported mask type for dynamic create_mask");
+          return failure();
         }
         results.push_back(maskAndRemaining->first);
         remaining = maskAndRemaining->second;
@@ -7365,6 +7358,22 @@ private:
       }
     }
     return std::make_pair(anyLane, activeInChunk);
+  }
+
+  FailureOr<std::pair<Value, Value>> buildDynamicMaskChunk(
+      VMICreateMaskOp op, Type resultType, Value remaining,
+      OneToNPatternRewriter &rewriter) const {
+    auto maskType = dyn_cast<MaskType>(resultType);
+    if (!maskType) {
+      return rewriter.notifyMatchFailure(op, "create_mask result must be mask");
+    }
+    FailureOr<std::pair<Value, Value>> maskAndRemaining =
+        createRuntimePrefixMask(op.getLoc(), maskType, remaining, rewriter);
+    if (failed(maskAndRemaining)) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported mask type for dynamic create_mask");
+    }
+    return *maskAndRemaining;
   }
 
   LogicalResult lowerConstantMask(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8327,13 +8327,69 @@ private:
     return success();
   }
 
+  FailureOr<SmallVector<Value>> materializeAlignedContiguousParts(
+      VMILoadOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value offset, ArrayRef<Type> contiguousTypes, int64_t lanesPerPart) const {
+    SmallVector<Value> parts;
+    parts.reserve(contiguousTypes.size());
+    for (auto [index, resultType] : llvm::enumerate(contiguousTypes)) {
+      if (!isa<VRegType>(resultType)) {
+        return rewriter.notifyMatchFailure(op, "load result must be vreg");
+      }
+      Value chunkOffset = createChunkOffset(
+          op.getLoc(), offset, index * lanesPerPart, rewriter);
+      parts.push_back(rewriter
+                          .create<VldsOp>(op.getLoc(), resultType,
+                                          /*updated_base=*/Type{}, source,
+                                          chunkOffset, /*dist=*/nullptr)
+                          .getResult());
+    }
+    return parts;
+  }
+
+  FailureOr<SmallVector<Value>> materializeUnalignedContiguousParts(
+      VMILoadOp op, OneToNPatternRewriter &rewriter, Value source, Value offset,
+      ArrayRef<Type> contiguousTypes, int64_t lanesPerPart) const {
+    Value unalignedBase = materializeBufferPointer(
+        source, getMemoryElementType(source.getType()),
+        getMemorySpace(source.getType()), rewriter, op.getLoc());
+    if (!unalignedBase) {
+      return rewriter.notifyMatchFailure(
+          op, "continuous unaligned load requires a ptr-compatible source");
+    }
+    unalignedBase = rewriter
+                        .create<AddPtrOp>(op.getLoc(), unalignedBase.getType(),
+                                          unalignedBase, offset)
+                        .getResult();
+    Value unalignedAlign = rewriter
+                               .create<VldasOp>(
+                                   op.getLoc(),
+                                   AlignType::get(rewriter.getContext()),
+                                   unalignedBase)
+                               .getResult();
+    SmallVector<Value> parts;
+    parts.reserve(contiguousTypes.size());
+    for (Type resultType : contiguousTypes) {
+      if (!isa<VRegType>(resultType)) {
+        return rewriter.notifyMatchFailure(op, "load result must be vreg");
+      }
+      Value increment =
+          rewriter.create<arith::ConstantIndexOp>(op.getLoc(), lanesPerPart);
+      auto load = rewriter.create<VldusOp>(
+          op.getLoc(), resultType, unalignedAlign.getType(),
+          unalignedBase.getType(), unalignedBase, unalignedAlign, increment);
+      parts.push_back(load.getResult());
+      unalignedAlign = load.getUpdatedAlign();
+      unalignedBase = load.getUpdatedBase();
+    }
+    return parts;
+  }
+
   LogicalResult lowerContiguous(
       VMILoadOp op, OneToNPatternRewriter &rewriter, Value source,
       Value offset, VMIVRegType resultVMIType, ArrayRef<Type> resultTypes,
       ArrayRef<Type> contiguousTypes, int64_t lanesPerPart,
       VMILayoutAttr contiguousLayout) const {
-    SmallVector<Value> contiguousParts;
-    contiguousParts.reserve(contiguousTypes.size());
     auto firstContiguousType = contiguousTypes.empty()
                                     ? VRegType{}
                                     : dyn_cast<VRegType>(contiguousTypes.front());
@@ -8342,51 +8398,17 @@ private:
         isDirectMemoryDistAddressLegal(
             op.getSource(), op.getOffset(), resultVMIType.getElementType(),
             firstContiguousType, VPTOMemoryOpFamily::Load, "NORM");
-    Value unalignedBase;
-    Value unalignedAlign;
-    if (!useAlignedAccess) {
-      unalignedBase = materializeBufferPointer(
-          source, resultVMIType.getElementType(),
-          getMemorySpace(source.getType()), rewriter, op.getLoc());
-      if (!unalignedBase) {
-        return rewriter.notifyMatchFailure(
-            op, "continuous unaligned load requires a ptr-compatible source");
-      }
-      unalignedBase = rewriter
-                          .create<AddPtrOp>(op.getLoc(), unalignedBase.getType(),
-                                            unalignedBase, offset)
-                          .getResult();
-      unalignedAlign = rewriter
-                           .create<VldasOp>(
-                               op.getLoc(), AlignType::get(rewriter.getContext()),
-                               unalignedBase)
-                           .getResult();
-    }
-    for (auto [index, resultType] : llvm::enumerate(contiguousTypes)) {
-      if (!isa<VRegType>(resultType)) {
-        return rewriter.notifyMatchFailure(op, "load result must be vreg");
-      }
-      if (useAlignedAccess) {
-        Value chunkOffset = createChunkOffset(
-            op.getLoc(), offset, index * lanesPerPart, rewriter);
-        contiguousParts.push_back(
-            rewriter
-                .create<VldsOp>(op.getLoc(), resultType, /*updated_base=*/Type{},
-                                source, chunkOffset, /*dist=*/nullptr)
-                .getResult());
-        continue;
-      }
-      Value increment =
-          rewriter.create<arith::ConstantIndexOp>(op.getLoc(), lanesPerPart);
-      auto load = rewriter.create<VldusOp>(
-          op.getLoc(), resultType, unalignedAlign.getType(),
-          unalignedBase.getType(), unalignedBase, unalignedAlign, increment);
-      contiguousParts.push_back(load.getResult());
-      unalignedAlign = load.getUpdatedAlign();
-      unalignedBase = load.getUpdatedBase();
+    FailureOr<SmallVector<Value>> contiguousParts =
+        useAlignedAccess
+            ? materializeAlignedContiguousParts(
+                  op, rewriter, source, offset, contiguousTypes, lanesPerPart)
+            : materializeUnalignedContiguousParts(
+                  op, rewriter, source, offset, contiguousTypes, lanesPerPart);
+    if (failed(contiguousParts)) {
+      return failure();
     }
     FailureOr<SmallVector<Value>> results = materializeDataLayoutConversion(
-        op, contiguousParts, resultTypes, contiguousLayout,
+        op, *contiguousParts, resultTypes, contiguousLayout,
         resultVMIType.getLayoutAttr(), resultVMIType.getElementType(),
         rewriter);
     if (failed(results)) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -4904,29 +4904,48 @@ static FailureOr<SmallVector<Value>> materializeContiguousToDeinterleaved4(
   return results;
 }
 
+enum class Deinterleaved4LayoutDirection {
+  Unsupported,
+  ToContiguous,
+  FromContiguous
+};
+
+static Deinterleaved4LayoutDirection getDeinterleaved4LayoutDirection(
+    VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout) {
+  bool sourceIsDeinterleaved4 =
+      sourceLayout && sourceLayout.isDeinterleaved() &&
+      sourceLayout.getFactor() == 4 && sourceLayout.getLaneStride() == 1;
+  bool resultIsDeinterleaved4 =
+      resultLayout && resultLayout.isDeinterleaved() &&
+      resultLayout.getFactor() == 4 && resultLayout.getLaneStride() == 1;
+  bool toContiguous = sourceIsDeinterleaved4 && resultLayout &&
+                      resultLayout.isContiguous() &&
+                      resultLayout.getLaneStride() == 1;
+  if (toContiguous) {
+    return Deinterleaved4LayoutDirection::ToContiguous;
+  }
+  bool fromContiguous = sourceLayout && sourceLayout.isContiguous() &&
+                        sourceLayout.getLaneStride() == 1 &&
+                        resultIsDeinterleaved4;
+  if (fromContiguous) {
+    return Deinterleaved4LayoutDirection::FromContiguous;
+  }
+  return Deinterleaved4LayoutDirection::Unsupported;
+}
+
 FailureOr<std::optional<SmallVector<Value>>> materializeDeinterleaved4Layout(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
     VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
     PatternRewriter &rewriter) {
-  auto isElementDeinterleaved = [](VMILayoutAttr layout) {
-    return layout.isDeinterleaved() && layout.getFactor() == 4 &&
-           layout.getLaneStride() == 1;
-  };
-  bool toContiguous = sourceLayout && sourceLayout.isDeinterleaved() &&
-                      isElementDeinterleaved(sourceLayout) && resultLayout &&
-                      resultLayout.isContiguous() &&
-                      resultLayout.getLaneStride() == 1;
-  bool fromContiguous = sourceLayout && sourceLayout.isContiguous() &&
-                        sourceLayout.getLaneStride() == 1 && resultLayout &&
-                        resultLayout.isDeinterleaved() &&
-                        isElementDeinterleaved(resultLayout);
-  if (!toContiguous && !fromContiguous) {
+  Deinterleaved4LayoutDirection direction =
+      getDeinterleaved4LayoutDirection(sourceLayout, resultLayout);
+  if (direction == Deinterleaved4LayoutDirection::Unsupported) {
     return std::nullopt;
   }
   bool missingParts = sourceParts.empty() || resultTypes.empty();
   if (missingParts) {
     (void)rewriter.notifyMatchFailure(
-        op, toContiguous
+        op, direction == Deinterleaved4LayoutDirection::ToContiguous
                 ? "deinterleaved=4 to contiguous materialization requires "
                   "at least one source and result part"
                 : "contiguous to deinterleaved=4 materialization requires "
@@ -4934,7 +4953,7 @@ FailureOr<std::optional<SmallVector<Value>>> materializeDeinterleaved4Layout(
     return failure();
   }
 
-  if (toContiguous) {
+  if (direction == Deinterleaved4LayoutDirection::ToContiguous) {
     FailureOr<SmallVector<Value>> results =
         materializeDeinterleaved4ToContiguous(op, sourceParts, resultTypes,
                                               rewriter);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6061,6 +6061,15 @@ FailureOr<SmallVector<Value>> materializeMaskGranularityConversion(
                                          rewriter);
 }
 
+static SmallVector<Type> repeatMaskPartType(Type partType, int64_t arity) {
+  SmallVector<Type> types;
+  types.reserve(arity);
+  for (int64_t i = 0; i < arity; ++i) {
+    types.push_back(partType);
+  }
+  return types;
+}
+
 FailureOr<SmallVector<Type>> getConvertedMaskPartTypes(VMIMaskType type) {
   FailureOr<int64_t> arity = getVMIPhysicalArity(type);
   FailureOr<StringRef> physicalGranularity =
@@ -6070,12 +6079,8 @@ FailureOr<SmallVector<Type>> getConvertedMaskPartTypes(VMIMaskType type) {
   if (invalidMaskTypes) {
     return failure();
   }
-  SmallVector<Type> types;
-  types.reserve(*arity);
   Type partType = MaskType::get(type.getContext(), *physicalGranularity);
-  for (int64_t i = 0; i < *arity; ++i)
-    types.push_back(partType);
-  return types;
+  return repeatMaskPartType(partType, *arity);
 }
 
 static FailureOr<VMILayoutAttr>

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18134,16 +18134,18 @@ LogicalResult verifyNoResidualVMIIR(ModuleOp module) {
 LogicalResult checkSupportedExtFShape(VMIExtFOp op,
                                       std::string *reason = nullptr) {
   VMILayoutSupport supports;
-  if (failed(supports.getExtFSupport(op, reason)))
+  if (failed(supports.getExtFSupport(op, reason))) {
     return failure();
+  }
   return success();
 }
 
 LogicalResult checkSupportedTruncFShape(VMITruncFOp op,
                                         std::string *reason = nullptr) {
   VMILayoutSupport supports;
-  if (failed(supports.getTruncFSupport(op, reason)))
+  if (failed(supports.getTruncFSupport(op, reason))) {
     return failure();
+  }
   return success();
 }
 
@@ -18189,15 +18191,17 @@ LogicalResult checkSupportedFPToIntShape(OpTy op, StringRef conversionName,
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !resultLayout)
+  if (!sourceLayout || !resultLayout) {
     return fail("requires assigned source/result layouts");
+  }
 
   Type srcElem = sourceType.getElementType();
   Type dstElem = resultType.getElementType();
   auto contract = lookup(srcElem, dstElem);
-  if (!contract)
+  if (!contract) {
     return fail(Twine("unsupported ") + conversionName +
                 " conversion element type pair");
+  }
 
   unsigned srcBits = pto::getPTOStorageElemBitWidth(srcElem);
   unsigned dstBits = pto::getPTOStorageElemBitWidth(dstElem);
@@ -18214,8 +18218,9 @@ LogicalResult checkSupportedFPToIntShape(OpTy op, StringRef conversionName,
     FailureOr<VMICastLayoutFact> fact =
         layoutSupport.getCastLayoutFactForLayouts(
             sourceType, resultType, sourceLayout, resultLayout, reason);
-    if (failed(fact))
+    if (failed(fact)) {
       return failure();
+    }
   }
 
   return success();
@@ -18509,12 +18514,12 @@ static LogicalResult checkActivePrefixIndexLayouts(
   };
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!maskLayout || !resultLayout)
-  {
+  if (!maskLayout || !resultLayout) {
     return fail("requires assigned mask and result layouts");
   }
-  if (!maskLayout.isContiguous() || !resultLayout.isContiguous())
-  {
+  bool nonContiguousLayout = !maskLayout.isContiguous() ||
+                             !resultLayout.isContiguous();
+  if (nonContiguousLayout) {
     return fail("requires contiguous mask and result layouts");
   }
   return success();
@@ -18542,8 +18547,8 @@ static LogicalResult checkActivePrefixIndexPhysicalChunks(
   }
   FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(maskArity) || failed(resultArity))
-  {
+  bool missingArity = failed(maskArity) || failed(resultArity);
+  if (missingArity) {
     return fail("requires computable mask and result physical arity");
   }
   if (*maskArity != 1 || *resultArity != 1) {
@@ -18680,8 +18685,9 @@ LogicalResult checkSupportedCompressStoreShape(
     VMICompressStoreOp op,
     std::string *reason = nullptr) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -18794,7 +18800,7 @@ static FailureOr<ReducePhysicalShapePlan> buildReducePhysicalShapePlan(
   }
 
   std::string fullChunkReason;
-  if (failed(checkFullDataPhysicalChunks(sourceType, &fullChunkReason)))
+  if (failed(checkFullDataPhysicalChunks(sourceType, &fullChunkReason))) {
     return fail(Twine("requires full source physical chunks so padding lanes "
                       "do not participate in the reduction; ") +
                 fullChunkReason);
@@ -18836,23 +18842,29 @@ LogicalResult
 checkSupportedGroupReduceShape(OpTy op, std::string *reason = nullptr) {
   VMILayoutSupport supports;
   if constexpr (std::is_same_v<OpTy, VMIGroupReduceAddFOp>) {
-    if (succeeded(supports.getGroupReduceAddFSupport(op, reason)))
+    if (succeeded(supports.getGroupReduceAddFSupport(op, reason))) {
       return success();
+    }
   } else if constexpr (std::is_same_v<OpTy, VMIGroupReduceMaxFOp>) {
-    if (succeeded(supports.getGroupReduceMaxFSupport(op, reason)))
+    if (succeeded(supports.getGroupReduceMaxFSupport(op, reason))) {
       return success();
+    }
   } else if constexpr (std::is_same_v<OpTy, VMIGroupReduceMaxIOp>) {
-    if (succeeded(supports.getGroupReduceMaxISupport(op, reason)))
+    if (succeeded(supports.getGroupReduceMaxISupport(op, reason))) {
       return success();
+    }
   } else if constexpr (std::is_same_v<OpTy, VMIGroupReduceMinFOp>) {
-    if (succeeded(supports.getGroupReduceMinFSupport(op, reason)))
+    if (succeeded(supports.getGroupReduceMinFSupport(op, reason))) {
       return success();
+    }
   } else if constexpr (std::is_same_v<OpTy, VMIGroupReduceMinIOp>) {
-    if (succeeded(supports.getGroupReduceMinISupport(op, reason)))
+    if (succeeded(supports.getGroupReduceMinISupport(op, reason))) {
       return success();
+    }
   } else {
-    if (succeeded(supports.getGroupReduceAddISupport(op, reason)))
+    if (succeeded(supports.getGroupReduceAddISupport(op, reason))) {
       return success();
+    }
   }
   return failure();
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9564,6 +9564,47 @@ static LogicalResult lowerGroupSlotLoadSlots8(
   return success();
 }
 
+static LogicalResult emitGroupSlotLoadSlots1Chunk(
+    Operation *op, Value source, Value offset, Value sourceGroupStride,
+    Type resultType, int64_t group, OneToNPatternRewriter &rewriter,
+    SmallVectorImpl<Value> &results) {
+  FailureOr<GroupSlotLoadResultPart> resultPart =
+      getGroupSlotLoadResultPart(op, resultType, rewriter);
+  if (failed(resultPart)) {
+    return failure();
+  }
+  FailureOr<Value> oneBlockMask = createPrefixMask(
+      op->getLoc(), resultPart->maskType, "PAT_VL1", rewriter);
+  if (failed(oneBlockMask)) {
+    return rewriter.notifyMatchFailure(op, "failed to create group_slot_load mask");
+  }
+  Value groupOffset = offset;
+  if (group != 0) {
+    Value groupIndex =
+        rewriter.create<arith::ConstantIndexOp>(op->getLoc(), group);
+    Value rowOffset = rewriter
+                          .create<arith::MulIOp>(op->getLoc(),
+                                                 sourceGroupStride, groupIndex)
+                          .getResult();
+    groupOffset = rewriter
+                      .create<arith::AddIOp>(op->getLoc(), groupOffset,
+                                             rowOffset)
+                      .getResult();
+  }
+  Value slotBase = rewriter
+                       .create<AddPtrOp>(op->getLoc(), source.getType(), source,
+                                         groupOffset)
+                       .getResult();
+  auto zeroI16 = rewriter.create<arith::ConstantIntOp>(op->getLoc(), 0, 16);
+  results.push_back(
+      rewriter
+          .create<VsldbOp>(op->getLoc(), resultPart->valueType,
+                          /*updated_base=*/Type{}, slotBase, zeroI16, zeroI16,
+                          *oneBlockMask)
+          .getResult());
+  return success();
+}
+
 static LogicalResult lowerGroupSlotLoadSlots1(
     Operation *op, Value source, Value offset, Value sourceGroupStride,
     VMIVRegType resultVMIType, TypeRange resultTypes,
@@ -9585,46 +9626,12 @@ static LogicalResult lowerGroupSlotLoadSlots1(
                 Twine(alignedStrideElems) +
                 " elements for 32B lane-0 vsldb alignment");
   }
-  auto makeI16 = [&rewriter, &op](int64_t value) -> Value {
-    return rewriter.create<arith::ConstantIntOp>(op->getLoc(), value, 16);
-  };
-  auto makePtr = [&rewriter, &source, &op](Value elementOffset) -> Value {
-    return rewriter
-        .create<AddPtrOp>(op->getLoc(), source.getType(), source, elementOffset)
-        .getResult();
-  };
-  Value zeroI16 = makeI16(0);
   for (auto [group, resultType] : llvm::enumerate(resultTypes)) {
-    FailureOr<GroupSlotLoadResultPart> resultPart =
-        getGroupSlotLoadResultPart(op, resultType, rewriter);
-    if (failed(resultPart)) {
+    if (failed(emitGroupSlotLoadSlots1Chunk(
+            op, source, offset, sourceGroupStride, resultType,
+            static_cast<int64_t>(group), rewriter, results))) {
       return failure();
     }
-    FailureOr<Value> oneBlockMask =
-        createPrefixMask(op->getLoc(), resultPart->maskType, "PAT_VL1",
-                         rewriter);
-    if (failed(oneBlockMask)) {
-      return rewriter.notifyMatchFailure(
-          op, "failed to create group_slot_load mask");
-    }
-    Value groupOffset = offset;
-    if (group != 0) {
-      Value groupIndex =
-          rewriter.create<arith::ConstantIndexOp>(op->getLoc(), group);
-      Value rowOffset = rewriter
-                            .create<arith::MulIOp>(
-                                op->getLoc(), sourceGroupStride, groupIndex)
-                            .getResult();
-      groupOffset =
-          rewriter.create<arith::AddIOp>(op->getLoc(), groupOffset, rowOffset)
-              .getResult();
-    }
-    Value slotBase = makePtr(groupOffset);
-    results.push_back(rewriter
-                          .create<VsldbOp>(op->getLoc(), resultPart->valueType,
-                                           /*updated_base=*/Type{}, slotBase,
-                                           zeroI16, zeroI16, *oneBlockMask)
-                          .getResult());
   }
   return success();
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5187,20 +5187,36 @@ materializeDataLayoutViaContiguous(
   return std::optional<SmallVector<Value>>(std::move(*results));
 }
 
+struct DataLayoutMaterializationContext {
+  Operation *op;
+  ValueRange sourceParts;
+  TypeRange resultTypes;
+  VMILayoutAttr sourceLayout;
+  VMILayoutAttr resultLayout;
+  Type sourceVMIElementType;
+  PatternRewriter &rewriter;
+};
+
+template <typename Materializer>
+static FailureOr<std::optional<SmallVector<Value>>>
+tryDataLayoutMaterializer(const DataLayoutMaterializationContext &context,
+                          Materializer materializer) {
+  return materializer(context);
+}
+
 FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
     VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
     Type sourceVMIElementType, PatternRewriter &rewriter) {
-  auto tryMaterializer =
-      [](auto materializer) -> FailureOr<std::optional<SmallVector<Value>>> {
-    return materializer();
-  };
-  FailureOr<std::optional<SmallVector<Value>>> simple = tryMaterializer(
-      [op, sourceParts, resultTypes, sourceLayout, resultLayout,
-       sourceVMIElementType, &rewriter]() {
+  DataLayoutMaterializationContext context{
+      op, sourceParts, resultTypes, sourceLayout, resultLayout,
+      sourceVMIElementType, rewriter};
+  FailureOr<std::optional<SmallVector<Value>>> simple = tryDataLayoutMaterializer(
+      context, [](const DataLayoutMaterializationContext &context) {
         return materializeSimpleDataLayoutConversion(
-          op, sourceParts, resultTypes, sourceLayout, resultLayout,
-          sourceVMIElementType, rewriter);
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout,
+            context.sourceVMIElementType, context.rewriter);
       });
   if (failed(simple)) {
     return failure();
@@ -5209,10 +5225,10 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
     return std::move(**simple);
   }
   FailureOr<std::optional<SmallVector<Value>>> deinterleaved2 =
-      tryMaterializer([op, sourceParts, resultTypes, sourceLayout, resultLayout,
-                       &rewriter]() {
+      tryDataLayoutMaterializer(context, [](const DataLayoutMaterializationContext &context) {
         return materializeDeinterleaved2Layout(
-            op, sourceParts, resultTypes, sourceLayout, resultLayout, rewriter);
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout, context.rewriter);
       });
   if (failed(deinterleaved2)) {
     return failure();
@@ -5220,12 +5236,12 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
   if (deinterleaved2->has_value()) {
     return std::move(**deinterleaved2);
   }
-  FailureOr<std::optional<SmallVector<Value>>> laneStride = tryMaterializer(
-      [op, sourceParts, resultTypes, sourceLayout, resultLayout,
-       sourceVMIElementType, &rewriter]() {
+  FailureOr<std::optional<SmallVector<Value>>> laneStride =
+      tryDataLayoutMaterializer(context, [](const DataLayoutMaterializationContext &context) {
         return materializeDataLaneStrideConversion(
-          op, sourceParts, resultTypes, sourceLayout, resultLayout,
-          sourceVMIElementType, rewriter);
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout,
+            context.sourceVMIElementType, context.rewriter);
       });
   if (failed(laneStride)) {
     return failure();
@@ -5233,12 +5249,12 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
   if (laneStride->has_value()) {
     return std::move(**laneStride);
   }
-  FailureOr<std::optional<SmallVector<Value>>> viaContiguous = tryMaterializer(
-      [op, sourceParts, resultTypes, sourceLayout, resultLayout,
-       sourceVMIElementType, &rewriter]() {
+  FailureOr<std::optional<SmallVector<Value>>> viaContiguous =
+      tryDataLayoutMaterializer(context, [](const DataLayoutMaterializationContext &context) {
         return materializeDataLayoutViaContiguous(
-          op, sourceParts, resultTypes, sourceLayout, resultLayout,
-          sourceVMIElementType, rewriter);
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout,
+            context.sourceVMIElementType, context.rewriter);
       });
   if (failed(viaContiguous)) {
     return failure();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2996,6 +2996,65 @@ FailureOr<Value> createDenseLaneStrideStorePredicate(
       .getResult();
 }
 
+static FailureOr<int64_t> computeShuffleForwardingSourceChunk(
+    VMIVRegType sourceType, VMIVRegType resultType, ArrayRef<int64_t> indices,
+    int64_t resultPart, int64_t resultChunk, int64_t lanesPerPart,
+    std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> FailureOr<int64_t> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  std::optional<int64_t> sourcePart;
+  std::optional<int64_t> sourceChunk;
+  for (int64_t lane = 0; lane < lanesPerPart; ++lane) {
+    FailureOr<bool> padding =
+        isPaddingLane(resultType, resultPart, resultChunk, lane);
+    if (failed(padding)) {
+      return fail("failed to classify result padding lanes");
+    }
+    if (*padding) {
+      continue;
+    }
+    FailureOr<int64_t> logicalLane =
+        mapPhysicalLaneToLogical(resultType, resultPart, resultChunk, lane);
+    bool logicalLaneOutOfRange =
+        succeeded(logicalLane) &&
+        *logicalLane >= static_cast<int64_t>(indices.size());
+    if (failed(logicalLane)) {
+      return fail("failed to map result lane");
+    }
+    if (logicalLaneOutOfRange) {
+      return fail("failed to map result lane");
+    }
+    FailureOr<VMIPhysicalLane> sourcePhysical =
+        mapLogicalLaneToPhysical(sourceType, indices[*logicalLane]);
+    if (failed(sourcePhysical)) {
+      return fail("failed to map source lane");
+    }
+    if (sourcePhysical->lane != lane) {
+      return fail("requires same-lane physical chunks");
+    }
+    if (!sourcePart) {
+      sourcePart = sourcePhysical->part;
+      sourceChunk = sourcePhysical->chunk;
+    } else if (*sourcePart != sourcePhysical->part ||
+               *sourceChunk != sourcePhysical->chunk) {
+      return fail("requires one source chunk per result chunk");
+    }
+  }
+  if (!sourcePart || !sourceChunk) {
+    return fail("requires at least one logical lane per result chunk");
+  }
+  FailureOr<int64_t> sourceFlatIndex =
+      getDataFlatPartIndex(sourceType, *sourcePart, *sourceChunk);
+  if (failed(sourceFlatIndex)) {
+    return fail("source part range is out of bounds");
+  }
+  return *sourceFlatIndex;
+}
+
 FailureOr<SmallVector<int64_t>>
 computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> FailureOr<SmallVector<int64_t>> {
@@ -3027,45 +3086,13 @@ computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
       return fail("requires known result physical chunks");
 
     for (int64_t resultChunk = 0; resultChunk < *resultChunks; ++resultChunk) {
-      std::optional<int64_t> sourcePart;
-      std::optional<int64_t> sourceChunk;
-      for (int64_t lane = 0; lane < *lanesPerPart; ++lane) {
-        FailureOr<bool> padding =
-            isPaddingLane(resultType, resultPart, resultChunk, lane);
-        if (failed(padding))
-          return fail("failed to classify result padding lanes");
-        if (*padding)
-          continue;
-
-        FailureOr<int64_t> resultLogicalLane =
-            mapPhysicalLaneToLogical(resultType, resultPart, resultChunk, lane);
-        if (failed(resultLogicalLane) ||
-            *resultLogicalLane >= static_cast<int64_t>(indices.size()))
-          return fail("failed to map result lane");
-
-        FailureOr<VMIPhysicalLane> sourcePhysical =
-            mapLogicalLaneToPhysical(sourceType, indices[*resultLogicalLane]);
-        if (failed(sourcePhysical))
-          return fail("failed to map source lane");
-        if (sourcePhysical->lane != lane)
-          return fail("requires same-lane physical chunks");
-
-        if (!sourcePart) {
-          sourcePart = sourcePhysical->part;
-          sourceChunk = sourcePhysical->chunk;
-          continue;
-        }
-        if (*sourcePart != sourcePhysical->part ||
-            *sourceChunk != sourcePhysical->chunk)
-          return fail("requires one source chunk per result chunk");
-      }
-
-      if (!sourcePart || !sourceChunk)
-        return fail("requires at least one logical lane per result chunk");
       FailureOr<int64_t> sourceFlatIndex =
-          getDataFlatPartIndex(sourceType, *sourcePart, *sourceChunk);
-      if (failed(sourceFlatIndex))
-        return fail("source part range is out of bounds");
+          computeShuffleForwardingSourceChunk(
+              sourceType, resultType, indices, resultPart, resultChunk,
+              *lanesPerPart, reason);
+      if (failed(sourceFlatIndex)) {
+        return failure();
+      }
       sourceFlatIndices.push_back(*sourceFlatIndex);
     }
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8652,6 +8652,29 @@ public:
   }
 };
 
+struct GroupSlotLoadResultPart {
+  VRegType valueType;
+  MaskType maskType;
+};
+
+static FailureOr<GroupSlotLoadResultPart> getGroupSlotLoadResultPart(
+    Operation *op, Type resultType, OneToNPatternRewriter &rewriter) {
+  auto vregType = dyn_cast<VRegType>(resultType);
+  if (!vregType) {
+    (void)rewriter.notifyMatchFailure(op,
+                                      "group_slot_load result must be vreg");
+    return failure();
+  }
+  FailureOr<MaskType> maskType =
+      getMaskTypeForVReg(vregType, rewriter.getContext());
+  if (failed(maskType)) {
+    (void)rewriter.notifyMatchFailure(
+        op, "unsupported element type for group_slot_load mask");
+    return failure();
+  }
+  return GroupSlotLoadResultPart{*vregType, *maskType};
+}
+
 static LogicalResult lowerGroupSlotLoadSlots8(
     Operation *op, Value source, Value offset, Value sourceGroupStride,
     VMIVRegType resultVMIType, TypeRange resultTypes, int64_t numGroups,
@@ -8690,16 +8713,10 @@ static LogicalResult lowerGroupSlotLoadSlots8(
     return success();
   }
   for (auto [chunk, resultType] : llvm::enumerate(resultTypes)) {
-    auto vregType = dyn_cast<VRegType>(resultType);
-    if (!vregType) {
-      return rewriter.notifyMatchFailure(
-          op, "group_slot_load result must be vreg");
-    }
-    FailureOr<MaskType> maskType =
-        getMaskTypeForVReg(vregType, rewriter.getContext());
-    if (failed(maskType)) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported element type for group_slot_load mask");
+    FailureOr<GroupSlotLoadResultPart> resultPart =
+        getGroupSlotLoadResultPart(op, resultType, rewriter);
+    if (failed(resultPart)) {
+      return failure();
     }
     int64_t groupBegin = static_cast<int64_t>(chunk) * 8;
     int64_t activeGroups = std::min<int64_t>(8, numGroups - groupBegin);
@@ -8709,7 +8726,7 @@ static LogicalResult lowerGroupSlotLoadSlots8(
     }
     std::string pattern = (Twine("PAT_VL") + Twine(activeGroups)).str();
     FailureOr<Value> slotMask =
-        createPrefixMask(op->getLoc(), *maskType, pattern, rewriter);
+        createPrefixMask(op->getLoc(), resultPart->maskType, pattern, rewriter);
     if (failed(slotMask)) {
       return rewriter.notifyMatchFailure(
           op, "failed to create slots=8 group_slot_load mask");
@@ -8718,7 +8735,7 @@ static LogicalResult lowerGroupSlotLoadSlots8(
                                           rewriter);
     Value slotBase = makePtr(groupOffset);
     results.push_back(rewriter
-                          .create<VsldbOp>(op->getLoc(), vregType,
+                          .create<VsldbOp>(op->getLoc(), resultPart->valueType,
                                            /*updated_base=*/Type{}, slotBase,
                                            zeroI16, zeroI16, *slotMask)
                           .getResult());
@@ -8757,19 +8774,14 @@ static LogicalResult lowerGroupSlotLoadSlots1(
   };
   Value zeroI16 = makeI16(0);
   for (auto [group, resultType] : llvm::enumerate(resultTypes)) {
-    auto vregType = dyn_cast<VRegType>(resultType);
-    if (!vregType) {
-      return rewriter.notifyMatchFailure(op,
-                                         "group_slot_load result must be vreg");
-    }
-    FailureOr<MaskType> maskType =
-        getMaskTypeForVReg(vregType, rewriter.getContext());
-    if (failed(maskType)) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported element type for group_slot_load mask");
+    FailureOr<GroupSlotLoadResultPart> resultPart =
+        getGroupSlotLoadResultPart(op, resultType, rewriter);
+    if (failed(resultPart)) {
+      return failure();
     }
     FailureOr<Value> oneBlockMask =
-        createPrefixMask(op->getLoc(), *maskType, "PAT_VL1", rewriter);
+        createPrefixMask(op->getLoc(), resultPart->maskType, "PAT_VL1",
+                         rewriter);
     if (failed(oneBlockMask)) {
       return rewriter.notifyMatchFailure(
           op, "failed to create group_slot_load mask");
@@ -8788,7 +8800,7 @@ static LogicalResult lowerGroupSlotLoadSlots1(
     }
     Value slotBase = makePtr(groupOffset);
     results.push_back(rewriter
-                          .create<VsldbOp>(op->getLoc(), vregType,
+                          .create<VsldbOp>(op->getLoc(), resultPart->valueType,
                                            /*updated_base=*/Type{}, slotBase,
                                            zeroI16, zeroI16, *oneBlockMask)
                           .getResult());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10507,6 +10507,35 @@ struct OneToNVMIMaskedLoadOpPattern
   using OneToNOpConversionPattern<VMIMaskedLoadOp>::OneToNOpConversionPattern;
 
 private:
+  FailureOr<Value> materializeGatherPart(
+      VMIGatherOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value indices, Value mask, Value passthru, Type resultType,
+      bool allActive) const {
+    bool invalidPartTypes = !isa<VRegType>(indices.getType()) ||
+                            !isa<MaskType>(mask.getType()) ||
+                            passthru.getType() != resultType ||
+                            !isa<VRegType>(resultType);
+    if (invalidPartTypes) {
+      return rewriter.notifyMatchFailure(
+          op, "gather physical part type mismatch");
+    }
+    unsigned resultBits = pto::getPTOStorageElemBitWidth(
+        cast<VRegType>(resultType).getElementType());
+    Value gathered = resultBits == 16
+                         ? rewriter.create<Vgather2Op>(
+                               op.getLoc(), resultType, source, indices, mask)
+                               .getResult()
+                         : rewriter.create<Vgather2BcOp>(
+                               op.getLoc(), resultType, source, indices, mask)
+                               .getResult();
+    if (allActive) {
+      return gathered;
+    }
+    return rewriter
+        .create<VselOp>(op.getLoc(), resultType, gathered, passthru, mask)
+        .getResult();
+  }
+
   LogicalResult lowerPhysicalParts(
       VMIMaskedLoadOp op, OneToNPatternRewriter &rewriter, Value source,
       Value offset, ValueRange maskParts, ValueRange passthruParts,
@@ -10601,32 +10630,12 @@ private:
     results.reserve(resultTypes.size());
     for (auto [indices, mask, passthru, resultType] :
          llvm::zip_equal(indicesParts, maskParts, passthruParts, resultTypes)) {
-      bool invalidPartTypes =
-          !isa<VRegType>(indices.getType()) || !isa<MaskType>(mask.getType()) ||
-          passthru.getType() != resultType || !isa<VRegType>(resultType);
-      if (invalidPartTypes) {
-        return rewriter.notifyMatchFailure(
-            op, "gather physical part type mismatch");
+      FailureOr<Value> result = materializeGatherPart(
+          op, rewriter, source, indices, mask, passthru, resultType, allActive);
+      if (failed(result)) {
+        return failure();
       }
-      unsigned resultBits = pto::getPTOStorageElemBitWidth(
-          cast<VRegType>(resultType).getElementType());
-      Value gathered =
-          resultBits == 16
-              ? rewriter
-                    .create<Vgather2Op>(op.getLoc(), resultType, source, indices,
-                                        mask)
-                    .getResult()
-              : rewriter
-                    .create<Vgather2BcOp>(op.getLoc(), resultType, source,
-                                          indices, mask)
-                    .getResult();
-      results.push_back(
-          allActive
-              ? gathered
-              : rewriter
-                    .create<VselOp>(op.getLoc(), resultType, gathered, passthru,
-                                    mask)
-                    .getResult());
+      results.push_back(*result);
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11311,33 +11311,47 @@ private:
         .getResult();
   }
 
+  FailureOr<int64_t> validateDirectBRCShape(
+      VMIGroupBroadcastLoadOp op, Value source, ArrayRef<Type> resultTypes,
+      int64_t numGroups, OneToNPatternRewriter &rewriter) const {
+    bool invalidArity =
+        numGroups <= 0 ||
+        static_cast<int64_t>(resultTypes.size()) % numGroups != 0;
+    if (invalidArity) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast_load BRC result arity is not divisible by num_groups");
+    }
+    if (!isa<PtrType>(source.getType())) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast_load BRC lowering requires !pto.ptr source");
+    }
+    int64_t chunksPerGroup =
+        static_cast<int64_t>(resultTypes.size()) / numGroups;
+    bool invalidChunkArity =
+        chunksPerGroup <= 0 ||
+        static_cast<int64_t>(resultTypes.size()) != numGroups * chunksPerGroup;
+    if (invalidChunkArity) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast_load BRC physical arity mismatch");
+    }
+    return chunksPerGroup;
+  }
+
   LogicalResult lowerDirectBRC(
       VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
       Value source, Value offset, Value sourceGroupStride,
       ArrayRef<Type> resultTypes, int64_t numGroups,
       StringRef brcDist) const {
-    if (numGroups <= 0 ||
-        static_cast<int64_t>(resultTypes.size()) % numGroups != 0) {
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast_load BRC result arity is not divisible by num_groups");
-    }
-    int64_t chunksPerGroup =
-        static_cast<int64_t>(resultTypes.size()) / numGroups;
-    if (!isa<PtrType>(source.getType())) {
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast_load BRC lowering requires !pto.ptr source");
-    }
-    if (chunksPerGroup <= 0 ||
-        static_cast<int64_t>(resultTypes.size()) !=
-            numGroups * chunksPerGroup) {
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast_load BRC physical arity mismatch");
+    FailureOr<int64_t> chunksPerGroup = validateDirectBRCShape(
+        op, source, resultTypes, numGroups, rewriter);
+    if (failed(chunksPerGroup)) {
+      return failure();
     }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (auto [index, resultType] : llvm::enumerate(resultTypes)) {
-      int64_t group = static_cast<int64_t>(index) / chunksPerGroup;
+      int64_t group = static_cast<int64_t>(index) / *chunksPerGroup;
       FailureOr<Value> result = buildDirectBRCResult(
           op, rewriter, source, offset, sourceGroupStride, resultType, group,
           brcDist);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12140,36 +12140,51 @@ private:
                                  offset, rowStride, numGroups);
   }
 
+  enum class GroupStoreLayoutKind { Scalar, Compact, Slots1, Slots8, General };
+
+  GroupStoreLayoutKind classifyGroupStoreLayout(
+      VMIGroupStoreOp op, VMIVRegType valueVMIType, VMILayoutAttr layout) const {
+    int64_t numGroups = op.getNumGroupsAttr().getInt();
+    bool scalar = numGroups == 1 && valueVMIType.getElementCount() == 1;
+    if (scalar) {
+      return GroupStoreLayoutKind::Scalar;
+    }
+    bool compact = isCompactSmallGroupStore(
+        layout, valueVMIType, numGroups, getConstantIndexValue(op.getRowStride()));
+    if (compact) {
+      return GroupStoreLayoutKind::Compact;
+    }
+    bool slots1 = layout && layout.isGroupSlots() && layout.getSlots() == 1 &&
+                  layout.getNumGroups() == numGroups;
+    if (slots1) {
+      return GroupStoreLayoutKind::Slots1;
+    }
+    bool slots8 = layout && layout.isGroupSlots() && layout.getSlots() == 8 &&
+                  layout.getNumGroups() == numGroups;
+    return slots8 ? GroupStoreLayoutKind::Slots8 : GroupStoreLayoutKind::General;
+  }
+
   LogicalResult lowerByLayout(
       VMIGroupStoreOp op, OpAdaptor adaptor,
       OneToNPatternRewriter &rewriter, VMIVRegType valueVMIType,
       VMILayoutAttr layout, Value destination, Value offset,
       Value rowStride) const {
-    bool compactSmallGroupStore = isCompactSmallGroupStore(
-        layout, valueVMIType, op.getNumGroupsAttr().getInt(),
-        getConstantIndexValue(op.getRowStride()));
-    bool isScalarGroupStore = op.getNumGroupsAttr().getInt() == 1 &&
-                              valueVMIType.getElementCount() == 1;
-    if (isScalarGroupStore) {
+    GroupStoreLayoutKind layoutKind =
+        classifyGroupStoreLayout(op, valueVMIType, layout);
+    if (layoutKind == GroupStoreLayoutKind::Scalar) {
       return lowerScalarGroupStore(op, adaptor, rewriter, valueVMIType,
                                    destination, offset);
     }
-    if (compactSmallGroupStore) {
+    if (layoutKind == GroupStoreLayoutKind::Compact) {
       return lowerCompactSmallGroupStore(op, adaptor, rewriter, valueVMIType,
                                          layout, destination, offset);
     }
 
-    bool isSlots1Layout =
-        layout && layout.isGroupSlots() && layout.getSlots() == 1 &&
-        layout.getNumGroups() == op.getNumGroupsAttr().getInt();
-    if (isSlots1Layout) {
+    if (layoutKind == GroupStoreLayoutKind::Slots1) {
       return lowerSlots1(op, adaptor, rewriter, valueVMIType, layout,
                          destination, offset, rowStride);
     }
-    bool isSlots8Layout =
-        layout && layout.isGroupSlots() && layout.getSlots() == 8 &&
-        layout.getNumGroups() == op.getNumGroupsAttr().getInt();
-    if (isSlots8Layout) {
+    if (layoutKind == GroupStoreLayoutKind::Slots8) {
       return lowerSlots8Dispatch(op, adaptor, rewriter, valueVMIType, layout,
                                  destination, offset, rowStride);
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3383,20 +3383,26 @@ FailureOr<int64_t> computeShuffleLane0SplatSourcePart(VMIShuffleOp op,
   };
 
   ArrayRef<int64_t> indices = op.getIndices();
-  if (indices.empty())
+  if (indices.empty()) {
     return fail("requires non-empty indices");
-  if (!llvm::all_of(indices, [](int64_t index) { return index == 0; }))
+  }
+  bool hasNonZeroIndex =
+      !llvm::all_of(indices, [](int64_t index) { return index == 0; });
+  if (hasNonZeroIndex) {
     return fail("requires every result lane to select source lane 0");
+  }
 
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   FailureOr<VMIPhysicalLane> sourceLane =
       mapLogicalLaneToPhysical(sourceType, 0);
-  if (failed(sourceLane))
+  if (failed(sourceLane)) {
     return fail("failed to map source lane 0");
+  }
   FailureOr<int64_t> sourceFlatIndex =
       getDataFlatPartIndex(sourceType, sourceLane->part, sourceLane->chunk);
-  if (failed(sourceFlatIndex))
+  if (failed(sourceFlatIndex)) {
     return fail("source lane 0 part range is out of bounds");
+  }
   return *sourceFlatIndex;
 }
 
@@ -3413,23 +3419,27 @@ computeShuffleVselrPlans(VMIShuffleOp op, std::string *reason) {
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(sourceType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return fail("requires known lanes per physical part");
+  }
 
   ArrayRef<int64_t> indices = op.getIndices();
-  if (indices.empty())
+  if (indices.empty()) {
     return fail("requires non-empty indices");
+  }
 
   FailureOr<int64_t> resultFactor = getDataLayoutFactor(resultType);
-  if (failed(resultFactor))
+  if (failed(resultFactor)) {
     return fail("requires assigned result layout");
+  }
 
   SmallVector<ShuffleVselrPlan> plans;
   for (int64_t resultPart = 0; resultPart < *resultFactor; ++resultPart) {
     FailureOr<int64_t> resultChunks =
         getDataChunksInPart(resultType, resultPart);
-    if (failed(resultChunks))
+    if (failed(resultChunks)) {
       return fail("requires known result physical chunks");
+    }
 
     for (int64_t resultChunk = 0; resultChunk < *resultChunks; ++resultChunk) {
       FailureOr<ShuffleVselrPlan> plan = computeShuffleVselrPlanForChunk(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9444,6 +9444,37 @@ private:
     return success();
   }
 
+  FailureOr<Value> materializeBlockDeinterleavedChunk(
+      VMIGroupLoadOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value offset, Value rowStride, Type resultType, int64_t part,
+      int64_t chunk, int64_t blockElems, int64_t constantRowStride) const {
+    auto vregType = dyn_cast<VRegType>(resultType);
+    if (!vregType) {
+      return rewriter.notifyMatchFailure(
+          op, "block_deinterleaved group_load result must be vreg");
+    }
+    FailureOr<Value> allMask =
+        createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
+    if (failed(allMask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to create block_deinterleaved group_load mask");
+    }
+    Value blockStride = rewriter.create<arith::ConstantIntOp>(
+        op.getLoc(), constantRowStride / 8, 16);
+    Value zeroI16 = rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0, 16);
+    Value chunkOffset = createGroupChunkOffset(
+        op.getLoc(), offset, rowStride, chunk * 8, part * blockElems,
+        rewriter);
+    Value chunkBase = rewriter
+                          .create<AddPtrOp>(op.getLoc(), source.getType(), source,
+                                            chunkOffset)
+                          .getResult();
+    return rewriter
+        .create<VsldbOp>(op.getLoc(), vregType, Type{}, chunkBase, blockStride,
+                         zeroI16, *allMask)
+        .getResult();
+  }
+
   LogicalResult lowerBlockDeinterleaved(
       VMIGroupLoadOp op, OneToNPatternRewriter &rewriter, Value source,
       Value offset, Value rowStride, VMIVRegType resultVMIType,
@@ -9456,40 +9487,19 @@ private:
       return rewriter.notifyMatchFailure(
           op, "block_deinterleaved group_load arity mismatch");
     }
-    auto makeI16 = [&rewriter, &op](int64_t value) -> Value {
-      return rewriter.create<arith::ConstantIntOp>(op.getLoc(), value, 16);
-    };
-    Value blockStride = makeI16(constantRowStride / 8);
-    Value zeroI16 = makeI16(0);
     constexpr int64_t kGroupsPerBlockLoad = 8;
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (int64_t part = 0; part < factor; ++part) {
       for (int64_t chunk = 0; chunk < chunksPerPart; ++chunk) {
         int64_t flatIndex = part * chunksPerPart + chunk;
-        auto vregType = dyn_cast<VRegType>(resultTypes[flatIndex]);
-        if (!vregType) {
-          return rewriter.notifyMatchFailure(
-              op, "block_deinterleaved group_load result must be vreg");
+        FailureOr<Value> result = materializeBlockDeinterleavedChunk(
+            op, rewriter, source, offset, rowStride, resultTypes[flatIndex],
+            part, chunk, blockElems, constantRowStride);
+        if (failed(result)) {
+          return failure();
         }
-        FailureOr<Value> allMask =
-            createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
-        if (failed(allMask)) {
-          return rewriter.notifyMatchFailure(
-              op, "failed to create block_deinterleaved group_load mask");
-        }
-        Value chunkOffset = createGroupChunkOffset(
-            op.getLoc(), offset, rowStride, chunk * kGroupsPerBlockLoad,
-            part * blockElems, rewriter);
-        Value chunkBase = rewriter
-                              .create<AddPtrOp>(op.getLoc(), source.getType(),
-                                                source, chunkOffset)
-                              .getResult();
-        results.push_back(rewriter
-                              .create<VsldbOp>(op.getLoc(), vregType, Type{},
-                                               chunkBase, blockStride, zeroI16,
-                                               *allMask)
-                              .getResult());
+        results.push_back(*result);
       }
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -16223,6 +16223,29 @@ private:
     return resultVRegTypes;
   }
 
+  FailureOr<VRegType> getUniformExtensionSourceType(
+      OpT op, ValueRange sourceParts,
+      OneToNPatternRewriter &rewriter) const {
+    if (sourceParts.empty()) {
+      return rewriter.notifyMatchFailure(
+          op, "integer extension requires at least one physical source chunk");
+    }
+    auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
+    if (!sourceType) {
+      return rewriter.notifyMatchFailure(
+          op, "expected physical integer extension source");
+    }
+    for (Value sourcePart : sourceParts) {
+      auto currentSourceType = dyn_cast<VRegType>(sourcePart.getType());
+      if (!currentSourceType || currentSourceType != sourceType) {
+        return rewriter.notifyMatchFailure(
+            op, "integer extension source physical parts must have matching "
+                "type");
+      }
+    }
+    return sourceType;
+  }
+
 public:
   LogicalResult
   matchAndRewrite(OpT op,
@@ -16237,24 +16260,12 @@ public:
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (sourceParts.empty()) {
-      return rewriter.notifyMatchFailure(
-          op, "integer extension requires at least one physical source chunk");
+    FailureOr<VRegType> maybeSourceType =
+        getUniformExtensionSourceType(op, sourceParts, rewriter);
+    if (failed(maybeSourceType)) {
+      return failure();
     }
-
-    auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
-    if (!sourceType) {
-      return rewriter.notifyMatchFailure(
-          op, "expected physical integer extension source");
-    }
-    for (Value sourcePart : sourceParts) {
-      auto currentSourceType = dyn_cast<VRegType>(sourcePart.getType());
-      if (!currentSourceType || currentSourceType != sourceType) {
-        return rewriter.notifyMatchFailure(
-            op, "integer extension source physical parts must have matching "
-                "type");
-      }
-    }
+    VRegType sourceType = *maybeSourceType;
 
     VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
     VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -15048,8 +15048,9 @@ struct OneToNVMIGroupBroadcastOpPattern
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     SmallVector<Value> results;
     if (failed(lowerGroupBroadcastParts(
@@ -18685,6 +18686,17 @@ static LogicalResult checkActivePrefixIndexPhysicalChunks(
                       "lanes cannot affect the observable prefix; ") +
                 maskFullReason);
   }
+  return success();
+}
+
+static LogicalResult checkActivePrefixIndexSingleChunk(
+    VMIMaskType maskType, VMIVRegType resultType, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
   FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
   bool missingArity = failed(maskArity) || failed(resultArity);
@@ -18710,11 +18722,14 @@ static FailureOr<ActivePrefixIndexShapePlan> buildActivePrefixIndexShapePlan(
 
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
-  bool invalidActivePrefixShape =
-      failed(checkActivePrefixIndexLayouts(maskType, resultType, reason)) ||
-      failed(checkActivePrefixIndexPhysicalChunks(maskType, resultType,
-                                                  reason));
-  if (invalidActivePrefixShape) {
+  if (failed(checkActivePrefixIndexLayouts(maskType, resultType, reason))) {
+    return failure();
+  }
+  if (failed(checkActivePrefixIndexPhysicalChunks(maskType, resultType,
+                                                  reason))) {
+    return failure();
+  }
+  if (failed(checkActivePrefixIndexSingleChunk(maskType, resultType, reason))) {
     return failure();
   }
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -14634,10 +14634,10 @@ private:
     return success();
   }
 
-  LogicalResult lowerDenseGroupSlotExtension(
-      OpT op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
-      VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
-      IntegerType resultIntegerType, unsigned sourceBits, unsigned resultBits,
+  FailureOr<Value> buildDenseGroupSlotExtensionResult(
+      OpT op, Value sourcePart, Type resultType, VMIVRegType sourceVMIType,
+      VMIVRegType resultVMIType, IntegerType resultIntegerType,
+      unsigned sourceBits, unsigned resultBits,
       OneToNPatternRewriter &rewriter) const {
     FailureOr<int64_t> sourceLanes =
         getDataLanesPerPart(sourceVMIType.getElementType());
@@ -14645,65 +14645,79 @@ private:
         getDataLanesPerPart(resultVMIType.getElementType());
     bool carrierShapeMismatch =
         failed(sourceLanes) || failed(resultLanes) ||
-        *sourceLanes != *resultLanes * static_cast<int64_t>(resultBits / sourceBits);
+        *sourceLanes !=
+            *resultLanes * static_cast<int64_t>(resultBits / sourceBits);
     if (carrierShapeMismatch) {
       return rewriter.notifyMatchFailure(
           op, "unsupported dense group-slot integer extension carrier shape");
     }
 
+    auto physicalResultType = dyn_cast<VRegType>(resultType);
+    bool invalidResultType =
+        !physicalResultType ||
+        physicalResultType.getElementCount() != *resultLanes ||
+        pto::getPTOStorageElemBitWidth(physicalResultType.getElementType()) !=
+            resultBits;
+    if (invalidResultType) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported dense group-slot integer extension result type");
+    }
+
+    Value current = sourcePart;
+    unsigned currentBits = sourceBits;
+    while (currentBits < resultBits) {
+      unsigned nextBits = currentBits * 2;
+      auto nextElementType = IntegerType::get(
+          rewriter.getContext(), nextBits, resultIntegerType.getSignedness());
+      FailureOr<int64_t> nextLanes =
+          getDataLanesPerPart(nextElementType);
+      if (failed(nextLanes)) {
+        return rewriter.notifyMatchFailure(
+            op, "failed to derive dense group-slot unpack result lanes");
+      }
+      auto nextType =
+          VRegType::get(rewriter.getContext(), *nextLanes, nextElementType);
+      bool unpackLaneMismatch =
+          cast<VRegType>(current.getType()).getElementCount() != *nextLanes * 2;
+      if (unpackLaneMismatch) {
+        return rewriter.notifyMatchFailure(
+            op, "dense group-slot unpack source/result lane mismatch");
+      }
+      Value part = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
+      if constexpr (std::is_same_v<OpT, VMIExtSIOp>) {
+        current = rewriter.create<VsunpackOp>(op.getLoc(), nextType, current,
+                                              part)
+                      .getResult();
+      } else {
+        current = rewriter.create<VzunpackOp>(op.getLoc(), nextType, current,
+                                              part)
+                      .getResult();
+      }
+      currentBits = nextBits;
+    }
+    FailureOr<Value> result =
+        bitcastVReg(op.getLoc(), current, physicalResultType, rewriter);
+    if (failed(result)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to materialize dense group-slot unpack result");
+    }
+    return *result;
+  }
+
+  LogicalResult lowerDenseGroupSlotExtension(
+      OpT op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+      IntegerType resultIntegerType, unsigned sourceBits, unsigned resultBits,
+      OneToNPatternRewriter &rewriter) const {
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (auto [sourcePart, resultType] :
          llvm::zip_equal(sourceParts, resultTypes)) {
-      auto physicalResultType = dyn_cast<VRegType>(resultType);
-      bool invalidResultType =
-          !physicalResultType ||
-          physicalResultType.getElementCount() != *resultLanes ||
-          pto::getPTOStorageElemBitWidth(physicalResultType.getElementType()) !=
-              resultBits;
-      if (invalidResultType) {
-        return rewriter.notifyMatchFailure(
-            op, "unsupported dense group-slot integer extension result type");
-      }
-
-      Value current = sourcePart;
-      unsigned currentBits = sourceBits;
-      while (currentBits < resultBits) {
-        unsigned nextBits = currentBits * 2;
-        auto nextElementType = IntegerType::get(
-            rewriter.getContext(), nextBits, resultIntegerType.getSignedness());
-        FailureOr<int64_t> nextLanes =
-            getDataLanesPerPart(nextElementType);
-        if (failed(nextLanes)) {
-          return rewriter.notifyMatchFailure(
-              op, "failed to derive dense group-slot unpack result lanes");
-        }
-        auto nextType =
-            VRegType::get(rewriter.getContext(), *nextLanes, nextElementType);
-        bool unpackLaneMismatch =
-            cast<VRegType>(current.getType()).getElementCount() !=
-            *nextLanes * 2;
-        if (unpackLaneMismatch) {
-          return rewriter.notifyMatchFailure(
-              op, "dense group-slot unpack source/result lane mismatch");
-        }
-        Value part = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
-        if constexpr (std::is_same_v<OpT, VMIExtSIOp>) {
-          current = rewriter.create<VsunpackOp>(op.getLoc(), nextType, current,
-                                                part)
-                        .getResult();
-        } else {
-          current = rewriter.create<VzunpackOp>(op.getLoc(), nextType, current,
-                                                part)
-                        .getResult();
-        }
-        currentBits = nextBits;
-      }
-      FailureOr<Value> result =
-          bitcastVReg(op.getLoc(), current, physicalResultType, rewriter);
+      FailureOr<Value> result = buildDenseGroupSlotExtensionResult(
+          op, sourcePart, resultType, sourceVMIType, resultVMIType,
+          resultIntegerType, sourceBits, resultBits, rewriter);
       if (failed(result)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to materialize dense group-slot unpack result");
+        return failure();
       }
       results.push_back(*result);
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -1860,8 +1860,9 @@ LogicalResult checkDeinterleaved2GroupStoreChunkShape(
     int64_t *groupCount, int64_t *chunksPerGroupPerPart,
     std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -3441,12 +3442,14 @@ FailureOr<Value> materializeConstantMaskChunk(Location loc, MaskType maskType,
 FailureOr<Value> createPowerOfTwoRemainder(Location loc, Value value,
                                            int64_t modulus, Value allMask,
                                            PatternRewriter &rewriter) {
-  if (modulus <= 0)
+  if (modulus <= 0) {
     return failure();
+  }
 
   auto vectorType = dyn_cast<VRegType>(value.getType());
-  if (!vectorType)
+  if (!vectorType) {
     return failure();
+  }
 
   std::optional<int64_t> shift = getPowerOfTwoLog2(modulus);
   if (!shift)
@@ -5291,8 +5294,9 @@ FailureOr<SmallVector<Value>> materializeEnsureLayoutConversion(
   }
 
   SmallVector<Type> resultTypes;
-  if (failed(typeConverter.convertType(resultType, resultTypes)))
+  if (failed(typeConverter.convertType(resultType, resultTypes))) {
     return failure();
+  }
   return materializeDataLayoutConversion(op, sourceParts, resultTypes,
                                          sourceLayout, resultLayout,
                                          sourceType.getElementType(), rewriter);
@@ -5816,27 +5820,39 @@ LogicalResult checkSupportedMaskGranularityMaterialization(
     VMIMaskType sourceType,
     VMIMaskType resultType, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (sourceType.getElementCount() != resultType.getElementCount())
+  bool laneCountMismatch =
+      sourceType.getElementCount() != resultType.getElementCount();
+  if (laneCountMismatch) {
     return fail("requires source and result mask lane counts to match");
-  if (sourceType.getLayoutAttr() != resultType.getLayoutAttr())
+  }
+  bool layoutMismatch = sourceType.getLayoutAttr() != resultType.getLayoutAttr();
+  if (layoutMismatch) {
     return fail("requires source and result mask layouts to match");
+  }
 
-  if (!VMIMaskType::isConcreteGranularity(sourceType.getGranularity()) ||
-      !VMIMaskType::isConcreteGranularity(resultType.getGranularity()))
+  bool nonConcreteGranularity =
+      !VMIMaskType::isConcreteGranularity(sourceType.getGranularity()) ||
+      !VMIMaskType::isConcreteGranularity(resultType.getGranularity());
+  if (nonConcreteGranularity) {
     return fail("requires concrete b8/b16/b32 source and result "
                 "granularities");
+  }
 
   FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(sourceArity) || failed(resultArity))
+  bool missingArity = failed(sourceArity) || failed(resultArity);
+  if (missingArity) {
     return fail("requires computable source/result physical arity");
-  if (*sourceArity < 1 || *resultArity < 1)
+  }
+  if (*sourceArity < 1 || *resultArity < 1) {
     return fail("requires non-empty source/result physical arity");
+  }
 
   return success();
 }
@@ -6204,8 +6220,9 @@ static bool isElementDeinterleavedLayout(VMILayoutAttr layout,
 FailureOr<Value> createAllFalseMaskLike(Location loc, Value value,
                                         PatternRewriter &rewriter) {
   auto maskType = dyn_cast<MaskType>(value.getType());
-  if (!maskType)
+  if (!maskType) {
     return failure();
+  }
   return createPrefixMask(loc, maskType, "PAT_ALLF", rewriter);
 }
 
@@ -18085,8 +18102,9 @@ LogicalResult checkSupportedChannelSplitShape(VMIChannelSplitOp op,
 
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
-  if (!sourceLayout)
+  if (!sourceLayout) {
     return fail("requires assigned source layout");
+  }
   bool invalidSourceLayout =
       !sourceLayout.isContiguous() && sourceLayout != plan->expectedLayout;
   if (invalidSourceLayout) {
@@ -18094,8 +18112,9 @@ LogicalResult checkSupportedChannelSplitShape(VMIChannelSplitOp op,
                 "deinterleaved channel layout");
 
   FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
-  if (failed(sourceArity))
+  if (failed(sourceArity)) {
     return fail("requires computable source physical arity");
+  }
   if (failed(checkChannelSplitResultShape(op, *sourceArity, reason))) {
     return failure();
   }
@@ -18106,8 +18125,9 @@ LogicalResult checkSupportedChannelSplitShape(VMIChannelSplitOp op,
 LogicalResult checkSupportedChannelMergeShape(VMIChannelMergeOp op,
                                               std::string *reason = nullptr) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -18333,9 +18353,10 @@ LogicalResult checkSupportedCompressStoreShape(
     return failure();
   }
 
-  if (!isa<PtrType>(op.getDestination().getType()))
+  if (!isa<PtrType>(op.getDestination().getType())) {
     return fail("requires !pto.ptr destination because pto.vstur is "
                 "pointer-only");
+  }
 
   return success();
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -16899,6 +16899,47 @@ private:
     return std::make_pair(supportsDirect, supportsPacked);
   }
 
+  FailureOr<SmallVector<Value>> lowerGroupSlotTruncParts(
+      VMITruncIOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+      VMILayoutAttr resultLayout, unsigned sourceBits, unsigned resultBits,
+      bool supportsPacked, Value activeSlotMask, StringAttr sat,
+      OneToNPatternRewriter &rewriter) const {
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (auto [sourcePart, physicalResultType] :
+         llvm::zip_equal(sourceParts, resultTypes)) {
+      auto sourceType = dyn_cast<VRegType>(sourcePart.getType());
+      auto resultType = dyn_cast<VRegType>(physicalResultType);
+      bool validPhysicalTypes =
+          sourceType &&
+          pto::getPTOStorageElemBitWidth(sourceType.getElementType()) ==
+              sourceBits &&
+          resultType;
+      if (!validPhysicalTypes) {
+        rewriter.notifyMatchFailure(
+            op, "unsupported group-slot trunci physical type");
+        return failure();
+      }
+      if (supportsPacked) {
+        results.push_back(rewriter
+                              .create<VcvtOp>(op.getLoc(), resultType, sourcePart,
+                                              activeSlotMask, nullptr, sat,
+                                              rewriter.getStringAttr("EVEN"))
+                              .getResult());
+        continue;
+      }
+      FailureOr<Value> lowered = lowerGroupSlotTruncPart(
+          op, sourcePart, sourceType, resultType, resultVMIType, resultLayout,
+          sourceBits, resultBits, activeSlotMask, sat, rewriter);
+      if (failed(lowered)) {
+        return failure();
+      }
+      results.push_back(*lowered);
+    }
+    return results;
+  }
+
   LogicalResult lowerGroupSlotTrunc(
       VMITruncIOp op, OpAdaptor adaptor, OneToNPatternRewriter &rewriter,
       VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
@@ -16917,8 +16958,6 @@ private:
         pto::getPTOStorageElemBitWidth(resultVMIType.getElementType());
     bool supportsPacked = modes->second;
 
-    SmallVector<Value> results;
-    results.reserve(resultTypes.size());
     StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
     const char *activeSlotPattern =
         sourceLayout.getSlots() == 1 ? "PAT_VL1" : "PAT_VL8";
@@ -16930,36 +16969,14 @@ private:
       return rewriter.notifyMatchFailure(
           op, "failed to build group-slot trunci active slot mask");
     }
-    for (auto [sourcePart, physicalResultType] :
-         llvm::zip_equal(sourceParts, resultTypes)) {
-      auto sourceType = dyn_cast<VRegType>(sourcePart.getType());
-      auto resultType = dyn_cast<VRegType>(physicalResultType);
-      bool validPhysicalTypes =
-          sourceType &&
-          pto::getPTOStorageElemBitWidth(sourceType.getElementType()) ==
-              sourceLogicalBits &&
-          resultType;
-      if (!validPhysicalTypes) {
-        return rewriter.notifyMatchFailure(
-            op, "unsupported group-slot trunci physical type");
-      }
-      if (supportsPacked) {
-        results.push_back(rewriter
-                              .create<VcvtOp>(op.getLoc(), resultType, sourcePart,
-                                              *activeSlotMask, nullptr, sat,
-                                              rewriter.getStringAttr("EVEN"))
-                              .getResult());
-        continue;
-      }
-      FailureOr<Value> lowered = lowerGroupSlotTruncPart(
-          op, sourcePart, sourceType, resultType, resultVMIType, resultLayout,
-          sourceLogicalBits, resultLogicalBits, *activeSlotMask, sat, rewriter);
-      if (failed(lowered)) {
-        return failure();
-      }
-      results.push_back(*lowered);
+    FailureOr<SmallVector<Value>> results = lowerGroupSlotTruncParts(
+        op, sourceParts, resultTypes, sourceVMIType, resultVMIType,
+        resultLayout, sourceLogicalBits, resultLogicalBits, supportsPacked,
+        *activeSlotMask, sat, rewriter);
+    if (failed(results)) {
+      return failure();
     }
-    finalizeResults(op, results, false, resultTypes, rewriter);
+    finalizeResults(op, *results, false, resultTypes, rewriter);
     return success();
   }
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18667,23 +18667,27 @@ std::optional<WalkResult> verifySupportedVMIStandardOp(
   return verifySupportedVMIConversionOp(op);
 }
 
+static WalkResult verifySupportedVMIToVPTOOp(
+    Operation *op, bool enableStableGatherMaskedLoad) {
+  if (auto standardResult = verifySupportedVMIStandardOp(
+          op, enableStableGatherMaskedLoad);
+      standardResult.has_value()) {
+    return *standardResult;
+  }
+  if (auto channelShuffleResult = verifySupportedVMIChannelShuffleOp(op);
+      channelShuffleResult.has_value()) {
+    return *channelShuffleResult;
+  }
+  return WalkResult::advance();
+}
+
 LogicalResult
 verifySupportedVMIToVPTOOps(ModuleOp module,
                             bool enableStableGatherMaskedLoad) {
-  WalkResult result = module.walk([&enableStableGatherMaskedLoad](Operation *op) {
-    if (auto standardResult = verifySupportedVMIStandardOp(
-            op, enableStableGatherMaskedLoad);
-        standardResult.has_value()) {
-      return *standardResult;
-    }
-
-    if (auto channelShuffleResult = verifySupportedVMIChannelShuffleOp(op);
-        channelShuffleResult.has_value()) {
-      return *channelShuffleResult;
-    }
-
-    return WalkResult::advance();
-  });
+  WalkResult result = module.walk(
+      [&enableStableGatherMaskedLoad](Operation *op) {
+        return verifySupportedVMIToVPTOOp(op, enableStableGatherMaskedLoad);
+      });
   return failure(result.wasInterrupted());
 }
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18279,11 +18279,18 @@ static FailureOr<GroupBroadcastShapePlan> buildGroupBroadcastShapePlan(
 LogicalResult checkSupportedGroupBroadcastShape(
     VMIGroupBroadcastOp op,
     std::string *reason = nullptr) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
   FailureOr<GroupBroadcastShapePlan> plan =
       buildGroupBroadcastShapePlan(op, reason);
   if (failed(plan)) {
     return failure();
   }
+  auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutAttr resultLayout = plan->resultLayout;
   int64_t groupSize = plan->groupSize;
   int64_t lanesPerPart = plan->lanesPerPart;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3522,6 +3522,22 @@ FailureOr<ShuffleVselrPlan> computeShuffleVselrPlanForChunk(
                           state->descending.value_or(false)};
 }
 
+static FailureOr<int64_t> getShuffleResultChunkCount(
+    VMIVRegType resultType, int64_t resultPart, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> FailureOr<int64_t> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  FailureOr<int64_t> resultChunks =
+      getDataChunksInPart(resultType, resultPart);
+  if (failed(resultChunks)) {
+    return fail("requires known result physical chunks");
+  }
+  return *resultChunks;
+}
+
 FailureOr<int64_t> computeShuffleLane0SplatSourcePart(VMIShuffleOp op,
                                                       std::string *reason) {
   auto fail = [&reason](const Twine &message) -> FailureOr<int64_t> {
@@ -3585,7 +3601,7 @@ computeShuffleVselrPlans(VMIShuffleOp op, std::string *reason) {
   SmallVector<ShuffleVselrPlan> plans;
   for (int64_t resultPart = 0; resultPart < *resultFactor; ++resultPart) {
     FailureOr<int64_t> resultChunks =
-        getDataChunksInPart(resultType, resultPart);
+        getShuffleResultChunkCount(resultType, resultPart, reason);
     if (failed(resultChunks)) {
       return fail("requires known result physical chunks");
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10507,32 +10507,25 @@ struct OneToNVMIMaskedLoadOpPattern
   using OneToNOpConversionPattern<VMIMaskedLoadOp>::OneToNOpConversionPattern;
 
 private:
-  FailureOr<Value> materializeGatherPart(
-      VMIGatherOp op, OneToNPatternRewriter &rewriter, Value source,
-      Value indices, Value mask, Value passthru, Type resultType,
-      bool allActive) const {
-    bool invalidPartTypes = !isa<VRegType>(indices.getType()) ||
-                            !isa<MaskType>(mask.getType()) ||
+  FailureOr<Value> materializeMaskedLoadPart(
+      VMIMaskedLoadOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value offset, Value mask, Value passthru, Type resultType,
+      int64_t index, int64_t lanesPerPart) const {
+    bool invalidPartTypes = !isa<MaskType>(mask.getType()) ||
                             passthru.getType() != resultType ||
                             !isa<VRegType>(resultType);
     if (invalidPartTypes) {
       return rewriter.notifyMatchFailure(
-          op, "gather physical part type mismatch");
+          op, "masked_load physical part type mismatch");
     }
-    unsigned resultBits = pto::getPTOStorageElemBitWidth(
-        cast<VRegType>(resultType).getElementType());
-    Value gathered = resultBits == 16
-                         ? rewriter.create<Vgather2Op>(
-                               op.getLoc(), resultType, source, indices, mask)
-                               .getResult()
-                         : rewriter.create<Vgather2BcOp>(
-                               op.getLoc(), resultType, source, indices, mask)
-                               .getResult();
-    if (allActive) {
-      return gathered;
-    }
+    Value chunkOffset = createChunkOffset(
+        op.getLoc(), offset, index * lanesPerPart, rewriter);
+    Value loaded = rewriter
+                       .create<VldsOp>(op.getLoc(), resultType, Type{}, source,
+                                       chunkOffset, nullptr)
+                       .getResult();
     return rewriter
-        .create<VselOp>(op.getLoc(), resultType, gathered, passthru, mask)
+        .create<VselOp>(op.getLoc(), resultType, loaded, passthru, mask)
         .getResult();
   }
 
@@ -10551,24 +10544,13 @@ private:
     for (auto [index, maskPassthruAndType] : llvm::enumerate(
              llvm::zip_equal(maskParts, passthruParts, resultTypes))) {
       auto [mask, passthru, resultType] = maskPassthruAndType;
-      bool invalidPartTypes = !isa<MaskType>(mask.getType()) ||
-                              passthru.getType() != resultType ||
-                              !isa<VRegType>(resultType);
-      if (invalidPartTypes) {
-        return rewriter.notifyMatchFailure(
-            op, "masked_load physical part type mismatch");
+      FailureOr<Value> result = materializeMaskedLoadPart(
+          op, rewriter, source, offset, mask, passthru, resultType, index,
+          lanesPerPart);
+      if (failed(result)) {
+        return failure();
       }
-      Value chunkOffset = createChunkOffset(
-          op.getLoc(), offset, index * lanesPerPart, rewriter);
-      Value loaded = rewriter
-                         .create<VldsOp>(op.getLoc(), resultType,
-                                         /*updated_base=*/Type{}, source,
-                                         chunkOffset, /*dist=*/nullptr)
-                         .getResult();
-      results.push_back(rewriter
-                            .create<VselOp>(op.getLoc(), resultType, loaded,
-                                            passthru, mask)
-                            .getResult());
+      results.push_back(*result);
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12598,6 +12598,39 @@ private:
     return slots8 ? GroupStoreLayoutKind::Slots8 : GroupStoreLayoutKind::General;
   }
 
+  LogicalResult lowerGeneralGroupStore(
+      VMIGroupStoreOp op, OpAdaptor adaptor,
+      OneToNPatternRewriter &rewriter, VMIVRegType valueVMIType,
+      Value destination, Value offset, Value rowStride) const {
+    VMILayoutSupport supports;
+    FailureOr<VMIGroupStoreLayoutFact> fact =
+        supports.getGroupStoreLayoutFact(op, valueVMIType);
+    if (failed(fact)) {
+      return rewriter.notifyMatchFailure(
+          op, "group_store layout does not match the support table");
+    }
+    if (fact->blockClass == VMIGroupBlockClass::OneBlock) {
+      return lowerOneBlockGroupStore(
+          op, adaptor, rewriter, valueVMIType, *fact, destination, offset,
+          rowStride);
+    }
+    int64_t d2LanesPerPart = 0;
+    int64_t d2GroupCount = 0;
+    int64_t d2ChunksPerGroupPerPart = 0;
+    std::string d2Reason;
+    bool hasDeinterleaved2Shape = succeeded(checkDeinterleaved2GroupStoreChunkShape(
+        valueVMIType, fact->groupSize, &d2LanesPerPart, &d2GroupCount,
+        &d2ChunksPerGroupPerPart, &d2Reason));
+    if (hasDeinterleaved2Shape) {
+      return lowerDeinterleaved2GroupStore(
+          op, adaptor, rewriter, valueVMIType, *fact, destination, offset,
+          rowStride);
+    }
+    return lowerContiguousGroupStore(
+        op, adaptor, rewriter, valueVMIType, *fact, destination, offset,
+        rowStride);
+  }
+
   LogicalResult lowerByLayout(
       VMIGroupStoreOp op, OpAdaptor adaptor,
       OneToNPatternRewriter &rewriter, VMIVRegType valueVMIType,
@@ -12623,34 +12656,8 @@ private:
                                  destination, offset, rowStride);
     }
 
-    VMILayoutSupport supports;
-    FailureOr<VMIGroupStoreLayoutFact> fact =
-        supports.getGroupStoreLayoutFact(op, valueVMIType);
-    if (failed(fact)) {
-      return rewriter.notifyMatchFailure(
-          op, "group_store layout does not match the support table");
-    }
-    if (fact->blockClass == VMIGroupBlockClass::OneBlock) {
-      return lowerOneBlockGroupStore(
-          op, adaptor, rewriter, valueVMIType, *fact, destination, offset,
-          rowStride);
-    }
-
-    int64_t d2LanesPerPart = 0;
-    int64_t d2GroupCount = 0;
-    int64_t d2ChunksPerGroupPerPart = 0;
-    std::string d2Reason;
-    bool hasDeinterleaved2Shape = succeeded(checkDeinterleaved2GroupStoreChunkShape(
-        valueVMIType, fact->groupSize, &d2LanesPerPart, &d2GroupCount,
-        &d2ChunksPerGroupPerPart, &d2Reason));
-    if (hasDeinterleaved2Shape) {
-      return lowerDeinterleaved2GroupStore(
-          op, adaptor, rewriter, valueVMIType, *fact, destination, offset,
-          rowStride);
-    }
-    return lowerContiguousGroupStore(
-        op, adaptor, rewriter, valueVMIType, *fact, destination, offset,
-        rowStride);
+    return lowerGeneralGroupStore(op, adaptor, rewriter, valueVMIType,
+                                  destination, offset, rowStride);
   }
 
 public:

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18333,32 +18333,30 @@ std::optional<WalkResult> verifySupportedVMIMultiplyLongOp(Operation *op) {
   return std::nullopt;
 }
 
+template <typename SpecialOp, typename ShapeCheck>
+std::optional<WalkResult> verifySpecialUnaryShape(
+    SpecialOp op, ShapeCheck check, StringRef diagnostic) {
+  std::string reason;
+  if (succeeded(check(op, &reason))) {
+    return WalkResult::advance();
+  }
+  op.emitError() << kVMIDiagUnsupportedPrefix << diagnostic << reason << ")";
+  return WalkResult::interrupt();
+}
+
 std::optional<WalkResult> verifySupportedVMISpecialUnaryOp(Operation *op) {
   if (auto relu = dyn_cast<VMIReluOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedReluShape(relu, &reason))) {
-      return WalkResult::advance();
-    }
-    relu.emitError()
-        << kVMIDiagUnsupportedPrefix
-        << "pto.vmi.relu direct lowering requires physical vreg parts with "
-           "b32 predicates for si32 or matching b16/b32 predicates for "
-           "f16/f32 ("
-        << reason << ")";
-    return WalkResult::interrupt();
+    return verifySpecialUnaryShape(
+        relu, checkSupportedReluShape,
+        "pto.vmi.relu direct lowering requires physical vreg parts with b32 "
+        "predicates for si32 or matching b16/b32 predicates for f16/f32 (");
   }
   if (auto vselr = dyn_cast<VMIVselrOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedVselrShape(vselr, &reason))) {
-      return WalkResult::advance();
-    }
-    vselr.emitError()
-        << kVMIDiagUnsupportedPrefix
-        << "pto.vmi.vselr supports only contiguous lane_stride=1 layouts "
-           "with N=64, 128, or 256 for 8-bit, N=64 or 128 for 16-bit, "
-           "or N=64 for 32-bit elements ("
-        << reason << ")";
-    return WalkResult::interrupt();
+    return verifySpecialUnaryShape(
+        vselr, checkSupportedVselrShape,
+        "pto.vmi.vselr supports only contiguous lane_stride=1 layouts with "
+        "N=64, 128, or 256 for 8-bit, N=64 or 128 for 16-bit, or N=64 for "
+        "32-bit elements (");
   }
   return std::nullopt;
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11163,6 +11163,22 @@ struct OneToNVMIGroupBroadcastLoadOpPattern
   using OneToNOpConversionPattern<VMIGroupBroadcastLoadOp>::OneToNOpConversionPattern;
 
 private:
+  FailureOr<Value> emitE2BPacket(
+      VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
+      Value source, Value offset, Type packetType, int64_t chunk,
+      StringRef e2bDist) const {
+    if (!isa<VRegType>(packetType)) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast_load result must be vreg");
+    }
+    Value packetOffset =
+        createChunkOffset(op.getLoc(), offset, chunk * 8, rewriter);
+    return rewriter
+        .create<VldsOp>(op.getLoc(), packetType, Type{}, source, packetOffset,
+                        rewriter.getStringAttr(e2bDist))
+        .getResult();
+  }
+
   FailureOr<SmallVector<Value>> emitE2BPackets(
       VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
       Value source, Value offset, ArrayRef<Type> resultTypes,
@@ -11170,18 +11186,12 @@ private:
     SmallVector<Value> packets;
     packets.reserve(chunksPerPart);
     for (int64_t chunk = 0; chunk < chunksPerPart; ++chunk) {
-      Type packetType = resultTypes[chunk];
-      if (!isa<VRegType>(packetType)) {
-        return rewriter.notifyMatchFailure(
-            op, "group_broadcast_load result must be vreg");
+      FailureOr<Value> packet = emitE2BPacket(
+          op, rewriter, source, offset, resultTypes[chunk], chunk, e2bDist);
+      if (failed(packet)) {
+        return failure();
       }
-      Value packetOffset =
-          createChunkOffset(op.getLoc(), offset, chunk * 8, rewriter);
-      packets.push_back(rewriter
-                            .create<VldsOp>(op.getLoc(), packetType, Type{},
-                                            source, packetOffset,
-                                            rewriter.getStringAttr(e2bDist))
-                            .getResult());
+      packets.push_back(*packet);
     }
     return packets;
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -14185,6 +14185,37 @@ struct OneToNVMITruncFOpPattern : OneToNOpConversionPattern<VMITruncFOp> {
   using OneToNOpConversionPattern<VMITruncFOp>::OneToNOpConversionPattern;
 
 private:
+  FailureOr<Value> lowerGroupSlotTruncPart(
+      VMITruncFOp op, Value sourcePart, Type physicalResultType,
+      Value activeSlotMask, StringAttr sat,
+      OneToNPatternRewriter &rewriter) const {
+    auto sourceType = dyn_cast<VRegType>(sourcePart.getType());
+    auto resultType = dyn_cast<VRegType>(physicalResultType);
+    const bool invalidTypes =
+        !sourceType || !sourceType.getElementType().isF32() || !resultType;
+    if (invalidTypes) {
+      rewriter.notifyMatchFailure(
+          op, "unsupported group-slot truncf physical type");
+      return failure();
+    }
+    unsigned resultBits =
+        pto::getPTOStorageElemBitWidth(resultType.getElementType());
+    const bool unsupportedResultBits = resultBits != 16 && resultBits != 8;
+    if (unsupportedResultBits) {
+      rewriter.notifyMatchFailure(
+          op, "unsupported group-slot truncf physical type");
+      return failure();
+    }
+    StringAttr part =
+        rewriter.getStringAttr(resultBits == 16 ? "EVEN" : "P0");
+    StringAttr rnd = rewriter.getStringAttr(
+        getTruncFRoundMode(op, resultType.getElementType()));
+    return rewriter
+        .create<VcvtOp>(op.getLoc(), resultType, sourcePart, activeSlotMask,
+                        rnd, sat, part)
+        .getResult();
+  }
+
   static Value makeVcvtSourceView(Location loc, Value sourcePart,
                                   bool sourceIsPackedBF16x2,
                                   VRegType vcvtSourceVRegType,
@@ -14337,29 +14368,12 @@ private:
     StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
     for (auto [sourcePart, physicalResultType] :
          llvm::zip_equal(sourceParts, resultTypes)) {
-      auto sourceType = dyn_cast<VRegType>(sourcePart.getType());
-      auto resultType = dyn_cast<VRegType>(physicalResultType);
-      bool invalidTypes =
-          !sourceType || !sourceType.getElementType().isF32() || !resultType;
-      if (invalidTypes) {
-        return rewriter.notifyMatchFailure(
-            op, "unsupported group-slot truncf physical type");
+      FailureOr<Value> result = lowerGroupSlotTruncPart(
+          op, sourcePart, physicalResultType, *activeSlotMask, sat, rewriter);
+      if (failed(result)) {
+        return failure();
       }
-      unsigned physicalResultBits =
-          pto::getPTOStorageElemBitWidth(resultType.getElementType());
-      bool unsupportedResultBits = physicalResultBits != 16 && physicalResultBits != 8;
-      if (unsupportedResultBits) {
-        return rewriter.notifyMatchFailure(
-            op, "unsupported group-slot truncf physical type");
-      }
-      StringAttr part = rewriter.getStringAttr(
-          physicalResultBits == 16 ? "EVEN" : "P0");
-      StringAttr rnd = rewriter.getStringAttr(
-          getTruncFRoundMode(op, resultType.getElementType()));
-      results.push_back(rewriter
-                            .create<VcvtOp>(op.getLoc(), resultType, sourcePart,
-                                           *activeSlotMask, rnd, sat, part)
-                            .getResult());
+      results.push_back(*result);
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6645,6 +6645,22 @@ materializeMaskGranularityCastStagingForFactor(
   return std::optional<SmallVector<Value>>(std::move(*result));
 }
 
+static std::optional<bool> getMaskStagingDirection(
+    VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout, int64_t factor) {
+  bool sourceContiguous = sourceLayout && sourceLayout.isContiguous() &&
+                          sourceLayout.getLaneStride() == 1;
+  bool resultContiguous = resultLayout && resultLayout.isContiguous() &&
+                          resultLayout.getLaneStride() == 1;
+  bool sourceDeinterleaved =
+      isElementDeinterleavedLayout(sourceLayout, factor) && resultContiguous;
+  bool resultDeinterleaved =
+      sourceContiguous && isElementDeinterleavedLayout(resultLayout, factor);
+  if (!sourceDeinterleaved && !resultDeinterleaved) {
+    return std::nullopt;
+  }
+  return sourceDeinterleaved;
+}
+
 FailureOr<std::optional<SmallVector<Value>>>
 materializeMaskGranularityCastStagingLayout(
     Operation *op, VMIMaskType sourceType, VMIMaskType resultType,
@@ -6652,10 +6668,22 @@ materializeMaskGranularityCastStagingLayout(
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
   for (int64_t factor : {2L, 4L}) {
+    std::optional<bool> sourceIsDeinterleaved =
+        getMaskStagingDirection(sourceLayout, resultLayout, factor);
+    if (!sourceIsDeinterleaved) {
+      continue;
+    }
+    FailureOr<SmallVector<Value>> materialized =
+        *sourceIsDeinterleaved
+            ? materializeStagingDeintToContiguousMaskLayout(
+                  op, sourceParts, resultTypes, factor, rewriter)
+            : materializeStagingContiguousToDeintMaskLayout(
+                  op, sourceParts, resultTypes, factor, rewriter);
+    if (failed(materialized)) {
+      return failure();
+    }
     FailureOr<std::optional<SmallVector<Value>>> result =
-        materializeMaskGranularityCastStagingForFactor(
-            op, sourceLayout, resultLayout, sourceParts, resultTypes, factor,
-            rewriter);
+        std::optional<SmallVector<Value>>(std::move(*materialized));
     if (failed(result)) {
       return failure();
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2224,20 +2224,24 @@ checkSupportedGroupStoreByLayout(VMIGroupStoreOp op, VMIVRegType valueType,
   VMILayoutSupport supports;
   FailureOr<VMIGroupStoreLayoutFact> fact =
       supports.getGroupStoreLayoutFact(op, valueType, reason);
-  if (failed(fact))
+  if (failed(fact)) {
     return failure();
+  }
   if (failed(checkSupportedStoreShape(valueType,
                                       op.getDestination(),
-                                      op.getDestination().getType(), reason)))
+                                      op.getDestination().getType(), reason))) {
     return failure();
+  }
   if (fact->blockClass == VMIGroupBlockClass::OneBlock) {
-    if (failed(getOneBlockGroupStorePlan(op, valueType, *fact, reason)))
+    if (failed(getOneBlockGroupStorePlan(op, valueType, *fact, reason))) {
       return failure();
+    }
     return success();
   }
   if (succeeded(
-          checkSupportedGroupChunkShape(valueType, fact->groupSize, reason)))
+          checkSupportedGroupChunkShape(valueType, fact->groupSize, reason))) {
     return success();
+  }
 
   int64_t lanesPerPart = 0;
   int64_t groupCount = 0;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7246,6 +7246,8 @@ private:
     }
 
     llvm::DenseMap<std::pair<Type, int64_t>, Value> sharedChunks;
+    IotaMaterializationContext context{op.getLoc(), base, op.getOrderAttr(),
+                                       rewriter};
     for (auto [index, resultType] : llvm::enumerate(resultTypes)) {
       if (!isa<VRegType>(resultType)) {
         return rewriter.notifyMatchFailure(op, "iota result must be vreg");
@@ -7257,8 +7259,6 @@ private:
       auto key = std::make_pair(resultType, laneOffset);
       auto it = sharedChunks.find(key);
       if (it == sharedChunks.end()) {
-        IotaMaterializationContext context{op.getLoc(), base,
-                                          op.getOrderAttr(), rewriter};
         FailureOr<Value> result;
         if (physMultipleOfGroupSize && groupSize < lanesPerPart) {
           result = createSubVLGroupPeriodicChunk(context, resultType,
@@ -7280,12 +7280,12 @@ private:
   LogicalResult lowerContiguousIota(
       IotaOp op, Value base, TypeRange resultTypes, int64_t lanesPerPart,
       OneToNPatternRewriter &rewriter, SmallVectorImpl<Value> &results) const {
+    IotaMaterializationContext context{op.getLoc(), base, op.getOrderAttr(),
+                                       rewriter};
     for (auto [index, resultType] : llvm::enumerate(resultTypes)) {
       if (!isa<VRegType>(resultType)) {
         return rewriter.notifyMatchFailure(op, "iota result must be vreg");
       }
-      IotaMaterializationContext context{op.getLoc(), base, op.getOrderAttr(),
-                                         rewriter};
       FailureOr<Value> result = createIotaContiguousChunk(
           context, resultType, static_cast<int64_t>(index) * lanesPerPart);
       if (failed(result)) {
@@ -7309,11 +7309,11 @@ private:
               "layout factor");
     }
     int64_t chunksPerPart = resultTypes.size() / factor;
+    IotaMaterializationContext context{op.getLoc(), base, op.getOrderAttr(),
+                                       rewriter};
     for (int64_t part = 0; part < factor; ++part) {
       for (int64_t chunk = 0; chunk < chunksPerPart; ++chunk) {
         Type resultType = resultTypes[part * chunksPerPart + chunk];
-        IotaMaterializationContext context{op.getLoc(), base,
-                                           op.getOrderAttr(), rewriter};
         FailureOr<Value> result = createIotaDeinterleavedChunk(
             context, resultType, factor, part, chunk, lanesPerPart);
         if (failed(result)) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10378,6 +10378,34 @@ private:
     return success();
   }
 
+  LogicalResult emitOneBlockGroupStorePart(
+      VMIGroupStoreOp op, Value value, int64_t part,
+      VMIVRegType valueVMIType, const OneBlockGroupStorePlan &plan,
+      Value destination, Value offset, Value rowStride, Value blockStride,
+      Value repeatStride, OneToNPatternRewriter &rewriter) const {
+    auto vregType = dyn_cast<VRegType>(value.getType());
+    if (!vregType) {
+      return rewriter.notifyMatchFailure(
+          op, "one-block group_store value must be vreg");
+    }
+    FailureOr<Value> mask = createContiguousStoreMask(
+        op.getLoc(), valueVMIType, part, vregType, rewriter);
+    if (failed(mask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to create one-block group_store mask");
+    }
+    Value partOffset = createGroupChunkOffset(
+        op.getLoc(), offset, rowStride, part * plan.groupsPerPart,
+        /*inGroupLaneOffset=*/0, rewriter);
+    Value base = rewriter
+                     .create<AddPtrOp>(op.getLoc(), destination.getType(),
+                                       destination, partOffset)
+                     .getResult();
+    rewriter.create<VsstbOp>(op.getLoc(), /*updated_base=*/Type{}, value, base,
+                             blockStride, repeatStride, *mask);
+    return success();
+  }
+
   LogicalResult lowerOneBlockGroupStore(
       VMIGroupStoreOp op, OpAdaptor adaptor, OneToNPatternRewriter &rewriter,
       VMIVRegType valueVMIType, const VMIGroupStoreLayoutFact &fact,
@@ -10402,26 +10430,11 @@ private:
     Value repeatStride = rewriter.create<arith::ConstantIntOp>(
         op.getLoc(), 0, 16);
     for (auto [part, value] : llvm::enumerate(valueParts)) {
-      auto vregType = dyn_cast<VRegType>(value.getType());
-      if (!vregType) {
-        return rewriter.notifyMatchFailure(
-            op, "one-block group_store value must be vreg");
+      if (failed(emitOneBlockGroupStorePart(
+              op, value, part, valueVMIType, *plan, destination, offset,
+              rowStride, blockStride, repeatStride, rewriter))) {
+        return failure();
       }
-      FailureOr<Value> mask = createContiguousStoreMask(
-          op.getLoc(), valueVMIType, part, vregType, rewriter);
-      if (failed(mask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to create one-block group_store mask");
-      }
-      Value partOffset = createGroupChunkOffset(
-          op.getLoc(), offset, rowStride, part * plan->groupsPerPart,
-          /*inGroupLaneOffset=*/0, rewriter);
-      Value base = rewriter
-                       .create<AddPtrOp>(op.getLoc(), destination.getType(),
-                                         destination, partOffset)
-                       .getResult();
-      rewriter.create<VsstbOp>(op.getLoc(), /*updated_base=*/Type{}, value, base,
-                               blockStride, repeatStride, *mask);
     }
     rewriter.eraseOp(op);
     return success();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3304,6 +3304,39 @@ static FailureOr<bool> getShuffleLaneDirection(
   return descending && !ascending;
 }
 
+static FailureOr<VMIPhysicalLane> getShuffleSourceLane(
+    VMIVRegType sourceType, VMIVRegType resultType,
+    ArrayRef<int64_t> indices, int64_t resultPart, int64_t resultChunk,
+    int64_t lane, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> FailureOr<VMIPhysicalLane> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  FailureOr<bool> padding =
+      isPaddingLane(resultType, resultPart, resultChunk, lane);
+  bool invalidPadding = failed(padding) || *padding;
+  if (invalidPadding) {
+    return fail("requires full physical result chunks");
+  }
+  FailureOr<int64_t> logicalLane =
+      mapPhysicalLaneToLogical(resultType, resultPart, resultChunk, lane);
+  bool logicalLaneOutOfRange =
+      succeeded(logicalLane) &&
+      *logicalLane >= static_cast<int64_t>(indices.size());
+  bool invalidLogicalLane = failed(logicalLane) || logicalLaneOutOfRange;
+  if (invalidLogicalLane) {
+    return fail("failed to map result lane");
+  }
+  FailureOr<VMIPhysicalLane> sourceLane =
+      mapLogicalLaneToPhysical(sourceType, indices[*logicalLane]);
+  if (failed(sourceLane)) {
+    return fail("failed to map source lane");
+  }
+  return *sourceLane;
+}
+
 FailureOr<ShuffleVselrPlan> computeShuffleVselrPlanForChunk(
     VMIVRegType sourceType, VMIVRegType resultType, ArrayRef<int64_t> indices,
     int64_t resultPart, int64_t resultChunk, int64_t lanesPerPart,
@@ -3319,30 +3352,10 @@ FailureOr<ShuffleVselrPlan> computeShuffleVselrPlanForChunk(
   std::optional<int64_t> baseLane;
   std::optional<bool> descending;
   for (int64_t lane = 0; lane < lanesPerPart; ++lane) {
-    FailureOr<bool> padding =
-        isPaddingLane(resultType, resultPart, resultChunk, lane);
-    bool hasPadding = succeeded(padding) && *padding;
-    if (failed(padding)) {
-      return fail("requires full physical result chunks");
-    }
-    if (hasPadding) {
-      return fail("requires full physical result chunks");
-    }
-    FailureOr<int64_t> resultLogicalLane =
-        mapPhysicalLaneToLogical(resultType, resultPart, resultChunk, lane);
-    bool resultLaneOutOfRange =
-        succeeded(resultLogicalLane) &&
-        *resultLogicalLane >= static_cast<int64_t>(indices.size());
-    if (failed(resultLogicalLane)) {
-      return fail("failed to map result lane");
-    }
-    if (resultLaneOutOfRange) {
-      return fail("failed to map result lane");
-    }
-    FailureOr<VMIPhysicalLane> sourcePhysical =
-        mapLogicalLaneToPhysical(sourceType, indices[*resultLogicalLane]);
+    FailureOr<VMIPhysicalLane> sourcePhysical = getShuffleSourceLane(
+        sourceType, resultType, indices, resultPart, resultChunk, lane, reason);
     if (failed(sourcePhysical)) {
-      return fail("failed to map source lane");
+      return failure();
     }
     if (!sourcePart) {
       sourcePart = sourcePhysical->part;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18044,6 +18044,65 @@ struct ReducePhysicalShapePlan {
 };
 
 template <typename OpTy>
+static LogicalResult checkReduceLayouts(OpTy op, VMILayoutAttr *sourceLayout,
+                                        VMILayoutAttr *maskLayout,
+                                        VMILayoutAttr *resultLayout,
+                                        std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  auto sourceType = cast<VMIVRegType>(op.getSource().getType());
+  auto maskType = cast<VMIMaskType>(op.getMask().getType());
+  auto resultType = cast<VMIVRegType>(op.getResult().getType());
+  *sourceLayout = sourceType.getLayoutAttr();
+  *maskLayout = maskType.getLayoutAttr();
+  *resultLayout = resultType.getLayoutAttr();
+  if (!*sourceLayout || !*maskLayout || !*resultLayout) {
+    return fail("requires assigned source, mask, and result layouts");
+  }
+  bool nonContiguousLayout = !sourceLayout->isContiguous() ||
+                             !maskLayout->isContiguous() ||
+                             !resultLayout->isContiguous();
+  if (nonContiguousLayout) {
+    return fail("requires contiguous source, mask, and result layouts");
+  }
+  return success();
+}
+
+static LogicalResult checkReducePhysicalArity(
+    VMIVRegType sourceType, VMIMaskType maskType, VMIVRegType resultType,
+    int64_t *sourceArity, int64_t *resultArity, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  FailureOr<int64_t> sourceParts = getVMIPhysicalArity(sourceType);
+  FailureOr<int64_t> maskParts = getVMIPhysicalArity(maskType);
+  FailureOr<int64_t> resultParts = getVMIPhysicalArity(resultType);
+  bool cannotComputeArity = failed(sourceParts) || failed(maskParts) ||
+                            failed(resultParts);
+  if (cannotComputeArity) {
+    return fail("requires computable physical arity");
+  }
+  bool mismatchedInputArity = *sourceParts < 1 || *maskParts != *sourceParts;
+  if (mismatchedInputArity) {
+    return fail("requires source and mask physical arity to match and be "
+                "non-empty");
+  }
+  if (*resultParts != 1) {
+    return fail("requires one result physical chunk");
+  }
+  *sourceArity = *sourceParts;
+  *resultArity = *resultParts;
+  return success();
+}
+
+template <typename OpTy>
 static FailureOr<ReducePhysicalShapePlan> buildReducePhysicalShapePlan(
     OpTy op, std::string *reason) {
   auto fail = [&reason](const Twine &message)
@@ -18057,14 +18116,13 @@ static FailureOr<ReducePhysicalShapePlan> buildReducePhysicalShapePlan(
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
-  VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
-  VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !maskLayout || !resultLayout)
-    return fail("requires assigned source, mask, and result layouts");
-  if (!sourceLayout.isContiguous() || !maskLayout.isContiguous() ||
-      !resultLayout.isContiguous())
-    return fail("requires contiguous source, mask, and result layouts");
+  VMILayoutAttr sourceLayout;
+  VMILayoutAttr maskLayout;
+  VMILayoutAttr resultLayout;
+  if (failed(checkReduceLayouts(op, &sourceLayout, &maskLayout, &resultLayout,
+                                reason))) {
+    return failure();
+  }
 
   std::string fullChunkReason;
   if (failed(checkFullDataPhysicalChunks(sourceType, &fullChunkReason)))
@@ -18072,19 +18130,15 @@ static FailureOr<ReducePhysicalShapePlan> buildReducePhysicalShapePlan(
                       "do not participate in the reduction; ") +
                 fullChunkReason);
 
-  FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
-  FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
-  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(sourceArity) || failed(maskArity) || failed(resultArity))
-    return fail("requires computable physical arity");
-  if (*sourceArity < 1 || *maskArity != *sourceArity)
-    return fail("requires source and mask physical arity to match and be "
-                "non-empty");
-  if (*resultArity != 1)
-    return fail("requires one result physical chunk");
+  int64_t sourceArity;
+  int64_t resultArity;
+  if (failed(checkReducePhysicalArity(sourceType, maskType, resultType,
+                                      &sourceArity, &resultArity, reason))) {
+    return failure();
+  }
 
   return ReducePhysicalShapePlan{sourceLayout, maskLayout, resultLayout,
-                                 *sourceArity, *resultArity};
+                                 sourceArity, resultArity};
 }
 
 template <typename OpTy>

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5660,14 +5660,21 @@ static FailureOr<std::optional<SmallVector<Value>>> materializeIdentityMaskLayou
       SmallVector<Value>(sourceParts.begin(), sourceParts.end()));
 }
 
+struct MaskLayoutMaterializationContext {
+  Operation *op;
+  ValueRange sourceParts;
+  TypeRange resultTypes;
+  VMILayoutAttr sourceLayout;
+  VMILayoutAttr resultLayout;
+  PatternRewriter &rewriter;
+};
+
 template <typename Materializer>
-static FailureOr<std::optional<SmallVector<Value>>> tryMaskLayoutMaterializer(
+static FailureOr<std::optional<SmallVector<Value>>>
+tryMaskLayoutMaterializer(
+    const MaskLayoutMaterializationContext &context,
     Materializer materializer) {
-  FailureOr<std::optional<SmallVector<Value>>> result = materializer();
-  if (failed(result)) {
-    return failure();
-  }
-  return result;
+  return materializer(context);
 }
 
 FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
@@ -5681,12 +5688,13 @@ FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
     return failure();
   }
 
+  MaskLayoutMaterializationContext context{
+      op, sourceParts, resultTypes, sourceLayout, resultLayout, rewriter};
   FailureOr<std::optional<SmallVector<Value>>> identity =
-      tryMaskLayoutMaterializer([op, sourceParts, resultTypes, sourceLayout,
-                                 resultLayout, &rewriter]() {
-        return materializeIdentityMaskLayout(op, sourceParts, resultTypes,
-                                             sourceLayout, resultLayout,
-                                             rewriter);
+      tryMaskLayoutMaterializer(context, [](const MaskLayoutMaterializationContext &context) {
+        return materializeIdentityMaskLayout(
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout, context.rewriter);
       });
   if (failed(identity)) {
     return failure();
@@ -5696,11 +5704,10 @@ FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
   }
 
   FailureOr<std::optional<SmallVector<Value>>> deinterleaved2 =
-      tryMaskLayoutMaterializer([op, sourceParts, resultTypes, sourceLayout,
-                                 resultLayout, &rewriter]() {
+      tryMaskLayoutMaterializer(context, [](const MaskLayoutMaterializationContext &context) {
         return materializeDeinterleaved2MaskLayout(
-            op, sourceParts, resultTypes, sourceLayout, resultLayout,
-            rewriter);
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout, context.rewriter);
       });
   if (failed(deinterleaved2)) {
     return failure();
@@ -5710,11 +5717,10 @@ FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
   }
 
   FailureOr<std::optional<SmallVector<Value>>> laneStride =
-      tryMaskLayoutMaterializer([op, sourceParts, resultTypes, sourceLayout,
-                                 resultLayout, &rewriter]() {
+      tryMaskLayoutMaterializer(context, [](const MaskLayoutMaterializationContext &context) {
         return materializeMaskLaneStrideLayout(
-            op, sourceParts, resultTypes, sourceLayout, resultLayout,
-            rewriter);
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout, context.rewriter);
       });
   if (failed(laneStride)) {
     return failure();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3106,6 +3106,23 @@ struct ShuffleVselrPlan {
   bool descending = false;
 };
 
+static FailureOr<bool> getShuffleLaneDirection(
+    int64_t baseLane, int64_t resultLane, int64_t sourceLane,
+    std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> FailureOr<bool> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  bool ascending = sourceLane == baseLane + resultLane;
+  bool descending = sourceLane == baseLane - resultLane;
+  if (!ascending && !descending) {
+    return fail("requires ASC or DESC affine source lane indices");
+  }
+  return descending && !ascending;
+}
+
 FailureOr<ShuffleVselrPlan> computeShuffleVselrPlanForChunk(
     VMIVRegType sourceType, VMIVRegType resultType, ArrayRef<int64_t> indices,
     int64_t resultPart, int64_t resultChunk, int64_t lanesPerPart,
@@ -3156,19 +3173,16 @@ FailureOr<ShuffleVselrPlan> computeShuffleVselrPlanForChunk(
         *sourceChunk != sourcePhysical->chunk) {
       return fail("requires one source chunk per result chunk");
     }
-    int64_t ascExpected = *baseLane + lane;
-    int64_t descExpected = *baseLane - lane;
-    bool asc = sourcePhysical->lane == ascExpected;
-    bool desc = sourcePhysical->lane == descExpected;
-    if (!asc && !desc) {
-      return fail("requires ASC or DESC affine source lane indices");
+    FailureOr<bool> laneDescending = getShuffleLaneDirection(
+        *baseLane, lane, sourcePhysical->lane, reason);
+    if (failed(laneDescending)) {
+      return failure();
     }
-    bool laneDescending = desc && !asc;
     if (!descending) {
-      descending = laneDescending;
+      descending = *laneDescending;
       continue;
     }
-    if (*descending != laneDescending) {
+    if (*descending != *laneDescending) {
       return fail("requires one index order per result chunk");
     }
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6865,8 +6865,9 @@ struct OneToNVMIEnsureLayoutOpPattern
     FailureOr<SmallVector<Value>> results = materializeEnsureLayoutConversion(
         op, adaptor.getSource(), sourceType, resultType,
         *this->getTypeConverter(), rewriter);
-    if (failed(results))
+    if (failed(results)) {
       return failure();
+    }
     replaceOpWithFlatConvertedValues(rewriter, op, *results, *this->getTypeConverter());
     return success();
   }
@@ -6885,14 +6886,18 @@ struct OneToNVMIEnsureMaskLayoutOpPattern
     VMILayoutSupport supports;
     std::string supportReason;
     if (failed(supports.getEnsureMaskLayoutFact(sourceType, resultType,
-                                                &supportReason)))
+                                                &supportReason))) {
       return rewriter.notifyMatchFailure(
           op, Twine("ensure_mask_layout has no registered materialization "
                     "support: ") +
                   supportReason);
-    if (sourceType.getGranularity() != resultType.getGranularity())
+    }
+    bool granularityMismatch =
+        sourceType.getGranularity() != resultType.getGranularity();
+    if (granularityMismatch) {
       return rewriter.notifyMatchFailure(
           op, "mask layout helper cannot also change granularity");
+    }
     VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
     VMILayoutAttr resultLayout = resultType.getLayoutAttr();
 
@@ -6905,8 +6910,9 @@ struct OneToNVMIEnsureMaskLayoutOpPattern
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     FailureOr<SmallVector<Value>> results = materializeMaskLayoutConversion(
         op, sourceParts, resultTypes, sourceLayout, resultLayout, rewriter);
-    if (failed(results))
+    if (failed(results)) {
       return failure();
+    }
     replaceOpWithFlatConvertedValues(rewriter, op, *results, *this->getTypeConverter());
     return success();
   }
@@ -6945,15 +6951,21 @@ struct OneToNVMIEnsureMaskGranularityOpPattern
     FailureOr<SmallVector<Value>> results =
         materializeMaskGranularityCastConversion(
             op, sourceType, resultType, sourceParts, resultTypes, rewriter);
-    if (failed(results))
+    if (failed(results)) {
       return failure();
-    if (results->size() != resultTypes.size())
+    }
+    bool resultArityMismatch = results->size() != resultTypes.size();
+    if (resultArityMismatch) {
       return rewriter.notifyMatchFailure(
           op, "mask granularity cast result arity mismatch");
-    for (auto [result, type] : llvm::zip_equal(*results, resultTypes))
-      if (result.getType() != type)
+    }
+    for (auto [result, type] : llvm::zip_equal(*results, resultTypes)) {
+      bool resultTypeMismatch = result.getType() != type;
+      if (resultTypeMismatch) {
         return rewriter.notifyMatchFailure(
             op, "mask granularity cast result type mismatch");
+      }
+    }
     replaceOpWithFlatConvertedValues(rewriter, op, *results,
                                      *this->getTypeConverter());
     return success();
@@ -7066,13 +7078,15 @@ struct OneToNVMIBroadcastOpPattern : OneToNOpConversionPattern<VMIBroadcastOp> {
     results.reserve(resultTypes.size());
     for (Type resultType : resultTypes) {
       auto vregType = dyn_cast<VRegType>(resultType);
-      if (!vregType)
+      if (!vregType) {
         return rewriter.notifyMatchFailure(op, "broadcast result must be vreg");
+      }
       FailureOr<Value> mask =
           createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
-      if (failed(mask))
+      if (failed(mask)) {
         return rewriter.notifyMatchFailure(
             op, "unsupported element type for broadcast mask");
+      }
       StringAttr position =
           inputIsVReg ? rewriter.getStringAttr("LOWEST") : StringAttr{};
       results.push_back(rewriter
@@ -7106,22 +7120,26 @@ FailureOr<Value> createScalarOffsetConstant(Location loc, Type type,
 FailureOr<Value> createIotaChunkBase(Location loc, Value base,
                                      int64_t laneOffset, StringRef order,
                                      PatternRewriter &rewriter) {
-  if (laneOffset == 0)
+  if (laneOffset == 0) {
     return base;
+  }
 
   FailureOr<Value> offset =
       createScalarOffsetConstant(loc, base.getType(), laneOffset, rewriter);
-  if (failed(offset))
+  if (failed(offset)) {
     return failure();
+  }
 
   if (isa<IntegerType>(base.getType())) {
-    if (order == "DESC")
+    if (order == "DESC") {
       return rewriter.create<arith::SubIOp>(loc, base, *offset).getResult();
+    }
     return rewriter.create<arith::AddIOp>(loc, base, *offset).getResult();
   }
   if (isa<FloatType>(base.getType())) {
-    if (order == "DESC")
+    if (order == "DESC") {
       return rewriter.create<arith::SubFOp>(loc, base, *offset).getResult();
+    }
     return rewriter.create<arith::AddFOp>(loc, base, *offset).getResult();
   }
 
@@ -15117,6 +15135,47 @@ private:
     return resultVRegTypes;
   }
 
+  FailureOr<TruncFPhysicalPlan> buildPhysicalPlan(
+      VMITruncFOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      OneToNPatternRewriter &rewriter) const {
+    if (resultTypes.empty()) {
+      return rewriter.notifyMatchFailure(op, "truncf requires result chunks");
+    }
+    FailureOr<VRegType> sourceType =
+        getUniformSourceType(op, sourceParts, rewriter);
+    if (failed(sourceType)) {
+      return failure();
+    }
+    unsigned sourceBits =
+        pto::getPTOStorageElemBitWidth(sourceType->getElementType());
+    if (sourceBits != 32 && sourceBits != 16) {
+      return rewriter.notifyMatchFailure(
+          op, "truncf source bit width must be 32 or 16");
+    }
+    FailureOr<SmallVector<VRegType>> resultVRegTypes =
+        getUniformResultTypes(op, resultTypes, rewriter);
+    if (failed(resultVRegTypes)) {
+      return failure();
+    }
+    unsigned resultBits = pto::getPTOStorageElemBitWidth(
+        resultVRegTypes->front().getElementType());
+    if (resultBits == 0) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported physical truncf result type");
+    }
+    bool sourceIsPackedBF16x2 =
+        pto::isPTOBF16x2Type(sourceType->getElementType());
+    VRegType sourceViewType = *sourceType;
+    if (sourceIsPackedBF16x2) {
+      sourceViewType = VRegType::get(
+          rewriter.getContext(), sourceType->getElementCount() * 2,
+          BFloat16Type::get(rewriter.getContext()));
+    }
+    return TruncFPhysicalPlan{*sourceType, std::move(*resultVRegTypes),
+                              sourceViewType, sourceBits, resultBits,
+                              sourceIsPackedBF16x2};
+  }
+
   LogicalResult lowerDenseLaneStride(
       VMITruncFOp op, ValueRange sourceParts,
       ArrayRef<VRegType> resultTypes, StringRef part,
@@ -15381,34 +15440,15 @@ public:
                                  rewriter);
     }
 
-    if (resultTypes.empty()) {
-      return rewriter.notifyMatchFailure(op, "truncf requires result chunks");
-    }
-
-    FailureOr<VRegType> sourceType =
-        getUniformSourceType(op, sourceParts, rewriter);
-    if (failed(sourceType)) {
+    FailureOr<TruncFPhysicalPlan> physicalPlan =
+        buildPhysicalPlan(op, sourceParts, resultTypes, rewriter);
+    if (failed(physicalPlan)) {
       return failure();
     }
-    VRegType sourceType0 = *sourceType;
-    unsigned sourceBits = pto::getPTOStorageElemBitWidth(sourceType0.getElementType());
-    bool unsupportedSourceBits = sourceBits != 32 && sourceBits != 16;
-    if (unsupportedSourceBits) {
-      return rewriter.notifyMatchFailure(
-          op, "truncf source bit width must be 32 or 16");
-    }
-    // A packed bf16x2 physical source is consumed by pto.vcvt as raw bf16
-    // lanes (2 bf16 per bf16x2). Build the bf16 view type used for the source
-    // mask and for reinterpreting each source part before the VcvtOp. The
-    // logical lane count stays bf16x2-based; only the physical view widens.
-    bool sourceIsPackedBF16x2 =
-        pto::isPTOBF16x2Type(sourceType0.getElementType());
-    VRegType vcvtSourceVRegType = sourceType0;
-    if (sourceIsPackedBF16x2) {
-      vcvtSourceVRegType =
-          VRegType::get(rewriter.getContext(), sourceType0.getElementCount() * 2,
-                        BFloat16Type::get(rewriter.getContext()));
-    }
+    VRegType sourceType0 = physicalPlan->sourceType;
+    unsigned sourceBits = physicalPlan->sourceBits;
+    VRegType vcvtSourceVRegType = physicalPlan->sourceViewType;
+    bool sourceIsPackedBF16x2 = physicalPlan->sourceIsPackedBF16x2;
     // A packed bf16x2 source is consumed through its native bf16 view.
     // Group-slot layout for non-f32 sources is not supported yet.
     bool unsupportedGroupSlotLayout = sourceLayout && sourceLayout.isGroupSlots();
@@ -15416,20 +15456,8 @@ public:
       return rewriter.notifyMatchFailure(
           op, "group-slot layout for non-f32 truncf not supported");
     }
-    FailureOr<SmallVector<VRegType>> uniformResultTypes =
-        getUniformResultTypes(op, resultTypes, rewriter);
-    if (failed(uniformResultTypes)) {
-      return failure();
-    }
-    SmallVector<VRegType> resultVRegTypes = std::move(*uniformResultTypes);
-    if (pto::getPTOStorageElemBitWidth(
-            resultVRegTypes.front().getElementType()) == 0) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported physical truncf result type");
-    }
-
-    unsigned resultBits = pto::getPTOStorageElemBitWidth(
-        resultVRegTypes.front().getElementType());
+    SmallVector<VRegType> resultVRegTypes = physicalPlan->resultTypes;
+    unsigned resultBits = physicalPlan->resultBits;
     // Same-width fp->fp (bf16 -> f16, f16 -> bf16): dense contiguous 1:1,
     // no part; rnd always, sat follows the fp-to-fp contract.
     if (sourceBits == resultBits && sourceLayout && resultLayout &&

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11169,6 +11169,23 @@ private:
     return success();
   }
 
+  FailureOr<Value> buildDirectBRCResult(
+      VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
+      Value source, Value offset, Value sourceGroupStride, Type resultType,
+      int64_t group, StringRef brcDist) const {
+    auto vregType = dyn_cast<VRegType>(resultType);
+    if (!vregType) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast_load BRC result must be vreg");
+    }
+    Value groupOffset = createGroupChunkOffset(
+        op.getLoc(), offset, sourceGroupStride, group, 0, rewriter);
+    return rewriter
+        .create<VldsOp>(op.getLoc(), resultType, Type{}, source, groupOffset,
+                        rewriter.getStringAttr(brcDist))
+        .getResult();
+  }
+
   LogicalResult lowerDirectBRC(
       VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
       Value source, Value offset, Value sourceGroupStride,
@@ -11195,19 +11212,14 @@ private:
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (auto [index, resultType] : llvm::enumerate(resultTypes)) {
-      auto vregType = dyn_cast<VRegType>(resultType);
-      if (!vregType) {
-        return rewriter.notifyMatchFailure(
-            op, "group_broadcast_load BRC result must be vreg");
-      }
       int64_t group = static_cast<int64_t>(index) / chunksPerGroup;
-      Value groupOffset = createGroupChunkOffset(
-          op.getLoc(), offset, sourceGroupStride, group, 0, rewriter);
-      results.push_back(
-          rewriter
-              .create<VldsOp>(op.getLoc(), resultType, Type{}, source,
-                              groupOffset, rewriter.getStringAttr(brcDist))
-              .getResult());
+      FailureOr<Value> result = buildDirectBRCResult(
+          op, rewriter, source, offset, sourceGroupStride, resultType, group,
+          brcDist);
+      if (failed(result)) {
+        return failure();
+      }
+      results.push_back(*result);
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11365,6 +11365,70 @@ private:
                                  offset, rowStride, numGroups);
   }
 
+  LogicalResult lowerByLayout(
+      VMIGroupStoreOp op, OpAdaptor adaptor,
+      OneToNPatternRewriter &rewriter, VMIVRegType valueVMIType,
+      VMILayoutAttr layout, Value destination, Value offset,
+      Value rowStride) const {
+    bool compactSmallGroupStore = isCompactSmallGroupStore(
+        layout, valueVMIType, op.getNumGroupsAttr().getInt(),
+        getConstantIndexValue(op.getRowStride()));
+    bool isScalarGroupStore = op.getNumGroupsAttr().getInt() == 1 &&
+                              valueVMIType.getElementCount() == 1;
+    if (isScalarGroupStore) {
+      return lowerScalarGroupStore(op, adaptor, rewriter, valueVMIType,
+                                   destination, offset);
+    }
+    if (compactSmallGroupStore) {
+      return lowerCompactSmallGroupStore(op, adaptor, rewriter, valueVMIType,
+                                         layout, destination, offset);
+    }
+
+    bool isSlots1Layout =
+        layout && layout.isGroupSlots() && layout.getSlots() == 1 &&
+        layout.getNumGroups() == op.getNumGroupsAttr().getInt();
+    if (isSlots1Layout) {
+      return lowerSlots1(op, adaptor, rewriter, valueVMIType, layout,
+                         destination, offset, rowStride);
+    }
+    bool isSlots8Layout =
+        layout && layout.isGroupSlots() && layout.getSlots() == 8 &&
+        layout.getNumGroups() == op.getNumGroupsAttr().getInt();
+    if (isSlots8Layout) {
+      return lowerSlots8Dispatch(op, adaptor, rewriter, valueVMIType, layout,
+                                 destination, offset, rowStride);
+    }
+
+    VMILayoutSupport supports;
+    FailureOr<VMIGroupStoreLayoutFact> fact =
+        supports.getGroupStoreLayoutFact(op, valueVMIType);
+    if (failed(fact)) {
+      return rewriter.notifyMatchFailure(
+          op, "group_store layout does not match the support table");
+    }
+    if (fact->blockClass == VMIGroupBlockClass::OneBlock) {
+      return lowerOneBlockGroupStore(
+          op, adaptor, rewriter, valueVMIType, *fact, destination, offset,
+          rowStride);
+    }
+
+    int64_t d2LanesPerPart = 0;
+    int64_t d2GroupCount = 0;
+    int64_t d2ChunksPerGroupPerPart = 0;
+    std::string d2Reason;
+    bool hasDeinterleaved2Shape = succeeded(checkDeinterleaved2GroupStoreChunkShape(
+        valueVMIType, fact->groupSize, &d2LanesPerPart, &d2GroupCount,
+        &d2ChunksPerGroupPerPart, &d2Reason));
+    if (hasDeinterleaved2Shape) {
+      return lowerDeinterleaved2GroupStore(
+          op, adaptor, rewriter, valueVMIType, *fact, destination, offset,
+          rowStride);
+    }
+    return lowerContiguousGroupStore(
+        op, adaptor, rewriter, valueVMIType, *fact, destination, offset,
+        rowStride);
+  }
+
 public:
   LogicalResult
   matchAndRewrite(VMIGroupStoreOp op, OpAdaptor adaptor,
@@ -11387,73 +11451,13 @@ public:
       return failure();
     }
 
-    bool compactSmallGroupStore = isCompactSmallGroupStore(
-        layout, valueVMIType, op.getNumGroupsAttr().getInt(),
-        getConstantIndexValue(op.getRowStride()));
-
     // Unified scalar vstore is lowered to group_store(num_groups=1) before
     // layout assignment.  The producer may therefore carry the slots=8
     // layout selected by group_slot_load, even though the logical operation
     // still writes one scalar.  Preserve the scalar memory semantics here;
     // a masked ordinary vsts would require a 32-byte-aligned destination.
-    bool isScalarGroupStore = op.getNumGroupsAttr().getInt() == 1 &&
-                              valueVMIType.getElementCount() == 1;
-    if (isScalarGroupStore) {
-      return lowerScalarGroupStore(op, adaptor, rewriter, valueVMIType,
-                                   *destination, *offset);
-    }
-
-    if (compactSmallGroupStore) {
-      return lowerCompactSmallGroupStore(op, adaptor, rewriter, valueVMIType,
-                                         layout, *destination, *offset);
-    }
-
-    bool isSlots1Layout =
-        layout && layout.isGroupSlots() && layout.getSlots() == 1 &&
-        layout.getNumGroups() == op.getNumGroupsAttr().getInt();
-    if (isSlots1Layout) {
-      return lowerSlots1(op, adaptor, rewriter, valueVMIType, layout,
+    return lowerByLayout(op, adaptor, rewriter, valueVMIType, layout,
                          *destination, *offset, *rowStride);
-    }
-
-    bool isSlots8Layout =
-        layout && layout.isGroupSlots() && layout.getSlots() == 8 &&
-        layout.getNumGroups() == op.getNumGroupsAttr().getInt();
-    if (isSlots8Layout) {
-      return lowerSlots8Dispatch(op, adaptor, rewriter, valueVMIType, layout,
-                                 *destination, *offset, *rowStride);
-    }
-
-    VMILayoutSupport supports;
-    FailureOr<VMIGroupStoreLayoutFact> fact =
-        supports.getGroupStoreLayoutFact(op, valueVMIType);
-    if (failed(fact)) {
-      return rewriter.notifyMatchFailure(
-          op, "group_store layout does not match the support table");
-    }
-
-    if (fact->blockClass == VMIGroupBlockClass::OneBlock) {
-      return lowerOneBlockGroupStore(
-          op, adaptor, rewriter, valueVMIType, *fact, *destination, *offset,
-          *rowStride);
-    }
-
-    int64_t d2LanesPerPart = 0;
-    int64_t d2GroupCount = 0;
-    int64_t d2ChunksPerGroupPerPart = 0;
-    std::string d2Reason;
-    bool hasDeinterleaved2Shape = succeeded(checkDeinterleaved2GroupStoreChunkShape(
-        valueVMIType, fact->groupSize, &d2LanesPerPart, &d2GroupCount,
-        &d2ChunksPerGroupPerPart, &d2Reason));
-    if (hasDeinterleaved2Shape) {
-      return lowerDeinterleaved2GroupStore(
-          op, adaptor, rewriter, valueVMIType, *fact, *destination, *offset,
-          *rowStride);
-    }
-
-    return lowerContiguousGroupStore(
-        op, adaptor, rewriter, valueVMIType, *fact, *destination, *offset,
-        *rowStride);
   }
 };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -17049,6 +17049,25 @@ static FailureOr<VRegType> validateFpToIntSourceParts(
   return sourceType;
 }
 
+template <typename OpTy>
+static FailureOr<SmallVector<VRegType>> validateFpToIntResultParts(
+    OpTy op, TypeRange resultTypes, StringRef emptyDiagnostic,
+    StringRef typeDiagnostic, OneToNPatternRewriter &rewriter) {
+  if (resultTypes.empty()) {
+    return rewriter.notifyMatchFailure(op, emptyDiagnostic);
+  }
+  SmallVector<VRegType> resultVRegTypes;
+  resultVRegTypes.reserve(resultTypes.size());
+  for (Type physicalResultType : resultTypes) {
+    auto resultType = dyn_cast<VRegType>(physicalResultType);
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op, typeDiagnostic);
+    }
+    resultVRegTypes.push_back(resultType);
+  }
+  return resultVRegTypes;
+}
+
 struct OneToNVMIFPToSIOpPattern : OneToNOpConversionPattern<VMIFPToSIOp> {
   using OneToNOpConversionPattern<VMIFPToSIOp>::OneToNOpConversionPattern;
 
@@ -17065,21 +17084,9 @@ private:
   FailureOr<SmallVector<VRegType>> validateResultParts(
       VMIFPToSIOp op, TypeRange resultTypes,
       OneToNPatternRewriter &rewriter) const {
-    if (resultTypes.empty()) {
-      return rewriter.notifyMatchFailure(
-          op, "fptosi requires at least one physical result chunk");
-    }
-    SmallVector<VRegType> resultVRegTypes;
-    resultVRegTypes.reserve(resultTypes.size());
-    for (Type physicalResultType : resultTypes) {
-      auto resultType = dyn_cast<VRegType>(physicalResultType);
-      if (!resultType) {
-        return rewriter.notifyMatchFailure(
-            op, "unsupported physical fptosi result type");
-      }
-      resultVRegTypes.push_back(resultType);
-    }
-    return resultVRegTypes;
+    return validateFpToIntResultParts(
+        op, resultTypes, "fptosi requires at least one physical result chunk",
+        "unsupported physical fptosi result type", rewriter);
   }
 
 public:
@@ -17230,21 +17237,9 @@ private:
   FailureOr<SmallVector<VRegType>> validateResultParts(
       VMIFPToUIOp op, TypeRange resultTypes,
       OneToNPatternRewriter &rewriter) const {
-    if (resultTypes.empty()) {
-      return rewriter.notifyMatchFailure(
-          op, "fptoui requires at least one physical result chunk");
-    }
-    SmallVector<VRegType> resultVRegTypes;
-    resultVRegTypes.reserve(resultTypes.size());
-    for (Type physicalResultType : resultTypes) {
-      auto resultType = dyn_cast<VRegType>(physicalResultType);
-      if (!resultType) {
-        return rewriter.notifyMatchFailure(
-            op, "unsupported physical fptoui result type");
-      }
-      resultVRegTypes.push_back(resultType);
-    }
-    return resultVRegTypes;
+    return validateFpToIntResultParts(
+        op, resultTypes, "fptoui requires at least one physical result chunk",
+        "unsupported physical fptoui result type", rewriter);
   }
 
 public:

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9042,6 +9042,61 @@ private:
     return fact;
   }
 
+  LogicalResult lowerInterleaveByLayout(
+      SourceOp op, OneToNPatternRewriter &rewriter, ValueRange lhsParts,
+      ValueRange rhsParts, ValueRange maskParts, ArrayRef<Type> lowTypes,
+      ArrayRef<Type> highTypes, Type elementType,
+      const VMIInterleaveLayoutFact &fact) const {
+    auto isContiguous = [](VMILayoutAttr layout) {
+      return layout && layout.isContiguous() && layout.getLaneStride() == 1;
+    };
+    bool allSameLaneStride = fact.lhsLayout == fact.rhsLayout &&
+                             fact.lhsLayout == fact.maskLayout &&
+                             fact.lhsLayout == fact.lowLayout &&
+                             fact.lhsLayout == fact.highLayout &&
+                             fact.lhsLayout.isContiguous() &&
+                             fact.lhsLayout.getLaneStride() > 1;
+    if (allSameLaneStride) {
+      return lowerLaneStrideInterleave(op, rewriter, lhsParts, rhsParts,
+                                       lowTypes, highTypes, elementType, fact);
+    }
+    bool allContiguous = isContiguous(fact.lhsLayout) &&
+                         isContiguous(fact.rhsLayout) &&
+                         isContiguous(fact.maskLayout) &&
+                         isContiguous(fact.lowLayout) &&
+                         isContiguous(fact.highLayout);
+    if (allContiguous) {
+      return lowerContiguous(op, rewriter, lhsParts, rhsParts, maskParts,
+                             lowTypes, highTypes);
+    }
+    int64_t inputFactor = getElementDeinterleaveFactor(fact.lhsLayout);
+    int64_t outputFactor = getElementDeinterleaveFactor(fact.lowLayout);
+    bool zeroCopyVintlv = std::is_same_v<SourceOp, VMIVintlvOp> &&
+                          inputFactor > 0 && fact.rhsLayout == fact.lhsLayout &&
+                          fact.maskLayout == fact.lhsLayout &&
+                          fact.highLayout == fact.lowLayout &&
+                          outputFactor == 2 * inputFactor;
+    bool zeroCopyVdintlv = std::is_same_v<SourceOp, VMIVdintlvOp> &&
+                           inputFactor > 0 &&
+                           fact.rhsLayout == fact.lhsLayout &&
+                           fact.maskLayout == fact.lhsLayout &&
+                           fact.highLayout == fact.lowLayout &&
+                           inputFactor == 2 * outputFactor;
+    if (!zeroCopyVintlv && !zeroCopyVdintlv) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported interleave physical layout relation");
+    }
+    FailureOr<SmallVector<Value>> zeroCopyResults = materializeZeroCopyResults(
+        op, lhsParts, rhsParts, lowTypes, highTypes, inputFactor, outputFactor,
+        zeroCopyVintlv, rewriter);
+    if (failed(zeroCopyResults)) {
+      return failure();
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, *zeroCopyResults,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
 public:
 
   LogicalResult
@@ -13503,60 +13558,9 @@ public:
       return failure();
     }
 
-    auto isContiguous = [](VMILayoutAttr layout) {
-      return layout && layout.isContiguous() && layout.getLaneStride() == 1;
-    };
-    bool allSameLaneStride = fact->lhsLayout == fact->rhsLayout &&
-                             fact->lhsLayout == fact->maskLayout &&
-                             fact->lhsLayout == fact->lowLayout &&
-                             fact->lhsLayout == fact->highLayout &&
-                             fact->lhsLayout.isContiguous() &&
-                             fact->lhsLayout.getLaneStride() > 1;
-    if (allSameLaneStride) {
-      return lowerLaneStrideInterleave(op, rewriter, lhsParts, rhsParts,
-                                       lowTypes, highTypes,
-                                       lhsType.getElementType(), *fact);
-    }
-
-    bool allContiguous = isContiguous(fact->lhsLayout) &&
-                         isContiguous(fact->rhsLayout) &&
-                         isContiguous(fact->maskLayout) &&
-                         isContiguous(fact->lowLayout) &&
-                         isContiguous(fact->highLayout);
-    if (allContiguous) {
-      return lowerContiguous(op, rewriter, lhsParts, rhsParts, maskParts,
-                             lowTypes, highTypes);
-    }
-
-    int64_t inputFactor = getElementDeinterleaveFactor(fact->lhsLayout);
-    int64_t outputFactor = getElementDeinterleaveFactor(fact->lowLayout);
-    bool zeroCopyVintlv = std::is_same_v<SourceOp, VMIVintlvOp> &&
-                          inputFactor > 0 &&
-                          fact->rhsLayout == fact->lhsLayout &&
-                          fact->maskLayout == fact->lhsLayout &&
-                          fact->highLayout == fact->lowLayout &&
-                          outputFactor == 2 * inputFactor;
-    bool zeroCopyVdintlv = std::is_same_v<SourceOp, VMIVdintlvOp> &&
-                           inputFactor > 0 &&
-                           fact->rhsLayout == fact->lhsLayout &&
-                           fact->maskLayout == fact->lhsLayout &&
-                           fact->highLayout == fact->lowLayout &&
-                           inputFactor == 2 * outputFactor;
-    bool unsupportedZeroCopyRelation = !zeroCopyVintlv && !zeroCopyVdintlv;
-    if (unsupportedZeroCopyRelation) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported interleave physical layout relation");
-
-    FailureOr<SmallVector<Value>> zeroCopyResults = materializeZeroCopyResults(
-        op, lhsParts, rhsParts, lowTypes, highTypes, inputFactor, outputFactor,
-        zeroCopyVintlv, rewriter);
-    if (failed(zeroCopyResults)) {
-      return failure();
-    }
-
-    replaceOpWithFlatConvertedValues(rewriter, op, *zeroCopyResults,
-                                     *this->getTypeConverter());
-    return success();
+    return lowerInterleaveByLayout(
+        op, rewriter, lhsParts, rhsParts, maskParts, lowTypes, highTypes,
+        lhsType.getElementType(), *fact);
   }
 };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12915,6 +12915,37 @@ struct OneToNVMICompressStoreOpPattern
   using OneToNOpConversionPattern<
       VMICompressStoreOp>::OneToNOpConversionPattern;
 
+private:
+  LogicalResult lowerStore(VMICompressStoreOp op, Value destination,
+                           Value offset, Value value, Value mask,
+                           OneToNPatternRewriter &rewriter) const {
+    auto valueType = dyn_cast<VRegType>(value.getType());
+    auto destinationType = dyn_cast<PtrType>(destination.getType());
+    const bool invalidTypes =
+        !valueType || !isa<MaskType>(mask.getType()) || !destinationType;
+    if (invalidTypes) {
+      return rewriter.notifyMatchFailure(
+          op, "compress_store requires physical value/mask and ptr "
+              "destination");
+    }
+    Value storeBase =
+        rewriter
+            .create<AddPtrOp>(op.getLoc(), destination.getType(), destination,
+                              offset)
+            .getResult();
+    Value squeezed =
+        rewriter.create<VsqzOp>(op.getLoc(), valueType, value, mask).getResult();
+    auto align = rewriter.create<InitAlignOp>(
+        op.getLoc(), AlignType::get(rewriter.getContext()));
+    auto store = rewriter.create<VsturOp>(
+        op.getLoc(), align.getResult().getType(), align.getResult(), squeezed,
+        storeBase, rewriter.getStringAttr("POST_UPDATE"));
+    rewriter.create<VstarOp>(op.getLoc(), store.getAlignOut(), storeBase);
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+public:
   LogicalResult
   matchAndRewrite(VMICompressStoreOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
@@ -12924,39 +12955,21 @@ struct OneToNVMICompressStoreOpPattern
     FailureOr<Value> offset = getSingleValue(
         op, adaptor.getOffset(),
         "compress_store offset must convert to one value", rewriter);
-    if (failed(destination) || failed(offset))
+    const bool failedAddress = failed(destination) || failed(offset);
+    if (failedAddress) {
       return failure();
+    }
 
     ValueRange valueParts = adaptor.getValue();
     ValueRange maskParts = adaptor.getMask();
-    if (valueParts.size() != 1 || maskParts.size() != 1)
+    const bool invalidArity = valueParts.size() != 1 || maskParts.size() != 1;
+    if (invalidArity) {
       return rewriter.notifyMatchFailure(
           op, "compress_store supports only one physical part");
+    }
 
-    auto valueType = dyn_cast<VRegType>(valueParts.front().getType());
-    if (!valueType || !isa<MaskType>(maskParts.front().getType()) ||
-        !isa<PtrType>((*destination).getType()))
-      return rewriter.notifyMatchFailure(
-          op, "compress_store requires physical value/mask and ptr "
-              "destination");
-
-    Value storeBase =
-        rewriter
-            .create<AddPtrOp>(op.getLoc(), (*destination).getType(),
-                              *destination, *offset)
-            .getResult();
-    Value squeezed = rewriter
-                         .create<VsqzOp>(op.getLoc(), valueType,
-                                         valueParts.front(), maskParts.front())
-                         .getResult();
-    auto align = rewriter.create<InitAlignOp>(
-        op.getLoc(), AlignType::get(rewriter.getContext()));
-    auto store = rewriter.create<VsturOp>(
-        op.getLoc(), align.getResult().getType(), align.getResult(), squeezed,
-        storeBase, rewriter.getStringAttr("POST_UPDATE"));
-    rewriter.create<VstarOp>(op.getLoc(), store.getAlignOut(), storeBase);
-    rewriter.eraseOp(op);
-    return success();
+    return lowerStore(op, *destination, *offset, valueParts.front(),
+                      maskParts.front(), rewriter);
   }
 };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2004,6 +2004,24 @@ checkSupportedGroupLoadShape(VMIGroupLoadOp op, std::string *reason) {
 LogicalResult checkSupportedSlots1GroupSlotLoadShape(
     VMIGroupSlotLoadOp op, VMIVRegType resultType, std::string *reason);
 
+LogicalResult checkSupportedSlots8GroupSlotLoadShape(
+    VMIGroupSlotLoadOp op, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  std::optional<int64_t> sourceGroupStride =
+      getConstantIndexValue(op.getSourceGroupStride());
+  bool nonUnitSourceStride = !sourceGroupStride || *sourceGroupStride != 1;
+  if (nonUnitSourceStride) {
+    return fail("slots=8 group_slot_load requires constant unit "
+                "source_group_stride");
+  }
+  return success();
+}
+
 LogicalResult checkSupportedGroupSlotLoadShape(
     VMIGroupSlotLoadOp op,
     std::string *reason) {
@@ -2032,14 +2050,7 @@ LogicalResult checkSupportedGroupSlotLoadShape(
   }
 
   if (fact->slots == 8) {
-    std::optional<int64_t> sourceGroupStride =
-        getConstantIndexValue(op.getSourceGroupStride());
-    bool nonUnitSourceStride = !sourceGroupStride || *sourceGroupStride != 1;
-    if (nonUnitSourceStride) {
-      return fail("slots=8 group_slot_load requires constant unit "
-                  "source_group_stride");
-    }
-    return success();
+    return checkSupportedSlots8GroupSlotLoadShape(op, reason);
   }
 
   return checkSupportedSlots1GroupSlotLoadShape(op, resultType, reason);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12697,6 +12697,48 @@ struct OneToNVMIMaskedStoreOpPattern
   using OneToNOpConversionPattern<VMIMaskedStoreOp>::OneToNOpConversionPattern;
 
 private:
+  FailureOr<int64_t> emitLaneStrideMaskedStorePart(
+      VMIMaskedStoreOp op, OneToNPatternRewriter &rewriter, Value value,
+      Value mask, VMIVRegType valueVMIType, Value destination, Value offset,
+      StringRef dist, StringRef maskGranularity, int64_t index,
+      int64_t semanticOffset) const {
+    auto vregType = dyn_cast<VRegType>(value.getType());
+    bool invalidTypes = !vregType || !isa<MaskType>(mask.getType());
+    if (invalidTypes) {
+      return rewriter.notifyMatchFailure(
+          op, "lane_stride masked_store parts must be vreg/mask");
+    }
+    FailureOr<int64_t> activeLanes =
+        getActiveDataLanesInPhysicalChunk(valueVMIType, index);
+    if (failed(activeLanes)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to compute lane_stride masked_store active lanes");
+    }
+    if (*activeLanes == 0) {
+      return 0;
+    }
+    FailureOr<Value> storeMask = createDenseLaneStrideStorePredicate(
+        op.getLoc(), valueVMIType, index, mask, maskGranularity, rewriter);
+    if (failed(storeMask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to compact lane_stride masked_store predicate");
+    }
+    Value chunkOffset =
+        createChunkOffset(op.getLoc(), offset, semanticOffset, rewriter);
+    bool illegalAddress = !isDirectMemoryDistAddressLegal(
+        destination, chunkOffset, valueVMIType.getElementType(), vregType,
+        VPTOMemoryOpFamily::Store, dist);
+    if (illegalAddress) {
+      return rewriter.notifyMatchFailure(
+          op, "lane_stride masked_store requires a proven target alignment "
+              "for every physical store chunk");
+    }
+    rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{}, value,
+                            destination, chunkOffset,
+                            rewriter.getStringAttr(dist), *storeMask);
+    return *activeLanes;
+  }
+
   LogicalResult lowerLaneStride(
       VMIMaskedStoreOp op, OneToNPatternRewriter &rewriter,
       ValueRange valueParts, ValueRange maskParts, VMIVRegType valueVMIType,
@@ -12712,39 +12754,12 @@ private:
     for (auto [index, valueAndMask] :
          llvm::enumerate(llvm::zip_equal(valueParts, maskParts))) {
       auto [value, mask] = valueAndMask;
-      auto vregType = dyn_cast<VRegType>(value.getType());
-      if (!vregType || !isa<MaskType>(mask.getType())) {
-        return rewriter.notifyMatchFailure(
-            op, "lane_stride masked_store parts must be vreg/mask");
-      }
-      FailureOr<int64_t> activeLanes =
-          getActiveDataLanesInPhysicalChunk(valueVMIType, index);
+      FailureOr<int64_t> activeLanes = emitLaneStrideMaskedStorePart(
+          op, rewriter, value, mask, valueVMIType, destination, offset, dist,
+          maskGranularity, index, semanticOffset);
       if (failed(activeLanes)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to compute lane_stride masked_store active lanes");
+        return failure();
       }
-      if (*activeLanes == 0) {
-        continue;
-      }
-      FailureOr<Value> storeMask = createDenseLaneStrideStorePredicate(
-          op.getLoc(), valueVMIType, index, mask, maskGranularity, rewriter);
-      if (failed(storeMask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to compact lane_stride masked_store predicate");
-      }
-      Value chunkOffset =
-          createChunkOffset(op.getLoc(), offset, semanticOffset, rewriter);
-      bool illegalAddress = !isDirectMemoryDistAddressLegal(
-          destination, chunkOffset, valueVMIType.getElementType(), vregType,
-          VPTOMemoryOpFamily::Store, dist);
-      if (illegalAddress) {
-        return rewriter.notifyMatchFailure(
-            op, "lane_stride masked_store requires a proven target alignment "
-                "for every physical store chunk");
-      }
-      rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{}, value,
-                              destination, chunkOffset,
-                              rewriter.getStringAttr(dist), *storeMask);
       semanticOffset += *activeLanes;
     }
     rewriter.eraseOp(op);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -19133,6 +19133,39 @@ LogicalResult checkSupportedVmullShape(VMIVmullOp op,
   return checkVmullPhysicalShape(aType, maskType, reason);
 }
 
+static LogicalResult checkAddCarryMaskPort(VMIMaskType maskType,
+                                           VMILayoutAttr dataLayout,
+                                           int64_t dataArity,
+                                           std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  bool layoutMismatch = maskType.getLayoutAttr() != dataLayout;
+  if (layoutMismatch) {
+    return fail("requires all data and mask ports to share one layout");
+  }
+  bool unsupportedGranularity = maskType.getGranularity() != "b32";
+  if (unsupportedGranularity) {
+    return fail("requires b32 mask granularity");
+  }
+  FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
+  bool hasMatchingArity = succeeded(maskArity) && *maskArity == dataArity;
+  if (!hasMatchingArity) {
+    return fail("requires matching physical arity on data and mask ports");
+  }
+  FailureOr<StringRef> physicalGranularity =
+      getVMIMaskPhysicalGranularity(maskType);
+  bool unsupportedPhysicalGranularity = failed(physicalGranularity) ||
+                                        *physicalGranularity != "b32";
+  if (unsupportedPhysicalGranularity) {
+    return fail("requires physical b32 mask parts");
+  }
+  return success();
+}
+
 static LogicalResult
 checkSupportedVMIAddCarryPorts(VMIVRegType lhsType, VMIVRegType rhsType,
                                VMIVRegType resultType,
@@ -19158,19 +19191,10 @@ checkSupportedVMIAddCarryPorts(VMIVRegType lhsType, VMIVRegType rhsType,
   if (failed(dataArity) || *dataArity < 1)
     return fail("requires non-empty physical data parts");
   for (VMIMaskType maskType : maskTypes) {
-    if (maskType.getLayoutAttr() != lhsType.getLayoutAttr())
-      return fail("requires all data and mask ports to share one layout");
-    if (maskType.getGranularity() != "b32")
-      return fail("requires b32 mask granularity");
-    FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
-    bool hasMatchingArity = succeeded(maskArity) && *maskArity == *dataArity;
-    if (!hasMatchingArity) {
-      return fail("requires matching physical arity on data and mask ports");
+    if (failed(checkAddCarryMaskPort(maskType, lhsType.getLayoutAttr(),
+                                     *dataArity, reason))) {
+      return failure();
     }
-    FailureOr<StringRef> physicalGranularity =
-        getVMIMaskPhysicalGranularity(maskType);
-    if (failed(physicalGranularity) || *physicalGranularity != "b32")
-      return fail("requires physical b32 mask parts");
   }
   FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(lhsType.getElementType());
   bool hasExpectedLanes = succeeded(lanesPerPart) && *lanesPerPart == 64;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18276,32 +18276,23 @@ static FailureOr<GroupBroadcastShapePlan> buildGroupBroadcastShapePlan(
                                  *lanesPerPart, *groupSize, *resultFactor};
 }
 
-LogicalResult checkSupportedGroupBroadcastShape(
-    VMIGroupBroadcastOp op,
-    std::string *reason = nullptr) {
+static LogicalResult checkGroupBroadcastResultShape(
+    VMIVRegType resultType, VMILayoutAttr resultLayout, int64_t groupSize,
+    int64_t lanesPerPart, int64_t resultFactor, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
       *reason = message.str();
     }
     return failure();
   };
-  FailureOr<GroupBroadcastShapePlan> plan =
-      buildGroupBroadcastShapePlan(op, reason);
-  if (failed(plan)) {
-    return failure();
-  }
-  auto resultType = cast<VMIVRegType>(op.getResult().getType());
-  VMILayoutAttr resultLayout = plan->resultLayout;
-  int64_t groupSize = plan->groupSize;
-  int64_t lanesPerPart = plan->lanesPerPart;
-  int64_t resultFactor = plan->resultFactor;
   bool laneStridedDense =
       resultLayout.isDense() && resultLayout.getLaneStride() > 1;
   if (!laneStridedDense) {
     std::string fullChunkReason;
-    if (failed(checkFullDataPhysicalChunks(resultType, &fullChunkReason)))
+    if (failed(checkFullDataPhysicalChunks(resultType, &fullChunkReason))) {
       return fail(Twine("requires full result physical chunks; ") +
                   fullChunkReason);
+    }
   }
   if (resultFactor == 1) {
     return success();
@@ -18320,10 +18311,27 @@ LogicalResult checkSupportedGroupBroadcastShape(
     return success();
   }
   int64_t logicalSpanPerResultChunk = lanesPerPart * resultFactor;
-  if (*groupSize < *lanesPerPart || *groupSize % logicalSpanPerResultChunk != 0)
+  bool groupSpansMultipleChunks =
+      groupSize < lanesPerPart || groupSize % logicalSpanPerResultChunk != 0;
+  if (groupSpansMultipleChunks) {
     return fail("deinterleaved result requires every physical result chunk to "
                 "stay within one logical group");
+  }
   return success();
+}
+
+LogicalResult checkSupportedGroupBroadcastShape(
+    VMIGroupBroadcastOp op,
+    std::string *reason = nullptr) {
+  FailureOr<GroupBroadcastShapePlan> plan =
+      buildGroupBroadcastShapePlan(op, reason);
+  if (failed(plan)) {
+    return failure();
+  }
+  auto resultType = cast<VMIVRegType>(op.getResult().getType());
+  return checkGroupBroadcastResultShape(
+      resultType, plan->resultLayout, plan->groupSize, plan->lanesPerPart,
+      plan->resultFactor, reason);
 }
 
 LogicalResult checkSupportedVdhistShape(VMIVdhistOp op,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2390,6 +2390,35 @@ checkGatherElementContract(VMIVRegType resultType, VMIVRegType indicesType,
 }
 
 LogicalResult
+checkGatherLayoutAndSource(VMIGatherOp op, VMIVRegType resultType,
+                            VMIVRegType indicesType, VMIVRegType passthruType,
+                            VMIMaskType maskType, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
+  VMILayoutAttr indicesLayout = indicesType.getLayoutAttr();
+  VMILayoutAttr passthruLayout = passthruType.getLayoutAttr();
+  VMILayoutAttr maskLayout = maskType.getLayoutAttr();
+  if (!resultLayout || !indicesLayout || !passthruLayout || !maskLayout) {
+    return fail("requires assigned result, indices, passthru, and mask layouts");
+  }
+  bool nonContiguousLayout =
+      !resultLayout.isContiguous() || !indicesLayout.isContiguous() ||
+      !passthruLayout.isContiguous() || !maskLayout.isContiguous();
+  if (nonContiguousLayout) {
+    return fail("requires contiguous result, indices, passthru, and mask layouts");
+  }
+  if (!isa<PtrType>(op.getSource().getType())) {
+    return fail("requires !pto.ptr source because pto.vgather2_bc is pointer-only");
+  }
+  return success();
+}
+
+LogicalResult
 checkSupportedGatherShape(VMIGatherOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
@@ -2402,25 +2431,9 @@ checkSupportedGatherShape(VMIGatherOp op, std::string *reason) {
   auto indicesType = cast<VMIVRegType>(op.getIndices().getType());
   auto passthruType = cast<VMIVRegType>(op.getPassthru().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
-  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  VMILayoutAttr indicesLayout = indicesType.getLayoutAttr();
-  VMILayoutAttr passthruLayout = passthruType.getLayoutAttr();
-  VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  if (!resultLayout || !indicesLayout || !passthruLayout || !maskLayout) {
-    return fail("requires assigned result, indices, passthru, and mask "
-                "layouts");
-  }
-  bool nonContiguousLayout =
-      !resultLayout.isContiguous() || !indicesLayout.isContiguous() ||
-      !passthruLayout.isContiguous() || !maskLayout.isContiguous();
-  if (nonContiguousLayout) {
-    return fail("requires contiguous result, indices, passthru, and mask "
-                "layouts");
-  }
-
-  if (!isa<PtrType>(op.getSource().getType())) {
-    return fail("requires !pto.ptr source because pto.vgather2_bc is "
-                "pointer-only");
+  if (failed(checkGatherLayoutAndSource(op, resultType, indicesType,
+                                        passthruType, maskType, reason))) {
+    return failure();
   }
 
   Type sourceElemType = getMemoryElementType(op.getSource().getType());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3607,21 +3607,20 @@ struct DynamicGroupMaskPlan {
   int64_t arity;
 };
 
-static FailureOr<DynamicGroupMaskPlan> buildDynamicGroupMaskPlan(
-    VMICreateGroupMaskOp op, VMIMaskType resultVMIType, TypeRange resultTypes,
-    std::string *reason) {
-  auto fail = [&reason](const Twine &message)
-      -> FailureOr<DynamicGroupMaskPlan> {
+static LogicalResult checkDynamicGroupMaskLayout(
+    VMICreateGroupMaskOp op, VMIMaskType resultVMIType,
+    VMILayoutAttr *layout, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
       *reason = message.str();
     }
     return failure();
   };
-  VMILayoutAttr layout = resultVMIType.getLayoutAttr();
-  if (!layout) {
+  *layout = resultVMIType.getLayoutAttr();
+  if (!*layout) {
     return fail("dynamic create_group_mask requires assigned layout");
   }
-  bool unsupportedLaneStride = layout.getLaneStride() != 1;
+  bool unsupportedLaneStride = layout->getLaneStride() != 1;
   if (unsupportedLaneStride) {
     return fail("dynamic create_group_mask requires lane_stride=1 layout");
   }
@@ -3631,11 +3630,31 @@ static FailureOr<DynamicGroupMaskPlan> buildDynamicGroupMaskPlan(
   }
   int64_t numGroups = op.getNumGroupsAttr().getInt();
   int64_t groupSize = op.getGroupSizeAttr().getInt();
-  if (numGroups <= 0 || groupSize <= 0 ||
-      resultVMIType.getElementCount() != numGroups * groupSize) {
+  bool invalidLogicalShape =
+      numGroups <= 0 || groupSize <= 0 ||
+      resultVMIType.getElementCount() != numGroups * groupSize;
+  if (invalidLogicalShape) {
     return fail("dynamic create_group_mask requires result lane count to match "
                 "num_groups * group_size");
   }
+  if (!getPowerOfTwoLog2(groupSize)) {
+    return fail("dynamic create_group_mask currently requires power-of-two group_size");
+  }
+  return success();
+}
+
+static FailureOr<std::pair<int64_t, int64_t>>
+getDynamicGroupMaskPhysicalShape(VMICreateGroupMaskOp op,
+                                 VMIMaskType resultVMIType,
+                                 TypeRange resultTypes,
+                                 std::string *reason) {
+  auto fail = [&reason](const Twine &message)
+      -> FailureOr<std::pair<int64_t, int64_t>> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
   FailureOr<StringRef> physicalGranularity =
       getVMIMaskPhysicalGranularity(resultVMIType);
   FailureOr<int64_t> lanesPerPart =
@@ -3651,9 +3670,30 @@ static FailureOr<DynamicGroupMaskPlan> buildDynamicGroupMaskPlan(
   if (resultArityMismatch) {
     return fail("dynamic create_group_mask physical result count mismatch");
   }
-  if (!getPowerOfTwoLog2(groupSize)) {
-    return fail("dynamic create_group_mask currently requires power-of-two group_size");
+  return std::make_pair(*lanesPerPart, *arity);
+}
+
+static FailureOr<DynamicGroupMaskPlan> buildDynamicGroupMaskPlan(
+    VMICreateGroupMaskOp op, VMIMaskType resultVMIType, TypeRange resultTypes,
+    std::string *reason) {
+  auto fail = [&reason](const Twine &message)
+      -> FailureOr<DynamicGroupMaskPlan> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  VMILayoutAttr layout;
+  if (failed(checkDynamicGroupMaskLayout(op, resultVMIType, &layout, reason))) {
+    return failure();
   }
+  FailureOr<std::pair<int64_t, int64_t>> physicalShape =
+      getDynamicGroupMaskPhysicalShape(op, resultVMIType, resultTypes, reason);
+  if (failed(physicalShape)) {
+    return failure();
+  }
+  int64_t lanesPerPart = physicalShape->first;
+  int64_t arity = physicalShape->second;
   int64_t factor = layout.isDenseSplit() ? layout.getFactor() : 1;
   FailureOr<int64_t> blockElems = getVMILayoutBlockElems(resultVMIType);
   if (factor <= 0 || failed(blockElems) || *blockElems <= 0 ||
@@ -3663,7 +3703,7 @@ static FailureOr<DynamicGroupMaskPlan> buildDynamicGroupMaskPlan(
   if (!getPowerOfTwoLog2(*blockElems)) {
     return fail("dynamic create_group_mask requires a power-of-two physical block element count");
   }
-  return DynamicGroupMaskPlan{layout, factor, *blockElems, *lanesPerPart, *arity};
+  return DynamicGroupMaskPlan{layout, factor, *blockElems, lanesPerPart, arity};
 }
 
 static FailureOr<SmallVector<Value>> materializeDynamicGroupMaskChunks(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6290,6 +6290,20 @@ static FailureOr<SmallVector<Value>> materializeMaskGranularityParts(
   return results;
 }
 
+static LogicalResult checkMaskGranularityResultArity(
+    Operation *op, VMIMaskType resultType, size_t resultCount,
+    PatternRewriter &rewriter) {
+  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
+  bool resultArityMismatch =
+      failed(resultArity) || static_cast<int64_t>(resultCount) != *resultArity;
+  if (resultArityMismatch) {
+    (void)rewriter.notifyMatchFailure(
+        op, "mask granularity conversion result count mismatch");
+    return failure();
+  }
+  return success();
+}
+
 FailureOr<SmallVector<Value>> materializeAdjacentMaskGranularityConversion(
     Operation *op, VMIMaskType sourceType, VMIMaskType resultType,
     ValueRange sourceParts, PatternRewriter &rewriter) {
@@ -6309,12 +6323,9 @@ FailureOr<SmallVector<Value>> materializeAdjacentMaskGranularityConversion(
     return failure();
   }
 
-  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  bool resultArityMismatch =
-      failed(resultArity) ||
-      static_cast<int64_t>(results->size()) != *resultArity;
-  if (resultArityMismatch) {
-    return fail("mask granularity conversion result count mismatch");
+  if (failed(checkMaskGranularityResultArity(op, resultType, results->size(),
+                                             rewriter))) {
+    return failure();
   }
   return *results;
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11337,6 +11337,37 @@ private:
     return chunksPerGroup;
   }
 
+  FailureOr<std::pair<VMIVRegType, SmallVector<Type>>>
+  buildGroupBroadcastFallbackSourcePlan(
+      VMIGroupBroadcastLoadOp op, VMIVRegType resultVMIType,
+      int64_t numGroups, OneToNPatternRewriter &rewriter) const {
+    std::optional<int64_t> stride =
+        getConstantIndexValue(op.getSourceGroupStride());
+    int64_t slots = (stride && *stride == 1) ? 8 : 1;
+    auto sourceVMIType = VMIVRegType::get(
+        rewriter.getContext(), numGroups, resultVMIType.getElementType(),
+        VMILayoutAttr::getGroupSlots(rewriter.getContext(), numGroups, slots));
+    FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceVMIType);
+    if (failed(sourceArity)) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast_load fallback cannot derive physical types");
+    }
+    Type sourceElementType = getVMIPhysicalDataElementType(sourceVMIType);
+    FailureOr<int64_t> sourceLanesPerPart =
+        getDataLanesPerPart(sourceElementType);
+    if (failed(sourceLanesPerPart)) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast_load fallback cannot derive source lanes");
+    }
+    SmallVector<Type> sourceTypes;
+    sourceTypes.reserve(*sourceArity);
+    for (int64_t i = 0; i < *sourceArity; ++i) {
+      sourceTypes.push_back(VRegType::get(
+          rewriter.getContext(), *sourceLanesPerPart, sourceElementType));
+    }
+    return std::make_pair(sourceVMIType, std::move(sourceTypes));
+  }
+
   LogicalResult lowerDirectBRC(
       VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
       Value source, Value offset, Value sourceGroupStride,
@@ -11370,39 +11401,21 @@ private:
       Value source, Value offset, Value sourceGroupStride,
       VMIVRegType resultVMIType, ArrayRef<Type> resultTypes,
       int64_t numGroups) const {
-    std::optional<int64_t> stride =
-        getConstantIndexValue(op.getSourceGroupStride());
-    int64_t slots = (stride && *stride == 1) ? 8 : 1;
-    auto sourceVMIType = VMIVRegType::get(
-        rewriter.getContext(), numGroups, resultVMIType.getElementType(),
-        VMILayoutAttr::getGroupSlots(rewriter.getContext(), numGroups, slots));
-    FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceVMIType);
-    if (failed(sourceArity)) {
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast_load fallback cannot derive physical types");
-    }
-    Type sourceElementType = getVMIPhysicalDataElementType(sourceVMIType);
-    FailureOr<int64_t> sourceLanesPerPart =
-        getDataLanesPerPart(sourceElementType);
-    if (failed(sourceLanesPerPart)) {
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast_load fallback cannot derive source lanes");
-    }
-    SmallVector<Type> sourceTypes;
-    sourceTypes.reserve(*sourceArity);
-    for (int64_t i = 0; i < *sourceArity; ++i) {
-      sourceTypes.push_back(VRegType::get(
-          rewriter.getContext(), *sourceLanesPerPart, sourceElementType));
+    FailureOr<std::pair<VMIVRegType, SmallVector<Type>>> sourcePlan =
+        buildGroupBroadcastFallbackSourcePlan(op, resultVMIType, numGroups,
+                                              rewriter);
+    if (failed(sourcePlan)) {
+      return failure();
     }
     SmallVector<Value> sourceParts;
     if (failed(lowerGroupSlotLoadParts(
-            op, source, offset, sourceGroupStride, sourceVMIType, sourceTypes,
-            numGroups, rewriter, sourceParts))) {
+            op, source, offset, sourceGroupStride, sourcePlan->first,
+            sourcePlan->second, numGroups, rewriter, sourceParts))) {
       return failure();
     }
     SmallVector<Value> results;
     if (failed(lowerGroupBroadcastParts(
-            op, sourceParts, sourceVMIType, resultVMIType, resultTypes,
+            op, sourceParts, sourcePlan->first, resultVMIType, resultTypes,
             numGroups, rewriter, results))) {
       return failure();
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10462,6 +10462,37 @@ private:
     return success();
   }
 
+  FailureOr<bool> canUseDirectAccess(
+      VMIInterleaveStoreOp op, ValueRange lowParts,
+      VMIVRegType lowVMIType, StringRef dist) const {
+    auto firstType = lowParts.empty()
+                         ? VRegType{}
+                         : dyn_cast<VRegType>(lowParts.front().getType());
+    if (!firstType) {
+      return false;
+    }
+    return isDirectMemoryDistAddressLegal(
+        op.getDestination(), op.getOffset(), lowVMIType.getElementType(),
+        firstType, VPTOMemoryOpFamily::StoreX2, dist);
+  }
+
+  FailureOr<Value> getUnalignedBase(
+      VMIInterleaveStoreOp op, Value destination, Value offset,
+      VMIVRegType lowVMIType, OneToNPatternRewriter &rewriter) const {
+    Value streamBase = materializeBufferPointer(
+        destination, lowVMIType.getElementType(),
+        getMemorySpace(destination.getType()), rewriter, op.getLoc());
+    if (!streamBase) {
+      return rewriter.notifyMatchFailure(
+          op, "unaligned interleave_store requires a ptr-compatible "
+              "destination");
+    }
+    return rewriter
+        .create<AddPtrOp>(op.getLoc(), streamBase.getType(), streamBase,
+                          offset)
+        .getResult();
+  }
+
 public:
 
   LogicalResult
@@ -10470,8 +10501,7 @@ public:
     auto lowVMIType = cast<VMIVRegType>(op.getLow().getType());
     FailureOr<int64_t> lanesPerPart =
         getDataLanesPerPart(lowVMIType.getElementType());
-    if (failed(lanesPerPart))
-    {
+    if (failed(lanesPerPart)) {
       return rewriter.notifyMatchFailure(
           op, "interleave_store requires known physical lanes per part");
     }
@@ -10489,43 +10519,35 @@ public:
     FailureOr<Value> offset = getSingleValue(
         op, adaptor.getOffset(),
         "interleave_store offset must convert to one value", rewriter);
-    if (failed(destination) || failed(offset))
-    {
+    bool invalidAddressOperands = failed(destination) || failed(offset);
+    if (invalidAddressOperands) {
       return failure();
     }
 
     ValueRange lowParts = adaptor.getLow();
     ValueRange highParts = adaptor.getHigh();
-    if (lowParts.size() != highParts.size())
-    {
+    bool arityMismatch = lowParts.size() != highParts.size();
+    if (arityMismatch) {
       return rewriter.notifyMatchFailure(
           op, "interleave_store requires matching low/high physical arity");
     }
 
-    auto firstType = lowParts.empty()
-                         ? VRegType{}
-                         : dyn_cast<VRegType>(lowParts.front().getType());
-    bool useDirectAccess =
-        firstType &&
-        isDirectMemoryDistAddressLegal(op.getDestination(), op.getOffset(),
-                                       lowVMIType.getElementType(), firstType,
-                                       VPTOMemoryOpFamily::StoreX2, *dist);
+    FailureOr<bool> directAccess =
+        canUseDirectAccess(op, lowParts, lowVMIType, *dist);
+    if (failed(directAccess)) {
+      return failure();
+    }
+    bool useDirectAccess = *directAccess;
     SmallVector<Value> streamValues;
     SmallVector<int64_t> streamAdvances;
     Value streamBase;
     if (!useDirectAccess) {
-      streamBase = materializeBufferPointer(
-          *destination, lowVMIType.getElementType(),
-          getMemorySpace((*destination).getType()), rewriter, op.getLoc());
-      if (!streamBase) {
-        return rewriter.notifyMatchFailure(
-            op, "unaligned interleave_store requires a ptr-compatible "
-                "destination");
+      FailureOr<Value> base = getUnalignedBase(
+          op, *destination, *offset, lowVMIType, rewriter);
+      if (failed(base)) {
+        return failure();
       }
-      streamBase = rewriter
-                       .create<AddPtrOp>(op.getLoc(), streamBase.getType(),
-                                         streamBase, *offset)
-                       .getResult();
+      streamBase = *base;
     }
 
     for (size_t index = 0, e = lowParts.size(); index < e; ++index) {
@@ -10537,10 +10559,11 @@ public:
       }
     }
 
-    if (!useDirectAccess &&
-        failed(emitStatefulStoreStream(op, streamBase, streamValues,
-                                       streamAdvances, rewriter))) {
-      return failure();
+    if (!useDirectAccess) {
+      if (failed(emitStatefulStoreStream(op, streamBase, streamValues,
+                                         streamAdvances, rewriter))) {
+        return failure();
+      }
     }
 
     rewriter.eraseOp(op);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18932,6 +18932,22 @@ static LogicalResult checkReducePhysicalArity(
 }
 
 template <typename OpTy>
+static LogicalResult checkReduceSourceChunks(OpTy op, VMIVRegType sourceType,
+                                             std::string *reason) {
+  std::string fullChunkReason;
+  if (succeeded(checkFullDataPhysicalChunks(sourceType, &fullChunkReason))) {
+    return success();
+  }
+  if (reason) {
+    *reason = (Twine("requires full source physical chunks so padding lanes "
+                    "do not participate in the reduction; ") +
+               fullChunkReason)
+                  .str();
+  }
+  return failure();
+}
+
+template <typename OpTy>
 static FailureOr<ReducePhysicalShapePlan> buildReducePhysicalShapePlan(
     OpTy op, std::string *reason) {
   auto fail = [&reason](const Twine &message)
@@ -18953,11 +18969,8 @@ static FailureOr<ReducePhysicalShapePlan> buildReducePhysicalShapePlan(
     return failure();
   }
 
-  std::string fullChunkReason;
-  if (failed(checkFullDataPhysicalChunks(sourceType, &fullChunkReason))) {
-    return fail(Twine("requires full source physical chunks so padding lanes "
-                      "do not participate in the reduction; ") +
-                fullChunkReason);
+  if (failed(checkReduceSourceChunks(op, sourceType, reason))) {
+    return failure();
   }
 
   int64_t sourceArity;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12223,6 +12223,28 @@ private:
     }
   }
 
+  LogicalResult validateZeroCopyResultParts(
+      SourceOp op, ArrayRef<Value> results, TypeRange lowTypes,
+      TypeRange highTypes, OneToNPatternRewriter &rewriter) const {
+    SmallVector<Type> resultTypes;
+    resultTypes.reserve(lowTypes.size() + highTypes.size());
+    llvm::append_range(resultTypes, lowTypes);
+    llvm::append_range(resultTypes, highTypes);
+    bool resultArityMismatch = results.size() != resultTypes.size();
+    if (resultArityMismatch) {
+      return rewriter.notifyMatchFailure(
+          op, "zero-copy interleave result arity mismatch");
+    }
+    for (auto [value, resultType] : llvm::zip_equal(results, resultTypes)) {
+      bool resultTypeMismatch = value.getType() != resultType;
+      if (resultTypeMismatch) {
+        return rewriter.notifyMatchFailure(
+            op, "zero-copy interleave part type mismatch");
+      }
+    }
+    return success();
+  }
+
   FailureOr<SmallVector<Value>> materializeZeroCopyResults(
       SourceOp op, ValueRange lhsParts, ValueRange rhsParts,
       TypeRange lowTypes, TypeRange highTypes, int64_t inputFactor,
@@ -12249,21 +12271,9 @@ private:
                                    outputFactor);
     }
 
-    SmallVector<Type> resultTypes;
-    resultTypes.reserve(lowTypes.size() + highTypes.size());
-    llvm::append_range(resultTypes, lowTypes);
-    llvm::append_range(resultTypes, highTypes);
-    bool resultArityMismatch = results.size() != resultTypes.size();
-    if (resultArityMismatch) {
-      return rewriter.notifyMatchFailure(
-          op, "zero-copy interleave result arity mismatch");
-    }
-    for (auto [value, resultType] : llvm::zip_equal(results, resultTypes)) {
-      bool resultTypeMismatch = value.getType() != resultType;
-      if (resultTypeMismatch) {
-        return rewriter.notifyMatchFailure(
-            op, "zero-copy interleave part type mismatch");
-      }
+    if (failed(validateZeroCopyResultParts(op, results, lowTypes, highTypes,
+                                           rewriter))) {
+      return failure();
     }
     return results;
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7694,7 +7694,7 @@ FailureOr<Value> createResidualSubVLGroupPeriodicChunk(
                           allMask,
                           /*position=*/nullptr)
           .getResult();
-  for (int64_t localGroup = 0; localGroup < groupsPerChunk; ++localGroup) {
+  auto materializeGroup = [&](int64_t localGroup) -> FailureOr<Value> {
     Value adjusted = full;
     if (localGroup != 0) {
       int64_t delta = localGroup * groupSize;
@@ -7709,12 +7709,14 @@ FailureOr<Value> createResidualSubVLGroupPeriodicChunk(
                                         allMask)
                        .getResult();
       } else {
-        Value negOffset =
-            isa<FloatType>(base.getType())
-                ? rewriter.create<arith::NegFOp>(loc, *offsetScalar).getResult()
-                : rewriter
-                      .create<arith::SubIOp>(loc, zeroScalar, *offsetScalar)
-                      .getResult();
+        Value negOffset = isa<FloatType>(base.getType())
+                              ? rewriter.create<arith::NegFOp>(
+                                    loc, *offsetScalar)
+                                    .getResult()
+                              : rewriter
+                                    .create<arith::SubIOp>(
+                                        loc, zeroScalar, *offsetScalar)
+                                    .getResult();
         adjusted = rewriter
                        .create<VaddsOp>(loc, resultType, full, negOffset,
                                         allMask)
@@ -7727,9 +7729,16 @@ FailureOr<Value> createResidualSubVLGroupPeriodicChunk(
     if (failed(laneMask)) {
       return failure();
     }
-    result = rewriter
-                 .create<VselOp>(loc, resultType, adjusted, result, *laneMask)
-                 .getResult();
+    return rewriter
+        .create<VselOp>(loc, resultType, adjusted, result, *laneMask)
+        .getResult();
+  };
+  for (int64_t localGroup = 0; localGroup < groupsPerChunk; ++localGroup) {
+    FailureOr<Value> nextResult = materializeGroup(localGroup);
+    if (failed(nextResult)) {
+      return failure();
+    }
+    result = *nextResult;
   }
   return result;
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -15535,6 +15535,44 @@ private:
     MaskType rowMaskType;
   };
 
+  struct ContiguousGroupReduceShape {
+    int64_t lanesPerPart;
+    int64_t groupCount;
+    int64_t chunksPerGroup;
+    bool rowLocalSlots1Result;
+    int64_t expectedResultParts;
+  };
+
+  FailureOr<ContiguousGroupReduceShape> getContiguousGroupReduceShape(
+      OpTy op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+      ValueRange sourceParts, ValueRange maskParts, TypeRange resultTypes,
+      int64_t groupSize, OneToNPatternRewriter &rewriter) const {
+    int64_t lanesPerPart = 0;
+    int64_t groupCount = 0;
+    int64_t chunksPerGroup = 0;
+    if (failed(checkContiguousFullGroupChunks(op, sourceVMIType, groupSize,
+                                              &lanesPerPart, &groupCount,
+                                              &chunksPerGroup, rewriter))) {
+      return failure();
+    }
+    VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
+    bool rowLocalSlots1Result = resultLayout && resultLayout.isGroupSlots() &&
+                                resultLayout.getNumGroups() == groupCount &&
+                                resultLayout.getSlots() == 1;
+    int64_t expectedResultParts =
+        rowLocalSlots1Result ? groupCount : groupCount * chunksPerGroup;
+    bool invalidArity =
+        sourceParts.size() != maskParts.size() ||
+        static_cast<int64_t>(sourceParts.size()) != groupCount * chunksPerGroup ||
+        static_cast<int64_t>(resultTypes.size()) != expectedResultParts;
+    if (invalidArity) {
+      return rewriter.notifyMatchFailure(
+          op, "group_reduce requires matching source/mask/result arity");
+    }
+    return ContiguousGroupReduceShape{lanesPerPart, groupCount, chunksPerGroup,
+                                      rowLocalSlots1Result, expectedResultParts};
+  }
+
   FailureOr<ContiguousGroupReduceTypes> getContiguousGroupReduceTypes(
       OpTy op, ValueRange sourceParts, ValueRange maskParts,
       TypeRange resultTypes, OneToNPatternRewriter &rewriter) const {
@@ -15575,27 +15613,12 @@ private:
       OpTy op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
       ValueRange sourceParts, ValueRange maskParts, TypeRange resultTypes,
       int64_t groupSize, OneToNPatternRewriter &rewriter) const {
-    int64_t lanesPerPart = 0;
-    int64_t groupCount = 0;
-    int64_t chunksPerGroup = 0;
-    if (failed(checkContiguousFullGroupChunks(op, sourceVMIType, groupSize,
-                                              &lanesPerPart, &groupCount,
-                                              &chunksPerGroup, rewriter))) {
+    FailureOr<ContiguousGroupReduceShape> shape =
+        getContiguousGroupReduceShape(op, sourceVMIType, resultVMIType,
+                                      sourceParts, maskParts, resultTypes,
+                                      groupSize, rewriter);
+    if (failed(shape)) {
       return failure();
-    }
-    VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
-    bool rowLocalSlots1Result = resultLayout && resultLayout.isGroupSlots() &&
-                                resultLayout.getNumGroups() == groupCount &&
-                                resultLayout.getSlots() == 1;
-    int64_t expectedResultParts =
-        rowLocalSlots1Result ? groupCount : groupCount * chunksPerGroup;
-    bool invalidArity =
-        sourceParts.size() != maskParts.size() ||
-        static_cast<int64_t>(sourceParts.size()) != groupCount * chunksPerGroup ||
-        static_cast<int64_t>(resultTypes.size()) != expectedResultParts;
-    if (invalidArity) {
-      return rewriter.notifyMatchFailure(
-          op, "group_reduce requires matching source/mask/result arity");
     }
     FailureOr<ContiguousGroupReduceTypes> types =
         getContiguousGroupReduceTypes(op, sourceParts, maskParts, resultTypes,
@@ -15611,7 +15634,8 @@ private:
     }
     FailureOr<SmallVector<Value>> reducedResults =
         buildContiguousGroupReduceResults(
-            op, sourceParts, maskParts, groupCount, chunksPerGroup,
+            op, sourceParts, maskParts, shape->groupCount,
+            shape->chunksPerGroup,
             types->sourcePartType, types->rowResultType, types->maskType,
             *firstLaneMask,
             rewriter);
@@ -15619,8 +15643,8 @@ private:
       return failure();
     }
     FailureOr<SmallVector<Value>> results = restoreContiguousGroupResults(
-        op, *reducedResults, resultTypes, types->resultType, groupCount,
-        chunksPerGroup, rowLocalSlots1Result, rewriter);
+        op, *reducedResults, resultTypes, types->resultType, shape->groupCount,
+        shape->chunksPerGroup, shape->rowLocalSlots1Result, rewriter);
     if (failed(results)) {
       return failure();
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5480,10 +5480,11 @@ static FailureOr<SmallVector<Value>> materializeMaskLaneStrideUnpack(
   StringAttr lower = rewriter.getStringAttr("LOWER");
   StringAttr higher = rewriter.getStringAttr("HIGHER");
   for (auto [resultIndex, resultType] : llvm::enumerate(resultTypes)) {
-    auto maskType = dyn_cast<MaskType>(resultType);
-    if (!maskType) {
-      return rewriter.notifyMatchFailure(
-          op, "dense mask lane_stride unpack requires mask result type");
+    FailureOr<MaskType> maskType = getMaskLaneStrideResultType(
+        op, resultType, "dense mask lane_stride unpack requires mask result type",
+        rewriter);
+    if (failed(maskType)) {
+      return failure();
     }
     int64_t sourceIndex = resultIndex / laneStride;
     int64_t part = resultIndex % laneStride;
@@ -5492,16 +5493,27 @@ static FailureOr<SmallVector<Value>> materializeMaskLaneStrideUnpack(
                                ? (part >= 2 ? higher : lower)
                                : (part == 1 ? higher : lower);
     Value current = rewriter
-                        .create<PunpackOp>(op->getLoc(), maskType, source,
+                        .create<PunpackOp>(op->getLoc(), *maskType, source,
                                            firstPart)
                         .getResult();
     if (laneStride == 4) {
       current = rewriter.create<PunpackOp>(
-          op->getLoc(), maskType, current, part % 2 == 0 ? lower : higher);
+          op->getLoc(), *maskType, current, part % 2 == 0 ? lower : higher);
     }
     results.push_back(current);
   }
   return results;
+}
+
+static FailureOr<MaskType> getMaskLaneStrideResultType(
+    Operation *op, Type resultType, StringRef diagnostic,
+    PatternRewriter &rewriter) {
+  auto maskType = dyn_cast<MaskType>(resultType);
+  if (!maskType) {
+    (void)rewriter.notifyMatchFailure(op, diagnostic);
+    return failure();
+  }
+  return maskType;
 }
 
 struct MaskLaneStridePackContext {
@@ -5597,10 +5609,11 @@ static FailureOr<SmallVector<Value>> materializeMaskLaneStridePack(
   SmallVector<Value> results;
   results.reserve(resultTypes.size());
   for (auto [resultIndex, resultType] : llvm::enumerate(resultTypes)) {
-    auto maskType = dyn_cast<MaskType>(resultType);
-    if (!maskType) {
-      return rewriter.notifyMatchFailure(
-          op, "dense mask lane_stride pack requires mask result type");
+    FailureOr<MaskType> maskType = getMaskLaneStrideResultType(
+        op, resultType, "dense mask lane_stride pack requires mask result type",
+        rewriter);
+    if (failed(maskType)) {
+      return failure();
     }
     size_t base = resultIndex * static_cast<size_t>(laneStride);
     if (base >= sourceParts.size()) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12807,11 +12807,11 @@ private:
     return success();
   }
 
-  LogicalResult lowerContiguous(
+  FailureOr<std::pair<SmallVector<Value>, SmallVector<Value>>>
+  materializeContiguousMaskedStoreParts(
       VMIMaskedStoreOp op, OneToNPatternRewriter &rewriter,
       ValueRange valueParts, ValueRange maskParts, VMIVRegType valueVMIType,
-      VMIMaskType maskVMIType, Value destination, Value offset,
-      int64_t lanesPerPart) const {
+      VMIMaskType maskVMIType) const {
     SmallVector<Type> contiguousValueTypes;
     contiguousValueTypes.reserve(valueParts.size());
     for (Value value : valueParts) {
@@ -12825,7 +12825,6 @@ private:
     if (failed(storeParts)) {
       return failure();
     }
-
     SmallVector<Type> contiguousMaskTypes;
     contiguousMaskTypes.reserve(maskParts.size());
     for (Value mask : maskParts) {
@@ -12842,9 +12841,25 @@ private:
       return rewriter.notifyMatchFailure(
           op, "masked_store converted value/mask arity mismatch");
     }
+    return std::make_pair(std::move(*storeParts), std::move(*storeMasks));
+  }
+
+  LogicalResult lowerContiguous(
+      VMIMaskedStoreOp op, OneToNPatternRewriter &rewriter,
+      ValueRange valueParts, ValueRange maskParts, VMIVRegType valueVMIType,
+      VMIMaskType maskVMIType, Value destination, Value offset,
+      int64_t lanesPerPart) const {
+    FailureOr<std::pair<SmallVector<Value>, SmallVector<Value>>> converted =
+        materializeContiguousMaskedStoreParts(op, rewriter, valueParts,
+                                              maskParts, valueVMIType,
+                                              maskVMIType);
+    if (failed(converted)) {
+      return failure();
+    }
 
     for (auto [index, valueAndMask] :
-         llvm::enumerate(llvm::zip_equal(*storeParts, *storeMasks))) {
+         llvm::enumerate(llvm::zip_equal(converted->first,
+                                         converted->second))) {
       auto [value, mask] = valueAndMask;
       if (failed(emitContiguousMaskedStorePart(
               op, rewriter, value, mask, valueVMIType, destination, offset,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12539,6 +12539,42 @@ struct OneToNVMIGroupBroadcastLoadOpPattern
   using OneToNOpConversionPattern<VMIGroupBroadcastLoadOp>::OneToNOpConversionPattern;
 
 private:
+  LogicalResult validateDirectE2BBasicContract(
+      VMIGroupBroadcastLoadOp op, Value source, int64_t numGroups,
+      unsigned elementBits, VMILayoutAttr layout,
+      OneToNPatternRewriter &rewriter) const {
+    bool contiguousPacketLayout = layout && layout.isContiguous();
+    bool splitPacketLayout = layout && layout.isDeinterleaved() &&
+                             (layout.getFactor() == 2 ||
+                              layout.getFactor() == 4) &&
+                             layout.getLaneStride() == 1;
+    if (!contiguousPacketLayout && !splitPacketLayout) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast_load E2B lowering requires contiguous result "
+              "layout for direct group size or deinterleaved=2/4 result "
+              "layout for split group size");
+    }
+    if (elementBits != 16 && elementBits != 32) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast_load E2B lowering requires b16 or b32 element type");
+    }
+    std::optional<int64_t> stride =
+        getConstantIndexValue(op.getSourceGroupStride());
+    if (!stride || *stride != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast_load E2B lowering requires constant unit source_group_stride");
+    }
+    if (!isa<PtrType>(source.getType())) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast_load E2B lowering requires !pto.ptr source");
+    }
+    if (numGroups != 8) {
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast_load E2B lowering requires num_groups = 8");
+    }
+    return success();
+  }
+
   FailureOr<Value> emitE2BPacket(
       VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
       Value source, Value offset, Type packetType, int64_t chunk,
@@ -12596,36 +12632,9 @@ private:
       VMIVRegType resultVMIType, ArrayRef<Type> resultTypes,
       int64_t numGroups, unsigned elementBits, VMILayoutAttr layout,
       OneToNPatternRewriter &rewriter) const {
-    bool contiguousPacketLayout = layout && layout.isContiguous();
-    bool splitPacketLayout = layout && layout.isDeinterleaved() &&
-                             (layout.getFactor() == 2 ||
-                              layout.getFactor() == 4) &&
-                             layout.getLaneStride() == 1;
-    if (!contiguousPacketLayout && !splitPacketLayout) {
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast_load E2B lowering requires contiguous result "
-              "layout for direct group size or deinterleaved=2/4 result "
-              "layout for split group size");
-    }
-    if (elementBits != 16 && elementBits != 32) {
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast_load E2B lowering requires b16 or b32 element "
-              "type");
-    }
-    std::optional<int64_t> stride =
-        getConstantIndexValue(op.getSourceGroupStride());
-    if (!stride || *stride != 1) {
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast_load E2B lowering requires constant unit "
-              "source_group_stride");
-    }
-    if (!isa<PtrType>(source.getType())) {
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast_load E2B lowering requires !pto.ptr source");
-    }
-    if (numGroups != 8) {
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast_load E2B lowering requires num_groups = 8");
+    if (failed(validateDirectE2BBasicContract(op, source, numGroups,
+                                              elementBits, layout, rewriter))) {
+      return failure();
     }
     FailureOr<int64_t> chunksPerPart = getDataChunksInPart(resultVMIType, 0);
     bool invalidChunks = failed(chunksPerPart) || *chunksPerPart <= 0;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9656,22 +9656,12 @@ static LogicalResult lowerGroupSlotLoadParts(
   return failure();
 }
 
-static FailureOr<Value> materializeSlots1GroupBroadcastChunk(
-    Operation *op, Type resultType, VMIVRegType resultVMIType,
+static FailureOr<std::pair<SmallVector<int64_t>, SmallVector<int64_t>>>
+mapSlots1GroupBroadcastSources(
+    Operation *op, VMIVRegType resultVMIType,
     ValueRange sourceParts, int64_t part, int64_t chunk, int64_t firstGroup,
     int64_t groupSize, int64_t selectorPeriod, int64_t lanesPerPart,
-    OneToNPatternRewriter &rewriter, Value allMask) {
-  auto resultVRegType = dyn_cast<VRegType>(resultType);
-  if (!resultVRegType) {
-    return rewriter.notifyMatchFailure(
-        op, "group_broadcast requires uniform physical vreg types");
-  }
-  FailureOr<MaskType> resultMaskType =
-      getMaskTypeForVReg(resultVRegType, rewriter.getContext());
-  if (failed(resultMaskType)) {
-    return rewriter.notifyMatchFailure(
-        op, "group_broadcast cannot derive result mask type");
-  }
+    OneToNPatternRewriter &rewriter) {
   SmallVector<int64_t> laneSourceChunks(lanesPerPart, -1);
   SmallVector<int64_t> activeSourceChunks;
   for (int64_t lane = 0; lane < lanesPerPart; ++lane) {
@@ -9713,6 +9703,35 @@ static FailureOr<Value> materializeSlots1GroupBroadcastChunk(
     return rewriter.notifyMatchFailure(
         op, "group_broadcast result chunk has no active lanes");
   }
+  return std::make_pair(std::move(laneSourceChunks),
+                        std::move(activeSourceChunks));
+}
+
+static FailureOr<Value> materializeSlots1GroupBroadcastChunk(
+    Operation *op, Type resultType, VMIVRegType resultVMIType,
+    ValueRange sourceParts, int64_t part, int64_t chunk, int64_t firstGroup,
+    int64_t groupSize, int64_t selectorPeriod, int64_t lanesPerPart,
+    OneToNPatternRewriter &rewriter, Value allMask) {
+  auto resultVRegType = dyn_cast<VRegType>(resultType);
+  if (!resultVRegType) {
+    return rewriter.notifyMatchFailure(
+        op, "group_broadcast requires uniform physical vreg types");
+  }
+  FailureOr<MaskType> resultMaskType =
+      getMaskTypeForVReg(resultVRegType, rewriter.getContext());
+  if (failed(resultMaskType)) {
+    return rewriter.notifyMatchFailure(
+        op, "group_broadcast cannot derive result mask type");
+  }
+  FailureOr<std::pair<SmallVector<int64_t>, SmallVector<int64_t>>> mapping =
+      mapSlots1GroupBroadcastSources(op, resultVMIType, sourceParts,
+                                     part, chunk, firstGroup, groupSize,
+                                     selectorPeriod, lanesPerPart, rewriter);
+  if (failed(mapping)) {
+    return failure();
+  }
+  SmallVector<int64_t> laneSourceChunks = std::move(mapping->first);
+  SmallVector<int64_t> activeSourceChunks = std::move(mapping->second);
   auto splatSource = [&rewriter, &op, &resultType, &sourceParts, &allMask](
                          int64_t chunkIndex) {
     return rewriter

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10665,6 +10665,20 @@ struct OneToNVMIExpandLoadOpPattern
   using OneToNOpConversionPattern<VMIExpandLoadOp>::OneToNOpConversionPattern;
 
 private:
+  FailureOr<Value> materializeStaticExpandLoadPart(
+      VMIExpandLoadOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value offset, Type resultType, int64_t index, int64_t lanesPerPart) const {
+    if (!isa<VRegType>(resultType)) {
+      return rewriter.notifyMatchFailure(op, "expand_load result must be vreg");
+    }
+    Value chunkOffset = createChunkOffset(
+        op.getLoc(), offset, index * lanesPerPart, rewriter);
+    return rewriter
+        .create<VldsOp>(op.getLoc(), resultType, Type{}, source, chunkOffset,
+                        nullptr)
+        .getResult();
+  }
+
   LogicalResult lowerRuntimeExpandLoad(
       VMIExpandLoadOp op, OneToNPatternRewriter &rewriter, Value source,
       Value offset, ValueRange maskParts, ValueRange passthruParts,
@@ -10732,16 +10746,12 @@ private:
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (auto [index, resultType] : llvm::enumerate(resultTypes)) {
-      if (!isa<VRegType>(resultType)) {
-        return rewriter.notifyMatchFailure(op, "expand_load result must be vreg");
+      FailureOr<Value> result = materializeStaticExpandLoadPart(
+          op, rewriter, source, offset, resultType, index, *lanesPerPart);
+      if (failed(result)) {
+        return failure();
       }
-      Value chunkOffset = createChunkOffset(
-          op.getLoc(), offset, index * *lanesPerPart, rewriter);
-      results.push_back(
-          rewriter
-              .create<VldsOp>(op.getLoc(), resultType, Type{}, source,
-                              chunkOffset, nullptr)
-              .getResult());
+      results.push_back(*result);
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -17314,37 +17314,15 @@ private:
                          resultLayout.getLaneStride() == 4 &&
                          resultLogicalBits == 8 && physicalResultBits == 32;
     if (directCarrier) {
-      bool identicalCarrierType = sourcePart.getType() == resultType;
-      if (identicalCarrierType) {
-        return sourcePart;
-      }
-      return rewriter.create<VbitcastOp>(op.getLoc(), resultType, sourcePart)
-          .getResult();
+      return lowerGroupSlotDirectCarrier(op, sourcePart, resultType, rewriter);
     }
     bool wideCarrier = resultLayout.hasLaneStride() &&
                        resultLayout.getLaneStride() == 2 &&
                        resultLogicalBits == 16 && physicalResultBits == 32;
     if (wideCarrier) {
-      FailureOr<int64_t> lanes =
-          getDataLanesPerPart(resultVMIType.getElementType());
-      if (failed(lanes)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to derive group-slot trunci conversion lanes");
-      }
-      auto conversionType = VRegType::get(
-          rewriter.getContext(), *lanes, resultVMIType.getElementType());
-      Value converted = rewriter
-                            .create<VcvtOp>(op.getLoc(), conversionType,
-                                            sourcePart, activeSlotMask, nullptr,
-                                            sat, rewriter.getStringAttr("EVEN"))
-                            .getResult();
-      FailureOr<Value> carrier =
-          bitcastVReg(op.getLoc(), converted, resultType, rewriter);
-      if (failed(carrier)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to expose group-slot trunci result carrier");
-      }
-      return *carrier;
+      return lowerGroupSlotWideCarrier(op, sourcePart, resultType,
+                                       resultVMIType, activeSlotMask, sat,
+                                       rewriter);
     }
     bool validNarrowResult = physicalResultBits == 16 || physicalResultBits == 8;
     if (!validNarrowResult) {
@@ -17357,6 +17335,41 @@ private:
         .create<VcvtOp>(op.getLoc(), resultType, sourcePart, activeSlotMask,
                         nullptr, sat, part)
         .getResult();
+  }
+
+  FailureOr<Value> lowerGroupSlotDirectCarrier(
+      VMITruncIOp op, Value sourcePart, VRegType resultType,
+      OneToNPatternRewriter &rewriter) const {
+    return sourcePart.getType() == resultType
+               ? sourcePart
+               : rewriter.create<VbitcastOp>(op.getLoc(), resultType, sourcePart)
+                     .getResult();
+  }
+
+  FailureOr<Value> lowerGroupSlotWideCarrier(
+      VMITruncIOp op, Value sourcePart, VRegType resultType,
+      VMIVRegType resultVMIType, Value activeSlotMask, StringAttr sat,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<int64_t> lanes =
+        getDataLanesPerPart(resultVMIType.getElementType());
+    if (failed(lanes)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to derive group-slot trunci conversion lanes");
+    }
+    auto conversionType = VRegType::get(
+        rewriter.getContext(), *lanes, resultVMIType.getElementType());
+    Value converted = rewriter
+                          .create<VcvtOp>(op.getLoc(), conversionType,
+                                          sourcePart, activeSlotMask, nullptr,
+                                          sat, rewriter.getStringAttr("EVEN"))
+                          .getResult();
+    FailureOr<Value> carrier =
+        bitcastVReg(op.getLoc(), converted, resultType, rewriter);
+    if (failed(carrier)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to expose group-slot trunci result carrier");
+    }
+    return *carrier;
   }
 
   FailureOr<std::pair<bool, bool>> getGroupSlotTruncModes(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -13656,28 +13656,26 @@ private:
       ValueRange sourceParts, ValueRange maskParts, TypeRange resultTypes,
       OneToNPatternRewriter &rewriter) const {
     int64_t numGroups = op.getNumGroupsAttr().getInt();
-    if (plan == GroupReduceLoweringPlan::OneBlockVcgadd) {
+    switch (plan) {
+    case GroupReduceLoweringPlan::OneBlockVcgadd:
       return lowerOneBlock(op, sourceParts, maskParts, resultTypes, rewriter);
-    }
-    if (plan == GroupReduceLoweringPlan::TwoBlockDeinterleaved2VcgaddVadd) {
+    case GroupReduceLoweringPlan::TwoBlockDeinterleaved2VcgaddVadd:
       return lowerTwoBlock(op, sourceParts, maskParts, resultTypes, numGroups,
                            rewriter);
-    }
-    if (plan == GroupReduceLoweringPlan::FourBlockDeinterleaved4VcgaddTree) {
+    case GroupReduceLoweringPlan::FourBlockDeinterleaved4VcgaddTree:
       return lowerFourBlock(op, sourceParts, maskParts, resultTypes, numGroups,
                             rewriter);
-    }
-    if (plan == GroupReduceLoweringPlan::FullDeinterleaved2VcaddRows) {
+    case GroupReduceLoweringPlan::FullDeinterleaved2VcaddRows:
       return lowerFullDeinterleaved2(
           op, sourceVMIType, resultVMIType, sourceParts, maskParts, resultTypes,
           groupSize, rewriter);
-    }
-    if (plan != GroupReduceLoweringPlan::ContiguousVcaddRows) {
+    case GroupReduceLoweringPlan::ContiguousVcaddRows:
+      return lowerContiguousRows(op, sourceVMIType, resultVMIType, sourceParts,
+                                 maskParts, resultTypes, groupSize, rewriter);
+    default:
       return rewriter.notifyMatchFailure(op,
                                          "unknown group_reduce lowering plan");
     }
-    return lowerContiguousRows(op, sourceVMIType, resultVMIType, sourceParts,
-                               maskParts, resultTypes, groupSize, rewriter);
   }
 
   FailureOr<VRegType> getRowResultType(VRegType sourceType,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11699,6 +11699,29 @@ private:
     return success();
   }
 
+  FailureOr<std::pair<SmallVector<Value>, bool>> buildLaneStrideGroupOffsets(
+      VMIGroupStoreOp op, ValueRange valueParts, Value destination,
+      Value offset, Value rowStride, int64_t numGroups, StringRef dist,
+      OneToNPatternRewriter &rewriter) const {
+    SmallVector<Value> groupOffsets;
+    bool useDirectAccess = true;
+    for (auto [slotBlock, value] : llvm::enumerate(valueParts)) {
+      auto vregType = dyn_cast<VRegType>(value.getType());
+      if (!vregType) {
+        rewriter.notifyMatchFailure(op, "group_store value must be vreg");
+        return failure();
+      }
+      Value groupOffset = createGroupChunkOffset(
+          op.getLoc(), offset, rowStride, slotBlock * 8, 0, rewriter);
+      groupOffsets.push_back(groupOffset);
+      useDirectAccess &= isDirectMemoryDistAddressLegal(
+          op.getDestination(), groupOffset,
+          getMemoryElementType(destination.getType()), vregType,
+          VPTOMemoryOpFamily::Store, dist);
+    }
+    return std::make_pair(std::move(groupOffsets), useDirectAccess);
+  }
+
   LogicalResult lowerSlots8LaneStride(
       VMIGroupStoreOp op, OpAdaptor adaptor, OneToNPatternRewriter &rewriter,
       VMIVRegType valueVMIType, VMILayoutAttr layout, Value destination,
@@ -11714,22 +11737,14 @@ private:
     }
     ValueRange valueParts = adaptor.getValue();
     auto maskType = MaskType::get(rewriter.getContext(), *maskGranularity);
-    SmallVector<Value> groupOffsets;
-    bool useDirectAccess = true;
-    for (auto [slotBlock, value] : llvm::enumerate(valueParts)) {
-      auto vregType = dyn_cast<VRegType>(value.getType());
-      if (!vregType) {
-        return rewriter.notifyMatchFailure(op,
-                                           "group_store value must be vreg");
-      }
-      Value groupOffset = createGroupChunkOffset(
-          op.getLoc(), offset, rowStride, slotBlock * 8, 0, rewriter);
-      groupOffsets.push_back(groupOffset);
-      useDirectAccess &= isDirectMemoryDistAddressLegal(
-          op.getDestination(), groupOffset,
-          getMemoryElementType(op.getDestination().getType()), vregType,
-          VPTOMemoryOpFamily::Store, *dist);
+    FailureOr<std::pair<SmallVector<Value>, bool>> offsetPlan =
+        buildLaneStrideGroupOffsets(op, valueParts, destination, offset,
+                                     rowStride, numGroups, *dist, rewriter);
+    if (failed(offsetPlan)) {
+      return failure();
     }
+    SmallVector<Value> groupOffsets = std::move(offsetPlan->first);
+    bool useDirectAccess = offsetPlan->second;
     if (!useDirectAccess) {
       VMILayoutAttr compactLayout = VMILayoutAttr::getGroupSlots(
           rewriter.getContext(), layout.getNumGroups(), layout.getSlots());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -13290,6 +13290,50 @@ private:
     return success();
   }
 
+  FailureOr<Value> buildFourBlockGroupResult(
+      OpTy op, ValueRange sourceParts, ValueRange maskParts,
+      TypeRange resultTypes, int64_t resultIndex, int64_t resultPartCount,
+      int64_t numGroups, VRegType resultType, MaskType maskType,
+      OneToNPatternRewriter &rewriter) const {
+    SmallVector<Value, 4> partials;
+    partials.reserve(4);
+    for (int64_t part = 0; part < 4; ++part) {
+      int64_t sourceIndex = part * resultPartCount + resultIndex;
+      Value source = sourceParts[sourceIndex];
+      Value mask = maskParts[sourceIndex];
+      bool mismatchedTypes = resultTypes[resultIndex] != resultType ||
+                             source.getType() != resultType ||
+                             mask.getType() != maskType;
+      if (mismatchedTypes) {
+        return rewriter.notifyMatchFailure(
+            op, "four-block group_reduce requires uniform physical types");
+      }
+      partials.push_back(rewriter
+                             .create<GroupReduceOpTy>(op.getLoc(), resultType,
+                                                      source, mask)
+                             .getResult());
+    }
+    int64_t activeGroups = std::min<int64_t>(8, numGroups - resultIndex * 8);
+    FailureOr<Value> combineMask = createPrefixMaskForActiveLanes(
+        op.getLoc(), maskType, activeGroups, rewriter);
+    if (failed(combineMask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to create four-block group_reduce combine mask");
+    }
+    Value sum01 = rewriter
+                      .create<CombineOpTy>(op.getLoc(), resultType, partials[0],
+                                           partials[1], *combineMask)
+                      .getResult();
+    Value sum23 = rewriter
+                      .create<CombineOpTy>(op.getLoc(), resultType, partials[2],
+                                           partials[3], *combineMask)
+                      .getResult();
+    return rewriter
+        .create<CombineOpTy>(op.getLoc(), resultType, sum01, sum23,
+                             *combineMask)
+        .getResult();
+  }
+
   LogicalResult lowerFourBlock(
       OpTy op, ValueRange sourceParts, ValueRange maskParts,
       TypeRange resultTypes, int64_t numGroups,
@@ -13313,43 +13357,13 @@ private:
     results.reserve(resultPartCount);
     for (int64_t resultIndex = 0; resultIndex < resultPartCount;
          ++resultIndex) {
-      SmallVector<Value, 4> partials;
-      partials.reserve(4);
-      for (int64_t part = 0; part < 4; ++part) {
-        int64_t sourceIndex = part * resultPartCount + resultIndex;
-        Value source = sourceParts[sourceIndex];
-        Value mask = maskParts[sourceIndex];
-        bool mismatchedTypes = resultTypes[resultIndex] != resultType ||
-                               source.getType() != resultType ||
-                               mask.getType() != maskType;
-        if (mismatchedTypes) {
-          return rewriter.notifyMatchFailure(
-              op, "four-block group_reduce requires uniform physical types");
-        }
-        partials.push_back(rewriter
-                               .create<GroupReduceOpTy>(op.getLoc(), resultType,
-                                                        source, mask)
-                               .getResult());
+      FailureOr<Value> result = buildFourBlockGroupResult(
+          op, sourceParts, maskParts, resultTypes, resultIndex,
+          resultPartCount, numGroups, *resultType, *maskType, rewriter);
+      if (failed(result)) {
+        return failure();
       }
-      int64_t activeGroups = std::min<int64_t>(8, numGroups - resultIndex * 8);
-      FailureOr<Value> combineMask = createPrefixMaskForActiveLanes(
-          op.getLoc(), maskType, activeGroups, rewriter);
-      if (failed(combineMask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to create four-block group_reduce combine mask");
-      }
-      Value sum01 = rewriter
-                        .create<CombineOpTy>(op.getLoc(), resultType, partials[0],
-                                             partials[1], *combineMask)
-                        .getResult();
-      Value sum23 = rewriter
-                        .create<CombineOpTy>(op.getLoc(), resultType, partials[2],
-                                             partials[3], *combineMask)
-                        .getResult();
-      results.push_back(rewriter
-                            .create<CombineOpTy>(op.getLoc(), resultType, sum01,
-                                                 sum23, *combineMask)
-                            .getResult());
+      results.push_back(*result);
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8763,25 +8763,35 @@ private:
     return parts;
   }
 
+  FailureOr<SmallVector<Value>> materializeContiguousLoadParts(
+      VMILoadOp op, OneToNPatternRewriter &rewriter, Value source, Value offset,
+      VMIVRegType resultVMIType, ArrayRef<Type> contiguousTypes,
+      int64_t lanesPerPart) const {
+    auto firstType = contiguousTypes.empty()
+                         ? VRegType{}
+                         : dyn_cast<VRegType>(contiguousTypes.front());
+    bool useAlignedAccess =
+        firstType && isDirectMemoryDistAddressLegal(
+                          op.getSource(), op.getOffset(),
+                          resultVMIType.getElementType(), firstType,
+                          VPTOMemoryOpFamily::Load, "NORM");
+    if (useAlignedAccess) {
+      return materializeAlignedContiguousParts(
+          op, rewriter, source, offset, contiguousTypes, lanesPerPart);
+    }
+    return materializeUnalignedContiguousParts(
+        op, rewriter, source, offset, contiguousTypes, lanesPerPart);
+  }
+
   LogicalResult lowerContiguous(
       VMILoadOp op, OneToNPatternRewriter &rewriter, Value source,
       Value offset, VMIVRegType resultVMIType, ArrayRef<Type> resultTypes,
       ArrayRef<Type> contiguousTypes, int64_t lanesPerPart,
       VMILayoutAttr contiguousLayout) const {
-    auto firstContiguousType = contiguousTypes.empty()
-                                    ? VRegType{}
-                                    : dyn_cast<VRegType>(contiguousTypes.front());
-    bool useAlignedAccess =
-        firstContiguousType &&
-        isDirectMemoryDistAddressLegal(
-            op.getSource(), op.getOffset(), resultVMIType.getElementType(),
-            firstContiguousType, VPTOMemoryOpFamily::Load, "NORM");
     FailureOr<SmallVector<Value>> contiguousParts =
-        useAlignedAccess
-            ? materializeAlignedContiguousParts(
-                  op, rewriter, source, offset, contiguousTypes, lanesPerPart)
-            : materializeUnalignedContiguousParts(
-                  op, rewriter, source, offset, contiguousTypes, lanesPerPart);
+        materializeContiguousLoadParts(op, rewriter, source, offset,
+                                       resultVMIType, contiguousTypes,
+                                       lanesPerPart);
     if (failed(contiguousParts)) {
       return failure();
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2652,6 +2652,19 @@ checkScatterElementContract(VMIVRegType valueType, VMIVRegType indicesType,
   return success();
 }
 
+struct ScatterShapeTypes {
+  VMIVRegType value;
+  VMIVRegType indices;
+  VMIMaskType mask;
+};
+
+static ScatterShapeTypes getScatterShapeTypes(VMIScatterOp op) {
+  return ScatterShapeTypes{
+      cast<VMIVRegType>(op.getValue().getType()),
+      cast<VMIVRegType>(op.getIndices().getType()),
+      cast<VMIMaskType>(op.getMask().getType())};
+}
+
 LogicalResult
 checkSupportedScatterShape(VMIScatterOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
@@ -2661,20 +2674,18 @@ checkSupportedScatterShape(VMIScatterOp op, std::string *reason) {
     return failure();
   };
 
-  auto valueType = cast<VMIVRegType>(op.getValue().getType());
-  auto indicesType = cast<VMIVRegType>(op.getIndices().getType());
-  auto maskType = cast<VMIMaskType>(op.getMask().getType());
-  if (failed(checkScatterLayoutAndDestination(op, valueType, indicesType,
-                                              maskType, reason))) {
+  ScatterShapeTypes types = getScatterShapeTypes(op);
+  if (failed(checkScatterLayoutAndDestination(op, types.value, types.indices,
+                                              types.mask, reason))) {
     return failure();
   }
-  if (failed(checkScatterElementContract(valueType, indicesType, maskType,
-                                         reason))) {
+  if (failed(checkScatterElementContract(types.value, types.indices,
+                                         types.mask, reason))) {
     return failure();
   }
 
-  return checkSupportedScatterPhysicalShape(valueType, indicesType, maskType,
-                                            true, reason);
+  return checkSupportedScatterPhysicalShape(types.value, types.indices,
+                                            types.mask, true, reason);
 }
 
 LogicalResult

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11785,11 +11785,11 @@ private:
     return results;
   }
 
-  LogicalResult lowerDirectE2B(
-      VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
-      Value source, Value offset, VMIVRegType resultVMIType,
-      ArrayRef<Type> resultTypes, int64_t numGroups, unsigned elementBits,
-      VMILayoutAttr layout) const {
+  FailureOr<std::tuple<StringRef, int64_t, int64_t>> validateDirectE2BShape(
+      VMIGroupBroadcastLoadOp op, Value source,
+      VMIVRegType resultVMIType, ArrayRef<Type> resultTypes,
+      int64_t numGroups, unsigned elementBits, VMILayoutAttr layout,
+      OneToNPatternRewriter &rewriter) const {
     bool contiguousPacketLayout = layout && layout.isContiguous();
     bool splitPacketLayout = layout && layout.isDeinterleaved() &&
                              (layout.getFactor() == 2 ||
@@ -11806,7 +11806,6 @@ private:
           op, "group_broadcast_load E2B lowering requires b16 or b32 element "
               "type");
     }
-    StringRef e2bDist = elementBits == 16 ? "E2B_B16" : "E2B_B32";
     std::optional<int64_t> stride =
         getConstantIndexValue(op.getSourceGroupStride());
     if (!stride || *stride != 1) {
@@ -11849,13 +11848,31 @@ private:
       return rewriter.notifyMatchFailure(
           op, "group_broadcast_load expected one E2B packet in each part");
     }
+    StringRef e2bDist = elementBits == 16 ? "E2B_B16" : "E2B_B32";
+    return std::make_tuple(e2bDist, factor, *chunksPerPart);
+  }
+
+  LogicalResult lowerDirectE2B(
+      VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
+      Value source, Value offset, VMIVRegType resultVMIType,
+      ArrayRef<Type> resultTypes, int64_t numGroups, unsigned elementBits,
+      VMILayoutAttr layout) const {
+    FailureOr<std::tuple<StringRef, int64_t, int64_t>> shape =
+        validateDirectE2BShape(op, source, resultVMIType, resultTypes,
+                               numGroups, elementBits, layout, rewriter);
+    if (failed(shape)) {
+      return failure();
+    }
+    StringRef e2bDist = std::get<0>(*shape);
+    int64_t factor = std::get<1>(*shape);
+    int64_t chunksPerPart = std::get<2>(*shape);
     FailureOr<SmallVector<Value>> packets = emitE2BPackets(
-        op, rewriter, source, offset, resultTypes, *chunksPerPart, e2bDist);
+        op, rewriter, source, offset, resultTypes, chunksPerPart, e2bDist);
     if (failed(packets)) {
       return failure();
     }
     FailureOr<SmallVector<Value>> results = buildE2BResults(
-        op, *packets, resultTypes, factor, *chunksPerPart, rewriter);
+        op, *packets, resultTypes, factor, chunksPerPart, rewriter);
     if (failed(results)) {
       return failure();
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3644,8 +3644,7 @@ static LogicalResult checkDynamicGroupMaskLayout(
 }
 
 static FailureOr<std::pair<int64_t, int64_t>>
-getDynamicGroupMaskPhysicalShape(VMICreateGroupMaskOp op,
-                                 VMIMaskType resultVMIType,
+getDynamicGroupMaskPhysicalShape(VMIMaskType resultVMIType,
                                  TypeRange resultTypes,
                                  std::string *reason) {
   auto fail = [&reason](const Twine &message)
@@ -3688,7 +3687,7 @@ static FailureOr<DynamicGroupMaskPlan> buildDynamicGroupMaskPlan(
     return failure();
   }
   FailureOr<std::pair<int64_t, int64_t>> physicalShape =
-      getDynamicGroupMaskPhysicalShape(op, resultVMIType, resultTypes, reason);
+      getDynamicGroupMaskPhysicalShape(resultVMIType, resultTypes, reason);
   if (failed(physicalShape)) {
     return failure();
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12414,6 +12414,40 @@ template <typename SourceOp, typename TargetOp>
 struct OneToNVMIUnaryOpPattern : OneToNOpConversionPattern<SourceOp> {
   using OneToNOpConversionPattern<SourceOp>::OneToNOpConversionPattern;
 
+private:
+  LogicalResult lowerParts(SourceOp op, ValueRange sourceParts,
+                           ArrayRef<Type> resultTypes,
+                           OneToNPatternRewriter &rewriter) const {
+    const bool invalidArity = sourceParts.size() != resultTypes.size();
+    if (invalidArity) {
+      return rewriter.notifyMatchFailure(op, "physical unary arity mismatch");
+    }
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (auto [source, resultType] :
+         llvm::zip_equal(sourceParts, resultTypes)) {
+      auto vregType = dyn_cast<VRegType>(resultType);
+      const bool invalidPart = !vregType || source.getType() != resultType;
+      if (invalidPart) {
+        return rewriter.notifyMatchFailure(
+            op, "physical unary part type mismatch");
+      }
+      FailureOr<Value> mask =
+          createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
+      if (failed(mask)) {
+        return rewriter.notifyMatchFailure(
+            op, "unsupported element type for all-true unary mask");
+      }
+      results.push_back(
+          rewriter.create<TargetOp>(op.getLoc(), resultType, source, *mask)
+              .getResult());
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
+public:
   LogicalResult matchAndRewrite(
       SourceOp op,
       typename OneToNOpConversionPattern<SourceOp>::OpAdaptor adaptor,
@@ -12425,29 +12459,7 @@ struct OneToNVMIUnaryOpPattern : OneToNOpConversionPattern<SourceOp> {
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (sourceParts.size() != resultTypes.size())
-      return rewriter.notifyMatchFailure(op, "physical unary arity mismatch");
-
-    SmallVector<Value> results;
-    results.reserve(resultTypes.size());
-    for (auto [source, resultType] :
-         llvm::zip_equal(sourceParts, resultTypes)) {
-      auto vregType = dyn_cast<VRegType>(resultType);
-      if (!vregType || source.getType() != resultType)
-        return rewriter.notifyMatchFailure(op,
-                                           "physical unary part type mismatch");
-      FailureOr<Value> mask =
-          createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
-      if (failed(mask))
-        return rewriter.notifyMatchFailure(
-            op, "unsupported element type for all-true unary mask");
-      results.push_back(
-          rewriter.create<TargetOp>(op.getLoc(), resultType, source, *mask)
-              .getResult());
-    }
-
-    replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
-    return success();
+    return lowerParts(op, sourceParts, resultTypes, rewriter);
   }
 };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18814,6 +18814,17 @@ static LogicalResult checkSupportedCompressResultShape(
   return success();
 }
 
+static LogicalResult checkCompressStoreDestination(VMICompressStoreOp op,
+                                                   std::string *reason) {
+  if (isa<PtrType>(op.getDestination().getType())) {
+    return success();
+  }
+  if (reason) {
+    *reason = "requires !pto.ptr destination because pto.vstur is pointer-only";
+  }
+  return failure();
+}
+
 LogicalResult checkSupportedCompressShape(VMICompressOp op,
                                           std::string *reason = nullptr) {
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
@@ -18839,13 +18850,6 @@ LogicalResult checkSupportedCompressShape(VMICompressOp op,
 LogicalResult checkSupportedCompressStoreShape(
     VMICompressStoreOp op,
     std::string *reason = nullptr) {
-  auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
-
   auto valueType = cast<VMIVRegType>(op.getValue().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   FailureOr<CompressPhysicalShapePlan> plan = buildCompressPhysicalShapePlan(
@@ -18857,12 +18861,7 @@ LogicalResult checkSupportedCompressStoreShape(
     return failure();
   }
 
-  if (!isa<PtrType>(op.getDestination().getType())) {
-    return fail("requires !pto.ptr destination because pto.vstur is "
-                "pointer-only");
-  }
-
-  return success();
+  return checkCompressStoreDestination(op, reason);
 }
 
 struct ReducePhysicalShapePlan {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10577,6 +10577,30 @@ private:
     return success();
   }
 
+  FailureOr<Value> materializeCompactSmallGroupValue(
+      VMIGroupStoreOp op, ValueRange valueParts, VMIVRegType valueVMIType,
+      VMILayoutAttr layout, OneToNPatternRewriter &rewriter) const {
+    Value compactValue = valueParts.front();
+    bool alreadyCompact = layout.getLaneStride() == 1;
+    if (alreadyCompact) {
+      return compactValue;
+    }
+    VMILayoutAttr compactLayout = VMILayoutAttr::getGroupSlots(
+        rewriter.getContext(), layout.getNumGroups(), layout.getSlots());
+    auto compactVMIType = VMIVRegType::get(
+        rewriter.getContext(), valueVMIType.getElementCount(),
+        valueVMIType.getElementType(), compactLayout);
+    FailureOr<SmallVector<Value>> packed = materializeEnsureLayoutConversion(
+        op, valueParts, valueVMIType, compactVMIType,
+        *this->getTypeConverter(), rewriter);
+    bool invalidPacked = failed(packed) || packed->size() != 1;
+    if (invalidPacked) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to materialize compact group_store layout");
+    }
+    return packed->front();
+  }
+
   LogicalResult lowerCompactSmallGroupStore(
       VMIGroupStoreOp op, OpAdaptor adaptor,
       OneToNPatternRewriter &rewriter, VMIVRegType valueVMIType,
@@ -10593,28 +10617,15 @@ private:
           op, "compact small group_store requires vreg and ptr operands");
     }
 
-    Value compactValue = valueParts.front();
-    bool needsCompactLayout = layout.getLaneStride() != 1;
-    if (needsCompactLayout) {
-      VMILayoutAttr compactLayout = VMILayoutAttr::getGroupSlots(
-          rewriter.getContext(), layout.getNumGroups(), layout.getSlots());
-      auto compactVMIType = VMIVRegType::get(
-          rewriter.getContext(), valueVMIType.getElementCount(),
-          valueVMIType.getElementType(), compactLayout);
-      FailureOr<SmallVector<Value>> packed = materializeEnsureLayoutConversion(
-          op, valueParts, valueVMIType, compactVMIType,
-          *this->getTypeConverter(), rewriter);
-      bool invalidPacked = failed(packed) || packed->size() != 1;
-      if (invalidPacked) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to materialize compact group_store layout");
-      }
-      compactValue = packed->front();
+    FailureOr<Value> compactValue = materializeCompactSmallGroupValue(
+        op, valueParts, valueVMIType, layout, rewriter);
+    if (failed(compactValue)) {
+      return failure();
     }
 
     if (isKnownAddressAligned(destination, offset,
                               valueVMIType.getElementType(), 32)) {
-      auto compactType = dyn_cast<VRegType>(compactValue.getType());
+      auto compactType = dyn_cast<VRegType>(compactValue->getType());
       std::optional<std::string> normalDist =
           getX2MemoryDistToken(valueVMIType.getElementType(), "NORM");
       if (!compactType || !normalDist) {
@@ -10634,7 +10645,7 @@ private:
             op, "failed to create aligned compact group_store mask");
       }
       rewriter.create<VstsOp>(
-          op.getLoc(), /*updated_base=*/Type{}, compactValue, destination,
+          op.getLoc(), /*updated_base=*/Type{}, *compactValue, destination,
           offset, rewriter.getStringAttr(*normalDist), *storeMask);
       rewriter.eraseOp(op);
       return success();
@@ -10644,7 +10655,7 @@ private:
         rewriter.create<AddPtrOp>(op.getLoc(), destination.getType(),
                                   destination, offset)
             .getResult();
-    SmallVector<Value> streamValues{compactValue};
+    SmallVector<Value> streamValues{*compactValue};
     SmallVector<int64_t> streamAdvances{valueVMIType.getElementCount()};
     if (failed(emitStatefulStoreStream(op, elementBase, streamValues,
                                        streamAdvances, rewriter))) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3427,8 +3427,9 @@ FailureOr<SmallVector<ShuffleVselrPlan>>
 computeShuffleVselrPlans(VMIShuffleOp op, std::string *reason) {
   auto fail =
       [&reason](const Twine &message) -> FailureOr<SmallVector<ShuffleVselrPlan>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12455,6 +12455,44 @@ template <typename SourceOp, typename TargetOp>
 struct OneToNVMIMaskBinaryOpPattern : OneToNOpConversionPattern<SourceOp> {
   using OneToNOpConversionPattern<SourceOp>::OneToNOpConversionPattern;
 
+private:
+  LogicalResult lowerParts(SourceOp op, ValueRange lhsParts,
+                           ValueRange rhsParts, ArrayRef<Type> resultTypes,
+                           OneToNPatternRewriter &rewriter) const {
+    const bool invalidArity = lhsParts.size() != rhsParts.size() ||
+                              lhsParts.size() != resultTypes.size();
+    if (invalidArity) {
+      return rewriter.notifyMatchFailure(
+          op, "physical mask binary arity mismatch");
+    }
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (auto [lhs, rhs, resultType] :
+         llvm::zip_equal(lhsParts, rhsParts, resultTypes)) {
+      auto maskType = dyn_cast<MaskType>(resultType);
+      const bool invalidPart = !maskType || lhs.getType() != resultType ||
+                               rhs.getType() != resultType;
+      if (invalidPart) {
+        return rewriter.notifyMatchFailure(
+            op, "physical mask binary part type mismatch");
+      }
+      FailureOr<Value> seedMask =
+          createAllTrueMask(op.getLoc(), maskType, rewriter);
+      if (failed(seedMask)) {
+        return rewriter.notifyMatchFailure(
+            op, "unsupported mask type for all-true mask binary seed");
+      }
+      results.push_back(
+          rewriter
+              .create<TargetOp>(op.getLoc(), resultType, lhs, rhs, *seedMask)
+              .getResult());
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
+public:
   LogicalResult matchAndRewrite(
       SourceOp op,
       typename OneToNOpConversionPattern<SourceOp>::OpAdaptor adaptor,
@@ -12467,33 +12505,7 @@ struct OneToNVMIMaskBinaryOpPattern : OneToNOpConversionPattern<SourceOp> {
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (lhsParts.size() != rhsParts.size() ||
-        lhsParts.size() != resultTypes.size())
-      return rewriter.notifyMatchFailure(op,
-                                         "physical mask binary arity mismatch");
-
-    SmallVector<Value> results;
-    results.reserve(resultTypes.size());
-    for (auto [lhs, rhs, resultType] :
-         llvm::zip_equal(lhsParts, rhsParts, resultTypes)) {
-      auto maskType = dyn_cast<MaskType>(resultType);
-      if (!maskType || lhs.getType() != resultType ||
-          rhs.getType() != resultType)
-        return rewriter.notifyMatchFailure(
-            op, "physical mask binary part type mismatch");
-      FailureOr<Value> seedMask =
-          createAllTrueMask(op.getLoc(), maskType, rewriter);
-      if (failed(seedMask))
-        return rewriter.notifyMatchFailure(
-            op, "unsupported mask type for all-true mask binary seed");
-      results.push_back(
-          rewriter
-              .create<TargetOp>(op.getLoc(), resultType, lhs, rhs, *seedMask)
-              .getResult());
-    }
-
-    replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
-    return success();
+    return lowerParts(op, lhsParts, rhsParts, resultTypes, rewriter);
   }
 };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7111,11 +7111,12 @@ static FailureOr<std::optional<Value>> createSubVLPeriodicFastPath(
   return *powerOfTwo;
 }
 
-FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
-                                               Value base, int64_t groupSize,
-                                               StringAttr orderAttr,
-                                               PatternRewriter &rewriter) {
-  IotaMaterializationContext context{loc, base, orderAttr, rewriter};
+FailureOr<Value> createSubVLGroupPeriodicChunk(
+    const IotaMaterializationContext &context, Type resultType,
+    int64_t groupSize) {
+  Location loc = context.loc;
+  Value base = context.base;
+  PatternRewriter &rewriter = context.rewriter;
   auto vregType = dyn_cast<VRegType>(resultType);
   if (!vregType) {
     return failure();
@@ -7132,7 +7133,7 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
     return failure();
   }
 
-  StringRef order = orderAttr ? orderAttr.getValue() : StringRef("ASC");
+  StringRef order = getIotaOrder(context);
   FailureOr<std::optional<Value>> fastPath = createSubVLPeriodicFastPath(
       context, resultType, groupSize, order, *allMask);
   if (failed(fastPath)) {
@@ -7260,9 +7261,8 @@ private:
                                           op.getOrderAttr(), rewriter};
         FailureOr<Value> result;
         if (physMultipleOfGroupSize && groupSize < lanesPerPart) {
-          result = createSubVLGroupPeriodicChunk(
-              op.getLoc(), resultType, base, groupSize, op.getOrderAttr(),
-              rewriter);
+          result = createSubVLGroupPeriodicChunk(context, resultType,
+                                                 groupSize);
         } else {
           result = createIotaContiguousChunk(context, resultType, laneOffset);
         }
@@ -7284,10 +7284,10 @@ private:
       if (!isa<VRegType>(resultType)) {
         return rewriter.notifyMatchFailure(op, "iota result must be vreg");
       }
+      IotaMaterializationContext context{op.getLoc(), base, op.getOrderAttr(),
+                                         rewriter};
       FailureOr<Value> result = createIotaContiguousChunk(
-          IotaMaterializationContext{op.getLoc(), base, op.getOrderAttr(),
-                                     rewriter},
-          resultType, static_cast<int64_t>(index) * lanesPerPart);
+          context, resultType, static_cast<int64_t>(index) * lanesPerPart);
       if (failed(result)) {
         return rewriter.notifyMatchFailure(
             op, "failed to materialize contiguous iota chunk");
@@ -7312,10 +7312,10 @@ private:
     for (int64_t part = 0; part < factor; ++part) {
       for (int64_t chunk = 0; chunk < chunksPerPart; ++chunk) {
         Type resultType = resultTypes[part * chunksPerPart + chunk];
+        IotaMaterializationContext context{op.getLoc(), base,
+                                           op.getOrderAttr(), rewriter};
         FailureOr<Value> result = createIotaDeinterleavedChunk(
-            IotaMaterializationContext{op.getLoc(), base, op.getOrderAttr(),
-                                       rewriter},
-            resultType, factor, part, chunk, lanesPerPart);
+            context, resultType, factor, part, chunk, lanesPerPart);
         if (failed(result)) {
           return rewriter.notifyMatchFailure(
               op, "failed to materialize deinterleaved iota chunk");

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11874,6 +11874,41 @@ public:
 struct OneToNVMIVmullOpPattern : OneToNOpConversionPattern<VMIVmullOp> {
   using OneToNOpConversionPattern<VMIVmullOp>::OneToNOpConversionPattern;
 
+private:
+  LogicalResult lowerPart(VMIVmullOp op, Value lhs, Value rhs, Value mask,
+                          Type lowType, Type highType,
+                          SmallVectorImpl<Value> &lows,
+                          SmallVectorImpl<Value> &highs,
+                          OneToNPatternRewriter &rewriter) const {
+    auto dataType = dyn_cast<VRegType>(lowType);
+    auto maskType = dyn_cast<MaskType>(mask.getType());
+    const bool invalidShape =
+        !dataType || dataType.getElementCount() != 64 || lowType != highType ||
+        lhs.getType() != lowType || rhs.getType() != lowType;
+    if (invalidShape) {
+      return rewriter.notifyMatchFailure(
+          op, "vmull requires matching 64-lane physical data part types");
+    }
+    auto elementType = dyn_cast<IntegerType>(dataType.getElementType());
+    const bool invalidElementType =
+        !elementType || elementType.getWidth() != 32 ||
+        (!elementType.isSignless() && !elementType.isUnsigned());
+    if (invalidElementType) {
+      return rewriter.notifyMatchFailure(
+          op, "vmull requires physical i32 or ui32 data parts");
+    }
+    if (!maskType || !maskType.isB32()) {
+      return rewriter.notifyMatchFailure(
+          op, "vmull requires a corresponding b32 mask part");
+    }
+    auto vmull = rewriter.create<VmullOp>(op.getLoc(), lowType, highType, lhs,
+                                          rhs, mask);
+    lows.push_back(vmull.getLow());
+    highs.push_back(vmull.getHigh());
+    return success();
+  }
+
+public:
   LogicalResult
   matchAndRewrite(VMIVmullOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
@@ -11884,45 +11919,33 @@ struct OneToNVMIVmullOpPattern : OneToNOpConversionPattern<VMIVmullOp> {
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
     FailureOr<SmallVector<Type>> maybeHighTypes =
         getConvertedResultTypes(op, 1, *this->getTypeConverter());
-    if (failed(maybeLowTypes) || failed(maybeHighTypes))
+    const bool conversionFailed =
+        failed(maybeLowTypes) || failed(maybeHighTypes);
+    if (conversionFailed) {
       return failure();
+    }
     SmallVector<Type> lowTypes = std::move(*maybeLowTypes);
     SmallVector<Type> highTypes = std::move(*maybeHighTypes);
 
     size_t arity = aParts.size();
-    if (arity == 0 || bParts.size() != arity || maskParts.size() != arity ||
-        lowTypes.size() != arity || highTypes.size() != arity)
+    const bool invalidArity =
+        arity == 0 || bParts.size() != arity || maskParts.size() != arity ||
+        lowTypes.size() != arity || highTypes.size() != arity;
+    if (invalidArity) {
       return rewriter.notifyMatchFailure(
           op, "physical vmull arity mismatch across a, b, mask, low, and high");
+    }
 
     SmallVector<Value> lows;
     SmallVector<Value> highs;
     lows.reserve(arity);
     highs.reserve(arity);
     for (size_t index = 0; index < arity; ++index) {
-      Type lowType = lowTypes[index];
-      Type highType = highTypes[index];
-      auto dataType = dyn_cast<VRegType>(lowType);
-      auto maskType = dyn_cast<MaskType>(maskParts[index].getType());
-      if (!dataType || dataType.getElementCount() != 64 ||
-          lowType != highType || aParts[index].getType() != lowType ||
-          bParts[index].getType() != lowType)
-        return rewriter.notifyMatchFailure(
-            op, "vmull requires matching 64-lane physical data part types");
-      auto elementType = dyn_cast<IntegerType>(dataType.getElementType());
-      if (!elementType || elementType.getWidth() != 32 ||
-          (!elementType.isSignless() && !elementType.isUnsigned()))
-        return rewriter.notifyMatchFailure(
-            op, "vmull requires physical i32 or ui32 data parts");
-      if (!maskType || !maskType.isB32())
-        return rewriter.notifyMatchFailure(
-            op, "vmull requires a corresponding b32 mask part");
-
-      auto vmull = rewriter.create<VmullOp>(op.getLoc(), lowType, highType,
-                                            aParts[index], bParts[index],
-                                            maskParts[index]);
-      lows.push_back(vmull.getLow());
-      highs.push_back(vmull.getHigh());
+      if (failed(lowerPart(op, aParts[index], bParts[index], maskParts[index],
+                           lowTypes[index], highTypes[index], lows, highs,
+                           rewriter))) {
+        return failure();
+      }
     }
 
     SmallVector<Value> results;
@@ -12802,8 +12825,9 @@ struct OneToNVMIReduceAddIOpPattern
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     FailureOr<ReduceAddPhysicalPlan> plan = buildReduceAddPhysicalPlan(
         op, sourceParts, maskParts, resultTypes, rewriter, "reduce_addi");
@@ -12873,8 +12897,9 @@ struct OneToNVMIReduceAddFOpPattern
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     FailureOr<ReduceAddPhysicalPlan> plan = buildReduceAddPhysicalPlan(
         op, sourceParts, maskParts, resultTypes, rewriter, "reduce_addf");

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -4085,6 +4085,52 @@ static FailureOr<int64_t> validateConstantMaskChunk(
   return *lanesPerPart;
 }
 
+static FailureOr<Value> materializeNonPrefixConstantMask(
+    Location loc, MaskType maskType, ArrayRef<int8_t> activeLanes,
+    int64_t lanesPerPart, Value allTrue, PatternRewriter &rewriter) {
+  Value result;
+  for (int64_t lane = 0; lane < lanesPerPart;) {
+    while (lane < lanesPerPart && !activeLanes[lane]) {
+      ++lane;
+    }
+    if (lane >= lanesPerPart) {
+      break;
+    }
+    int64_t runBegin = lane;
+    while (lane < lanesPerPart && activeLanes[lane]) {
+      ++lane;
+    }
+    int64_t runEnd = lane;
+    FailureOr<Value> prefixEnd =
+        materializePrefixMask(loc, maskType, runEnd, lanesPerPart, rewriter);
+    if (failed(prefixEnd)) {
+      return failure();
+    }
+    Value runMask = *prefixEnd;
+    if (runBegin != 0) {
+      FailureOr<Value> prefixBegin = materializePrefixMask(
+          loc, maskType, runBegin, lanesPerPart, rewriter);
+      if (failed(prefixBegin)) {
+        return failure();
+      }
+      Value notPrefixBegin =
+          rewriter.create<PnotOp>(loc, maskType, *prefixBegin, allTrue)
+              .getResult();
+      runMask = rewriter
+                    .create<PandOp>(loc, maskType, *prefixEnd, notPrefixBegin,
+                                    allTrue)
+                    .getResult();
+    }
+    if (!result) {
+      result = runMask;
+    } else {
+      result = rewriter.create<PorOp>(loc, maskType, result, runMask, allTrue)
+                   .getResult();
+    }
+  }
+  return result;
+}
+
 FailureOr<Value> materializeConstantMaskChunk(Location loc, MaskType maskType,
                                               ArrayRef<int8_t> activeLanes,
                                               PatternRewriter &rewriter) {
@@ -4100,61 +4146,19 @@ FailureOr<Value> materializeConstantMaskChunk(Location loc, MaskType maskType,
                                  rewriter);
 
   FailureOr<Value> allTrue = createAllTrueMask(loc, maskType, rewriter);
-  if (failed(allTrue))
+  if (failed(allTrue)) {
     return failure();
-
-  auto materializeRun = [loc, maskType, lanesPerPart, &rewriter, &allTrue](
-                            int64_t runBegin,
-                            int64_t runEnd) -> FailureOr<Value> {
-    FailureOr<Value> prefixEnd =
-        materializePrefixMask(loc, maskType, runEnd, *lanesPerPart, rewriter);
-    if (failed(prefixEnd)) {
-      return failure();
-    }
-    if (runBegin == 0) {
-      return *prefixEnd;
-    }
-    FailureOr<Value> prefixBegin = materializePrefixMask(
-        loc, maskType, runBegin, *lanesPerPart, rewriter);
-    if (failed(prefixBegin)) {
-      return failure();
-    }
-    Value notPrefixBegin =
-        rewriter.create<PnotOp>(loc, maskType, *prefixBegin, *allTrue)
-            .getResult();
-    return rewriter
-        .create<PandOp>(loc, maskType, *prefixEnd, notPrefixBegin, *allTrue)
-        .getResult();
-  };
-
-  Value result;
-  int64_t lane = 0;
-  while (lane < *lanesPerPart) {
-    while (lane < *lanesPerPart && !activeLanes[lane])
-      ++lane;
-    if (lane >= *lanesPerPart)
-      break;
-
-    int64_t runBegin = lane;
-    while (lane < *lanesPerPart && activeLanes[lane])
-      ++lane;
-    int64_t runEnd = lane;
-
-    FailureOr<Value> runMask = materializeRun(runBegin, runEnd);
-    if (failed(runMask)) {
-      return failure();
-    }
-
-    if (!result) {
-      result = *runMask;
-      continue;
-    }
-    result = rewriter.create<PorOp>(loc, maskType, result, *runMask, *allTrue)
-                 .getResult();
   }
 
-  if (result)
-    return result;
+  FailureOr<Value> result = materializeNonPrefixConstantMask(
+      loc, maskType, activeLanes, *lanesPerPart, *allTrue, rewriter);
+  if (failed(result)) {
+    return failure();
+  }
+
+  if (*result) {
+    return *result;
+  }
   return materializePrefixMask(loc, maskType, 0, *lanesPerPart, rewriter);
 }
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18984,6 +18984,32 @@ static FailureOr<int64_t> checkChannelSplitResultShape(
   return resultArity;
 }
 
+static FailureOr<int64_t> checkChannelSplitSourceShape(
+    VMIChannelSplitOp op, VMILayoutAttr expectedLayout,
+    std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> FailureOr<int64_t> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  auto sourceType = cast<VMIVRegType>(op.getSource().getType());
+  VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
+  if (!sourceLayout) {
+    return fail("requires assigned source layout");
+  }
+  bool invalidSourceLayout =
+      !sourceLayout.isContiguous() && sourceLayout != expectedLayout;
+  if (invalidSourceLayout) {
+    return fail("requires source layout to be contiguous or matching deinterleaved channel layout");
+  }
+  FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
+  if (failed(sourceArity)) {
+    return fail("requires computable source physical arity");
+  }
+  return *sourceArity;
+}
+
 static LogicalResult checkChannelMergeResultShape(
     VMIChannelMergeOp op, VMILayoutAttr expectedLayout, int64_t inputArity,
     std::string *reason) {
@@ -19016,33 +19042,15 @@ static LogicalResult checkChannelMergeResultShape(
 
 LogicalResult checkSupportedChannelSplitShape(VMIChannelSplitOp op,
                                               std::string *reason = nullptr) {
-  auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
   FailureOr<ChannelShapePlan> plan =
       buildChannelShapePlan(op, op.getNumResults(), "channel_split", reason);
   if (failed(plan)) {
     return failure();
   }
-  int64_t channels = plan->channels;
-
-  auto sourceType = cast<VMIVRegType>(op.getSource().getType());
-  VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
-  if (!sourceLayout) {
-    return fail("requires assigned source layout");
-  }
-  bool invalidSourceLayout =
-      !sourceLayout.isContiguous() && sourceLayout != plan->expectedLayout;
-  if (invalidSourceLayout) {
-    return fail("requires source layout to be contiguous or matching "
-                "deinterleaved channel layout");
-
-  FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
+  FailureOr<int64_t> sourceArity =
+      checkChannelSplitSourceShape(op, plan->expectedLayout, reason);
   if (failed(sourceArity)) {
-    return fail("requires computable source physical arity");
+    return failure();
   }
   if (failed(checkChannelSplitResultShape(op, *sourceArity, reason))) {
     return failure();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5152,42 +5152,55 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
     VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
     Type sourceVMIElementType, PatternRewriter &rewriter) {
-  FailureOr<std::optional<SmallVector<Value>>> simple =
-      materializeSimpleDataLayoutConversion(
+  auto tryMaterializer =
+      [](auto materializer) -> FailureOr<std::optional<SmallVector<Value>>> {
+    return materializer();
+  };
+  FailureOr<std::optional<SmallVector<Value>>> simple = tryMaterializer(
+      [op, sourceParts, resultTypes, sourceLayout, resultLayout,
+       sourceVMIElementType, &rewriter]() {
+        return materializeSimpleDataLayoutConversion(
           op, sourceParts, resultTypes, sourceLayout, resultLayout,
           sourceVMIElementType, rewriter);
+      });
   if (failed(simple)) {
     return failure();
   }
   if (simple->has_value()) {
     return std::move(**simple);
   }
-
   FailureOr<std::optional<SmallVector<Value>>> deinterleaved2 =
-      materializeDeinterleaved2Layout(op, sourceParts, resultTypes,
-                                      sourceLayout, resultLayout, rewriter);
+      tryMaterializer([op, sourceParts, resultTypes, sourceLayout, resultLayout,
+                       &rewriter]() {
+        return materializeDeinterleaved2Layout(
+            op, sourceParts, resultTypes, sourceLayout, resultLayout, rewriter);
+      });
   if (failed(deinterleaved2)) {
     return failure();
   }
   if (deinterleaved2->has_value()) {
     return std::move(**deinterleaved2);
   }
-
-  FailureOr<std::optional<SmallVector<Value>>> laneStride =
-      materializeDataLaneStrideConversion(
+  FailureOr<std::optional<SmallVector<Value>>> laneStride = tryMaterializer(
+      [op, sourceParts, resultTypes, sourceLayout, resultLayout,
+       sourceVMIElementType, &rewriter]() {
+        return materializeDataLaneStrideConversion(
           op, sourceParts, resultTypes, sourceLayout, resultLayout,
           sourceVMIElementType, rewriter);
+      });
   if (failed(laneStride)) {
     return failure();
   }
   if (laneStride->has_value()) {
     return std::move(**laneStride);
   }
-
-  FailureOr<std::optional<SmallVector<Value>>> viaContiguous =
-      materializeDataLayoutViaContiguous(
+  FailureOr<std::optional<SmallVector<Value>>> viaContiguous = tryMaterializer(
+      [op, sourceParts, resultTypes, sourceLayout, resultLayout,
+       sourceVMIElementType, &rewriter]() {
+        return materializeDataLayoutViaContiguous(
           op, sourceParts, resultTypes, sourceLayout, resultLayout,
           sourceVMIElementType, rewriter);
+      });
   if (failed(viaContiguous)) {
     return failure();
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10231,6 +10231,44 @@ public:
     return success();
   }
 
+  FailureOr<bool> tryLowerDeinterleavedStore(
+      VMIStoreOp op, Value destination, Value offset, ValueRange valueParts,
+      VMIVRegType valueVMIType, int64_t lanesPerPart,
+      bool fullPhysicalChunks, bool noWiderThanContiguous,
+      OneToNPatternRewriter &rewriter) const {
+    VMILayoutSupport supports;
+    FailureOr<VMIStoreLayoutFact> storeFact =
+        supports.getStoreLayoutFact(valueVMIType);
+    bool candidate = succeeded(storeFact) &&
+                     storeFact->valueLayout.isDeinterleaved() &&
+                     storeFact->valueLayout.getFactor() == 2 &&
+                     fullPhysicalChunks && noWiderThanContiguous;
+    if (!candidate) {
+      return false;
+    }
+    std::optional<std::string> dist =
+        getX2MemoryDistToken(valueVMIType.getElementType(), "INTLV");
+    auto firstType = valueParts.empty()
+                         ? VRegType{}
+                         : dyn_cast<VRegType>(valueParts.front().getType());
+    bool canUseDist = dist && firstType &&
+                      isDirectMemoryDistAddressLegal(
+                          op.getDestination(), op.getOffset(),
+                          valueVMIType.getElementType(), firstType,
+                          VPTOMemoryOpFamily::StoreX2, *dist);
+    bool evenValuePartCount = valueParts.size() % 2 == 0;
+    if (!canUseDist || !evenValuePartCount) {
+      return false;
+    }
+    if (failed(emitDeinterleavedStore(
+            op, destination, offset, valueParts, lanesPerPart, *dist,
+            rewriter))) {
+      return failure();
+    }
+    rewriter.eraseOp(op);
+    return true;
+  }
+
   LogicalResult
   matchAndRewrite(VMIStoreOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
@@ -10285,34 +10323,14 @@ public:
           op, "failed to compare store physical footprint");
     }
 
-    VMILayoutSupport localSupports;
-    FailureOr<VMIStoreLayoutFact> storeFact =
-        localSupports.getStoreLayoutFact(valueVMIType);
-    bool canUseDeinterleavedStore =
-        succeeded(storeFact) && storeFact->valueLayout.isDeinterleaved() &&
-        storeFact->valueLayout.getFactor() == 2 && fullPhysicalChunks &&
-        *noWiderThanContiguous;
-    if (canUseDeinterleavedStore) {
-      std::optional<std::string> dist =
-          getX2MemoryDistToken(valueVMIType.getElementType(), "INTLV");
-      auto firstType = valueParts.empty()
-                           ? VRegType{}
-                           : dyn_cast<VRegType>(valueParts.front().getType());
-      bool canUseDist = dist && firstType &&
-                        isDirectMemoryDistAddressLegal(
-                            op.getDestination(), op.getOffset(),
-                            valueVMIType.getElementType(), firstType,
-                            VPTOMemoryOpFamily::StoreX2, *dist);
-      bool evenValuePartCount = valueParts.size() % 2 == 0;
-      if (canUseDist && evenValuePartCount) {
-        if (failed(emitDeinterleavedStore(
-                op, *destination, *offset, valueParts, *lanesPerPart, *dist,
-                rewriter))) {
-          return failure();
-        }
-        rewriter.eraseOp(op);
-        return success();
-      }
+    FailureOr<bool> deinterleavedStore = tryLowerDeinterleavedStore(
+        op, *destination, *offset, valueParts, valueVMIType, *lanesPerPart,
+        fullPhysicalChunks, *noWiderThanContiguous, rewriter);
+    if (failed(deinterleavedStore)) {
+      return failure();
+    }
+    if (*deinterleavedStore) {
+      return success();
     }
 
     FailureOr<SmallVector<Value>> storeParts = materializeDataLayoutConversion(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12291,22 +12291,72 @@ public:
 struct OneToNVMIVexpdifOpPattern : OneToNOpConversionPattern<VMIVexpdifOp> {
   using OneToNOpConversionPattern<VMIVexpdifOp>::OneToNOpConversionPattern;
 
+private:
+  FailureOr<Value> lowerF32Part(VMIVexpdifOp op, Value x, Value max,
+                                Value mask, Type resultType,
+                                OneToNPatternRewriter &rewriter) const {
+    auto vregType = dyn_cast<VRegType>(resultType);
+    auto maskType = dyn_cast<MaskType>(mask.getType());
+    const bool invalidPart =
+        !vregType || !maskType || !vregType.getElementType().isF32() ||
+        x.getType() != resultType || max.getType() != resultType ||
+        maskType.getGranularity() != "b32";
+    if (invalidPart) {
+      rewriter.notifyMatchFailure(
+          op, "f32 vexpdif requires matching f32 parts and b32 masks");
+      return failure();
+    }
+    return rewriter
+        .create<VexpdifOp>(op.getLoc(), resultType, x, max, mask,
+                           rewriter.getStringAttr("ODD"))
+        .getResult();
+  }
+
+  FailureOr<Value> lowerF16Part(VMIVexpdifOp op, Value x, Value max,
+                                Value mask, Type resultType, StringRef part,
+                                OneToNPatternRewriter &rewriter) const {
+    auto xType = dyn_cast<VRegType>(x.getType());
+    auto resultVRegType = dyn_cast<VRegType>(resultType);
+    auto maskType = dyn_cast<MaskType>(mask.getType());
+    const bool invalidPart =
+        !xType || !resultVRegType || !maskType ||
+        !xType.getElementType().isF16() ||
+        !resultVRegType.getElementType().isF32() ||
+        max.getType() != x.getType() || maskType.getGranularity() != "b16";
+    if (invalidPart) {
+      rewriter.notifyMatchFailure(
+          op, "f16 vexpdif requires matching f16 parts and b16 masks");
+      return failure();
+    }
+    return rewriter
+        .create<VexpdifOp>(op.getLoc(), resultType, x, max, mask,
+                           rewriter.getStringAttr(part))
+        .getResult();
+  }
+
+public:
   LogicalResult
   matchAndRewrite(VMIVexpdifOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
-    if (op.getPmode().has_value() && *op.getPmode() == "merge")
+    const bool requiresPassthru =
+        op.getPmode().has_value() && *op.getPmode() == "merge";
+    if (requiresPassthru) {
       return rewriter.notifyMatchFailure(
           op, "merge predicate mode requires an explicit passthru lowering");
+    }
 
     ValueRange xParts = adaptor.getX();
     ValueRange maxParts = adaptor.getMax();
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybeResultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybeResultTypes))
+    if (failed(maybeResultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
-    if (xParts.size() != maxParts.size() || xParts.size() != maskParts.size()) {
+    const bool invalidInputArity =
+        xParts.size() != maxParts.size() || xParts.size() != maskParts.size();
+    if (invalidInputArity) {
       return rewriter.notifyMatchFailure(op, "vexpdif physical arity mismatch");
     }
 
@@ -12315,29 +12365,25 @@ struct OneToNVMIVexpdifOpPattern : OneToNOpConversionPattern<VMIVexpdifOp> {
     results.reserve(resultTypes.size());
 
     if (sourceVMIType.getElementType().isF32()) {
-      if (xParts.size() != resultTypes.size()) {
+      const bool invalidF32Arity = xParts.size() != resultTypes.size();
+      if (invalidF32Arity) {
         return rewriter.notifyMatchFailure(
             op, "f32 vexpdif requires one result per source part");
       }
       for (auto [x, max, mask, resultType] :
            llvm::zip_equal(xParts, maxParts, maskParts, resultTypes)) {
-        auto vregType = dyn_cast<VRegType>(resultType);
-        auto maskType = dyn_cast<MaskType>(mask.getType());
-        if (!vregType || !maskType || !vregType.getElementType().isF32() ||
-            x.getType() != resultType || max.getType() != resultType ||
-            maskType.getGranularity() != "b32") {
-          return rewriter.notifyMatchFailure(
-              op, "f32 vexpdif requires matching f32 parts and b32 masks");
+        FailureOr<Value> result =
+            lowerF32Part(op, x, max, mask, resultType, rewriter);
+        if (failed(result)) {
+          return failure();
         }
-        results.push_back(rewriter
-                              .create<VexpdifOp>(op.getLoc(), resultType, x,
-                                                 max, mask,
-                                                 rewriter.getStringAttr("ODD"))
-                              .getResult());
+        results.push_back(*result);
       }
     } else {
-      if (!sourceVMIType.getElementType().isF16() ||
-          resultTypes.size() != 2 * xParts.size()) {
+      const bool invalidF16Arity =
+          !sourceVMIType.getElementType().isF16() ||
+          resultTypes.size() != 2 * xParts.size();
+      if (invalidF16Arity) {
         return rewriter.notifyMatchFailure(
             op, "f16 vexpdif requires EVEN/ODD f32 result parts");
       }
@@ -12348,21 +12394,12 @@ struct OneToNVMIVexpdifOpPattern : OneToNOpConversionPattern<VMIVexpdifOp> {
           Value max = maxParts[chunkIndex];
           Value mask = maskParts[chunkIndex];
           Type resultType = resultTypes[partIndex * xParts.size() + chunkIndex];
-          auto xType = dyn_cast<VRegType>(x.getType());
-          auto resultVRegType = dyn_cast<VRegType>(resultType);
-          auto maskType = dyn_cast<MaskType>(mask.getType());
-          if (!xType || !resultVRegType || !maskType ||
-              !xType.getElementType().isF16() ||
-              !resultVRegType.getElementType().isF32() ||
-              max.getType() != x.getType() ||
-              maskType.getGranularity() != "b16")
-            return rewriter.notifyMatchFailure(
-                op, "f16 vexpdif requires matching f16 parts and b16 masks");
-          results.push_back(rewriter
-                                .create<VexpdifOp>(op.getLoc(), resultType, x,
-                                                   max, mask,
-                                                   rewriter.getStringAttr(part))
-                                .getResult());
+          FailureOr<Value> result = lowerF16Part(
+              op, x, max, mask, resultType, part, rewriter);
+          if (failed(result)) {
+            return failure();
+          }
+          results.push_back(*result);
         }
       }
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10878,6 +10878,33 @@ private:
         .getResult();
   }
 
+  struct InterleaveStoreAddressPlan {
+    Value destination;
+    Value offset;
+    Value streamBase;
+    bool useDirectAccess;
+  };
+
+  FailureOr<InterleaveStoreAddressPlan> buildAddressPlan(
+      VMIInterleaveStoreOp op, Value destination, Value offset,
+      ValueRange lowParts, VMIVRegType lowVMIType, StringRef dist,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<bool> directAccess =
+        canUseDirectAccess(op, lowParts, lowVMIType, dist);
+    if (failed(directAccess)) {
+      return failure();
+    }
+    if (*directAccess) {
+      return InterleaveStoreAddressPlan{destination, offset, Value{}, true};
+    }
+    FailureOr<Value> base =
+        getUnalignedBase(op, destination, offset, lowVMIType, rewriter);
+    if (failed(base)) {
+      return failure();
+    }
+    return InterleaveStoreAddressPlan{destination, offset, *base, false};
+  }
+
 public:
 
   LogicalResult
@@ -10917,23 +10944,15 @@ public:
           op, "interleave_store requires matching low/high physical arity");
     }
 
-    FailureOr<bool> directAccess =
-        canUseDirectAccess(op, lowParts, lowVMIType, *dist);
-    if (failed(directAccess)) {
+    FailureOr<InterleaveStoreAddressPlan> addressPlan = buildAddressPlan(
+        op, *destination, *offset, lowParts, lowVMIType, *dist, rewriter);
+    if (failed(addressPlan)) {
       return failure();
     }
-    bool useDirectAccess = *directAccess;
+    bool useDirectAccess = addressPlan->useDirectAccess;
     SmallVector<Value> streamValues;
     SmallVector<int64_t> streamAdvances;
-    Value streamBase;
-    if (!useDirectAccess) {
-      FailureOr<Value> base = getUnalignedBase(
-          op, *destination, *offset, lowVMIType, rewriter);
-      if (failed(base)) {
-        return failure();
-      }
-      streamBase = *base;
-    }
+    Value streamBase = addressPlan->streamBase;
 
     for (size_t index = 0, e = lowParts.size(); index < e; ++index) {
       if (failed(emitInterleaveStoreChunk(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -13016,6 +13016,56 @@ static FailureOr<ReduceAddPhysicalPlan> buildReduceAddPhysicalPlan(
   return ReduceAddPhysicalPlan{*resultType, *maskType};
 }
 
+template <typename ReduceOp>
+static LogicalResult lowerReduceAddParts(
+    ReduceOp op, ValueRange sourceParts, ValueRange maskParts,
+    VRegType resultType, MaskType maskType, StringRef firstLaneDiagnostic,
+    OneToNPatternRewriter &rewriter, const TypeConverter &typeConverter) {
+  FailureOr<Value> combined = combineEquivalentMaskedParts<VaddOp>(
+      op.getLoc(), sourceParts, maskParts, resultType, rewriter);
+  if (succeeded(combined)) {
+    Value reduced = rewriter
+                        .create<VcaddOp>(op.getLoc(), resultType, *combined,
+                                         maskParts.front())
+                        .getResult();
+    replaceOpWithFlatConvertedValues(rewriter, op, SmallVector<Value>{reduced},
+                                     typeConverter);
+    return success();
+  }
+
+  Value accumulator = rewriter
+                          .create<VcaddOp>(op.getLoc(), resultType,
+                                           sourceParts.front(),
+                                           maskParts.front())
+                          .getResult();
+  const bool singlePart = sourceParts.size() == 1;
+  if (singlePart) {
+    replaceOpWithFlatConvertedValues(rewriter, op,
+                                     SmallVector<Value>{accumulator},
+                                     typeConverter);
+    return success();
+  }
+  FailureOr<Value> firstLaneMask =
+      createPrefixMask(op.getLoc(), maskType, "PAT_VL1", rewriter);
+  if (failed(firstLaneMask)) {
+    return rewriter.notifyMatchFailure(op, firstLaneDiagnostic);
+  }
+  for (size_t part = 1; part < sourceParts.size(); ++part) {
+    Value reduced = rewriter
+                        .create<VcaddOp>(op.getLoc(), resultType,
+                                         sourceParts[part], maskParts[part])
+                        .getResult();
+    accumulator = rewriter
+                      .create<VaddOp>(op.getLoc(), resultType, reduced,
+                                      accumulator, *firstLaneMask)
+                      .getResult();
+  }
+  replaceOpWithFlatConvertedValues(rewriter, op,
+                                   SmallVector<Value>{accumulator},
+                                   typeConverter);
+  return success();
+}
+
 struct OneToNVMIReduceAddIOpPattern
     : OneToNOpConversionPattern<VMIReduceAddIOp> {
   using OneToNOpConversionPattern<VMIReduceAddIOp>::OneToNOpConversionPattern;
@@ -13036,55 +13086,10 @@ struct OneToNVMIReduceAddIOpPattern
     if (failed(plan)) {
       return failure();
     }
-    VRegType resultType = plan->resultType;
-    MaskType maskType = plan->maskType;
-
-    FailureOr<Value> combined = combineEquivalentMaskedParts<VaddOp>(
-        op.getLoc(), sourceParts, maskParts, resultType, rewriter);
-    if (succeeded(combined)) {
-      Value reduced =
-          rewriter
-              .create<VcaddOp>(op.getLoc(), resultType, *combined,
-                               maskParts.front())
-              .getResult();
-      replaceOpWithFlatConvertedValues(
-          rewriter, op, SmallVector<Value>{reduced},
-          *this->getTypeConverter());
-      return success();
-    }
-
-    Value accumulator = rewriter
-                            .create<VcaddOp>(op.getLoc(), resultType,
-                                             sourceParts.front(),
-                                             maskParts.front())
-                            .getResult();
-    if (sourceParts.size() == 1) {
-      replaceOpWithFlatConvertedValues(
-          rewriter, op, SmallVector<Value>{accumulator},
-          *this->getTypeConverter());
-      return success();
-    }
-    FailureOr<Value> firstLaneMask =
-        createPrefixMask(op.getLoc(), maskType, "PAT_VL1", rewriter);
-    if (failed(firstLaneMask))
-      return rewriter.notifyMatchFailure(
-          op, "failed to create reduce_addi first-lane mask");
-    for (size_t part = 1; part < sourceParts.size(); ++part) {
-      Value reduced =
-          rewriter
-              .create<VcaddOp>(op.getLoc(), resultType, sourceParts[part],
-                               maskParts[part])
-              .getResult();
-      accumulator = rewriter
-                        .create<VaddOp>(op.getLoc(), resultType, reduced,
-                                        accumulator, *firstLaneMask)
-                        .getResult();
-    }
-
-    replaceOpWithFlatConvertedValues(
-            rewriter, op, SmallVector<Value>{accumulator},
-            *this->getTypeConverter());
-    return success();
+    return lowerReduceAddParts(
+        op, sourceParts, maskParts, plan->resultType, plan->maskType,
+        "failed to create reduce_addi first-lane mask", rewriter,
+        *this->getTypeConverter());
   }
 };
 
@@ -13108,55 +13113,10 @@ struct OneToNVMIReduceAddFOpPattern
     if (failed(plan)) {
       return failure();
     }
-    VRegType resultType = plan->resultType;
-    MaskType maskType = plan->maskType;
-
-    FailureOr<Value> combined = combineEquivalentMaskedParts<VaddOp>(
-        op.getLoc(), sourceParts, maskParts, resultType, rewriter);
-    if (succeeded(combined)) {
-      Value reduced =
-          rewriter
-              .create<VcaddOp>(op.getLoc(), resultType, *combined,
-                               maskParts.front())
-              .getResult();
-      replaceOpWithFlatConvertedValues(
-          rewriter, op, SmallVector<Value>{reduced},
-          *this->getTypeConverter());
-      return success();
-    }
-
-    Value accumulator = rewriter
-                            .create<VcaddOp>(op.getLoc(), resultType,
-                                             sourceParts.front(),
-                                             maskParts.front())
-                            .getResult();
-    if (sourceParts.size() == 1) {
-      replaceOpWithFlatConvertedValues(
-          rewriter, op, SmallVector<Value>{accumulator},
-          *this->getTypeConverter());
-      return success();
-    }
-    FailureOr<Value> firstLaneMask =
-        createPrefixMask(op.getLoc(), maskType, "PAT_VL1", rewriter);
-    if (failed(firstLaneMask))
-      return rewriter.notifyMatchFailure(
-          op, "failed to create reduce_addf first-lane mask");
-    for (size_t part = 1; part < sourceParts.size(); ++part) {
-      Value reduced =
-          rewriter
-              .create<VcaddOp>(op.getLoc(), resultType, sourceParts[part],
-                               maskParts[part])
-              .getResult();
-      accumulator = rewriter
-                        .create<VaddOp>(op.getLoc(), resultType, reduced,
-                                        accumulator, *firstLaneMask)
-                        .getResult();
-    }
-
-    replaceOpWithFlatConvertedValues(
-            rewriter, op, SmallVector<Value>{accumulator},
-            *this->getTypeConverter());
-    return success();
+    return lowerReduceAddParts(
+        op, sourceParts, maskParts, plan->resultType, plan->maskType,
+        "failed to create reduce_addf first-lane mask", rewriter,
+        *this->getTypeConverter());
   }
 };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -13725,6 +13725,38 @@ struct OneToNVMIInterleaveOpPattern : OneToNOpConversionPattern<SourceOp> {
   using OneToNOpConversionPattern<SourceOp>::OneToNOpConversionPattern;
 
 private:
+  FailureOr<std::pair<Value, Value>> materializeLaneStrideInterleavePair(
+      SourceOp op, OneToNPatternRewriter &rewriter, Value lhs, Value rhs,
+      Type lowType, Type highType, int64_t carrierBits) const {
+    FailureOr<VRegType> carrierType = getUnsignedCarrierVRegType(
+        rewriter.getContext(), static_cast<unsigned>(carrierBits));
+    if (failed(carrierType)) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported lane-stride interleave carrier width");
+    }
+    FailureOr<Value> carrierLhs =
+        bitcastVReg(op.getLoc(), lhs, *carrierType, rewriter);
+    FailureOr<Value> carrierRhs =
+        bitcastVReg(op.getLoc(), rhs, *carrierType, rewriter);
+    bool failedInputs = failed(carrierLhs) || failed(carrierRhs);
+    if (failedInputs) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to bitcast lane-stride interleave inputs");
+    }
+    auto interleave = rewriter.create<TargetOp>(
+        op.getLoc(), *carrierType, *carrierType, *carrierLhs, *carrierRhs);
+    FailureOr<Value> low =
+        bitcastVReg(op.getLoc(), interleave.getLow(), lowType, rewriter);
+    FailureOr<Value> high =
+        bitcastVReg(op.getLoc(), interleave.getHigh(), highType, rewriter);
+    bool failedResults = failed(low) || failed(high);
+    if (failedResults) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to bitcast lane-stride interleave results");
+    }
+    return std::make_pair(*low, *high);
+  }
+
   LogicalResult lowerLaneStrideInterleave(
       SourceOp op, OneToNPatternRewriter &rewriter, ValueRange lhsParts,
       ValueRange rhsParts, TypeRange lowTypes, TypeRange highTypes,
@@ -13745,33 +13777,14 @@ private:
       return rewriter.notifyMatchFailure(
           op, "invalid lane-stride interleave carrier width");
     }
-    FailureOr<VRegType> carrierType = getUnsignedCarrierVRegType(
-        rewriter.getContext(), static_cast<unsigned>(carrierBits));
-    if (failed(carrierType)) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported lane-stride interleave carrier width");
+    FailureOr<std::pair<Value, Value>> pair =
+        materializeLaneStrideInterleavePair(
+            op, rewriter, lhsParts.front(), rhsParts.front(), lowTypes.front(),
+            highTypes.front(), carrierBits);
+    if (failed(pair)) {
+      return failure();
     }
-    FailureOr<Value> carrierLhs =
-        bitcastVReg(op.getLoc(), lhsParts.front(), *carrierType, rewriter);
-    FailureOr<Value> carrierRhs =
-        bitcastVReg(op.getLoc(), rhsParts.front(), *carrierType, rewriter);
-    bool failedInputs = failed(carrierLhs) || failed(carrierRhs);
-    if (failedInputs) {
-      return rewriter.notifyMatchFailure(
-          op, "failed to bitcast lane-stride interleave inputs");
-    }
-    auto interleave = rewriter.create<TargetOp>(
-        op.getLoc(), *carrierType, *carrierType, *carrierLhs, *carrierRhs);
-    FailureOr<Value> low =
-        bitcastVReg(op.getLoc(), interleave.getLow(), lowTypes.front(), rewriter);
-    FailureOr<Value> high = bitcastVReg(op.getLoc(), interleave.getHigh(),
-                                        highTypes.front(), rewriter);
-    bool failedResults = failed(low) || failed(high);
-    if (failedResults) {
-      return rewriter.notifyMatchFailure(
-          op, "failed to bitcast lane-stride interleave results");
-    }
-    SmallVector<Value, 2> results = {*low, *high};
+    SmallVector<Value, 2> results = {pair->first, pair->second};
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());
     return success();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18420,6 +18420,31 @@ static FailureOr<VmullShapePlan> buildVmullShapePlan(
   return VmullShapePlan{aType, layout, *aArity};
 }
 
+static LogicalResult checkVmullPhysicalShape(VMIVRegType dataType,
+                                             VMIMaskType maskType,
+                                             std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  FailureOr<int64_t> lanesPerPart =
+      getDataLanesPerPart(dataType.getElementType());
+  Type physicalElementType = getVMIPhysicalDataElementType(dataType);
+  FailureOr<StringRef> physicalMaskGranularity =
+      getVMIMaskPhysicalGranularity(maskType);
+  bool invalidPhysicalShape =
+      failed(lanesPerPart) || *lanesPerPart != 64 ||
+      physicalElementType != dataType.getElementType() ||
+      failed(physicalMaskGranularity) || *physicalMaskGranularity != "b32";
+  if (invalidPhysicalShape) {
+    return fail("requires 64xi32/ui32 data parts with corresponding b32 mask "
+                "parts");
+  }
+  return success();
+}
+
 LogicalResult checkSupportedVmullShape(VMIVmullOp op,
                                        std::string *reason = nullptr) {
   FailureOr<VmullShapePlan> plan = buildVmullShapePlan(op, reason);
@@ -18427,23 +18452,8 @@ LogicalResult checkSupportedVmullShape(VMIVmullOp op,
     return failure();
   }
   VMIVRegType aType = plan->dataType;
-  auto resultType = cast<VMIVRegType>(op.getLow().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
-
-  FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(aType.getElementType());
-  Type physicalElementType = getVMIPhysicalDataElementType(aType);
-  FailureOr<StringRef> physicalMaskGranularity =
-      getVMIMaskPhysicalGranularity(maskType);
-  bool invalidPhysicalShape =
-      failed(lanesPerPart) || *lanesPerPart != 64 ||
-      physicalElementType != aType.getElementType() ||
-      failed(physicalMaskGranularity) || *physicalMaskGranularity != "b32";
-  if (invalidPhysicalShape) {
-    return fail("requires 64xi32/ui32 data parts with corresponding b32 mask "
-                "parts");
-  }
-
-  return success();
+  return checkVmullPhysicalShape(aType, maskType, reason);
 }
 
 static LogicalResult

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3039,6 +3039,19 @@ static LogicalResult checkMaskedStoreLayoutAndArity(
   return success();
 }
 
+static LogicalResult checkMaskedStoreContiguousMaterialization(
+    VMIVRegType valueType, VMIMaskType maskType, StringRef valueReason,
+    StringRef maskReason, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  return checkMaskedStoreContiguousMaterialization(
+      valueType, maskType, valueReason, maskReason, reason);
+}
+
 LogicalResult
 checkSupportedMaskedStoreShape(VMIVRegType valueType, VMIMaskType maskType,
                                Value destination, Type destinationType,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5642,6 +5642,18 @@ static std::optional<MaskLaneStrideLayoutPlan> getMaskLaneStrideLayoutPlan(
       unpack, unpack ? resultLayout.getLaneStride() : sourceLayout.getLaneStride()};
 }
 
+static LogicalResult checkMaskLaneStrideFactor(
+    Operation *op, const MaskLaneStrideLayoutPlan &plan,
+    PatternRewriter &rewriter) {
+  bool supportedFactor = plan.laneStride == 2 || plan.laneStride == 4;
+  if (supportedFactor) {
+    return success();
+  }
+  return rewriter.notifyMatchFailure(
+      op, plan.unpack ? "unsupported dense mask lane_stride unpack factor"
+                      : "unsupported dense mask lane_stride pack factor");
+}
+
 FailureOr<std::optional<SmallVector<Value>>> materializeMaskLaneStrideLayout(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
     VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
@@ -5652,10 +5664,8 @@ FailureOr<std::optional<SmallVector<Value>>> materializeMaskLaneStrideLayout(
     return std::nullopt;
   }
 
-  if (plan->laneStride != 2 && plan->laneStride != 4) {
-    return rewriter.notifyMatchFailure(
-        op, plan->unpack ? "unsupported dense mask lane_stride unpack factor"
-                         : "unsupported dense mask lane_stride pack factor");
+  if (failed(checkMaskLaneStrideFactor(op, *plan, rewriter))) {
+    return failure();
   }
 
   if (plan->unpack) {
@@ -5672,7 +5682,6 @@ FailureOr<std::optional<SmallVector<Value>>> materializeMaskLaneStrideLayout(
     return failure();
   }
   return std::optional<SmallVector<Value>>(std::move(*results));
-
 }
 
 static FailureOr<std::optional<SmallVector<Value>>> materializeIdentityMaskLayout(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6288,6 +6288,44 @@ FailureOr<SmallVector<Value>> materializeWideningMaskGranularityPart(
   return results;
 }
 
+static FailureOr<Value> materializeNarrowingMaskChunk(
+    Operation *op, MaskType resultMaskType, ValueRange sourceParts,
+    int64_t sourceOffset, int64_t sourceChunks, int64_t &consumed,
+    Value &allTrue, StringAttr lowerAttr, StringAttr higherAttr,
+    PatternRewriter &rewriter) {
+  if (consumed >= sourceChunks) {
+    (void)rewriter.notifyMatchFailure(
+        op, "narrowing mask granularity conversion ran out of source chunks");
+    return failure();
+  }
+  Value lowerSource = sourceParts[sourceOffset + consumed++];
+  Value packed = rewriter
+                     .create<PpackOp>(op->getLoc(), resultMaskType, lowerSource,
+                                      lowerAttr)
+                     .getResult();
+  if (consumed >= sourceChunks) {
+    return packed;
+  }
+  Value higherSource = sourceParts[sourceOffset + consumed++];
+  Value higher = rewriter
+                     .create<PpackOp>(op->getLoc(), resultMaskType, higherSource,
+                                      higherAttr)
+                     .getResult();
+  if (!allTrue) {
+    FailureOr<Value> mask =
+        createAllTrueMask(op->getLoc(), resultMaskType, rewriter);
+    if (failed(mask)) {
+      (void)rewriter.notifyMatchFailure(
+          op, "failed to create all-true mask for ppack merge");
+      return failure();
+    }
+    allTrue = *mask;
+  }
+  return rewriter
+      .create<PorOp>(op->getLoc(), resultMaskType, packed, higher, allTrue)
+      .getResult();
+}
+
 FailureOr<SmallVector<Value>> materializeNarrowingMaskGranularityPart(
     Operation *op, MaskType resultMaskType, ValueRange sourceParts,
     int64_t sourceOffset, int64_t sourceChunks, int64_t resultChunks,
@@ -6303,35 +6341,13 @@ FailureOr<SmallVector<Value>> materializeNarrowingMaskGranularityPart(
   Value allTrue;
   int64_t consumed = 0;
   for (int64_t chunk = 0; chunk < resultChunks; ++chunk) {
-    if (consumed >= sourceChunks) {
-      return fail("narrowing mask granularity conversion ran out of source "
-                  "chunks");
+    FailureOr<Value> packed = materializeNarrowingMaskChunk(
+        op, resultMaskType, sourceParts, sourceOffset, sourceChunks, consumed,
+        allTrue, lowerAttr, higherAttr, rewriter);
+    if (failed(packed)) {
+      return failure();
     }
-    Value lowerSource = sourceParts[sourceOffset + consumed++];
-    Value packed = rewriter
-                       .create<PpackOp>(op->getLoc(), resultMaskType,
-                                        lowerSource, lowerAttr)
-                       .getResult();
-    if (consumed < sourceChunks) {
-      Value higherSource = sourceParts[sourceOffset + consumed++];
-      Value higher = rewriter
-                         .create<PpackOp>(op->getLoc(), resultMaskType,
-                                          higherSource, higherAttr)
-                         .getResult();
-      if (!allTrue) {
-        FailureOr<Value> mask =
-            createAllTrueMask(op->getLoc(), resultMaskType, rewriter);
-        if (failed(mask)) {
-          return fail("failed to create all-true mask for ppack merge");
-        }
-        allTrue = *mask;
-      }
-      packed = rewriter
-                   .create<PorOp>(op->getLoc(), resultMaskType, packed, higher,
-                                  allTrue)
-                   .getResult();
-    }
-    results.push_back(packed);
+    results.push_back(*packed);
   }
   if (consumed != sourceChunks) {
     return fail("narrowing mask granularity conversion left unused source "

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3316,6 +3316,42 @@ static FailureOr<int64_t> computeShuffleForwardingSourceChunk(
   return *sourceFlatIndex;
 }
 
+struct ShuffleForwardingInputPlan {
+  VMIVRegType sourceType;
+  VMIVRegType resultType;
+  int64_t lanesPerPart;
+  int64_t resultFactor;
+};
+
+static FailureOr<ShuffleForwardingInputPlan>
+getShuffleForwardingInputPlan(VMIShuffleOp op, std::string *reason) {
+  auto sourceType = cast<VMIVRegType>(op.getSource().getType());
+  auto resultType = cast<VMIVRegType>(op.getResult().getType());
+  if (op.getIndices().empty()) {
+    if (reason) {
+      *reason = "requires non-empty indices";
+    }
+    return failure();
+  }
+  FailureOr<int64_t> lanesPerPart =
+      getDataLanesPerPart(sourceType.getElementType());
+  if (failed(lanesPerPart)) {
+    if (reason) {
+      *reason = "requires known lanes per physical part";
+    }
+    return failure();
+  }
+  FailureOr<int64_t> resultFactor = getDataLayoutFactor(resultType);
+  if (failed(resultFactor)) {
+    if (reason) {
+      *reason = "requires assigned result layout";
+    }
+    return failure();
+  }
+  return ShuffleForwardingInputPlan{sourceType, resultType, *lanesPerPart,
+                                    *resultFactor};
+}
+
 FailureOr<SmallVector<int64_t>>
 computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> FailureOr<SmallVector<int64_t>> {
@@ -3324,37 +3360,17 @@ computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
     }
     return failure();
   };
-
-  auto sourceType = cast<VMIVRegType>(op.getSource().getType());
-  auto resultType = cast<VMIVRegType>(op.getResult().getType());
-  auto validateInputs = [&sourceType, &resultType, &op, &fail]()
-      -> FailureOr<int64_t> {
-    FailureOr<int64_t> lanes =
-        getDataLanesPerPart(sourceType.getElementType());
-    if (failed(lanes)) {
-      return fail("requires known lanes per physical part");
-    }
-    if (op.getIndices().empty()) {
-      return fail("requires non-empty indices");
-    }
-    FailureOr<int64_t> factor = getDataLayoutFactor(resultType);
-    if (failed(factor)) {
-      return fail("requires assigned result layout");
-    }
-    return *lanes;
-  };
-  FailureOr<int64_t> lanesPerPart = validateInputs();
-  if (failed(lanesPerPart)) {
+  FailureOr<ShuffleForwardingInputPlan> input =
+      getShuffleForwardingInputPlan(op, reason);
+  if (failed(input)) {
     return failure();
   }
+  auto sourceType = input->sourceType;
+  auto resultType = input->resultType;
+  int64_t lanesPerPart = input->lanesPerPart;
   ArrayRef<int64_t> indices = op.getIndices();
-  FailureOr<int64_t> resultFactor = getDataLayoutFactor(resultType);
-  if (failed(resultFactor)) {
-    return failure();
-  }
-
   SmallVector<int64_t> sourceFlatIndices;
-  for (int64_t resultPart = 0; resultPart < *resultFactor; ++resultPart) {
+  for (int64_t resultPart = 0; resultPart < input->resultFactor; ++resultPart) {
     FailureOr<int64_t> resultChunks =
         getDataChunksInPart(resultType, resultPart);
     if (failed(resultChunks)) {
@@ -3365,7 +3381,7 @@ computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
       FailureOr<int64_t> sourceFlatIndex =
           computeShuffleForwardingSourceChunk(
               sourceType, resultType, indices, resultPart, resultChunk,
-              *lanesPerPart, reason);
+              lanesPerPart, reason);
       if (failed(sourceFlatIndex)) {
         return failure();
       }
@@ -4235,8 +4251,9 @@ FailureOr<Value> createScalarOffsetConstant(Location loc, Type type,
 
 Value createChunkOffset(Location loc, Value baseOffset, int64_t laneOffset,
                         PatternRewriter &rewriter) {
-  if (laneOffset == 0)
+  if (laneOffset == 0) {
     return baseOffset;
+  }
   Value delta = rewriter.create<arith::ConstantIndexOp>(loc, laneOffset);
   return rewriter.create<arith::AddIOp>(loc, baseOffset, delta).getResult();
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2918,6 +2918,30 @@ checkSupportedExpandLoadCommonShape(VMIExpandLoadOp op,
   return success();
 }
 
+static bool hasSafeExpandLoadAllActivePath(
+    VMIVRegType resultType, const VMIMemoryAccessPlan &accessPlan,
+    bool staticAllActive, std::string *pathReason) {
+  if (!staticAllActive) {
+    return false;
+  }
+  std::string fullChunkReason;
+  bool fullChunks =
+      succeeded(checkFullDataPhysicalChunks(resultType, &fullChunkReason));
+  if (fullChunks || accessPlan.front().readSafety.proven) {
+    return true;
+  }
+  std::string fallbackReason =
+      getUnavailableReadFallbackReason(VMIMemoryCoverageKind::Predicate);
+  *pathReason =
+      (Twine("requires full physical chunks or statically safe full-read "
+             "footprint; value ") +
+       fullChunkReason + ", safe-read proof " +
+       accessPlan.front().readSafety.reason +
+       "; fallback unavailable: " + fallbackReason)
+          .str();
+  return false;
+}
+
 LogicalResult
 checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
@@ -2940,32 +2964,16 @@ checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
   bool staticAllActive = isStaticAllActiveMask(
       op.getMask(), resultType.getElementCount(), &maskReason);
 
-  std::string fullChunkReason;
-  bool staticFullChunks =
-      staticAllActive &&
-      succeeded(checkFullDataPhysicalChunks(resultType, &fullChunkReason));
+  std::string allActivePathReason;
+  bool staticFullChunks = hasSafeExpandLoadAllActivePath(
+      resultType, accessPlan, staticAllActive, &allActivePathReason);
   if (staticFullChunks) {
     return success();
   }
 
-  if (staticAllActive && accessPlan.front().readSafety.proven) {
-    return success();
-  }
-
-  std::string allActivePathReason;
   if (!staticAllActive) {
     allActivePathReason =
         maskReason.empty() ? "requires static all-active mask" : maskReason;
-  } else {
-    std::string fallbackReason =
-        getUnavailableReadFallbackReason(VMIMemoryCoverageKind::Predicate);
-    allActivePathReason =
-        (Twine("requires full physical chunks or statically safe full-read "
-               "footprint; value ") +
-         fullChunkReason + ", safe-read proof " +
-         accessPlan.front().readSafety.reason +
-         "; fallback unavailable: " + fallbackReason)
-            .str();
   }
 
   return checkSupportedExpandLoadRuntimePath(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9467,6 +9467,29 @@ static FailureOr<GroupSlotLoadResultPart> getGroupSlotLoadResultPart(
   return GroupSlotLoadResultPart{*vregType, *maskType};
 }
 
+static LogicalResult lowerSingleGroupSlotLoad(
+    Operation *op, Value source, Value offset, VMIVRegType resultVMIType,
+    TypeRange resultTypes, OneToNPatternRewriter &rewriter,
+    SmallVectorImpl<Value> &results) {
+  std::optional<std::string> dist =
+      getScalarBroadcastLoadDistToken(resultVMIType.getElementType());
+  if (!dist) {
+    return rewriter.notifyMatchFailure(
+        op, "single-slot group_slot_load requires supported BRC load element width");
+  }
+  auto vregType = dyn_cast<VRegType>(resultTypes.front());
+  if (!vregType) {
+    return rewriter.notifyMatchFailure(
+        op, "single-slot group_slot_load result must be vreg");
+  }
+  results.push_back(rewriter
+                       .create<VldsOp>(op->getLoc(), vregType,
+                                       /*updated_base=*/Type{}, source, offset,
+                                       rewriter.getStringAttr(*dist))
+                       .getResult());
+  return success();
+}
+
 static LogicalResult lowerGroupSlotLoadSlots8(
     Operation *op, Value source, Value offset, Value sourceGroupStride,
     VMIVRegType resultVMIType, TypeRange resultTypes, int64_t numGroups,
@@ -9486,23 +9509,8 @@ static LogicalResult lowerGroupSlotLoadSlots8(
         .getResult();
   };
   if (numGroups == 1) {
-    std::optional<std::string> dist =
-        getScalarBroadcastLoadDistToken(resultVMIType.getElementType());
-    if (!dist) {
-      return rewriter.notifyMatchFailure(
-          op, "single-slot group_slot_load requires supported BRC load element width");
-    }
-    auto vregType = dyn_cast<VRegType>(resultTypes.front());
-    if (!vregType) {
-      return rewriter.notifyMatchFailure(
-          op, "single-slot group_slot_load result must be vreg");
-    }
-    results.push_back(rewriter
-                          .create<VldsOp>(op->getLoc(), vregType,
-                                          /*updated_base=*/Type{}, source,
-                                          offset, rewriter.getStringAttr(*dist))
-                          .getResult());
-    return success();
+    return lowerSingleGroupSlotLoad(op, source, offset, resultVMIType,
+                                    resultTypes, rewriter, results);
   }
   for (auto [chunk, resultType] : llvm::enumerate(resultTypes)) {
     FailureOr<GroupSlotLoadResultPart> resultPart =

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12259,6 +12259,47 @@ private:
     return success();
   }
 
+  LogicalResult emitContiguousMaskedStorePart(
+      VMIMaskedStoreOp op, OneToNPatternRewriter &rewriter, Value value,
+      Value mask, VMIVRegType valueVMIType, Value destination, Value offset,
+      int64_t index, int64_t lanesPerPart) const {
+    auto vregType = dyn_cast<VRegType>(value.getType());
+    bool invalidTypes = !vregType || !isa<MaskType>(mask.getType());
+    if (invalidTypes) {
+      return rewriter.notifyMatchFailure(
+          op, "masked_store converted parts must be vreg/mask");
+    }
+    FailureOr<int64_t> activeLanes =
+        getContiguousActiveDataLanes(valueVMIType, index);
+    if (failed(activeLanes)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to compute masked_store active lanes");
+    }
+    if (*activeLanes == 0) {
+      return success();
+    }
+    FailureOr<Value> storeMask = createMaskedStorePredicate(
+        op.getLoc(), valueVMIType, index, mask, vregType, rewriter);
+    if (failed(storeMask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to materialize masked_store predicate");
+    }
+    Value chunkOffset =
+        createChunkOffset(op.getLoc(), offset, index * lanesPerPart, rewriter);
+    bool illegalAddress = !isDirectMemoryDistAddressLegal(
+        destination, chunkOffset, valueVMIType.getElementType(), vregType,
+        VPTOMemoryOpFamily::Store, /*dist=*/{});
+    if (illegalAddress) {
+      return rewriter.notifyMatchFailure(
+          op, "masked_store requires a proven target alignment for every "
+              "physical store chunk");
+    }
+    rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{}, value,
+                            destination, chunkOffset, /*dist=*/nullptr,
+                            *storeMask);
+    return success();
+  }
+
   LogicalResult lowerContiguous(
       VMIMaskedStoreOp op, OneToNPatternRewriter &rewriter,
       ValueRange valueParts, ValueRange maskParts, VMIVRegType valueVMIType,
@@ -12298,40 +12339,11 @@ private:
     for (auto [index, valueAndMask] :
          llvm::enumerate(llvm::zip_equal(*storeParts, *storeMasks))) {
       auto [value, mask] = valueAndMask;
-      auto vregType = dyn_cast<VRegType>(value.getType());
-      bool invalidTypes = !vregType || !isa<MaskType>(mask.getType());
-      if (invalidTypes) {
-        return rewriter.notifyMatchFailure(
-            op, "masked_store converted parts must be vreg/mask");
+      if (failed(emitContiguousMaskedStorePart(
+              op, rewriter, value, mask, valueVMIType, destination, offset,
+              index, lanesPerPart))) {
+        return failure();
       }
-      FailureOr<int64_t> activeLanes =
-          getContiguousActiveDataLanes(valueVMIType, index);
-      if (failed(activeLanes)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to compute masked_store active lanes");
-      }
-      if (*activeLanes == 0) {
-        continue;
-      }
-      FailureOr<Value> storeMask = createMaskedStorePredicate(
-          op.getLoc(), valueVMIType, index, mask, vregType, rewriter);
-      if (failed(storeMask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to materialize masked_store predicate");
-      }
-      Value chunkOffset = createChunkOffset(
-          op.getLoc(), offset, index * lanesPerPart, rewriter);
-      bool illegalAddress = !isDirectMemoryDistAddressLegal(
-          destination, chunkOffset, valueVMIType.getElementType(), vregType,
-          VPTOMemoryOpFamily::Store, /*dist=*/{});
-      if (illegalAddress) {
-        return rewriter.notifyMatchFailure(
-            op, "masked_store requires a proven target alignment for every "
-                "physical store chunk");
-      }
-      rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{}, value,
-                              destination, chunkOffset, /*dist=*/nullptr,
-                              *storeMask);
     }
     rewriter.eraseOp(op);
     return success();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6705,6 +6705,25 @@ struct MaskGranularityCastPlan {
   VMIMaskType physicalResultType;
 };
 
+static FailureOr<SmallVector<Value>> materializeMaskGranularityCastThroughLayout(
+    Operation *op, VMIMaskType sourceType, VMIMaskType resultType,
+    ValueRange sourceParts, TypeRange resultTypes,
+    const MaskGranularityCastPlan &plan, PatternRewriter &rewriter) {
+  VMIMaskType granularityType = VMIMaskType::get(
+      op->getContext(), sourceType.getElementCount(),
+      plan.physicalResultType.getGranularity(),
+      plan.physicalSourceType.getLayoutAttr());
+  FailureOr<SmallVector<Value>> granularityParts =
+      materializeMaskGranularityConversion(
+          op, plan.physicalSourceType, granularityType, sourceParts, rewriter);
+  if (failed(granularityParts)) {
+    return failure();
+  }
+  return materializeMaskGranularityCastLayoutConversion(
+      op, granularityType, plan.physicalResultType, *granularityParts,
+      resultTypes, rewriter);
+}
+
 static FailureOr<SmallVector<Value>> materializeMaskGranularityCastParts(
     Operation *op, VMIMaskType sourceType, VMIMaskType resultType,
     ValueRange sourceParts, TypeRange resultTypes,
@@ -6718,20 +6737,8 @@ static FailureOr<SmallVector<Value>> materializeMaskGranularityCastParts(
         rewriter);
   }
 
-  VMIMaskType granularityType = VMIMaskType::get(
-      op->getContext(), sourceType.getElementCount(),
-      plan.physicalResultType.getGranularity(),
-      plan.physicalSourceType.getLayoutAttr());
-  FailureOr<SmallVector<Value>> granularityParts =
-      materializeMaskGranularityConversion(op, plan.physicalSourceType,
-                                           granularityType, sourceParts,
-                                           rewriter);
-  if (failed(granularityParts)) {
-    return failure();
-  }
-  return materializeMaskGranularityCastLayoutConversion(
-      op, granularityType, plan.physicalResultType, *granularityParts,
-      resultTypes, rewriter);
+  return materializeMaskGranularityCastThroughLayout(
+      op, sourceType, resultType, sourceParts, resultTypes, plan, rewriter);
 }
 
 static FailureOr<MaskGranularityCastPlan> buildMaskGranularityCastPlan(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10111,29 +10111,40 @@ private:
           op, "slots=1 group_store requires 1PT_B8/B16/B32 store support");
     }
     for (auto [group, value] : llvm::enumerate(valueParts)) {
-      auto vregType = dyn_cast<VRegType>(value.getType());
-      if (!vregType) {
-        return rewriter.notifyMatchFailure(op, "group_store value must be vreg");
+      if (failed(emitSlots1PointStore(op, value, group, destination, offset,
+                                      rowStride,
+                                      *pointDist, rewriter))) {
+        return failure();
       }
-      FailureOr<MaskType> maskType =
-          getMaskTypeForVReg(vregType, rewriter.getContext());
-      if (failed(maskType)) {
-        return rewriter.notifyMatchFailure(
-            op, "unsupported element type for group_store mask");
-      }
-      FailureOr<Value> mask =
-          createPrefixMask(op.getLoc(), *maskType, "PAT_VL1", rewriter);
-      if (failed(mask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to create slots=1 group_store mask");
-      }
-      Value groupOffset = createGroupChunkOffset(
-          op.getLoc(), offset, rowStride, group, 0, rewriter);
-      rewriter.create<VstsOp>(op.getLoc(), Type{}, value, destination,
-                              groupOffset, rewriter.getStringAttr(*pointDist),
-                              *mask);
     }
     rewriter.eraseOp(op);
+    return success();
+  }
+
+  LogicalResult emitSlots1PointStore(
+      VMIGroupStoreOp op, Value value, int64_t group, Value destination,
+      Value offset, Value rowStride, StringRef pointDist,
+      OneToNPatternRewriter &rewriter) const {
+    auto vregType = dyn_cast<VRegType>(value.getType());
+    if (!vregType) {
+      return rewriter.notifyMatchFailure(op, "group_store value must be vreg");
+    }
+    FailureOr<MaskType> maskType =
+        getMaskTypeForVReg(vregType, rewriter.getContext());
+    if (failed(maskType)) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported element type for group_store mask");
+    }
+    FailureOr<Value> mask =
+        createPrefixMask(op.getLoc(), *maskType, "PAT_VL1", rewriter);
+    if (failed(mask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to create slots=1 group_store mask");
+    }
+    Value groupOffset = createGroupChunkOffset(
+        op.getLoc(), offset, rowStride, group, 0, rewriter);
+    rewriter.create<VstsOp>(op.getLoc(), Type{}, value, destination, groupOffset,
+                            rewriter.getStringAttr(pointDist), *mask);
     return success();
   }
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -13880,32 +13880,17 @@ private:
     return results;
   }
 
-  LogicalResult lowerContiguousRows(
-      OpTy op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
-      ValueRange sourceParts, ValueRange maskParts, TypeRange resultTypes,
-      int64_t groupSize, OneToNPatternRewriter &rewriter) const {
-    int64_t lanesPerPart = 0;
-    int64_t groupCount = 0;
-    int64_t chunksPerGroup = 0;
-    if (failed(checkContiguousFullGroupChunks(op, sourceVMIType, groupSize,
-                                              &lanesPerPart, &groupCount,
-                                              &chunksPerGroup, rewriter))) {
-      return failure();
-    }
-    VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
-    bool rowLocalSlots1Result = resultLayout && resultLayout.isGroupSlots() &&
-                                resultLayout.getNumGroups() == groupCount &&
-                                resultLayout.getSlots() == 1;
-    int64_t expectedResultParts =
-        rowLocalSlots1Result ? groupCount : groupCount * chunksPerGroup;
-    bool invalidArity =
-        sourceParts.size() != maskParts.size() ||
-        static_cast<int64_t>(sourceParts.size()) != groupCount * chunksPerGroup ||
-        static_cast<int64_t>(resultTypes.size()) != expectedResultParts;
-    if (invalidArity) {
-      return rewriter.notifyMatchFailure(
-          op, "group_reduce requires matching source/mask/result arity");
-    }
+  struct ContiguousGroupReduceTypes {
+    VRegType resultType;
+    MaskType maskType;
+    VRegType sourcePartType;
+    VRegType rowResultType;
+    MaskType rowMaskType;
+  };
+
+  FailureOr<ContiguousGroupReduceTypes> getContiguousGroupReduceTypes(
+      OpTy op, ValueRange sourceParts, ValueRange maskParts,
+      TypeRange resultTypes, OneToNPatternRewriter &rewriter) const {
     for (Type resultType : resultTypes) {
       if (!isa<VRegType>(resultType)) {
         return rewriter.notifyMatchFailure(
@@ -13935,8 +13920,44 @@ private:
       return rewriter.notifyMatchFailure(
           op, "failed to derive group combine mask type");
     }
+    return ContiguousGroupReduceTypes{
+        *resultType, *maskType, *sourcePartType, *rowResultType, *rowMaskType};
+  }
+
+  LogicalResult lowerContiguousRows(
+      OpTy op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+      ValueRange sourceParts, ValueRange maskParts, TypeRange resultTypes,
+      int64_t groupSize, OneToNPatternRewriter &rewriter) const {
+    int64_t lanesPerPart = 0;
+    int64_t groupCount = 0;
+    int64_t chunksPerGroup = 0;
+    if (failed(checkContiguousFullGroupChunks(op, sourceVMIType, groupSize,
+                                              &lanesPerPart, &groupCount,
+                                              &chunksPerGroup, rewriter))) {
+      return failure();
+    }
+    VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
+    bool rowLocalSlots1Result = resultLayout && resultLayout.isGroupSlots() &&
+                                resultLayout.getNumGroups() == groupCount &&
+                                resultLayout.getSlots() == 1;
+    int64_t expectedResultParts =
+        rowLocalSlots1Result ? groupCount : groupCount * chunksPerGroup;
+    bool invalidArity =
+        sourceParts.size() != maskParts.size() ||
+        static_cast<int64_t>(sourceParts.size()) != groupCount * chunksPerGroup ||
+        static_cast<int64_t>(resultTypes.size()) != expectedResultParts;
+    if (invalidArity) {
+      return rewriter.notifyMatchFailure(
+          op, "group_reduce requires matching source/mask/result arity");
+    }
+    FailureOr<ContiguousGroupReduceTypes> types =
+        getContiguousGroupReduceTypes(op, sourceParts, maskParts, resultTypes,
+                                      rewriter);
+    if (failed(types)) {
+      return failure();
+    }
     FailureOr<Value> firstLaneMask =
-        createPrefixMask(op.getLoc(), *rowMaskType, "PAT_VL1", rewriter);
+        createPrefixMask(op.getLoc(), types->rowMaskType, "PAT_VL1", rewriter);
     if (failed(firstLaneMask)) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to create group_reduce masks");
@@ -13944,13 +13965,14 @@ private:
     FailureOr<SmallVector<Value>> reducedResults =
         buildContiguousGroupReduceResults(
             op, sourceParts, maskParts, groupCount, chunksPerGroup,
-            *sourcePartType, *rowResultType, *maskType, *firstLaneMask,
+            types->sourcePartType, types->rowResultType, types->maskType,
+            *firstLaneMask,
             rewriter);
     if (failed(reducedResults)) {
       return failure();
     }
     FailureOr<SmallVector<Value>> results = restoreContiguousGroupResults(
-        op, *reducedResults, resultTypes, resultType, groupCount,
+        op, *reducedResults, resultTypes, types->resultType, groupCount,
         chunksPerGroup, rowLocalSlots1Result, rewriter);
     if (failed(results)) {
       return failure();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11131,6 +11131,25 @@ private:
     return packets;
   }
 
+  FailureOr<SmallVector<Value>> buildE2BResults(
+      VMIGroupBroadcastLoadOp op, ArrayRef<Value> packets,
+      ArrayRef<Type> resultTypes, int64_t factor, int64_t chunksPerPart,
+      OneToNPatternRewriter &rewriter) const {
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (int64_t part = 0; part < factor; ++part) {
+      for (int64_t chunk = 0; chunk < chunksPerPart; ++chunk) {
+        int64_t flatIndex = part * chunksPerPart + chunk;
+        if (resultTypes[flatIndex] != resultTypes[chunk]) {
+          return rewriter.notifyMatchFailure(
+              op, "group_broadcast_load E2B reused packet type mismatch");
+        }
+        results.push_back(packets[chunk]);
+      }
+    }
+    return results;
+  }
+
   LogicalResult lowerDirectE2B(
       VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
       Value source, Value offset, VMIVRegType resultVMIType,
@@ -11200,19 +11219,12 @@ private:
     if (failed(packets)) {
       return failure();
     }
-    SmallVector<Value> results;
-    results.reserve(resultTypes.size());
-    for (int64_t part = 0; part < factor; ++part) {
-      for (int64_t chunk = 0; chunk < *chunksPerPart; ++chunk) {
-        int64_t flatIndex = part * *chunksPerPart + chunk;
-        if (resultTypes[flatIndex] != resultTypes[chunk]) {
-          return rewriter.notifyMatchFailure(
-              op, "group_broadcast_load E2B reused packet type mismatch");
-        }
-        results.push_back((*packets)[chunk]);
-      }
+    FailureOr<SmallVector<Value>> results = buildE2BResults(
+        op, *packets, resultTypes, factor, *chunksPerPart, rewriter);
+    if (failed(results)) {
+      return failure();
     }
-    replaceOpWithFlatConvertedValues(rewriter, op, results,
+    replaceOpWithFlatConvertedValues(rewriter, op, *results,
                                      *this->getTypeConverter());
     return success();
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5550,6 +5550,16 @@ static FailureOr<std::optional<SmallVector<Value>>> materializeIdentityMaskLayou
       SmallVector<Value>(sourceParts.begin(), sourceParts.end()));
 }
 
+template <typename Materializer>
+static FailureOr<std::optional<SmallVector<Value>>> tryMaskLayoutMaterializer(
+    Materializer materializer) {
+  FailureOr<std::optional<SmallVector<Value>>> result = materializer();
+  if (failed(result)) {
+    return failure();
+  }
+  return result;
+}
+
 FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
     VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
@@ -5562,8 +5572,12 @@ FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
   }
 
   FailureOr<std::optional<SmallVector<Value>>> identity =
-      materializeIdentityMaskLayout(op, sourceParts, resultTypes, sourceLayout,
-                                    resultLayout, rewriter);
+      tryMaskLayoutMaterializer([op, sourceParts, resultTypes, sourceLayout,
+                                 resultLayout, &rewriter]() {
+        return materializeIdentityMaskLayout(op, sourceParts, resultTypes,
+                                             sourceLayout, resultLayout,
+                                             rewriter);
+      });
   if (failed(identity)) {
     return failure();
   }
@@ -5572,8 +5586,12 @@ FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
   }
 
   FailureOr<std::optional<SmallVector<Value>>> deinterleaved2 =
-      materializeDeinterleaved2MaskLayout(
-          op, sourceParts, resultTypes, sourceLayout, resultLayout, rewriter);
+      tryMaskLayoutMaterializer([op, sourceParts, resultTypes, sourceLayout,
+                                 resultLayout, &rewriter]() {
+        return materializeDeinterleaved2MaskLayout(
+            op, sourceParts, resultTypes, sourceLayout, resultLayout,
+            rewriter);
+      });
   if (failed(deinterleaved2)) {
     return failure();
   }
@@ -5582,8 +5600,12 @@ FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
   }
 
   FailureOr<std::optional<SmallVector<Value>>> laneStride =
-      materializeMaskLaneStrideLayout(
-          op, sourceParts, resultTypes, sourceLayout, resultLayout, rewriter);
+      tryMaskLayoutMaterializer([op, sourceParts, resultTypes, sourceLayout,
+                                 resultLayout, &rewriter]() {
+        return materializeMaskLaneStrideLayout(
+            op, sourceParts, resultTypes, sourceLayout, resultLayout,
+            rewriter);
+      });
   if (failed(laneStride)) {
     return failure();
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11648,8 +11648,10 @@ private:
       SourceOp op, ValueRange sourceParts, Value scalar,
       ValueRange maskParts, ArrayRef<Type> resultTypes,
       OneToNPatternRewriter &rewriter) const {
-    if (sourceParts.empty() || sourceParts.size() != maskParts.size() ||
-        sourceParts.size() != resultTypes.size()) {
+    const bool invalidArity =
+        sourceParts.empty() || sourceParts.size() != maskParts.size() ||
+        sourceParts.size() != resultTypes.size();
+    if (invalidArity) {
       return rewriter.notifyMatchFailure(
           op, "physical vector-scalar arity mismatch");
     }
@@ -11711,6 +11713,47 @@ public:
 struct OneToNVMIVaddcOpPattern : OneToNOpConversionPattern<VMIVaddcOp> {
   using OneToNOpConversionPattern<VMIVaddcOp>::OneToNOpConversionPattern;
 
+private:
+  LogicalResult lowerParts(VMIVaddcOp op, ValueRange lhsParts,
+                           ValueRange rhsParts, ValueRange maskParts,
+                           ArrayRef<Type> resultTypes,
+                           ArrayRef<Type> carryTypes,
+                           SmallVectorImpl<Value> &results,
+                           SmallVectorImpl<Value> &carries,
+                           OneToNPatternRewriter &rewriter) const {
+    const bool invalidArity =
+        lhsParts.empty() || rhsParts.size() != lhsParts.size() ||
+        maskParts.size() != lhsParts.size() ||
+        resultTypes.size() != lhsParts.size() ||
+        carryTypes.size() != lhsParts.size();
+    if (invalidArity) {
+      return rewriter.notifyMatchFailure(op, "vaddc physical arity mismatch");
+    }
+    for (auto [lhs, rhs, mask, resultType, carryType] :
+         llvm::zip_equal(lhsParts, rhsParts, maskParts, resultTypes,
+                         carryTypes)) {
+      auto dataType = dyn_cast<VRegType>(resultType);
+      auto integerType = dataType
+                             ? dyn_cast<IntegerType>(dataType.getElementType())
+                             : IntegerType();
+      const bool invalidPart =
+          !dataType || !integerType || integerType.getWidth() != 32 ||
+          !isa<MaskType>(mask.getType()) || !isa<MaskType>(carryType) ||
+          !cast<MaskType>(carryType).isB32() || lhs.getType() != resultType ||
+          rhs.getType() != resultType;
+      if (invalidPart) {
+        return rewriter.notifyMatchFailure(
+            op, "vaddc requires matching 32-bit data and b32 mask parts");
+      }
+      auto addc = rewriter.create<VaddcOp>(op.getLoc(), resultType, carryType,
+                                           lhs, rhs, mask);
+      results.push_back(addc.getResult());
+      carries.push_back(addc.getCarry());
+    }
+    return success();
+  }
+
+public:
   LogicalResult matchAndRewrite(VMIVaddcOp op, OpAdaptor adaptor,
                                 OneToNPatternRewriter &rewriter) const override {
     ValueRange lhsParts = adaptor.getLhs();
@@ -11720,39 +11763,21 @@ struct OneToNVMIVaddcOpPattern : OneToNOpConversionPattern<VMIVaddcOp> {
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
     FailureOr<SmallVector<Type>> maybeCarryTypes =
         getConvertedResultTypes(op, 1, *this->getTypeConverter());
-    if (failed(maybeResultTypes) || failed(maybeCarryTypes))
+    const bool conversionFailed =
+        failed(maybeResultTypes) || failed(maybeCarryTypes);
+    if (conversionFailed) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
     SmallVector<Type> carryTypes = std::move(*maybeCarryTypes);
-
-    if (lhsParts.empty() || rhsParts.size() != lhsParts.size() ||
-        maskParts.size() != lhsParts.size() ||
-        resultTypes.size() != lhsParts.size() ||
-        carryTypes.size() != lhsParts.size())
-      return rewriter.notifyMatchFailure(op, "vaddc physical arity mismatch");
 
     SmallVector<Value> results;
     SmallVector<Value> carries;
     results.reserve(lhsParts.size());
     carries.reserve(lhsParts.size());
-    for (auto [lhs, rhs, mask, resultType, carryType] :
-         llvm::zip_equal(lhsParts, rhsParts, maskParts, resultTypes,
-                         carryTypes)) {
-      auto dataType = dyn_cast<VRegType>(resultType);
-      auto integerType = dataType
-                             ? dyn_cast<IntegerType>(dataType.getElementType())
-                             : IntegerType();
-      if (!dataType || !integerType || integerType.getWidth() != 32 ||
-          !isa<MaskType>(mask.getType()) || !isa<MaskType>(carryType) ||
-          !cast<MaskType>(carryType).isB32() ||
-          lhs.getType() != resultType || rhs.getType() != resultType)
-        return rewriter.notifyMatchFailure(
-            op, "vaddc requires matching 32-bit data and b32 mask parts");
-
-      auto addc = rewriter.create<VaddcOp>(op.getLoc(), resultType, carryType,
-                                           lhs, rhs, mask);
-      results.push_back(addc.getResult());
-      carries.push_back(addc.getCarry());
+    if (failed(lowerParts(op, lhsParts, rhsParts, maskParts, resultTypes,
+                          carryTypes, results, carries, rewriter))) {
+      return failure();
     }
 
     results.append(carries);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12188,21 +12188,13 @@ private:
       if (activeGroups <= 0) {
         break;
       }
-      Value selected = rewriter
-                           .create<VselrOp>(op.getLoc(), firstVRegType,
-                                            valueParts[partIndex], slotIndex)
-                           .getResult();
-      FailureOr<Value> laneMask = createLaneRangeMask(
-          op.getLoc(), maskType, localPart * 8,
-          localPart * 8 + activeGroups, rewriter);
-      if (failed(laneMask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to create packed group_store lane mask");
+      FailureOr<Value> nextMerged = mergePackedByteStoreBlockPart(
+          op, rewriter, valueParts[partIndex], slotIndex, merged,
+          firstVRegType, maskType, localPart * 8, activeGroups);
+      if (failed(nextMerged)) {
+        return failure();
       }
-      merged = rewriter
-                   .create<VselOp>(op.getLoc(), firstVRegType, selected, merged,
-                                   *laneMask)
-                   .getResult();
+      merged = *nextMerged;
     }
     int64_t activeGroups = std::min<int64_t>(32, numGroups - blockStart);
     FailureOr<Value> storeMask = createPrefixMaskForActiveLanes(
@@ -12214,6 +12206,24 @@ private:
     Value groupOffset = createGroupChunkOffset(
         op.getLoc(), offset, rowStride, blockStart, 0, rewriter);
     return std::make_tuple(merged, *storeMask, groupOffset);
+  }
+
+  FailureOr<Value> mergePackedByteStoreBlockPart(
+      VMIGroupStoreOp op, OneToNPatternRewriter &rewriter, Value value,
+      Value slotIndex, Value merged, VRegType valueType, MaskType maskType,
+      int64_t laneStart, int64_t activeGroups) const {
+    Value selected = rewriter
+                         .create<VselrOp>(op.getLoc(), valueType, value, slotIndex)
+                         .getResult();
+    FailureOr<Value> laneMask = createLaneRangeMask(
+        op.getLoc(), maskType, laneStart, laneStart + activeGroups, rewriter);
+    if (failed(laneMask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to create packed group_store lane mask");
+    }
+    return rewriter
+        .create<VselOp>(op.getLoc(), valueType, selected, merged, *laneMask)
+        .getResult();
   }
 
   FailureOr<Value> buildPackedByteStatefulValue(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2202,7 +2202,10 @@ checkSupportedGroupSlotsStoreShape(VMIGroupStoreOp op, VMIVRegType valueType,
 }
 
 LogicalResult
-checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
+checkSupportedGroupStoreByLayout(VMIGroupStoreOp op, VMIVRegType valueType,
+                                 VMILayoutAttr layout,
+                                 std::optional<int64_t> rowStride,
+                                 std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
       *reason = message.str();
@@ -2210,9 +2213,6 @@ checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
     return failure();
   };
 
-  auto valueType = cast<VMIVRegType>(op.getValue().getType());
-  VMILayoutAttr layout = valueType.getLayoutAttr();
-  std::optional<int64_t> rowStride = getConstantIndexValue(op.getRowStride());
   if (isCompactSmallGroupStore(layout, valueType,
                                op.getNumGroupsAttr().getInt(), rowStride)) {
     return checkSupportedCompactSmallGroupStoreShape(op, valueType, reason);
@@ -2245,6 +2245,15 @@ checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
   return checkDeinterleaved2GroupStoreChunkShape(
       valueType, fact->groupSize, &lanesPerPart, &groupCount,
       &chunksPerGroupPerPart, reason);
+}
+
+LogicalResult
+checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
+  auto valueType = cast<VMIVRegType>(op.getValue().getType());
+  VMILayoutAttr layout = valueType.getLayoutAttr();
+  std::optional<int64_t> rowStride = getConstantIndexValue(op.getRowStride());
+  return checkSupportedGroupStoreByLayout(op, valueType, layout, rowStride,
+                                          reason);
 }
 
 LogicalResult
@@ -12332,19 +12341,25 @@ struct OneToNVMIStrideStoreOpPattern
         "stride_store block_stride must convert to one value", rewriter);
     FailureOr<Value> repeatStride = Value(
         rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0, 16));
-    if (failed(destination) || failed(offset) || failed(blockStride) ||
-        failed(repeatStride))
+    bool failedOperands = failed(destination) || failed(offset) ||
+                          failed(blockStride) || failed(repeatStride);
+    if (failedOperands) {
       return failure();
+    }
 
     ValueRange valueParts = adaptor.getValue();
     ValueRange maskParts = adaptor.getMask();
-    if (valueParts.size() != 1 || maskParts.size() != 1)
+    bool invalidArity = valueParts.size() != 1 || maskParts.size() != 1;
+    if (invalidArity) {
       return rewriter.notifyMatchFailure(
           op, "stride_store supports one physical value/mask chunk");
-    if (!isa<VRegType>(valueParts.front().getType()) ||
-        !isa<MaskType>(maskParts.front().getType()))
+    }
+    bool invalidTypes = !isa<VRegType>(valueParts.front().getType()) ||
+                        !isa<MaskType>(maskParts.front().getType());
+    if (invalidTypes) {
       return rewriter.notifyMatchFailure(
           op, "stride_store requires physical vreg/mask parts");
+    }
 
     Value base = rewriter
                      .create<AddPtrOp>(op.getLoc(), (*destination).getType(),
@@ -12367,22 +12382,28 @@ struct OneToNVMIScatterOpPattern : OneToNOpConversionPattern<VMIScatterOp> {
     FailureOr<Value> destination = getSingleValue(
         op, adaptor.getDestination(),
         "scatter destination must convert to one value", rewriter);
-    if (failed(destination))
+    if (failed(destination)) {
       return failure();
+    }
 
     ValueRange valueParts = adaptor.getValue();
     ValueRange indicesParts = adaptor.getIndices();
     ValueRange maskParts = adaptor.getMask();
-    if (valueParts.size() != indicesParts.size() ||
-        valueParts.size() != maskParts.size())
+    bool invalidArity = valueParts.size() != indicesParts.size() ||
+                        valueParts.size() != maskParts.size();
+    if (invalidArity) {
       return rewriter.notifyMatchFailure(op, "scatter physical arity mismatch");
+    }
 
     for (auto [value, indices, mask] :
          llvm::zip_equal(valueParts, indicesParts, maskParts)) {
-      if (!isa<VRegType>(value.getType()) ||
-          !isa<VRegType>(indices.getType()) || !isa<MaskType>(mask.getType()))
+      bool invalidTypes = !isa<VRegType>(value.getType()) ||
+                          !isa<VRegType>(indices.getType()) ||
+                          !isa<MaskType>(mask.getType());
+      if (invalidTypes) {
         return rewriter.notifyMatchFailure(
             op, "scatter physical part type mismatch");
+      }
       rewriter.create<VscatterOp>(op.getLoc(), value, *destination, indices,
                                   mask);
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -14832,6 +14832,16 @@ struct OneToNVMIExtIOpPattern : OneToNOpConversionPattern<OpT> {
   using OneToNOpConversionPattern<OpT>::OneToNOpConversionPattern;
 
 private:
+  FailureOr<Value> buildFactorExtensionResult(
+      OpT op, Value sourcePart, VRegType resultType, Value mask,
+      StringRef part, OneToNPatternRewriter &rewriter) const {
+    return rewriter
+        .create<VcvtOp>(op.getLoc(), resultType, sourcePart, mask,
+                        /*rnd=*/nullptr, /*sat=*/nullptr,
+                        rewriter.getStringAttr(part))
+        .getResult();
+  }
+
   LogicalResult emitFactorExtension(
       OpT op, ValueRange sourceParts, ArrayRef<VRegType> resultVRegTypes,
       ArrayRef<StringRef> parts, int64_t factor, Value mask,
@@ -14842,12 +14852,12 @@ private:
       for (auto [chunkIndex, sourcePart] : llvm::enumerate(sourceParts)) {
         VRegType resultType =
             resultVRegTypes[partIndex * sourceParts.size() + chunkIndex];
-        results.push_back(
-            rewriter
-                .create<VcvtOp>(op.getLoc(), resultType, sourcePart, mask,
-                                /*rnd=*/nullptr, /*sat=*/nullptr,
-                                rewriter.getStringAttr(parts[partIndex]))
-                .getResult());
+        FailureOr<Value> result = buildFactorExtensionResult(
+            op, sourcePart, resultType, mask, parts[partIndex], rewriter);
+        if (failed(result)) {
+          return failure();
+        }
+        results.push_back(*result);
       }
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -15432,6 +15432,21 @@ public:
   }
 };
 
+static bool hasUnsupportedPackedTruncFConversion(Type sourceElementType,
+                                                 Type resultElementType) {
+  bool usesPackedCarrier =
+      isVMIPackedFloatCarrierType(sourceElementType) ||
+      isVMIPackedFloatCarrierType(resultElementType);
+  return usesPackedCarrier &&
+         !lookupVMIFpToFpContract(sourceElementType, resultElementType);
+}
+
+static bool hasGroupSlotTruncFLayouts(VMILayoutAttr sourceLayout,
+                                      VMILayoutAttr resultLayout) {
+  return sourceLayout && resultLayout && sourceLayout.isGroupSlots() &&
+         resultLayout.isGroupSlots();
+}
+
 struct OneToNVMITruncFOpPattern : OneToNOpConversionPattern<VMITruncFOp> {
   using OneToNOpConversionPattern<VMITruncFOp>::OneToNOpConversionPattern;
 
@@ -15755,11 +15770,8 @@ public:
     auto resultVMIType = cast<VMIVRegType>(op.getResult().getType());
     Type sourceElementType = sourceVMIType.getElementType();
     Type resultElementType = resultVMIType.getElementType();
-    bool unsupportedPackedConversion =
-        (isVMIPackedFloatCarrierType(sourceElementType) ||
-         isVMIPackedFloatCarrierType(resultElementType)) &&
-        !lookupVMIFpToFpContract(sourceElementType, resultElementType);
-    if (unsupportedPackedConversion) {
+    if (hasUnsupportedPackedTruncFConversion(sourceElementType,
+                                             resultElementType)) {
       return rewriter.notifyMatchFailure(
           op, "unsupported packed fp-to-fp truncf conversion");
     }
@@ -15773,10 +15785,7 @@ public:
 
     VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
     VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
-    bool groupSlotLayouts =
-        sourceLayout && resultLayout && sourceLayout.isGroupSlots() &&
-        resultLayout.isGroupSlots();
-    if (groupSlotLayouts) {
+    if (hasGroupSlotTruncFLayouts(sourceLayout, resultLayout)) {
       return lowerGroupSlotTrunc(op, sourceParts, resultTypes, sourceLayout,
                                  resultLayout, sourceVMIType, resultVMIType,
                                  rewriter);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9490,6 +9490,44 @@ static LogicalResult lowerSingleGroupSlotLoad(
   return success();
 }
 
+static LogicalResult emitGroupSlotLoadSlots8Chunk(
+    Operation *op, Value source, Value offset, Type resultType, int64_t chunk,
+    int64_t numGroups,
+    OneToNPatternRewriter &rewriter, SmallVectorImpl<Value> &results) {
+  FailureOr<GroupSlotLoadResultPart> resultPart =
+      getGroupSlotLoadResultPart(op, resultType, rewriter);
+  if (failed(resultPart)) {
+    return failure();
+  }
+  int64_t groupBegin = chunk * 8;
+  int64_t activeGroups = std::min<int64_t>(8, numGroups - groupBegin);
+  if (activeGroups <= 0) {
+    return rewriter.notifyMatchFailure(
+        op, "slots=8 group_slot_load has no active groups for chunk");
+  }
+  std::string pattern = (Twine("PAT_VL") + Twine(activeGroups)).str();
+  FailureOr<Value> slotMask = createPrefixMask(
+      op->getLoc(), resultPart->maskType, pattern, rewriter);
+  if (failed(slotMask)) {
+    return rewriter.notifyMatchFailure(
+        op, "failed to create slots=8 group_slot_load mask");
+  }
+  Value groupOffset =
+      createChunkOffset(op->getLoc(), offset, groupBegin, rewriter);
+  Value slotBase = rewriter
+                       .create<AddPtrOp>(op->getLoc(), source.getType(), source,
+                                         groupOffset)
+                       .getResult();
+  auto zeroI16 = rewriter.create<arith::ConstantIntOp>(op->getLoc(), 0, 16);
+  results.push_back(
+      rewriter
+          .create<VsldbOp>(op->getLoc(), resultPart->valueType,
+                          /*updated_base=*/Type{}, slotBase, zeroI16, zeroI16,
+                          *slotMask)
+          .getResult());
+  return success();
+}
+
 static LogicalResult lowerGroupSlotLoadSlots8(
     Operation *op, Value source, Value offset, Value sourceGroupStride,
     VMIVRegType resultVMIType, TypeRange resultTypes, int64_t numGroups,
@@ -9499,46 +9537,16 @@ static LogicalResult lowerGroupSlotLoadSlots8(
     return rewriter.notifyMatchFailure(
         op, "slots=8 group_slot_load requires constant unit stride");
   }
-  auto makeI16 = [&rewriter, &op](int64_t value) -> Value {
-    return rewriter.create<arith::ConstantIntOp>(op->getLoc(), value, 16);
-  };
-  Value zeroI16 = makeI16(0);
-  auto makePtr = [&rewriter, &source, &op](Value elementOffset) -> Value {
-    return rewriter
-        .create<AddPtrOp>(op->getLoc(), source.getType(), source, elementOffset)
-        .getResult();
-  };
   if (numGroups == 1) {
     return lowerSingleGroupSlotLoad(op, source, offset, resultVMIType,
                                     resultTypes, rewriter, results);
   }
   for (auto [chunk, resultType] : llvm::enumerate(resultTypes)) {
-    FailureOr<GroupSlotLoadResultPart> resultPart =
-        getGroupSlotLoadResultPart(op, resultType, rewriter);
-    if (failed(resultPart)) {
+    if (failed(emitGroupSlotLoadSlots8Chunk(
+            op, source, offset, resultType,
+            static_cast<int64_t>(chunk), numGroups, rewriter, results))) {
       return failure();
     }
-    int64_t groupBegin = static_cast<int64_t>(chunk) * 8;
-    int64_t activeGroups = std::min<int64_t>(8, numGroups - groupBegin);
-    if (activeGroups <= 0) {
-      return rewriter.notifyMatchFailure(
-          op, "slots=8 group_slot_load has no active groups for chunk");
-    }
-    std::string pattern = (Twine("PAT_VL") + Twine(activeGroups)).str();
-    FailureOr<Value> slotMask =
-        createPrefixMask(op->getLoc(), resultPart->maskType, pattern, rewriter);
-    if (failed(slotMask)) {
-      return rewriter.notifyMatchFailure(
-          op, "failed to create slots=8 group_slot_load mask");
-    }
-    Value groupOffset = createChunkOffset(op->getLoc(), offset, groupBegin,
-                                          rewriter);
-    Value slotBase = makePtr(groupOffset);
-    results.push_back(rewriter
-                          .create<VsldbOp>(op->getLoc(), resultPart->valueType,
-                                           /*updated_base=*/Type{}, slotBase,
-                                           zeroI16, zeroI16, *slotMask)
-                          .getResult());
   }
   return success();
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -14961,7 +14961,7 @@ private:
         *resultType, *maskType, *sourcePartType, *rowResultType, *rowMaskType};
   }
 
-  LogicalResult lowerFullDeinterleaved2(
+  FailureOr<std::pair<int64_t, int64_t>> validateFullDeinterleaved2Shape(
       OpTy op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
       ValueRange sourceParts, ValueRange maskParts, TypeRange resultTypes,
       int64_t groupSize, OneToNPatternRewriter &rewriter) const {
@@ -14985,8 +14985,8 @@ private:
               "multiple of two physical chunks");
     }
     int64_t groupCount = sourceVMIType.getElementCount() / groupSize;
-    int64_t chunksPerGroupPerPart = groupSize / (2 * *lanesPerPart);
-    int64_t chunksPerPart = groupCount * chunksPerGroupPerPart;
+    int64_t chunksPerGroup = groupSize / (2 * *lanesPerPart);
+    int64_t chunksPerPart = groupCount * chunksPerGroup;
     bool invalidArity = sourceParts.size() != maskParts.size() ||
                         static_cast<int64_t>(sourceParts.size()) !=
                             2 * chunksPerPart ||
@@ -14995,6 +14995,23 @@ private:
       return rewriter.notifyMatchFailure(
           op, "deinterleaved=2 group_reduce arity mismatch");
     }
+    return std::make_pair(groupCount, chunksPerGroup);
+  }
+
+  LogicalResult lowerFullDeinterleaved2(
+      OpTy op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+      ValueRange sourceParts, ValueRange maskParts, TypeRange resultTypes,
+      int64_t groupSize, OneToNPatternRewriter &rewriter) const {
+    FailureOr<std::pair<int64_t, int64_t>> shape =
+        validateFullDeinterleaved2Shape(
+            op, sourceVMIType, resultVMIType, sourceParts, maskParts,
+            resultTypes, groupSize, rewriter);
+    if (failed(shape)) {
+      return failure();
+    }
+    int64_t groupCount = shape->first;
+    int64_t chunksPerGroupPerPart = shape->second;
+    int64_t chunksPerPart = groupCount * chunksPerGroupPerPart;
     FailureOr<Deinterleaved2GroupReduceTypes> types =
         getDeinterleaved2GroupReduceTypes(op, sourceParts, maskParts,
                                           resultTypes, rewriter);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10011,6 +10011,40 @@ private:
     return emitStatefulStoreStream(op, storeBase, values, advances, rewriter);
   }
 
+  FailureOr<Value> buildPackedSlots1Value(
+      VMIGroupStoreOp op, OneToNPatternRewriter &rewriter,
+      ValueRange valueParts, VMILayoutAttr layout, VRegType firstType,
+      MaskType maskType, Value allMask) const {
+    Value packed = rewriter
+                       .create<VdupOp>(op.getLoc(), firstType,
+                                       valueParts.front(), allMask,
+                                       rewriter.getStringAttr("LOWEST"))
+                       .getResult();
+    for (int64_t group = 1; group < layout.getNumGroups(); ++group) {
+      auto vregType = dyn_cast<VRegType>(valueParts[group].getType());
+      if (!vregType || vregType != firstType) {
+        return rewriter.notifyMatchFailure(
+            op, "packed group_store requires uniform vreg parts");
+      }
+      Value splat = rewriter
+                        .create<VdupOp>(op.getLoc(), firstType, valueParts[group],
+                                        allMask,
+                                        rewriter.getStringAttr("LOWEST"))
+                        .getResult();
+      FailureOr<Value> laneMask = createLaneRangeMask(
+          op.getLoc(), maskType, group, group + 1, rewriter);
+      if (failed(laneMask)) {
+        return rewriter.notifyMatchFailure(
+            op, "failed to create packed group_store lane mask");
+      }
+      packed = rewriter
+                   .create<VselOp>(op.getLoc(), firstType, splat, packed,
+                                   *laneMask)
+                   .getResult();
+    }
+    return packed;
+  }
+
   LogicalResult lowerSlots1PackedUnitStride(
       VMIGroupStoreOp op, OneToNPatternRewriter &rewriter,
       ValueRange valueParts, VMIVRegType valueVMIType, VMILayoutAttr layout,
@@ -10028,32 +10062,10 @@ private:
       return rewriter.notifyMatchFailure(
           op, "unsupported element type for packed group_store mask");
     }
-    Value packed = rewriter
-                       .create<VdupOp>(op.getLoc(), firstType,
-                                       valueParts.front(), *allMask,
-                                       rewriter.getStringAttr("LOWEST"))
-                       .getResult();
-    for (int64_t group = 1; group < layout.getNumGroups(); ++group) {
-      auto vregType = dyn_cast<VRegType>(valueParts[group].getType());
-      if (!vregType || vregType != firstType) {
-        return rewriter.notifyMatchFailure(
-            op, "packed group_store requires uniform vreg parts");
-      }
-      Value splat = rewriter
-                        .create<VdupOp>(op.getLoc(), firstType,
-                                        valueParts[group], *allMask,
-                                        rewriter.getStringAttr("LOWEST"))
-                        .getResult();
-      FailureOr<Value> laneMask = createLaneRangeMask(
-          op.getLoc(), *maskType, group, group + 1, rewriter);
-      if (failed(laneMask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to create packed group_store lane mask");
-      }
-      packed = rewriter
-                   .create<VselOp>(op.getLoc(), firstType, splat, packed,
-                                   *laneMask)
-                   .getResult();
+    FailureOr<Value> packed = buildPackedSlots1Value(
+        op, rewriter, valueParts, layout, *firstType, *maskType, *allMask);
+    if (failed(packed)) {
+      return failure();
     }
     if (isKnownAddressAligned(destination, offset,
                                valueVMIType.getElementType(), 32)) {
@@ -10063,7 +10075,7 @@ private:
         return rewriter.notifyMatchFailure(
             op, "failed to create packed group_store store mask");
       }
-      rewriter.create<VstsOp>(op.getLoc(), Type{}, packed, destination, offset,
+      rewriter.create<VstsOp>(op.getLoc(), Type{}, *packed, destination, offset,
                               nullptr, *storeMask);
     } else {
       Value storeBase = materializeBufferPointer(
@@ -10077,7 +10089,7 @@ private:
                       .create<AddPtrOp>(op.getLoc(), storeBase.getType(),
                                         storeBase, offset)
                       .getResult();
-      SmallVector<Value> streamValues{packed};
+      SmallVector<Value> streamValues{*packed};
       SmallVector<int64_t> streamAdvances{layout.getNumGroups()};
       if (failed(emitStatefulStoreStream(op, storeBase, streamValues,
                                          streamAdvances, rewriter))) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10043,6 +10043,48 @@ struct OneToNVMIStoreOpPattern : OneToNOpConversionPattern<VMIStoreOp> {
   using OneToNOpConversionPattern<VMIStoreOp>::OneToNOpConversionPattern;
 
 private:
+  struct StorePhysicalPlan {
+    SmallVector<Type> contiguousTypes;
+    VMILayoutAttr contiguousLayout;
+    int64_t lanesPerPart;
+    bool fullPhysicalChunks;
+    bool noWiderThanContiguous;
+  };
+
+  FailureOr<StorePhysicalPlan> buildPhysicalPlan(
+      VMIStoreOp op, ValueRange valueParts, VMIVRegType valueVMIType,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<int64_t> lanesPerPart =
+        getDataLanesPerPart(valueVMIType.getElementType());
+    if (failed(lanesPerPart)) {
+      return rewriter.notifyMatchFailure(
+          op, "store requires known physical lanes per part");
+    }
+    VMILayoutAttr contiguousLayout =
+        VMILayoutAttr::getContiguous(rewriter.getContext());
+    FailureOr<SmallVector<Type>> contiguousTypes =
+        getContiguousStoreTypes(op, valueVMIType, rewriter);
+    if (failed(contiguousTypes)) {
+      return failure();
+    }
+    SmallVector<Type> valuePartTypes;
+    valuePartTypes.reserve(valueParts.size());
+    for (Value value : valueParts) {
+      valuePartTypes.push_back(value.getType());
+    }
+    FailureOr<bool> noWiderThanContiguous =
+        hasNoWiderFootprintThanContiguous(valuePartTypes, *contiguousTypes);
+    if (failed(noWiderThanContiguous)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to compare store physical footprint");
+    }
+    return StorePhysicalPlan{std::move(*contiguousTypes), contiguousLayout,
+                             *lanesPerPart,
+                             succeeded(checkFullDataPhysicalChunks(
+                                 valueVMIType, nullptr)),
+                             *noWiderThanContiguous};
+  }
+
   FailureOr<SmallVector<Type>> getContiguousStoreTypes(
       VMIStoreOp op, VMIVRegType valueVMIType,
       OneToNPatternRewriter &rewriter) const {
@@ -10320,15 +10362,6 @@ public:
   matchAndRewrite(VMIStoreOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
     auto valueVMIType = cast<VMIVRegType>(op.getValue().getType());
-    FailureOr<int64_t> lanesPerPart =
-        getDataLanesPerPart(valueVMIType.getElementType());
-    bool unknownLanesPerPart = failed(lanesPerPart);
-    if (unknownLanesPerPart) {
-      return rewriter.notifyMatchFailure(
-          op, "store requires known physical lanes per part");
-    }
-    bool fullPhysicalChunks =
-        succeeded(checkFullDataPhysicalChunks(valueVMIType, nullptr));
     FailureOr<Value> destination =
         getSingleValue(op, adaptor.getDestination(),
                        "store destination must convert to one value", rewriter);
@@ -10341,6 +10374,11 @@ public:
     }
 
     ValueRange valueParts = adaptor.getValue();
+    FailureOr<StorePhysicalPlan> plan =
+        buildPhysicalPlan(op, valueParts, valueVMIType, rewriter);
+    if (failed(plan)) {
+      return failure();
+    }
     FailureOr<bool> laneStrideStore = tryLowerLaneStrideStore(
         op, *destination, *offset, valueParts, valueVMIType, rewriter);
     if (failed(laneStrideStore)) {
@@ -10350,29 +10388,10 @@ public:
       return success();
     }
 
-    VMILayoutAttr contiguousLayout =
-        VMILayoutAttr::getContiguous(rewriter.getContext());
-    FailureOr<SmallVector<Type>> maybeContiguousTypes =
-        getContiguousStoreTypes(op, valueVMIType, rewriter);
-    if (failed(maybeContiguousTypes)) {
-      return failure();
-    }
-    SmallVector<Type> contiguousTypes = std::move(*maybeContiguousTypes);
-    SmallVector<Type> valuePartTypes;
-    valuePartTypes.reserve(valueParts.size());
-    for (Value value : valueParts) {
-      valuePartTypes.push_back(value.getType());
-    }
-    FailureOr<bool> noWiderThanContiguous =
-        hasNoWiderFootprintThanContiguous(valuePartTypes, contiguousTypes);
-    if (failed(noWiderThanContiguous)) {
-      return rewriter.notifyMatchFailure(
-          op, "failed to compare store physical footprint");
-    }
-
     FailureOr<bool> deinterleavedStore = tryLowerDeinterleavedStore(
-        op, *destination, *offset, valueParts, valueVMIType, *lanesPerPart,
-        fullPhysicalChunks, *noWiderThanContiguous, rewriter);
+        op, *destination, *offset, valueParts, valueVMIType,
+        plan->lanesPerPart, plan->fullPhysicalChunks,
+        plan->noWiderThanContiguous, rewriter);
     if (failed(deinterleavedStore)) {
       return failure();
     }
@@ -10381,15 +10400,15 @@ public:
     }
 
     FailureOr<SmallVector<Value>> storeParts = materializeDataLayoutConversion(
-        op, valueParts, contiguousTypes, valueVMIType.getLayoutAttr(),
-        contiguousLayout, valueVMIType.getElementType(), rewriter);
+        op, valueParts, plan->contiguousTypes, valueVMIType.getLayoutAttr(),
+        plan->contiguousLayout, valueVMIType.getElementType(), rewriter);
     if (failed(storeParts)) {
       return failure();
     }
 
     if (failed(lowerContiguousStoreParts(
             op, *destination, *offset, *storeParts, valueVMIType,
-            *lanesPerPart, fullPhysicalChunks, rewriter))) {
+            plan->lanesPerPart, plan->fullPhysicalChunks, rewriter))) {
       return failure();
     }
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11511,27 +11511,34 @@ private:
       }
       rewriter.create<VstsOp>(op.getLoc(), Type{}, *packed, destination, offset,
                               nullptr, *storeMask);
-    } else {
-      Value storeBase = materializeBufferPointer(
-          destination, valueVMIType.getElementType(),
-          getMemorySpace(destination.getType()), rewriter, op.getLoc());
-      if (!storeBase) {
-        return rewriter.notifyMatchFailure(
-            op, "packed unaligned group_store requires a ptr-compatible destination");
-      }
-      storeBase = rewriter
-                      .create<AddPtrOp>(op.getLoc(), storeBase.getType(),
-                                        storeBase, offset)
-                      .getResult();
-      SmallVector<Value> streamValues{*packed};
-      SmallVector<int64_t> streamAdvances{layout.getNumGroups()};
-      if (failed(emitStatefulStoreStream(op, storeBase, streamValues,
-                                         streamAdvances, rewriter))) {
+    } else if (failed(emitPackedSlots1StoreStream(
+                   op, rewriter, destination, offset, valueVMIType, *packed,
+                   layout.getNumGroups()))) {
         return failure();
-      }
     }
     rewriter.eraseOp(op);
     return success();
+  }
+
+  LogicalResult emitPackedSlots1StoreStream(
+      VMIGroupStoreOp op, OneToNPatternRewriter &rewriter, Value destination,
+      Value offset, VMIVRegType valueVMIType, Value packed,
+      int64_t numGroups) const {
+    Value storeBase = materializeBufferPointer(
+        destination, valueVMIType.getElementType(),
+        getMemorySpace(destination.getType()), rewriter, op.getLoc());
+    if (!storeBase) {
+      return rewriter.notifyMatchFailure(
+          op, "packed unaligned group_store requires a ptr-compatible destination");
+    }
+    storeBase = rewriter
+                    .create<AddPtrOp>(op.getLoc(), storeBase.getType(), storeBase,
+                                      offset)
+                    .getResult();
+    SmallVector<Value> streamValues{packed};
+    SmallVector<int64_t> streamAdvances{numGroups};
+    return emitStatefulStoreStream(op, storeBase, streamValues, streamAdvances,
+                                   rewriter);
   }
 
   LogicalResult lowerSlots1PointStores(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -14024,6 +14024,24 @@ struct OneToNVMIExtFOpPattern : OneToNOpConversionPattern<VMIExtFOp> {
   using OneToNOpConversionPattern<VMIExtFOp>::OneToNOpConversionPattern;
 
 private:
+  struct ResultViewPlan {
+    bool isPackedBF16x2;
+    VRegType vcvtResultType;
+  };
+
+  ResultViewPlan buildResultViewPlan(ArrayRef<VRegType> resultTypes,
+                                     OneToNPatternRewriter &rewriter) const {
+    bool isPackedBF16x2 =
+        pto::isPTOBF16x2Type(resultTypes.front().getElementType());
+    VRegType vcvtResultType = resultTypes.front();
+    if (isPackedBF16x2) {
+      vcvtResultType = VRegType::get(
+          rewriter.getContext(), resultTypes.front().getElementCount() * 2,
+          BFloat16Type::get(rewriter.getContext()));
+    }
+    return ResultViewPlan{isPackedBF16x2, vcvtResultType};
+  }
+
   static Value createVcvtResult(Location loc, VRegType resultType,
                                 Value sourcePart, Value mask, StringAttr rnd,
                                 StringAttr sat, StringAttr part,
@@ -14111,15 +14129,8 @@ public:
     // lanes per bf16x2 lane) and reinterpret each vcvt result with a
     // physical-noop VbitcastOp, mirroring the source-side reinterpret in
     // OneToNVMITruncFOpPattern (viewVcvtSource).
-    bool resultIsPackedBF16x2 =
-        pto::isPTOBF16x2Type(resultVRegTypes.front().getElementType());
-    VRegType vcvtResultVRegType = resultVRegTypes.front();
-    if (resultIsPackedBF16x2) {
-      vcvtResultVRegType =
-          VRegType::get(rewriter.getContext(),
-                        resultVRegTypes.front().getElementCount() * 2,
-                        BFloat16Type::get(rewriter.getContext()));
-    }
+    ResultViewPlan viewPlan =
+        buildResultViewPlan(resultVRegTypes, rewriter);
     VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
     VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
     if (sourceLayout && resultLayout && sourceLayout.isContiguous() &&
@@ -14136,8 +14147,8 @@ public:
       }
 
       return lowerLaneStride(op, rewriter, sourceParts, resultVRegTypes,
-                             *mask, part, resultIsPackedBF16x2,
-                             vcvtResultVRegType);
+                             *mask, part, viewPlan.isPackedBF16x2,
+                             viewPlan.vcvtResultType);
     }
 
     ArrayRef<StringRef> parts;
@@ -14165,8 +14176,8 @@ public:
     }
 
     return lowerFactor(op, rewriter, sourceParts, resultVRegTypes, parts,
-                       factor, *mask, resultIsPackedBF16x2,
-                       vcvtResultVRegType);
+                       factor, *mask, viewPlan.isPackedBF16x2,
+                       viewPlan.vcvtResultType);
   }
 };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5395,24 +5395,43 @@ static FailureOr<SmallVector<Value>> materializeContiguousToDeinterleaved2Mask(
   return results;
 }
 
+enum class Deinterleaved2MaskLayoutDirection {
+  Unsupported,
+  ToContiguous,
+  FromContiguous
+};
+
+static Deinterleaved2MaskLayoutDirection getDeinterleaved2MaskDirection(
+    VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout) {
+  bool sourceIsDeinterleaved2 =
+      sourceLayout && sourceLayout.isDeinterleaved() &&
+      sourceLayout.getFactor() == 2 && sourceLayout.getLaneStride() == 1;
+  bool resultIsDeinterleaved2 =
+      resultLayout && resultLayout.isDeinterleaved() &&
+      resultLayout.getFactor() == 2 && resultLayout.getLaneStride() == 1;
+  bool toContiguous = sourceIsDeinterleaved2 && resultLayout &&
+                      resultLayout.isContiguous() &&
+                      resultLayout.getLaneStride() == 1;
+  bool fromContiguous = sourceLayout && sourceLayout.isContiguous() &&
+                        sourceLayout.getLaneStride() == 1 &&
+                        resultIsDeinterleaved2;
+  if (toContiguous) {
+    return Deinterleaved2MaskLayoutDirection::ToContiguous;
+  }
+  if (fromContiguous) {
+    return Deinterleaved2MaskLayoutDirection::FromContiguous;
+  }
+  return Deinterleaved2MaskLayoutDirection::Unsupported;
+}
+
 static FailureOr<std::optional<SmallVector<Value>>>
 materializeDeinterleaved2MaskLayout(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
     VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
     PatternRewriter &rewriter) {
-  auto isElementDeinterleaved = [](VMILayoutAttr layout) {
-    return layout.isDeinterleaved() && layout.getFactor() == 2 &&
-           layout.getLaneStride() == 1;
-  };
-  bool toContiguous = sourceLayout && sourceLayout.isDeinterleaved() &&
-                      isElementDeinterleaved(sourceLayout) && resultLayout &&
-                      resultLayout.isContiguous() &&
-                      resultLayout.getLaneStride() == 1;
-  bool fromContiguous = sourceLayout && sourceLayout.isContiguous() &&
-                        sourceLayout.getLaneStride() == 1 && resultLayout &&
-                        resultLayout.isDeinterleaved() &&
-                        isElementDeinterleaved(resultLayout);
-  if (!toContiguous && !fromContiguous) {
+  Deinterleaved2MaskLayoutDirection direction =
+      getDeinterleaved2MaskDirection(sourceLayout, resultLayout);
+  if (direction == Deinterleaved2MaskLayoutDirection::Unsupported) {
     return std::nullopt;
   }
   bool invalidArity = sourceParts.size() != resultTypes.size() ||
@@ -5427,7 +5446,7 @@ materializeDeinterleaved2MaskLayout(
     return failure();
   }
 
-  if (toContiguous) {
+  if (direction == Deinterleaved2MaskLayoutDirection::ToContiguous) {
     FailureOr<SmallVector<Value>> results =
         materializeDeinterleaved2MaskToContiguous(op, sourceParts, resultTypes,
                                                   rewriter);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -15274,6 +15274,36 @@ private:
     return success();
   }
 
+  FailureOr<Value> buildContiguousGroupReduceResult(
+      OpTy op, ValueRange sourceParts, ValueRange maskParts, int64_t group,
+      int64_t chunksPerGroup, VRegType sourcePartType, VRegType rowResultType,
+      MaskType maskType, Value firstLaneMask,
+      OneToNPatternRewriter &rewriter) const {
+    Value accumulator;
+    for (int64_t chunk = 0; chunk < chunksPerGroup; ++chunk) {
+      int64_t index = group * chunksPerGroup + chunk;
+      bool mismatchedTypes = sourceParts[index].getType() != sourcePartType ||
+                             maskParts[index].getType() != maskType;
+      if (mismatchedTypes) {
+        return rewriter.notifyMatchFailure(
+            op, "group_reduce requires uniform physical chunk types");
+      }
+      Value reduced = rewriter
+                          .create<RowReduceOpTy>(op.getLoc(), rowResultType,
+                                                 sourceParts[index],
+                                                 maskParts[index])
+                          .getResult();
+      accumulator = accumulator
+                        ? rewriter
+                              .create<CombineOpTy>(op.getLoc(), rowResultType,
+                                                   reduced, accumulator,
+                                                   firstLaneMask)
+                              .getResult()
+                        : reduced;
+    }
+    return accumulator;
+  }
+
   FailureOr<SmallVector<Value>> buildContiguousGroupReduceResults(
       OpTy op, ValueRange sourceParts, ValueRange maskParts,
       int64_t groupCount, int64_t chunksPerGroup, VRegType sourcePartType,
@@ -15282,29 +15312,13 @@ private:
     SmallVector<Value> results;
     results.reserve(groupCount);
     for (int64_t group = 0; group < groupCount; ++group) {
-      Value accumulator;
-      for (int64_t chunk = 0; chunk < chunksPerGroup; ++chunk) {
-        int64_t index = group * chunksPerGroup + chunk;
-        bool mismatchedTypes = sourceParts[index].getType() != sourcePartType ||
-                               maskParts[index].getType() != maskType;
-        if (mismatchedTypes) {
-          return rewriter.notifyMatchFailure(
-              op, "group_reduce requires uniform physical chunk types");
-        }
-        Value reduced =
-            rewriter
-                .create<RowReduceOpTy>(op.getLoc(), rowResultType,
-                                       sourceParts[index], maskParts[index])
-                .getResult();
-        accumulator =
-            accumulator
-                ? rewriter
-                      .create<CombineOpTy>(op.getLoc(), rowResultType, reduced,
-                                           accumulator, firstLaneMask)
-                      .getResult()
-                : reduced;
+      FailureOr<Value> result = buildContiguousGroupReduceResult(
+          op, sourceParts, maskParts, group, chunksPerGroup, sourcePartType,
+          rowResultType, maskType, firstLaneMask, rewriter);
+      if (failed(result)) {
+        return failure();
       }
-      results.push_back(accumulator);
+      results.push_back(*result);
     }
     return results;
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7337,6 +7337,36 @@ private:
     return success();
   }
 
+  FailureOr<std::pair<bool, int64_t>> getConstantMaskChunkActivity(
+      VMICreateMaskOp op, VMIMaskType resultVMIType, int64_t part,
+      int64_t chunk, int64_t activeLanes, int64_t lanesPerPart,
+      OneToNPatternRewriter &rewriter) const {
+    bool anyLane = false;
+    int64_t activeInChunk = 0;
+    for (int64_t lane = 0; lane < lanesPerPart; ++lane) {
+      FailureOr<bool> padding =
+          isPaddingLane(resultVMIType, part, chunk, lane);
+      if (failed(padding)) {
+        return rewriter.notifyMatchFailure(
+            op, "failed to map create_mask physical padding lane");
+      }
+      if (*padding) {
+        continue;
+      }
+      anyLane = true;
+      FailureOr<int64_t> logicalLane =
+          mapPhysicalLaneToLogical(resultVMIType, part, chunk, lane);
+      if (failed(logicalLane)) {
+        return rewriter.notifyMatchFailure(
+            op, "failed to map create_mask physical lane");
+      }
+      if (*logicalLane < activeLanes) {
+        ++activeInChunk;
+      }
+    }
+    return std::make_pair(anyLane, activeInChunk);
+  }
+
   LogicalResult lowerConstantMask(
       VMICreateMaskOp op, int64_t activeLanes, VMIMaskType resultVMIType,
       VMILayoutAttr layout, TypeRange resultTypes, int64_t lanesPerPart,
@@ -7346,29 +7376,14 @@ private:
     results.reserve(resultTypes.size());
     for (int64_t part = 0; part < factor; ++part) {
       for (int64_t chunk = 0;; ++chunk) {
-        bool anyLane = false;
-        int64_t activeInChunk = 0;
-        for (int64_t lane = 0; lane < lanesPerPart; ++lane) {
-          FailureOr<bool> padding =
-              isPaddingLane(resultVMIType, part, chunk, lane);
-          if (failed(padding)) {
-            return rewriter.notifyMatchFailure(
-                op, "failed to map create_mask physical padding lane");
-          }
-          if (*padding) {
-            continue;
-          }
-          anyLane = true;
-          FailureOr<int64_t> logicalLane =
-              mapPhysicalLaneToLogical(resultVMIType, part, chunk, lane);
-          if (failed(logicalLane)) {
-            return rewriter.notifyMatchFailure(
-                op, "failed to map create_mask physical lane");
-          }
-          if (*logicalLane < activeLanes) {
-            ++activeInChunk;
-          }
+        FailureOr<std::pair<bool, int64_t>> activity =
+            getConstantMaskChunkActivity(op, resultVMIType, part, chunk,
+                                         activeLanes, lanesPerPart, rewriter);
+        if (failed(activity)) {
+          return failure();
         }
+        bool anyLane = activity->first;
+        int64_t activeInChunk = activity->second;
         if (!anyLane) {
           break;
         }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -4103,6 +4103,30 @@ FailureOr<Value> materializeConstantMaskChunk(Location loc, MaskType maskType,
   if (failed(allTrue))
     return failure();
 
+  auto materializeRun = [loc, maskType, lanesPerPart, &rewriter, &allTrue](
+                            int64_t runBegin,
+                            int64_t runEnd) -> FailureOr<Value> {
+    FailureOr<Value> prefixEnd =
+        materializePrefixMask(loc, maskType, runEnd, *lanesPerPart, rewriter);
+    if (failed(prefixEnd)) {
+      return failure();
+    }
+    if (runBegin == 0) {
+      return *prefixEnd;
+    }
+    FailureOr<Value> prefixBegin = materializePrefixMask(
+        loc, maskType, runBegin, *lanesPerPart, rewriter);
+    if (failed(prefixBegin)) {
+      return failure();
+    }
+    Value notPrefixBegin =
+        rewriter.create<PnotOp>(loc, maskType, *prefixBegin, *allTrue)
+            .getResult();
+    return rewriter
+        .create<PandOp>(loc, maskType, *prefixEnd, notPrefixBegin, *allTrue)
+        .getResult();
+  };
+
   Value result;
   int64_t lane = 0;
   while (lane < *lanesPerPart) {
@@ -4116,31 +4140,16 @@ FailureOr<Value> materializeConstantMaskChunk(Location loc, MaskType maskType,
       ++lane;
     int64_t runEnd = lane;
 
-    FailureOr<Value> prefixEnd =
-        materializePrefixMask(loc, maskType, runEnd, *lanesPerPart, rewriter);
-    if (failed(prefixEnd))
+    FailureOr<Value> runMask = materializeRun(runBegin, runEnd);
+    if (failed(runMask)) {
       return failure();
-
-    Value runMask = *prefixEnd;
-    if (runBegin != 0) {
-      FailureOr<Value> prefixBegin = materializePrefixMask(
-          loc, maskType, runBegin, *lanesPerPart, rewriter);
-      if (failed(prefixBegin))
-        return failure();
-      Value notPrefixBegin =
-          rewriter.create<PnotOp>(loc, maskType, *prefixBegin, *allTrue)
-              .getResult();
-      runMask = rewriter
-                    .create<PandOp>(loc, maskType, *prefixEnd, notPrefixBegin,
-                                    *allTrue)
-                    .getResult();
     }
 
     if (!result) {
-      result = runMask;
+      result = *runMask;
       continue;
     }
-    result = rewriter.create<PorOp>(loc, maskType, result, runMask, *allTrue)
+    result = rewriter.create<PorOp>(loc, maskType, result, *runMask, *allTrue)
                  .getResult();
   }
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10558,6 +10558,21 @@ private:
     return values;
   }
 
+  FailureOr<Value> materializeUnalignedStoreBase(
+      VMIStoreOp op, Value destination, Value offset,
+      VMIVRegType valueVMIType, OneToNPatternRewriter &rewriter) const {
+    Value storeBase = materializeBufferPointer(
+        destination, valueVMIType.getElementType(),
+        getMemorySpace(destination.getType()), rewriter, op.getLoc());
+    if (!storeBase) {
+      return rewriter.notifyMatchFailure(
+          op, "continuous unaligned store requires a ptr-compatible destination");
+    }
+    return rewriter
+        .create<AddPtrOp>(op.getLoc(), storeBase.getType(), storeBase, offset)
+        .getResult();
+  }
+
   LogicalResult lowerContiguousStoreParts(
       VMIStoreOp op, Value destination, Value offset, ValueRange storeParts,
       VMIVRegType valueVMIType, int64_t lanesPerPart, bool fullPhysicalChunks,
@@ -10576,17 +10591,11 @@ private:
           fullPhysicalChunks, rewriter);
     }
 
-    Value storeBase = materializeBufferPointer(
-        destination, valueVMIType.getElementType(),
-        getMemorySpace(destination.getType()), rewriter, op.getLoc());
-    if (!storeBase) {
-      return rewriter.notifyMatchFailure(
-          op, "continuous unaligned store requires a ptr-compatible destination");
+    FailureOr<Value> storeBase = materializeUnalignedStoreBase(
+        op, destination, offset, valueVMIType, rewriter);
+    if (failed(storeBase)) {
+      return failure();
     }
-    storeBase = rewriter
-                    .create<AddPtrOp>(op.getLoc(), storeBase.getType(),
-                                      storeBase, offset)
-                    .getResult();
     SmallVector<int64_t> advances;
     FailureOr<SmallVector<Value>> values = collectUnalignedStoreValues(
         op, storeParts, valueVMIType, lanesPerPart, fullPhysicalChunks, advances,
@@ -10594,7 +10603,7 @@ private:
     if (failed(values)) {
       return failure();
     }
-    if (failed(emitStatefulStoreStream(op, storeBase, *values, advances,
+    if (failed(emitStatefulStoreStream(op, *storeBase, *values, advances,
                                        rewriter))) {
       return failure();
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10674,6 +10674,62 @@ struct OneToNVMIExpandLoadOpPattern
   using OneToNOpConversionPattern<VMIExpandLoadOp>::OneToNOpConversionPattern;
 
 private:
+  LogicalResult lowerRuntimeExpandLoad(
+      VMIExpandLoadOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value offset, ValueRange maskParts, ValueRange passthruParts,
+      ArrayRef<Type> resultTypes) const {
+    bool invalidRuntimeArity = resultTypes.size() != 1 || maskParts.size() != 1 ||
+                               passthruParts.size() != 1;
+    if (invalidRuntimeArity) {
+      return rewriter.notifyMatchFailure(
+          op, "runtime expand_load supports only one physical chunk");
+    }
+    auto resultType = dyn_cast<VRegType>(resultTypes.front());
+    auto maskType = dyn_cast<MaskType>(maskParts.front().getType());
+    bool invalidRuntimeTypes =
+        !resultType || !maskType || passthruParts.front().getType() != resultType;
+    if (invalidRuntimeTypes) {
+      return rewriter.notifyMatchFailure(
+          op, "runtime expand_load requires physical result/passthru/mask");
+    }
+    if (!isa<PtrType>(source.getType())) {
+      return rewriter.notifyMatchFailure(op, "runtime expand_load requires ptr");
+    }
+    Value gatherBase = rewriter
+                           .create<AddPtrOp>(op.getLoc(), source.getType(), source,
+                                             offset)
+                           .getResult();
+    auto indexType = VRegType::get(rewriter.getContext(),
+                                   resultType.getElementCount(),
+                                   rewriter.getI32Type());
+    FailureOr<Value> indexSeedMask =
+        createAllTrueMaskForVReg(op.getLoc(), indexType, rewriter);
+    if (failed(indexSeedMask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to create runtime expand_load index seed mask");
+    }
+    Value zero = rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0, 32);
+    Value carrier = rewriter
+                        .create<VdupOp>(op.getLoc(), indexType, zero,
+                                       *indexSeedMask, /*position=*/nullptr)
+                        .getResult();
+    Value indices = rewriter
+                        .create<VusqzOp>(op.getLoc(), indexType, carrier,
+                                        maskParts.front())
+                        .getResult();
+    Value gathered = rewriter
+                         .create<Vgather2BcOp>(op.getLoc(), resultType, gatherBase,
+                                               indices, maskParts.front())
+                         .getResult();
+    Value result = rewriter
+                       .create<VselOp>(op.getLoc(), resultType, gathered,
+                                       passthruParts.front(), maskParts.front())
+                       .getResult();
+    replaceOpWithFlatConvertedValues(rewriter, op, SmallVector<Value>{result},
+                                     *this->getTypeConverter());
+    return success();
+  }
+
   LogicalResult lowerStaticExpandLoad(
       VMIExpandLoadOp op, OneToNPatternRewriter &rewriter, Value source,
       Value offset, VMIVRegType resultVMIType, ArrayRef<Type> resultTypes) const {
@@ -10730,64 +10786,9 @@ public:
                                    resultVMIType, resultTypes);
     }
 
-    ValueRange maskParts = adaptor.getMask();
-    ValueRange passthruParts = adaptor.getPassthru();
-    bool invalidRuntimeArity = resultTypes.size() != 1 || maskParts.size() != 1 ||
-                               passthruParts.size() != 1;
-    if (invalidRuntimeArity) {
-      return rewriter.notifyMatchFailure(
-          op, "runtime expand_load supports only one physical chunk");
-    }
-
-    auto resultType = dyn_cast<VRegType>(resultTypes.front());
-    auto maskType = dyn_cast<MaskType>(maskParts.front().getType());
-    bool invalidRuntimeTypes =
-        !resultType || !maskType || passthruParts.front().getType() != resultType;
-    if (invalidRuntimeTypes) {
-      return rewriter.notifyMatchFailure(
-          op, "runtime expand_load requires physical result/passthru/mask");
-    }
-
-    auto baseType = dyn_cast<PtrType>((*source).getType());
-    if (!baseType) {
-      return rewriter.notifyMatchFailure(op,
-                                         "runtime expand_load requires ptr");
-    }
-    Value gatherBase = rewriter
-                           .create<AddPtrOp>(op.getLoc(), (*source).getType(),
-                                             *source, *offset)
-                           .getResult();
-    auto indexType =
-        VRegType::get(rewriter.getContext(), resultType.getElementCount(),
-                      rewriter.getI32Type());
-    FailureOr<Value> indexSeedMask =
-        createAllTrueMaskForVReg(op.getLoc(), indexType, rewriter);
-    if (failed(indexSeedMask)) {
-      return rewriter.notifyMatchFailure(
-          op, "failed to create runtime expand_load index seed mask");
-    }
-    Value zero = rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0, 32);
-    Value carrier =
-        rewriter
-            .create<VdupOp>(op.getLoc(), indexType, zero, *indexSeedMask,
-                            /*position=*/nullptr)
-            .getResult();
-    Value indices =
-        rewriter
-            .create<VusqzOp>(op.getLoc(), indexType, carrier, maskParts.front())
-            .getResult();
-    Value gathered =
-        rewriter
-            .create<Vgather2BcOp>(op.getLoc(), resultType, gatherBase, indices,
-                                  maskParts.front())
-            .getResult();
-    Value result = rewriter
-                       .create<VselOp>(op.getLoc(), resultType, gathered,
-                                       passthruParts.front(), maskParts.front())
-                       .getResult();
-    replaceOpWithFlatConvertedValues(rewriter, op, SmallVector<Value>{*result},
-                                     *this->getTypeConverter());
-    return success();
+    return lowerRuntimeExpandLoad(op, rewriter, *source, *offset,
+                                  adaptor.getMask(), adaptor.getPassthru(),
+                                  resultTypes);
   }
 };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -1940,6 +1940,33 @@ LogicalResult checkSupportedBlockDeinterleavedGroupLoadShape(
 }
 
 LogicalResult
+checkSupportedContiguousGroupLoadShape(VMIGroupLoadOp op,
+                                       VMIVRegType resultType,
+                                       int64_t groupSize, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+
+  VMILayoutSupport supports;
+  if (failed(supports.getGroupLoadLayoutFact(op, reason))) {
+    return failure();
+  }
+  if (failed(checkSupportedLoadShape(resultType, op.getSource(),
+                                     op.getSource().getType(), std::nullopt,
+                                     reason))) {
+    return failure();
+  }
+  std::optional<int64_t> rowStride = getConstantIndexValue(op.getRowStride());
+  if (rowStride && *rowStride == groupSize) {
+    return success();
+  }
+  return checkSupportedGroupChunkShape(resultType, groupSize, reason);
+}
+
+LogicalResult
 checkSupportedGroupLoadShape(VMIGroupLoadOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
@@ -1950,25 +1977,18 @@ checkSupportedGroupLoadShape(VMIGroupLoadOp op, std::string *reason) {
 
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!resultLayout)
+  if (!resultLayout) {
     return fail("requires assigned result layout");
+  }
   FailureOr<int64_t> groupSize = getGroupSizeFromNumGroups(
       resultType, op.getNumGroupsAttr().getInt(), reason);
-  if (failed(groupSize))
+  if (failed(groupSize)) {
     return failure();
+  }
 
   if (resultLayout.isContiguous()) {
-    VMILayoutSupport supports;
-    if (failed(supports.getGroupLoadLayoutFact(op, reason)))
-      return failure();
-    if (failed(checkSupportedLoadShape(resultType, op.getSource(),
-                                       op.getSource().getType(), std::nullopt,
-                                       reason)))
-      return failure();
-    std::optional<int64_t> rowStride = getConstantIndexValue(op.getRowStride());
-    if (rowStride && *rowStride == *groupSize)
-      return success();
-    return checkSupportedGroupChunkShape(resultType, *groupSize, reason);
+    return checkSupportedContiguousGroupLoadShape(op, resultType, *groupSize,
+                                                  reason);
   }
 
   if (resultLayout.isBlockDeinterleaved() &&
@@ -2031,8 +2051,10 @@ LogicalResult checkSupportedSlots1GroupSlotLoadShape(
 
   unsigned elementBits =
       pto::getPTOStorageElemBitWidth(resultType.getElementType());
-  if (elementBits == 0 || 256 % elementBits != 0)
+  bool unsupportedElementWidth = elementBits == 0 || 256 % elementBits != 0;
+  if (unsupportedElementWidth) {
     return fail("slots=1 group_slot_load requires supported element width");
+  }
   int64_t alignedStrideElems = 256 / elementBits;
   std::optional<int64_t> sourceGroupStride =
       getConstantIndexValue(op.getSourceGroupStride());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8454,6 +8454,26 @@ private:
     return success();
   }
 
+  LogicalResult lowerByLayout(
+      VMIMaskedStoreOp op, OneToNPatternRewriter &rewriter,
+      ValueRange valueParts, ValueRange maskParts, VMIVRegType valueVMIType,
+      VMIMaskType maskVMIType, Value destination, Value offset,
+      int64_t lanesPerPart) const {
+    std::optional<std::string> dist =
+        getDenseLaneStrideStoreDistToken(valueVMIType);
+    if (dist) {
+      std::optional<StringRef> maskGranularity =
+          getDenseLaneStrideMaskedStoreMaskGranularity(valueVMIType);
+      if (maskGranularity) {
+        return lowerLaneStride(op, rewriter, valueParts, maskParts,
+                               valueVMIType, maskVMIType, destination, offset,
+                               *dist, *maskGranularity);
+      }
+    }
+    return lowerContiguous(op, rewriter, valueParts, maskParts, valueVMIType,
+                           maskVMIType, destination, offset, lanesPerPart);
+  }
+
   std::optional<LogicalResult> lowerDirectDeinterleaved(
       VMILoadOp op, OneToNPatternRewriter &rewriter, Value source, Value offset,
       VMIVRegType resultVMIType, VMILayoutAttr resultLayout,
@@ -11712,19 +11732,8 @@ public:
     }
 
     auto maskVMIType = cast<VMIMaskType>(op.getMask().getType());
-    if (std::optional<std::string> dist =
-            getDenseLaneStrideStoreDistToken(valueVMIType)) {
-      std::optional<StringRef> maskGranularity =
-          getDenseLaneStrideMaskedStoreMaskGranularity(valueVMIType);
-      if (maskGranularity) {
-        return lowerLaneStride(op, rewriter, valueParts, maskParts,
-                               valueVMIType, maskVMIType, *destination, *offset,
-                               *dist, *maskGranularity);
-      }
-    }
-
-    return lowerContiguous(op, rewriter, valueParts, maskParts, valueVMIType,
-                           maskVMIType, *destination, *offset, *lanesPerPart);
+    return lowerByLayout(op, rewriter, valueParts, maskParts, valueVMIType,
+                         maskVMIType, *destination, *offset, *lanesPerPart);
   }
 };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -13229,6 +13229,44 @@ private:
     return success();
   }
 
+  FailureOr<Value> buildTwoBlockGroupResult(
+      OpTy op, ValueRange sourceParts, ValueRange maskParts,
+      TypeRange resultTypes, int64_t resultIndex, int64_t resultPartCount,
+      int64_t numGroups, VRegType resultType, MaskType maskType,
+      OneToNPatternRewriter &rewriter) const {
+    Value loSource = sourceParts[resultIndex];
+    Value hiSource = sourceParts[resultPartCount + resultIndex];
+    Value loMask = maskParts[resultIndex];
+    Value hiMask = maskParts[resultPartCount + resultIndex];
+    bool mismatchedTypes = resultTypes[resultIndex] != resultType ||
+                           loSource.getType() != resultType ||
+                           hiSource.getType() != resultType ||
+                           loMask.getType() != maskType ||
+                           hiMask.getType() != maskType;
+    if (mismatchedTypes) {
+      return rewriter.notifyMatchFailure(
+          op, "two-block group_reduce requires uniform physical types");
+    }
+    int64_t activeGroups = std::min<int64_t>(8, numGroups - resultIndex * 8);
+    FailureOr<Value> combineMask = createPrefixMaskForActiveLanes(
+        op.getLoc(), maskType, activeGroups, rewriter);
+    if (failed(combineMask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to create two-block group_reduce combine mask");
+    }
+    Value lo = rewriter
+                   .create<GroupReduceOpTy>(op.getLoc(), resultType, loSource,
+                                            loMask)
+                   .getResult();
+    Value hi = rewriter
+                   .create<GroupReduceOpTy>(op.getLoc(), resultType, hiSource,
+                                            hiMask)
+                   .getResult();
+    return rewriter
+        .create<CombineOpTy>(op.getLoc(), resultType, lo, hi, *combineMask)
+        .getResult();
+  }
+
   LogicalResult lowerTwoBlock(
       OpTy op, ValueRange sourceParts, ValueRange maskParts,
       TypeRange resultTypes, int64_t numGroups,
@@ -13252,38 +13290,13 @@ private:
     results.reserve(resultPartCount);
     for (int64_t resultIndex = 0; resultIndex < resultPartCount;
          ++resultIndex) {
-      Value loSource = sourceParts[resultIndex];
-      Value hiSource = sourceParts[resultPartCount + resultIndex];
-      Value loMask = maskParts[resultIndex];
-      Value hiMask = maskParts[resultPartCount + resultIndex];
-      bool mismatchedTypes = resultTypes[resultIndex] != resultType ||
-                             loSource.getType() != resultType ||
-                             hiSource.getType() != resultType ||
-                             loMask.getType() != maskType ||
-                             hiMask.getType() != maskType;
-      if (mismatchedTypes) {
-        return rewriter.notifyMatchFailure(
-            op, "two-block group_reduce requires uniform physical types");
+      FailureOr<Value> result = buildTwoBlockGroupResult(
+          op, sourceParts, maskParts, resultTypes, resultIndex, resultPartCount,
+          numGroups, *resultType, *maskType, rewriter);
+      if (failed(result)) {
+        return failure();
       }
-      int64_t activeGroups = std::min<int64_t>(8, numGroups - resultIndex * 8);
-      FailureOr<Value> combineMask = createPrefixMaskForActiveLanes(
-          op.getLoc(), maskType, activeGroups, rewriter);
-      if (failed(combineMask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to create two-block group_reduce combine mask");
-      }
-      Value lo = rewriter
-                     .create<GroupReduceOpTy>(op.getLoc(), resultType, loSource,
-                                              loMask)
-                     .getResult();
-      Value hi = rewriter
-                     .create<GroupReduceOpTy>(op.getLoc(), resultType, hiSource,
-                                              hiMask)
-                     .getResult();
-      results.push_back(rewriter
-                            .create<CombineOpTy>(op.getLoc(), resultType, lo,
-                                                 hi, *combineMask)
-                            .getResult());
+      results.push_back(*result);
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6939,19 +6939,31 @@ FailureOr<Value> createIotaChunkBase(Location loc, Value base,
   return failure();
 }
 
-FailureOr<Value> createIotaContiguousChunk(Location loc, Type resultType,
-                                           Value base, int64_t laneOffset,
-                                           StringAttr orderAttr,
-                                           PatternRewriter &rewriter) {
+struct IotaMaterializationContext {
+  Location loc;
+  Value base;
+  StringAttr orderAttr;
+  PatternRewriter &rewriter;
+};
+
+static StringRef getIotaOrder(const IotaMaterializationContext &context) {
+  return context.orderAttr ? context.orderAttr.getValue() : StringRef("ASC");
+}
+
+FailureOr<Value> createIotaContiguousChunk(
+    const IotaMaterializationContext &context, Type resultType,
+    int64_t laneOffset) {
   // Contiguous iota is a direct VCI of the absolute chunk base (ASC
   // `vci(offset_sreg)`). Group-periodic VL128 {group=2} shares one such VL64
   // result across both physical parts (see sharedChunks below).
-  StringRef order = orderAttr ? orderAttr.getValue() : StringRef("ASC");
+  StringRef order = getIotaOrder(context);
   FailureOr<Value> chunkBase =
-      createIotaChunkBase(loc, base, laneOffset, order, rewriter);
+      createIotaChunkBase(context.loc, context.base, laneOffset, order,
+                          context.rewriter);
   if (failed(chunkBase))
     return failure();
-  return rewriter.create<VciOp>(loc, resultType, *chunkBase, orderAttr)
+  return context.rewriter
+      .create<VciOp>(context.loc, resultType, *chunkBase, context.orderAttr)
       .getResult();
 }
 
@@ -7064,9 +7076,11 @@ FailureOr<Value> createResidualSubVLGroupPeriodicChunk(
 }
 
 static FailureOr<std::optional<Value>> createSubVLPeriodicFastPath(
-    Location loc, Type resultType, Value base, int64_t groupSize,
-    StringAttr orderAttr, StringRef order, Value allMask,
-    PatternRewriter &rewriter) {
+    const IotaMaterializationContext &context, Type resultType,
+    int64_t groupSize, StringRef order, Value allMask) {
+  Location loc = context.loc;
+  Value base = context.base;
+  PatternRewriter &rewriter = context.rewriter;
   if (groupSize == 1) {
     return std::optional<Value>(
         rewriter
@@ -7081,8 +7095,8 @@ static FailureOr<std::optional<Value>> createSubVLPeriodicFastPath(
   }
   int64_t groupsPerChunk = vregType.getElementCount() / groupSize;
   if (groupsPerChunk == 1) {
-    FailureOr<Value> result = createIotaContiguousChunk(
-        loc, resultType, base, /*laneOffset=*/0, orderAttr, rewriter);
+    FailureOr<Value> result =
+        createIotaContiguousChunk(context, resultType, /*laneOffset=*/0);
     if (failed(result)) {
       return failure();
     }
@@ -7101,6 +7115,7 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
                                                Value base, int64_t groupSize,
                                                StringAttr orderAttr,
                                                PatternRewriter &rewriter) {
+  IotaMaterializationContext context{loc, base, orderAttr, rewriter};
   auto vregType = dyn_cast<VRegType>(resultType);
   if (!vregType) {
     return failure();
@@ -7119,7 +7134,7 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
 
   StringRef order = orderAttr ? orderAttr.getValue() : StringRef("ASC");
   FailureOr<std::optional<Value>> fastPath = createSubVLPeriodicFastPath(
-      loc, resultType, base, groupSize, orderAttr, order, *allMask, rewriter);
+      context, resultType, groupSize, order, *allMask);
   if (failed(fastPath)) {
     return failure();
   }
@@ -7129,8 +7144,7 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
 
   int64_t groupsPerChunk = lanesPerPart / groupSize;
   FailureOr<Value> full =
-      createIotaContiguousChunk(loc, resultType, base, /*laneOffset=*/0,
-                                orderAttr, rewriter);
+      createIotaContiguousChunk(context, resultType, /*laneOffset=*/0);
   FailureOr<MaskType> maskType =
       getMaskTypeForVReg(vregType, rewriter.getContext());
   FailureOr<Value> zeroScalar =
@@ -7146,12 +7160,13 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
       groupSize, groupsPerChunk, rewriter);
 }
 
-FailureOr<Value> createIotaDeinterleavedChunk(Location loc, Type resultType,
-                                              Value base, int64_t factor,
-                                              int64_t part, int64_t chunk,
-                                              int64_t lanesPerPart,
-                                              StringAttr orderAttr,
-                                              PatternRewriter &rewriter) {
+FailureOr<Value> createIotaDeinterleavedChunk(
+    const IotaMaterializationContext &context, Type resultType, int64_t factor,
+    int64_t part, int64_t chunk, int64_t lanesPerPart) {
+  Location loc = context.loc;
+  Value base = context.base;
+  StringAttr orderAttr = context.orderAttr;
+  PatternRewriter &rewriter = context.rewriter;
   auto vregType = dyn_cast<VRegType>(resultType);
   if (!vregType)
     return failure();
@@ -7241,15 +7256,15 @@ private:
       auto key = std::make_pair(resultType, laneOffset);
       auto it = sharedChunks.find(key);
       if (it == sharedChunks.end()) {
+        IotaMaterializationContext context{op.getLoc(), base,
+                                          op.getOrderAttr(), rewriter};
         FailureOr<Value> result;
         if (physMultipleOfGroupSize && groupSize < lanesPerPart) {
           result = createSubVLGroupPeriodicChunk(
               op.getLoc(), resultType, base, groupSize, op.getOrderAttr(),
               rewriter);
         } else {
-          result = createIotaContiguousChunk(
-              op.getLoc(), resultType, base, laneOffset, op.getOrderAttr(),
-              rewriter);
+          result = createIotaContiguousChunk(context, resultType, laneOffset);
         }
         if (failed(result)) {
           return rewriter.notifyMatchFailure(
@@ -7270,9 +7285,9 @@ private:
         return rewriter.notifyMatchFailure(op, "iota result must be vreg");
       }
       FailureOr<Value> result = createIotaContiguousChunk(
-          op.getLoc(), resultType, base,
-          static_cast<int64_t>(index) * lanesPerPart, op.getOrderAttr(),
-          rewriter);
+          IotaMaterializationContext{op.getLoc(), base, op.getOrderAttr(),
+                                     rewriter},
+          resultType, static_cast<int64_t>(index) * lanesPerPart);
       if (failed(result)) {
         return rewriter.notifyMatchFailure(
             op, "failed to materialize contiguous iota chunk");
@@ -7298,8 +7313,9 @@ private:
       for (int64_t chunk = 0; chunk < chunksPerPart; ++chunk) {
         Type resultType = resultTypes[part * chunksPerPart + chunk];
         FailureOr<Value> result = createIotaDeinterleavedChunk(
-            op.getLoc(), resultType, base, factor, part, chunk, lanesPerPart,
-            op.getOrderAttr(), rewriter);
+            IotaMaterializationContext{op.getLoc(), base, op.getOrderAttr(),
+                                       rewriter},
+            resultType, factor, part, chunk, lanesPerPart);
         if (failed(result)) {
           return rewriter.notifyMatchFailure(
               op, "failed to materialize deinterleaved iota chunk");

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2932,6 +2932,65 @@ checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
       op, resultType, passthruType, maskType, allActivePathReason, reason);
 }
 
+static LogicalResult checkMaskedStoreFullChunks(VMIVRegType valueType,
+                                                VMIMaskType maskType,
+                                                std::string &valueReason,
+                                                std::string &maskReason) {
+  return succeeded(checkFullDataPhysicalChunks(valueType, &valueReason)) &&
+                 succeeded(checkFullVMIPhysicalChunks(maskType, &maskReason))
+             ? success()
+             : failure();
+}
+
+static LogicalResult checkMaskedStoreLayoutAndArity(
+    VMIVRegType valueType, VMIMaskType maskType, std::string &valueReason,
+    std::string &maskReason, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  VMILayoutAttr valueLayout = valueType.getLayoutAttr();
+  VMILayoutAttr maskLayout = maskType.getLayoutAttr();
+  if (!valueLayout || !maskLayout) {
+    return fail("requires assigned value and mask layouts");
+  }
+  FailureOr<int64_t> valueArity = getVMIPhysicalArity(valueType);
+  FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
+  bool mismatchedArity = failed(valueArity) || failed(maskArity) ||
+                         *valueArity != *maskArity;
+  if (mismatchedArity) {
+    return fail("requires matching value/mask physical arity");
+  }
+  if (valueLayout.hasDenseLaneStride()) {
+    VMILayoutSupport supports;
+    if (succeeded(supports.getMaskedStoreLayoutFact(valueType, maskType,
+                                                    reason))) {
+      return success();
+    }
+  }
+  std::string valueMaterializationReason;
+  FailureOr<int64_t> valueParts = getContiguousMaterializationPartCount(
+      valueType, &valueMaterializationReason);
+  if (failed(valueParts)) {
+    return fail(Twine("value cannot materialize to contiguous; value ") +
+                valueReason + ", materialization " +
+                valueMaterializationReason);
+  }
+  std::string maskMaterializationReason;
+  FailureOr<int64_t> maskParts = getContiguousMaterializationPartCount(
+      maskType, &maskMaterializationReason);
+  if (failed(maskParts)) {
+    return fail(Twine("mask cannot materialize to contiguous; mask ") +
+                maskReason + ", materialization " + maskMaterializationReason);
+  }
+  if (*valueParts != *maskParts) {
+    return fail("requires value/mask contiguous materialization arity to match");
+  }
+  return success();
+}
+
 LogicalResult
 checkSupportedMaskedStoreShape(VMIVRegType valueType, VMIMaskType maskType,
                                Value destination, Type destinationType,
@@ -2940,58 +2999,21 @@ checkSupportedMaskedStoreShape(VMIVRegType valueType, VMIMaskType maskType,
       buildWriteAccessPlan(destination, destinationType, valueType,
                            VMIMemoryCoverageKind::Predicate);
   if (!accessPlan.layoutSupport.isSupported()) {
-    if (reason)
+    if (reason) {
       *reason = accessPlan.layoutSupport.reason;
+    }
     return failure();
   }
 
   std::string valueReason;
   std::string maskReason;
-  if (succeeded(checkFullDataPhysicalChunks(valueType, &valueReason)) &&
-      succeeded(checkFullVMIPhysicalChunks(maskType, &maskReason)))
+  if (succeeded(checkMaskedStoreFullChunks(valueType, maskType, valueReason,
+                                            maskReason))) {
     return success();
-
-  auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
-      *reason = message.str();
-    return failure();
-  };
-
-  VMILayoutAttr valueLayout = valueType.getLayoutAttr();
-  VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  if (!valueLayout || !maskLayout)
-    return fail("requires assigned value and mask layouts");
-
-  FailureOr<int64_t> valueArity = getVMIPhysicalArity(valueType);
-  FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
-  if (failed(valueArity) || failed(maskArity) || *valueArity != *maskArity)
-    return fail("requires matching value/mask physical arity");
-
-  if (valueLayout.hasDenseLaneStride()) {
-    VMILayoutSupport supports;
-    if (succeeded(
-            supports.getMaskedStoreLayoutFact(valueType, maskType, reason)))
-      return success();
   }
 
-  std::string valueMaterializationReason;
-  FailureOr<int64_t> valueParts = getContiguousMaterializationPartCount(
-      valueType, &valueMaterializationReason);
-  if (failed(valueParts))
-    return fail(Twine("value cannot materialize to contiguous; value ") +
-                valueReason + ", materialization " +
-                valueMaterializationReason);
-
-  std::string maskMaterializationReason;
-  FailureOr<int64_t> maskParts = getContiguousMaterializationPartCount(
-      maskType, &maskMaterializationReason);
-  if (failed(maskParts))
-    return fail(Twine("mask cannot materialize to contiguous; mask ") +
-                maskReason + ", materialization " + maskMaterializationReason);
-  if (*valueParts != *maskParts)
-    return fail(
-        "requires value/mask contiguous materialization arity to match");
-  return success();
+  return checkMaskedStoreLayoutAndArity(valueType, maskType, valueReason,
+                                        maskReason, reason);
 }
 
 FailureOr<int64_t> getContiguousActiveDataLanes(VMIVRegType vmiType,
@@ -3188,8 +3210,9 @@ static FailureOr<int64_t> computeShuffleForwardingSourceChunk(
 FailureOr<SmallVector<int64_t>>
 computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> FailureOr<SmallVector<int64_t>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7176,8 +7176,9 @@ FailureOr<Value> createIotaContiguousChunk(
   FailureOr<Value> chunkBase =
       createIotaChunkBase(context.loc, context.base, laneOffset, order,
                           context.rewriter);
-  if (failed(chunkBase))
+  if (failed(chunkBase)) {
     return failure();
+  }
   return context.rewriter
       .create<VciOp>(context.loc, resultType, *chunkBase, context.orderAttr)
       .getResult();
@@ -7385,16 +7386,19 @@ FailureOr<Value> createIotaDeinterleavedChunk(
   StringAttr orderAttr = context.orderAttr;
   PatternRewriter &rewriter = context.rewriter;
   auto vregType = dyn_cast<VRegType>(resultType);
-  if (!vregType)
+  if (!vregType) {
     return failure();
+  }
 
   FailureOr<Value> mask = createAllTrueMaskForVReg(loc, vregType, rewriter);
   FailureOr<Value> zero =
       createScalarOffsetConstant(loc, base.getType(), 0, rewriter);
   FailureOr<Value> factorScalar =
       createScalarOffsetConstant(loc, base.getType(), factor, rewriter);
-  if (failed(mask) || failed(zero) || failed(factorScalar))
+  bool failedIotaInputs = failed(mask) || failed(zero) || failed(factorScalar);
+  if (failedIotaInputs) {
     return failure();
+  }
 
   Value local =
       rewriter.create<VciOp>(loc, resultType, *zero, StringAttr{}).getResult();
@@ -7406,8 +7410,9 @@ FailureOr<Value> createIotaDeinterleavedChunk(
   int64_t partOffset = part + factor * chunk * lanesPerPart;
   FailureOr<Value> biasedBase =
       createIotaChunkBase(loc, base, partOffset, order, rewriter);
-  if (failed(biasedBase))
+  if (failed(biasedBase)) {
     return failure();
+  }
 
   if (order == "DESC") {
     Value baseVector = rewriter
@@ -7623,12 +7628,14 @@ struct OneToNVMIConstantOpPattern : OneToNOpConversionPattern<VMIConstantOp> {
   matchAndRewrite(VMIConstantOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
     auto denseAttr = dyn_cast<DenseElementsAttr>(op.getValue());
-    if (!denseAttr || !denseAttr.isSplat())
+    if (!denseAttr || !denseAttr.isSplat()) {
       return rewriter.notifyMatchFailure(
           op, "only splat dense data constants are supported");
+    }
     auto splatAttr = dyn_cast<TypedAttr>(denseAttr.getSplatValue<Attribute>());
-    if (!splatAttr)
+    if (!splatAttr) {
       return rewriter.notifyMatchFailure(op, "splat constant must be typed");
+    }
 
     // arith.constant only accepts signless integer types, whereas VMI vregs may
     // carry signed/unsigned element types (e.g. ui16). Remap an unsigned/signed
@@ -7653,13 +7660,15 @@ struct OneToNVMIConstantOpPattern : OneToNOpConversionPattern<VMIConstantOp> {
     results.reserve(resultTypes.size());
     for (Type resultType : resultTypes) {
       auto vregType = dyn_cast<VRegType>(resultType);
-      if (!vregType)
+      if (!vregType) {
         return rewriter.notifyMatchFailure(op, "constant result must be vreg");
+      }
       FailureOr<Value> mask =
           createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
-      if (failed(mask))
+      if (failed(mask)) {
         return rewriter.notifyMatchFailure(
             op, "unsupported element type for constant mask");
+      }
       results.push_back(rewriter
                             .create<VdupOp>(op.getLoc(), resultType, scalar,
                                             *mask,
@@ -7689,25 +7698,30 @@ struct OneToNVMIConstantMaskOpPattern
     std::string reason;
     FailureOr<SmallVector<ConstantMaskChunkMaterialization>> materializations =
         computeConstantMaskMaterialization(op, &reason);
-    if (failed(materializations))
+    if (failed(materializations)) {
       return rewriter.notifyMatchFailure(op, Twine("constant_mask ") + reason);
+    }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (const ConstantMaskChunkMaterialization &materialization :
          *materializations) {
-      if (results.size() >= resultTypes.size())
+      bool tooManyMasks = results.size() >= resultTypes.size();
+      if (tooManyMasks) {
         return rewriter.notifyMatchFailure(
             op, "constant_mask produced too many physical masks");
+      }
       auto maskType = dyn_cast<MaskType>(resultTypes[results.size()]);
-      if (!maskType)
+      if (!maskType) {
         return rewriter.notifyMatchFailure(op,
                                            "constant_mask result must be mask");
+      }
       FailureOr<Value> mask = materializeConstantMaskChunk(
           op.getLoc(), maskType, materialization.activeLanes, rewriter);
-      if (failed(mask))
+      if (failed(mask)) {
         return rewriter.notifyMatchFailure(
             op, "failed to materialize constant_mask physical chunk");
+      }
       results.push_back(*mask);
     }
 
@@ -9978,22 +9992,27 @@ public:
 
     ValueRange maskParts = adaptor.getMask();
     ValueRange passthruParts = adaptor.getPassthru();
-    if (resultTypes.size() != 1 || maskParts.size() != 1 ||
-        passthruParts.size() != 1)
+    bool invalidRuntimeArity = resultTypes.size() != 1 || maskParts.size() != 1 ||
+                               passthruParts.size() != 1;
+    if (invalidRuntimeArity) {
       return rewriter.notifyMatchFailure(
           op, "runtime expand_load supports only one physical chunk");
+    }
 
     auto resultType = dyn_cast<VRegType>(resultTypes.front());
     auto maskType = dyn_cast<MaskType>(maskParts.front().getType());
-    if (!resultType || !maskType ||
-        passthruParts.front().getType() != resultType)
+    bool invalidRuntimeTypes =
+        !resultType || !maskType || passthruParts.front().getType() != resultType;
+    if (invalidRuntimeTypes) {
       return rewriter.notifyMatchFailure(
           op, "runtime expand_load requires physical result/passthru/mask");
+    }
 
     auto baseType = dyn_cast<PtrType>((*source).getType());
-    if (!baseType)
+    if (!baseType) {
       return rewriter.notifyMatchFailure(op,
                                          "runtime expand_load requires ptr");
+    }
     Value gatherBase = rewriter
                            .create<AddPtrOp>(op.getLoc(), (*source).getType(),
                                              *source, *offset)
@@ -10003,9 +10022,10 @@ public:
                       rewriter.getI32Type());
     FailureOr<Value> indexSeedMask =
         createAllTrueMaskForVReg(op.getLoc(), indexType, rewriter);
-    if (failed(indexSeedMask))
+    if (failed(indexSeedMask)) {
       return rewriter.notifyMatchFailure(
           op, "failed to create runtime expand_load index seed mask");
+    }
     Value zero = rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0, 32);
     Value carrier =
         rewriter

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5117,6 +5117,38 @@ FailureOr<std::optional<SmallVector<Value>>> materializeDataLaneStrideConversion
   return std::nullopt;
 }
 
+static FailureOr<SmallVector<Value>> materializeDeinterleaved4Group(
+    Operation *op, ArrayRef<Value> groupParts, TypeRange resultTypes,
+    PatternRewriter &rewriter, size_t resultStart) {
+  Type chunkType = groupParts.front().getType();
+  bool mismatchedSources = llvm::any_of(
+      groupParts, [chunkType](Value part) { return part.getType() != chunkType; });
+  if (mismatchedSources) {
+    return rewriter.notifyMatchFailure(
+        op, "vintlv deinterleaved=4 requires matching source part types");
+  }
+  size_t resultEnd = std::min(resultTypes.size(), resultStart + 4);
+  for (size_t resultIndex = resultStart; resultIndex < resultEnd;
+       ++resultIndex) {
+    if (resultTypes[resultIndex] != chunkType) {
+      return rewriter.notifyMatchFailure(
+          op, "vintlv requires operands and results to share one type");
+    }
+  }
+  auto even = rewriter.create<VintlvOp>(op->getLoc(), chunkType, chunkType,
+                                        groupParts[0], groupParts[2]);
+  auto odd = rewriter.create<VintlvOp>(op->getLoc(), chunkType, chunkType,
+                                       groupParts[1], groupParts[3]);
+  auto low = rewriter.create<VintlvOp>(
+      op->getLoc(), chunkType, chunkType, even.getLow(), odd.getLow());
+  auto high = rewriter.create<VintlvOp>(
+      op->getLoc(), chunkType, chunkType, even.getHigh(), odd.getHigh());
+  SmallVector<Value> results = {low.getLow(), low.getHigh(), high.getLow(),
+                                high.getHigh()};
+  results.resize(resultEnd - resultStart);
+  return results;
+}
+
 static FailureOr<SmallVector<Value>> materializeDeinterleaved4ToContiguous(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
     PatternRewriter &rewriter) {
@@ -5150,39 +5182,14 @@ static FailureOr<SmallVector<Value>> materializeDeinterleaved4ToContiguous(
     Value p1 = getSourcePart(1, i);
     Value p2 = getSourcePart(2, i);
     Value p3 = getSourcePart(3, i);
-    Type chunkType = p0.getType();
-    bool mismatchedSources = p1.getType() != chunkType ||
-                             p2.getType() != chunkType ||
-                             p3.getType() != chunkType;
-    if (mismatchedSources) {
-      return rewriter.notifyMatchFailure(
-          op, "vintlv deinterleaved=4 requires matching source part types");
+    SmallVector<Value> groupParts = {p0, p1, p2, p3};
+    FailureOr<SmallVector<Value>> groupResults =
+        materializeDeinterleaved4Group(op, groupParts, resultTypes, rewriter,
+                                       results.size());
+    if (failed(groupResults)) {
+      return failure();
     }
-    for (size_t resultIndex = results.size();
-         resultIndex < resultTypes.size() && resultIndex < results.size() + 4;
-         ++resultIndex) {
-      if (resultTypes[resultIndex] != chunkType) {
-        return rewriter.notifyMatchFailure(
-            op, "vintlv requires operands and results to share one type");
-      }
-    }
-    auto even = rewriter.create<VintlvOp>(op->getLoc(), chunkType, chunkType,
-                                          p0, p2);
-    auto odd = rewriter.create<VintlvOp>(op->getLoc(), chunkType, chunkType,
-                                         p1, p3);
-    auto low = rewriter.create<VintlvOp>(
-        op->getLoc(), chunkType, chunkType, even.getLow(), odd.getLow());
-    auto high = rewriter.create<VintlvOp>(
-        op->getLoc(), chunkType, chunkType, even.getHigh(), odd.getHigh());
-    Value groupResults[] = {low.getLow(), low.getHigh(), high.getLow(),
-                            high.getHigh()};
-    for (Value result : groupResults) {
-      bool resultLimitReached = results.size() >= resultTypes.size();
-      if (resultLimitReached) {
-        break;
-      }
-      results.push_back(result);
-    }
+    llvm::append_range(results, *groupResults);
   }
   return results;
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -16771,34 +16771,13 @@ private:
     Value current = sourcePart;
     unsigned currentBits = sourceBits;
     while (currentBits < resultBits) {
-      unsigned nextBits = currentBits * 2;
-      auto nextElementType = IntegerType::get(
-          rewriter.getContext(), nextBits, resultIntegerType.getSignedness());
-      FailureOr<int64_t> nextLanes =
-          getDataLanesPerPart(nextElementType);
-      if (failed(nextLanes)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to derive dense group-slot unpack result lanes");
+      FailureOr<Value> next = extendDenseGroupSlotCarrier(
+          op, current, currentBits, resultIntegerType, rewriter);
+      if (failed(next)) {
+        return failure();
       }
-      auto nextType =
-          VRegType::get(rewriter.getContext(), *nextLanes, nextElementType);
-      bool unpackLaneMismatch =
-          cast<VRegType>(current.getType()).getElementCount() != *nextLanes * 2;
-      if (unpackLaneMismatch) {
-        return rewriter.notifyMatchFailure(
-            op, "dense group-slot unpack source/result lane mismatch");
-      }
-      Value part = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
-      if constexpr (std::is_same_v<OpT, VMIExtSIOp>) {
-        current = rewriter.create<VsunpackOp>(op.getLoc(), nextType, current,
-                                              part)
-                      .getResult();
-      } else {
-        current = rewriter.create<VzunpackOp>(op.getLoc(), nextType, current,
-                                              part)
-                      .getResult();
-      }
-      currentBits = nextBits;
+      current = *next;
+      currentBits *= 2;
     }
     FailureOr<Value> result =
         bitcastVReg(op.getLoc(), current, *physicalResultType, rewriter);
@@ -16807,6 +16786,36 @@ private:
           op, "failed to materialize dense group-slot unpack result");
     }
     return *result;
+  }
+
+  FailureOr<Value> extendDenseGroupSlotCarrier(
+      OpT op, Value current, unsigned currentBits,
+      IntegerType resultIntegerType,
+      OneToNPatternRewriter &rewriter) const {
+    unsigned nextBits = currentBits * 2;
+    auto nextElementType = IntegerType::get(
+        rewriter.getContext(), nextBits, resultIntegerType.getSignedness());
+    FailureOr<int64_t> nextLanes = getDataLanesPerPart(nextElementType);
+    if (failed(nextLanes)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to derive dense group-slot unpack result lanes");
+    }
+    auto nextType =
+        VRegType::get(rewriter.getContext(), *nextLanes, nextElementType);
+    auto currentType = dyn_cast<VRegType>(current.getType());
+    bool unpackLaneMismatch =
+        !currentType || currentType.getElementCount() != *nextLanes * 2;
+    if (unpackLaneMismatch) {
+      return rewriter.notifyMatchFailure(
+          op, "dense group-slot unpack source/result lane mismatch");
+    }
+    Value part = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
+    if constexpr (std::is_same_v<OpT, VMIExtSIOp>) {
+      return rewriter.create<VsunpackOp>(op.getLoc(), nextType, current, part)
+          .getResult();
+    }
+    return rewriter.create<VzunpackOp>(op.getLoc(), nextType, current, part)
+        .getResult();
   }
 
   LogicalResult lowerDenseGroupSlotExtension(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12732,6 +12732,30 @@ public:
 struct OneToNVMIVselrOpPattern : OneToNOpConversionPattern<VMIVselrOp> {
   using OneToNOpConversionPattern<VMIVselrOp>::OneToNOpConversionPattern;
 
+private:
+  FailureOr<Value> lowerPart(VMIVselrOp op, Value source, Value index,
+                             Type resultType,
+                             OneToNPatternRewriter &rewriter) const {
+    auto sourceType = dyn_cast<VRegType>(source.getType());
+    auto indexType = dyn_cast<VRegType>(index.getType());
+    auto resultVRegType = dyn_cast<VRegType>(resultType);
+    const bool invalidPart =
+        !sourceType || !indexType || !resultVRegType ||
+        sourceType != resultVRegType ||
+        sourceType.getElementCount() != indexType.getElementCount() ||
+        pto::getPTOStorageElemBitWidth(sourceType.getElementType()) !=
+            pto::getPTOStorageElemBitWidth(indexType.getElementType());
+    if (invalidPart) {
+      rewriter.notifyMatchFailure(
+          op, "vselr physical source/index/result type mismatch");
+      return failure();
+    }
+    return rewriter
+        .create<VselrOp>(op.getLoc(), resultVRegType, source, index)
+        .getResult();
+  }
+
+public:
   LogicalResult
   matchAndRewrite(VMIVselrOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
@@ -12739,32 +12763,25 @@ struct OneToNVMIVselrOpPattern : OneToNOpConversionPattern<VMIVselrOp> {
     ValueRange indexParts = adaptor.getIndex();
     FailureOr<SmallVector<Type>> maybeResultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybeResultTypes))
+    if (failed(maybeResultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
 
-    if (sourceParts.size() != 1 || indexParts.size() != 1 ||
-        resultTypes.size() != 1)
+    const bool invalidArity = sourceParts.size() != 1 ||
+                              indexParts.size() != 1 || resultTypes.size() != 1;
+    if (invalidArity) {
       return rewriter.notifyMatchFailure(
           op, "vselr supports only one physical source/index/result part");
+    }
 
-    Value source = sourceParts.front();
-    Value index = indexParts.front();
-    auto sourceType = dyn_cast<VRegType>(source.getType());
-    auto indexType = dyn_cast<VRegType>(index.getType());
-    auto resultType = dyn_cast<VRegType>(resultTypes.front());
-    if (!sourceType || !indexType || !resultType ||
-        sourceType != resultType ||
-        sourceType.getElementCount() != indexType.getElementCount() ||
-        pto::getPTOStorageElemBitWidth(sourceType.getElementType()) !=
-            pto::getPTOStorageElemBitWidth(indexType.getElementType()))
-      return rewriter.notifyMatchFailure(
-          op, "vselr physical source/index/result type mismatch");
-
-    Value result =
-        rewriter.create<VselrOp>(op.getLoc(), resultType, source, index)
-            .getResult();
-    replaceOpWithFlatConvertedValues(rewriter, op, result,
+    FailureOr<Value> result = lowerPart(op, sourceParts.front(),
+                                        indexParts.front(), resultTypes.front(),
+                                        rewriter);
+    if (failed(result)) {
+      return failure();
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, *result,
                                      *this->getTypeConverter());
     return success();
   }
@@ -12785,26 +12802,33 @@ struct OneToNVMIActivePrefixIndexOpPattern
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (maskParts.size() != 1 || resultTypes.size() != 1)
+    const bool invalidArity = maskParts.size() != 1 || resultTypes.size() != 1;
+    if (invalidArity) {
       return rewriter.notifyMatchFailure(
           op, "active_prefix_index supports only one physical part");
+    }
 
     auto resultType = dyn_cast<VRegType>(resultTypes.front());
     auto maskType = dyn_cast<MaskType>(maskParts.front().getType());
-    if (!resultType || !maskType)
+    const bool invalidPartTypes = !resultType || !maskType;
+    if (invalidPartTypes) {
       return rewriter.notifyMatchFailure(
           op, "active_prefix_index requires physical vreg/mask parts");
+    }
 
     auto intType = dyn_cast<IntegerType>(resultType.getElementType());
-    if (!intType || !intType.isSignless())
+    const bool invalidElementType = !intType || !intType.isSignless();
+    if (invalidElementType) {
       return rewriter.notifyMatchFailure(
           op, "active_prefix_index requires signless integer result part");
+    }
 
     FailureOr<Value> seedMask =
         createAllTrueMaskForVReg(op.getLoc(), resultType, rewriter);
-    if (failed(seedMask))
+    if (failed(seedMask)) {
       return rewriter.notifyMatchFailure(
           op, "unsupported element type for active_prefix_index seed mask");
+    }
 
     Value zero = rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0,
                                                        intType.getWidth());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -16314,9 +16314,10 @@ public:
           resultBits == sourceBits * 2 ? StringRef("EVEN") : StringRef("P0");
       FailureOr<Value> mask =
           createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
-      if (failed(mask))
+      if (failed(mask)) {
         return rewriter.notifyMatchFailure(
             op, "failed to build integer extension seed mask");
+      }
 
       SmallVector<Value> results;
       results.reserve(resultTypes.size());
@@ -18944,29 +18945,27 @@ struct GroupBroadcastShapePlan {
   int64_t resultFactor;
 };
 
-static FailureOr<GroupBroadcastShapePlan> buildGroupBroadcastShapePlan(
-    VMIGroupBroadcastOp op, std::string *reason) {
-  auto fail = [&reason](const Twine &message)
-      -> FailureOr<GroupBroadcastShapePlan> {
+static LogicalResult checkGroupBroadcastLogicalContract(
+    VMIGroupBroadcastOp op, VMIVRegType sourceType, VMIVRegType resultType,
+    VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
+    int64_t numGroups, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
       *reason = message.str();
     }
     return failure();
   };
-  auto sourceType = cast<VMIVRegType>(op.getSource().getType());
-  auto resultType = cast<VMIVRegType>(op.getResult().getType());
   bool mismatchedElementTypes =
       sourceType.getElementType() != resultType.getElementType();
   if (mismatchedElementTypes) {
     return fail("requires source/result element type to match");
   }
-  VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
-  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !resultLayout) {
+  bool missingLayouts = !sourceLayout || !resultLayout;
+  if (missingLayouts) {
     return fail("requires assigned source/result layouts");
   }
-  int64_t numGroups = op.getNumGroupsAttr().getInt();
-  if (numGroups <= 0) {
+  bool invalidGroupCount = numGroups <= 0;
+  if (invalidGroupCount) {
     return fail("requires positive num_groups");
   }
   bool sourceLaneCountMismatch = sourceType.getElementCount() != numGroups;
@@ -18982,12 +18981,14 @@ static FailureOr<GroupBroadcastShapePlan> buildGroupBroadcastShapePlan(
   if (sourceLayoutMismatch) {
     return fail("requires matching num_groups source layout");
   }
-  if (resultLayout.isGroupSlots()) {
+  bool resultUsesGroupSlots = resultLayout.isGroupSlots();
+  if (resultUsesGroupSlots) {
     return fail("requires dense result layout");
   }
-
-  if (sourceLayout.getSlots() > 0 && sourceLayout.getSlots() != 8 &&
-      sourceLayout.getSlots() != 1) {
+  bool unsupportedSlots = sourceLayout.getSlots() > 0 &&
+                          sourceLayout.getSlots() != 8 &&
+                          sourceLayout.getSlots() != 1;
+  if (unsupportedSlots) {
     return fail("supports only slots=8 or slots=1 group_broadcast source "
                 "layouts");
   }
@@ -18995,6 +18996,28 @@ static FailureOr<GroupBroadcastShapePlan> buildGroupBroadcastShapePlan(
   std::string supportReason;
   if (failed(supports.getGroupBroadcastSupport(op, &supportReason))) {
     return fail(supportReason);
+  }
+  return success();
+}
+
+static FailureOr<GroupBroadcastShapePlan> buildGroupBroadcastShapePlan(
+    VMIGroupBroadcastOp op, std::string *reason) {
+  auto fail = [&reason](const Twine &message)
+      -> FailureOr<GroupBroadcastShapePlan> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  auto sourceType = cast<VMIVRegType>(op.getSource().getType());
+  auto resultType = cast<VMIVRegType>(op.getResult().getType());
+  VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
+  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
+  int64_t numGroups = op.getNumGroupsAttr().getInt();
+  if (failed(checkGroupBroadcastLogicalContract(
+          op, sourceType, resultType, sourceLayout, resultLayout, numGroups,
+          reason))) {
+    return failure();
   }
 
   FailureOr<int64_t> lanesPerPart =

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2018,22 +2018,27 @@ LogicalResult checkSupportedGroupSlotLoadShape(
   VMILayoutSupport supports;
   FailureOr<VMIGroupSlotLayoutFact> fact = supports.getGroupSlotLoadLayoutFact(
       resultType, op.getNumGroupsAttr().getInt(), reason);
-  if (failed(fact))
+  if (failed(fact)) {
     return failure();
+  }
 
   VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(
       op.getSource(), op.getOffset(), resultType, VMIMemoryCoverageKind::Dense);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
-  if (!isa<PtrType>(op.getSource().getType()))
+  }
+  if (!isa<PtrType>(op.getSource().getType())) {
     return fail("group_slot_load requires !pto.ptr source");
+  }
 
   if (fact->slots == 8) {
     std::optional<int64_t> sourceGroupStride =
         getConstantIndexValue(op.getSourceGroupStride());
-    if (!sourceGroupStride || *sourceGroupStride != 1)
+    bool nonUnitSourceStride = !sourceGroupStride || *sourceGroupStride != 1;
+    if (nonUnitSourceStride) {
       return fail("slots=8 group_slot_load requires constant unit "
                   "source_group_stride");
+    }
     return success();
   }
 
@@ -2059,19 +2064,19 @@ LogicalResult checkSupportedSlots1GroupSlotLoadShape(
   std::optional<int64_t> sourceGroupStride =
       getConstantIndexValue(op.getSourceGroupStride());
   if (!sourceGroupStride || *sourceGroupStride <= 0 ||
-      *sourceGroupStride % alignedStrideElems != 0)
+      *sourceGroupStride % alignedStrideElems != 0) {
     return fail(Twine("slots=1 group_slot_load currently lowers as one "
                       "lane-0 vsldb per group and requires constant "
                       "positive source_group_stride divisible by ") +
                 Twine(alignedStrideElems) +
                 " elements for 32B load alignment; packed or unaligned "
                 "scalar load lowering is not implemented");
+  }
   return success();
 }
 
-LogicalResult checkSupportedGroupBroadcastLoadShape(
-    VMIGroupBroadcastLoadOp op,
-    std::string *reason) {
+LogicalResult checkSupportedGroupBroadcastLoadMemory(
+    VMIGroupBroadcastLoadOp op, VMIVRegType resultType, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
       *reason = message.str();
@@ -2079,18 +2084,26 @@ LogicalResult checkSupportedGroupBroadcastLoadShape(
     return failure();
   };
 
-  VMILayoutSupport supports;
-  if (failed(supports.getGroupBroadcastLoadSupport(op, reason)))
-    return failure();
   VMIMemoryAccessPlan accessPlan =
-      buildReadAccessPlan(op.getSource(), op.getOffset(),
-                          cast<VMIVRegType>(op.getResult().getType()),
+      buildReadAccessPlan(op.getSource(), op.getOffset(), resultType,
                           VMIMemoryCoverageKind::Dense);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
-  if (!isa<PtrType>(op.getSource().getType()))
+  }
+  if (!isa<PtrType>(op.getSource().getType())) {
     return fail("group_broadcast_load requires !pto.ptr source");
+  }
   return success();
+}
+
+LogicalResult checkSupportedGroupBroadcastLoadShape(
+    VMIGroupBroadcastLoadOp op, std::string *reason) {
+  VMILayoutSupport supports;
+  if (failed(supports.getGroupBroadcastLoadSupport(op, reason))) {
+    return failure();
+  }
+  return checkSupportedGroupBroadcastLoadMemory(
+      op, cast<VMIVRegType>(op.getResult().getType()), reason);
 }
 
 static bool isCompactSmallGroupStore(VMILayoutAttr layout,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7779,7 +7779,9 @@ FailureOr<Value> createResidualSubVLGroupPeriodicChunk(
                           allMask,
                           /*position=*/nullptr)
           .getResult();
-  auto materializeGroup = [&](int64_t localGroup) -> FailureOr<Value> {
+  auto materializeGroup =
+      [&loc, resultType, base, order, full, maskType, zeroScalar, groupSize,
+       &rewriter](int64_t localGroup) -> FailureOr<Value> {
     Value adjusted = full;
     if (localGroup != 0) {
       int64_t delta = localGroup * groupSize;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2775,6 +2775,39 @@ checkSupportedExpandLoadRuntimePath(
 }
 
 LogicalResult
+checkSupportedExpandLoadCommonShape(VMIExpandLoadOp op,
+                                     VMIVRegType resultType,
+                                     VMIVRegType passthruType,
+                                     VMIMaskType maskType,
+                                     VMIMemoryAccessPlan &accessPlan,
+                                     std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  accessPlan = buildReadAccessPlan(op.getSource(), op.getOffset(), resultType,
+                                   VMIMemoryCoverageKind::Predicate);
+  if (!accessPlan.layoutSupport.isSupported()) {
+    return fail(accessPlan.layoutSupport.reason);
+  }
+  bool missingLayout = !resultType.getLayoutAttr() ||
+                       !passthruType.getLayoutAttr() ||
+                       !maskType.getLayoutAttr();
+  if (missingLayout) {
+    return fail("requires assigned result, passthru, and mask layouts");
+  }
+  bool nonContiguousLayout = !resultType.getLayoutAttr().isContiguous() ||
+                             !passthruType.getLayoutAttr().isContiguous() ||
+                             !maskType.getLayoutAttr().isContiguous();
+  if (nonContiguousLayout) {
+    return fail("requires contiguous result, passthru, and mask layouts");
+  }
+  return success();
+}
+
+LogicalResult
 checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
@@ -2786,23 +2819,10 @@ checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   auto passthruType = cast<VMIVRegType>(op.getPassthru().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
-  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  VMILayoutAttr passthruLayout = passthruType.getLayoutAttr();
-  VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  VMIMemoryAccessPlan accessPlan =
-      buildReadAccessPlan(op.getSource(), op.getOffset(), resultType,
-                          VMIMemoryCoverageKind::Predicate);
-  if (!accessPlan.layoutSupport.isSupported()) {
-    return fail(accessPlan.layoutSupport.reason);
-  }
-  if (!resultLayout || !passthruLayout || !maskLayout) {
-    return fail("requires assigned result, passthru, and mask layouts");
-  }
-  bool nonContiguousLayout = !resultLayout.isContiguous() ||
-                             !passthruLayout.isContiguous() ||
-                             !maskLayout.isContiguous();
-  if (nonContiguousLayout) {
-    return fail("requires contiguous result, passthru, and mask layouts");
+  VMIMemoryAccessPlan accessPlan;
+  if (failed(checkSupportedExpandLoadCommonShape(
+          op, resultType, passthruType, maskType, accessPlan, reason))) {
+    return failure();
   }
 
   std::string maskReason;
@@ -2810,9 +2830,12 @@ checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
       op.getMask(), resultType.getElementCount(), &maskReason);
 
   std::string fullChunkReason;
-  if (staticAllActive &&
-      succeeded(checkFullDataPhysicalChunks(resultType, &fullChunkReason)))
+  bool staticFullChunks =
+      staticAllActive &&
+      succeeded(checkFullDataPhysicalChunks(resultType, &fullChunkReason));
+  if (staticFullChunks) {
     return success();
+  }
 
   if (staticAllActive && accessPlan.front().readSafety.proven) {
     return success();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -14294,8 +14294,9 @@ classifyGroupReduceLoweringPlan(VMIVRegType sourceType, VMIMaskType maskType,
   FailureOr<VMIGroupReduceLayoutFact> fact =
       supports.getGroupReduceLayoutFactForLayouts(
           sourceType, maskType, resultType, numGroups, reason);
-  if (failed(fact))
+  if (failed(fact)) {
     return failure();
+  }
 
   switch (fact->blockClass) {
   case VMIGroupBlockClass::QuarterBlock:
@@ -15395,11 +15396,13 @@ public:
         buildResultViewPlan(resultVRegTypes, rewriter);
     VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
     VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
-    if (sourceLayout && resultLayout && sourceLayout.isContiguous() &&
+    bool denseLaneStrideExtension =
+        sourceLayout && resultLayout && sourceLayout.isContiguous() &&
         resultLayout.isContiguous() && resultLayout.getLaneStride() == 1 &&
         ((sourceBits == 16 && sourceLayout.getLaneStride() == 2) ||
          (sourceBits == 8 && sourceLayout.getLaneStride() == 4)) &&
-        resultTypes.size() == sourceParts.size()) {
+        resultTypes.size() == sourceParts.size();
+    if (denseLaneStrideExtension) {
       StringRef part = sourceBits == 16 ? StringRef("EVEN") : StringRef("P0");
       FailureOr<Value> mask =
           createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
@@ -15822,19 +15825,23 @@ public:
     unsigned resultBits = physicalPlan->resultBits;
     // Same-width fp->fp (bf16 -> f16, f16 -> bf16): dense contiguous 1:1,
     // no part; rnd always, sat follows the fp-to-fp contract.
-    if (sourceBits == resultBits && sourceLayout && resultLayout &&
+    bool sameWidthContiguous =
+        sourceBits == resultBits && sourceLayout && resultLayout &&
         sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 1 &&
         resultLayout.isContiguous() && resultLayout.getLaneStride() == 1 &&
-        sourceParts.size() == resultTypes.size()) {
+        sourceParts.size() == resultTypes.size();
+    if (sameWidthContiguous) {
       StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
       return lowerSameWidth(op, sourceParts, resultVRegTypes,
                             vcvtSourceVRegType, sat, rewriter);
     }
 
-    if (sourceLayout && resultLayout && sourceLayout.isContiguous() &&
+    bool denseLaneStrideNarrowing =
+        sourceLayout && resultLayout && sourceLayout.isContiguous() &&
         sourceLayout.getLaneStride() == 1 && resultLayout.isContiguous() &&
         resultLayout.getLaneStride() != 1 &&
-        sourceParts.size() == resultTypes.size()) {
+        sourceParts.size() == resultTypes.size();
+    if (denseLaneStrideNarrowing) {
       bool isEven32To16 =
           resultBits == 16 && resultLayout.getLaneStride() == 2;
       bool isPacked32To8 =
@@ -16420,6 +16427,40 @@ struct OneToNVMITruncIOpPattern : OneToNOpConversionPattern<VMITruncIOp> {
   using OneToNOpConversionPattern<VMITruncIOp>::OneToNOpConversionPattern;
 
 private:
+  FailureOr<std::pair<VRegType, VRegType>> getUniformTruncTypes(
+      VMITruncIOp op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      OneToNPatternRewriter &rewriter) const {
+    bool emptyPhysicalParts = sourceParts.empty() || resultTypes.empty();
+    if (emptyPhysicalParts) {
+      return rewriter.notifyMatchFailure(
+          op, "trunci requires non-empty physical source and result parts");
+    }
+    auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
+    auto resultType = dyn_cast<VRegType>(resultTypes.front());
+    bool invalidTypes =
+        !sourceType || !isa<IntegerType>(sourceType.getElementType()) ||
+        !resultType || !isa<IntegerType>(resultType.getElementType());
+    if (invalidTypes) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported physical trunci source/result type");
+    }
+    for (Value sourcePart : sourceParts) {
+      auto currentType = dyn_cast<VRegType>(sourcePart.getType());
+      if (!currentType || currentType != sourceType) {
+        return rewriter.notifyMatchFailure(
+            op, "trunci source physical parts must have matching integer type");
+      }
+    }
+    for (Type physicalResultType : resultTypes) {
+      auto currentType = dyn_cast<VRegType>(physicalResultType);
+      if (!currentType || currentType != resultType) {
+        return rewriter.notifyMatchFailure(
+            op, "trunci result physical parts must have matching integer type");
+      }
+    }
+    return std::make_pair(*sourceType, *resultType);
+  }
+
   void finalizeResults(VMITruncIOp op, SmallVectorImpl<Value> &results,
                        bool s32ToS8Alias, ArrayRef<Type> originalResultTypes,
                        OneToNPatternRewriter &rewriter) const {
@@ -16727,35 +16768,13 @@ public:
                                  resultTypes);
     }
 
-    bool emptyPhysicalParts = sourceParts.empty() || resultTypes.empty();
-    if (emptyPhysicalParts) {
-      return rewriter.notifyMatchFailure(
-          op, "trunci requires non-empty physical source and result parts");
+    FailureOr<std::pair<VRegType, VRegType>> uniformTypes =
+        getUniformTruncTypes(op, sourceParts, resultTypes, rewriter);
+    if (failed(uniformTypes)) {
+      return failure();
     }
-
-    auto sourceType0 = dyn_cast<VRegType>(sourceParts.front().getType());
-    auto resultType0 = dyn_cast<VRegType>(resultTypes.front());
-    bool invalidPhysicalTypes =
-        !sourceType0 || !isa<IntegerType>(sourceType0.getElementType()) ||
-        !resultType0 || !isa<IntegerType>(resultType0.getElementType());
-    if (invalidPhysicalTypes) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported physical trunci source/result type");
-    }
-    for (Value sourcePart : sourceParts) {
-      auto sourceType = dyn_cast<VRegType>(sourcePart.getType());
-      if (!sourceType || sourceType != sourceType0) {
-        return rewriter.notifyMatchFailure(
-            op, "trunci source physical parts must have matching integer type");
-      }
-    }
-    for (Type resultType : resultTypes) {
-      auto resultVRegType = dyn_cast<VRegType>(resultType);
-      if (!resultVRegType || resultVRegType != resultType0) {
-        return rewriter.notifyMatchFailure(
-            op, "trunci result physical parts must have matching integer type");
-      }
-    }
+    VRegType sourceType0 = uniformTypes->first;
+    VRegType resultType0 = uniformTypes->second;
 
     unsigned sourceBits =
         pto::getPTOStorageElemBitWidth(sourceType0.getElementType());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6460,39 +6460,50 @@ static FailureOr<SmallVector<Value, 4>> materializeContiguousToDeintMaskGroup(
   return results;
 }
 
-static FailureOr<SmallVector<Value>> flattenStagingMaskParts(
-    Operation *op, ArrayRef<SmallVector<Value, 4>> parts, int64_t factor,
-    int64_t groups, TypeRange resultTypes, PatternRewriter &rewriter) {
-  SmallVector<Value> results;
-  results.reserve(resultTypes.size());
-  for (int64_t part = 0; part < factor; ++part) {
-    bool invalidPartArity =
-        parts[part].size() != static_cast<size_t>(groups);
-    if (invalidPartArity) {
+struct StagingMaskPartAccumulator {
+  SmallVector<SmallVector<Value, 4>, 4> parts;
+  int64_t factor;
+  int64_t groups;
+
+  StagingMaskPartAccumulator(int64_t factor, int64_t groups)
+      : parts(factor), factor(factor), groups(groups) {
+    for (SmallVector<Value, 4> &part : parts) {
+      part.reserve(static_cast<size_t>(groups));
+    }
+  }
+
+  LogicalResult append(Operation *op, ArrayRef<Value> values,
+                       PatternRewriter &rewriter) {
+    bool invalidArity = values.size() != static_cast<size_t>(factor);
+    if (invalidArity) {
       (void)rewriter.notifyMatchFailure(
           op, "staging contiguous mask layout result arity mismatch");
       return failure();
     }
-    results.append(parts[part]);
+    for (int64_t part = 0; part < factor; ++part) {
+      parts[part].push_back(values[part]);
+    }
+    return success();
   }
-  return results;
-}
 
-static LogicalResult materializeStagingMaskGroup(
-    Operation *op, ValueRange sourceParts, TypeRange resultTypes, int64_t factor,
-    int64_t groups, int64_t groupIndex,
-    SmallVectorImpl<SmallVector<Value, 4>> &parts, PatternRewriter &rewriter) {
-  FailureOr<SmallVector<Value, 4>> materialized =
-      materializeContiguousToDeintMaskGroup(
-          op, sourceParts, resultTypes, factor, groups, groupIndex, rewriter);
-  if (failed(materialized)) {
-    return failure();
+  FailureOr<SmallVector<Value>> flatten(Operation *op,
+                                        TypeRange resultTypes,
+                                        PatternRewriter &rewriter) {
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (int64_t part = 0; part < factor; ++part) {
+      bool invalidPartArity =
+          parts[part].size() != static_cast<size_t>(groups);
+      if (invalidPartArity) {
+        (void)rewriter.notifyMatchFailure(
+            op, "staging contiguous mask layout result arity mismatch");
+        return failure();
+      }
+      results.append(parts[part]);
+    }
+    return results;
   }
-  for (int64_t part = 0; part < factor; ++part) {
-    parts[part].push_back((*materialized)[part]);
-  }
-  return success();
-}
+};
 
 FailureOr<SmallVector<Value>> materializeStagingContiguousToDeintMaskLayout(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
@@ -6515,20 +6526,21 @@ FailureOr<SmallVector<Value>> materializeStagingContiguousToDeintMaskLayout(
     return fail("staging contiguous mask layout has too many source parts");
   }
 
-  SmallVector<SmallVector<Value, 4>, 4> parts(factor);
-  for (int64_t part = 0; part < factor; ++part)
-    parts[part].reserve(groups);
+  StagingMaskPartAccumulator accumulator(factor, groups);
 
   for (int64_t i = 0; i < groups; ++i) {
-    if (failed(materializeStagingMaskGroup(
-            op, sourceParts, resultTypes, factor, groups, i, parts,
-            rewriter))) {
+    FailureOr<SmallVector<Value, 4>> materialized =
+        materializeContiguousToDeintMaskGroup(
+            op, sourceParts, resultTypes, factor, groups, i, rewriter);
+    if (failed(materialized)) {
+      return failure();
+    }
+    if (failed(accumulator.append(op, *materialized, rewriter))) {
       return failure();
     }
   }
 
-  return flattenStagingMaskParts(op, parts, factor, groups, resultTypes,
-                                 rewriter);
+  return accumulator.flatten(op, resultTypes, rewriter);
 }
 
 FailureOr<SmallVector<Value>> materializeMaskGranularityCastLayoutConversion(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5076,13 +5076,48 @@ getDataLayoutIntermediatePlan(VMILayoutAttr sourceLayout,
   return std::nullopt;
 }
 
-FailureOr<std::optional<SmallVector<Value>>>
-materializeDataLayoutViaContiguous(
+static FailureOr<SmallVector<Value>> materializeDataLayoutThroughContiguous(
+    Operation *op, ValueRange sourceParts, TypeRange resultTypes,
+    VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
+    Type sourceVMIElementType, PatternRewriter &rewriter,
+    const DataLayoutIntermediatePlan &plan) {
+  VMILayoutAttr contiguous =
+      VMILayoutAttr::getContiguous(rewriter.getContext());
+  SmallVector<Type> intermediateTypes(
+      plan.intermediateCount, sourceParts.front().getType());
+  FailureOr<SmallVector<Value>> dense = materializeDataLayoutConversion(
+      op, sourceParts, intermediateTypes, sourceLayout, contiguous,
+      sourceVMIElementType, rewriter);
+  if (failed(dense)) {
+    return failure();
+  }
+  return materializeDataLayoutConversion(op, *dense, resultTypes, contiguous,
+                                         resultLayout, sourceVMIElementType,
+                                         rewriter);
+}
+
+static FailureOr<SmallVector<Value>> materializeDataLayoutThroughDeinterleaved(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
     VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
     Type sourceVMIElementType, PatternRewriter &rewriter) {
   VMILayoutAttr contiguous =
       VMILayoutAttr::getContiguous(rewriter.getContext());
+  FailureOr<SmallVector<Value>> dense = materializeDataLayoutConversion(
+      op, sourceParts, resultTypes, sourceLayout, contiguous,
+      sourceVMIElementType, rewriter);
+  if (failed(dense)) {
+    return failure();
+  }
+  return materializeDataLayoutConversion(op, *dense, resultTypes, contiguous,
+                                         resultLayout, sourceVMIElementType,
+                                         rewriter);
+}
+
+FailureOr<std::optional<SmallVector<Value>>>
+materializeDataLayoutViaContiguous(
+    Operation *op, ValueRange sourceParts, TypeRange resultTypes,
+    VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
+    Type sourceVMIElementType, PatternRewriter &rewriter) {
   std::optional<DataLayoutIntermediatePlan> plan =
       getDataLayoutIntermediatePlan(sourceLayout, resultLayout,
                                     sourceParts.size());
@@ -5094,29 +5129,23 @@ materializeDataLayoutViaContiguous(
   }
 
   if (plan->kind == DataLayoutIntermediatePlan::Kind::Deinterleaved) {
-    FailureOr<SmallVector<Value>> dense = materializeDataLayoutConversion(
-        op, sourceParts, resultTypes, sourceLayout, contiguous,
-        sourceVMIElementType, rewriter);
-    if (failed(dense)) {
+    FailureOr<SmallVector<Value>> results =
+        materializeDataLayoutThroughDeinterleaved(
+            op, sourceParts, resultTypes, sourceLayout, resultLayout,
+            sourceVMIElementType, rewriter);
+    if (failed(results)) {
       return failure();
     }
-    return materializeDataLayoutConversion(
-        op, *dense, resultTypes, contiguous, resultLayout,
-        sourceVMIElementType, rewriter);
+    return std::optional<SmallVector<Value>>(std::move(*results));
   }
 
-  size_t intermediateCount = plan->intermediateCount;
-  SmallVector<Type> intermediateTypes(intermediateCount,
-                                      sourceParts.front().getType());
-  FailureOr<SmallVector<Value>> dense = materializeDataLayoutConversion(
-      op, sourceParts, intermediateTypes, sourceLayout, contiguous,
-      sourceVMIElementType, rewriter);
-  if (failed(dense)) {
+  FailureOr<SmallVector<Value>> results = materializeDataLayoutThroughContiguous(
+      op, sourceParts, resultTypes, sourceLayout, resultLayout,
+      sourceVMIElementType, rewriter, *plan);
+  if (failed(results)) {
     return failure();
   }
-  return materializeDataLayoutConversion(
-      op, *dense, resultTypes, contiguous, resultLayout, sourceVMIElementType,
-      rewriter);
+  return std::optional<SmallVector<Value>>(std::move(*results));
 }
 
 FailureOr<SmallVector<Value>> materializeDataLayoutConversion(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7969,6 +7969,40 @@ struct OneToNVMICreateGroupMaskOpPattern
       VMICreateGroupMaskOp>::OneToNOpConversionPattern;
 
 private:
+  FailureOr<SmallVector<Value>> materializeGroupMaskResults(
+      VMICreateGroupMaskOp op,
+      ArrayRef<ConstantMaskChunkMaterialization> materializations,
+      ArrayRef<Type> resultTypes, StringRef overflowDiagnostic,
+      OneToNPatternRewriter &rewriter) const {
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (const ConstantMaskChunkMaterialization &materialization :
+         materializations) {
+      bool tooManyMasks = results.size() >= resultTypes.size();
+      if (tooManyMasks) {
+        return rewriter.notifyMatchFailure(op, overflowDiagnostic);
+      }
+      auto maskType = dyn_cast<MaskType>(resultTypes[results.size()]);
+      if (!maskType) {
+        return rewriter.notifyMatchFailure(
+            op, "create_group_mask result must be mask");
+      }
+      FailureOr<Value> mask = materializeConstantMaskChunk(
+          op.getLoc(), maskType, materialization.activeLanes, rewriter);
+      if (failed(mask)) {
+        return rewriter.notifyMatchFailure(
+            op, "failed to materialize create_group_mask physical chunk");
+      }
+      results.push_back(*mask);
+    }
+    bool resultArityMismatch = results.size() != resultTypes.size();
+    if (resultArityMismatch) {
+      return rewriter.notifyMatchFailure(
+          op, "create_group_mask physical result count mismatch");
+    }
+    return results;
+  }
+
   LogicalResult lowerDynamicMask(
       VMICreateGroupMaskOp op, OpAdaptor adaptor,
       OneToNPatternRewriter &rewriter, VMIMaskType resultVMIType,
@@ -8025,33 +8059,11 @@ private:
           op, Twine("create_group_mask ") + reason);
     }
 
-    SmallVector<Value> results;
-    results.reserve(resultTypes.size());
-    for (const ConstantMaskChunkMaterialization &materialization :
-         *materializations) {
-      bool tooManyMasks = results.size() >= resultTypes.size();
-      if (tooManyMasks) {
-        return rewriter.notifyMatchFailure(
-            op, "create_group_mask produced too many physical masks");
-      }
-      auto maskType = dyn_cast<MaskType>(resultTypes[results.size()]);
-      if (!maskType) {
-        return rewriter.notifyMatchFailure(
-            op, "create_group_mask result must be mask");
-      }
-      FailureOr<Value> mask = materializeConstantMaskChunk(
-          op.getLoc(), maskType, materialization.activeLanes, rewriter);
-      if (failed(mask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to materialize create_group_mask physical chunk");
-      }
-      results.push_back(*mask);
-    }
-
-    bool resultArityMismatch = results.size() != resultTypes.size();
-    if (resultArityMismatch) {
-      return rewriter.notifyMatchFailure(
-          op, "create_group_mask physical result count mismatch");
+    FailureOr<SmallVector<Value>> results = materializeGroupMaskResults(
+        op, *materializations, resultTypes,
+        "create_group_mask produced too many physical masks", rewriter);
+    if (failed(results)) {
+      return failure();
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());
@@ -8084,29 +8096,9 @@ private:
       return rewriter.notifyMatchFailure(
           op, Twine("create_group_mask ") + contiguousReason);
     }
-    SmallVector<Value> contiguousParts;
-    contiguousParts.reserve(materializations->size());
-    for (const ConstantMaskChunkMaterialization &materialization :
-         *materializations) {
-      bool tooManyMasks = contiguousParts.size() >= resultTypes.size();
-      if (tooManyMasks) {
-        return rewriter.notifyMatchFailure(
-            op, "create_group_mask produced too many contiguous masks");
-      }
-      auto maskType = dyn_cast<MaskType>(resultTypes[contiguousParts.size()]);
-      if (!maskType) {
-        return rewriter.notifyMatchFailure(
-            op, "create_group_mask result must be mask");
-      }
-      FailureOr<Value> mask = materializeConstantMaskChunk(
-          op.getLoc(), maskType, materialization.activeLanes, rewriter);
-      if (failed(mask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to materialize create_group_mask contiguous chunk");
-      }
-      contiguousParts.push_back(*mask);
-    }
-    return contiguousParts;
+    return materializeGroupMaskResults(
+        op, *materializations, resultTypes,
+        "create_group_mask produced too many contiguous masks", rewriter);
   }
 
   LogicalResult lowerFactor4Block(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9871,6 +9871,67 @@ struct GroupBroadcastLoweringContext {
   int64_t selectorPeriod;
 };
 
+static FailureOr<Value> materializeConstantGroupBroadcastSelector(
+    GroupBroadcastSelectorContext &context, int64_t baseIndex,
+    OneToNPatternRewriter &rewriter) {
+  FailureOr<Value> baseScalar = createScalarOffsetConstant(
+      context.op->getLoc(), context.indexScalarType, baseIndex, rewriter);
+  if (failed(baseScalar)) {
+    return failure();
+  }
+  return rewriter
+      .create<VdupOp>(context.op->getLoc(), context.indexType, *baseScalar,
+                      context.allMask, /*position=*/nullptr)
+      .getResult();
+}
+
+static FailureOr<Value> materializeGroupBroadcastRamp(
+    GroupBroadcastSelectorContext &context, int64_t baseIndex,
+    OneToNPatternRewriter &rewriter) {
+  if (!context.sharedRamp) {
+    FailureOr<Value> zero = createScalarOffsetConstant(
+        context.op->getLoc(), context.indexScalarType, 0, rewriter);
+    if (failed(zero)) {
+      return failure();
+    }
+    context.sharedRamp =
+        rewriter.create<VciOp>(context.op->getLoc(), context.indexType, *zero,
+                               StringAttr{})
+            .getResult();
+    if (*context.selectorShift != 0) {
+      Value shift = createI16Constant(context.op->getLoc(),
+                                      *context.selectorShift, rewriter);
+      context.sharedRamp =
+          rewriter
+              .create<VshrsOp>(context.op->getLoc(), context.indexType,
+                               context.sharedRamp, shift, context.allMask)
+              .getResult();
+    }
+    if (*context.sourceLaneStrideShift != 0) {
+      Value shift = createI16Constant(
+          context.op->getLoc(), *context.sourceLaneStrideShift, rewriter);
+      context.sharedRamp =
+          rewriter
+              .create<VshlsOp>(context.op->getLoc(), context.indexType,
+                               context.sharedRamp, shift, context.allMask)
+              .getResult();
+    }
+  }
+  Value selector = context.sharedRamp;
+  if (baseIndex != 0) {
+    FailureOr<Value> baseScalar = createScalarOffsetConstant(
+        context.op->getLoc(), context.indexScalarType, baseIndex, rewriter);
+    if (failed(baseScalar)) {
+      return failure();
+    }
+    selector = rewriter
+                   .create<VaddsOp>(context.op->getLoc(), context.indexType,
+                                    selector, *baseScalar, context.allMask)
+                   .getResult();
+  }
+  return selector;
+}
+
 static FailureOr<GroupBroadcastLoweringContext>
 createGroupBroadcastLoweringContext(
     Operation *op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
@@ -9945,62 +10006,18 @@ static FailureOr<Value> getGroupBroadcastSelector(
   }
 
   if (context.kind == GroupBroadcastSelectorKind::Constant) {
-    FailureOr<Value> baseScalar = createScalarOffsetConstant(
-        context.op->getLoc(), context.indexScalarType, baseIndex, rewriter);
-    if (failed(baseScalar)) {
+    FailureOr<Value> selector = materializeConstantGroupBroadcastSelector(
+        context, baseIndex, rewriter);
+    if (failed(selector)) {
       return failure();
     }
-    Value selector =
-        rewriter
-            .create<VdupOp>(context.op->getLoc(), context.indexType,
-                            *baseScalar, context.allMask,
-                            /*position=*/nullptr)
-            .getResult();
     context.selectorByBaseIndex.try_emplace(baseIndex, selector);
     return selector;
   }
-
-  if (!context.sharedRamp) {
-    FailureOr<Value> zero = createScalarOffsetConstant(
-        context.op->getLoc(), context.indexScalarType, 0, rewriter);
-    if (failed(zero)) {
-      return failure();
-    }
-    context.sharedRamp =
-        rewriter.create<VciOp>(context.op->getLoc(), context.indexType,
-                               *zero, StringAttr{})
-            .getResult();
-    if (*context.selectorShift != 0) {
-      Value shift = createI16Constant(context.op->getLoc(),
-                                      *context.selectorShift, rewriter);
-      context.sharedRamp =
-          rewriter
-              .create<VshrsOp>(context.op->getLoc(), context.indexType,
-                               context.sharedRamp, shift, context.allMask)
-              .getResult();
-    }
-    if (*context.sourceLaneStrideShift != 0) {
-      Value shift = createI16Constant(
-          context.op->getLoc(), *context.sourceLaneStrideShift, rewriter);
-      context.sharedRamp =
-          rewriter
-              .create<VshlsOp>(context.op->getLoc(), context.indexType,
-                               context.sharedRamp, shift, context.allMask)
-              .getResult();
-    }
-  }
-
-  Value selector = context.sharedRamp;
-  if (baseIndex != 0) {
-    FailureOr<Value> baseScalar = createScalarOffsetConstant(
-        context.op->getLoc(), context.indexScalarType, baseIndex, rewriter);
-    if (failed(baseScalar)) {
-      return failure();
-    }
-    selector = rewriter
-                   .create<VaddsOp>(context.op->getLoc(), context.indexType,
-                                    selector, *baseScalar, context.allMask)
-                   .getResult();
+  FailureOr<Value> selector =
+      materializeGroupBroadcastRamp(context, baseIndex, rewriter);
+  if (failed(selector)) {
+    return failure();
   }
   context.selectorByBaseIndex.try_emplace(baseIndex, selector);
   return selector;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11445,6 +11445,30 @@ private:
     return emitStatefulStoreStream(op, storeBase, values, advances, rewriter);
   }
 
+  FailureOr<Value> materializePackedSlots1Group(
+      VMIGroupStoreOp op, OneToNPatternRewriter &rewriter, Value value,
+      int64_t group, VRegType firstType, MaskType maskType, Value allMask,
+      Value packed) const {
+    auto vregType = dyn_cast<VRegType>(value.getType());
+    if (!vregType || vregType != firstType) {
+      return rewriter.notifyMatchFailure(
+          op, "packed group_store requires uniform vreg parts");
+    }
+    Value splat = rewriter
+                      .create<VdupOp>(op.getLoc(), firstType, value, allMask,
+                                      rewriter.getStringAttr("LOWEST"))
+                      .getResult();
+    FailureOr<Value> laneMask =
+        createLaneRangeMask(op.getLoc(), maskType, group, group + 1, rewriter);
+    if (failed(laneMask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to create packed group_store lane mask");
+    }
+    return rewriter
+        .create<VselOp>(op.getLoc(), firstType, splat, packed, *laneMask)
+        .getResult();
+  }
+
   FailureOr<Value> buildPackedSlots1Value(
       VMIGroupStoreOp op, OneToNPatternRewriter &rewriter,
       ValueRange valueParts, VMILayoutAttr layout, VRegType firstType,
@@ -11455,26 +11479,13 @@ private:
                                        rewriter.getStringAttr("LOWEST"))
                        .getResult();
     for (int64_t group = 1; group < layout.getNumGroups(); ++group) {
-      auto vregType = dyn_cast<VRegType>(valueParts[group].getType());
-      if (!vregType || vregType != firstType) {
-        return rewriter.notifyMatchFailure(
-            op, "packed group_store requires uniform vreg parts");
+      FailureOr<Value> nextPacked = materializePackedSlots1Group(
+          op, rewriter, valueParts[group], group, firstType, maskType, allMask,
+          packed);
+      if (failed(nextPacked)) {
+        return failure();
       }
-      Value splat = rewriter
-                        .create<VdupOp>(op.getLoc(), firstType, valueParts[group],
-                                        allMask,
-                                        rewriter.getStringAttr("LOWEST"))
-                        .getResult();
-      FailureOr<Value> laneMask = createLaneRangeMask(
-          op.getLoc(), maskType, group, group + 1, rewriter);
-      if (failed(laneMask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to create packed group_store lane mask");
-      }
-      packed = rewriter
-                   .create<VselOp>(op.getLoc(), firstType, splat, packed,
-                                   *laneMask)
-                   .getResult();
+      packed = *nextPacked;
     }
     return packed;
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3312,20 +3312,30 @@ computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
 
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
-  FailureOr<int64_t> lanesPerPart =
-      getDataLanesPerPart(sourceType.getElementType());
+  auto validateInputs = [&sourceType, &resultType, &op, &fail]()
+      -> FailureOr<int64_t> {
+    FailureOr<int64_t> lanes =
+        getDataLanesPerPart(sourceType.getElementType());
+    if (failed(lanes)) {
+      return fail("requires known lanes per physical part");
+    }
+    if (op.getIndices().empty()) {
+      return fail("requires non-empty indices");
+    }
+    FailureOr<int64_t> factor = getDataLayoutFactor(resultType);
+    if (failed(factor)) {
+      return fail("requires assigned result layout");
+    }
+    return *lanes;
+  };
+  FailureOr<int64_t> lanesPerPart = validateInputs();
   if (failed(lanesPerPart)) {
-    return fail("requires known lanes per physical part");
+    return failure();
   }
-
   ArrayRef<int64_t> indices = op.getIndices();
-  if (indices.empty()) {
-    return fail("requires non-empty indices");
-  }
-
   FailureOr<int64_t> resultFactor = getDataLayoutFactor(resultType);
   if (failed(resultFactor)) {
-    return fail("requires assigned result layout");
+    return failure();
   }
 
   SmallVector<int64_t> sourceFlatIndices;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8226,6 +8226,35 @@ private:
     return *maskAndRemaining;
   }
 
+  FailureOr<Value> materializeConstantMaskValue(
+      VMICreateMaskOp op, Type resultType, int64_t activeInChunk,
+      int64_t lanesPerPart, OneToNPatternRewriter &rewriter) const {
+    auto maskType = dyn_cast<MaskType>(resultType);
+    if (!maskType) {
+      return rewriter.notifyMatchFailure(op, "create_mask result must be mask");
+    }
+    std::optional<std::string> pattern =
+        getPrefixPattern(activeInChunk, lanesPerPart);
+    if (pattern) {
+      FailureOr<Value> mask =
+          createPrefixMask(op.getLoc(), maskType, *pattern, rewriter);
+      if (failed(mask)) {
+        return rewriter.notifyMatchFailure(
+            op, "unsupported mask type for create_mask");
+      }
+      return *mask;
+    }
+    FailureOr<std::pair<Value, Value>> maskAndRemaining =
+        createRuntimePrefixMask(
+            op.getLoc(), maskType,
+            createI32Constant(op.getLoc(), activeInChunk, rewriter), rewriter);
+    if (failed(maskAndRemaining)) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported mask type for create_mask plt fallback");
+    }
+    return maskAndRemaining->first;
+  }
+
   LogicalResult lowerConstantMask(
       VMICreateMaskOp op, int64_t activeLanes, VMIMaskType resultVMIType,
       VMILayoutAttr layout, TypeRange resultTypes, int64_t lanesPerPart,
@@ -8251,33 +8280,13 @@ private:
           return rewriter.notifyMatchFailure(
               op, "create_mask produced too many physical masks");
         }
-        auto maskType = dyn_cast<MaskType>(resultTypes[results.size()]);
-        if (!maskType) {
-          return rewriter.notifyMatchFailure(
-              op, "create_mask result must be mask");
+        FailureOr<Value> mask = materializeConstantMaskValue(
+            op, resultTypes[results.size()], activeInChunk, lanesPerPart,
+            rewriter);
+        if (failed(mask)) {
+          return failure();
         }
-        std::optional<std::string> pattern =
-            getPrefixPattern(activeInChunk, lanesPerPart);
-        if (pattern) {
-          FailureOr<Value> mask =
-              createPrefixMask(op.getLoc(), maskType, *pattern, rewriter);
-          if (failed(mask)) {
-            return rewriter.notifyMatchFailure(
-                op, "unsupported mask type for create_mask");
-          }
-          results.push_back(*mask);
-          continue;
-        }
-        FailureOr<std::pair<Value, Value>> maskAndRemaining =
-            createRuntimePrefixMask(
-                op.getLoc(), maskType,
-                createI32Constant(op.getLoc(), activeInChunk, rewriter),
-                rewriter);
-        if (failed(maskAndRemaining)) {
-          return rewriter.notifyMatchFailure(
-              op, "unsupported mask type for create_mask plt fallback");
-        }
-        results.push_back(maskAndRemaining->first);
+        results.push_back(*mask);
       }
     }
     bool resultArityMismatch = results.size() != resultTypes.size();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18429,29 +18429,17 @@ std::optional<WalkResult> verifySupportedVMIMemoryStoreOp(Operation *op) {
 
 std::optional<WalkResult> verifySupportedVMIStructuredLoadOp(Operation *op) {
   if (auto load = dyn_cast<VMIDeinterleaveLoadOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedDeinterleaveLoadShape(load, &reason))) {
-      return WalkResult::advance();
-    }
-    load.emitError()
-        << kVMIDiagUnsupportedPrefix
-        << "pto.vmi.deinterleave_load lowers through pto.vldsx2 only for "
-           "matching contiguous full low/high result chunks with a supported "
-           "UB source and 8/16/32-bit element type ("
-        << reason << ")";
-    return WalkResult::interrupt();
+    return verifySupportedShapeOp(
+        load, checkSupportedDeinterleaveLoadShape,
+        "pto.vmi.deinterleave_load lowers through pto.vldsx2 only for "
+        "matching contiguous full low/high result chunks with a supported "
+        "UB source and 8/16/32-bit element type (");
   }
   if (auto load = dyn_cast<VMIStrideLoadOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedStrideLoadShape(load, &reason))) {
-      return WalkResult::advance();
-    }
-    load.emitError()
-        << kVMIDiagUnsupportedPrefix
-        << "pto.vmi.stride_load lowers through pto.vsldb only for one "
-           "contiguous physical result/mask chunk and a supported UB source ("
-        << reason << ")";
-    return WalkResult::interrupt();
+    return verifySupportedShapeOp(
+        load, checkSupportedStrideLoadShape,
+        "pto.vmi.stride_load lowers through pto.vsldb only for one "
+        "contiguous physical result/mask chunk and a supported UB source (");
   }
   if (auto load = dyn_cast<VMIGroupLoadOp>(op)) {
     std::string reason;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -16752,25 +16752,22 @@ private:
         .getResult();
   }
 
-  LogicalResult lowerGroupSlotTrunc(
-      VMITruncIOp op, OpAdaptor adaptor, OneToNPatternRewriter &rewriter,
-      VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+  FailureOr<std::pair<bool, bool>> getGroupSlotTruncModes(
+      VMITruncIOp op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
       VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
-      ArrayRef<Type> resultTypes) const {
-    unsigned sourceLogicalBits =
+      ValueRange sourceParts, ArrayRef<Type> resultTypes,
+      OneToNPatternRewriter &rewriter) const {
+    unsigned sourceBits =
         pto::getPTOStorageElemBitWidth(sourceVMIType.getElementType());
-    unsigned resultLogicalBits =
+    unsigned resultBits =
         pto::getPTOStorageElemBitWidth(resultVMIType.getElementType());
     bool supportsDirect =
-        (sourceLogicalBits == 32 &&
-         (resultLogicalBits == 16 || resultLogicalBits == 8)) ||
-        (sourceLogicalBits == 16 && resultLogicalBits == 8 &&
-         sourceLayout.getSlots() == 1);
+        (sourceBits == 32 && (resultBits == 16 || resultBits == 8)) ||
+        (sourceBits == 16 && resultBits == 8 && sourceLayout.getSlots() == 1);
     bool supportsPacked =
-        sourceLogicalBits == 16 && resultLogicalBits == 8 &&
-        sourceLayout.getSlots() == 8 && resultLayout.getSlots() == 8 &&
-        resultLayout.hasLaneStride() && resultLayout.getLaneStride() == 2;
-    ValueRange sourceParts = adaptor.getSource();
+        sourceBits == 16 && resultBits == 8 && sourceLayout.getSlots() == 8 &&
+        resultLayout.getSlots() == 8 && resultLayout.hasLaneStride() &&
+        resultLayout.getLaneStride() == 2;
     bool invalidShape =
         sourceLayout.getNumGroups() != resultLayout.getNumGroups() ||
         sourceLayout.getSlots() != resultLayout.getSlots() ||
@@ -16778,8 +16775,29 @@ private:
         (!supportsDirect && !supportsPacked) ||
         sourceParts.size() != resultTypes.size();
     if (invalidShape) {
-      return rewriter.notifyMatchFailure(op, "unsupported group-slot trunci shape");
+      rewriter.notifyMatchFailure(op, "unsupported group-slot trunci shape");
+      return failure();
     }
+    return std::make_pair(supportsDirect, supportsPacked);
+  }
+
+  LogicalResult lowerGroupSlotTrunc(
+      VMITruncIOp op, OpAdaptor adaptor, OneToNPatternRewriter &rewriter,
+      VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
+      VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
+      ArrayRef<Type> resultTypes) const {
+    ValueRange sourceParts = adaptor.getSource();
+    FailureOr<std::pair<bool, bool>> modes = getGroupSlotTruncModes(
+        op, sourceVMIType, resultVMIType, sourceLayout, resultLayout,
+        sourceParts, resultTypes, rewriter);
+    if (failed(modes)) {
+      return failure();
+    }
+    unsigned sourceLogicalBits =
+        pto::getPTOStorageElemBitWidth(sourceVMIType.getElementType());
+    unsigned resultLogicalBits =
+        pto::getPTOStorageElemBitWidth(resultVMIType.getElementType());
+    bool supportsPacked = modes->second;
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8725,6 +8725,12 @@ private:
     return parts;
   }
 
+  struct UnalignedLoadPart {
+    Value result;
+    Value base;
+    Value align;
+  };
+
   FailureOr<SmallVector<Value>> materializeUnalignedContiguousParts(
       VMILoadOp op, OneToNPatternRewriter &rewriter, Value source, Value offset,
       ArrayRef<Type> contiguousTypes, int64_t lanesPerPart) const {
@@ -8748,19 +8754,32 @@ private:
     SmallVector<Value> parts;
     parts.reserve(contiguousTypes.size());
     for (Type resultType : contiguousTypes) {
-      if (!isa<VRegType>(resultType)) {
-        return rewriter.notifyMatchFailure(op, "load result must be vreg");
+      FailureOr<UnalignedLoadPart> updatedState = emitUnalignedLoadPart(
+          op, rewriter, unalignedBase, unalignedAlign, resultType,
+          lanesPerPart);
+      if (failed(updatedState)) {
+        return failure();
       }
-      Value increment =
-          rewriter.create<arith::ConstantIndexOp>(op.getLoc(), lanesPerPart);
-      auto load = rewriter.create<VldusOp>(
-          op.getLoc(), resultType, unalignedAlign.getType(),
-          unalignedBase.getType(), unalignedBase, unalignedAlign, increment);
-      parts.push_back(load.getResult());
-      unalignedAlign = load.getUpdatedAlign();
-      unalignedBase = load.getUpdatedBase();
+      parts.push_back(updatedState->result);
+      unalignedBase = updatedState->base;
+      unalignedAlign = updatedState->align;
     }
     return parts;
+  }
+
+  FailureOr<UnalignedLoadPart> emitUnalignedLoadPart(
+      VMILoadOp op, OneToNPatternRewriter &rewriter, Value base, Value align,
+      Type resultType, int64_t lanesPerPart) const {
+    if (!isa<VRegType>(resultType)) {
+      return rewriter.notifyMatchFailure(op, "load result must be vreg");
+    }
+    Value increment =
+        rewriter.create<arith::ConstantIndexOp>(op.getLoc(), lanesPerPart);
+    auto load = rewriter.create<VldusOp>(
+        op.getLoc(), resultType, align.getType(), base.getType(), base, align,
+        increment);
+    return UnalignedLoadPart{load.getResult(), load.getUpdatedBase(),
+                             load.getUpdatedAlign()};
   }
 
   FailureOr<SmallVector<Value>> materializeContiguousLoadParts(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5127,10 +5127,10 @@ static FailureOr<SmallVector<Value>> materializeDeinterleaved4ToContiguous(
             "exceeds source footprint");
     return failure();
   }
-  SmallVector<size_t> counts;
-  SmallVector<size_t> offsets;
   size_t base = sourceParts.size() / 4;
   size_t remainder = sourceParts.size() % 4;
+  SmallVector<size_t> counts;
+  SmallVector<size_t> offsets;
   size_t offset = 0;
   for (size_t part = 0; part < 4; ++part) {
     counts.push_back(base + (part < remainder ? 1 : 0));
@@ -9335,10 +9335,9 @@ private:
     return success();
   }
 
-  LogicalResult lowerBlockF32(
-      VMIGroupLoadOp op, OneToNPatternRewriter &rewriter, Value source,
-      Value offset, Value rowStride, VMIVRegType resultVMIType,
-      VMILayoutAttr resultLayout) const {
+  FailureOr<std::pair<int64_t, int64_t>> validateBlockF32Shape(
+      VMIGroupLoadOp op, Value source, VMIVRegType resultVMIType,
+      VMILayoutAttr resultLayout, OneToNPatternRewriter &rewriter) const {
     FailureOr<int64_t> groupSize = getGroupSizeFromNumGroups(
         resultVMIType, op.getNumGroupsAttr().getInt());
     if (failed(groupSize)) {
@@ -9348,36 +9347,43 @@ private:
     bool validFactorShape =
         (*groupSize == 16 && resultLayout.getFactor() == 2) ||
         (*groupSize == 32 && resultLayout.getFactor() == 4);
-    if (!validFactorShape) {
-      return rewriter.notifyMatchFailure(
-          op, "block_deinterleaved group_load requires S=16/factor=2 or "
-              "S=32/factor=4");
-    }
-    bool validGroupCount = op.getNumGroupsAttr().getInt() % 8 == 0;
-    if (!validGroupCount) {
-      return rewriter.notifyMatchFailure(
-          op, "block_deinterleaved group_load requires num_groups multiple "
-              "of 8");
-    }
     std::optional<int64_t> constantRowStride =
         getConstantIndexValue(op.getRowStride());
     bool validRowStride = constantRowStride && *constantRowStride > 0 &&
                           *constantRowStride % 8 == 0;
-    if (!validRowStride) {
+    bool validGroupCount = op.getNumGroupsAttr().getInt() % 8 == 0;
+    if (!validFactorShape || !validGroupCount || !validRowStride ||
+        !isa<PtrType>(source.getType())) {
       return rewriter.notifyMatchFailure(
-          op, "block_deinterleaved group_load requires constant positive "
-              "row_stride divisible by 8 f32 elements");
+          op, !validFactorShape
+                  ? "block_deinterleaved group_load requires S=16/factor=2 or S=32/factor=4"
+                  : !validGroupCount
+                        ? "block_deinterleaved group_load requires num_groups multiple of 8"
+                        : !validRowStride
+                              ? "block_deinterleaved group_load requires constant positive "
+                                "row_stride divisible by 8 f32 elements"
+                              : "block_deinterleaved group_load requires !pto.ptr source");
     }
-    if (!isa<PtrType>(source.getType())) {
-      return rewriter.notifyMatchFailure(
-          op, "block_deinterleaved group_load requires !pto.ptr source");
+    return std::make_pair(*constantRowStride, resultLayout.getFactor());
+  }
+
+  LogicalResult lowerBlockF32(
+      VMIGroupLoadOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value offset, Value rowStride, VMIVRegType resultVMIType,
+      VMILayoutAttr resultLayout) const {
+    FailureOr<std::pair<int64_t, int64_t>> shape =
+        validateBlockF32Shape(op, source, resultVMIType, resultLayout,
+                              rewriter);
+    if (failed(shape)) {
+      return failure();
     }
+    int64_t constantRowStride = shape->first;
+    int64_t factor = shape->second;
     FailureOr<SmallVector<Type>> maybeResultTypes = getResultTypes(op, rewriter);
     if (failed(maybeResultTypes)) {
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
-    int64_t factor = resultLayout.getFactor();
     FailureOr<int64_t> blockElems = getVMILayoutBlockElems(resultVMIType);
     FailureOr<int64_t> chunksPerPart =
         getDataChunksInPart(resultVMIType, 0);
@@ -9401,7 +9407,7 @@ private:
     }
     return lowerBlockDeinterleaved(
         op, rewriter, source, offset, rowStride, resultVMIType, resultTypes,
-        resultLayout, factor, *blockElems, *chunksPerPart, *constantRowStride);
+        resultLayout, factor, *blockElems, *chunksPerPart, constantRowStride);
   }
 
   LogicalResult lowerByLayout(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3171,36 +3171,50 @@ FailureOr<Value> createMaskedStorePredicate(Location loc, VMIVRegType vmiType,
       .getResult();
 }
 
+static FailureOr<Value> compactDenseLaneStrideStorePredicate(
+    Location loc, Value userMask, VMILayoutAttr layout, StringRef targetGranularity,
+    PatternRewriter &rewriter) {
+  auto sourceMaskType = dyn_cast<MaskType>(userMask.getType());
+  if (!sourceMaskType || !layout) {
+    return failure();
+  }
+  auto targetMaskType = MaskType::get(rewriter.getContext(), targetGranularity);
+  Value compactMask = userMask;
+  StringRef sourceGranularity = sourceMaskType.getGranularity();
+  StringAttr lower = rewriter.getStringAttr("LOWER");
+  if (sourceGranularity == targetGranularity) {
+    return compactMask;
+  }
+  bool unpackLaneStride2 = layout.getLaneStride() == 2;
+  if (unpackLaneStride2) {
+    Value unpacked = rewriter
+                         .create<PunpackOp>(loc, targetMaskType, compactMask,
+                                            lower)
+                         .getResult();
+    return unpacked;
+  }
+  bool supportsLaneStride4 = layout.getLaneStride() == 4 &&
+                             sourceGranularity == "b8" &&
+                             targetGranularity == "b32";
+  if (!supportsLaneStride4) {
+    return failure();
+  }
+  auto b16MaskType = MaskType::get(rewriter.getContext(), "b16");
+  compactMask = rewriter
+                    .create<PunpackOp>(loc, b16MaskType, compactMask, lower)
+                    .getResult();
+  return rewriter
+      .create<PunpackOp>(loc, targetMaskType, compactMask, lower)
+      .getResult();
+}
+
 FailureOr<Value> createDenseLaneStrideStorePredicate(
     Location loc, VMIVRegType vmiType, int64_t chunk, Value userMask,
     StringRef targetGranularity, PatternRewriter &rewriter) {
-  auto sourceMaskType = dyn_cast<MaskType>(userMask.getType());
-  if (!sourceMaskType)
-    return failure();
-  auto targetMaskType = MaskType::get(rewriter.getContext(), targetGranularity);
-  Value compactMask = userMask;
   VMILayoutAttr layout = vmiType.getLayoutAttr();
-  if (!layout)
-    return failure();
-
-  auto lower = rewriter.getStringAttr("LOWER");
-  StringRef sourceGranularity = sourceMaskType.getGranularity();
-  if (sourceGranularity == targetGranularity) {
-    compactMask = userMask;
-  } else if (layout.getLaneStride() == 2) {
-    compactMask =
-        rewriter.create<PunpackOp>(loc, targetMaskType, compactMask, lower)
-            .getResult();
-  } else if (layout.getLaneStride() == 4 && sourceGranularity == "b8" &&
-             targetGranularity == "b32") {
-    auto b16MaskType = MaskType::get(rewriter.getContext(), "b16");
-    compactMask =
-        rewriter.create<PunpackOp>(loc, b16MaskType, compactMask, lower)
-            .getResult();
-    compactMask =
-        rewriter.create<PunpackOp>(loc, targetMaskType, compactMask, lower)
-            .getResult();
-  } else {
+  FailureOr<Value> compactMask = compactDenseLaneStrideStorePredicate(
+      loc, userMask, layout, targetGranularity, rewriter);
+  if (failed(compactMask)) {
     return failure();
   }
 
@@ -3210,15 +3224,16 @@ FailureOr<Value> createDenseLaneStrideStorePredicate(
   if (failed(activeLanes) || failed(maskLanes))
     return failure();
   if (*activeLanes == *maskLanes)
-    return compactMask;
+    return *compactMask;
 
+  auto targetMaskType = MaskType::get(rewriter.getContext(), targetGranularity);
   FailureOr<Value> tailMask = createPrefixMaskForActiveLanes(
       loc, targetMaskType, *activeLanes, rewriter);
   FailureOr<Value> allTrue = createAllTrueMask(loc, targetMaskType, rewriter);
   if (failed(tailMask) || failed(allTrue))
     return failure();
   return rewriter
-      .create<PandOp>(loc, targetMaskType, compactMask, *tailMask, *allTrue)
+      .create<PandOp>(loc, targetMaskType, *compactMask, *tailMask, *allTrue)
       .getResult();
 }
 
@@ -4657,8 +4672,9 @@ FailureOr<SmallVector<Value>> materializeContiguousToLaneStride(
   MLIRContext *ctx = rewriter.getContext();
   FailureOr<VRegType> inputCarrier =
       getUnsignedCarrierVRegType(ctx, *elementBits);
-  if (failed(inputCarrier))
+  if (failed(inputCarrier)) {
     return failure();
+  }
 
   SmallVector<Value> results;
   results.reserve(resultTypes.size());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10773,21 +10773,14 @@ struct OneToNVMIExpandLoadOpPattern
   using OneToNOpConversionPattern<VMIExpandLoadOp>::OneToNOpConversionPattern;
 
 private:
-  FailureOr<Value> materializeStaticExpandLoadPart(
-      VMIExpandLoadOp op, OneToNPatternRewriter &rewriter, Value source,
-      Value offset, Type resultType, int64_t index, int64_t lanesPerPart) const {
-    if (!isa<VRegType>(resultType)) {
-      return rewriter.notifyMatchFailure(op, "expand_load result must be vreg");
-    }
-    Value chunkOffset = createChunkOffset(
-        op.getLoc(), offset, index * lanesPerPart, rewriter);
-    return rewriter
-        .create<VldsOp>(op.getLoc(), resultType, Type{}, source, chunkOffset,
-                        nullptr)
-        .getResult();
-  }
+  struct RuntimeExpandLoadPlan {
+    VRegType resultType;
+    Value gatherBase;
+    Value mask;
+    Value passthru;
+  };
 
-  LogicalResult lowerRuntimeExpandLoad(
+  FailureOr<RuntimeExpandLoadPlan> buildRuntimeExpandLoadPlan(
       VMIExpandLoadOp op, OneToNPatternRewriter &rewriter, Value source,
       Value offset, ValueRange maskParts, ValueRange passthruParts,
       ArrayRef<Type> resultTypes) const {
@@ -10812,8 +10805,15 @@ private:
                            .create<AddPtrOp>(op.getLoc(), source.getType(), source,
                                              offset)
                            .getResult();
+    return RuntimeExpandLoadPlan{*resultType, gatherBase, maskParts.front(),
+                                 passthruParts.front()};
+  }
+
+  FailureOr<Value> materializeRuntimeExpandLoad(
+      VMIExpandLoadOp op, OneToNPatternRewriter &rewriter,
+      const RuntimeExpandLoadPlan &plan) const {
     auto indexType = VRegType::get(rewriter.getContext(),
-                                   resultType.getElementCount(),
+                                   plan.resultType.getElementCount(),
                                    rewriter.getI32Type());
     FailureOr<Value> indexSeedMask =
         createAllTrueMaskForVReg(op.getLoc(), indexType, rewriter);
@@ -10828,17 +10828,47 @@ private:
                         .getResult();
     Value indices = rewriter
                         .create<VusqzOp>(op.getLoc(), indexType, carrier,
-                                        maskParts.front())
+                                        plan.mask)
                         .getResult();
     Value gathered = rewriter
-                         .create<Vgather2BcOp>(op.getLoc(), resultType, gatherBase,
-                                               indices, maskParts.front())
+                         .create<Vgather2BcOp>(op.getLoc(), plan.resultType,
+                                               plan.gatherBase, indices,
+                                               plan.mask)
                          .getResult();
-    Value result = rewriter
-                       .create<VselOp>(op.getLoc(), resultType, gathered,
-                                       passthruParts.front(), maskParts.front())
-                       .getResult();
-    replaceOpWithFlatConvertedValues(rewriter, op, SmallVector<Value>{result},
+    return rewriter
+        .create<VselOp>(op.getLoc(), plan.resultType, gathered, plan.passthru,
+                        plan.mask)
+        .getResult();
+  }
+
+  FailureOr<Value> materializeStaticExpandLoadPart(
+      VMIExpandLoadOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value offset, Type resultType, int64_t index, int64_t lanesPerPart) const {
+    if (!isa<VRegType>(resultType)) {
+      return rewriter.notifyMatchFailure(op, "expand_load result must be vreg");
+    }
+    Value chunkOffset = createChunkOffset(
+        op.getLoc(), offset, index * lanesPerPart, rewriter);
+    return rewriter
+        .create<VldsOp>(op.getLoc(), resultType, Type{}, source, chunkOffset,
+                        nullptr)
+        .getResult();
+  }
+
+  LogicalResult lowerRuntimeExpandLoad(
+      VMIExpandLoadOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value offset, ValueRange maskParts, ValueRange passthruParts,
+      ArrayRef<Type> resultTypes) const {
+    FailureOr<RuntimeExpandLoadPlan> plan = buildRuntimeExpandLoadPlan(
+        op, rewriter, source, offset, maskParts, passthruParts, resultTypes);
+    if (failed(plan)) {
+      return failure();
+    }
+    FailureOr<Value> result = materializeRuntimeExpandLoad(op, rewriter, *plan);
+    if (failed(result)) {
+      return failure();
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, SmallVector<Value>{*result},
                                      *this->getTypeConverter());
     return success();
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11424,58 +11424,95 @@ private:
     return success();
   }
 
+  FailureOr<bool> tryLowerDirectBRC(
+      VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
+      Value source, Value offset, Value sourceGroupStride,
+      VMIVRegType resultVMIType, ArrayRef<Type> resultTypes, int64_t numGroups,
+      FailureOr<VMIGroupBroadcastLoadDirectFact> &directFact) const {
+    bool candidate = succeeded(directFact) &&
+                     directFact->kind == VMIGroupBroadcastLoadDirectKind::BRC &&
+                     !resultTypes.empty();
+    if (!candidate) {
+      return false;
+    }
+    unsigned bits =
+        pto::getPTOStorageElemBitWidth(resultVMIType.getElementType());
+    std::optional<StringRef> dist;
+    if (bits == 8) {
+      dist = StringRef("BRC_B8");
+    } else if (bits == 16) {
+      dist = StringRef("BRC_B16");
+    } else if (bits == 32) {
+      dist = StringRef("BRC_B32");
+    }
+    auto firstType = dyn_cast<VRegType>(resultTypes.front());
+    bool legal = dist && firstType && isDirectMemoryDistAddressLegal(
+                                  op.getSource(), op.getOffset(),
+                                  resultVMIType.getElementType(), firstType,
+                                  VPTOMemoryOpFamily::Load, *dist);
+    if (!legal) {
+      return false;
+    }
+    if (failed(lowerDirectBRC(op, rewriter, source, offset, sourceGroupStride,
+                              resultTypes, numGroups, *dist))) {
+      return failure();
+    }
+    return true;
+  }
+
+  FailureOr<bool> tryLowerDirectE2B(
+      VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
+      Value source, Value offset, VMIVRegType resultVMIType,
+      ArrayRef<Type> resultTypes, int64_t numGroups,
+      FailureOr<VMIGroupBroadcastLoadDirectFact> &directFact) const {
+    bool candidate = succeeded(directFact) &&
+                     directFact->kind == VMIGroupBroadcastLoadDirectKind::E2B &&
+                     !resultTypes.empty();
+    if (!candidate) {
+      return false;
+    }
+    unsigned bits = directFact->layout.elementBits;
+    StringRef dist = bits == 16 ? StringRef("E2B_B16") : StringRef("E2B_B32");
+    auto firstType = dyn_cast<VRegType>(resultTypes.front());
+    bool legal = (bits == 16 || bits == 32) && firstType &&
+                 isDirectMemoryDistAddressLegal(
+                     op.getSource(), op.getOffset(),
+                     resultVMIType.getElementType(), firstType,
+                     VPTOMemoryOpFamily::Load, dist);
+    if (!legal) {
+      return false;
+    }
+    if (failed(lowerDirectE2B(op, rewriter, source, offset, resultVMIType,
+                              resultTypes, numGroups, bits,
+                              resultVMIType.getLayoutAttr()))) {
+      return failure();
+    }
+    return true;
+  }
+
   LogicalResult lowerDirectOrFallback(
       VMIGroupBroadcastLoadOp op, OneToNPatternRewriter &rewriter,
       Value source, Value offset, Value sourceGroupStride,
       VMIVRegType resultVMIType, ArrayRef<Type> resultTypes, int64_t numGroups,
       FailureOr<VMIGroupBroadcastLoadDirectFact> &directFact) const {
-    auto getBRCDist = [&resultVMIType]() -> std::optional<StringRef> {
-      unsigned bits =
-          pto::getPTOStorageElemBitWidth(resultVMIType.getElementType());
-      if (bits == 8) {
-        return StringRef("BRC_B8");
-      }
-      if (bits == 16) {
-        return StringRef("BRC_B16");
-      }
-      if (bits == 32) {
-        return StringRef("BRC_B32");
-      }
-      return std::nullopt;
-    };
-    bool canUseBRC = succeeded(directFact) &&
-                     directFact->kind == VMIGroupBroadcastLoadDirectKind::BRC &&
-                     !resultTypes.empty();
-    if (canUseBRC) {
-      std::optional<StringRef> dist = getBRCDist();
-      auto firstType = dyn_cast<VRegType>(resultTypes.front());
-      canUseBRC = dist && firstType && isDirectMemoryDistAddressLegal(
-                                      op.getSource(), op.getOffset(),
-                                      resultVMIType.getElementType(), firstType,
-                                      VPTOMemoryOpFamily::Load, *dist);
-      if (canUseBRC) {
-        return lowerDirectBRC(op, rewriter, source, offset, sourceGroupStride,
-                              resultTypes, numGroups, *dist);
-      }
+    FailureOr<bool> loweredBRC = tryLowerDirectBRC(
+        op, rewriter, source, offset, sourceGroupStride, resultVMIType,
+        resultTypes, numGroups, directFact);
+    if (failed(loweredBRC)) {
+      return failure();
+    }
+    if (*loweredBRC) {
+      return success();
     }
 
-    bool canUseE2B = succeeded(directFact) &&
-                     directFact->kind == VMIGroupBroadcastLoadDirectKind::E2B &&
-                     !resultTypes.empty();
-    if (canUseE2B) {
-      unsigned bits = directFact->layout.elementBits;
-      StringRef dist = bits == 16 ? StringRef("E2B_B16") : StringRef("E2B_B32");
-      auto firstType = dyn_cast<VRegType>(resultTypes.front());
-      canUseE2B = (bits == 16 || bits == 32) && firstType &&
-                  isDirectMemoryDistAddressLegal(
-                      op.getSource(), op.getOffset(),
-                      resultVMIType.getElementType(), firstType,
-                      VPTOMemoryOpFamily::Load, dist);
-      if (canUseE2B) {
-        return lowerDirectE2B(op, rewriter, source, offset, resultVMIType,
-                              resultTypes, numGroups, bits,
-                              resultVMIType.getLayoutAttr());
-      }
+    FailureOr<bool> loweredE2B = tryLowerDirectE2B(
+        op, rewriter, source, offset, resultVMIType, resultTypes, numGroups,
+        directFact);
+    if (failed(loweredE2B)) {
+      return failure();
+    }
+    if (*loweredE2B) {
+      return success();
     }
     return lowerGroupSlotFallback(op, rewriter, source, offset,
                                   sourceGroupStride, resultVMIType, resultTypes,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -13710,6 +13710,51 @@ private:
     return results;
   }
 
+  struct Deinterleaved2GroupReduceTypes {
+    VRegType resultType;
+    MaskType maskType;
+    VRegType sourcePartType;
+    VRegType rowResultType;
+    MaskType rowMaskType;
+  };
+
+  FailureOr<Deinterleaved2GroupReduceTypes>
+  getDeinterleaved2GroupReduceTypes(
+      OpTy op, ValueRange sourceParts, ValueRange maskParts,
+      TypeRange resultTypes, OneToNPatternRewriter &rewriter) const {
+    for (Type resultType : resultTypes) {
+      if (!isa<VRegType>(resultType)) {
+        return rewriter.notifyMatchFailure(
+            op, "deinterleaved=2 group_reduce result must be vreg");
+      }
+    }
+    auto resultType = dyn_cast<VRegType>(resultTypes.front());
+    auto maskType = dyn_cast<MaskType>(maskParts.front().getType());
+    if (!resultType || !maskType) {
+      return rewriter.notifyMatchFailure(
+          op, "deinterleaved=2 group_reduce requires physical vreg/mask");
+    }
+    auto sourcePartType = dyn_cast<VRegType>(sourceParts.front().getType());
+    if (!sourcePartType) {
+      return rewriter.notifyMatchFailure(
+          op, "deinterleaved=2 group_reduce source must be vreg");
+    }
+    FailureOr<VRegType> rowResultType =
+        getRowResultType(sourcePartType, resultType);
+    if (failed(rowResultType)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to derive deinterleaved=2 row-reduction type");
+    }
+    FailureOr<MaskType> rowMaskType =
+        getMaskTypeForVReg(*rowResultType, rewriter.getContext());
+    if (failed(rowMaskType)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to derive deinterleaved=2 combine mask type");
+    }
+    return Deinterleaved2GroupReduceTypes{
+        *resultType, *maskType, *sourcePartType, *rowResultType, *rowMaskType};
+  }
+
   LogicalResult lowerFullDeinterleaved2(
       OpTy op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
       ValueRange sourceParts, ValueRange maskParts, TypeRange resultTypes,
@@ -13744,37 +13789,14 @@ private:
       return rewriter.notifyMatchFailure(
           op, "deinterleaved=2 group_reduce arity mismatch");
     }
-    for (Type resultType : resultTypes) {
-      if (!isa<VRegType>(resultType)) {
-        return rewriter.notifyMatchFailure(
-            op, "deinterleaved=2 group_reduce result must be vreg");
-      }
-    }
-    auto resultType = dyn_cast<VRegType>(resultTypes.front());
-    auto maskType = dyn_cast<MaskType>(maskParts.front().getType());
-    if (!resultType || !maskType) {
-      return rewriter.notifyMatchFailure(
-          op, "deinterleaved=2 group_reduce requires physical vreg/mask");
-    }
-    auto sourcePartType = dyn_cast<VRegType>(sourceParts.front().getType());
-    if (!sourcePartType) {
-      return rewriter.notifyMatchFailure(
-          op, "deinterleaved=2 group_reduce source must be vreg");
-    }
-    FailureOr<VRegType> rowResultType =
-        getRowResultType(sourcePartType, resultType);
-    if (failed(rowResultType)) {
-      return rewriter.notifyMatchFailure(
-          op, "failed to derive deinterleaved=2 row-reduction type");
-    }
-    FailureOr<MaskType> rowMaskType =
-        getMaskTypeForVReg(*rowResultType, rewriter.getContext());
-    if (failed(rowMaskType)) {
-      return rewriter.notifyMatchFailure(
-          op, "failed to derive deinterleaved=2 combine mask type");
+    FailureOr<Deinterleaved2GroupReduceTypes> types =
+        getDeinterleaved2GroupReduceTypes(op, sourceParts, maskParts,
+                                          resultTypes, rewriter);
+    if (failed(types)) {
+      return failure();
     }
     FailureOr<Value> firstLaneMask =
-        createPrefixMask(op.getLoc(), *rowMaskType, "PAT_VL1", rewriter);
+        createPrefixMask(op.getLoc(), types->rowMaskType, "PAT_VL1", rewriter);
     if (failed(firstLaneMask)) {
       return rewriter.notifyMatchFailure(
           op, "failed to create deinterleaved=2 group_reduce lane mask");
@@ -13782,13 +13804,14 @@ private:
     FailureOr<SmallVector<Value>> reducedResults =
         buildDeinterleaved2GroupResults(
             op, sourceParts, maskParts, groupCount, chunksPerGroupPerPart,
-            chunksPerPart, *sourcePartType, *rowResultType, *maskType,
+            chunksPerPart, types->sourcePartType, types->rowResultType,
+            types->maskType,
             *firstLaneMask, rewriter);
     if (failed(reducedResults)) {
       return failure();
     }
     FailureOr<SmallVector<Value>> results = restoreDeinterleaved2GroupResults(
-        op, *reducedResults, resultTypes, resultType, rewriter);
+        op, *reducedResults, resultTypes, types->resultType, rewriter);
     if (failed(results)) {
       return failure();
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2022,16 +2022,28 @@ LogicalResult checkSupportedSlots8GroupSlotLoadShape(
   return success();
 }
 
-LogicalResult checkSupportedGroupSlotLoadShape(
-    VMIGroupSlotLoadOp op,
-    std::string *reason) {
+static LogicalResult checkGroupSlotLoadMemoryContract(
+    VMIGroupSlotLoadOp op, VMIVRegType resultType, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
       *reason = message.str();
     }
     return failure();
   };
+  VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(
+      op.getSource(), op.getOffset(), resultType, VMIMemoryCoverageKind::Dense);
+  if (!accessPlan.layoutSupport.isSupported()) {
+    return fail(accessPlan.layoutSupport.reason);
+  }
+  if (!isa<PtrType>(op.getSource().getType())) {
+    return fail("group_slot_load requires !pto.ptr source");
+  }
+  return success();
+}
 
+LogicalResult checkSupportedGroupSlotLoadShape(
+    VMIGroupSlotLoadOp op,
+    std::string *reason) {
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutSupport supports;
   FailureOr<VMIGroupSlotLayoutFact> fact = supports.getGroupSlotLoadLayoutFact(
@@ -2040,13 +2052,8 @@ LogicalResult checkSupportedGroupSlotLoadShape(
     return failure();
   }
 
-  VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(
-      op.getSource(), op.getOffset(), resultType, VMIMemoryCoverageKind::Dense);
-  if (!accessPlan.layoutSupport.isSupported()) {
-    return fail(accessPlan.layoutSupport.reason);
-  }
-  if (!isa<PtrType>(op.getSource().getType())) {
-    return fail("group_slot_load requires !pto.ptr source");
+  if (failed(checkGroupSlotLoadMemoryContract(op, resultType, reason))) {
+    return failure();
   }
 
   if (fact->slots == 8) {
@@ -3020,8 +3027,9 @@ FailureOr<int64_t> getContiguousActiveDataLanes(VMIVRegType vmiType,
                                                 int64_t chunk) {
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(vmiType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return failure();
+  }
 
   int64_t remaining = vmiType.getElementCount() - chunk * *lanesPerPart;
   return std::clamp<int64_t>(remaining, 0, *lanesPerPart);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2709,6 +2709,33 @@ checkSinglePhysicalStrideAccess(Type dataType, Type maskType,
   return success();
 }
 
+static LogicalResult checkStrideMemoryContract(
+    Type dataType, Type maskType, VMILayoutAttr dataLayout,
+    VMILayoutAttr maskLayout, Type pointerType, StringRef dataName,
+    StringRef pointerDiagnostic, StringRef arityDiagnostic,
+    std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  if (!dataLayout || !maskLayout) {
+    return fail(Twine("requires assigned ") + dataName + " and mask layouts");
+  }
+  bool nonContiguousLayout =
+      !dataLayout.isContiguous() || !maskLayout.isContiguous();
+  if (nonContiguousLayout) {
+    return fail(Twine("requires contiguous ") + dataName +
+                " and mask layouts");
+  }
+  if (!isa<PtrType>(pointerType)) {
+    return fail(pointerDiagnostic);
+  }
+  return checkSinglePhysicalStrideAccess(dataType, maskType, arityDiagnostic,
+                                         reason);
+}
+
 LogicalResult
 checkSupportedStrideStoreShape(VMIStrideStoreOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
@@ -2720,29 +2747,17 @@ checkSupportedStrideStoreShape(VMIStrideStoreOp op, std::string *reason) {
 
   auto valueType = cast<VMIVRegType>(op.getValue().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
-  VMILayoutAttr valueLayout = valueType.getLayoutAttr();
-  VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  if (!valueLayout || !maskLayout) {
-    return fail("requires assigned value and mask layouts");
-  }
-  bool nonContiguousLayout = !valueLayout.isContiguous() ||
-                             !maskLayout.isContiguous();
-  if (nonContiguousLayout) {
-    return fail("requires contiguous value and mask layouts");
-  }
-
-  if (!isa<PtrType>(op.getDestination().getType())) {
-    return fail("requires !pto.ptr destination because pto.vsstb is "
-                "pointer-only");
-  }
-  if (failed(checkSupportedStoreShape(valueType,
-                                      op.getDestination(),
-                                      op.getDestination().getType(), reason)))
+  if (failed(checkSupportedStoreShape(valueType, op.getDestination(),
+                                      op.getDestination().getType(), reason))) {
     return failure();
+  }
 
-  return checkSinglePhysicalStrideAccess(
-      valueType, maskType,
-      "currently supports one physical value/mask chunk", reason);
+  return checkStrideMemoryContract(
+      valueType, maskType, valueType.getLayoutAttr(), maskType.getLayoutAttr(),
+      op.getDestination().getType(), "value",
+      "requires !pto.ptr destination because pto.vsstb is "
+      "pointer-only", "currently supports one physical value/mask chunk",
+      reason);
 }
 
 LogicalResult
@@ -2756,18 +2771,10 @@ checkSupportedStrideLoadShape(VMIStrideLoadOp op, std::string *reason) {
 
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
-  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  if (!resultLayout || !maskLayout)
-    return fail("requires assigned result and mask layouts");
-  if (!resultLayout.isContiguous() || !maskLayout.isContiguous())
-    return fail("requires contiguous result and mask layouts");
-
-  if (!isa<PtrType>(op.getSource().getType()))
-    return fail("requires !pto.ptr source because pto.vsldb is pointer-only");
-
-  return checkSinglePhysicalStrideAccess(
-      resultType, maskType,
+  return checkStrideMemoryContract(
+      resultType, maskType, resultType.getLayoutAttr(), maskType.getLayoutAttr(),
+      op.getSource().getType(), "result",
+      "requires !pto.ptr source because pto.vsldb is pointer-only",
       "currently supports one physical result/mask chunk", reason);
 }
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12525,6 +12525,41 @@ template <typename SourceOp, typename TargetOp>
 struct OneToNVMIMaskUnaryOpPattern : OneToNOpConversionPattern<SourceOp> {
   using OneToNOpConversionPattern<SourceOp>::OneToNOpConversionPattern;
 
+private:
+  LogicalResult lowerParts(SourceOp op, ValueRange sourceParts,
+                           ArrayRef<Type> resultTypes,
+                           OneToNPatternRewriter &rewriter) const {
+    const bool invalidArity = sourceParts.size() != resultTypes.size();
+    if (invalidArity) {
+      return rewriter.notifyMatchFailure(
+          op, "physical mask unary arity mismatch");
+    }
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (auto [source, resultType] :
+         llvm::zip_equal(sourceParts, resultTypes)) {
+      auto maskType = dyn_cast<MaskType>(resultType);
+      const bool invalidPart = !maskType || source.getType() != resultType;
+      if (invalidPart) {
+        return rewriter.notifyMatchFailure(
+            op, "physical mask unary part type mismatch");
+      }
+      FailureOr<Value> seedMask =
+          createAllTrueMask(op.getLoc(), maskType, rewriter);
+      if (failed(seedMask)) {
+        return rewriter.notifyMatchFailure(
+            op, "unsupported mask type for all-true mask unary seed");
+      }
+      results.push_back(
+          rewriter.create<TargetOp>(op.getLoc(), resultType, source, *seedMask)
+              .getResult());
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
+public:
   LogicalResult matchAndRewrite(
       SourceOp op,
       typename OneToNOpConversionPattern<SourceOp>::OpAdaptor adaptor,
@@ -12536,30 +12571,7 @@ struct OneToNVMIMaskUnaryOpPattern : OneToNOpConversionPattern<SourceOp> {
       return failure();
     }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (sourceParts.size() != resultTypes.size())
-      return rewriter.notifyMatchFailure(op,
-                                         "physical mask unary arity mismatch");
-
-    SmallVector<Value> results;
-    results.reserve(resultTypes.size());
-    for (auto [source, resultType] :
-         llvm::zip_equal(sourceParts, resultTypes)) {
-      auto maskType = dyn_cast<MaskType>(resultType);
-      if (!maskType || source.getType() != resultType)
-        return rewriter.notifyMatchFailure(
-            op, "physical mask unary part type mismatch");
-      FailureOr<Value> seedMask =
-          createAllTrueMask(op.getLoc(), maskType, rewriter);
-      if (failed(seedMask))
-        return rewriter.notifyMatchFailure(
-            op, "unsupported mask type for all-true mask unary seed");
-      results.push_back(
-          rewriter.create<TargetOp>(op.getLoc(), resultType, source, *seedMask)
-              .getResult());
-    }
-
-    replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
-    return success();
+    return lowerParts(op, sourceParts, resultTypes, rewriter);
   }
 };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8793,6 +8793,37 @@ private:
     return success();
   }
 
+  FailureOr<std::array<Value, 4>> materializeDeinterleaved4LoadGroup(
+      VMILoadOp op, OneToNPatternRewriter &rewriter, Value source,
+      Value offset, ArrayRef<Type> resultTypes, int64_t groups,
+      int64_t group, int64_t lanesPerPart, StringRef dist) const {
+    Type types[4] = {resultTypes[group], resultTypes[groups + group],
+                     resultTypes[2 * groups + group],
+                     resultTypes[3 * groups + group]};
+    bool mismatchedTypes = types[0] != types[1] || types[0] != types[2] ||
+                           types[0] != types[3];
+    if (mismatchedTypes) {
+      return rewriter.notifyMatchFailure(
+          op, "vldsx2 deinterleaved=4 load requires matching part types");
+    }
+    Value firstOffset = createChunkOffset(
+        op.getLoc(), offset, group * 4 * lanesPerPart, rewriter);
+    Value secondOffset = createChunkOffset(
+        op.getLoc(), offset, (group * 4 + 2) * lanesPerPart, rewriter);
+    auto first = rewriter.create<Vldsx2Op>(
+        op.getLoc(), types[0], types[1], Type{}, source, firstOffset,
+        rewriter.getStringAttr(dist));
+    auto second = rewriter.create<Vldsx2Op>(
+        op.getLoc(), types[2], types[3], Type{}, source, secondOffset,
+        rewriter.getStringAttr(dist));
+    auto even = rewriter.create<VdintlvOp>(
+        op.getLoc(), types[0], types[2], first.getLow(), second.getLow());
+    auto odd = rewriter.create<VdintlvOp>(
+        op.getLoc(), types[1], types[3], first.getHigh(), second.getHigh());
+    return std::array<Value, 4>{even.getLow(), odd.getLow(), even.getHigh(),
+                                odd.getHigh()};
+  }
+
   LogicalResult lowerDeinterleaved4(
       VMILoadOp op, OneToNPatternRewriter &rewriter, Value source, Value offset,
       ArrayRef<Type> resultTypes, int64_t lanesPerPart, StringRef dist) const {
@@ -8807,34 +8838,16 @@ private:
       part.reserve(groups);
     }
     for (int64_t group = 0; group < groups; ++group) {
-      Type types[4] = {resultTypes[group], resultTypes[groups + group],
-                       resultTypes[2 * groups + group],
-                       resultTypes[3 * groups + group]};
-      bool mismatchedTypes = types[0] != types[1] || types[0] != types[2] ||
-                             types[0] != types[3];
-      if (mismatchedTypes) {
-        return rewriter.notifyMatchFailure(
-            op, "vldsx2 deinterleaved=4 load requires matching part types");
+      FailureOr<std::array<Value, 4>> groupValues =
+          materializeDeinterleaved4LoadGroup(
+              op, rewriter, source, offset, resultTypes, groups, group,
+              lanesPerPart, dist);
+      if (failed(groupValues)) {
+        return failure();
       }
-      Value firstOffset =
-          createChunkOffset(op.getLoc(), offset, group * 4 * lanesPerPart,
-                            rewriter);
-      Value secondOffset = createChunkOffset(
-          op.getLoc(), offset, (group * 4 + 2) * lanesPerPart, rewriter);
-      auto first = rewriter.create<Vldsx2Op>(
-          op.getLoc(), types[0], types[1], Type{}, source, firstOffset,
-          rewriter.getStringAttr(dist));
-      auto second = rewriter.create<Vldsx2Op>(
-          op.getLoc(), types[2], types[3], Type{}, source, secondOffset,
-          rewriter.getStringAttr(dist));
-      auto even = rewriter.create<VdintlvOp>(
-          op.getLoc(), types[0], types[2], first.getLow(), second.getLow());
-      auto odd = rewriter.create<VdintlvOp>(
-          op.getLoc(), types[1], types[3], first.getHigh(), second.getHigh());
-      parts[0].push_back(even.getLow());
-      parts[1].push_back(odd.getLow());
-      parts[2].push_back(even.getHigh());
-      parts[3].push_back(odd.getHigh());
+      for (size_t part = 0; part < 4; ++part) {
+        parts[part].push_back((*groupValues)[part]);
+      }
     }
     SmallVector<Value> results;
     results.reserve(resultTypes.size());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10427,6 +10427,29 @@ private:
     return success();
   }
 
+  LogicalResult emitAlignedSlots8LaneStride(
+      VMIGroupStoreOp op, OneToNPatternRewriter &rewriter,
+      ValueRange valueParts, ArrayRef<Value> groupOffsets, Value destination,
+      MaskType maskType, int64_t numGroups, StringRef dist) const {
+    for (auto [slotBlock, value] : llvm::enumerate(valueParts)) {
+      if (!isa<VRegType>(value.getType())) {
+        return rewriter.notifyMatchFailure(op,
+                                           "group_store value must be vreg");
+      }
+      int64_t activeGroups = std::min<int64_t>(8, numGroups - slotBlock * 8);
+      FailureOr<Value> mask = createPrefixMaskForActiveLanes(
+          op.getLoc(), maskType, activeGroups, rewriter);
+      if (failed(mask)) {
+        return rewriter.notifyMatchFailure(
+            op, "failed to create packed slots=8 group_store mask");
+      }
+      rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{}, value,
+                              destination, groupOffsets[slotBlock],
+                              rewriter.getStringAttr(dist), *mask);
+    }
+    return success();
+  }
+
   LogicalResult lowerSlots8LaneStride(
       VMIGroupStoreOp op, OpAdaptor adaptor, OneToNPatternRewriter &rewriter,
       VMIVRegType valueVMIType, VMILayoutAttr layout, Value destination,
@@ -10485,21 +10508,10 @@ private:
       rewriter.eraseOp(op);
       return success();
     }
-    for (auto [slotBlock, value] : llvm::enumerate(valueParts)) {
-      if (!isa<VRegType>(value.getType())) {
-        return rewriter.notifyMatchFailure(op,
-                                           "group_store value must be vreg");
-      }
-      int64_t activeGroups = std::min<int64_t>(8, numGroups - slotBlock * 8);
-      FailureOr<Value> mask = createPrefixMaskForActiveLanes(
-          op.getLoc(), maskType, activeGroups, rewriter);
-      if (failed(mask)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to create packed slots=8 group_store mask");
-      }
-      rewriter.create<VstsOp>(op.getLoc(), /*updated_base=*/Type{}, value,
-                              destination, groupOffsets[slotBlock],
-                              rewriter.getStringAttr(*dist), *mask);
+    if (failed(emitAlignedSlots8LaneStride(
+            op, rewriter, valueParts, groupOffsets, destination, maskType,
+            numGroups, *dist))) {
+      return failure();
     }
     rewriter.eraseOp(op);
     return success();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18291,28 +18291,27 @@ std::optional<WalkResult> verifySupportedVMIConversionOp(Operation *op) {
   return std::nullopt;
 }
 
+template <typename CarryOp, typename ShapeCheck>
+std::optional<WalkResult> verifyAddCarryShape(CarryOp op, ShapeCheck check,
+                                               StringRef diagnostic) {
+  std::string reason;
+  if (succeeded(check(op, &reason))) {
+    return WalkResult::advance();
+  }
+  op.emitError() << kVMIDiagUnsupportedPrefix << diagnostic << reason << ")";
+  return WalkResult::interrupt();
+}
+
 std::optional<WalkResult> verifySupportedVMIAddCarryOp(Operation *op) {
   if (auto addc = dyn_cast<VMIVaddcOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedVMIAddcShape(addc, &reason))) {
-      return WalkResult::advance();
-    }
-    addc.emitError() << kVMIDiagUnsupportedPrefix
-                     << "pto.vmi.vaddc requires matching 32-bit data and "
-                        "b32 mask parts ("
-                     << reason << ")";
-    return WalkResult::interrupt();
+    return verifyAddCarryShape(
+        addc, checkSupportedVMIAddcShape,
+        "pto.vmi.vaddc requires matching 32-bit data and b32 mask parts (");
   }
   if (auto addcs = dyn_cast<VMIVaddcsOp>(op)) {
-    std::string reason;
-    if (succeeded(checkSupportedVMIAddcsShape(addcs, &reason))) {
-      return WalkResult::advance();
-    }
-    addcs.emitError() << kVMIDiagUnsupportedPrefix
-                      << "pto.vmi.vaddcs requires matching 32-bit data and "
-                         "b32 mask parts ("
-                      << reason << ")";
-    return WalkResult::interrupt();
+    return verifyAddCarryShape(
+        addcs, checkSupportedVMIAddcsShape,
+        "pto.vmi.vaddcs requires matching 32-bit data and b32 mask parts (");
   }
   return std::nullopt;
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9237,14 +9237,18 @@ private:
     return fact;
   }
 
-  LogicalResult lowerInterleaveByLayout(
-      SourceOp op, OneToNPatternRewriter &rewriter, ValueRange lhsParts,
-      ValueRange rhsParts, ValueRange maskParts, ArrayRef<Type> lowTypes,
-      ArrayRef<Type> highTypes, Type elementType,
-      const VMIInterleaveLayoutFact &fact) const {
-    auto isContiguous = [](VMILayoutAttr layout) {
-      return layout && layout.isContiguous() && layout.getLaneStride() == 1;
-    };
+  enum class InterleaveLoweringKind { LaneStride, Contiguous, ZeroCopy };
+
+  struct InterleaveLoweringPlan {
+    InterleaveLoweringKind kind;
+    int64_t inputFactor = 0;
+    int64_t outputFactor = 0;
+    bool zeroCopyVintlv = false;
+  };
+
+  FailureOr<InterleaveLoweringPlan> classifyInterleaveLowering(
+      SourceOp op, const VMIInterleaveLayoutFact &fact,
+      OneToNPatternRewriter &rewriter) const {
     bool allSameLaneStride = fact.lhsLayout == fact.rhsLayout &&
                              fact.lhsLayout == fact.maskLayout &&
                              fact.lhsLayout == fact.lowLayout &&
@@ -9252,17 +9256,18 @@ private:
                              fact.lhsLayout.isContiguous() &&
                              fact.lhsLayout.getLaneStride() > 1;
     if (allSameLaneStride) {
-      return lowerLaneStrideInterleave(op, rewriter, lhsParts, rhsParts,
-                                       lowTypes, highTypes, elementType, fact);
+      return InterleaveLoweringPlan{InterleaveLoweringKind::LaneStride};
     }
+    auto isContiguous = [](VMILayoutAttr layout) {
+      return layout && layout.isContiguous() && layout.getLaneStride() == 1;
+    };
     bool allContiguous = isContiguous(fact.lhsLayout) &&
                          isContiguous(fact.rhsLayout) &&
                          isContiguous(fact.maskLayout) &&
                          isContiguous(fact.lowLayout) &&
                          isContiguous(fact.highLayout);
     if (allContiguous) {
-      return lowerContiguous(op, rewriter, lhsParts, rhsParts, maskParts,
-                             lowTypes, highTypes);
+      return InterleaveLoweringPlan{InterleaveLoweringKind::Contiguous};
     }
     int64_t inputFactor = getElementDeinterleaveFactor(fact.lhsLayout);
     int64_t outputFactor = getElementDeinterleaveFactor(fact.lowLayout);
@@ -9281,9 +9286,31 @@ private:
       return rewriter.notifyMatchFailure(
           op, "unsupported interleave physical layout relation");
     }
+    return InterleaveLoweringPlan{InterleaveLoweringKind::ZeroCopy, inputFactor,
+                                  outputFactor, zeroCopyVintlv};
+  }
+
+  LogicalResult lowerInterleaveByLayout(
+      SourceOp op, OneToNPatternRewriter &rewriter, ValueRange lhsParts,
+      ValueRange rhsParts, ValueRange maskParts, ArrayRef<Type> lowTypes,
+      ArrayRef<Type> highTypes, Type elementType,
+      const VMIInterleaveLayoutFact &fact) const {
+    FailureOr<InterleaveLoweringPlan> plan =
+        classifyInterleaveLowering(op, fact, rewriter);
+    if (failed(plan)) {
+      return failure();
+    }
+    if (plan->kind == InterleaveLoweringKind::LaneStride) {
+      return lowerLaneStrideInterleave(op, rewriter, lhsParts, rhsParts,
+                                       lowTypes, highTypes, elementType, fact);
+    }
+    if (plan->kind == InterleaveLoweringKind::Contiguous) {
+      return lowerContiguous(op, rewriter, lhsParts, rhsParts, maskParts,
+                             lowTypes, highTypes);
+    }
     FailureOr<SmallVector<Value>> zeroCopyResults = materializeZeroCopyResults(
-        op, lhsParts, rhsParts, lowTypes, highTypes, inputFactor, outputFactor,
-        zeroCopyVintlv, rewriter);
+        op, lhsParts, rhsParts, lowTypes, highTypes, plan->inputFactor,
+        plan->outputFactor, plan->zeroCopyVintlv, rewriter);
     if (failed(zeroCopyResults)) {
       return failure();
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10278,33 +10278,42 @@ private:
       for (int64_t chunk = 0; chunk < chunksPerGroup; ++chunk) {
         int64_t lowIndex = group * chunksPerGroup + chunk;
         int64_t highIndex = chunksPerPart + lowIndex;
-        Value low = valueParts[lowIndex];
-        Value high = valueParts[highIndex];
-        bool matchingTypes = low.getType() == high.getType();
-        if (!matchingTypes) {
-          return rewriter.notifyMatchFailure(
-              op, "vstsx2 group_store requires matching low/high types");
+        if (failed(emitDeinterleaved2GroupStorePair(
+                op, valueParts[lowIndex], valueParts[highIndex], group, chunk,
+                lanesPerPart, destination, offset, rowStride, *dist,
+                rewriter))) {
+          return failure();
         }
-        auto vregType = dyn_cast<VRegType>(low.getType());
-        if (!vregType) {
-          return rewriter.notifyMatchFailure(op,
-                                             "group_store value must be vreg");
-        }
-        FailureOr<Value> mask =
-            createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
-        if (failed(mask)) {
-          return rewriter.notifyMatchFailure(
-              op, "unsupported element type for group_store mask");
-        }
-        Value chunkOffset = createGroupChunkOffset(
-            op.getLoc(), offset, rowStride, group,
-            chunk * 2 * lanesPerPart, rewriter);
-        rewriter.create<Vstsx2Op>(op.getLoc(), low, high, destination,
-                                  chunkOffset, rewriter.getStringAttr(*dist),
-                                  *mask);
       }
     }
     rewriter.eraseOp(op);
+    return success();
+  }
+
+  LogicalResult emitDeinterleaved2GroupStorePair(
+      VMIGroupStoreOp op, Value low, Value high, int64_t group, int64_t chunk,
+      int64_t lanesPerPart, Value destination, Value offset, Value rowStride,
+      StringRef dist, OneToNPatternRewriter &rewriter) const {
+    bool mismatchedTypes = low.getType() != high.getType();
+    if (mismatchedTypes) {
+      return rewriter.notifyMatchFailure(
+          op, "vstsx2 group_store requires matching low/high types");
+    }
+    auto vregType = dyn_cast<VRegType>(low.getType());
+    if (!vregType) {
+      return rewriter.notifyMatchFailure(op, "group_store value must be vreg");
+    }
+    FailureOr<Value> mask =
+        createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
+    if (failed(mask)) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported element type for group_store mask");
+    }
+    Value chunkOffset = createGroupChunkOffset(
+        op.getLoc(), offset, rowStride, group, chunk * 2 * lanesPerPart,
+        rewriter);
+    rewriter.create<Vstsx2Op>(op.getLoc(), low, high, destination, chunkOffset,
+                              rewriter.getStringAttr(dist), *mask);
     return success();
   }
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3825,10 +3825,15 @@ static FailureOr<Value> applyGroupMaskPadding(
       .getResult();
 }
 
-static FailureOr<Value> buildDynamicGroupMaskLaneIndex(
-    VMICreateGroupMaskOp op, int64_t factor, int64_t blockElems, int64_t part,
-    int64_t chunk, int64_t lanesPerPart, Value allMask,
-    PatternRewriter &rewriter) {
+struct DynamicGroupMaskBlockIndex {
+  Value partBlock;
+  Value inBlockLane;
+  std::optional<int64_t> blockShift;
+};
+
+static FailureOr<DynamicGroupMaskBlockIndex> buildDynamicGroupMaskBlockIndex(
+    VMICreateGroupMaskOp op, int64_t blockElems, int64_t chunk,
+    int64_t lanesPerPart, Value allMask, PatternRewriter &rewriter) {
   Location loc = op.getLoc();
   MLIRContext *ctx = rewriter.getContext();
   Type i32 = rewriter.getI32Type();
@@ -3841,6 +3846,10 @@ static FailureOr<Value> buildDynamicGroupMaskLaneIndex(
   Value inBlockLane = createI32Constant(loc, 0, rewriter);
   std::optional<int64_t> blockShiftValue = getPowerOfTwoLog2(blockElems);
   if (blockElems != 1) {
+    if (!blockShiftValue) {
+      return rewriter.notifyMatchFailure(
+          op, "dynamic create_group_mask block size must be a power of two");
+    }
     Value blockShift = createI16Constant(loc, *blockShiftValue, rewriter);
     partBlock = rewriter
                     .create<VshrsOp>(loc, indexVectorType, indexInPart,
@@ -3855,9 +3864,19 @@ static FailureOr<Value> buildDynamicGroupMaskLaneIndex(
                                       blockBase, allMask)
                       .getResult();
   }
+  return DynamicGroupMaskBlockIndex{partBlock, inBlockLane, blockShiftValue};
+}
+
+static Value buildDynamicGroupMaskLogicalLane(
+    VMICreateGroupMaskOp op, int64_t factor, int64_t blockElems, int64_t part,
+    const DynamicGroupMaskBlockIndex &blockIndex, Value allMask,
+    PatternRewriter &rewriter) {
+  Location loc = op.getLoc();
+  auto indexVectorType = cast<VRegType>(blockIndex.partBlock.getType());
   Value factorScalar = createI32Constant(loc, factor, rewriter);
   Value logicalBlock = rewriter
-                           .create<VmulsOp>(loc, indexVectorType, partBlock,
+                           .create<VmulsOp>(loc, indexVectorType,
+                                            blockIndex.partBlock,
                                             factorScalar, allMask)
                            .getResult();
   if (part != 0) {
@@ -3869,7 +3888,7 @@ static FailureOr<Value> buildDynamicGroupMaskLaneIndex(
   }
   Value logicalLane = logicalBlock;
   if (blockElems != 1) {
-    Value blockShift = createI16Constant(loc, *blockShiftValue, rewriter);
+    Value blockShift = createI16Constant(loc, *blockIndex.blockShift, rewriter);
     Value logicalBlockBase = rewriter
                                  .create<VshlsOp>(loc, indexVectorType,
                                                   logicalBlock, blockShift,
@@ -3877,10 +3896,24 @@ static FailureOr<Value> buildDynamicGroupMaskLaneIndex(
                                  .getResult();
     logicalLane = rewriter
                       .create<VaddOp>(loc, indexVectorType, logicalBlockBase,
-                                      inBlockLane, allMask)
+                                      blockIndex.inBlockLane, allMask)
                       .getResult();
   }
   return logicalLane;
+}
+
+static FailureOr<Value> buildDynamicGroupMaskLaneIndex(
+    VMICreateGroupMaskOp op, int64_t factor, int64_t blockElems, int64_t part,
+    int64_t chunk, int64_t lanesPerPart, Value allMask,
+    PatternRewriter &rewriter) {
+  FailureOr<DynamicGroupMaskBlockIndex> blockIndex =
+      buildDynamicGroupMaskBlockIndex(op, blockElems, chunk, lanesPerPart,
+                                      allMask, rewriter);
+  if (failed(blockIndex)) {
+    return failure();
+  }
+  return buildDynamicGroupMaskLogicalLane(op, factor, blockElems, part,
+                                          *blockIndex, allMask, rewriter);
 }
 
 FailureOr<Value> materializeDynamicGroupMaskChunk(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -17232,11 +17232,13 @@ public:
     unsigned resultBits = pto::getPTOStorageElemBitWidth(
         resultVRegTypes.front().getElementType());
 
-    if (sourceLayout && resultLayout && sourceLayout.isContiguous() &&
+    bool directLaneStrideAlias =
+        sourceLayout && resultLayout && sourceLayout.isContiguous() &&
         resultLayout.isContiguous() && resultLayout.getLaneStride() == 1 &&
         ((resultBits == sourceBits * 2 && sourceLayout.getLaneStride() == 2) ||
          (resultBits == sourceBits * 4 && sourceLayout.getLaneStride() == 4)) &&
-        resultTypes.size() == sourceParts.size()) {
+        resultTypes.size() == sourceParts.size();
+    if (directLaneStrideAlias) {
       StringRef part =
           resultBits == sourceBits * 2 ? StringRef("EVEN") : StringRef("P0");
       FailureOr<Value> mask =
@@ -21128,11 +21130,8 @@ std::optional<WalkResult> verifySupportedVMINormalReductionOp(Operation *op) {
 }
 
 std::optional<WalkResult> verifySupportedVMIGroupReductionOp(Operation *op) {
-  auto verifyGroupReduction = [](auto reduce, StringRef diagnostic) {
-    return verifySupportedGroupReduceOp(reduce, diagnostic);
-  };
   if (auto reduce = dyn_cast<VMIGroupReduceAddFOp>(op)) {
-    return verifyGroupReduction(
+    return verifySupportedGroupReduceOp(
         reduce,
         "pto.vmi.group_reduce_addf lowers through pto.vcgadd for 32B blocks "
         "or through pto.vcadd for contiguous full source/mask chunks, "
@@ -21140,21 +21139,21 @@ std::optional<WalkResult> verifySupportedVMIGroupReductionOp(Operation *op) {
         "num_groups deriving a group size aligned to physical chunks (");
   }
   if (auto reduce = dyn_cast<VMIGroupReduceAddIOp>(op)) {
-    return verifyGroupReduction(
+    return verifySupportedGroupReduceOp(
         reduce,
         "pto.vmi.group_reduce_addi lowers through pto.vcgadd/vadd for "
         "supported 32B block classes or through an internal widening "
         "pto.vcadd path for aligned full chunks (");
   }
   if (auto reduce = dyn_cast<VMIGroupReduceMaxIOp>(op)) {
-    return verifyGroupReduction(
+    return verifySupportedGroupReduceOp(
         reduce,
         "pto.vmi.group_reduce_maxi lowers through pto.vcgmax/vmax for "
         "supported 32B block classes or through pto.vcmax for aligned full "
         "chunks (");
   }
   if (auto reduce = dyn_cast<VMIGroupReduceMaxFOp>(op)) {
-    return verifyGroupReduction(
+    return verifySupportedGroupReduceOp(
         reduce,
         "pto.vmi.group_reduce_maxf lowers through pto.vcgmax/vmax for 32B "
         "blocks or through pto.vcmax for contiguous full chunks, matching "
@@ -21163,14 +21162,14 @@ std::optional<WalkResult> verifySupportedVMIGroupReductionOp(Operation *op) {
         "physical chunks (");
   }
   if (auto reduce = dyn_cast<VMIGroupReduceMinFOp>(op)) {
-    return verifyGroupReduction(
+    return verifySupportedGroupReduceOp(
         reduce,
         "pto.vmi.group_reduce_minf lowers through pto.vcgmin/vmin for "
         "supported 32B block classes or through pto.vcmin for aligned full "
         "chunks (");
   }
   if (auto reduce = dyn_cast<VMIGroupReduceMinIOp>(op)) {
-    return verifyGroupReduction(
+    return verifySupportedGroupReduceOp(
         reduce,
         "pto.vmi.group_reduce_mini lowers through pto.vcgmin/vmin for "
         "supported 32B block classes or through pto.vcmin for aligned full "

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18587,26 +18587,13 @@ private:
       VMIShuffleOp op, ValueRange sourceParts, Type resultType,
       const ShuffleVselrPlan &plan,
       OneToNPatternRewriter &rewriter) const {
-    bool sourceOutOfBounds =
-        plan.sourceFlatIndex < 0 ||
-        plan.sourceFlatIndex >= static_cast<int64_t>(sourceParts.size());
-    if (sourceOutOfBounds) {
-      return rewriter.notifyMatchFailure(
-          op, "shuffle vselr source part range is out of bounds");
-    }
-    auto sourceVRegType =
-        dyn_cast<VRegType>(sourceParts[plan.sourceFlatIndex].getType());
-    auto resultVRegType = dyn_cast<VRegType>(resultType);
-    bool invalidTypes =
-        !sourceVRegType || !resultVRegType ||
-        sourceVRegType.getElementCount() != resultVRegType.getElementCount() ||
-        sourceVRegType.getElementType() != resultVRegType.getElementType();
-    if (invalidTypes) {
-      return rewriter.notifyMatchFailure(
-          op, "shuffle vselr source/result type mismatch");
+    FailureOr<VRegType> sourceVRegType = getShuffleVselrSourceType(
+        op, sourceParts, resultType, plan.sourceFlatIndex, rewriter);
+    if (failed(sourceVRegType)) {
+      return failure();
     }
     unsigned indexBits =
-        pto::getPTOStorageElemBitWidth(sourceVRegType.getElementType());
+        pto::getPTOStorageElemBitWidth(sourceVRegType->getElementType());
     bool unsupportedIndexBits =
         indexBits != 8 && indexBits != 16 && indexBits != 32;
     if (unsupportedIndexBits) {
@@ -18615,7 +18602,7 @@ private:
     }
     auto indexElementType = IntegerType::get(rewriter.getContext(), indexBits);
     Type indexType = VRegType::get(rewriter.getContext(),
-                                   sourceVRegType.getElementCount(),
+                                   sourceVRegType->getElementCount(),
                                    indexElementType);
     FailureOr<Value> base = createScalarOffsetConstant(
         op.getLoc(), indexElementType, plan.baseLane, rewriter);
@@ -18632,6 +18619,29 @@ private:
         .create<VselrOp>(op.getLoc(), resultType,
                          sourceParts[plan.sourceFlatIndex], indexVector)
         .getResult();
+  }
+
+  FailureOr<VRegType> getShuffleVselrSourceType(
+      VMIShuffleOp op, ValueRange sourceParts, Type resultType,
+      int64_t sourceIndex, OneToNPatternRewriter &rewriter) const {
+    bool sourceOutOfBounds =
+        sourceIndex < 0 || sourceIndex >= static_cast<int64_t>(sourceParts.size());
+    if (sourceOutOfBounds) {
+      return rewriter.notifyMatchFailure(
+          op, "shuffle vselr source part range is out of bounds");
+    }
+    auto sourceVRegType =
+        dyn_cast<VRegType>(sourceParts[sourceIndex].getType());
+    auto resultVRegType = dyn_cast<VRegType>(resultType);
+    bool invalidTypes =
+        !sourceVRegType || !resultVRegType ||
+        sourceVRegType.getElementCount() != resultVRegType.getElementCount() ||
+        sourceVRegType.getElementType() != resultVRegType.getElementType();
+    if (invalidTypes) {
+      return rewriter.notifyMatchFailure(
+          op, "shuffle vselr source/result type mismatch");
+    }
+    return *sourceVRegType;
   }
 
   LogicalResult lowerVselr(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11790,6 +11790,52 @@ public:
 struct OneToNVMIVaddcsOpPattern : OneToNOpConversionPattern<VMIVaddcsOp> {
   using OneToNOpConversionPattern<VMIVaddcsOp>::OneToNOpConversionPattern;
 
+private:
+  LogicalResult lowerParts(VMIVaddcsOp op, ValueRange lhsParts,
+                           ValueRange rhsParts, ValueRange carryInParts,
+                           ValueRange maskParts, ArrayRef<Type> resultTypes,
+                           ArrayRef<Type> carryTypes,
+                           SmallVectorImpl<Value> &results,
+                           SmallVectorImpl<Value> &carries,
+                           OneToNPatternRewriter &rewriter) const {
+    const bool invalidArity =
+        lhsParts.empty() || rhsParts.size() != lhsParts.size() ||
+        carryInParts.size() != lhsParts.size() ||
+        maskParts.size() != lhsParts.size() ||
+        resultTypes.size() != lhsParts.size() ||
+        carryTypes.size() != lhsParts.size();
+    if (invalidArity) {
+      return rewriter.notifyMatchFailure(op,
+                                         "vaddcs physical arity mismatch");
+    }
+    for (auto [lhs, rhs, carryIn, mask, resultType, carryType] :
+         llvm::zip_equal(lhsParts, rhsParts, carryInParts, maskParts,
+                         resultTypes, carryTypes)) {
+      auto dataType = dyn_cast<VRegType>(resultType);
+      auto integerType = dataType
+                             ? dyn_cast<IntegerType>(dataType.getElementType())
+                             : IntegerType();
+      const bool invalidPart =
+          !dataType || !integerType || integerType.getWidth() != 32 ||
+          !isa<MaskType>(carryIn.getType()) || !isa<MaskType>(mask.getType()) ||
+          !isa<MaskType>(carryType) ||
+          !cast<MaskType>(carryIn.getType()).isB32() ||
+          !cast<MaskType>(mask.getType()).isB32() ||
+          !cast<MaskType>(carryType).isB32() || lhs.getType() != resultType ||
+          rhs.getType() != resultType;
+      if (invalidPart) {
+        return rewriter.notifyMatchFailure(
+            op, "vaddcs requires matching 32-bit data and b32 mask parts");
+      }
+      auto addcs = rewriter.create<VaddcsOp>(
+          op.getLoc(), resultType, carryType, lhs, rhs, carryIn, mask);
+      results.push_back(addcs.getResult());
+      carries.push_back(addcs.getCarry());
+    }
+    return success();
+  }
+
+public:
   LogicalResult matchAndRewrite(VMIVaddcsOp op, OpAdaptor adaptor,
                                 OneToNPatternRewriter &rewriter) const override {
     ValueRange lhsParts = adaptor.getLhs();
@@ -11800,43 +11846,22 @@ struct OneToNVMIVaddcsOpPattern : OneToNOpConversionPattern<VMIVaddcsOp> {
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
     FailureOr<SmallVector<Type>> maybeCarryTypes =
         getConvertedResultTypes(op, 1, *this->getTypeConverter());
-    if (failed(maybeResultTypes) || failed(maybeCarryTypes))
+    const bool conversionFailed =
+        failed(maybeResultTypes) || failed(maybeCarryTypes);
+    if (conversionFailed) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
     SmallVector<Type> carryTypes = std::move(*maybeCarryTypes);
-
-    if (lhsParts.empty() || rhsParts.size() != lhsParts.size() ||
-        carryInParts.size() != lhsParts.size() ||
-        maskParts.size() != lhsParts.size() ||
-        resultTypes.size() != lhsParts.size() ||
-        carryTypes.size() != lhsParts.size())
-      return rewriter.notifyMatchFailure(op, "vaddcs physical arity mismatch");
 
     SmallVector<Value> results;
     SmallVector<Value> carries;
     results.reserve(lhsParts.size());
     carries.reserve(lhsParts.size());
-    for (auto [lhs, rhs, carryIn, mask, resultType, carryType] :
-         llvm::zip_equal(lhsParts, rhsParts, carryInParts, maskParts,
-                         resultTypes, carryTypes)) {
-      auto dataType = dyn_cast<VRegType>(resultType);
-      auto integerType = dataType
-                             ? dyn_cast<IntegerType>(dataType.getElementType())
-                             : IntegerType();
-      if (!dataType || !integerType || integerType.getWidth() != 32 ||
-          !isa<MaskType>(carryIn.getType()) || !isa<MaskType>(mask.getType()) ||
-          !isa<MaskType>(carryType) ||
-          !cast<MaskType>(carryIn.getType()).isB32() ||
-          !cast<MaskType>(mask.getType()).isB32() ||
-          !cast<MaskType>(carryType).isB32() ||
-          lhs.getType() != resultType || rhs.getType() != resultType)
-        return rewriter.notifyMatchFailure(
-            op, "vaddcs requires matching 32-bit data and b32 mask parts");
-
-      auto addcs = rewriter.create<VaddcsOp>(op.getLoc(), resultType, carryType,
-                                             lhs, rhs, carryIn, mask);
-      results.push_back(addcs.getResult());
-      carries.push_back(addcs.getCarry());
+    if (failed(lowerParts(op, lhsParts, rhsParts, carryInParts, maskParts,
+                          resultTypes, carryTypes, results, carries,
+                          rewriter))) {
+      return failure();
     }
 
     results.append(carries);

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5977,28 +5977,38 @@ static FailureOr<SmallVector<Value>> materializeMaskGranularityStep(
       op, currentType, nextType, currentParts, rewriter);
 }
 
+static FailureOr<VMIMaskType> buildNextMaskGranularityType(
+    VMIMaskType currentType, int rank, PatternRewriter &rewriter,
+    Operation *op) {
+  StringRef granularity = getMaskGranularityForRank(rank);
+  if (granularity.empty()) {
+    (void)rewriter.notifyMatchFailure(
+        op, "invalid target mask granularity rank");
+    return failure();
+  }
+  return VMIMaskType::get(op->getContext(), currentType.getElementCount(),
+                          granularity, currentType.getLayoutAttr());
+}
+
 static FailureOr<SmallVector<Value>> materializeMaskGranularitySteps(
-    Operation *op, VMIMaskType sourceType, VMIMaskType resultType,
-    ValueRange sourceParts, int sourceRank, int resultRank,
-    PatternRewriter &rewriter) {
+    Operation *op, VMIMaskType sourceType, ValueRange sourceParts,
+    int sourceRank, int resultRank, PatternRewriter &rewriter) {
   VMIMaskType currentType = sourceType;
   SmallVector<Value> currentParts(sourceParts.begin(), sourceParts.end());
   while (currentRank != resultRank) {
     bool ascending = currentRank < resultRank;
     currentRank += ascending ? 1 : -1;
-    StringRef nextGranularity = getMaskGranularityForRank(currentRank);
-    if (nextGranularity.empty()) {
-      (void)rewriter.notifyMatchFailure(
-          op, "invalid target mask granularity rank");
+    FailureOr<VMIMaskType> nextType = buildNextMaskGranularityType(
+        currentType, currentRank, rewriter, op);
+    if (failed(nextType)) {
       return failure();
     }
     FailureOr<SmallVector<Value>> nextParts = materializeMaskGranularityStep(
-        op, currentType, nextGranularity, currentParts, rewriter);
+        op, currentType, nextType->getGranularity(), currentParts, rewriter);
     if (failed(nextParts)) {
       return failure();
     }
-    currentType = VMIMaskType::get(op->getContext(), currentType.getElementCount(),
-                                   nextGranularity, currentType.getLayoutAttr());
+    currentType = *nextType;
     currentParts = std::move(*nextParts);
   }
   return currentParts;
@@ -6021,9 +6031,8 @@ FailureOr<SmallVector<Value>> materializeMaskGranularityConversion(
         op, sourceType, resultType, sourceParts, rewriter);
   }
 
-  return materializeMaskGranularitySteps(op, sourceType, resultType,
-                                         sourceParts, currentRank, resultRank,
-                                         rewriter);
+  return materializeMaskGranularitySteps(op, sourceType, sourceParts,
+                                         currentRank, resultRank, rewriter);
 }
 
 FailureOr<SmallVector<Type>> getConvertedMaskPartTypes(VMIMaskType type) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -4043,14 +4043,26 @@ FailureOr<Value> materializePrefixMask(Location loc, MaskType maskType,
   return maskAndRemaining->first;
 }
 
+static FailureOr<int64_t> validateConstantMaskChunk(
+    MaskType maskType, ArrayRef<int8_t> activeLanes) {
+  FailureOr<int64_t> lanesPerPart =
+      getMaskLanesPerPart(maskType.getGranularity());
+  bool invalidShape = failed(lanesPerPart) ||
+                      static_cast<int64_t>(activeLanes.size()) != *lanesPerPart;
+  if (invalidShape) {
+    return failure();
+  }
+  return *lanesPerPart;
+}
+
 FailureOr<Value> materializeConstantMaskChunk(Location loc, MaskType maskType,
                                               ArrayRef<int8_t> activeLanes,
                                               PatternRewriter &rewriter) {
   FailureOr<int64_t> lanesPerPart =
-      getMaskLanesPerPart(maskType.getGranularity());
-  if (failed(lanesPerPart) ||
-      static_cast<int64_t>(activeLanes.size()) != *lanesPerPart)
+      validateConstantMaskChunk(maskType, activeLanes);
+  if (failed(lanesPerPart)) {
     return failure();
+  }
 
   if (std::optional<int64_t> prefixCount =
           getPrefixActiveLaneCount(activeLanes))

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -16236,10 +16236,9 @@ private:
         op, "unsupported physical integer extension source/result width relation");
   }
 
-  FailureOr<Value> buildDenseGroupSlotExtensionResult(
-      OpT op, Value sourcePart, Type resultType, VMIVRegType sourceVMIType,
-      VMIVRegType resultVMIType, IntegerType resultIntegerType,
-      unsigned sourceBits, unsigned resultBits,
+  FailureOr<VRegType> validateDenseGroupSlotExtensionResult(
+      OpT op, Type resultType, VMIVRegType sourceVMIType,
+      VMIVRegType resultVMIType, unsigned sourceBits, unsigned resultBits,
       OneToNPatternRewriter &rewriter) const {
     FailureOr<int64_t> sourceLanes =
         getDataLanesPerPart(sourceVMIType.getElementType());
@@ -16249,20 +16248,32 @@ private:
         failed(sourceLanes) || failed(resultLanes) ||
         *sourceLanes !=
             *resultLanes * static_cast<int64_t>(resultBits / sourceBits);
-    if (carrierShapeMismatch) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported dense group-slot integer extension carrier shape");
-    }
-
     auto physicalResultType = dyn_cast<VRegType>(resultType);
     bool invalidResultType =
-        !physicalResultType ||
+        !physicalResultType || failed(resultLanes) ||
         physicalResultType.getElementCount() != *resultLanes ||
         pto::getPTOStorageElemBitWidth(physicalResultType.getElementType()) !=
             resultBits;
-    if (invalidResultType) {
+    if (carrierShapeMismatch || invalidResultType) {
       return rewriter.notifyMatchFailure(
-          op, "unsupported dense group-slot integer extension result type");
+          op, carrierShapeMismatch
+                  ? "unsupported dense group-slot integer extension carrier shape"
+                  : "unsupported dense group-slot integer extension result type");
+    }
+    return *physicalResultType;
+  }
+
+  FailureOr<Value> buildDenseGroupSlotExtensionResult(
+      OpT op, Value sourcePart, Type resultType, VMIVRegType sourceVMIType,
+      VMIVRegType resultVMIType, IntegerType resultIntegerType,
+      unsigned sourceBits, unsigned resultBits,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<VRegType> physicalResultType =
+        validateDenseGroupSlotExtensionResult(
+            op, resultType, sourceVMIType, resultVMIType, sourceBits,
+            resultBits, rewriter);
+    if (failed(physicalResultType)) {
+      return failure();
     }
 
     Value current = sourcePart;
@@ -16298,7 +16309,7 @@ private:
       currentBits = nextBits;
     }
     FailureOr<Value> result =
-        bitcastVReg(op.getLoc(), current, physicalResultType, rewriter);
+        bitcastVReg(op.getLoc(), current, *physicalResultType, rewriter);
     if (failed(result)) {
       return rewriter.notifyMatchFailure(
           op, "failed to materialize dense group-slot unpack result");

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -13790,58 +13790,90 @@ static LogicalResult lowerHistogramChunk(
 }
 
 template <typename VMIOp, typename VPTOHistOp>
+struct HistogramPhysicalPlan {
+  ValueRange sourceParts;
+  ValueRange maskParts;
+  SmallVector<Value, 2> halves;
+  SmallVector<Value, 2> binConsts;
+  VRegType partType;
+  int64_t lanesPerPart;
+  size_t halfCount;
+};
+
+template <typename VMIOp>
+static FailureOr<HistogramPhysicalPlan<VMIOp>> prepareHistogramPhysicalPlan(
+    VMIOp op,
+    typename OneToNOpConversionPattern<VMIOp>::OpAdaptor adaptor,
+    OneToNPatternRewriter &rewriter) {
+  ValueRange accParts = adaptor.getAcc();
+  ValueRange sourceParts = adaptor.getSource();
+  ValueRange maskParts = adaptor.getMask();
+  size_t halfCount = accParts.size();
+  const bool invalidHalfCount = halfCount != 1 && halfCount != 2;
+  if (invalidHalfCount) {
+    return rewriter.notifyMatchFailure(
+        op, "expected one or two accumulator parts");
+  }
+  const bool invalidSourceMaskArity =
+      sourceParts.empty() || sourceParts.size() != maskParts.size();
+  if (invalidSourceMaskArity) {
+    return rewriter.notifyMatchFailure(
+        op, "expected matching source/mask chunks");
+  }
+  auto partType = dyn_cast<VRegType>(accParts.front().getType());
+  if (!partType) {
+    return rewriter.notifyMatchFailure(op, "expected ui16 acc parts");
+  }
+  const bool mismatchedSecondHalf =
+      halfCount == 2 && accParts[1].getType() != partType;
+  if (mismatchedSecondHalf) {
+    return rewriter.notifyMatchFailure(op,
+                                       "expected matching ui16 acc parts");
+  }
+  auto sourceType = cast<VMIVRegType>(op.getSource().getType());
+  FailureOr<int64_t> lanesPerPart =
+      getDataLanesPerPart(sourceType.getElementType());
+  if (failed(lanesPerPart)) {
+    return rewriter.notifyMatchFailure(op, "failed to compute source lanes");
+  }
+  Location loc = op.getLoc();
+  SmallVector<Value, 2> binConsts;
+  binConsts.push_back(createI32Constant(loc, 0, rewriter));
+  if (halfCount == 2) {
+    binConsts.push_back(createI32Constant(loc, 1, rewriter));
+  }
+  return HistogramPhysicalPlan<VMIOp>{
+      sourceParts, maskParts, SmallVector<Value, 2>(accParts.begin(), accParts.end()),
+      std::move(binConsts), *partType, *lanesPerPart, halfCount};
+}
+
+template <typename VMIOp, typename VPTOHistOp>
 static LogicalResult
 lowerVMIHistogramToVPTO(VMIOp op,
                         typename OneToNOpConversionPattern<VMIOp>::OpAdaptor
                             adaptor,
                         TypeConverter *typeConverter,
                         OneToNPatternRewriter &rewriter) {
-  ValueRange accParts    = adaptor.getAcc();
-  ValueRange sourceParts = adaptor.getSource();
-  ValueRange maskParts   = adaptor.getMask();
+  FailureOr<HistogramPhysicalPlan<VMIOp>> plan =
+      prepareHistogramPhysicalPlan(op, adaptor, rewriter);
+  if (failed(plan)) {
+    return failure();
+  }
 
-  // Allow 1 (Bin_N0-only, 128×ui16) or 2 (Bin_N0+Bin_N1, 256×ui16) halves
-  size_t halfCount = accParts.size();
-  if (halfCount != 1 && halfCount != 2)
-    return rewriter.notifyMatchFailure(
-        op, "expected one or two accumulator parts");
-  if (sourceParts.empty() || sourceParts.size() != maskParts.size())
-    return rewriter.notifyMatchFailure(
-        op, "expected matching source/mask chunks");
-
-  auto partType = dyn_cast<VRegType>(accParts[0].getType());
-  if (!partType)
-    return rewriter.notifyMatchFailure(op, "expected ui16 acc parts");
-  if (halfCount == 2 && accParts[1].getType() != partType)
-    return rewriter.notifyMatchFailure(op,
-                                       "expected matching ui16 acc parts");
-
-  auto sourceType = cast<VMIVRegType>(op.getSource().getType());
-  FailureOr<int64_t> lanesPerPart =
-      getDataLanesPerPart(sourceType.getElementType());
-  if (failed(lanesPerPart))
-    return rewriter.notifyMatchFailure(op, "failed to compute source lanes");
-
-  Location loc = op.getLoc();
-  SmallVector<Value, 2> binConsts;
-  binConsts.push_back(createI32Constant(loc, 0, rewriter));
-  if (halfCount == 2)
-    binConsts.push_back(createI32Constant(loc, 1, rewriter));
-
-  SmallVector<Value, 2> halves(accParts.begin(), accParts.end());
-
-  for (size_t index = 0, e = sourceParts.size(); index < e; ++index) {
+  for (size_t index = 0, e = plan->sourceParts.size(); index < e; ++index) {
     if (failed(lowerHistogramChunk<VMIOp, VPTOHistOp>(
-            op, sourceParts[index], maskParts[index],
-            static_cast<int64_t>(index) * *lanesPerPart, *lanesPerPart, halves,
-            binConsts, partType, rewriter))) {
+            op, plan->sourceParts[index], plan->maskParts[index],
+            static_cast<int64_t>(index) * plan->lanesPerPart,
+            plan->lanesPerPart, plan->halves, plan->binConsts, plan->partType,
+            rewriter))) {
       return failure();
     }
   }
 
   replaceOpWithFlatConvertedValues(
       rewriter, op,
-      SmallVector<Value>(halves.begin(), halves.begin() + halfCount),
+      SmallVector<Value>(plan->halves.begin(),
+                         plan->halves.begin() + plan->halfCount),
       *typeConverter);
   return success();
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -15035,6 +15035,47 @@ struct OneToNVMITruncFOpPattern : OneToNOpConversionPattern<VMITruncFOp> {
   using OneToNOpConversionPattern<VMITruncFOp>::OneToNOpConversionPattern;
 
 private:
+  FailureOr<VRegType> getUniformSourceType(
+      VMITruncFOp op, ValueRange sourceParts,
+      OneToNPatternRewriter &rewriter) const {
+    if (sourceParts.empty()) {
+      return rewriter.notifyMatchFailure(op,
+                                         "truncf requires source chunks");
+    }
+    auto firstType = dyn_cast<VRegType>(sourceParts.front().getType());
+    if (!firstType) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported physical truncf source type");
+    }
+    for (Value sourcePart : sourceParts) {
+      auto sourceType = dyn_cast<VRegType>(sourcePart.getType());
+      if (!sourceType || sourceType != firstType) {
+        return rewriter.notifyMatchFailure(
+            op, "truncf source physical parts must have matching type");
+      }
+    }
+    return firstType;
+  }
+
+  FailureOr<SmallVector<VRegType>> getUniformResultTypes(
+      VMITruncFOp op, ArrayRef<Type> resultTypes,
+      OneToNPatternRewriter &rewriter) const {
+    SmallVector<VRegType> resultVRegTypes;
+    resultVRegTypes.reserve(resultTypes.size());
+    for (Type physicalResultType : resultTypes) {
+      auto resultType = dyn_cast<VRegType>(physicalResultType);
+      bool invalidType = !resultType ||
+                         (!resultVRegTypes.empty() &&
+                          resultType != resultVRegTypes.front());
+      if (invalidType) {
+        return rewriter.notifyMatchFailure(
+            op, "unsupported physical truncf result type");
+      }
+      resultVRegTypes.push_back(resultType);
+    }
+    return resultVRegTypes;
+  }
+
   LogicalResult lowerDenseLaneStride(
       VMITruncFOp op, ValueRange sourceParts,
       ArrayRef<VRegType> resultTypes, StringRef part,
@@ -15303,10 +15344,12 @@ public:
       return rewriter.notifyMatchFailure(op, "truncf requires result chunks");
     }
 
-    auto sourceType0 = dyn_cast<VRegType>(sourceParts.front().getType());
-    if (!sourceType0) {
-      return rewriter.notifyMatchFailure(op, "unsupported physical truncf source type");
+    FailureOr<VRegType> sourceType =
+        getUniformSourceType(op, sourceParts, rewriter);
+    if (failed(sourceType)) {
+      return failure();
     }
+    VRegType sourceType0 = *sourceType;
     unsigned sourceBits = pto::getPTOStorageElemBitWidth(sourceType0.getElementType());
     bool unsupportedSourceBits = sourceBits != 32 && sourceBits != 16;
     if (unsupportedSourceBits) {
@@ -15332,25 +15375,16 @@ public:
       return rewriter.notifyMatchFailure(
           op, "group-slot layout for non-f32 truncf not supported");
     }
-    for (Value sourcePart : sourceParts) {
-      auto sourceType = dyn_cast<VRegType>(sourcePart.getType());
-      if (!sourceType || sourceType != sourceType0) {
-        return rewriter.notifyMatchFailure(
-            op, "truncf source physical parts must have matching type");
-      }
+    FailureOr<SmallVector<VRegType>> uniformResultTypes =
+        getUniformResultTypes(op, resultTypes, rewriter);
+    if (failed(uniformResultTypes)) {
+      return failure();
     }
-
-    SmallVector<VRegType> resultVRegTypes;
-    resultVRegTypes.reserve(resultTypes.size());
-    for (Type physicalResultType : resultTypes) {
-      auto resultType = dyn_cast<VRegType>(physicalResultType);
-      if (!resultType ||
-          (resultVRegTypes.empty() ? pto::getPTOStorageElemBitWidth(
-                                         resultType.getElementType()) == 0
-                                   : resultType != resultVRegTypes.front()))
-        return rewriter.notifyMatchFailure(
-            op, "unsupported physical truncf result type");
-      resultVRegTypes.push_back(resultType);
+    SmallVector<VRegType> resultVRegTypes = std::move(*uniformResultTypes);
+    if (pto::getPTOStorageElemBitWidth(
+            resultVRegTypes.front().getElementType()) == 0) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported physical truncf result type");
     }
 
     unsigned resultBits = pto::getPTOStorageElemBitWidth(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2709,42 +2709,45 @@ checkSinglePhysicalStrideAccess(Type dataType, Type maskType,
   return success();
 }
 
+struct StrideMemoryContract {
+  Type dataType;
+  Type maskType;
+  VMILayoutAttr dataLayout;
+  VMILayoutAttr maskLayout;
+  Type pointerType;
+  StringRef dataName;
+  StringRef pointerDiagnostic;
+  StringRef arityDiagnostic;
+};
+
 static LogicalResult checkStrideMemoryContract(
-    Type dataType, Type maskType, VMILayoutAttr dataLayout,
-    VMILayoutAttr maskLayout, Type pointerType, StringRef dataName,
-    StringRef pointerDiagnostic, StringRef arityDiagnostic,
-    std::string *reason) {
+    const StrideMemoryContract &contract, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
       *reason = message.str();
     }
     return failure();
   };
-  if (!dataLayout || !maskLayout) {
-    return fail(Twine("requires assigned ") + dataName + " and mask layouts");
-  }
-  bool nonContiguousLayout =
-      !dataLayout.isContiguous() || !maskLayout.isContiguous();
-  if (nonContiguousLayout) {
-    return fail(Twine("requires contiguous ") + dataName +
+  if (!contract.dataLayout || !contract.maskLayout) {
+    return fail(Twine("requires assigned ") + contract.dataName +
                 " and mask layouts");
   }
-  if (!isa<PtrType>(pointerType)) {
-    return fail(pointerDiagnostic);
+  bool nonContiguousLayout =
+      !contract.dataLayout.isContiguous() ||
+      !contract.maskLayout.isContiguous();
+  if (nonContiguousLayout) {
+    return fail(Twine("requires contiguous ") + contract.dataName +
+                " and mask layouts");
   }
-  return checkSinglePhysicalStrideAccess(dataType, maskType, arityDiagnostic,
-                                         reason);
+  if (!isa<PtrType>(contract.pointerType)) {
+    return fail(contract.pointerDiagnostic);
+  }
+  return checkSinglePhysicalStrideAccess(
+      contract.dataType, contract.maskType, contract.arityDiagnostic, reason);
 }
 
 LogicalResult
 checkSupportedStrideStoreShape(VMIStrideStoreOp op, std::string *reason) {
-  auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
-
   auto valueType = cast<VMIVRegType>(op.getValue().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   if (failed(checkSupportedStoreShape(valueType, op.getDestination(),
@@ -2752,30 +2755,32 @@ checkSupportedStrideStoreShape(VMIStrideStoreOp op, std::string *reason) {
     return failure();
   }
 
-  return checkStrideMemoryContract(
-      valueType, maskType, valueType.getLayoutAttr(), maskType.getLayoutAttr(),
-      op.getDestination().getType(), "value",
-      "requires !pto.ptr destination because pto.vsstb is "
-      "pointer-only", "currently supports one physical value/mask chunk",
-      reason);
+  StrideMemoryContract contract{
+      valueType,
+      maskType,
+      valueType.getLayoutAttr(),
+      maskType.getLayoutAttr(),
+      op.getDestination().getType(),
+      "value",
+      "requires !pto.ptr destination because pto.vsstb is pointer-only",
+      "currently supports one physical value/mask chunk"};
+  return checkStrideMemoryContract(contract, reason);
 }
 
 LogicalResult
 checkSupportedStrideLoadShape(VMIStrideLoadOp op, std::string *reason) {
-  auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason) {
-      *reason = message.str();
-    }
-    return failure();
-  };
-
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
-  return checkStrideMemoryContract(
-      resultType, maskType, resultType.getLayoutAttr(), maskType.getLayoutAttr(),
-      op.getSource().getType(), "result",
+  StrideMemoryContract contract{
+      resultType,
+      maskType,
+      resultType.getLayoutAttr(),
+      maskType.getLayoutAttr(),
+      op.getSource().getType(),
+      "result",
       "requires !pto.ptr source because pto.vsldb is pointer-only",
-      "currently supports one physical result/mask chunk", reason);
+      "currently supports one physical result/mask chunk"};
+  return checkStrideMemoryContract(contract, reason);
 }
 
 Value stripMaskMaterialization(Value value) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -14865,6 +14865,16 @@ private:
     return success();
   }
 
+  FailureOr<Value> buildDenseLaneExtensionResult(
+      OpT op, Value sourcePart, VRegType resultType, Value mask,
+      StringRef part, OneToNPatternRewriter &rewriter) const {
+    return rewriter
+        .create<VcvtOp>(op.getLoc(), resultType, sourcePart, mask,
+                        /*rnd=*/nullptr, /*sat=*/nullptr,
+                        rewriter.getStringAttr(part))
+        .getResult();
+  }
+
   LogicalResult emitDenseLaneExtension(
       OpT op, ValueRange sourceParts, ArrayRef<VRegType> resultTypes,
       VRegType sourceType, StringRef part,
@@ -14879,12 +14889,12 @@ private:
     results.reserve(resultTypes.size());
     for (auto [sourcePart, resultType] :
          llvm::zip_equal(sourceParts, resultTypes)) {
-      results.push_back(
-          rewriter
-              .create<VcvtOp>(op.getLoc(), resultType, sourcePart, *mask,
-                              /*rnd=*/nullptr, /*sat=*/nullptr,
-                              rewriter.getStringAttr(part))
-              .getResult());
+      FailureOr<Value> result = buildDenseLaneExtensionResult(
+          op, sourcePart, resultType, *mask, part, rewriter);
+      if (failed(result)) {
+        return failure();
+      }
+      results.push_back(*result);
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10531,17 +10531,9 @@ static LogicalResult lowerGroupBroadcastResultChunks(
         return rewriter.notifyMatchFailure(
             op, "group_broadcast physical result count is too small");
       }
-      Type resultType = resultTypes[flatIndex];
-      auto resultVRegType = dyn_cast<VRegType>(resultType);
-      bool mismatchedResultType =
-          !resultVRegType || resultVRegType != expectedSourceType;
-      if (mismatchedResultType) {
-        return rewriter.notifyMatchFailure(
-            op, "group_broadcast requires uniform physical vreg types");
-      }
-      FailureOr<Value> chunkResult = lowerGroupBroadcastChunk(
-          op, resultType, resultVMIType, sourceParts, fact, context, part, chunk,
-          rewriter);
+      FailureOr<Value> chunkResult = lowerGroupBroadcastResultChunk(
+          op, resultTypes[flatIndex], resultVMIType, sourceParts, fact, context,
+          expectedSourceType, part, chunk, rewriter);
       if (failed(chunkResult)) {
         return failure();
       }
@@ -10553,6 +10545,22 @@ static LogicalResult lowerGroupBroadcastResultChunks(
         op, "group_broadcast physical result count is too large");
   }
   return success();
+}
+
+static FailureOr<Value> lowerGroupBroadcastResultChunk(
+    Operation *op, Type resultType, VMIVRegType resultVMIType,
+    ValueRange sourceParts, const VMIGroupBroadcastLayoutFact &fact,
+    GroupBroadcastLoweringContext &context, VRegType expectedSourceType,
+    int64_t part, int64_t chunk, OneToNPatternRewriter &rewriter) {
+  auto resultVRegType = dyn_cast<VRegType>(resultType);
+  bool mismatchedResultType =
+      !resultVRegType || resultVRegType != expectedSourceType;
+  if (mismatchedResultType) {
+    return rewriter.notifyMatchFailure(
+        op, "group_broadcast requires uniform physical vreg types");
+  }
+  return lowerGroupBroadcastChunk(op, resultType, resultVMIType, sourceParts,
+                                  fact, context, part, chunk, rewriter);
 }
 
 static LogicalResult lowerGroupBroadcastParts(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -17959,15 +17959,35 @@ static FailureOr<CompressPhysicalShapePlan> buildCompressPhysicalShapePlan(
   return CompressPhysicalShapePlan{valueType, maskType};
 }
 
-LogicalResult checkSupportedCompressShape(VMICompressOp op,
-                                          std::string *reason = nullptr) {
+static LogicalResult checkSupportedCompressResultShape(
+    VMIVRegType resultType, StringRef layoutMessage,
+    StringRef computableArityMessage, StringRef arityMessage,
+    std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
       *reason = message.str();
     }
     return failure();
   };
+  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
+  if (!resultLayout) {
+    return fail(layoutMessage);
+  }
+  if (!resultLayout.isContiguous()) {
+    return fail("requires contiguous result layouts");
+  }
+  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
+  if (failed(resultArity)) {
+    return fail(computableArityMessage);
+  }
+  if (*resultArity != 1) {
+    return fail(arityMessage);
+  }
+  return success();
+}
 
+LogicalResult checkSupportedCompressShape(VMICompressOp op,
+                                          std::string *reason = nullptr) {
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
@@ -17980,25 +18000,12 @@ LogicalResult checkSupportedCompressShape(VMICompressOp op,
   if (failed(plan)) {
     return failure();
   }
-  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!resultLayout) {
-    return fail("requires assigned result layouts");
-  }
-  if (!resultLayout.isContiguous()) {
-    return fail("requires contiguous result layouts");
-  }
-  FailureOr<int64_t> sourceArity = getVMIPhysicalArity(plan->valueType);
-  FailureOr<int64_t> maskArity = getVMIPhysicalArity(plan->maskType);
-  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(resultArity)) {
-    return fail("requires computable source, mask, and result physical arity");
-  }
-  if (*resultArity != 1) {
-    return fail("requires a single physical chunk; multi-chunk compress needs "
-                "cross-chunk compaction");
-  }
-
-  return success();
+  return checkSupportedCompressResultShape(
+      resultType, "requires assigned result layouts",
+      "requires computable source, mask, and result physical arity",
+      "requires a single physical chunk; multi-chunk compress needs "
+      "cross-chunk compaction",
+      reason);
 }
 
 LogicalResult checkSupportedCompressStoreShape(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -13544,6 +13544,31 @@ private:
     return results;
   }
 
+  FailureOr<SmallVector<Value>> restoreContiguousGroupResults(
+      OpTy op, ArrayRef<Value> reducedResults, TypeRange resultTypes,
+      VRegType resultType, int64_t groupCount, int64_t chunksPerGroup,
+      bool rowLocalSlots1Result,
+      OneToNPatternRewriter &rewriter) const {
+    SmallVector<Value> results(resultTypes.size());
+    for (int64_t group = 0; group < groupCount; ++group) {
+      FailureOr<Value> finalResult =
+          bitcastVReg(op.getLoc(), reducedResults[group], resultType, rewriter);
+      if (failed(finalResult)) {
+        return rewriter.notifyMatchFailure(
+            op, "failed to restore group result type");
+      }
+      int64_t destChunk = rowLocalSlots1Result ? group : group * chunksPerGroup;
+      if (rowLocalSlots1Result) {
+        results[destChunk] = *finalResult;
+      } else {
+        for (int64_t chunk = 0; chunk < chunksPerGroup; ++chunk) {
+          results[destChunk + chunk] = *finalResult;
+        }
+      }
+    }
+    return results;
+  }
+
   LogicalResult lowerContiguousRows(
       OpTy op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
       ValueRange sourceParts, ValueRange maskParts, TypeRange resultTypes,
@@ -13613,25 +13638,13 @@ private:
     if (failed(reducedResults)) {
       return failure();
     }
-    SmallVector<Value> results(resultTypes.size());
-    for (int64_t group = 0; group < groupCount; ++group) {
-      FailureOr<Value> finalResult =
-          bitcastVReg(op.getLoc(), (*reducedResults)[group], resultType,
-                      rewriter);
-      if (failed(finalResult)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to restore group result type");
-      }
-      int64_t destChunk = rowLocalSlots1Result ? group : group * chunksPerGroup;
-      if (rowLocalSlots1Result) {
-        results[destChunk] = *finalResult;
-      } else {
-        for (int64_t chunk = 0; chunk < chunksPerGroup; ++chunk) {
-          results[destChunk + chunk] = *finalResult;
-        }
-      }
+    FailureOr<SmallVector<Value>> results = restoreContiguousGroupResults(
+        op, *reducedResults, resultTypes, resultType, groupCount,
+        chunksPerGroup, rowLocalSlots1Result, rewriter);
+    if (failed(results)) {
+      return failure();
     }
-    replaceOpWithFlatConvertedValues(rewriter, op, results,
+    replaceOpWithFlatConvertedValues(rewriter, op, *results,
                                      *this->getTypeConverter());
     return success();
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5452,6 +5452,60 @@ tryDataLayoutMaterializer(const DataLayoutMaterializationContext &context,
   return materializer(context);
 }
 
+static FailureOr<std::optional<SmallVector<Value>>>
+tryDataLayoutMaterializers(const DataLayoutMaterializationContext &context) {
+  auto tryMaterializer =
+      [&context](auto materializer)
+          -> FailureOr<std::optional<SmallVector<Value>>> {
+    FailureOr<std::optional<SmallVector<Value>>> result =
+        tryDataLayoutMaterializer(context, materializer);
+    if (failed(result)) {
+      return failure();
+    }
+    return result;
+  };
+
+  FailureOr<std::optional<SmallVector<Value>>> simple = tryMaterializer(
+      [](const DataLayoutMaterializationContext &context) {
+        return materializeSimpleDataLayoutConversion(
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout,
+            context.sourceVMIElementType, context.rewriter);
+      });
+  bool simpleHandled = failed(simple) || simple->has_value();
+  if (simpleHandled) {
+    return simple;
+  }
+  FailureOr<std::optional<SmallVector<Value>>> deinterleaved2 = tryMaterializer(
+      [](const DataLayoutMaterializationContext &context) {
+        return materializeDeinterleaved2Layout(
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout, context.rewriter);
+      });
+  bool deinterleaved2Handled =
+      failed(deinterleaved2) || deinterleaved2->has_value();
+  if (deinterleaved2Handled) {
+    return deinterleaved2;
+  }
+  FailureOr<std::optional<SmallVector<Value>>> laneStride = tryMaterializer(
+      [](const DataLayoutMaterializationContext &context) {
+        return materializeDataLaneStrideConversion(
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout,
+            context.sourceVMIElementType, context.rewriter);
+      });
+  bool laneStrideHandled = failed(laneStride) || laneStride->has_value();
+  if (laneStrideHandled) {
+    return laneStride;
+  }
+  return tryMaterializer([](const DataLayoutMaterializationContext &context) {
+    return materializeDataLayoutViaContiguous(
+        context.op, context.sourceParts, context.resultTypes,
+        context.sourceLayout, context.resultLayout,
+        context.sourceVMIElementType, context.rewriter);
+  });
+}
+
 FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
     VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
@@ -5459,56 +5513,13 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
   DataLayoutMaterializationContext context{
       op, sourceParts, resultTypes, sourceLayout, resultLayout,
       sourceVMIElementType, rewriter};
-  FailureOr<std::optional<SmallVector<Value>>> simple = tryDataLayoutMaterializer(
-      context, [](const DataLayoutMaterializationContext &context) {
-        return materializeSimpleDataLayoutConversion(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout,
-            context.sourceVMIElementType, context.rewriter);
-      });
-  if (failed(simple)) {
+  FailureOr<std::optional<SmallVector<Value>>> results =
+      tryDataLayoutMaterializers(context);
+  if (failed(results)) {
     return failure();
   }
-  if (simple->has_value()) {
-    return std::move(**simple);
-  }
-  FailureOr<std::optional<SmallVector<Value>>> deinterleaved2 =
-      tryDataLayoutMaterializer(context, [](const DataLayoutMaterializationContext &context) {
-        return materializeDeinterleaved2Layout(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout, context.rewriter);
-      });
-  if (failed(deinterleaved2)) {
-    return failure();
-  }
-  if (deinterleaved2->has_value()) {
-    return std::move(**deinterleaved2);
-  }
-  FailureOr<std::optional<SmallVector<Value>>> laneStride =
-      tryDataLayoutMaterializer(context, [](const DataLayoutMaterializationContext &context) {
-        return materializeDataLaneStrideConversion(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout,
-            context.sourceVMIElementType, context.rewriter);
-      });
-  if (failed(laneStride)) {
-    return failure();
-  }
-  if (laneStride->has_value()) {
-    return std::move(**laneStride);
-  }
-  FailureOr<std::optional<SmallVector<Value>>> viaContiguous =
-      tryDataLayoutMaterializer(context, [](const DataLayoutMaterializationContext &context) {
-        return materializeDataLayoutViaContiguous(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout,
-            context.sourceVMIElementType, context.rewriter);
-      });
-  if (failed(viaContiguous)) {
-    return failure();
-  }
-  if (viaContiguous->has_value()) {
-    return std::move(**viaContiguous);
+  if (results->has_value()) {
+    return std::move(**results);
   }
 
   (void)rewriter.notifyMatchFailure(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6923,6 +6923,32 @@ struct OneToNVMIEnsureMaskGranularityOpPattern
   using OneToNOpConversionPattern<
       VMIEnsureMaskGranularityOp>::OneToNOpConversionPattern;
 
+private:
+  LogicalResult replaceCheckedResults(
+      VMIEnsureMaskGranularityOp op, OneToNPatternRewriter &rewriter,
+      FailureOr<SmallVector<Value>> results, ArrayRef<Type> resultTypes) const {
+    if (failed(results)) {
+      return failure();
+    }
+    bool resultArityMismatch = results->size() != resultTypes.size();
+    if (resultArityMismatch) {
+      return rewriter.notifyMatchFailure(
+          op, "mask granularity cast result arity mismatch");
+    }
+    for (auto [result, type] : llvm::zip_equal(*results, resultTypes)) {
+      bool resultTypeMismatch = result.getType() != type;
+      if (resultTypeMismatch) {
+        return rewriter.notifyMatchFailure(
+            op, "mask granularity cast result type mismatch");
+      }
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, *results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
+public:
+
   LogicalResult
   matchAndRewrite(VMIEnsureMaskGranularityOp op, OpAdaptor adaptor,
                   OneToNPatternRewriter &rewriter) const override {
@@ -6951,24 +6977,7 @@ struct OneToNVMIEnsureMaskGranularityOpPattern
     FailureOr<SmallVector<Value>> results =
         materializeMaskGranularityCastConversion(
             op, sourceType, resultType, sourceParts, resultTypes, rewriter);
-    if (failed(results)) {
-      return failure();
-    }
-    bool resultArityMismatch = results->size() != resultTypes.size();
-    if (resultArityMismatch) {
-      return rewriter.notifyMatchFailure(
-          op, "mask granularity cast result arity mismatch");
-    }
-    for (auto [result, type] : llvm::zip_equal(*results, resultTypes)) {
-      bool resultTypeMismatch = result.getType() != type;
-      if (resultTypeMismatch) {
-        return rewriter.notifyMatchFailure(
-            op, "mask granularity cast result type mismatch");
-      }
-    }
-    replaceOpWithFlatConvertedValues(rewriter, op, *results,
-                                     *this->getTypeConverter());
-    return success();
+    return replaceCheckedResults(op, rewriter, std::move(results), resultTypes);
   }
 
 private:

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -20548,11 +20548,8 @@ static std::optional<WalkResult> verifySupportedVMIStructuredMaskedStoreOp(
   return std::nullopt;
 }
 
-std::optional<WalkResult> verifySupportedVMIStructuredStoreOp(Operation *op) {
-  if (auto maskedStore = verifySupportedVMIStructuredMaskedStoreOp(op);
-      maskedStore.has_value()) {
-    return maskedStore;
-  }
+static std::optional<WalkResult> verifySupportedVMIInterleaveStoreOp(
+    Operation *op) {
   if (auto store = dyn_cast<VMIInterleaveStoreOp>(op)) {
     return verifySupportedShapeOp(
         store, checkSupportedInterleaveStoreShape,
@@ -20560,6 +20557,10 @@ std::optional<WalkResult> verifySupportedVMIStructuredStoreOp(Operation *op) {
         "contiguous full low/high input chunks with a supported UB destination "
         "and 8/16/32-bit element type (");
   }
+  return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMIGroupStoreOp(Operation *op) {
   if (auto store = dyn_cast<VMIGroupStoreOp>(op)) {
     return verifySupportedShapeOp(
         store, checkSupportedGroupStoreShape,
@@ -20567,12 +20568,20 @@ std::optional<WalkResult> verifySupportedVMIStructuredStoreOp(Operation *op) {
         "supported value layout lowering through one-block vsstb, full-chunk "
         "vsts, or deinterleaved vstsx2 (");
   }
+  return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMIStrideStoreOp(Operation *op) {
   if (auto store = dyn_cast<VMIStrideStoreOp>(op)) {
     return verifySupportedShapeOp(
         store, checkSupportedStrideStoreShape,
         "pto.vmi.stride_store lowers through pto.vsstb only for one contiguous "
         "physical value/mask chunk and a supported UB destination (");
   }
+  return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMIScatterOp(Operation *op) {
   if (auto scatter = dyn_cast<VMIScatterOp>(op)) {
     return verifySupportedShapeOp(
         scatter, checkSupportedScatterShape,
@@ -20581,6 +20590,24 @@ std::optional<WalkResult> verifySupportedVMIStructuredStoreOp(Operation *op) {
         "i32 indices, and b32 masks (");
   }
   return std::nullopt;
+}
+
+std::optional<WalkResult> verifySupportedVMIStructuredStoreOp(Operation *op) {
+  if (auto maskedStore = verifySupportedVMIStructuredMaskedStoreOp(op);
+      maskedStore.has_value()) {
+    return maskedStore;
+  }
+  if (auto result = verifySupportedVMIInterleaveStoreOp(op);
+      result.has_value()) {
+    return result;
+  }
+  if (auto result = verifySupportedVMIGroupStoreOp(op); result.has_value()) {
+    return result;
+  }
+  if (auto result = verifySupportedVMIStrideStoreOp(op); result.has_value()) {
+    return result;
+  }
+  return verifySupportedVMIScatterOp(op);
 }
 
 static LogicalResult checkSupportedVMIStoreShape(VMIStoreOp op,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -1357,6 +1357,17 @@ struct VMIStatefulOffsetRange {
   int64_t maximum;
 };
 
+static std::optional<int64_t> convertFiniteRangeBound(
+    const APInt &bound, bool unsignedInterpretation) {
+  if (unsignedInterpretation) {
+    return bound.getActiveBits() > 63
+               ? std::nullopt
+               : std::optional<int64_t>(bound.getZExtValue());
+  }
+  return bound.isSignedIntN(64) ? std::optional<int64_t>(bound.getSExtValue())
+                                : std::nullopt;
+}
+
 static FailureOr<VMIStatefulOffsetRange>
 getStatefulOffsetRange(Value source, Value offset, std::string *reason) {
   auto fail = [&reason](const Twine &message)
@@ -1384,25 +1395,10 @@ getStatefulOffsetRange(Value source, Value offset, std::string *reason) {
       PTOAnalysisResult<PTOFiniteRange> range =
           valueEvolution.getRange(offset, loop);
       if (range) {
-        auto convertBound =
-            [](const APInt &bound,
-               bool unsignedInterpretation) -> std::optional<int64_t> {
-          if (unsignedInterpretation) {
-            bool exceedsSignedInt64 = bound.getActiveBits() > 63;
-            if (exceedsSignedInt64) {
-              return std::nullopt;
-            }
-            return static_cast<int64_t>(bound.getZExtValue());
-          }
-          if (!bound.isSignedIntN(64)) {
-            return std::nullopt;
-          }
-          return bound.getSExtValue();
-        };
-        minOffset = convertBound(range.value->lowerInclusive,
-                                 range.value->unsignedInterpretation);
-        maxOffset = convertBound(range.value->upperInclusive,
-                                 range.value->unsignedInterpretation);
+        minOffset = convertFiniteRangeBound(
+            range.value->lowerInclusive, range.value->unsignedInterpretation);
+        maxOffset = convertFiniteRangeBound(
+            range.value->upperInclusive, range.value->unsignedInterpretation);
       }
     }
   }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -1368,6 +1368,59 @@ static std::optional<int64_t> convertFiniteRangeBound(
                                 : std::nullopt;
 }
 
+struct VMIStatefulReadEnvelopes {
+  VMIByteInterval readable;
+  VMIByteInterval candidate;
+};
+
+static FailureOr<VMIStatefulReadEnvelopes> buildStatefulReadEnvelopes(
+    int64_t staticElements, VMIStatefulOffsetRange offsetRange,
+    int64_t elementBytes, int64_t physicalFootprint, int64_t remainder,
+    std::string *reason) {
+  auto fail = [&reason](const Twine &message)
+      -> FailureOr<VMIStatefulReadEnvelopes> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  int64_t minOffsetBytes;
+  int64_t maxOffsetBytes;
+  int64_t allocationBytes;
+  int64_t footprintBytes;
+  bool envelopeOverflows =
+      llvm::MulOverflow(offsetRange.minimum, elementBytes, minOffsetBytes) ||
+      llvm::MulOverflow(offsetRange.maximum, elementBytes, maxOffsetBytes) ||
+      llvm::MulOverflow(staticElements, elementBytes, allocationBytes) ||
+      llvm::MulOverflow(physicalFootprint, elementBytes, footprintBytes);
+  if (envelopeOverflows) {
+    return fail("stateful byte read envelope overflows int64");
+  }
+
+  constexpr int64_t blockBytes = 32;
+  int64_t roundedInput;
+  int64_t roundedEnd;
+  bool roundedEndOverflows =
+      llvm::AddOverflow(footprintBytes, remainder, roundedInput) ||
+      llvm::AddOverflow(roundedInput, blockBytes - 1, roundedEnd);
+  if (roundedEndOverflows) {
+    return fail("stateful byte read envelope overflows int64");
+  }
+  roundedEnd = roundedEnd / blockBytes * blockBytes - remainder;
+
+  int64_t physicalBegin;
+  int64_t physicalEnd;
+  bool physicalEnvelopeOverflows =
+      llvm::SubOverflow(minOffsetBytes, remainder, physicalBegin) ||
+      llvm::AddOverflow(maxOffsetBytes, roundedEnd, physicalEnd);
+  if (physicalEnvelopeOverflows) {
+    return fail("stateful byte read envelope overflows int64");
+  }
+  return VMIStatefulReadEnvelopes{
+      VMIByteInterval{0, allocationBytes},
+      VMIByteInterval{physicalBegin, physicalEnd}};
+}
+
 static FailureOr<VMIStatefulOffsetRange>
 getStatefulOffsetRange(Value source, Value offset, std::string *reason) {
   auto fail = [&reason](const Twine &message)
@@ -1457,41 +1510,19 @@ computeSafeStatefulReadProof(Value source, Value offset,
     return fail("requires computable physical read footprint");
   }
 
-  int64_t minOffsetBytes;
-  int64_t maxOffsetBytes;
-  int64_t allocationBytes;
   int64_t footprintElements;
-  int64_t footprintBytes;
-  bool envelopeOverflows =
-      llvm::MulOverflow(offsetRange->minimum, elementBytes, minOffsetBytes) ||
-      llvm::MulOverflow(offsetRange->maximum, elementBytes, maxOffsetBytes) ||
-      llvm::MulOverflow(*staticElements, elementBytes, allocationBytes) ||
-      llvm::MulOverflow(*arity, *lanesPerPart, footprintElements) ||
-      llvm::MulOverflow(footprintElements, elementBytes, footprintBytes);
-  if (envelopeOverflows) {
+  if (llvm::MulOverflow(*arity, *lanesPerPart, footprintElements)) {
     return fail("stateful byte read envelope overflows int64");
   }
-
-  int64_t roundedInput;
-  int64_t roundedEnd;
-  bool roundedEndOverflows =
-      llvm::AddOverflow(footprintBytes, *remainder, roundedInput) ||
-      llvm::AddOverflow(roundedInput, blockBytes - 1, roundedEnd);
-  if (roundedEndOverflows) {
-    return fail("stateful byte read envelope overflows int64");
+  std::string envelopeReason;
+  FailureOr<VMIStatefulReadEnvelopes> envelopes = buildStatefulReadEnvelopes(
+      *staticElements, *offsetRange, elementBytes, footprintElements,
+      *remainder, &envelopeReason);
+  if (failed(envelopes)) {
+    return fail(envelopeReason);
   }
-  roundedEnd = roundedEnd / blockBytes * blockBytes - *remainder;
-
-  int64_t physicalBegin;
-  int64_t physicalEnd;
-  bool physicalEnvelopeOverflows =
-      llvm::SubOverflow(minOffsetBytes, *remainder, physicalBegin) ||
-      llvm::AddOverflow(maxOffsetBytes, roundedEnd, physicalEnd);
-  if (physicalEnvelopeOverflows) {
-    return fail("stateful byte read envelope overflows int64");
-  }
-  proof.readableEnvelope = VMIByteInterval{0, allocationBytes};
-  proof.candidateReadEnvelope = VMIByteInterval{physicalBegin, physicalEnd};
+  proof.readableEnvelope = envelopes->readable;
+  proof.candidateReadEnvelope = envelopes->candidate;
   proof.proven = proof.readableEnvelope->contains(*proof.candidateReadEnvelope);
   if (!proof.proven) {
     proof.reason = (Twine("stateful physical read envelope [") +
@@ -1910,8 +1941,9 @@ LogicalResult checkSupportedBlockDeinterleavedGroupLoadShape(
 LogicalResult
 checkSupportedGroupLoadShape(VMIGroupLoadOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -1955,8 +1987,9 @@ LogicalResult checkSupportedGroupSlotLoadShape(
     VMIGroupSlotLoadOp op,
     std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2170,8 +2203,9 @@ checkSupportedGroupSlotsStoreShape(VMIGroupStoreOp op, VMIVRegType valueType,
 LogicalResult
 checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2229,13 +2263,18 @@ checkSupportedMaskedLoadShape(VMIMaskedLoadOp op, std::string *reason) {
   VMIMemoryAccessPlan accessPlan =
       buildReadAccessPlan(op.getSource(), op.getOffset(), resultType,
                           VMIMemoryCoverageKind::Predicate);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
-  if (!resultLayout || !passthruLayout || !maskLayout)
+  }
+  if (!resultLayout || !passthruLayout || !maskLayout) {
     return fail("requires assigned result, passthru, and mask layouts");
-  if (!resultLayout.isContiguous() || !passthruLayout.isContiguous() ||
-      !maskLayout.isContiguous())
+  }
+  bool nonContiguousLayout = !resultLayout.isContiguous() ||
+                             !passthruLayout.isContiguous() ||
+                             !maskLayout.isContiguous();
+  if (nonContiguousLayout) {
     return fail("requires contiguous result, passthru, and mask layouts");
+  }
 
   std::string fullChunkReason;
   if (succeeded(checkFullDataPhysicalChunks(resultType, &fullChunkReason)))
@@ -2257,9 +2296,8 @@ LogicalResult checkSupportedGatherPhysicalShape(
     VMIVRegType resultType, VMIVRegType indicesType, VMIVRegType passthruType,
     VMIMaskType maskType, bool requiresFullChunks, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason) {
+    if (reason)
       *reason = message.str();
-    }
     return failure();
   };
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
@@ -2690,8 +2728,9 @@ checkSupportedExpandLoadRuntimePath(
 LogicalResult
 checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2704,13 +2743,18 @@ checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
   VMIMemoryAccessPlan accessPlan =
       buildReadAccessPlan(op.getSource(), op.getOffset(), resultType,
                           VMIMemoryCoverageKind::Predicate);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
-  if (!resultLayout || !passthruLayout || !maskLayout)
+  }
+  if (!resultLayout || !passthruLayout || !maskLayout) {
     return fail("requires assigned result, passthru, and mask layouts");
-  if (!resultLayout.isContiguous() || !passthruLayout.isContiguous() ||
-      !maskLayout.isContiguous())
+  }
+  bool nonContiguousLayout = !resultLayout.isContiguous() ||
+                             !passthruLayout.isContiguous() ||
+                             !maskLayout.isContiguous();
+  if (nonContiguousLayout) {
     return fail("requires contiguous result, passthru, and mask layouts");
+  }
 
   std::string maskReason;
   bool staticAllActive = isStaticAllActiveMask(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8994,6 +8994,54 @@ private:
     return success();
   }
 
+  FailureOr<std::pair<SmallVector<Type>, SmallVector<Type>>>
+  getInterleaveResultTypes(
+      SourceOp op, ValueRange lhsParts, ValueRange rhsParts,
+      ValueRange maskParts, OneToNPatternRewriter &rewriter) const {
+    FailureOr<SmallVector<Type>> maybeLowTypes =
+        getConvertedResultTypes(op, 0, *this->getTypeConverter());
+    FailureOr<SmallVector<Type>> maybeHighTypes =
+        getConvertedResultTypes(op, 1, *this->getTypeConverter());
+    bool failedResultTypes = failed(maybeLowTypes) || failed(maybeHighTypes);
+    if (failedResultTypes) {
+      return failure();
+    }
+    bool arityMismatch = lhsParts.size() != rhsParts.size() ||
+                         lhsParts.size() != maybeLowTypes->size() ||
+                         lhsParts.size() != maybeHighTypes->size();
+    if (arityMismatch) {
+      rewriter.notifyMatchFailure(op, "physical interleave arity mismatch");
+      return failure();
+    }
+    bool maskArityMismatch =
+        !maskParts.empty() && maskParts.size() != lhsParts.size();
+    if (maskArityMismatch) {
+      rewriter.notifyMatchFailure(op, "physical interleave mask arity mismatch");
+      return failure();
+    }
+    return std::make_pair(std::move(*maybeLowTypes),
+                          std::move(*maybeHighTypes));
+  }
+
+  FailureOr<VMIInterleaveLayoutFact> getInterleaveLayoutFact(
+      SourceOp op, VMIVRegType lhsType, VMIVRegType rhsType,
+      VMIMaskType maskType, VMIVRegType lowType, VMIVRegType highType,
+      OneToNPatternRewriter &rewriter) const {
+    VMILayoutSupport supports;
+    FailureOr<VMIInterleaveLayoutFact> fact;
+    if constexpr (std::is_same_v<SourceOp, VMIVintlvOp>) {
+      fact = supports.getVintlvLayoutFactForLayouts(
+          lhsType, rhsType, maskType, lowType, highType);
+    } else {
+      fact = supports.getVdintlvLayoutFactForLayouts(
+          lhsType, rhsType, maskType, lowType, highType);
+    }
+    if (failed(fact)) {
+      rewriter.notifyMatchFailure(op, "unsupported interleave layout relation");
+    }
+    return fact;
+  }
+
 public:
 
   LogicalResult
@@ -13436,47 +13484,23 @@ public:
     ValueRange lhsParts = adaptor.getLhs();
     ValueRange rhsParts = adaptor.getRhs();
     ValueRange maskParts = adaptor.getMask();
-    FailureOr<SmallVector<Type>> maybeLowTypes =
-        getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    FailureOr<SmallVector<Type>> maybeHighTypes =
-        getConvertedResultTypes(op, 1, *this->getTypeConverter());
-    bool failedResultTypes = failed(maybeLowTypes) || failed(maybeHighTypes);
-    if (failedResultTypes) {
+    FailureOr<std::pair<SmallVector<Type>, SmallVector<Type>>> resultTypes =
+        getInterleaveResultTypes(op, lhsParts, rhsParts, maskParts, rewriter);
+    if (failed(resultTypes)) {
       return failure();
     }
-    SmallVector<Type> lowTypes = std::move(*maybeLowTypes);
-    SmallVector<Type> highTypes = std::move(*maybeHighTypes);
-    bool arityMismatch = lhsParts.size() != rhsParts.size() ||
-        lhsParts.size() != lowTypes.size() ||
-        lhsParts.size() != highTypes.size();
-    if (arityMismatch) {
-      return rewriter.notifyMatchFailure(op,
-                                         "physical interleave arity mismatch");
-    }
-    bool maskArityMismatch =
-        !maskParts.empty() && maskParts.size() != lhsParts.size();
-    if (maskArityMismatch) {
-      return rewriter.notifyMatchFailure(
-          op, "physical interleave mask arity mismatch");
-    }
+    SmallVector<Type> lowTypes = std::move(resultTypes->first);
+    SmallVector<Type> highTypes = std::move(resultTypes->second);
 
     auto lhsType = cast<VMIVRegType>(op.getLhs().getType());
     auto rhsType = cast<VMIVRegType>(op.getRhs().getType());
     auto maskType = cast<VMIMaskType>(op.getMask().getType());
     auto lowType = cast<VMIVRegType>(op.getLow().getType());
     auto highType = cast<VMIVRegType>(op.getHigh().getType());
-    VMILayoutSupport supports;
-    FailureOr<VMIInterleaveLayoutFact> fact;
-    if constexpr (std::is_same_v<SourceOp, VMIVintlvOp>) {
-      fact = supports.getVintlvLayoutFactForLayouts(
-          lhsType, rhsType, maskType, lowType, highType);
-    } else {
-      fact = supports.getVdintlvLayoutFactForLayouts(
-          lhsType, rhsType, maskType, lowType, highType);
-    }
+    FailureOr<VMIInterleaveLayoutFact> fact = getInterleaveLayoutFact(
+        op, lhsType, rhsType, maskType, lowType, highType, rewriter);
     if (failed(fact)) {
-      return rewriter.notifyMatchFailure(
-          op, "unsupported interleave layout relation");
+      return failure();
     }
 
     auto isContiguous = [](VMILayoutAttr layout) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5796,6 +5796,32 @@ buildMaskGranularityConversionPlan(
       MaskType::get(op->getContext(), resultType.getGranularity())};
 }
 
+static FailureOr<SmallVector<Value>> materializeMaskGranularityParts(
+    Operation *op, VMIMaskType sourceType, VMIMaskType resultType,
+    ValueRange sourceParts, const MaskGranularityConversionPlan &plan,
+    PatternRewriter &rewriter) {
+  SmallVector<Value> results;
+  int64_t sourceOffset = 0;
+  for (int64_t part = 0; part < plan.layoutFactor; ++part) {
+    FailureOr<int64_t> sourceChunks = getVMITypeChunksInPart(sourceType, part);
+    if (failed(sourceChunks)) {
+      (void)rewriter.notifyMatchFailure(
+          op, "requires computable source chunks per layout part");
+      return failure();
+    }
+    FailureOr<SmallVector<Value>> partResults =
+        materializeAdjacentMaskGranularityPart(
+            op, sourceType, resultType, sourceParts, plan.sourceRank,
+            plan.resultRank, plan.resultMaskType, part, sourceOffset, rewriter);
+    if (failed(partResults)) {
+      return failure();
+    }
+    results.append(*partResults);
+    sourceOffset += *sourceChunks;
+  }
+  return results;
+}
+
 FailureOr<SmallVector<Value>> materializeAdjacentMaskGranularityConversion(
     Operation *op, VMIMaskType sourceType, VMIMaskType resultType,
     ValueRange sourceParts, PatternRewriter &rewriter) {
@@ -5809,30 +5835,20 @@ FailureOr<SmallVector<Value>> materializeAdjacentMaskGranularityConversion(
   if (failed(plan)) {
     return failure();
   }
-  SmallVector<Value> results;
-
-  int64_t sourceOffset = 0;
-  for (int64_t part = 0; part < plan->layoutFactor; ++part) {
-    FailureOr<int64_t> sourceChunks = getVMITypeChunksInPart(sourceType, part);
-    FailureOr<SmallVector<Value>> partResults =
-        materializeAdjacentMaskGranularityPart(
-            op, sourceType, resultType, sourceParts, plan->sourceRank,
-            plan->resultRank, plan->resultMaskType, part, sourceOffset,
-            rewriter);
-    if (failed(partResults)) {
-      return failure();
-    }
-    results.append(*partResults);
-    sourceOffset += *sourceChunks;
+  FailureOr<SmallVector<Value>> results = materializeMaskGranularityParts(
+      op, sourceType, resultType, sourceParts, *plan, rewriter);
+  if (failed(results)) {
+    return failure();
   }
 
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
   bool resultArityMismatch =
-      failed(resultArity) || static_cast<int64_t>(results.size()) != *resultArity;
+      failed(resultArity) ||
+      static_cast<int64_t>(results->size()) != *resultArity;
   if (resultArityMismatch) {
     return fail("mask granularity conversion result count mismatch");
   }
-  return results;
+  return *results;
 }
 
 static FailureOr<SmallVector<Value>> materializeMaskGranularityStep(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7780,8 +7780,8 @@ FailureOr<Value> createResidualSubVLGroupPeriodicChunk(
                           /*position=*/nullptr)
           .getResult();
   auto materializeGroup =
-      [&loc, resultType, base, order, full, maskType, zeroScalar, groupSize,
-       &rewriter](int64_t localGroup) -> FailureOr<Value> {
+      [&loc, resultType, base, order, full, maskType, zeroScalar, allMask,
+       groupSize, &rewriter](int64_t localGroup) -> FailureOr<Value> {
     Value adjusted = full;
     if (localGroup != 0) {
       int64_t delta = localGroup * groupSize;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9199,6 +9199,25 @@ private:
                           std::move(*maybeHighTypes));
   }
 
+  FailureOr<std::pair<SmallVector<Type>, SmallVector<Type>>>
+  getDeinterleaveLoadResultTypes(
+      VMIDeinterleaveLoadOp op, OneToNPatternRewriter &rewriter) const {
+    FailureOr<SmallVector<Type>> lowTypes =
+        getConvertedResultTypes(op, 0, *this->getTypeConverter());
+    FailureOr<SmallVector<Type>> highTypes =
+        getConvertedResultTypes(op, 1, *this->getTypeConverter());
+    bool failedTypeConversion = failed(lowTypes) || failed(highTypes);
+    if (failedTypeConversion) {
+      return failure();
+    }
+    bool mismatchedArity = lowTypes->size() != highTypes->size();
+    if (mismatchedArity) {
+      return rewriter.notifyMatchFailure(
+          op, "deinterleave_load requires matching low/high physical arity");
+    }
+    return std::make_pair(std::move(*lowTypes), std::move(*highTypes));
+  }
+
   FailureOr<VMIInterleaveLayoutFact> getInterleaveLayoutFact(
       SourceOp op, VMIVRegType lhsType, VMIVRegType rhsType,
       VMIMaskType maskType, VMIVRegType lowType, VMIVRegType highType,
@@ -9304,27 +9323,13 @@ public:
           op, "deinterleave_load requires vldsx2 DINTLV element support");
     }
 
-    FailureOr<SmallVector<Type>> maybe_lowTypes =
-
-        getConvertedResultTypes(op, 0, *this->getTypeConverter());
-
-    if (failed(maybe_lowTypes)) {
+    FailureOr<std::pair<SmallVector<Type>, SmallVector<Type>>> resultTypes =
+        getDeinterleaveLoadResultTypes(op, rewriter);
+    if (failed(resultTypes)) {
       return failure();
     }
-
-    SmallVector<Type> lowTypes = std::move(*maybe_lowTypes);
-    FailureOr<SmallVector<Type>> maybe_highTypes =
-        getConvertedResultTypes(op, 1, *this->getTypeConverter());
-    bool failedHighTypeConversion = failed(maybe_highTypes);
-    if (failedHighTypeConversion) {
-      return failure();
-    }
-    SmallVector<Type> highTypes = std::move(*maybe_highTypes);
-    bool mismatchedLowHighArity = lowTypes.size() != highTypes.size();
-    if (mismatchedLowHighArity) {
-      return rewriter.notifyMatchFailure(
-          op, "deinterleave_load requires matching low/high physical arity");
-    }
+    SmallVector<Type> lowTypes = std::move(resultTypes->first);
+    SmallVector<Type> highTypes = std::move(resultTypes->second);
 
     auto firstType =
         lowTypes.empty() ? VRegType{} : dyn_cast<VRegType>(lowTypes.front());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -2073,8 +2073,9 @@ LogicalResult checkSupportedGroupBroadcastLoadShape(
     VMIGroupBroadcastLoadOp op,
     std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2537,6 +2538,68 @@ LogicalResult checkSupportedScatterPhysicalShape(
 }
 
 LogicalResult
+checkScatterLayoutAndDestination(VMIScatterOp op, VMIVRegType valueType,
+                                 VMIVRegType indicesType, VMIMaskType maskType,
+                                 std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  VMILayoutAttr valueLayout = valueType.getLayoutAttr();
+  VMILayoutAttr indicesLayout = indicesType.getLayoutAttr();
+  VMILayoutAttr maskLayout = maskType.getLayoutAttr();
+  bool missingLayout = !valueLayout || !indicesLayout || !maskLayout;
+  if (missingLayout) {
+    return fail("requires assigned value, indices, and mask layouts");
+  }
+  bool nonContiguousLayout = !valueLayout.isContiguous() ||
+                             !indicesLayout.isContiguous() ||
+                             !maskLayout.isContiguous();
+  if (nonContiguousLayout) {
+    return fail("requires contiguous value, indices, and mask layouts");
+  }
+  if (!isa<PtrType>(op.getDestination().getType())) {
+    return fail("requires !pto.ptr destination because pto.vscatter is "
+                "pointer-only");
+  }
+  return success();
+}
+
+LogicalResult
+checkScatterElementContract(VMIVRegType valueType, VMIVRegType indicesType,
+                            VMIMaskType maskType,
+                            std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> LogicalResult {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  unsigned valueBits =
+      pto::getPTOStorageElemBitWidth(valueType.getElementType());
+  auto indexElementType = dyn_cast<IntegerType>(indicesType.getElementType());
+  if (!indexElementType || indexElementType.isSigned()) {
+    return fail("requires signless or unsigned integer indices");
+  }
+  bool isB8Scatter = valueBits == 8 && indexElementType.getWidth() == 16 &&
+                     maskType.getGranularity() == "b16";
+  bool isB16Scatter = valueBits == 16 && indexElementType.getWidth() == 16 &&
+                      maskType.getGranularity() == "b16";
+  bool isB32Scatter = valueBits == 32 && indexElementType.getWidth() == 32 &&
+                      maskType.getGranularity() == "b32";
+  bool unsupportedContract = !isB8Scatter && !isB16Scatter && !isB32Scatter;
+  if (unsupportedContract) {
+    return fail("requires either 32-bit values with 32-bit indices and b32 "
+                "mask, 16-bit values with 16-bit indices and b16 "
+                "mask, or 8-bit values with 16-bit indices and b16 "
+                "mask");
+  }
+  return success();
+}
+
+LogicalResult
 checkSupportedScatterShape(VMIScatterOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
     if (reason) {
@@ -2548,37 +2611,14 @@ checkSupportedScatterShape(VMIScatterOp op, std::string *reason) {
   auto valueType = cast<VMIVRegType>(op.getValue().getType());
   auto indicesType = cast<VMIVRegType>(op.getIndices().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
-  VMILayoutAttr valueLayout = valueType.getLayoutAttr();
-  VMILayoutAttr indicesLayout = indicesType.getLayoutAttr();
-  VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  if (!valueLayout || !indicesLayout || !maskLayout)
-    return fail("requires assigned value, indices, and mask layouts");
-  if (!valueLayout.isContiguous() || !indicesLayout.isContiguous() ||
-      !maskLayout.isContiguous())
-    return fail("requires contiguous value, indices, and mask layouts");
-
-  if (!isa<PtrType>(op.getDestination().getType()))
-    return fail("requires !pto.ptr destination because pto.vscatter is "
-                "pointer-only");
-
-  unsigned valueBits =
-      pto::getPTOStorageElemBitWidth(valueType.getElementType());
-  auto indexElementType = dyn_cast<IntegerType>(indicesType.getElementType());
-  if (!indexElementType || indexElementType.isSigned())
-    return fail("requires signless or unsigned integer indices");
-  bool isB8Scatter = valueBits == 8 &&
-                     indexElementType.getWidth() == 16 &&
-                     maskType.getGranularity() == "b16";
-  bool isB16Scatter = valueBits == 16 &&
-                      indexElementType.getWidth() == 16 &&
-                      maskType.getGranularity() == "b16";
-  bool isB32Scatter = valueBits == 32 && indexElementType.getWidth() == 32 &&
-                      maskType.getGranularity() == "b32";
-  if (!isB8Scatter && !isB16Scatter && !isB32Scatter)
-    return fail("requires either 32-bit values with 32-bit indices and b32 "
-                "mask, 16-bit values with 16-bit indices and b16 "
-                "mask, or 8-bit values with 16-bit indices and b16 "
-                "mask");
+  if (failed(checkScatterLayoutAndDestination(op, valueType, indicesType,
+                                              maskType, reason))) {
+    return failure();
+  }
+  if (failed(checkScatterElementContract(valueType, indicesType, maskType,
+                                         reason))) {
+    return failure();
+  }
 
   return checkSupportedScatterPhysicalShape(valueType, indicesType, maskType,
                                             true, reason);
@@ -2608,8 +2648,9 @@ checkSinglePhysicalStrideAccess(Type dataType, Type maskType,
 LogicalResult
 checkSupportedStrideStoreShape(VMIStrideStoreOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2617,14 +2658,19 @@ checkSupportedStrideStoreShape(VMIStrideStoreOp op, std::string *reason) {
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   VMILayoutAttr valueLayout = valueType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  if (!valueLayout || !maskLayout)
+  if (!valueLayout || !maskLayout) {
     return fail("requires assigned value and mask layouts");
-  if (!valueLayout.isContiguous() || !maskLayout.isContiguous())
+  }
+  bool nonContiguousLayout = !valueLayout.isContiguous() ||
+                             !maskLayout.isContiguous();
+  if (nonContiguousLayout) {
     return fail("requires contiguous value and mask layouts");
+  }
 
-  if (!isa<PtrType>(op.getDestination().getType()))
+  if (!isa<PtrType>(op.getDestination().getType())) {
     return fail("requires !pto.ptr destination because pto.vsstb is "
                 "pointer-only");
+  }
   if (failed(checkSupportedStoreShape(valueType,
                                       op.getDestination(),
                                       op.getDestination().getType(), reason)))
@@ -2638,8 +2684,9 @@ checkSupportedStrideStoreShape(VMIStrideStoreOp op, std::string *reason) {
 LogicalResult
 checkSupportedStrideLoadShape(VMIStrideLoadOp op, std::string *reason) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6014,6 +6014,29 @@ static FailureOr<SmallVector<Value>> materializeMaskGranularitySteps(
   return currentParts;
 }
 
+struct MaskGranularityRoute {
+  int sourceRank;
+  int resultRank;
+  bool adjacent;
+};
+
+static FailureOr<MaskGranularityRoute> classifyMaskGranularityRoute(
+    Operation *op, VMIMaskType sourceType, VMIMaskType resultType,
+    PatternRewriter &rewriter) {
+  auto fail = [&rewriter, op](const Twine &message)
+      -> FailureOr<MaskGranularityRoute> {
+    (void)rewriter.notifyMatchFailure(op, message);
+    return failure();
+  };
+  int sourceRank = getMaskGranularityRank(sourceType.getGranularity());
+  int resultRank = getMaskGranularityRank(resultType.getGranularity());
+  if (sourceRank < 0 || resultRank < 0) {
+    return fail("requires concrete source and result mask granularity ranks");
+  }
+  return MaskGranularityRoute{sourceRank, resultRank,
+                              std::abs(sourceRank - resultRank) == 1};
+}
+
 FailureOr<SmallVector<Value>> materializeMaskGranularityConversion(
     Operation *op, VMIMaskType sourceType, VMIMaskType resultType, ValueRange sourceParts,
     PatternRewriter &rewriter) {
@@ -6023,16 +6046,19 @@ FailureOr<SmallVector<Value>> materializeMaskGranularityConversion(
     return failure();
   }
 
-  int currentRank = getMaskGranularityRank(sourceType.getGranularity());
-  int resultRank = getMaskGranularityRank(resultType.getGranularity());
-  bool isAdjacent = std::abs(currentRank - resultRank) == 1;
-  if (isAdjacent) {
+  FailureOr<MaskGranularityRoute> route = classifyMaskGranularityRoute(
+      op, sourceType, resultType, rewriter);
+  if (failed(route)) {
+    return failure();
+  }
+  if (route->adjacent) {
     return materializeAdjacentMaskGranularityConversion(
         op, sourceType, resultType, sourceParts, rewriter);
   }
 
   return materializeMaskGranularitySteps(op, sourceType, sourceParts,
-                                         currentRank, resultRank, rewriter);
+                                         route->sourceRank, route->resultRank,
+                                         rewriter);
 }
 
 FailureOr<SmallVector<Type>> getConvertedMaskPartTypes(VMIMaskType type) {

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6085,6 +6085,7 @@ static FailureOr<SmallVector<Value>> materializeMaskGranularitySteps(
     int sourceRank, int resultRank, PatternRewriter &rewriter) {
   VMIMaskType currentType = sourceType;
   SmallVector<Value> currentParts(sourceParts.begin(), sourceParts.end());
+  int currentRank = sourceRank;
   while (currentRank != resultRank) {
     bool ascending = currentRank < resultRank;
     currentRank += ascending ? 1 : -1;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -6555,6 +6555,11 @@ static FailureOr<SmallVector<Value>> forwardIdentityMaskParts(
   return SmallVector<Value>(sourceParts.begin(), sourceParts.end());
 }
 
+static bool requiresMaskDenseSplitFallback(VMILayoutAttr sourceLayout,
+                                           VMILayoutAttr resultLayout) {
+  return sourceLayout.isDenseSplit() || resultLayout.isDenseSplit();
+}
+
 FailureOr<std::optional<SmallVector<Value>>>
 materializeMaskGranularityCastLayoutFallback(
     Operation *op, VMIMaskType sourceType, VMIMaskType resultType,
@@ -6576,9 +6581,7 @@ materializeMaskGranularityCastLayoutFallback(
     return std::move(*staging);
   }
 
-  bool requiresContiguousFallback =
-      sourceLayout.isDenseSplit() || resultLayout.isDenseSplit();
-  if (!requiresContiguousFallback) {
+  if (!requiresMaskDenseSplitFallback(sourceLayout, resultLayout)) {
     return std::nullopt;
   }
   FailureOr<SmallVector<Value>> contiguous =

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -14185,6 +14185,39 @@ struct OneToNVMITruncFOpPattern : OneToNOpConversionPattern<VMITruncFOp> {
   using OneToNOpConversionPattern<VMITruncFOp>::OneToNOpConversionPattern;
 
 private:
+  LogicalResult lowerDenseLaneStride(
+      VMITruncFOp op, ValueRange sourceParts,
+      ArrayRef<VRegType> resultTypes, StringRef part,
+      bool sourceIsPackedBF16x2, VRegType vcvtSourceVRegType,
+      OneToNPatternRewriter &rewriter) const {
+    FailureOr<Value> sourceMask =
+        createAllTrueMaskForVReg(op.getLoc(), vcvtSourceVRegType, rewriter);
+    if (failed(sourceMask)) {
+      return rewriter.notifyMatchFailure(op, "failed to build truncf masks");
+    }
+    StringAttr rnd = rewriter.getStringAttr(
+        getTruncFRoundMode(op, resultTypes.front().getElementType()));
+    StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
+    StringAttr partAttr = rewriter.getStringAttr(part);
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (auto [sourcePart, resultType] :
+         llvm::zip_equal(sourceParts, resultTypes)) {
+      results.push_back(rewriter
+                            .create<VcvtOp>(
+                                op.getLoc(), resultType,
+                                makeVcvtSourceView(
+                                    op.getLoc(), sourcePart,
+                                    sourceIsPackedBF16x2, vcvtSourceVRegType,
+                                    rewriter),
+                                *sourceMask, rnd, sat, partAttr)
+                            .getResult());
+    }
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+
   FailureOr<Value> lowerGroupSlotTruncPart(
       VMITruncFOp op, Value sourcePart, Type physicalResultType,
       Value activeSlotMask, StringAttr sat,
@@ -14487,7 +14520,6 @@ public:
         sourceLayout.getLaneStride() == 1 && resultLayout.isContiguous() &&
         resultLayout.getLaneStride() != 1 &&
         sourceParts.size() == resultTypes.size()) {
-      StringRef part;
       bool isEven32To16 =
           resultBits == 16 && resultLayout.getLaneStride() == 2;
       bool isPacked32To8 =
@@ -14499,33 +14531,10 @@ public:
         return rewriter.notifyMatchFailure(
             op, "unsupported dense lane_stride truncf result layout");
       }
-      part = isPacked32To8 ? "P0" : "EVEN";
-
-      FailureOr<Value> sourceMask =
-          createAllTrueMaskForVReg(op.getLoc(), vcvtSourceVRegType, rewriter);
-      if (failed(sourceMask)) {
-        return rewriter.notifyMatchFailure(op, "failed to build truncf masks");
-      }
-
-      StringAttr rnd = rewriter.getStringAttr(
-          getTruncFRoundMode(op, resultVRegTypes.front().getElementType()));
-      StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
-      StringAttr partAttr = rewriter.getStringAttr(part);
-      SmallVector<Value> results;
-      results.reserve(resultTypes.size());
-      for (auto [sourcePart, resultType] :
-           llvm::zip_equal(sourceParts, resultVRegTypes)) {
-        results.push_back(rewriter
-                              .create<VcvtOp>(op.getLoc(), resultType,
-                                              makeVcvtSourceView(
-                                                  op.getLoc(), sourcePart,
-                                                  sourceIsPackedBF16x2,
-                                                  vcvtSourceVRegType, rewriter),
-                                              *sourceMask, rnd, sat, partAttr)
-                              .getResult());
-      }
-      replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
-      return success();
+      StringRef part = isPacked32To8 ? "P0" : "EVEN";
+      return lowerDenseLaneStride(op, sourceParts, resultVRegTypes, part,
+                                  sourceIsPackedBF16x2, vcvtSourceVRegType,
+                                  rewriter);
     }
 
     ArrayRef<StringRef> allParts;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -17571,6 +17571,34 @@ static FailureOr<ChannelShapePlan> buildChannelShapePlan(
       channels, VMILayoutAttr::getDeinterleaved(op.getContext(), channels)};
 }
 
+static FailureOr<int64_t> checkChannelSplitResultShape(
+    VMIChannelSplitOp op, int64_t sourceArity, std::string *reason) {
+  auto fail = [&reason](const Twine &message) -> FailureOr<int64_t> {
+    if (reason) {
+      *reason = message.str();
+    }
+    return failure();
+  };
+  int64_t resultArity = 0;
+  for (Value result : op.getResults()) {
+    VMILayoutAttr resultLayout =
+        cast<VMIVRegType>(result.getType()).getLayoutAttr();
+    if (!resultLayout || !resultLayout.isContiguous()) {
+      return fail("requires every result layout to be contiguous");
+    }
+    FailureOr<int64_t> arity =
+        getVMIPhysicalArity(cast<VMIVRegType>(result.getType()));
+    if (failed(arity)) {
+      return fail("requires computable result physical arity");
+    }
+    resultArity += *arity;
+  }
+  if (sourceArity != resultArity) {
+    return fail("requires source and result to have the same physical arity");
+  }
+  return resultArity;
+}
+
 LogicalResult checkSupportedChannelSplitShape(VMIChannelSplitOp op,
                                               std::string *reason = nullptr) {
   auto fail = [&reason](const Twine &message) -> LogicalResult {
@@ -17596,26 +17624,12 @@ LogicalResult checkSupportedChannelSplitShape(VMIChannelSplitOp op,
     return fail("requires source layout to be contiguous or matching "
                 "deinterleaved channel layout");
 
-  for (Value result : op.getResults()) {
-    VMILayoutAttr resultLayout =
-        cast<VMIVRegType>(result.getType()).getLayoutAttr();
-    if (!resultLayout || !resultLayout.isContiguous())
-      return fail("requires every result layout to be contiguous");
-  }
-
   FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
-  int64_t resultArity = 0;
-  for (Value result : op.getResults()) {
-    FailureOr<int64_t> arity =
-        getVMIPhysicalArity(cast<VMIVRegType>(result.getType()));
-    if (failed(arity))
-      return fail("requires computable result physical arity");
-    resultArity += *arity;
-  }
   if (failed(sourceArity))
     return fail("requires computable source physical arity");
-  if (*sourceArity != resultArity)
-    return fail("requires source and result to have the same physical arity");
+  if (failed(checkChannelSplitResultShape(op, *sourceArity, reason))) {
+    return failure();
+  }
 
   return success();
 }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -17027,6 +17027,28 @@ static LogicalResult lowerWidenFpToInt(
   return success();
 }
 
+template <typename OpTy>
+static FailureOr<VRegType> validateFpToIntSourceParts(
+    OpTy op, ValueRange sourceParts, StringRef emptyDiagnostic,
+    StringRef expectedTypeDiagnostic, StringRef mismatchDiagnostic,
+    OneToNPatternRewriter &rewriter) {
+  if (sourceParts.empty()) {
+    return rewriter.notifyMatchFailure(op, emptyDiagnostic);
+  }
+  auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
+  if (!sourceType) {
+    return rewriter.notifyMatchFailure(op, expectedTypeDiagnostic);
+  }
+  for (Value sourcePart : sourceParts) {
+    auto currentType = dyn_cast<VRegType>(sourcePart.getType());
+    bool mismatchedType = !currentType || currentType != sourceType;
+    if (mismatchedType) {
+      return rewriter.notifyMatchFailure(op, mismatchDiagnostic);
+    }
+  }
+  return sourceType;
+}
+
 struct OneToNVMIFPToSIOpPattern : OneToNOpConversionPattern<VMIFPToSIOp> {
   using OneToNOpConversionPattern<VMIFPToSIOp>::OneToNOpConversionPattern;
 
@@ -17034,24 +17056,10 @@ private:
   FailureOr<VRegType> validateSourceParts(
       VMIFPToSIOp op, ValueRange sourceParts,
       OneToNPatternRewriter &rewriter) const {
-    if (sourceParts.empty()) {
-      return rewriter.notifyMatchFailure(
-          op, "fptosi requires at least one physical source chunk");
-    }
-    auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
-    if (!sourceType) {
-      return rewriter.notifyMatchFailure(op,
-                                         "expected physical fptosi source type");
-    }
-    for (Value sourcePart : sourceParts) {
-      auto currentType = dyn_cast<VRegType>(sourcePart.getType());
-      bool mismatchedType = !currentType || currentType != sourceType;
-      if (mismatchedType) {
-        return rewriter.notifyMatchFailure(
-            op, "fptosi source physical parts must have matching type");
-      }
-    }
-    return sourceType;
+    return validateFpToIntSourceParts(
+        op, sourceParts, "fptosi requires at least one physical source chunk",
+        "expected physical fptosi source type",
+        "fptosi source physical parts must have matching type", rewriter);
   }
 
   FailureOr<SmallVector<VRegType>> validateResultParts(
@@ -17213,24 +17221,10 @@ private:
   FailureOr<VRegType> validateSourceParts(
       VMIFPToUIOp op, ValueRange sourceParts,
       OneToNPatternRewriter &rewriter) const {
-    if (sourceParts.empty()) {
-      return rewriter.notifyMatchFailure(
-          op, "fptoui requires at least one physical source chunk");
-    }
-    auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
-    if (!sourceType) {
-      return rewriter.notifyMatchFailure(op,
-                                         "expected physical fptoui source type");
-    }
-    for (Value sourcePart : sourceParts) {
-      auto currentType = dyn_cast<VRegType>(sourcePart.getType());
-      bool mismatchedType = !currentType || currentType != sourceType;
-      if (mismatchedType) {
-        return rewriter.notifyMatchFailure(
-            op, "fptoui source physical parts must have matching type");
-      }
-    }
-    return sourceType;
+    return validateFpToIntSourceParts(
+        op, sourceParts, "fptoui requires at least one physical source chunk",
+        "expected physical fptoui source type",
+        "fptoui source physical parts must have matching type", rewriter);
   }
 
   FailureOr<SmallVector<VRegType>> validateResultParts(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3433,6 +3433,50 @@ static FailureOr<VMIPhysicalLane> getShuffleSourceLane(
   return *sourceLane;
 }
 
+struct ShuffleChunkLaneState {
+  int64_t sourcePart = 0;
+  int64_t sourceChunk = 0;
+  int64_t baseLane = 0;
+  std::optional<bool> descending;
+};
+
+static FailureOr<ShuffleChunkLaneState> updateShuffleChunkLaneState(
+    VMIVRegType sourceType, VMIVRegType resultType, ArrayRef<int64_t> indices,
+    int64_t resultPart, int64_t resultChunk, int64_t lane,
+    std::optional<ShuffleChunkLaneState> state,
+    std::string *reason) {
+  FailureOr<VMIPhysicalLane> sourcePhysical = getShuffleSourceLane(
+      sourceType, resultType, indices, resultPart, resultChunk, lane, reason);
+  if (failed(sourcePhysical)) {
+    return failure();
+  }
+  if (!state) {
+    return ShuffleChunkLaneState{sourcePhysical->part, sourcePhysical->chunk,
+                                 sourcePhysical->lane, false};
+  }
+  bool sourceChunkMismatch = state->sourcePart != sourcePhysical->part ||
+                             state->sourceChunk != sourcePhysical->chunk;
+  if (sourceChunkMismatch) {
+    if (reason) {
+      *reason = "requires one source chunk per result chunk";
+    }
+    return failure();
+  }
+  FailureOr<bool> laneDescending = getShuffleLaneDirection(
+      state->baseLane, lane, sourcePhysical->lane, reason);
+  if (failed(laneDescending)) {
+    return failure();
+  }
+  if (state->descending && *laneDescending != *state->descending) {
+    if (reason) {
+      *reason = "requires one index order per result chunk";
+    }
+    return failure();
+  }
+  state->descending = *laneDescending;
+  return *state;
+}
+
 FailureOr<ShuffleVselrPlan> computeShuffleVselrPlanForChunk(
     VMIVRegType sourceType, VMIVRegType resultType, ArrayRef<int64_t> indices,
     int64_t resultPart, int64_t resultChunk, int64_t lanesPerPart,
@@ -3443,48 +3487,23 @@ FailureOr<ShuffleVselrPlan> computeShuffleVselrPlanForChunk(
     }
     return failure();
   };
-  std::optional<int64_t> sourcePart;
-  std::optional<int64_t> sourceChunk;
-  std::optional<int64_t> baseLane;
-  std::optional<bool> descending;
+  std::optional<ShuffleChunkLaneState> state;
   for (int64_t lane = 0; lane < lanesPerPart; ++lane) {
-    FailureOr<VMIPhysicalLane> sourcePhysical = getShuffleSourceLane(
-        sourceType, resultType, indices, resultPart, resultChunk, lane, reason);
-    if (failed(sourcePhysical)) {
+    FailureOr<ShuffleChunkLaneState> nextState = updateShuffleChunkLaneState(
+        sourceType, resultType, indices, resultPart, resultChunk, lane,
+        state, reason);
+    if (failed(nextState)) {
       return failure();
     }
-    if (!sourcePart) {
-      sourcePart = sourcePhysical->part;
-      sourceChunk = sourcePhysical->chunk;
-      baseLane = sourcePhysical->lane;
-      continue;
-    }
-    bool sourceChunkMismatch =
-        *sourcePart != sourcePhysical->part ||
-        *sourceChunk != sourcePhysical->chunk;
-    if (sourceChunkMismatch) {
-      return fail("requires one source chunk per result chunk");
-    }
-    FailureOr<bool> laneDescending = getShuffleLaneDirection(
-        *baseLane, lane, sourcePhysical->lane, reason);
-    if (failed(laneDescending)) {
-      return failure();
-    }
-    if (!descending) {
-      descending = *laneDescending;
-      continue;
-    }
-    bool laneOrderMismatch = *descending != *laneDescending;
-    if (laneOrderMismatch) {
-      return fail("requires one index order per result chunk");
-    }
+    state = *nextState;
   }
   FailureOr<int64_t> sourceFlatIndex =
-      getDataFlatPartIndex(sourceType, *sourcePart, *sourceChunk);
+      getDataFlatPartIndex(sourceType, state->sourcePart, state->sourceChunk);
   if (failed(sourceFlatIndex)) {
     return fail("source part range is out of bounds");
   }
-  return ShuffleVselrPlan{*sourceFlatIndex, *baseLane, descending.value_or(false)};
+  return ShuffleVselrPlan{*sourceFlatIndex, state->baseLane,
+                          state->descending.value_or(false)};
 }
 
 FailureOr<int64_t> computeShuffleLane0SplatSourcePart(VMIShuffleOp op,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -14959,6 +14959,31 @@ private:
     return success();
   }
 
+  FailureOr<Value> buildLegacyGroupSlotExtensionResult(
+      OpT op, Value sourcePart, Type resultType, VRegType conversionSourceType,
+      Value slotMask, StringAttr part, unsigned resultBits,
+      OneToNPatternRewriter &rewriter) const {
+    auto resultVRegType = dyn_cast<VRegType>(resultType);
+    bool invalidResultType =
+        !resultVRegType ||
+        pto::getPTOStorageElemBitWidth(resultVRegType.getElementType()) !=
+            resultBits;
+    if (invalidResultType) {
+      return rewriter.notifyMatchFailure(
+          op, "unsupported group-slot integer extension result type");
+    }
+    FailureOr<Value> conversionSource = bitcastVReg(
+        op.getLoc(), sourcePart, conversionSourceType, rewriter);
+    if (failed(conversionSource)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to expose group-slot extension source elements");
+    }
+    return rewriter
+        .create<VcvtOp>(op.getLoc(), resultVRegType, *conversionSource, slotMask,
+                        /*rnd=*/nullptr, /*sat=*/nullptr, part)
+        .getResult();
+  }
+
   LogicalResult lowerLegacyGroupSlotExtension(
       OpT op, ValueRange sourceParts, ArrayRef<Type> resultTypes,
       VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
@@ -15008,27 +15033,13 @@ private:
     results.reserve(resultTypes.size());
     for (auto [sourcePart, resultType] :
          llvm::zip_equal(sourceParts, resultTypes)) {
-      auto resultVRegType = dyn_cast<VRegType>(resultType);
-      bool invalidResultType =
-          !resultVRegType ||
-          pto::getPTOStorageElemBitWidth(resultVRegType.getElementType()) !=
-              resultBits;
-      if (invalidResultType) {
-        return rewriter.notifyMatchFailure(
-            op, "unsupported group-slot integer extension result type");
+      FailureOr<Value> result = buildLegacyGroupSlotExtensionResult(
+          op, sourcePart, resultType, conversionSourceType, *slotMask, part,
+          resultBits, rewriter);
+      if (failed(result)) {
+        return failure();
       }
-      FailureOr<Value> conversionSource = bitcastVReg(
-          op.getLoc(), sourcePart, conversionSourceType, rewriter);
-      if (failed(conversionSource)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to expose group-slot extension source elements");
-      }
-      results.push_back(rewriter
-                            .create<VcvtOp>(op.getLoc(), resultVRegType,
-                                           *conversionSource, *slotMask,
-                                           /*rnd=*/nullptr, /*sat=*/nullptr,
-                                           part)
-                            .getResult());
+      results.push_back(*result);
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -20503,21 +20503,8 @@ std::optional<WalkResult> verifySupportedVMIMemoryAdvancedLoadOp(
   return std::nullopt;
 }
 
-std::optional<WalkResult> verifySupportedVMIStructuredStoreOp(Operation *op) {
-  if (auto store = dyn_cast<VMIInterleaveStoreOp>(op)) {
-    return verifySupportedShapeOp(
-        store, checkSupportedInterleaveStoreShape,
-        "pto.vmi.interleave_store lowers through pto.vstsx2 only for matching "
-        "contiguous full low/high input chunks with a supported UB destination "
-        "and 8/16/32-bit element type (");
-  }
-  if (auto store = dyn_cast<VMIGroupStoreOp>(op)) {
-    return verifySupportedShapeOp(
-        store, checkSupportedGroupStoreShape,
-        "pto.vmi.group_store requires a supported UB destination and a table-"
-        "supported value layout lowering through one-block vsstb, full-chunk "
-        "vsts, or deinterleaved vstsx2 (");
-  }
+static std::optional<WalkResult> verifySupportedVMIStructuredMaskedStoreOp(
+    Operation *op) {
   if (auto store = dyn_cast<VMIMaskedStoreOp>(op)) {
     std::string reason;
     if (succeeded(checkSupportedMaskedStoreShape(
@@ -20534,6 +20521,28 @@ std::optional<WalkResult> verifySupportedVMIStructuredStoreOp(Operation *op) {
            "destination ("
         << reason << ")";
     return WalkResult::interrupt();
+  }
+  return std::nullopt;
+}
+
+std::optional<WalkResult> verifySupportedVMIStructuredStoreOp(Operation *op) {
+  if (auto maskedStore = verifySupportedVMIStructuredMaskedStoreOp(op);
+      maskedStore.has_value()) {
+    return maskedStore;
+  }
+  if (auto store = dyn_cast<VMIInterleaveStoreOp>(op)) {
+    return verifySupportedShapeOp(
+        store, checkSupportedInterleaveStoreShape,
+        "pto.vmi.interleave_store lowers through pto.vstsx2 only for matching "
+        "contiguous full low/high input chunks with a supported UB destination "
+        "and 8/16/32-bit element type (");
+  }
+  if (auto store = dyn_cast<VMIGroupStoreOp>(op)) {
+    return verifySupportedShapeOp(
+        store, checkSupportedGroupStoreShape,
+        "pto.vmi.group_store requires a supported UB destination and a table-"
+        "supported value layout lowering through one-block vsstb, full-chunk "
+        "vsts, or deinterleaved vstsx2 (");
   }
   if (auto store = dyn_cast<VMIStrideStoreOp>(op)) {
     return verifySupportedShapeOp(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -4679,6 +4679,29 @@ FailureOr<SmallVector<Value>> materializeContiguousToLaneStride(
   return results;
 }
 
+static FailureOr<Value> mergeLaneStrideCarrierPair(
+    Operation *op, Value lowCarrier, Value highCarrier, unsigned carrierBits,
+    PatternRewriter &rewriter) {
+  FailureOr<Value> low = packToPreviousCarrier(
+      op->getLoc(), lowCarrier, carrierBits / 2, "LOWER", rewriter);
+  if (failed(low)) {
+    return failure();
+  }
+  FailureOr<Value> high = packToPreviousCarrier(
+      op->getLoc(), highCarrier, carrierBits / 2, "HIGHER", rewriter);
+  if (failed(high)) {
+    return failure();
+  }
+  FailureOr<Value> mask = createAllTrueMaskForVReg(
+      op->getLoc(), cast<VRegType>((*low).getType()), rewriter);
+  if (failed(mask)) {
+    return failure();
+  }
+  return rewriter.create<VorOp>(op->getLoc(), (*low).getType(), *low, *high,
+                                *mask)
+      .getResult();
+}
+
 static FailureOr<Value> materializeLaneStrideResultPart(
     Operation *op, ValueRange sourceParts, Type resultType, size_t sourceBegin,
     size_t sourceEnd, unsigned elementBits, unsigned carrierBits,
@@ -4699,27 +4722,23 @@ static FailureOr<Value> materializeLaneStrideResultPart(
     SmallVector<Value> nextLevel;
     nextLevel.reserve((currentLevel.size() + 1) / 2);
     for (size_t index = 0; index < currentLevel.size(); index += 2) {
-      FailureOr<Value> low = packToPreviousCarrier(
-          op->getLoc(), currentLevel[index], currentBits / 2, "LOWER",
-          rewriter);
-      if (failed(low)) {
-        return failure();
-      }
-      Value merged = *low;
+      Value merged;
       if (index + 1 < currentLevel.size()) {
-        FailureOr<Value> high = packToPreviousCarrier(
-            op->getLoc(), currentLevel[index + 1], currentBits / 2, "HIGHER",
+        FailureOr<Value> pair = mergeLaneStrideCarrierPair(
+            op, currentLevel[index], currentLevel[index + 1], currentBits,
             rewriter);
-        FailureOr<Value> mask = createAllTrueMaskForVReg(
-            op->getLoc(), cast<VRegType>((*low).getType()), rewriter);
-        bool failedMergeInputs = failed(high) || failed(mask);
-        if (failedMergeInputs) {
+        if (failed(pair)) {
           return failure();
         }
-        merged = rewriter
-                     .create<VorOp>(op->getLoc(), (*low).getType(), *low,
-                                    *high, *mask)
-                     .getResult();
+        merged = *pair;
+      } else {
+        FailureOr<Value> low = packToPreviousCarrier(
+            op->getLoc(), currentLevel[index], currentBits / 2, "LOWER",
+            rewriter);
+        if (failed(low)) {
+          return failure();
+        }
+        merged = *low;
       }
       nextLevel.push_back(merged);
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -11754,6 +11754,36 @@ private:
     return std::make_pair(std::move(groupOffsets), useDirectAccess);
   }
 
+  FailureOr<SmallVector<Value>> materializeLaneStrideStreamValues(
+      VMIGroupStoreOp op, ValueRange valueParts, VMIVRegType valueVMIType,
+      VMILayoutAttr layout, OneToNPatternRewriter &rewriter) const {
+    VMILayoutAttr compactLayout = VMILayoutAttr::getGroupSlots(
+        rewriter.getContext(), layout.getNumGroups(), layout.getSlots());
+    auto compactType = VMIVRegType::get(
+        rewriter.getContext(), valueVMIType.getElementCount(),
+        valueVMIType.getElementType(), compactLayout);
+    FailureOr<SmallVector<Value>> compactValues = materializeEnsureLayoutConversion(
+        op, valueParts, valueVMIType, compactType,
+        *this->getTypeConverter(), rewriter);
+    bool invalidCompactValues = failed(compactValues) ||
+                                compactValues->size() != valueParts.size();
+    if (invalidCompactValues) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to compact unaligned slots=8 group_store");
+    }
+    return *compactValues;
+  }
+
+  SmallVector<int64_t> buildLaneStrideStreamAdvances(
+      int64_t numGroups, size_t valueCount) const {
+    SmallVector<int64_t> advances;
+    advances.reserve(valueCount);
+    for (size_t slotBlock = 0; slotBlock < valueCount; ++slotBlock) {
+      advances.push_back(std::min<int64_t>(8, numGroups - slotBlock * 8));
+    }
+    return advances;
+  }
+
   LogicalResult lowerSlots8LaneStride(
       VMIGroupStoreOp op, OpAdaptor adaptor, OneToNPatternRewriter &rewriter,
       VMIVRegType valueVMIType, VMILayoutAttr layout, Value destination,
@@ -11778,25 +11808,14 @@ private:
     SmallVector<Value> groupOffsets = std::move(offsetPlan->first);
     bool useDirectAccess = offsetPlan->second;
     if (!useDirectAccess) {
-      VMILayoutAttr compactLayout = VMILayoutAttr::getGroupSlots(
-          rewriter.getContext(), layout.getNumGroups(), layout.getSlots());
-      auto compactType = VMIVRegType::get(
-          rewriter.getContext(), valueVMIType.getElementCount(),
-          valueVMIType.getElementType(), compactLayout);
-      FailureOr<SmallVector<Value>> compactValues = materializeEnsureLayoutConversion(
-          op, valueParts, valueVMIType, compactType,
-          *this->getTypeConverter(), rewriter);
-      bool invalidCompactValues = failed(compactValues) ||
-                                  compactValues->size() != valueParts.size();
-      if (invalidCompactValues) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to compact unaligned slots=8 group_store");
+      FailureOr<SmallVector<Value>> compactValues =
+          materializeLaneStrideStreamValues(op, valueParts, valueVMIType,
+                                            layout, rewriter);
+      if (failed(compactValues)) {
+        return failure();
       }
-      SmallVector<int64_t> advances;
-      for (size_t slotBlock = 0; slotBlock < compactValues->size();
-           ++slotBlock) {
-        advances.push_back(std::min<int64_t>(8, numGroups - slotBlock * 8));
-      }
+      SmallVector<int64_t> advances =
+          buildLaneStrideStreamAdvances(numGroups, compactValues->size());
       if (failed(emitGroupStoreStream(op, destination, offset, *compactValues,
                                       advances, rewriter))) {
         return failure();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -13188,6 +13188,23 @@ struct OneToNVMIGroupReduceOpPattern : OneToNOpConversionPattern<OpTy> {
   using OneToNOpConversionPattern<OpTy>::OneToNOpConversionPattern;
 
 private:
+  FailureOr<Value> buildOneBlockGroupResult(
+      OpTy op, Value sourcePart, Value maskPart, Type resultType,
+      VRegType expectedResultType, MaskType expectedMaskType,
+      OneToNPatternRewriter &rewriter) const {
+    bool mismatchedTypes = sourcePart.getType() != expectedResultType ||
+                           maskPart.getType() != expectedMaskType ||
+                           resultType != expectedResultType;
+    if (mismatchedTypes) {
+      return rewriter.notifyMatchFailure(
+          op, "vcg group_reduce path requires uniform physical chunk types");
+    }
+    return rewriter
+        .create<GroupReduceOpTy>(op.getLoc(), expectedResultType, sourcePart,
+                                 maskPart)
+        .getResult();
+  }
+
   LogicalResult lowerOneBlock(
       OpTy op, ValueRange sourceParts, ValueRange maskParts,
       TypeRange resultTypes, OneToNPatternRewriter &rewriter) const {
@@ -13204,25 +13221,16 @@ private:
       return rewriter.notifyMatchFailure(
           op, "vcg group_reduce path requires physical vreg/mask");
     }
-    for (auto [sourcePart, maskPart, physicalResultType] :
-         llvm::zip_equal(sourceParts, maskParts, resultTypes)) {
-      bool mismatchedTypes = sourcePart.getType() != resultType ||
-                             maskPart.getType() != maskType ||
-                             physicalResultType != resultType;
-      if (mismatchedTypes) {
-        return rewriter.notifyMatchFailure(
-            op, "vcg group_reduce path requires uniform physical chunk types");
-      }
-    }
-
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (auto [sourceIndex, sourcePart] : llvm::enumerate(sourceParts)) {
-      results.push_back(rewriter
-                            .create<GroupReduceOpTy>(op.getLoc(), resultType,
-                                                     sourcePart,
-                                                     maskParts[sourceIndex])
-                            .getResult());
+      FailureOr<Value> result = buildOneBlockGroupResult(
+          op, sourcePart, maskParts[sourceIndex], resultTypes[sourceIndex],
+          *resultType, *maskType, rewriter);
+      if (failed(result)) {
+        return failure();
+      }
+      results.push_back(*result);
     }
     replaceOpWithFlatConvertedValues(rewriter, op, results,
                                      *this->getTypeConverter());

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -18051,32 +18051,34 @@ std::optional<WalkResult> verifySupportedVMILayoutOp(Operation *op) {
 }
 
 template <typename MaskCheck>
+WalkResult verifySupportedCompareValue(Operation *op, StringRef opName,
+                                       VMIVRegType lhsType, MaskCheck checkMaskable,
+                                       LogicalResult predicateCheck) {
+  WalkResult physical = checkMaskable(op, opName, lhsType);
+  if (physical.wasInterrupted()) {
+    return physical;
+  }
+  if (succeeded(predicateCheck)) {
+    return WalkResult::advance();
+  }
+  return WalkResult::interrupt();
+}
+
+template <typename MaskCheck>
 std::optional<WalkResult> verifySupportedVMICompareOp(Operation *op,
                                                       MaskCheck checkMaskable) {
   if (auto cmpf = dyn_cast<VMICmpFOp>(op)) {
-    WalkResult physical = checkMaskable(
-        op, "pto.vmi.cmpf", cast<VMIVRegType>(cmpf.getLhs().getType()));
-    if (physical.wasInterrupted()) {
-      return physical;
-    }
-    if (succeeded(checkSupportedComparePredicate<VMICmpFOp>(
-            op, cmpf.getPredicate()))) {
-      return WalkResult::advance();
-    }
-    return WalkResult::interrupt();
+    return verifySupportedCompareValue(
+        op, "pto.vmi.cmpf", cast<VMIVRegType>(cmpf.getLhs().getType()),
+        checkMaskable,
+        checkSupportedComparePredicate<VMICmpFOp>(op, cmpf.getPredicate()));
   }
 
   if (auto cmpi = dyn_cast<VMICmpIOp>(op)) {
-    WalkResult physical = checkMaskable(
-        op, "pto.vmi.cmpi", cast<VMIVRegType>(cmpi.getLhs().getType()));
-    if (physical.wasInterrupted()) {
-      return physical;
-    }
-    if (succeeded(checkSupportedComparePredicate<VMICmpIOp>(
-            op, cmpi.getPredicate()))) {
-      return WalkResult::advance();
-    }
-    return WalkResult::interrupt();
+    return verifySupportedCompareValue(
+        op, "pto.vmi.cmpi", cast<VMIVRegType>(cmpi.getLhs().getType()),
+        checkMaskable,
+        checkSupportedComparePredicate<VMICmpIOp>(op, cmpi.getPredicate()));
   }
 
   return std::nullopt;

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5967,6 +5967,42 @@ tryMaskLayoutMaterializer(
   return materializer(context);
 }
 
+static FailureOr<std::optional<SmallVector<Value>>>
+tryMaskLayoutMaterializers(const MaskLayoutMaterializationContext &context) {
+  FailureOr<std::optional<SmallVector<Value>>> identity =
+      tryMaskLayoutMaterializer(context, [](const MaskLayoutMaterializationContext &context) {
+        return materializeIdentityMaskLayout(
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout, context.rewriter);
+      });
+  if (failed(identity)) {
+    return failure();
+  }
+  if (identity->has_value()) {
+    return std::move(*identity);
+  }
+
+  FailureOr<std::optional<SmallVector<Value>>> deinterleaved2 =
+      tryMaskLayoutMaterializer(context, [](const MaskLayoutMaterializationContext &context) {
+        return materializeDeinterleaved2MaskLayout(
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout, context.rewriter);
+      });
+  if (failed(deinterleaved2)) {
+    return failure();
+  }
+  if (deinterleaved2->has_value()) {
+    return std::move(*deinterleaved2);
+  }
+
+  return tryMaskLayoutMaterializer(
+      context, [](const MaskLayoutMaterializationContext &context) {
+        return materializeMaskLaneStrideLayout(
+            context.op, context.sourceParts, context.resultTypes,
+            context.sourceLayout, context.resultLayout, context.rewriter);
+      });
+}
+
 FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
     Operation *op, ValueRange sourceParts, TypeRange resultTypes,
     VMILayoutAttr sourceLayout, VMILayoutAttr resultLayout,
@@ -5980,43 +6016,13 @@ FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
 
   MaskLayoutMaterializationContext context{
       op, sourceParts, resultTypes, sourceLayout, resultLayout, rewriter};
-  FailureOr<std::optional<SmallVector<Value>>> identity =
-      tryMaskLayoutMaterializer(context, [](const MaskLayoutMaterializationContext &context) {
-        return materializeIdentityMaskLayout(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout, context.rewriter);
-      });
-  if (failed(identity)) {
+  FailureOr<std::optional<SmallVector<Value>>> results =
+      tryMaskLayoutMaterializers(context);
+  if (failed(results)) {
     return failure();
   }
-  if (identity->has_value()) {
-    return std::move(**identity);
-  }
-
-  FailureOr<std::optional<SmallVector<Value>>> deinterleaved2 =
-      tryMaskLayoutMaterializer(context, [](const MaskLayoutMaterializationContext &context) {
-        return materializeDeinterleaved2MaskLayout(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout, context.rewriter);
-      });
-  if (failed(deinterleaved2)) {
-    return failure();
-  }
-  if (deinterleaved2->has_value()) {
-    return std::move(**deinterleaved2);
-  }
-
-  FailureOr<std::optional<SmallVector<Value>>> laneStride =
-      tryMaskLayoutMaterializer(context, [](const MaskLayoutMaterializationContext &context) {
-        return materializeMaskLaneStrideLayout(
-            context.op, context.sourceParts, context.resultTypes,
-            context.sourceLayout, context.resultLayout, context.rewriter);
-      });
-  if (failed(laneStride)) {
-    return failure();
-  }
-  if (laneStride->has_value()) {
-    return std::move(**laneStride);
+  if (results->has_value()) {
+    return std::move(**results);
   }
 
   (void)rewriter.notifyMatchFailure(

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -7748,10 +7748,10 @@ struct OneToNVMIIotaOpPattern : OneToNOpConversionPattern<IotaOp> {
       typename OneToNOpConversionPattern<IotaOp>::OpAdaptor;
 
 private:
-  LogicalResult lowerGroupedIota(
-      IotaOp op, Value base, VMIVRegType resultVMIType,
-      VMILayoutAttr layout, TypeRange resultTypes, int64_t lanesPerPart,
-      OneToNPatternRewriter &rewriter, SmallVectorImpl<Value> &results) const {
+  FailureOr<std::pair<int64_t, int64_t>> validateGroupedIotaShape(
+      IotaOp op, VMIVRegType resultVMIType, VMILayoutAttr layout,
+      TypeRange resultTypes, int64_t lanesPerPart,
+      OneToNPatternRewriter &rewriter) const {
     int64_t numGroups = op.getGroupAttr().getInt();
     int64_t logicalLanes = resultVMIType.getElementCount();
     if (numGroups <= 0 || logicalLanes % numGroups != 0) {
@@ -7759,17 +7759,15 @@ private:
           op, "grouped iota requires group to divide logical lane count");
     }
     int64_t groupSize = logicalLanes / numGroups;
-    bool groupSizeMultipleOfPhys = groupSize % lanesPerPart == 0;
-    bool physMultipleOfGroupSize = lanesPerPart % groupSize == 0;
-    if (!groupSizeMultipleOfPhys && !physMultipleOfGroupSize) {
+    bool compatibleShape = groupSize % lanesPerPart == 0 ||
+                           lanesPerPart % groupSize == 0;
+    if (!compatibleShape) {
       return rewriter.notifyMatchFailure(
-          op, "grouped iota requires group_size to divide or be a multiple "
-              "of physical lanes per part");
+          op, "grouped iota requires group_size to divide or be a multiple of physical lanes per part");
     }
     if (!layout.isContiguous()) {
       return rewriter.notifyMatchFailure(
-          op, "grouped iota currently supports contiguous layout only; "
-              "ensure_layout to contiguous before lowering");
+          op, "grouped iota currently supports contiguous layout only; ensure_layout to contiguous before lowering");
     }
     int64_t expectedArity =
         (logicalLanes + lanesPerPart - 1) / lanesPerPart;
@@ -7779,6 +7777,21 @@ private:
       return rewriter.notifyMatchFailure(
           op, "grouped contiguous iota physical result count mismatch");
     }
+    return std::make_pair(groupSize, expectedArity);
+  }
+
+  LogicalResult lowerGroupedIota(
+      IotaOp op, Value base, VMIVRegType resultVMIType,
+      VMILayoutAttr layout, TypeRange resultTypes, int64_t lanesPerPart,
+      OneToNPatternRewriter &rewriter, SmallVectorImpl<Value> &results) const {
+    FailureOr<std::pair<int64_t, int64_t>> shape = validateGroupedIotaShape(
+        op, resultVMIType, layout, resultTypes, lanesPerPart, rewriter);
+    if (failed(shape)) {
+      return failure();
+    }
+    int64_t groupSize = shape->first;
+    bool groupSizeMultipleOfPhys = groupSize % lanesPerPart == 0;
+    bool physMultipleOfGroupSize = lanesPerPart % groupSize == 0;
 
     llvm::DenseMap<std::pair<Type, int64_t>, Value> sharedChunks;
     IotaMaterializationContext context{op.getLoc(), base, op.getOrderAttr(),

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -20866,7 +20866,8 @@ WalkResult verifySupportedChannelOp(ChannelOp op, int64_t channels,
   return WalkResult::interrupt();
 }
 
-std::optional<WalkResult> verifySupportedVMIConversionOp(Operation *op) {
+static std::optional<WalkResult> verifySupportedVMIFloatConversionOp(
+    Operation *op) {
   if (auto fptosi = dyn_cast<VMIFPToSIOp>(op)) {
     return verifySupportedShapeOp(
         fptosi, checkSupportedFPToSIShape,
@@ -20885,6 +20886,11 @@ std::optional<WalkResult> verifySupportedVMIConversionOp(Operation *op) {
         sitofp, checkSupportedSIToFPShape,
         "pto.vmi.sitofp supports si32->f32 or si8->f16 conversion shapes (");
   }
+  return std::nullopt;
+}
+
+static std::optional<WalkResult> verifySupportedVMIIntegerConversionOp(
+    Operation *op) {
   if (auto extsi = dyn_cast<VMIExtSIOp>(op)) {
     return verifySupportedShapeOp(
         extsi, checkSupportedExtSIShape,
@@ -20920,6 +20926,14 @@ std::optional<WalkResult> verifySupportedVMIConversionOp(Operation *op) {
         "width-changing forms restricted to supported layout table rows (");
   }
   return std::nullopt;
+}
+
+std::optional<WalkResult> verifySupportedVMIConversionOp(Operation *op) {
+  if (auto result = verifySupportedVMIFloatConversionOp(op);
+      result.has_value()) {
+    return result;
+  }
+  return verifySupportedVMIIntegerConversionOp(op);
 }
 
 template <typename CarryOp, typename ShapeCheck>

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -13905,6 +13905,45 @@ struct OneToNVMIReduceMinMaxOpPattern : OneToNOpConversionPattern<SourceOp> {
   using OneToNOpConversionPattern<SourceOp>::OneToNOpConversionPattern;
 
 private:
+  LogicalResult lowerSequentialReduction(
+      SourceOp op, ValueRange sourceParts, ValueRange maskParts,
+      VRegType resultType, MaskType maskType,
+      OneToNPatternRewriter &rewriter) const {
+    Value accumulator =
+        rewriter
+            .create<ChunkReduceOp>(op.getLoc(), resultType, sourceParts.front(),
+                                   maskParts.front())
+            .getResult();
+    const bool singlePart = sourceParts.size() == 1;
+    if (singlePart) {
+      replaceOpWithFlatConvertedValues(
+          rewriter, op, SmallVector<Value>{accumulator},
+          *this->getTypeConverter());
+      return success();
+    }
+    FailureOr<Value> firstLaneMask =
+        createPrefixMask(op.getLoc(), maskType, "PAT_VL1", rewriter);
+    if (failed(firstLaneMask)) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to create min/max reduction first-lane mask");
+    }
+    for (size_t part = 1; part < sourceParts.size(); ++part) {
+      Value reduced = rewriter
+                          .create<ChunkReduceOp>(op.getLoc(), resultType,
+                                                 sourceParts[part],
+                                                 maskParts[part])
+                          .getResult();
+      accumulator = rewriter
+                        .create<CombineOp>(op.getLoc(), resultType, reduced,
+                                           accumulator, *firstLaneMask)
+                        .getResult();
+    }
+    replaceOpWithFlatConvertedValues(
+        rewriter, op, SmallVector<Value>{accumulator},
+        *this->getTypeConverter());
+    return success();
+  }
+
   FailureOr<std::pair<VRegType, MaskType>> validatePhysicalParts(
       SourceOp op, ValueRange sourceParts, ValueRange maskParts,
       TypeRange resultTypes, OneToNPatternRewriter &rewriter) const {
@@ -13954,38 +13993,8 @@ private:
       return success();
     }
 
-    Value accumulator = rewriter
-                            .create<ChunkReduceOp>(op.getLoc(), resultType,
-                                                   sourceParts.front(),
-                                                   maskParts.front())
-                            .getResult();
-    if (sourceParts.size() == 1) {
-      replaceOpWithFlatConvertedValues(
-          rewriter, op, SmallVector<Value>{accumulator},
-          *this->getTypeConverter());
-      return success();
-    }
-    FailureOr<Value> firstLaneMask =
-        createPrefixMask(op.getLoc(), maskType, "PAT_VL1", rewriter);
-    if (failed(firstLaneMask)) {
-      return rewriter.notifyMatchFailure(
-          op, "failed to create min/max reduction first-lane mask");
-    }
-    for (size_t part = 1; part < sourceParts.size(); ++part) {
-      Value reduced = rewriter
-                          .create<ChunkReduceOp>(op.getLoc(), resultType,
-                                                 sourceParts[part],
-                                                 maskParts[part])
-                          .getResult();
-      accumulator = rewriter
-                        .create<CombineOp>(op.getLoc(), resultType, reduced,
-                                           accumulator, *firstLaneMask)
-                        .getResult();
-    }
-    replaceOpWithFlatConvertedValues(
-        rewriter, op, SmallVector<Value>{accumulator},
-        *this->getTypeConverter());
-    return success();
+    return lowerSequentialReduction(op, sourceParts, maskParts, resultType,
+                                    maskType, rewriter);
   }
 
 public:

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -13405,6 +13405,23 @@ private:
     return results;
   }
 
+  FailureOr<SmallVector<Value>> restoreDeinterleaved2GroupResults(
+      OpTy op, ArrayRef<Value> reducedResults, TypeRange resultTypes,
+      VRegType resultType, OneToNPatternRewriter &rewriter) const {
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (Value reducedResult : reducedResults) {
+      FailureOr<Value> finalResult =
+          bitcastVReg(op.getLoc(), reducedResult, resultType, rewriter);
+      if (failed(finalResult)) {
+        return rewriter.notifyMatchFailure(
+            op, "failed to restore deinterleaved=2 group result type");
+      }
+      results.push_back(*finalResult);
+    }
+    return results;
+  }
+
   LogicalResult lowerFullDeinterleaved2(
       OpTy op, VMIVRegType sourceVMIType, VMIVRegType resultVMIType,
       ValueRange sourceParts, ValueRange maskParts, TypeRange resultTypes,
@@ -13482,18 +13499,12 @@ private:
     if (failed(reducedResults)) {
       return failure();
     }
-    SmallVector<Value> results(resultTypes.size());
-    for (int64_t group = 0; group < groupCount; ++group) {
-      FailureOr<Value> finalResult =
-          bitcastVReg(op.getLoc(), (*reducedResults)[group], resultType,
-                      rewriter);
-      if (failed(finalResult)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to restore deinterleaved=2 group result type");
-      }
-      results[group] = *finalResult;
+    FailureOr<SmallVector<Value>> results = restoreDeinterleaved2GroupResults(
+        op, *reducedResults, resultTypes, resultType, rewriter);
+    if (failed(results)) {
+      return failure();
     }
-    replaceOpWithFlatConvertedValues(rewriter, op, results,
+    replaceOpWithFlatConvertedValues(rewriter, op, *results,
                                      *this->getTypeConverter());
     return success();
   }


### PR DESCRIPTION
## 摘要

按静态检查报告对 `VMIToVPTO.cpp` 做整体结构整改，按语义族统一采用“输入/shape 合同 → physical plan/fact → layout 路由 → per-part/chunk 发射 → 结果替换”的 lowering 组织方式。

主要覆盖：
- verifier、memory/read proof、store/interleave-store、deinterleave/group/group-broadcast lowering；
- iota、TruncF/TruncI、ExtI/ExtF、FPToUI 等 conversion 路径；
- interleave 分类、CF switch、vmull shape 合同；
- data/mask layout materialization 与重复参数簇收敛为语义化 context/plan；
- 补齐控制流花括号，移除 warning suppression，审计 lambda capture 和 anonymous namespace；
- 同步静态检查整改报告与验证边界。

## 验证

- `VMIToVPTO.cpp` 真实单文件编译：`exit=0`，无 warning/error；
- `python3 .agents/skills/enforce-ptoas-code-compliance/scripts/check_changed_code.py --repo . --base origin/master --fail-on none`：`errors=0 warnings=0`；
- `git diff --check`：通过；
- Lizard `--length 50 --CCN 20 --warnings_only`：当前结果 0 个命中；
- 代表性 VMI load/store、deinterleave、group-broadcast、interleave、FPToUI、CF switch 用例通过，非法用例保持预期失败。

## 说明

原始报告中的 `Data Clumps` 以及内部口径的 `huge_method`/`huge_cyclomatic_complexity` 需要内部 AST 分析器才能做等价复扫；当前环境未提供该分析器，报告中已明确记录这一限制。