### PR TITLE
Fix unsafe scale-address hoisting in A5 TMOV normalization

### DIFF
--- a/docs/designs/adr-1463-safe-scale-address-hoisting.md
+++ b/docs/designs/adr-1463-safe-scale-address-hoisting.md
@@ -1,0 +1,45 @@
+# ADR: safe A5 scale-address hoisting
+
+Status: proposed
+
+Issue: https://github.com/hw-native-sys/PTOAS/issues/1463
+
+## Context
+
+A5 TMOV normalization moves `pto.tget_scale_addr` before an earlier MAT to
+SCALING `pto.tmov` using the same destination. Moving the binding alone can
+place its source use before its definition. Simply skipping that move is not
+a complete repair: EmitC lowers the binding to `GetScaleAddr` and `TASSIGN`,
+which must establish the destination address before the matched copy.
+
+## Decision
+
+Use MLIR dominance to recognize operands already available before the copy,
+including block arguments and definitions outside the current block. For
+unavailable operands, collect a same-block dependency slice before mutating IR.
+Allow logical `pto.alloc_tile` handles and region-free, effect-free,
+speculatable scalar computations only. Recursively check allocation addresses
+and dynamic valid extents. Move the collected definitions in dependency order,
+then the binding, without cloning allocations or moving the copy.
+
+Reject an unsupported dependency with a diagnostic at the binding and notes at
+the blocking definition and matched copy. A failed collection performs no
+moves for that binding. Do not silently leave its address binding after the
+copy. This is a bounded repair, not a general scheduling or alias analysis.
+
+The existing matching and intervening-destination-use rules remain unchanged.
+Unmatched bindings are unchanged. No dialect syntax, public API, or command-line
+option changes. Existing safe normalization and non-scaling TMOV normalization
+retain their behavior.
+
+## Consequences and validation
+
+The reported late-allocation case compiles with the definition and binding
+before TMOV. Inputs requiring movement of calls, loads, or region operations
+receive a specific normalization error instead of invalid SSA. SSA dominance
+alone does not authorize moving a side-effecting dependency.
+
+Regression tests cover late/early allocations, both operand sides, captured
+values and block arguments, scalar dependency chains, unsupported dependencies,
+unchanged matching boundaries, repeated execution, and final EmitC binding/copy
+order. These compiler checks do not establish hardware numerical correctness.

--- a/lib/PTO/Transforms/PTOA5NormalizeTMovPass.cpp
+++ b/lib/PTO/Transforms/PTOA5NormalizeTMovPass.cpp
@@ -9,8 +9,11 @@
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 namespace mlir {
 namespace pto {
@@ -107,6 +110,83 @@ static pto::TMovOp findMatchingScaleTileTMov(pto::TGetScaleAddrOp op) {
   return {};
 }
 
+static bool isScaleAddrScalarType(Type type) {
+  return isa<IntegerType, IndexType, FloatType>(type);
+}
+
+static bool canHoistScaleAddrDependency(Operation *op) {
+  if (op->getNumRegions() || op->getNumSuccessors()) {
+    return false;
+  }
+  // alloc_tile creates a logical handle, not a data transfer. Its address and
+  // dynamic valid-shape operands are checked recursively before moving it.
+  if (isa<pto::AllocTileOp>(op)) {
+    return true;
+  }
+  return llvm::all_of(op->getOperandTypes(), isScaleAddrScalarType) &&
+         llvm::all_of(op->getResultTypes(), isScaleAddrScalarType) &&
+         isPure(op);
+}
+
+// Collect the complete dependency slice without modifying IR. In particular,
+// a rejected later operand must not leave an earlier allocation half-hoisted.
+static LogicalResult collectScaleAddrDependencies(
+    Value value, Operation *anchor, Operation *scaleAddr,
+    DominanceInfo &dominance, llvm::SmallPtrSetImpl<Operation *> &collected,
+    SmallVectorImpl<Operation *> &dependencies, Operation *&blockingDef) {
+  if (dominance.dominates(value, anchor)) {
+    return success();
+  }
+  Operation *def = value.getDefiningOp();
+  if (!def || def->getBlock() != anchor->getBlock() ||
+      !anchor->isBeforeInBlock(def) || !def->isBeforeInBlock(scaleAddr) ||
+      !canHoistScaleAddrDependency(def)) {
+    blockingDef = def;
+    return failure();
+  }
+  if (collected.contains(def)) {
+    return success();
+  }
+  for (Value operand : def->getOperands()) {
+    if (failed(collectScaleAddrDependencies(operand, anchor, scaleAddr,
+                                           dominance, collected, dependencies,
+                                           blockingDef))) {
+      return failure();
+    }
+  }
+  collected.insert(def);
+  dependencies.push_back(def);
+  return success();
+}
+
+static LogicalResult hoistScaleAddr(pto::TGetScaleAddrOp op,
+                                   pto::TMovOp matchingTMov,
+                                   DominanceInfo &dominance) {
+  llvm::SmallPtrSet<Operation *, kRiskyOpReserveSize> collected;
+  SmallVector<Operation *, kRiskyOpReserveSize> dependencies;
+  Operation *blockingDef = nullptr;
+  for (Value operand : op->getOperands()) {
+    if (failed(collectScaleAddrDependencies(
+            operand, matchingTMov, op, dominance, collected, dependencies,
+            blockingDef))) {
+      auto diagnostic = op.emitOpError(
+          "cannot safely establish scaling address before matching TMOV: "
+          "operand dependency cannot be hoisted");
+      if (blockingDef) {
+        diagnostic.attachNote(blockingDef->getLoc())
+            << "blocking dependency: " << blockingDef->getName();
+      }
+      diagnostic.attachNote(matchingTMov.getLoc()) << "matching TMOV is here";
+      return failure();
+    }
+  }
+  for (Operation *dependency : dependencies) {
+    dependency->moveBefore(matchingTMov);
+  }
+  op->moveBefore(matchingTMov);
+  return success();
+}
+
 template <typename CfgT>
 static auto buildRowMajorConfigImpl(int, MLIRContext *ctx,
                                     pto::BLayoutAttr rowMajor, CfgT cfg)
@@ -190,13 +270,17 @@ struct PTOA5NormalizeTMovPass
     }
 
     SmallVector<pto::TGetScaleAddrOp, kRiskyOpReserveSize> scaleAddrOps;
+    DominanceInfo dominance(func);
     func.walk([&](pto::TGetScaleAddrOp op) { scaleAddrOps.push_back(op); });
     for (pto::TGetScaleAddrOp op : scaleAddrOps) {
       auto matchingTMov = findMatchingScaleTileTMov(op);
       if (!matchingTMov) {
         continue;
       }
-      op->moveBefore(matchingTMov);
+      if (failed(hoistScaleAddr(op, matchingTMov, dominance))) {
+        signalPassFailure();
+        return;
+      }
     }
 
     SmallVector<pto::TMovOp, kRiskyOpReserveSize> riskyOps;

--- a/test/lit/pto/issue1463_scale_addr_emitc.pto
+++ b/test/lit/pto/issue1463_scale_addr_emitc.pto
@@ -1,0 +1,21 @@
+// RUN: ptoas --pto-arch=a5 %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @a5_normalize_tmov_use_before_def() attributes {pto.kernel} {
+    %11 = pto.alloc_tile : !pto.tile_buf<mat, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+    %15 = pto.alloc_tile : !pto.tile_buf<scaling, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+
+    pto.tmov ins(%11 : !pto.tile_buf<mat, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>)
+      outs(%15 : !pto.tile_buf<scaling, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>)
+
+    %13 = pto.alloc_tile : !pto.tile_buf<left, 1x512xf8E4M3FN, valid=1x128, blayout=col_major, slayout=row_major>
+
+    pto.tget_scale_addr ins(%13 : !pto.tile_buf<left, 1x512xf8E4M3FN, valid=1x128, blayout=col_major, slayout=row_major>)
+      outs(%15 : !pto.tile_buf<scaling, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>)
+    return
+  }
+}
+
+// CHECK: GetScaleAddr
+// CHECK: TASSIGN
+// CHECK: TMOV

--- a/test/lit/pto/issue1463_scale_addr_hoist.pto
+++ b/test/lit/pto/issue1463_scale_addr_hoist.pto
@@ -1,0 +1,143 @@
+// RUN: pto-test-opt --pto-a5-normalize-tmov %s | FileCheck %s
+// RUN: pto-test-opt --pass-pipeline="builtin.module(func.func(pto-a5-normalize-tmov,pto-a5-normalize-tmov))" %s | FileCheck %s
+
+// Issue #1463: definitions and address binding must precede the scale copy.
+!mat = !pto.tile_buf<mat, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+!scale = !pto.tile_buf<scaling, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+!left = !pto.tile_buf<left, 1x512xf8E4M3FN, valid=1x128, blayout=col_major, slayout=row_major>
+!right = !pto.tile_buf<right, 128x32xf8E4M3FN, valid=128x16, slayout=col_major>
+!rscale = !pto.tile_buf<scaling, 4x32x!pto.f8E8M0, valid=4x16, blayout=col_major, slayout=col_major, fractal=32>
+!rmat = !pto.tile_buf<mat, 4x32x!pto.f8E8M0, valid=4x16, blayout=col_major, slayout=col_major, fractal=32>
+!dynamic = !pto.tile_buf<left, 1x512xf8E4M3FN, valid=?x?, blayout=col_major, slayout=row_major>
+
+module attributes {pto.target_arch = "a5"} {
+  func.func private @consume(!scale)
+  // CHECK-LABEL: func.func @late_left(
+  // CHECK: %[[SRC:.*]] = pto.alloc_tile {{.*}}!pto.tile_buf<left,
+  // CHECK-NEXT: pto.tget_scale_addr ins(%[[SRC]]
+  // CHECK-NEXT: pto.tmov
+  func.func @late_left() {
+    %mat = pto.alloc_tile : !mat
+    %dst = pto.alloc_tile : !scale
+    pto.tmov ins(%mat : !mat) outs(%dst : !scale)
+    %src = pto.alloc_tile : !left
+    pto.tget_scale_addr ins(%src : !left) outs(%dst : !scale)
+    return
+  }
+
+  // CHECK-LABEL: func.func @early_left(
+  // CHECK: %[[EARLY:.*]] = pto.alloc_tile {{.*}}!pto.tile_buf<left,
+  // CHECK-NEXT: pto.tget_scale_addr ins(%[[EARLY]]
+  // CHECK-NEXT: pto.tmov
+  func.func @early_left() {
+    %mat = pto.alloc_tile : !mat
+    %dst = pto.alloc_tile : !scale
+    %src = pto.alloc_tile : !left
+    pto.tmov ins(%mat : !mat) outs(%dst : !scale)
+    pto.tget_scale_addr ins(%src : !left) outs(%dst : !scale)
+    return
+  }
+
+  // CHECK-LABEL: func.func @late_right(
+  // CHECK: %[[RIGHT:.*]] = pto.alloc_tile {{.*}}!pto.tile_buf<right,
+  // CHECK-NEXT: pto.tget_scale_addr ins(%[[RIGHT]]
+  // CHECK-NEXT: pto.tmov
+  func.func @late_right() {
+    %mat = pto.alloc_tile : !rmat
+    %dst = pto.alloc_tile : !rscale
+    pto.tmov ins(%mat : !rmat) outs(%dst : !rscale)
+    %src = pto.alloc_tile : !right
+    pto.tget_scale_addr ins(%src : !right) outs(%dst : !rscale)
+    return
+  }
+
+  // CHECK-LABEL: func.func @block_argument(
+  // CHECK: pto.tget_scale_addr
+  // CHECK-NEXT: pto.tmov
+  func.func @block_argument(%src : !left) {
+    %mat = pto.alloc_tile : !mat
+    %dst = pto.alloc_tile : !scale
+    pto.tmov ins(%mat : !mat) outs(%dst : !scale)
+    pto.tget_scale_addr ins(%src : !left) outs(%dst : !scale)
+    return
+  }
+
+  // CHECK-LABEL: func.func @outer_capture(
+  // CHECK: scf.if
+  // CHECK: pto.tget_scale_addr
+  // CHECK-NEXT: pto.tmov
+  func.func @outer_capture(%cond : i1) {
+    %src = pto.alloc_tile : !left
+    scf.if %cond {
+      %mat = pto.alloc_tile : !mat
+      %dst = pto.alloc_tile : !scale
+      pto.tmov ins(%mat : !mat) outs(%dst : !scale)
+      pto.tget_scale_addr ins(%src : !left) outs(%dst : !scale)
+    }
+    return
+  }
+
+  // CHECK-LABEL: func.func @predecessor_definition(
+  // CHECK: cf.br
+  // CHECK: pto.tget_scale_addr
+  // CHECK-NEXT: pto.tmov
+  func.func @predecessor_definition() {
+    %src = pto.alloc_tile : !left
+    cf.br ^next
+    ^next:
+    %mat = pto.alloc_tile : !mat
+    %dst = pto.alloc_tile : !scale
+    pto.tmov ins(%mat : !mat) outs(%dst : !scale)
+    pto.tget_scale_addr ins(%src : !left) outs(%dst : !scale)
+    return
+  }
+
+  // CHECK-LABEL: func.func @dynamic_dependencies(
+  // CHECK: arith.constant 128
+  // CHECK: arith.index_cast
+  // CHECK: arith.addi
+  // CHECK: arith.minsi
+  // CHECK: pto.alloc_tile addr =
+  // CHECK-NEXT: pto.tget_scale_addr
+  // CHECK-NEXT: pto.tmov
+  func.func @dynamic_dependencies(%base : i64, %n : index) {
+    %mat = pto.alloc_tile : !mat
+    %dst = pto.alloc_tile : !scale
+    pto.tmov ins(%mat : !mat) outs(%dst : !scale)
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %offset = arith.index_cast %c128 : index to i64
+    %addr = arith.addi %base, %offset : i64
+    %valid = arith.minsi %n, %c128 : index
+    %src = pto.alloc_tile addr = %addr valid_row = %c1 valid_col = %valid : !dynamic
+    pto.tget_scale_addr ins(%src : !dynamic) outs(%dst : !scale)
+    return
+  }
+
+  // CHECK-LABEL: func.func @intervening_dst_use(
+  // CHECK: pto.tmov
+  // CHECK: pto.alloc_tile {{.*}}!pto.tile_buf<left,
+  // CHECK: call @consume
+  // CHECK: pto.tget_scale_addr
+  func.func @intervening_dst_use() {
+    %mat = pto.alloc_tile : !mat
+    %dst = pto.alloc_tile : !scale
+    pto.tmov ins(%mat : !mat) outs(%dst : !scale)
+    %src = pto.alloc_tile : !left
+    func.call @consume(%dst) : (!scale) -> ()
+    pto.tget_scale_addr ins(%src : !left) outs(%dst : !scale)
+    return
+  }
+
+  // CHECK-LABEL: func.func @no_matching_tmov(
+  // CHECK: pto.alloc_tile
+  // CHECK: pto.alloc_tile
+  // CHECK-NEXT: pto.tget_scale_addr
+  // CHECK-NEXT: return
+  func.func @no_matching_tmov() {
+    %dst = pto.alloc_tile : !scale
+    %src = pto.alloc_tile : !left
+    pto.tget_scale_addr ins(%src : !left) outs(%dst : !scale)
+    return
+  }
+}

--- a/test/lit/pto/issue1463_scale_addr_hoist_atomic.pto
+++ b/test/lit/pto/issue1463_scale_addr_hoist_atomic.pto
@@ -1,0 +1,28 @@
+// RUN: not pto-test-opt --pto-a5-normalize-tmov --mlir-print-ir-after-failure %s 2>&1 | FileCheck %s
+
+!mat = !pto.tile_buf<mat, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+!scale = !pto.tile_buf<scaling, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+!dynamic = !pto.tile_buf<left, 1x512xf8E4M3FN, valid=?x?, blayout=col_major, slayout=row_major>
+module attributes {pto.target_arch = "a5"} {
+  func.func private @extent() -> index
+  func.func @atomic_failure() {
+    %mat = pto.alloc_tile : !mat
+    %dst = pto.alloc_tile : !scale
+    pto.tmov ins(%mat : !mat) outs(%dst : !scale)
+    // Collected constants must remain here when the later extent is rejected.
+    %c1 = arith.constant 1 : index
+    %addr = arith.constant 1024 : i64
+    %valid = func.call @extent() : () -> index
+    %src = pto.alloc_tile addr = %addr valid_row = %c1 valid_col = %valid : !dynamic
+    pto.tget_scale_addr ins(%src : !dynamic) outs(%dst : !scale)
+    return
+  }
+}
+
+// CHECK: IR Dump After
+// CHECK: pto.tmov
+// CHECK: arith.constant 1
+// CHECK-NEXT: {{.*}}arith.constant 1024
+// CHECK-NEXT: {{.*}}call @extent
+// CHECK-NEXT: {{.*}}pto.alloc_tile addr =
+// CHECK-NEXT: pto.tget_scale_addr

--- a/test/lit/pto/issue1463_scale_addr_hoist_invalid.pto
+++ b/test/lit/pto/issue1463_scale_addr_hoist_invalid.pto
@@ -1,0 +1,99 @@
+// RUN: pto-test-opt --split-input-file --verify-diagnostics --pto-a5-normalize-tmov %s
+
+!mat = !pto.tile_buf<mat, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+!scale = !pto.tile_buf<scaling, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+!dynamic = !pto.tile_buf<left, 1x512xf8E4M3FN, valid=?x?, blayout=col_major, slayout=row_major>
+module attributes {pto.target_arch = "a5"} {
+  func.func private @address() -> i64
+  func.func @call_dependency() {
+    %c0 = arith.constant 0 : index
+    %zero = arith.constant 0 : i64
+    %mat = pto.alloc_tile : !mat
+    %dst = pto.alloc_tile : !scale
+    // expected-note@+1 {{matching TMOV is here}}
+    pto.tmov ins(%mat : !mat) outs(%dst : !scale)
+    %c1 = arith.constant 1 : index
+    // expected-note@+1 {{blocking dependency: func.call}}
+    %addr = func.call @address() : () -> i64
+    %src = pto.alloc_tile addr = %addr valid_row = %c1 valid_col = %c1 : !dynamic
+    // expected-error@+1 {{cannot safely establish scaling address before matching TMOV: operand dependency cannot be hoisted}}
+    pto.tget_scale_addr ins(%src : !dynamic) outs(%dst : !scale)
+    return
+  }
+}
+
+// -----
+
+!mat = !pto.tile_buf<mat, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+!scale = !pto.tile_buf<scaling, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+!dynamic = !pto.tile_buf<left, 1x512xf8E4M3FN, valid=?x?, blayout=col_major, slayout=row_major>
+module attributes {pto.target_arch = "a5"} {
+
+  func.func @load_dependency(%mem : memref<1xi64>) {
+    %c0 = arith.constant 0 : index
+    %zero = arith.constant 0 : i64
+    %mat = pto.alloc_tile : !mat
+    %dst = pto.alloc_tile : !scale
+    // expected-note@+1 {{matching TMOV is here}}
+    pto.tmov ins(%mat : !mat) outs(%dst : !scale)
+    %c1 = arith.constant 1 : index
+    // expected-note@+1 {{blocking dependency: memref.load}}
+    %addr = memref.load %mem[%c0] : memref<1xi64>
+    %src = pto.alloc_tile addr = %addr valid_row = %c1 valid_col = %c1 : !dynamic
+    // expected-error@+1 {{cannot safely establish scaling address before matching TMOV: operand dependency cannot be hoisted}}
+    pto.tget_scale_addr ins(%src : !dynamic) outs(%dst : !scale)
+    return
+  }
+}
+
+// -----
+
+!mat = !pto.tile_buf<mat, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+!scale = !pto.tile_buf<scaling, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+!dynamic = !pto.tile_buf<left, 1x512xf8E4M3FN, valid=?x?, blayout=col_major, slayout=row_major>
+module attributes {pto.target_arch = "a5"} {
+
+  func.func @region_dependency(%cond : i1) {
+    %c0 = arith.constant 0 : index
+    %zero = arith.constant 0 : i64
+    %mat = pto.alloc_tile : !mat
+    %dst = pto.alloc_tile : !scale
+    // expected-note@+1 {{matching TMOV is here}}
+    pto.tmov ins(%mat : !mat) outs(%dst : !scale)
+    %c1 = arith.constant 1 : index
+    // expected-note@+1 {{blocking dependency: scf.if}}
+    %addr = scf.if %cond -> i64 {
+      scf.yield %zero : i64
+    } else {
+      scf.yield %zero : i64
+    }
+    %src = pto.alloc_tile addr = %addr valid_row = %c1 valid_col = %c1 : !dynamic
+    // expected-error@+1 {{cannot safely establish scaling address before matching TMOV: operand dependency cannot be hoisted}}
+    pto.tget_scale_addr ins(%src : !dynamic) outs(%dst : !scale)
+    return
+  }
+}
+
+// -----
+
+!mat = !pto.tile_buf<mat, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+!scale = !pto.tile_buf<scaling, 1x4x!pto.f8E8M0, slayout=row_major, fractal=32>
+!dynamic = !pto.tile_buf<left, 1x512xf8E4M3FN, valid=?x?, blayout=col_major, slayout=row_major>
+module attributes {pto.target_arch = "a5"} {
+  func.func @non_speculatable_dependency(%num : i64, %den : i64) {
+    %c0 = arith.constant 0 : index
+    %zero = arith.constant 0 : i64
+    %mat = pto.alloc_tile : !mat
+    %dst = pto.alloc_tile : !scale
+    // expected-note@+1 {{matching TMOV is here}}
+    pto.tmov ins(%mat : !mat) outs(%dst : !scale)
+    %c1 = arith.constant 1 : index
+    // expected-note@+1 {{blocking dependency: arith.divsi}}
+    %addr = arith.divsi %num, %den : i64
+    %src = pto.alloc_tile addr = %addr valid_row = %c1 valid_col = %c1 : !dynamic
+    // expected-error@+1 {{cannot safely establish scaling address before matching TMOV: operand dependency cannot be hoisted}}
+    pto.tget_scale_addr ins(%src : !dynamic) outs(%dst : !scale)
+    return
+  }
+}
+


### PR DESCRIPTION
A5 TMOV normalization could move `tget_scale_addr` above its source definition, turning valid input into a dominance error. Collect and validate the complete dependency slice first, then move logical allocations and pure, speculatable scalar dependencies before the binding and scale copy. Unsupported dependencies produce an actionable diagnostic without partially moving the slice.

Fixes #1463.

The existing matching/intervening-destination-use rules remain unchanged. Dominance checks handle block arguments and outer/predecessor definitions. Calls, loads, region operations and non-speculatable calculations are not hoisted. See [ADR](docs/designs/adr-1463-safe-scale-address-hoisting.md) for the bounded scheduling policy and why silently skipping the binding is insufficient.

Validation at `93848f393`:
- LLVM 19.1.7 build completed; PTOAS C++ assertions enabled (`-O2 -UNDEBUG`), linked LLVM libraries built with assertions disabled.
- Targeted lit: 9/9 passed, including late LEFT/RIGHT allocations, cross-block dominance, dynamic/shared scalar dependencies, failure atomicity, rejected dependencies, idempotence, EmitC order and existing TMOV normalization.
- Original bug/control both pass. Generated C++ binds the scaling address before the corresponding TMOV.
- Gemvmx and MatmulMxLowPrecision compile through EmitC with binding/copy order retained.
- Full lit with Python 3.12: **1,870 passed, 1 unsupported, 0 failed** (1,871 discovered).
- Full `runop.sh --enablebc all`: **871 OK, 0 FAIL, 19 SKIP**.
- The initial Python 3.9 full-suite attempt was stopped after an unrelated upstream PTODSL `str | int` import failure; the complete suites were rerun with Python 3.12 without a source workaround.
- A5 board/numerical and VF performance acceptance are pending; compiler checks do not establish hardware correctness or performance.

CI status:
- License-header and VMI source-patch checks passed.
- [build-and-test](https://github.com/hw-native-sys/PTOAS/actions/runs/34185116128) fails **before compiling this change**, in strict CMake 4 configure: `FetchContent_Populate(cann-cmake)` triggers CMP0169 with `-Werror=dev` at `cmake/fetch_cann_cmake.cmake:74`. The same failure is present in the [preceding unrelated CI run](https://github.com/hw-native-sys/PTOAS/actions/runs/34164525859). This PR does not modify CMake or CI files.
- Wheel builds are still running; simulator/board checks were skipped by CI. Keeping the PR draft while the existing configure blocker prevents full CI acceptance.
