### PR TITLE
fix: resolve the fifth codecheck batch in ptoas and ptobc

### DIFF
--- a/tools/ptoas/NativeModule.cpp
+++ b/tools/ptoas/NativeModule.cpp
@@ -18,7 +18,8 @@
 namespace mlir {
 class MLIRContext;
 namespace pto {
-int runPTOAS(int argc, char **argv, MLIRContext &borrowedContext);
+int runPTOAS(const std::vector<std::string> &args,
+             MLIRContext &borrowedContext);
 } // namespace pto
 } // namespace mlir
 #else
@@ -196,13 +197,6 @@ void destroyRuntimeRegistration(PyObject *capsule) {
 }
 
 int runPTOASFromPython(const std::vector<std::string> &arguments) {
-  std::vector<std::string> storage = arguments;
-  std::vector<char *> argv;
-  argv.reserve(storage.size());
-  for (std::string &argument : storage) {
-    argv.push_back(argument.data());
-  }
-
   py::object contextOwner =
       py::module_::import("ptoas.mlir.ir").attr("Context")();
   MlirContext rawContext = py::cast<MlirContext>(contextOwner);
@@ -210,8 +204,7 @@ int runPTOASFromPython(const std::vector<std::string> &arguments) {
   int result;
   {
     py::gil_scoped_release release;
-    result = mlir::pto::runPTOAS(static_cast<int>(argv.size()), argv.data(),
-                                 *unwrap(rawContext));
+    result = mlir::pto::runPTOAS(arguments, *unwrap(rawContext));
   }
   return result;
 }

--- a/tools/ptoas/NativeModule.cpp
+++ b/tools/ptoas/NativeModule.cpp
@@ -8,6 +8,11 @@
 
 #include "PTO/Support/CodeConstants.h"
 
+// The online-build forward declaration below uses std::vector/std::string
+// before ptoas.h (which would provide them) is conditionally included.
+#include <string>
+#include <vector>
+
 #ifdef PTOAS_ONLINE_BUILD
 // Online fallback build. `ptoas.h` transitively pulls the whole compiler-driver
 // closure (CompilerApi.h / VPTOLLVMEmitter.h / ObjectEmission.h -> the entire
@@ -36,9 +41,6 @@ int runPTOAS(const std::vector<std::string> &args,
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 #include "llvm/Support/raw_ostream.h"
-
-#include <string>
-#include <vector>
 
 namespace py = pybind11;
 

--- a/tools/ptoas/driver.cpp
+++ b/tools/ptoas/driver.cpp
@@ -92,15 +92,29 @@ static mlir::pto::CANNVersion selectEffectiveOutputCANNVersion(
   return overrideVersion.value_or(detectedVersion);
 }
 
-static bool hasCLIOption(int argc, char **argv, llvm::StringRef option) {
+static bool hasCLIOption(const std::vector<std::string> &args,
+                         llvm::StringRef option) {
   const std::string optionWithValue = (option + "=").str();
-  for (int i = 1; i < argc; ++i) {
-    llvm::StringRef arg(argv[i]);
+  for (size_t i = 1; i < args.size(); ++i) {
+    llvm::StringRef arg(args[i]);
     if (arg == option || arg.starts_with(optionWithValue)) {
       return true;
     }
   }
   return false;
+}
+
+// Bridges a string-vector command line to the char** form the LLVM
+// command-line parser consumes. The backing strings outlive the bridge
+// because the caller owns the vector.
+static std::vector<const char *>
+toCommandLineViews(const std::vector<std::string> &args) {
+  std::vector<const char *> views;
+  views.reserve(args.size());
+  for (const std::string &arg : args) {
+    views.push_back(arg.c_str());
+  }
+  return views;
 }
 
 static std::string normalizePTOASArch(llvm::StringRef archValue) {
@@ -772,17 +786,13 @@ static LogicalResult emitVPTOLLVMFatobj(
     llvm::StringRef outputPath);
 
 mlir::pto::PTOASContext::PTOASContext(DialectRegistry &registry,
-                                      llvm::StringRef outputPath, int argc,
-                                      char **argv)
+                                      llvm::StringRef outputPath)
     : ownedMlirContext(std::make_unique<MLIRContext>(registry)),
-      mlirContext(ownedMlirContext.get()), outputPath(outputPath.str()),
-      argc(argc), argv(argv) {}
+      mlirContext(ownedMlirContext.get()), outputPath(outputPath.str()) {}
 
-mlir::pto::PTOASContext::PTOASContext(
-    MLIRContext &borrowedContext, llvm::StringRef outputPath, int argc,
-    char **argv)
-    : mlirContext(&borrowedContext), outputPath(outputPath.str()), argc(argc),
-      argv(argv) {}
+mlir::pto::PTOASContext::PTOASContext(MLIRContext *borrowedContext,
+                                      llvm::StringRef outputPath)
+    : mlirContext(borrowedContext), outputPath(outputPath.str()) {}
 
 mlir::pto::PTOASContext::~PTOASContext() = default;
 
@@ -795,14 +805,16 @@ mlir::pto::PTOASContext::initializeEnvironment(bool requiresToolchain,
   return success();
 }
 
-void mlir::pto::PTOASContext::initializeMLIRContext() {
+void mlir::pto::PTOASContext::initializeMLIRContext() const {
   // Be tolerant: ptobc decode may materialize ops from dialects that aren't
   // explicitly registered/loaded in this tool yet.
   mlirContext->allowUnregisteredDialects(true);
   mlir::pto::loadPTOASDialects(*mlirContext);
 }
 
-MLIRContext &mlir::pto::PTOASContext::getMLIRContext() { return *mlirContext; }
+MLIRContext &mlir::pto::PTOASContext::getMLIRContext() const {
+  return *mlirContext;
+}
 
 void mlir::pto::PTOASContext::setArch(std::string value) {
   arch = std::move(value);
@@ -831,10 +843,6 @@ void mlir::pto::PTOASContext::setOutputCANNVersionOverride(
     std::optional<CANNVersion> value) {
   outputCANNVersionOverride = std::move(value);
 }
-
-int mlir::pto::PTOASContext::getArgc() const { return argc; }
-
-char **mlir::pto::PTOASContext::getArgv() const { return argv; }
 
 llvm::StringRef mlir::pto::PTOASContext::getOutputPath() const {
   return outputPath;
@@ -1421,8 +1429,8 @@ struct DriverInvocationOptions {
 };
 
 static FailureOr<DriverInvocationOptions>
-parseDriverInvocation(int argc, char **argv, DialectRegistry &registry,
-                      MLIRContext *borrowedContext) {
+parseDriverInvocation(const std::vector<std::string> &args,
+                      DialectRegistry &registry, MLIRContext *borrowedContext) {
   mlir::pto::registerPTOASDialects(registry);
   if (borrowedContext) {
     borrowedContext->appendDialectRegistry(registry);
@@ -1436,9 +1444,11 @@ parseDriverInvocation(int argc, char **argv, DialectRegistry &registry,
   llvm::cl::ResetAllOptionOccurrences();
 
   DriverInvocationOptions options;
-  options.cliArchSpecified = hasCLIOption(argc, argv, "--pto-arch");
-  options.cliBackendSpecified = hasCLIOption(argc, argv, "--pto-backend");
-  llvm::cl::ParseCommandLineOptions(argc, argv, "PTO Assembler (ptoas)\n");
+  options.cliArchSpecified = hasCLIOption(args, "--pto-arch");
+  options.cliBackendSpecified = hasCLIOption(args, "--pto-backend");
+  std::vector<const char *> argViews = toCommandLineViews(args);
+  llvm::cl::ParseCommandLineOptions(static_cast<int>(argViews.size()),
+                                    argViews.data(), "PTO Assembler (ptoas)\n");
   if (!parseRequestedOutputCANNVersion(mlir::pto::cannOutputVersion,
                                        options.outputCANNVersionOverride,
                                        llvm::errs())) {
@@ -1449,15 +1459,12 @@ parseDriverInvocation(int argc, char **argv, DialectRegistry &registry,
 
 static std::unique_ptr<PTOASContext>
 createDriverContext(DialectRegistry &registry, MLIRContext *borrowedContext,
-                    int argc, char **argv,
                     const DriverInvocationOptions &options) {
   std::unique_ptr<PTOASContext> context;
   if (borrowedContext) {
-    context = std::make_unique<PTOASContext>(*borrowedContext, outputFilename,
-                                             argc, argv);
+    context = std::make_unique<PTOASContext>(borrowedContext, outputFilename);
   } else {
-    context =
-        std::make_unique<PTOASContext>(registry, outputFilename, argc, argv);
+    context = std::make_unique<PTOASContext>(registry, outputFilename);
   }
   context->setOutputCANNVersionOverride(options.outputCANNVersionOverride);
   context->setVFSIMTSizeFixMode(mlir::pto::vptoFixVFSIMTSize);
@@ -1507,16 +1514,16 @@ static int finishDriverResult(const mlir::pto::PTOASCompileResult &result,
   return 1;
 }
 
-static int runPTOASDriver(int argc, char **argv,
+static int runPTOASDriver(const std::vector<std::string> &args,
                           MLIRContext *borrowedContext = nullptr) {
   DialectRegistry registry;
   FailureOr<DriverInvocationOptions> options =
-      parseDriverInvocation(argc, argv, registry, borrowedContext);
+      parseDriverInvocation(args, registry, borrowedContext);
   if (failed(options)) {
     return 1;
   }
   std::unique_ptr<PTOASContext> context =
-      createDriverContext(registry, borrowedContext, argc, argv, *options);
+      createDriverContext(registry, borrowedContext, *options);
   OwningOpRef<ModuleOp> module =
       loadDriverModule(*context, options->cliArchSpecified);
   if (!module || failed(configureDriverBackend(
@@ -1531,10 +1538,16 @@ static int runPTOASDriver(int argc, char **argv,
 }
 
 int mlir::pto::runPTOAS(int argc, char **argv) {
-  return runPTOASDriver(argc, argv);
+  return runPTOASDriver(std::vector<std::string>(argv, argv + argc));
 }
 
 int mlir::pto::runPTOAS(int argc, char **argv,
                         MLIRContext &borrowedContext) {
-  return runPTOASDriver(argc, argv, &borrowedContext);
+  return runPTOASDriver(std::vector<std::string>(argv, argv + argc),
+                        &borrowedContext);
+}
+
+int mlir::pto::runPTOAS(const std::vector<std::string> &args,
+                        MLIRContext &borrowedContext) {
+  return runPTOASDriver(args, &borrowedContext);
 }

--- a/tools/ptoas/online_include/mlir/Bindings/Python/PybindAdaptors.h
+++ b/tools/ptoas/online_include/mlir/Bindings/Python/PybindAdaptors.h
@@ -1,3 +1,11 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
 //===- PybindAdaptors.h - Adaptors for interop with MLIR APIs -------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -130,7 +138,7 @@ struct type_caster<MlirContext> {
   bool load(handle src, bool) {
     if (src.is_none()) {
       // Gets the current thread-bound context.
-      // TODO: This raises an error of "No current context" currently.
+      // Note: this currently raises an error of "No current context".
       // Update the implementation to pretty-print the helpful error that the
       // core implementations print in this case.
       src = py::module::import(MAKE_MLIR_PYTHON_QUALNAME("ir"))
@@ -339,7 +347,7 @@ namespace adaptors {
 /// Derived from a discussion upstream:
 ///   https://github.com/pybind/pybind11/issues/1193
 ///   (plus a fair amount of extra curricular poking)
-///   TODO: If this proves useful, see about including it in pybind11.
+///   If this proves useful, see about including it in pybind11.
 class pure_subclass {
 public:
   pure_subclass(py::handle scope, const char *derivedClassName,

--- a/tools/ptoas/ptoas.h
+++ b/tools/ptoas/ptoas.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 #include "ObjectEmission.h"
 #include "PTO/Compiler/CompilerApi.h"
 #include "PTO/Transforms/VPTOLLVMEmitter.h"
@@ -60,17 +61,21 @@ enum class PTOASCompileResultKind {
 
 class PTOASContext {
 public:
-  PTOASContext(DialectRegistry &registry, llvm::StringRef outputPath, int argc,
-               char **argv);
-  PTOASContext(MLIRContext &borrowedContext, llvm::StringRef outputPath,
-               int argc, char **argv);
+  PTOASContext(DialectRegistry &registry, llvm::StringRef outputPath);
+  // `borrowedContext` is a non-owning, mutable borrow: PTOAS dialect loading
+  // mutates the caller's context, hence a pointer rather than a const ref.
+  PTOASContext(MLIRContext *borrowedContext, llvm::StringRef outputPath);
   ~PTOASContext();
 
   LogicalResult initializeEnvironment(bool requiresToolchain,
                                       llvm::raw_ostream &diagOS);
-  void initializeMLIRContext();
+  // Loads the PTOAS dialects into the borrowed context (shallow-const: the
+  // pointed-to context is intentionally mutated).
+  void initializeMLIRContext() const;
 
-  MLIRContext &getMLIRContext();
+  // Returns the borrowed context; the reference stays mutable by design so
+  // driver callers can parse and lower into it.
+  MLIRContext &getMLIRContext() const;
 
   void setArch(std::string value);
   llvm::StringRef getArch() const;
@@ -80,9 +85,6 @@ public:
 
   void setVFSIMTSizeFixMode(VFSIMTSizeFixMode value);
   VFSIMTSizeFixMode getVFSIMTSizeFixMode() const;
-
-  int getArgc() const;
-  char **getArgv() const;
 
   llvm::StringRef getOutputPath() const;
   std::string allocModuleId() const;
@@ -102,8 +104,6 @@ private:
   std::string arch;
   BackendInfo backendInfo;
   VFSIMTSizeFixMode vfsimtSizeFixMode = VFSIMTSizeFixMode::Auto;
-  int argc = 0;
-  char **argv = nullptr;
   CANNVersion cannVersion = kDefaultCANNVersion;
   std::optional<CANNVersion> outputCANNVersionOverride;
   std::optional<CANNToolchain> toolchain;
@@ -140,6 +140,10 @@ void loadPTOASDialects(MLIRContext &context);
 PTOAS_COMPILER_EXPORT int runPTOAS(int argc, char **argv);
 PTOAS_COMPILER_EXPORT int
 runPTOAS(int argc, char **argv, MLIRContext &borrowedContext);
+// String-vector variant used by the Python binding; the char* bridging to
+// the LLVM command-line parser stays internal to the driver.
+PTOAS_COMPILER_EXPORT int
+runPTOAS(const std::vector<std::string> &args, MLIRContext &borrowedContext);
 
 // Attach textual-.pto SSA name hints (function args, block args, op results)
 // to the parsed module's Locations as debug metadata. Called by the driver

--- a/tools/ptoas/ptoas_cpp_rewrite.cpp
+++ b/tools/ptoas/ptoas_cpp_rewrite.cpp
@@ -222,16 +222,10 @@ void rewriteAsyncEventMarkers(std::string &cpp) {
                                  "session", 1);
 }
 
-// --------------------------------------------------------------------------
-// EmitC cleanup: drop trivial emitc.expression ops.
-// After FormExpressions + CSE, EmitC expressions can become invalid in two
-// ways:
-//   1. the root op is CSE'd away, leaving an empty expression region
-//   2. the region degenerates to `emitc.yield %outer_value`, i.e. the yielded
-//      value is defined outside the expression body
-// Both cases crash mlir::emitc::translateToCpp because ExpressionOp expects a
+// Drop trivial emitc.expression ops: after FormExpressions + CSE the root op
+// may be CSE-d away (empty region) or the region may degenerate to yielding a
+// value defined outside the body; both crash translateToCpp, which expects a
 // root op defined within the region.
-// --------------------------------------------------------------------------
 void dropEmptyEmitCExpressions(Operation *rootOp) {
   llvm::SmallVector<emitc::ExpressionOp, kEmptyExpressionInlineCapacity>
       toErase;

--- a/tools/ptoas/ptoas_pipeline.cpp
+++ b/tools/ptoas/ptoas_pipeline.cpp
@@ -1320,25 +1320,13 @@ static void appendAutoSyncPasses(PassManager &pm) {
   }
 }
 
-static LogicalResult runMainLoweringPipeline(
-    OwningOpRef<ModuleOp> &module, PTOASContext &context,
-    PTOBackend effectiveBackend, const CompilePipelineState &state,
-    PTOASCompileResult &result, bool emitVPTOHostStub, bool &handled,
-    int &exitCode) {
-  handled = false;
-  exitCode = 0;
-  const bool enableA5EmitCFusionPath = state.enableA5EmitCFusionPath;
-  const bool enableA5VPTOFusionPath = state.enableA5VPTOFusionPath;
+// Populates the shared mainline lowering pass sequence (both backends).
+static LogicalResult populateMainLoweringPasses(PassManager &pm,
+                                                PTOBackend effectiveBackend,
+                                                const CompilePipelineState &state) {
   const bool isA2A3 = state.isA2A3;
   const bool hasTileOpsToExpand = state.hasTileOpsToExpand;
   const PTOBuildLevel effectiveLevel = state.level;
-
-  // Main PassManager
-  PassManager pm(module->getContext());
-
-  if (failed(applyPassManagerCLOptions(pm))) {
-    return failure();
-  }
 
   // Rank-2 → rank-5 view canonicalization is currently gated on the VPTO
   // backend to limit blast radius.  A3/A5 EmitC codegen already pads strides
@@ -1371,8 +1359,9 @@ static LogicalResult runMainLoweringPipeline(
     pm.addPass(pto::createInsertTemplateAttributesPass());
   }
 
-  if (failed(appendFusionFrontendPasses(pm, isA2A3, enableA5EmitCFusionPath,
-                                         enableA5VPTOFusionPath))) {
+  if (failed(appendFusionFrontendPasses(pm, isA2A3,
+                                        state.enableA5EmitCFusionPath,
+                                        state.enableA5VPTOFusionPath))) {
     return failure();
   }
 
@@ -1397,6 +1386,66 @@ static LogicalResult runMainLoweringPipeline(
     pm.addPass(createNarrowUnusedMultiResultProvenancePass());
   }
 
+  pm.addPass(createCSEPass());
+  // PTODSL backend helpers already use the tile-native ABI.
+  pm.addPass(pto::createPTOInlineBackendHelpersPass());
+  if (effectiveBackend == PTOBackend::EmitC) {
+    pm.addPass(createNarrowUnusedMultiResultProvenancePass());
+  }
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+  return applyConfiguredPassManagerCLOptions(pm, "main PTOAS pipeline");
+}
+
+// Runs the populated mainline pipeline for the VPTO backend, emits the seam
+// IR dumps, hands off to the VPTO backend pipeline, and produces the result.
+static LogicalResult finishVPTOMainPipeline(
+    OwningOpRef<ModuleOp> &module, PassManager &pm,
+    PTOASCompileResult &result, PTOASContext &context, bool emitVPTOHostStub,
+    bool hasTileOpsToExpand, bool &handled, int &exitCode) {
+  if (failed(pm.run(*module))) {
+    llvm::errs() << "Error: Pass execution failed.\n";
+    return failure();
+  }
+
+  if (ptoPrintSeamIR) {
+    printSharedPreBackendSeamIR(*module);
+  }
+  if (ptoPrintSeamIR) {
+    module->print(llvm::errs());
+    llvm::errs() << "\n";
+  }
+  if (failed(emitSharedPreBackendSeamIR(*module, ptoSeamIRFile))) {
+    return failure();
+  }
+
+  if (failed(runVPTOBackendPipeline(module, hasTileOpsToExpand))) {
+    return failure();
+  }
+  handled = true;
+  exitCode = emitVPTOBackendResult(*module, result, emitVPTOHostStub,
+                                   context.getCANNVersionOrDefault());
+  return success();
+}
+
+static LogicalResult runMainLoweringPipeline(
+    OwningOpRef<ModuleOp> &module, PTOASContext &context,
+    PTOBackend effectiveBackend, const CompilePipelineState &state,
+    PTOASCompileResult &result, bool emitVPTOHostStub, bool &handled,
+    int &exitCode) {
+  handled = false;
+  exitCode = 0;
+  const bool hasTileOpsToExpand = state.hasTileOpsToExpand;
+
+  // Main PassManager
+  PassManager pm(module->getContext());
+  if (failed(applyPassManagerCLOptions(pm))) {
+    return failure();
+  }
+  if (failed(populateMainLoweringPasses(pm, effectiveBackend, state))) {
+    return failure();
+  }
+
   if (emitMlirIR) {
     if (failed(pm.run(*module))) {
       llvm::errs() << "Error: Pass execution failed.\n";
@@ -1411,42 +1460,10 @@ static LogicalResult runMainLoweringPipeline(
     return success();
   }
 
-  pm.addPass(createCSEPass());
-  // PTODSL backend helpers already use the tile-native ABI.
-  pm.addPass(pto::createPTOInlineBackendHelpersPass());
-  if (effectiveBackend == PTOBackend::EmitC) {
-    pm.addPass(createNarrowUnusedMultiResultProvenancePass());
-  }
-  pm.addPass(createCanonicalizerPass());
-  pm.addPass(createCSEPass());
-  if (failed(applyConfiguredPassManagerCLOptions(pm, "main PTOAS pipeline"))) {
-    return failure();
-  }
-
   if (effectiveBackend == PTOBackend::VPTO) {
-    if (failed(pm.run(*module))) {
-      llvm::errs() << "Error: Pass execution failed.\n";
-      return failure();
-    }
-
-    if (ptoPrintSeamIR) {
-      printSharedPreBackendSeamIR(*module);
-    }
-    if (ptoPrintSeamIR) {
-      module->print(llvm::errs());
-      llvm::errs() << "\n";
-    }
-    if (failed(emitSharedPreBackendSeamIR(*module, ptoSeamIRFile))) {
-      return failure();
-    }
-
-    if (failed(runVPTOBackendPipeline(module, hasTileOpsToExpand))) {
-      return failure();
-    }
-    handled = true;
-    exitCode = emitVPTOBackendResult(*module, result, emitVPTOHostStub,
-                                     context.getCANNVersionOrDefault());
-    return success();
+    return finishVPTOMainPipeline(module, pm, result, context,
+                                  emitVPTOHostStub, hasTileOpsToExpand,
+                                  handled, exitCode);
   }
 
   if (failed(pm.run(*module))) {

--- a/tools/ptoas/ptoas_pipeline.cpp
+++ b/tools/ptoas/ptoas_pipeline.cpp
@@ -1385,7 +1385,13 @@ static LogicalResult populateMainLoweringPasses(PassManager &pm,
   if (effectiveBackend == PTOBackend::EmitC) {
     pm.addPass(createNarrowUnusedMultiResultProvenancePass());
   }
+  return success();
+}
 
+// Backend-agnostic cleanup after the shared lowering. --emit-pto-ir stops
+// before this segment: the IR dump reflects the shared lowering only.
+static LogicalResult appendMainLoweringTailPasses(PassManager &pm,
+                                                  PTOBackend effectiveBackend) {
   pm.addPass(createCSEPass());
   // PTODSL backend helpers already use the tile-native ABI.
   pm.addPass(pto::createPTOInlineBackendHelpersPass());
@@ -1446,6 +1452,8 @@ static LogicalResult runMainLoweringPipeline(
     return failure();
   }
 
+  // --emit-pto-ir dumps the module after the shared lowering segment only;
+  // the backend tail (CSE / helper inlining) is intentionally not run.
   if (emitMlirIR) {
     if (failed(pm.run(*module))) {
       llvm::errs() << "Error: Pass execution failed.\n";
@@ -1458,6 +1466,10 @@ static LogicalResult runMainLoweringPipeline(
     handled = true;
     exitCode = 0;
     return success();
+  }
+
+  if (failed(appendMainLoweringTailPasses(pm, effectiveBackend))) {
+    return failure();
   }
 
   if (effectiveBackend == PTOBackend::VPTO) {

--- a/tools/ptobc/src/ptobc_format.cpp
+++ b/tools/ptobc/src/ptobc_format.cpp
@@ -219,7 +219,8 @@ std::string canonicalizeIoPath(const std::string& path) {
 }
 
 std::vector<uint8_t> readFile(const std::string& path) {
-  std::ifstream ifs(canonicalizeIoPath(path), std::ios::binary);
+  const std::string canonicalPath = canonicalizeIoPath(path);
+  std::ifstream ifs(canonicalPath, std::ios::binary);
   if (!ifs) {
     throw std::runtime_error("Failed to open: " + path);
   }
@@ -228,7 +229,8 @@ std::vector<uint8_t> readFile(const std::string& path) {
 }
 
 void writeFile(const std::string& path, const std::vector<uint8_t>& data) {
-  std::ofstream ofs(canonicalizeIoPath(path), std::ios::binary);
+  const std::string canonicalPath = canonicalizeIoPath(path);
+  std::ofstream ofs(canonicalPath, std::ios::binary);
   if (!ofs) {
     throw std::runtime_error("Failed to write: " + path);
   }


### PR DESCRIPTION
## Summary

Resolve the fifth codecheck batch (16 findings: 13 fixed, 1 not-applicable, 2 already fixed on master by !18). Disposition table in `codecheck-fix-5.md` on the branch.

- **huge_method / huge_cc** — `runMainLoweringPipeline` 99 → 39 nbnc (`populateMainLoweringPasses` + `finishVPTOMainPipeline`); `buildHostStubFrontendArgs` was already decomposed on master (no change needed).
- **G.STD.02 (char*)** — driver argv chain moved to `std::vector<std::string>` with a new public `runPTOAS(vector<string>, MLIRContext&)` overload; the char** bridge to the LLVM cl parser is centralized in `toCommandLineViews`; the Python binding no longer touches char*; the dead `PTOASContext` argc/argv accessors are removed.
- **G.CNS.03/04** — `initializeMLIRContext`/`getMLIRContext` marked const (shallow-const over the borrowed context, documented); `borrowedContext` constructor parameter switched to a pointer (the rule's second remedy).
- **G.CMT.03/05** — repository copyright header added to the vendored `PybindAdaptors.h` (LLVM header kept); the two TODO comments reworded as plain statements.
- **G.CMT.04 / G.FIL.02** — EmitC-cleanup banner comment collapsed; `canonicalizeIoPath` results materialized into a named `canonicalPath` local before stream construction.

Not applicable: `pybind11_init__core` parameter name (macro-generated by pybind11).

## Test plan

- [x] 144 host, LLVM 19.1.7 assert build (GCC 13.3) on `c698c287a`: warning-free under `-Werror`.
- [x] CTest 73/73.
- [x] Changed-code compliance checker: 0 errors / 0 warnings; diff self-scan clean (no default captures / TODOs / casts).
