### PR TITLE
feat: add A2/A3 TIMG2COL tile operation

### DIFF
--- a/docs/isa/tile-op/04-dma-data-movement.md
+++ b/docs/isa/tile-op/04-dma-data-movement.md
@@ -3,7 +3,7 @@
 > **Category:** GM↔on-chip DMA for tile buffers
 > **Pipelines:** PIPE_MTE2 (GM→UB), PIPE_MTE3 (UB→GM), PIPE_FIX (when source is `loc=acc`)
 
-This chapter documents the public tile DMA instructions `pto.tload` and `pto.tstore`. Other raw scalar load/store helpers are outside the current tile-instruction subset and are not covered here.
+This chapter documents the public tile DMA instructions `pto.tload`, `pto.tstore`, and the L1-to-L0A feature-map transfer `pto.timg2col`. Other raw scalar load/store helpers are outside the current tile-instruction subset and are not covered here.
 
 ---
 
@@ -86,3 +86,40 @@ pto.tstore ins(%src : !pto.tile_buf<...>)
 pto.tstore ins(%tb : !pto.tile_buf<vec, 16x16xf16>)
            outs(%pv : !pto.partition_tensor_view<16x16xf16>)
 ```
+
+
+## `pto.timg2col`
+
+A2/A3 `TIMG2COL` unfolds a feature map from Mat (L1) to Left (L0A), on
+`PIPE_MTE1`. Both operands are rank-2 tile buffers with the same element type
+(`f16`, `bf16`, `f32`, or `i8`). The source is a fully valid NZ tile `[H*W, C]`;
+its packed bytes are `NC1HWC0` when `H*W` is divisible by 16 and C is divisible
+by `C0=32/sizeof(dtype)`. Both tiles use 512-byte fractals. The destination
+uses `blayout=row_major, slayout=row_major`.
+
+```mlir
+pto.timg2col ins(%src, %pos_m, %pos_k : !pto.tile_buf<mat, 64x32xf16,
+    blayout=col_major, slayout=row_major>, index, index)
+  outs(%dst : !pto.tile_buf<left, 16x32xf16,
+    blayout=row_major, slayout=row_major>)
+  {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=3 : i64, kernel_w=3 : i64,
+   pad_top=1 : i64, pad_bottom=1 : i64, pad_left=1 : i64, pad_right=1 : i64}
+```
+
+`fmap_h/w` and `kernel_h/w` are required. `stride_h/w` and `dilation_h/w`
+default to 1; `pad_top/bottom/left/right` default to 0. Padding supplies zero.
+The lowering creates a ConvTile descriptor aliasing the existing L1 buffer,
+sets its geometry, and invokes `TIMG2COL` with `FMATRIX_A_AUTO`, configuring
+FMATRIX, repeat and padding registers on every call.
+
+For destination `[M,K]`, the unfolded row axis enumerates output H/W and the
+column axis enumerates C1/kernel H/kernel W/C0. Matmul weights must use that
+same K order. M is divisible by 16 and K by C0. `pos_m` and `pos_k` select the
+window; both must fit uint16 and keep the whole destination window in range.
+`pos_k` must be C0-aligned. Runtime source valid dimensions must equal its
+physical dimensions. Static violations are rejected by the verifier.
+
+Image H/W and C fit uint16; kernel H/W are in [1,511]; stride and dilation
+are in [1,255]; each padding value is in [0,255]. Destination M/K fit uint16.
+This primitive handles spatial convolution. A temporal kernel for causal
+3-D convolution needs an outer loop and accumulation over temporal slices.

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -4566,6 +4566,48 @@ def TExpandsOp : PTO_TOp<"texpands", [
   }];
 }
 
+def TImg2colOp : PTO_TOp<"timg2col", [
+  PTO_DpsInitOpInterface,
+  OpPipeInterface,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "Unfold a full NZ feature map from Mat into Left using TIMG2COL";
+  let description = [{
+    The source is a fully valid NZ tile [H*W, C], whose packed storage is
+    NC1HWC0 when H*W is divisible by 16 and C is C0-aligned (C0=32/sizeof(T)).
+    The destination selects [M, K] from the unfolded matrix: M enumerates
+    output H/W and K enumerates C1/kernel H/kernel W/C0. Padding is zero.
+    FMATRIX, repeat and padding registers are configured by every operation.
+    Dynamic positions must fit uint16 and keep the complete window in range;
+    posK must be C0-aligned. Geometry and destination dimensions are static.
+  }];
+  let arguments = (ins
+    PTODpsType:$src, AnyTypeOf<[Index, I64, UI64]>:$posM,
+    AnyTypeOf<[Index, I64, UI64]>:$posK, PTODpsType:$dst,
+    I64Attr:$fmap_h, I64Attr:$fmap_w,
+    I64Attr:$kernel_h, I64Attr:$kernel_w,
+    DefaultValuedAttr<I64Attr, "1">:$stride_h,
+    DefaultValuedAttr<I64Attr, "1">:$stride_w,
+    DefaultValuedAttr<I64Attr, "1">:$dilation_h,
+    DefaultValuedAttr<I64Attr, "1">:$dilation_w,
+    DefaultValuedAttr<I64Attr, "0">:$pad_top,
+    DefaultValuedAttr<I64Attr, "0">:$pad_bottom,
+    DefaultValuedAttr<I64Attr, "0">:$pad_left,
+    DefaultValuedAttr<I64Attr, "0">:$pad_right
+  );
+  let results = (outs);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    `ins` `(` $src `,` $posM `,` $posK `:` qualified(type($src)) `,`
+      type($posM) `,` type($posK) `)`
+    `outs` `(` $dst `:` qualified(type($dst)) `)` attr-dict
+  }];
+  let extraClassDeclaration = [{
+    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_MTE1; }
+    ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
+  }];
+}
+
 def TExtractOp : PTO_TOp<"textract", [
   AttrSizedOperandSegments,
   PTO_DpsInitOpInterface,

--- a/lib/PTO/IR/Parts/PTOOpsPart05.cpp
+++ b/lib/PTO/IR/Parts/PTOOpsPart05.cpp
@@ -1199,7 +1199,8 @@ mlir::LogicalResult mlir::pto::TImg2colOp::verify()
     if (getPTOMemorySpaceEnum(src) != AddressSpace::MAT || getPTOMemorySpaceEnum(dst) != AddressSpace::LEFT)
         return emitOpError("expects Mat source and Left destination");
     Type elem = src.getElementType();
-    if (elem != dst.getElementType() || !(elem.isF16() || elem.isBF16() || elem.isF32() || elem.isInteger(8)))
+    if (elem != dst.getElementType() ||
+        !(elem.isF16() || elem.isBF16() || elem.isF32() || elem.isSignlessInteger(8) || elem.isSignedInteger(8)))
         return emitOpError("expects matching f16/bf16/f32/i8 element types");
     const int64_t c0 = 256 / elem.getIntOrFloatBitWidth();
     if (src.getBLayoutValueI32() != static_cast<int32_t>(BLayout::ColMajor) ||

--- a/lib/PTO/IR/Parts/PTOOpsPart05.cpp
+++ b/lib/PTO/IR/Parts/PTOOpsPart05.cpp
@@ -1190,6 +1190,71 @@ static LogicalResult verifyTExtractA5(TExtractOp op) {
   return success();
 }
 
+mlir::LogicalResult mlir::pto::TImg2colOp::verify()
+{
+    auto src = dyn_cast<TileBufType>(getSrc().getType());
+    auto dst = dyn_cast<TileBufType>(getDst().getType());
+    if (!src || !dst || src.getRank() != 2 || dst.getRank() != 2)
+        return emitOpError("expects rank-2 tile_buf operands");
+    if (getPTOMemorySpaceEnum(src) != AddressSpace::MAT || getPTOMemorySpaceEnum(dst) != AddressSpace::LEFT)
+        return emitOpError("expects Mat source and Left destination");
+    Type elem = src.getElementType();
+    if (elem != dst.getElementType() || !(elem.isF16() || elem.isBF16() || elem.isF32() || elem.isInteger(8)))
+        return emitOpError("expects matching f16/bf16/f32/i8 element types");
+    const int64_t c0 = 256 / elem.getIntOrFloatBitWidth();
+    if (src.getBLayoutValueI32() != static_cast<int32_t>(BLayout::ColMajor) ||
+        src.getSLayoutValueI32() != static_cast<int32_t>(SLayout::RowMajor) ||
+        dst.getBLayoutValueI32() != static_cast<int32_t>(BLayout::RowMajor) ||
+        dst.getSLayoutValueI32() != static_cast<int32_t>(SLayout::RowMajor))
+        return emitOpError("expects NZ source and row_major/row_major destination");
+    if (src.getSFractalSizeI32() != 512 || dst.getSFractalSizeI32() != 512)
+        return emitOpError("expects 512-byte fractals");
+    for (auto entry :
+         {std::make_pair(getFmapHAttr().getInt(), int64_t{65535}),
+          std::make_pair(getFmapWAttr().getInt(), int64_t{65535}),
+          std::make_pair(getKernelHAttr().getInt(), int64_t{511}),
+          std::make_pair(getKernelWAttr().getInt(), int64_t{511}),
+          std::make_pair(getStrideHAttr().getInt(), int64_t{255}),
+          std::make_pair(getStrideWAttr().getInt(), int64_t{255}),
+          std::make_pair(getDilationHAttr().getInt(), int64_t{255}),
+          std::make_pair(getDilationWAttr().getInt(), int64_t{255})}) {
+        if (entry.first < 1 || entry.first > entry.second)
+            return emitOpError("image/kernel/stride/dilation exceeds instruction range");
+    }
+    for (int64_t pad :
+         {getPadTopAttr().getInt(), getPadBottomAttr().getInt(), getPadLeftAttr().getInt(), getPadRightAttr().getInt()})
+        if (pad < 0 || pad > 255)
+            return emitOpError("padding must be in [0, 255]");
+    auto sourceShape = src.getShape();
+    if (sourceShape[0] != getFmapHAttr().getInt() * getFmapWAttr().getInt() || sourceShape[0] % 16 != 0 ||
+        sourceShape[1] <= 0 || sourceShape[1] > 65535 || sourceShape[1] % c0 != 0)
+        return emitOpError("expects source [H*W, C] aligned to [16, C0]");
+    auto sourceValid = getValidShapeVec(getSrc());
+    for (unsigned i = 0; i < 2; ++i)
+        if (sourceValid[i] >= 0 && sourceValid[i] != sourceShape[i])
+            return emitOpError("expects fully valid source");
+    const int64_t h = getFmapHAttr().getInt() + getPadTopAttr().getInt() + getPadBottomAttr().getInt() -
+                      getDilationHAttr().getInt() * (getKernelHAttr().getInt() - 1) - 1;
+    const int64_t w = getFmapWAttr().getInt() + getPadLeftAttr().getInt() + getPadRightAttr().getInt() -
+                      getDilationWAttr().getInt() * (getKernelWAttr().getInt() - 1) - 1;
+    if (h < 0 || w < 0)
+        return emitOpError("kernel exceeds padded image");
+    const int64_t bounds[] = {
+        (h / getStrideHAttr().getInt() + 1) * (w / getStrideWAttr().getInt() + 1),
+        sourceShape[1] * getKernelHAttr().getInt() * getKernelWAttr().getInt()};
+    Value positions[] = {getPosM(), getPosK()};
+    for (unsigned i = 0; i < 2; ++i) {
+        const int64_t dim = dst.getShape()[i];
+        if (dim <= 0 || dim > 65535 || dim % (i == 0 ? 16 : c0) || dim > bounds[i])
+            return emitOpError("destination must fit unfolded image and align to [16, C0]");
+        auto pos = getConstantIntegerValue(positions[i]);
+        if (pos && (*pos < 0 || *pos > 65535 || *pos + dim > bounds[i] || (i == 1 && *pos % c0)))
+            return emitOpError("position is out of bounds or posK is not C0-aligned");
+    }
+    return dispatchVerifierByArch(
+        getOperation(), []() { return success(); }, [&]() { return emitOpError("TIMG2COL currently supports A2/A3"); });
+}
+
 mlir::LogicalResult mlir::pto::TExtractOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult { return verifyTExtractA2A3(*this); };
   auto verifyA5 = [&]() -> LogicalResult { return verifyTExtractA5(*this); };

--- a/lib/PTO/IR/Parts/PTOOpsPart11.cpp
+++ b/lib/PTO/IR/Parts/PTOOpsPart11.cpp
@@ -1109,6 +1109,8 @@ void TExpandsOp::getEffects(
   PTO_ADD_WRITE(getDstMutable());
 }
 
+PTO_DEFINE_UNARY_EFFECTS(mlir::pto::TImg2colOp, getSrcMutable(), getDstMutable())
+
 // TEXTRACT: Read(src) -> Write(dst)
 void TExtractOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {

--- a/lib/PTO/Transforms/PTOToEmitC/PTOToEmitCPass.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC/PTOToEmitCPass.cpp
@@ -688,12 +688,15 @@ struct EmitPTOManualPass
     bool eventIdArray = false;
     bool tRandom = false;
     bool globalTensorData = false;
+    bool tImg2col = false;
     bool bitcast = false;
   };
 
   static HelperFlags collectHelperFlags(ModuleOp mop) {
     HelperFlags flags;
     mop.walk([&](Operation *op) {
+      if (isa<mlir::pto::TImg2colOp>(op))
+        flags.tImg2col = true;
       if (isa<mlir::pto::DeclareEventIdArrayOp>(op))
         flags.eventIdArray = true;
       if (isa<mlir::pto::TRandomOp>(op))
@@ -757,6 +760,36 @@ static AICORE inline auto PTOAS__GLOBAL_TENSOR_DATA(Tensor &tensor)
   return tensor.data();
 }
 )cpp"));
+    }
+    if (flags.tImg2col) {
+        builder.create<emitc::VerbatimOp>(loc, builder.getStringAttr(R"cpp(
+            template <
+                int H, int W, int KH, int KW, int SH, int SW, int DH, int DW, int PT, int PB, int PL, int PR,
+                typename DstTile, typename SrcTile>
+            static AICORE inline void PTOAS__TIMG2COL(DstTile& dst, SrcTile& src, uint16_t posM, uint16_t posK)
+            {
+                using T = typename SrcTile::DType;
+                constexpr int C0 = 32 / sizeof(T);
+                constexpr int C = SrcTile::Cols;
+                using Fmap = ConvTile<TileType::Mat, T, H * W * C * sizeof(T), Layout::NC1HWC0, ConvTileShape<1, C / C0, H, W, C0>>;
+                Fmap fmap;
+                fmap.data() = src.data();
+                fmap.SetFmapH(H);
+                fmap.SetFmapW(W);
+                fmap.SetChannelSize(C);
+                fmap.SetFilterH(KH);
+                fmap.SetFilterW(KW);
+                fmap.SetStrideH(SH);
+                fmap.SetStrideW(SW);
+                fmap.SetDilationH(DH);
+                fmap.SetDilationW(DW);
+                fmap.SetPadList(0, PL);
+                fmap.SetPadList(1, PR);
+                fmap.SetPadList(2, PT);
+                fmap.SetPadList(3, PB);
+                TIMG2COL<DstTile, Fmap, SetFmatrixMode::FMATRIX_A_AUTO>(dst, fmap, posM, posK);
+            }
+        )cpp"));
     }
     if (flags.eventIdArray) {
       builder.create<emitc::VerbatimOp>(

--- a/lib/PTO/Transforms/PTOToEmitC/PTOToEmitCTensor.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC/PTOToEmitCTensor.cpp
@@ -810,6 +810,26 @@ static StringRef getTInsertModeToken(pto::TInsertMode mode) {
   llvm_unreachable("unknown TInsertMode");
 }
 
+struct PTOImg2colToEmitC : public OpConversionPattern<pto::TImg2colOp> {
+    using OpConversionPattern<pto::TImg2colOp>::OpConversionPattern;
+
+    LogicalResult matchAndRewrite(
+        pto::TImg2colOp op, OpAdaptor adaptor, ConversionPatternRewriter& rewriter) const override
+    {
+        SmallVector<Attribute> templateArgs;
+        for (int64_t value :
+             {op.getFmapH(), op.getFmapW(), op.getKernelH(), op.getKernelW(), op.getStrideH(), op.getStrideW(),
+              op.getDilationH(), op.getDilationW(), op.getPadTop(), op.getPadBottom(), op.getPadLeft(),
+              op.getPadRight()})
+            templateArgs.push_back(rewriter.getI64IntegerAttr(value));
+        rewriter.create<emitc::CallOpaqueOp>(
+            op.getLoc(), TypeRange{}, "PTOAS__TIMG2COL", ArrayAttr{}, rewriter.getArrayAttr(templateArgs),
+            ValueRange{adaptor.getDst(), adaptor.getSrc(), adaptor.getPosM(), adaptor.getPosK()});
+        rewriter.eraseOp(op);
+        return success();
+    }
+};
+
 struct PTOExtractToEmitC : public OpConversionPattern<pto::TExtractOp> {
   using OpConversionPattern<pto::TExtractOp>::OpConversionPattern;
 
@@ -1957,6 +1977,7 @@ void populateTensorPatterns(RewritePatternSet &patterns,
   patterns.add<PTOExpToEmitC>(typeConverter, ctx);
   patterns.add<PTOExpandsToEmitC>(typeConverter, ctx);
   patterns.add<PTOExtractToEmitC, PTOInsertToEmitC>(typeConverter, ctx);
+  patterns.add<PTOImg2colToEmitC>(typeConverter, ctx);
   patterns.add<PTOFillPadToEmitC>(typeConverter, ctx);
   patterns.add<PTOGatherToEmitC>(typeConverter, ctx);
   patterns.add<PTOGatherbToEmitC>(typeConverter, ctx);

--- a/test/lit/pto/timg2col_a3_emitc.pto
+++ b/test/lit/pto/timg2col_a3_emitc.pto
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 %s | FileCheck %s
+
+// CHECK: fmap.data() = src.data();
+// CHECK: FMATRIX_A_AUTO
+
+func.func @img2col_f16() {
+  %m = arith.constant 16 : index
+  %k = arith.constant 32 : i64
+  %src = pto.alloc_tile : !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>
+  %dst = pto.alloc_tile : !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, index, i64)
+    outs(%dst : !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=3 : i64, kernel_w=3 : i64,
+      pad_top=1 : i64, pad_bottom=1 : i64, pad_left=1 : i64, pad_right=1 : i64}
+  return
+}
+// CHECK-LABEL: AICORE void img2col_f16(
+// CHECK: PTOAS__TIMG2COL<8, 8, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1>(
+
+func.func @img2col_bf16() {
+  %m = arith.constant 16 : index
+  %k = arith.constant 32 : i64
+  %src = pto.alloc_tile : !pto.tile_buf<mat, 64x32xbf16, blayout=col_major, slayout=row_major>
+  %dst = pto.alloc_tile : !pto.tile_buf<left, 16x32xbf16, blayout=row_major, slayout=row_major>
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xbf16, blayout=col_major, slayout=row_major>, index, i64)
+    outs(%dst : !pto.tile_buf<left, 16x32xbf16, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=3 : i64, kernel_w=3 : i64,
+      pad_top=1 : i64, pad_bottom=1 : i64, pad_left=1 : i64, pad_right=1 : i64}
+  return
+}
+// CHECK-LABEL: AICORE void img2col_bf16(
+// CHECK: PTOAS__TIMG2COL<8, 8, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1>(
+
+func.func @img2col_f32() {
+  %m = arith.constant 16 : index
+  %k = arith.constant 32 : i64
+  %src = pto.alloc_tile : !pto.tile_buf<mat, 64x32xf32, blayout=col_major, slayout=row_major>
+  %dst = pto.alloc_tile : !pto.tile_buf<left, 16x32xf32, blayout=row_major, slayout=row_major>
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xf32, blayout=col_major, slayout=row_major>, index, i64)
+    outs(%dst : !pto.tile_buf<left, 16x32xf32, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=3 : i64, kernel_w=3 : i64,
+      pad_top=1 : i64, pad_bottom=1 : i64, pad_left=1 : i64, pad_right=1 : i64}
+  return
+}
+// CHECK-LABEL: AICORE void img2col_f32(
+// CHECK: PTOAS__TIMG2COL<8, 8, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1>(
+
+func.func @img2col_i8() {
+  %m = arith.constant 16 : index
+  %k = arith.constant 32 : i64
+  %src = pto.alloc_tile : !pto.tile_buf<mat, 64x32xi8, blayout=col_major, slayout=row_major>
+  %dst = pto.alloc_tile : !pto.tile_buf<left, 16x32xi8, blayout=row_major, slayout=row_major>
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xi8, blayout=col_major, slayout=row_major>, index, i64)
+    outs(%dst : !pto.tile_buf<left, 16x32xi8, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=3 : i64, kernel_w=3 : i64,
+      pad_top=1 : i64, pad_bottom=1 : i64, pad_left=1 : i64, pad_right=1 : i64}
+  return
+}
+// CHECK-LABEL: AICORE void img2col_i8(
+// CHECK: PTOAS__TIMG2COL<8, 8, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1>(
+
+func.func @img2col_unsigned(%k: ui64) {
+  %m = arith.constant 0 : index
+  %src = pto.alloc_tile : !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>
+  %dst = pto.alloc_tile : !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, index, ui64)
+    outs(%dst : !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=1 : i64, kernel_w=1 : i64}
+  return
+}
+// CHECK-LABEL: AICORE void img2col_unsigned(
+// CHECK: PTOAS__TIMG2COL<8, 8, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0>(

--- a/test/lit/pto/timg2col_invalid.pto
+++ b/test/lit/pto/timg2col_invalid.pto
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s --split-input-file --verify-diagnostics
+
+func.func @invalid_0(%src: !pto.tile_buf<vec, 64x32xf16, blayout=col_major, slayout=row_major>, %dst: !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>) {
+  %m = arith.constant 0 : index
+  %k = arith.constant 0 : index
+  // expected-error @+1 {{expects Mat source and Left destination}}
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<vec, 64x32xf16, blayout=col_major, slayout=row_major>, index, index)
+    outs(%dst : !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=1 : i64, kernel_w=1 : i64}
+  return
+}
+
+// -----
+
+func.func @invalid_1(%src: !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, %dst: !pto.tile_buf<left, 16x32xbf16, blayout=row_major, slayout=row_major>) {
+  %m = arith.constant 0 : index
+  %k = arith.constant 0 : index
+  // expected-error @+1 {{expects matching}}
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, index, index)
+    outs(%dst : !pto.tile_buf<left, 16x32xbf16, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=1 : i64, kernel_w=1 : i64}
+  return
+}
+
+// -----
+
+func.func @invalid_2(%src: !pto.tile_buf<mat, 64x32xf16, blayout=row_major, slayout=row_major>, %dst: !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>) {
+  %m = arith.constant 0 : index
+  %k = arith.constant 0 : index
+  // expected-error @+1 {{expects NZ source}}
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xf16, blayout=row_major, slayout=row_major>, index, index)
+    outs(%dst : !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=1 : i64, kernel_w=1 : i64}
+  return
+}
+
+// -----
+
+func.func @invalid_3(%src: !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, %dst: !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>) {
+  %m = arith.constant 0 : index
+  %k = arith.constant 0 : index
+  // expected-error @+1 {{instruction range}}
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, index, index)
+    outs(%dst : !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=1 : i64, kernel_w=1 : i64, stride_h=0 : i64}
+  return
+}
+
+// -----
+
+func.func @invalid_4(%src: !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, %dst: !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>) {
+  %m = arith.constant 0 : index
+  %k = arith.constant 0 : index
+  // expected-error @+1 {{padding must be}}
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, index, index)
+    outs(%dst : !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=1 : i64, kernel_w=1 : i64, pad_top=256 : i64}
+  return
+}
+
+// -----
+
+func.func @invalid_5(%src: !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, %dst: !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>) {
+  %m = arith.constant 0 : index
+  %k = arith.constant 0 : index
+  // expected-error @+1 {{instruction range}}
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, index, index)
+    outs(%dst : !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=1 : i64, kernel_w=1 : i64, dilation_w=256 : i64}
+  return
+}
+
+// -----
+
+func.func @invalid_6(%src: !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, %dst: !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>) {
+  %m = arith.constant 0 : index
+  %k = arith.constant 1 : index
+  // expected-error @+1 {{position is out of bounds}}
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, index, index)
+    outs(%dst : !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=1 : i64, kernel_w=1 : i64}
+  return
+}
+
+// -----
+
+func.func @invalid_7(%src: !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, %dst: !pto.tile_buf<left, 16x64xf16, blayout=row_major, slayout=row_major>) {
+  %m = arith.constant 0 : index
+  %k = arith.constant 0 : index
+  // expected-error @+1 {{destination must fit}}
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xf16, blayout=col_major, slayout=row_major>, index, index)
+    outs(%dst : !pto.tile_buf<left, 16x64xf16, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=1 : i64, kernel_w=1 : i64}
+  return
+}

--- a/test/lit/pto/timg2col_invalid.pto
+++ b/test/lit/pto/timg2col_invalid.pto
@@ -8,6 +8,18 @@
 
 // RUN: pto-test-opt %s --split-input-file --verify-diagnostics
 
+func.func @invalid_unsigned_element(%src: !pto.tile_buf<mat, 64x32xui8, blayout=col_major, slayout=row_major>, %dst: !pto.tile_buf<left, 16x32xui8, blayout=row_major, slayout=row_major>) {
+  %m = arith.constant 0 : index
+  %k = arith.constant 0 : index
+  // expected-error @+1 {{expects matching f16/bf16/f32/i8 element types}}
+  pto.timg2col ins(%src, %m, %k : !pto.tile_buf<mat, 64x32xui8, blayout=col_major, slayout=row_major>, index, index)
+    outs(%dst : !pto.tile_buf<left, 16x32xui8, blayout=row_major, slayout=row_major>)
+    {fmap_h=8 : i64, fmap_w=8 : i64, kernel_h=1 : i64, kernel_w=1 : i64}
+  return
+}
+
+// -----
+
 func.func @invalid_0(%src: !pto.tile_buf<vec, 64x32xf16, blayout=col_major, slayout=row_major>, %dst: !pto.tile_buf<left, 16x32xf16, blayout=row_major, slayout=row_major>) {
   %m = arith.constant 0 : index
   %k = arith.constant 0 : index


### PR DESCRIPTION
TIMG2COL is needed to compose VAE convolution from existing PTO primitives. Add `pto.timg2col` for A2/A3: it unfolds a packed feature map in Mat memory directly into a Left tile for matrix multiplication.

The operation validates geometry, layout, element types, and offset bounds, and participates in DMA scheduling through `PIPE_MTE1` and DPS memory effects. EmitC lowering aliases the existing NZ Mat allocation as an NC1HWC0 ConvTile and configures FMATRIX automatically, without allocating another feature-map buffer.

Compiler dependency for https://github.com/hw-native-sys/pypto/pull/2731, addressing the missing convolution primitive discussed in https://github.com/hw-native-sys/pypto/issues/2665.

Validation:
- ARM64 and x86_64 compiler distribution CI builds pass at `67eee78f`.
- EmitC FileCheck passes for FP16, BF16, FP32, INT8, and unsigned runtime offsets using that ARM64 artifact.
- The latest PTOIR library at `aa96e870c` builds locally. A verifier-only driver using MLIR's diagnostic verifier passes all nine invalid-input chunks, all five positive fixture functions, and all eight final PyPTO convolution kernel IR files. The later commit only tightens unsigned element-type rejection; lowering is unchanged.
- All eight companion PyPTO convolution ST cases pass on NPU devices 1 and 3 with exact integer-valued goldens. An initial device-3 AICPU execution exception did not reproduce in the existing matmul control or the full convolution rerun.

The main `build-and-test` CI job fails before compilation in strict CMake 4 configuration: `FetchContent_Populate(cann-cmake)` triggers CMP0169 at `cmake/fetch_cann_cmake.cmake:74`. The same existing failure is documented in https://github.com/hw-native-sys/PTOAS/pull/1488. This PR does not change CMake or CI configuration. Full lit-suite validation is not claimed; keeping the PR in draft while the existing configure blocker remains.
