### PR TITLE
fix(sync): balance multi-tile prefetch event boundaries

### DIFF
--- a/docs/designs/ptoas-multi-buffer-explicit-design.md
+++ b/docs/designs/ptoas-multi-buffer-explicit-design.md
@@ -227,7 +227,7 @@ struct SlotInfo {
 | Const(a) ↔ Dyn(%k) | – | ⚠️ 保守 alias，全同步 | dyn event id（仅 %k==a 时同步） |
 | Dyn(%j) ↔ Dyn(%k), 表达式相同 | – | ⚠️ 保守 alias | 真冲突 + dyn event id |
 | Dyn(%j) ↔ Dyn(%k), 可证 disjoint | – | ⚠️ 保守 alias | 同 iter 不冲突，跨 iter dyn event id |
-| Dyn ↔ Dyn 不可证 | – | ⚠️ 保守 alias | N 个 dyn event id |
+| Dyn ↔ Dyn 不可证 | – | ⚠️ 保守 alias | 保留依赖，使用静态 event id |
 
 dyn event id 分配 + `set_flag_dyn` / `wait_flag_dyn` 生成留作 follow-up（需要扩展 `SyncEventIdAllocation` 和 `SyncCodegen`）。
 
@@ -355,6 +355,19 @@ ptoas 自动行为：
 - 同步分析：producer slot 表达式 `(iv+1)%2`，consumer slot `iv%2` → 同 iter disjoint / 跨 iter 冲突 → 2 个 dyn event id；
 - emit `set_flag_dyn` / `wait_flag_dyn`，event id value 与 slot 表达式同源。
 
+循环边界必须按槽位配平事件，不能对所有槽位统一 prime / drain：
+
+- V→MTE2：循环前只初始化 slot 1 的事件。slot 0 的第一次循环内写入必须等待第 0 次计算完成。
+- MTE2→V：循环前只初始化 slot 0 的循环事件；预加载本身另有完整的 MTE2→V 同步。slot 1 必须等待实际预取完成。
+- 执行 `n` 次后，V→MTE2 只 drain slot `(n + 1) % 2`，MTE2→V 只 drain slot `n % 2`。`n = 0` 时也遵循同一规则。
+
+对步长为 1、非负常量下界、槽位形如 `(iv + 非负常量) remui N` 的循环，
+按每个槽位第一次 set / wait 的先后关系生成边界同步，并在循环结束时按最终轮转位置计算剩余事件。
+生产者和消费者必须直接位于同一个循环体内。嵌套循环在所属循环的每次入口和出口完成配平，
+外层循环不再为这对操作添加重复的跨迭代事件。若两个槽位表达式不同且无法证明这样的轮转，
+则保留同次迭代的依赖，并使用单个静态事件进行保守同步；不假定未知表达式会遍历所有槽位。
+已证明轮转的事件组在资源不足时使用 `PIPE_ALL` 保守同步，不将多个槽位折叠成单个事件。
+
 ### 7.3 例 3：N=4 同表达式轮转
 
 ```mlir
@@ -476,7 +489,7 @@ lit test/lit/pto/multi_tile_prefetch_insert_sync.pto
 
 ### 当前限制
 
-- **affine 分析仅覆盖核心几种形态**：`compareSlotSSA` 当前能证 `iv % N` / `(iv ± c) % N` / 同 SSA / 纯常量；不能证 `(iv * c) % N`、跨函数 / 跨循环的 SSA 等价、非 `arith.remui` 包装的 slot 表达式。命中不到时退回 kUnknown / 保守 N dyn event id。
+- **affine 分析仅覆盖核心几种形态**：`compareSlotSSA` 当前能证 `iv % N` / `(iv ± c) % N` / 同 SSA / 纯常量；不能证 `(iv * c) % N`、跨函数 / 跨循环的 SSA 等价、非 `arith.remui` 包装的 slot 表达式。不同表达式的轮转无法证明时，使用静态事件保守同步（见 §7.2）。
 - **PlanMemory N>2 不复用 Stage1**：N>2 的兄弟 slot 不走 SPEC_LEVEL_1 "ping/pong 相邻摆放"优化，用更多内存。N=2 路径不变。
 - 初版仅支持 `loc=vec` / `loc=mat` local memory。
 - function argument / return 上的 `multi_tile_buf` 不支持（多 buffer 所有权限定在 ptoas 内）。

--- a/include/PTO/Transforms/InsertSync/SyncCommon.h
+++ b/include/PTO/Transforms/InsertSync/SyncCommon.h
@@ -166,8 +166,17 @@ struct BaseMemInfo {
  
 using DepBaseMemInfoPairVec =
     SmallVector<std::pair<const BaseMemInfo *, const BaseMemInfo *>>;
- 
+
 // 表示一个具体的同步指令 (Set, Wait, Barrier)
+// A unit-step loop visits slot `(iv + offset) % count` once per rotation.
+// Boundary flags compare each lane's first set and wait in that rotation.
+struct SlotEventSchedule {
+    Operation* loop{nullptr};
+    uint32_t producerOffset{0};
+    uint32_t consumerOffset{0};
+    bool producerBeforeConsumer{false};
+};
+
 class SyncOperation {
 public:
   enum class TYPE {
@@ -198,6 +207,9 @@ public:
   // hardware event-id index. Empty when this sync is single-buffer.
   Value slotSSAExpr;
   uint32_t slotCount{1};
+  std::optional<SlotEventSchedule> slotSchedule;
+  // Present only on the synthetic loop prime/drain for this event lane.
+  std::optional<uint32_t> boundarySlot;
   Value lowestCommonAncestorBuffer{nullptr};
   int reuseCntForWiden{0};
   bool reallocatedLoopHeadTailSync{false};

--- a/include/PTO/Transforms/SlotAffineAnalysis.h
+++ b/include/PTO/Transforms/SlotAffineAnalysis.h
@@ -14,6 +14,8 @@
 // provably disjoint modulo N, or indeterminate. The result lets sync
 // shrink event-id count or skip same-iter forward syncs entirely when
 // producer and consumer touch different slots in every iteration.
+// Rotation offsets also determine which slot events are initially available
+// and which releases remain outstanding at the loop boundary.
 //
 //===----------------------------------------------------------------------===//
 
@@ -22,6 +24,7 @@
 
 #include "mlir/IR/Value.h"
 #include <cstdint>
+#include <optional>
 
 namespace mlir {
 namespace pto {
@@ -52,6 +55,11 @@ mlir::Value findMultiTileSlotExpr(mlir::Value v);
 ///   compareSlotSSA(%iv % 2, %j % 2)          -> kUnknown   // diff symbols
 ///   compareSlotSSA(arith.constant 0, arith.constant 1) -> kDisjoint
 SlotRelation compareSlotSSA(mlir::Value a, mlir::Value b, uint32_t N);
+
+/// Recognize `(iv + nonnegative constant) remui N` for boundary event
+/// accounting. The returned offset is reduced modulo N. Other expressions
+/// require conservative synchronization rather than assumed slot rotation.
+std::optional<uint32_t> getSlotRotationOffset(mlir::Value slot, mlir::Value inductionVar, uint32_t count);
 
 } // namespace pto
 } // namespace mlir

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -477,30 +477,89 @@ void InsertSyncAnalysis::InsertSync(
   MemAnalyze(nowCompound, frontCompound, syncRecordList, forEndIndex);
 }
 
+static std::optional<std::pair<Value, Value>> getDependencySlots(const DepBaseMemInfoPairVec& dependencies)
+{
+    Value producerSlot;
+    Value consumerSlot;
+    for (const auto& pair : dependencies) {
+        if (!pair.first || !pair.second) {
+            return std::nullopt;
+        }
+        Value producer = findMultiTileSlotExpr(pair.second->baseBuffer);
+        Value consumer = findMultiTileSlotExpr(pair.first->baseBuffer);
+        if (!producer || !consumer) {
+            return std::nullopt;
+        }
+        bool mismatchedProducer = producerSlot && producerSlot != producer;
+        bool mismatchedConsumer = consumerSlot && consumerSlot != consumer;
+        if (mismatchedProducer || mismatchedConsumer) {
+            return std::nullopt;
+        }
+        producerSlot = producer;
+        consumerSlot = consumer;
+    }
+    if (!producerSlot || !consumerSlot) {
+        return std::nullopt;
+    }
+    return std::make_pair(producerSlot, consumerSlot);
+}
+
+static std::optional<SlotEventSchedule> getSlotEventSchedule(
+    Value producerSlot, Value consumerSlot, Operation* producer, Operation* consumer, uint32_t count)
+{
+    Block* producerBlock = producer->getBlock();
+    Block* consumerBlock = consumer->getBlock();
+    if (producerBlock != consumerBlock) {
+        return std::nullopt;
+    }
+    auto loop = dyn_cast<scf::ForOp>(producer->getParentOp());
+    if (!loop) {
+        return std::nullopt;
+    }
+    IntegerAttr lowerBound;
+    bool unitStep = matchPattern(loop.getStep(), m_One());
+    bool constantLowerBound = matchPattern(loop.getLowerBound(), m_Constant(&lowerBound));
+    if (!unitStep || !constantLowerBound) {
+        return std::nullopt;
+    }
+    if (lowerBound.getValue().isNegative()) {
+        return std::nullopt;
+    }
+    auto producerOffset = getSlotRotationOffset(producerSlot, loop.getInductionVar(), count);
+    auto consumerOffset = getSlotRotationOffset(consumerSlot, loop.getInductionVar(), count);
+    if (!producerOffset || !consumerOffset) {
+        return std::nullopt;
+    }
+    return SlotEventSchedule{loop, *producerOffset, *consumerOffset, producer->isBeforeInBlock(consumer)};
+}
+
 // Returns true if a *same-iter* multi-buffer dep pair can be dropped
 // because the producer's and consumer's slot SSA expressions are provably
 // disjoint modulo N. Only applied to forward (non-back-edge) deps -- the
 // back-edge path still needs to sync per-slot via dyn event id (the
 // prefetch idiom). When the analysis is inconclusive (kUnknown / kEqual)
 // the dep is kept and the existing conservative path runs.
-static bool isForwardDepDroppableBySlotAffine(const BaseMemInfo *a,
-                                              const BaseMemInfo *b) {
-  if (!a || !b) {
-    return false;
-  }
-  size_t aN = a->baseAddresses.size();
-  size_t bN = b->baseAddresses.size();
-  size_t n = std::max(aN, bN);
-  if (n < kPtoMultiBufferMinNum) {
-    return false;
-  }
-  Value slotA = findMultiTileSlotExpr(a->baseBuffer);
-  Value slotB = findMultiTileSlotExpr(b->baseBuffer);
-  if (!slotA || !slotB) {
-    return false;
-  }
-  return compareSlotSSA(slotA, slotB, static_cast<uint32_t>(n)) ==
-         SlotRelation::kDisjoint;
+static bool isForwardDepDroppableBySlotAffine(
+    const BaseMemInfo* a, const BaseMemInfo* b, Operation* consumer, Operation* producer)
+{
+    if (!a || !b) {
+        return false;
+    }
+    size_t aN = a->baseAddresses.size();
+    size_t bN = b->baseAddresses.size();
+    size_t n = std::max(aN, bN);
+    if (n < kPtoMultiBufferMinNum) {
+        return false;
+    }
+    Value slotA = findMultiTileSlotExpr(a->baseBuffer);
+    Value slotB = findMultiTileSlotExpr(b->baseBuffer);
+    if (!slotA || !slotB) {
+        return false;
+    }
+    // Removing the forward edge requires a balanced slot rotation on the back
+    // edge. Unknown schedules retain static program-order synchronization.
+    return getSlotEventSchedule(slotB, slotA, producer, consumer, static_cast<uint32_t>(n)).has_value() &&
+           compareSlotSSA(slotA, slotB, static_cast<uint32_t>(n)) == SlotRelation::kDisjoint;
 }
 
 void InsertSyncAnalysis::MemAnalyze(
@@ -518,18 +577,31 @@ void InsertSyncAnalysis::MemAnalyze(
 
   // Same-iter (forward) deps: drop pairs that the affine analysis proves
   // touch disjoint slots in every iteration of the multi-buffer loop.
-  // Back-edge deps stay untouched -- they still need per-slot syncing
-  // through the dyn-event-id pipeline.
-  if (!forEndIndex.has_value()) {
-    auto isDroppable = [](const std::pair<const BaseMemInfo *,
-                                          const BaseMemInfo *> &pair) {
-      return isForwardDepDroppableBySlotAffine(pair.first, pair.second);
-    };
-    depVec.erase(std::remove_if(depVec.begin(), depVec.end(), isDroppable),
-                 depVec.end());
-    if (depVec.empty()) {
-      return;
-    }
+  // The owning loop still needs per-slot back-edge synchronization; its
+  // boundaries also close the dependency across enclosing iterations.
+  auto dependencySlots = getDependencySlots(depVec);
+  int slotCount = GetEventIdNum(depVec);
+  bool uniformSlots = slotCount > 1 && dependencySlots.has_value();
+  if (forEndIndex && uniformSlots) {
+      auto schedule = getSlotEventSchedule(
+          dependencySlots->first, dependencySlots->second, frontCompound->elementOp, nowCompound->elementOp, slotCount);
+      Operation* scope = syncIR_[*forEndIndex]->elementOp;
+      if (schedule && scope->isProperAncestor(schedule->loop)) {
+          // The owning loop drains its slot events on every exit. An enclosing
+          // loop must not add another carried token to these same operations.
+          return;
+      }
+  }
+  bool forwardDependency = !forEndIndex.has_value();
+  if (forwardDependency && uniformSlots) {
+      auto isDroppable = [nowCompound, frontCompound](const std::pair<const BaseMemInfo*, const BaseMemInfo*>& pair) {
+          return isForwardDepDroppableBySlotAffine(
+              pair.first, pair.second, nowCompound->elementOp, frontCompound->elementOp);
+      };
+      depVec.erase(std::remove_if(depVec.begin(), depVec.end(), isDroppable), depVec.end());
+      if (depVec.empty()) {
+          return;
+      }
   }
 
   if (CanPrunePipeVBarrier(nowCompound, frontCompound, depVec, forEndIndex)) {
@@ -673,50 +745,36 @@ void InsertSyncAnalysis::InsertPipeBarrierSync(
 
 // Resolve one unambiguous producer/consumer slot SSA pair for the whole
 // dependency group and configure a dynamic set/wait pair with it. Returns the
-// effective event-id count: when the group decomposes into a single slot
-// expression per side, slotSSAExpr/slotCount are filled and `eventIdNum` is
-// kept; otherwise a single static event id is used for the whole group.
+// effective event-id count. Keep per-slot events for a balanced rotation or
+// equal slot expressions; missing, ambiguous, or unproven distinct expressions
+// use one static event for the whole group.
 static int configureDynEventSlots(
-    SyncOperation *setOp, SyncOperation *waitOp,
-    const DepBaseMemInfoPairVec &depBaseMemInfosVec, int eventIdNum) {
-  if (eventIdNum <= 1) {
+    SyncOperation* setOp, SyncOperation* waitOp, const DepBaseMemInfoPairVec& depBaseMemInfosVec, int eventIdNum,
+    Operation* producer, Operation* consumer, Operation* loop)
+{
+    if (eventIdNum <= 1) {
+        return eventIdNum;
+    }
+    auto slots = getDependencySlots(depBaseMemInfosVec);
+    if (!slots) {
+        return 1;
+    }
+    auto [producerSlot, consumerSlot] = *slots;
+    auto schedule = getSlotEventSchedule(producerSlot, consumerSlot, producer, consumer, eventIdNum);
+    if (schedule && schedule->loop != loop) {
+        schedule.reset();
+    }
+    bool sameSlot = compareSlotSSA(producerSlot, consumerSlot, eventIdNum) == SlotRelation::kEqual;
+    if (!schedule && !sameSlot) {
+        return 1;
+    }
+    setOp->slotSchedule = schedule;
+    waitOp->slotSchedule = schedule;
+    setOp->slotSSAExpr = producerSlot;
+    setOp->slotCount = static_cast<uint32_t>(eventIdNum);
+    waitOp->slotSSAExpr = consumerSlot;
+    waitOp->slotCount = static_cast<uint32_t>(eventIdNum);
     return eventIdNum;
-  }
-  Value producerSlot;
-  Value consumerSlot;
-  bool hasAmbiguousSlot = false;
-  for (auto &pair : depBaseMemInfosVec) {
-    Value pairProducerSlot;
-    Value pairConsumerSlot;
-    if (pair.second && pair.second->baseBuffer) {
-      pairProducerSlot = findMultiTileSlotExpr(pair.second->baseBuffer);
-    }
-    if (pair.first && pair.first->baseBuffer) {
-      pairConsumerSlot = findMultiTileSlotExpr(pair.first->baseBuffer);
-    }
-    if (!pairProducerSlot || !pairConsumerSlot) {
-      hasAmbiguousSlot = true;
-      break;
-    }
-    if ((producerSlot && producerSlot != pairProducerSlot) ||
-        (consumerSlot && consumerSlot != pairConsumerSlot)) {
-      hasAmbiguousSlot = true;
-      break;
-    }
-    producerSlot = pairProducerSlot;
-    consumerSlot = pairConsumerSlot;
-  }
-  if (hasAmbiguousSlot || !producerSlot || !consumerSlot) {
-    // Missing or ambiguous slot SSA -- fall back to a single event id. This
-    // also keeps non-multi-buffer codepaths untouched if their baseAddresses
-    // have multiple entries for another reason.
-    return 1;
-  }
-  setOp->slotSSAExpr = producerSlot;
-  setOp->slotCount = static_cast<uint32_t>(eventIdNum);
-  waitOp->slotSSAExpr = consumerSlot;
-  waitOp->slotCount = static_cast<uint32_t>(eventIdNum);
-  return eventIdNum;
 }
 
 void InsertSyncAnalysis::InsertCrossPipeEventSync(
@@ -740,11 +798,11 @@ void InsertSyncAnalysis::InsertCrossPipeEventSync(
   // dyn event IDs are warranted, also plumb the per-side slot SSA so
   // codegen can lower into `pto.set_flag_dyn` / `pto.wait_flag_dyn`.
   if (forEndIndex.has_value()) {
-    int eventIdNum = configureDynEventSlots(
-        setOp.get(), waitOp.get(), depBaseMemInfosVec,
-        GetEventIdNum(depBaseMemInfosVec));
-    setOp->eventIdNum = eventIdNum;
-    waitOp->eventIdNum = eventIdNum;
+      int eventIdNum = configureDynEventSlots(
+          setOp.get(), waitOp.get(), depBaseMemInfosVec, GetEventIdNum(depBaseMemInfosVec), frontCompound->elementOp,
+          nowCompound->elementOp, syncIR_[*forEndIndex]->elementOp);
+      setOp->eventIdNum = eventIdNum;
+      waitOp->eventIdNum = eventIdNum;
   }
 
   syncIR_[insertSetId]->pipeAfter.push_back(setOp.get());

--- a/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
@@ -164,6 +164,44 @@ static void createSetOrWaitFlagOp(IRRewriter &rewriter, Operation *op,
   rewriter.create<pto::SetFlagOp>(op->getLoc(), srcPipe, dstPipe, eventId);
 }
 
+// The first visit to a lane occurs at `(lane - phase - offset) mod N`.
+// Work with residues so the boundary calculation cannot overflow the IV.
+static Value getFirstSlotVisit(
+    IRRewriter& rewriter, Location loc, Value phase, uint32_t lane, uint32_t offset, uint32_t count)
+{
+    Value modulus = rewriter.create<arith::ConstantIndexOp>(loc, count);
+    Value phaseMod = rewriter.create<arith::RemUIOp>(loc, phase, modulus);
+    uint32_t residue = (lane + count - offset) % count;
+    Value shiftedLane = rewriter.create<arith::ConstantIndexOp>(loc, residue + count);
+    Value distance = rewriter.create<arith::SubIOp>(loc, shiftedLane, phaseMod);
+    return rewriter.create<arith::RemUIOp>(loc, distance, modulus);
+}
+
+static void createSlotBoundaryFlag(
+    IRRewriter& rewriter, Operation* op, SyncOperation* sync, pto::PipeAttr srcPipe, pto::PipeAttr dstPipe,
+    pto::EventAttr eventId)
+{
+    const auto& schedule = *sync->slotSchedule;
+    auto loop = cast<scf::ForOp>(schedule.loop);
+    Location loc = op->getLoc();
+    Value phase = loop.getLowerBound();
+    if (sync->isSyncWaitType()) {
+        // For a unit-step loop, max(lb, ub) is the next IV even for zero trips.
+        Value entered = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt, phase, loop.getUpperBound());
+        phase = rewriter.create<arith::SelectOp>(loc, entered, loop.getUpperBound(), phase);
+    }
+    Value firstSet =
+        getFirstSlotVisit(rewriter, loc, phase, *sync->boundarySlot, schedule.producerOffset, sync->slotCount);
+    Value firstWait =
+        getFirstSlotVisit(rewriter, loc, phase, *sync->boundarySlot, schedule.consumerOffset, sync->slotCount);
+    auto predicate = schedule.producerBeforeConsumer ? arith::CmpIPredicate::ult : arith::CmpIPredicate::ule;
+    Value pending = rewriter.create<arith::CmpIOp>(loc, predicate, firstWait, firstSet);
+    auto guard = rewriter.create<scf::IfOp>(loc, pending, false);
+    OpBuilder::InsertionGuard insertionGuard(rewriter);
+    rewriter.setInsertionPointToStart(guard.thenBlock());
+    createSetOrWaitFlagOp(rewriter, op, sync, srcPipe, dstPipe, eventId);
+}
+
 // ==============================================================================
 // 2. SyncCodegen Implementation
 // ==============================================================================
@@ -367,6 +405,10 @@ void SyncCodegen::CreateSetWaitOpForSingleBuffer(IRRewriter &rewriter,
   auto srcPipe = getPipeAttr(rewriter, sync->GetActualSrcPipe());
   auto dstPipe = getPipeAttr(rewriter, sync->GetActualDstPipe());
   auto eventId = getEventAttr(rewriter, sync->eventIds[0]);
+  if (sync->boundarySlot) {
+      createSlotBoundaryFlag(rewriter, op, sync, srcPipe, dstPipe, eventId);
+      return;
+  }
   createSetOrWaitFlagOp(rewriter, op, sync, srcPipe, dstPipe, eventId);
 }
 

--- a/lib/PTO/Transforms/InsertSync/SyncEventIdAllocation.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncEventIdAllocation.cpp
@@ -173,13 +173,14 @@ void SyncEventIdAllocation::SetEventId(SyncOperation *sync) {
     for (auto &id : canAllocaEventId) {
       SetEventPool(sync, id);
     }
-  } else if (reallocatedPipePair.contains(ScopePair(sync)) &&
-             (canAllocaEventId.size() < idSize)) {
-    // Reallocate strategy: reduce usage to 1
-    assert(canAllocaEventId.size() > 0);
-    SetEventPool(sync, canAllocaEventId[0]);
-    sync->eventIdNum = 1;
+  } else if (
+      !sync->slotSchedule && reallocatedPipePair.contains(ScopePair(sync)) && (canAllocaEventId.size() < idSize)) {
+      // Reallocate strategy: reduce usage to 1
+      SetEventPool(sync, canAllocaEventId[0]);
+      sync->eventIdNum = 1;
   }
+  // A slot rotation cannot collapse to one token after forward edges were
+  // pruned. Leave it unallocated so the existing PIPE_ALL fallback orders it.
 }
 
 SmallVector<int> SyncEventIdAllocation::UpdateBlockAvailableEventId(
@@ -414,24 +415,34 @@ void SyncEventIdAllocation::UpdateBackwardMatchSync(
   syncFront->eventIds.push_back(eventId);
   syncEnd->eventIds.push_back(eventId);
 
-  if (reallocatedPipePair.contains(ScopePair(setFlag))) {
-    auto *ptr = dyn_cast<LoopInstanceElement>(
-        syncIR_[setFlag->GetForEndIndex().value()].get());
-    assert(ptr != nullptr);
-    syncFront->SetSyncIRIndex(ptr->beginId);
-    syncEnd->SetSyncIRIndex(ptr->endId);
-    syncFront->reallocatedLoopHeadTailSync = true;
-    syncEnd->reallocatedLoopHeadTailSync = true;
-    syncIR_[ptr->beginId]->pipeBefore.push_back(syncFront.get());
-    // Insert the synthetic tail wait ahead of existing loop-end sets so the
-    // loop tail anchor does not emit a new set before consuming the carried
-    // event of the previous iteration.
-    syncIR_[ptr->endId]->pipeAfter.push_front(syncEnd.get());
+  if (setFlag->slotSchedule) {
+      syncFront->slotSchedule = setFlag->slotSchedule;
+      syncEnd->slotSchedule = setFlag->slotSchedule;
+      syncFront->slotCount = setFlag->slotCount;
+      syncEnd->slotCount = setFlag->slotCount;
+      syncFront->boundarySlot = static_cast<uint32_t>(setFlag->eventIds.size() - 1);
+      syncEnd->boundarySlot = syncFront->boundarySlot;
+  }
+
+  if (setFlag->slotSchedule || reallocatedPipePair.contains(ScopePair(setFlag))) {
+      auto* ptr = dyn_cast<LoopInstanceElement>(syncIR_[setFlag->GetForEndIndex().value()].get());
+      checkCondition(ptr != nullptr, "expected a loop for backward event boundaries");
+      syncFront->SetSyncIRIndex(ptr->beginId);
+      syncEnd->SetSyncIRIndex(ptr->endId);
+      // Slot predicates depend on this loop's bounds and cannot move to the
+      // function boundary through MoveOutBackwardMatchSync.
+      syncFront->reallocatedLoopHeadTailSync = !setFlag->slotSchedule;
+      syncEnd->reallocatedLoopHeadTailSync = !setFlag->slotSchedule;
+      syncIR_[ptr->beginId]->pipeBefore.push_back(syncFront.get());
+      // Insert the synthetic tail wait ahead of existing loop-end sets so the
+      // loop tail anchor does not emit a new set before consuming the carried
+      // event of the previous iteration.
+      syncIR_[ptr->endId]->pipeAfter.push_front(syncEnd.get());
   } else {
-    syncFront->SetSyncIRIndex(0);
-    syncEnd->SetSyncIRIndex(syncIR_.size() - 1);
-    syncIR_[0]->pipeBefore.push_back(syncFront.get());
-    syncIR_[syncIR_.size() - 1]->pipeAfter.push_back(syncEnd.get());
+      syncFront->SetSyncIRIndex(0);
+      syncEnd->SetSyncIRIndex(syncIR_.size() - 1);
+      syncIR_[0]->pipeBefore.push_back(syncFront.get());
+      syncIR_[syncIR_.size() - 1]->pipeAfter.push_back(syncEnd.get());
   }
 
   insertedBackwardSync.insert(syncFront.get());

--- a/lib/PTO/Transforms/Passes/SlotAffineAnalysis.cpp
+++ b/lib/PTO/Transforms/Passes/SlotAffineAnalysis.cpp
@@ -179,6 +179,45 @@ static int64_t pyMod(int64_t a, int64_t n) {
 
 } // namespace
 
+std::optional<uint32_t> getSlotRotationOffset(Value slot, Value inductionVar, uint32_t count)
+{
+    if (!slot || !inductionVar || count == 0) {
+        return std::nullopt;
+    }
+    auto rem = slot.getDefiningOp<arith::RemUIOp>();
+    if (!rem) {
+        return std::nullopt;
+    }
+    IntegerAttr modulus;
+    bool constantModulus = matchPattern(rem.getRhs(), m_Constant(&modulus));
+    if (!constantModulus) {
+        return std::nullopt;
+    }
+    const APInt& modulusValue = modulus.getValue();
+    if (modulusValue != count) {
+        return std::nullopt;
+    }
+    Value inner = rem.getLhs();
+    if (inner == inductionVar) {
+        return 0;
+    }
+    auto add = inner.getDefiningOp<arith::AddIOp>();
+    if (!add) {
+        return std::nullopt;
+    }
+    Value constant = add.getLhs() == inductionVar ? add.getRhs() : add.getLhs();
+    IntegerAttr offset;
+    bool inductionAdd = add.getLhs() == inductionVar || add.getRhs() == inductionVar;
+    bool constantOffset = matchPattern(constant, m_Constant(&offset));
+    if (!inductionAdd || !constantOffset) {
+        return std::nullopt;
+    }
+    if (offset.getValue().isNegative()) {
+        return std::nullopt;
+    }
+    return static_cast<uint32_t>(offset.getValue().urem(count));
+}
+
 SlotRelation compareSlotSSA(Value a, Value b, uint32_t N) {
   if (!a || !b || N == 0) {
     return SlotRelation::kUnknown;

--- a/test/lit/lit.cfg.py
+++ b/test/lit/lit.cfg.py
@@ -59,6 +59,7 @@ llvm_config.with_system_environment(
 # MLIR Python runtime together with generated PTO dialect modules and the PTO
 # extension under one build-tree Python root.
 if getattr(config, 'enable_bindings_python', False):
+    config.available_features.add('pto-python-bindings')
     llvm_config.with_environment(
         'PYTHONPATH', [config.ptoas_python_dir], append_path=True)
 

--- a/test/lit/pto/Inputs/check_multi_tile_prefetch_sync.py
+++ b/test/lit/pto/Inputs/check_multi_tile_prefetch_sync.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Check emitted flag balance and cross-pipe happens-before edges for #1519.
+
+This evaluates scalar IR and builds vector clocks for the issued pipe commands.
+It checks binary event tokens and tile RAW/WAR/WAW ordering, without relying on
+the CPU simulator's no-op flag stubs or on a particular event-id assignment.
+"""
+
+import operator
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from ptoas.mlir.dialects import pto
+from ptoas.mlir.ir import Context, IntegerAttr, Module
+
+
+PIPES = ("PIPE_MTE2", "PIPE_V", "PIPE_MTE3")
+BINARY = {
+    "arith.addi": operator.add,
+    "arith.subi": operator.sub,
+    "arith.muli": operator.mul,
+    "arith.andi": operator.and_,
+    "arith.remui": operator.mod,
+    "arith.remsi": operator.mod,
+}
+COMPARE = (operator.eq, operator.ne, operator.lt, operator.le, operator.gt,
+           operator.ge, operator.lt, operator.le, operator.gt, operator.ge)
+
+
+class Protocol:
+    def __init__(self):
+        self.events = {}
+        self.clocks = {pipe: [0] * len(PIPES) for pipe in PIPES}
+        self.readers = {}
+        self.writers = {}
+
+    def flag(self, op, values):
+        src = re.search(r"PIPE_\w+", str(op.attributes["src_pipe"])).group()
+        dst = re.search(r"PIPE_\w+", str(op.attributes["dst_pipe"])).group()
+        event = values[0] if values else int(
+            re.search(r"EVENT_ID(\d+)", str(op.attributes["event_id"])).group(1))
+        key = (src, dst, event)
+        if "set_flag" in op.name:
+            if key in self.events:
+                raise ValueError(f"duplicate set without wait: {key}")
+            self.events[key] = tuple(self.clocks[src])
+        else:
+            if key not in self.events:
+                raise ValueError(f"wait without set: {key}")
+            released = self.events.pop(key)
+            self.clocks[dst] = list(map(max, self.clocks[dst], released))
+
+    def require_order(self, earlier, pipe, address, hazard):
+        if any(a > b for a, b in zip(earlier, self.clocks[pipe])):
+            raise ValueError(f"unordered {hazard} at tile address {address}, pipe {pipe}")
+
+    def access(self, pipe, reads, writes):
+        self.clocks[pipe][PIPES.index(pipe)] += 1
+        clock = tuple(self.clocks[pipe])
+        for address in reads:
+            if address in self.writers:
+                self.require_order(self.writers[address], pipe, address, "RAW")
+            self.readers.setdefault(address, {})[pipe] = clock
+        for address in writes:
+            if address in self.writers:
+                self.require_order(self.writers[address], pipe, address, "WAW")
+            for reader in self.readers.get(address, {}).values():
+                self.require_order(reader, pipe, address, "WAR")
+            self.readers[address] = {}
+            self.writers[address] = clock
+
+    def barrier(self, op):
+        if "PIPE_ALL" in str(op):
+            joined = list(map(max, *self.clocks.values()))
+            self.clocks = {pipe: list(joined) for pipe in PIPES}
+
+
+def scalar(op, values):
+    if op.name == "arith.constant":
+        return IntegerAttr(op.attributes["value"]).value
+    if op.name in BINARY:
+        return BINARY[op.name](*values)
+    if op.name == "arith.cmpi":
+        return COMPARE[IntegerAttr(op.attributes["predicate"]).value](*values)
+    if op.name == "arith.select":
+        return values[1] if values[0] else values[2]
+    if op.name in ("arith.index_cast", "arith.index_castui"):
+        return values[0]
+    raise ValueError(f"unsupported scalar operation: {op.name}")
+
+
+def run_loop(op, values, env, protocol):
+    lower, upper, step, *carried = values
+    body = op.regions[0].blocks[0]
+    for induction in range(lower, upper, step):
+        env.update(zip(body.arguments, (induction, *carried)))
+        carried = run_block(body, env, protocol)
+    env.update(zip(op.results, carried))
+
+
+def run_block(block, env, protocol):
+    for view in block.operations:
+        op = view.operation
+        values = [env[value] for value in op.operands]
+        if op.name.startswith("arith."):
+            env[op.results[0]] = scalar(op, values)
+        elif op.name == "scf.for":
+            run_loop(op, values, env, protocol)
+        elif op.name == "scf.if":
+            region = op.regions[0 if values[0] else 1]
+            if region.blocks:
+                results = run_block(region.blocks[0], env, protocol)
+                env.update(zip(op.results, results))
+        elif op.name in ("scf.yield", "func.return"):
+            return values
+        elif op.name == "pto.alloc_tile":
+            env[op.results[0]] = values[0]
+        elif "flag" in op.name:
+            protocol.flag(op, values)
+        elif op.name == "pto.tload":
+            protocol.access("PIPE_MTE2", [], [values[-1]])
+        elif op.name == "pto.tadd":
+            protocol.access("PIPE_V", values[:2], [values[2]])
+        elif op.name == "pto.barrier":
+            protocol.barrier(op)
+        else:
+            raise ValueError(f"unsupported test operation: {op.name}")
+    return []
+
+
+def check_module(text, label):
+    with Context() as context:
+        pto.register_dialect(context, load=True)
+        module = Module.parse(text)
+        for func in module.body.operations:
+            body = func.regions[0].blocks[0]
+            for upper in range(-1, 13):
+                protocol = Protocol()
+                env = dict(zip(body.arguments, (None, upper, 1)))
+                try:
+                    run_block(body, env, protocol)
+                    if protocol.events:
+                        raise ValueError(f"undrained events: {tuple(protocol.events)}")
+                except ValueError as error:
+                    raise ValueError(f"{label}, upper={upper}: {error}") from error
+
+
+def variants(source):
+    yield "remui", source
+    yield "remsi", source.replace("arith.remui", "arith.remsi")
+    yield "andi", source.replace("arith.remui", "arith.andi").replace(
+        "%i,    %c2", "%i,    %c1").replace("%next, %c2", "%next, %c1")
+    yield "lower_one", source.replace("%i = %c0 to", "%i = %c1 to").replace(
+        "%mb[%c0]", "%mb[%c1]")
+    yield "step_two", source.replace("step %c1", "step %c2")
+    yield "dynamic_lower", source.replace(
+        "%n : index)", "%n : index, %lower : index)").replace(
+            "%i = %c0 to", "%i = %lower to").replace("%mb[%c0]", "%mb[%c1]")
+    for count in (3, 4, 8, 16):
+        yield f"count_{count}", source.replace(
+            "count=2", f"count={count}").replace(
+                "%c2 = arith.constant 2", f"%c2 = arith.constant {count}")
+    multiplied = source.replace("%next     = arith.addi  %i,", (
+        "%c3 = arith.constant 3 : index\n"
+        "      %scaled = arith.muli %i, %c3 : index\n"
+        "      %next     = arith.addi  %scaled,"))
+    yield "odd_multiplier", multiplied.replace("%i,    %c2", "%scaled,    %c2")
+    carried = source.replace(
+        "scf.for %i = %c0 to %n step %c1 {",
+        "%last_slot = scf.for %i = %c0 to %n step %c1 "
+        "iter_args(%slot = %c0) -> (index) {")
+    carried = carried.replace(
+        "%cur_idx  = arith.remui %i,    %c2 : index",
+        "%cur_idx = arith.addi %slot, %c0 : index").replace(
+        "%next_idx = arith.remui %next, %c2 : index",
+        "%next_idx = arith.subi %c1, %slot : index").replace(
+        "    }\n    return", "      scf.yield %next_idx : index\n    }\n    return")
+    yield "loop_carried", carried
+    epilogue = """    %last_idx = arith.remui %n, %c2 : index
+    %last = pto.multi_tile_get %mb[%last_idx] : !pto.multi_tile_buf<vec, 16x16xf16, count=2>
+      -> !pto.tile_buf<vec, 16x16xf16>
+    pto.tadd ins(%last, %last : !pto.tile_buf<vec, 16x16xf16>, !pto.tile_buf<vec, 16x16xf16>)
+      outs(%acc : !pto.tile_buf<vec, 16x16xf16>)
+"""
+    yield "epilogue", source.replace("    return", epilogue + "    return")
+    yield "epilogue_remsi", source.replace(
+        "    return", epilogue + "    return").replace("arith.remui", "arith.remsi")
+    yield "nested", source.replace(
+        "    // preload iter", "    scf.for %outer = %c0 to %c2 step %c1 {\n    // preload iter").replace(
+            "    return", "    }\n    return")
+
+
+def main():
+    compiler = shutil.which(sys.argv[1])
+    if compiler is None:
+        raise FileNotFoundError(sys.argv[1])
+    source = Path(sys.argv[2]).resolve().read_text(encoding="utf-8")
+    check_module(Path(sys.argv[3]).resolve().read_text(encoding="utf-8"), "repro")
+    with tempfile.TemporaryDirectory(prefix="pto-prefetch-sync-") as directory:
+        root = Path(directory)
+        for label, text in variants(source):
+            for level in ("level2", "level3"):
+                if level == "level3":
+                    text = text.replace(
+                        "%mb = pto.alloc_multi_tile :", (
+                            "%base = arith.constant 0 : i64\n"
+                            "    %acc_base = arith.constant 8192 : i64\n"
+                            "    %mb = pto.alloc_multi_tile addr = %base :")).replace(
+                                "%acc = pto.alloc_tile :", "%acc = pto.alloc_tile addr = %acc_base :")
+                input_path = root / f"{label}-{level}.pto"
+                output_path = root / f"{label}-{level}-sync.pto"
+                input_path.write_text(text, encoding="utf-8")
+                result = subprocess.run(
+                    [compiler, str(input_path), "--enable-insert-sync", "--pto-arch=a3",
+                     f"--pto-level={level}", "--emit-pto-ir", "-o", str(output_path)],
+                    check=False, capture_output=True, text=True, timeout=60)
+                if result.returncode != 0:
+                    raise ValueError(f"{label}-{level}: compiler failed\n{result.stderr}")
+                check_module(output_path.read_text(encoding="utf-8"), f"{label}-{level}")
+    print("prefetch sync: balanced events and ordered tile accesses")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/lit/pto/multi_tile_affine_disjoint_slots.pto
+++ b/test/lit/pto/multi_tile_affine_disjoint_slots.pto
@@ -6,7 +6,8 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: ptoas --enable-insert-sync --mlir-print-ir-after=pto-insert-sync %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --enable-insert-sync --emit-pto-ir %s -o %t
+// RUN: pto-test-opt %t --canonicalize | FileCheck %s
 
 // Affine slot disjoint optimization: producer touches slot `(iv+1) % 2`,
 // consumer touches slot `iv % 2`. The slot SSA expressions are provably
@@ -55,20 +56,29 @@ module {
   }
 }
 
-// Pre-loop primes 2 per-slot events for the back-edge sync.
+// Prime only the first free write slot and the first ready read slot.
 // CHECK-LABEL: func.func @prefetch_disjoint_slots
-// CHECK: pto.set_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID0>]
+// CHECK-NOT: pto.set_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID0>]
 // CHECK: pto.set_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID1>]
-// CHECK: scf.for
+// CHECK-NEXT: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+// CHECK-NEXT: scf.for
 // Loop body: back-edge dyn wait, the tload, then dyn set after tstore.
 // The same-iter MTE2 -> MTE3 forward sync has been dropped by the affine
 // disjoint-slot proof.
 // CHECK: pto.wait_flag_dyn[<PIPE_MTE3>, <PIPE_MTE2>,
 // CHECK: pto.tload
+// CHECK: pto.set_flag_dyn[<PIPE_MTE2>, <PIPE_MTE3>,
 // CHECK-NOT: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>
 // CHECK-NOT: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>
+// CHECK: pto.wait_flag_dyn[<PIPE_MTE2>, <PIPE_MTE3>,
 // CHECK: pto.tstore
 // CHECK: pto.set_flag_dyn[<PIPE_MTE3>, <PIPE_MTE2>,
-// Post-loop drains.
-// CHECK: pto.wait_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID0>]
-// CHECK: pto.wait_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID1>]
+// Drain each candidate only when its tail slot predicate is true.
+// CHECK: scf.if
+// CHECK-NEXT: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID1>]
+// CHECK: scf.if
+// CHECK-NEXT: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+// CHECK: scf.if
+// CHECK-NEXT: pto.wait_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID1>]
+// CHECK: scf.if
+// CHECK-NEXT: pto.wait_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID0>]

--- a/test/lit/pto/multi_tile_alias_slot_dyn_event_id.pto
+++ b/test/lit/pto/multi_tile_alias_slot_dyn_event_id.pto
@@ -6,8 +6,8 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: ptoas --enable-insert-sync --mlir-print-ir-after=pto-insert-sync \
-// RUN:   %s 2>&1 1>/dev/null | FileCheck %s --check-prefix=INSERT
+// RUN: ptoas --enable-insert-sync --emit-pto-ir %s -o %t
+// RUN: pto-test-opt %t --canonicalize | FileCheck %s --check-prefix=INSERT
 
 // The producer/consumer slots are hidden behind tile alias ops. The sync
 // analysis must still trace them back to `pto.multi_tile_get` and keep the
@@ -55,12 +55,21 @@ module {
 }
 
 // INSERT-LABEL: func.func @multi_tile_alias_slot_dyn_event_id
-// INSERT: pto.set_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID0>]
+// INSERT-NOT: pto.set_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID0>]
 // INSERT: pto.set_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID1>]
-// INSERT: scf.for
+// INSERT-NEXT: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+// INSERT-NEXT: scf.for
 // INSERT: pto.wait_flag_dyn[<PIPE_MTE3>, <PIPE_MTE2>,
 // INSERT: pto.tload
+// INSERT: pto.set_flag_dyn[<PIPE_MTE2>, <PIPE_MTE3>,
+// INSERT: pto.wait_flag_dyn[<PIPE_MTE2>, <PIPE_MTE3>,
 // INSERT: pto.tstore
 // INSERT: pto.set_flag_dyn[<PIPE_MTE3>, <PIPE_MTE2>,
-// INSERT: pto.wait_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID0>]
-// INSERT: pto.wait_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID1>]
+// INSERT: scf.if
+// INSERT-NEXT: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID1>]
+// INSERT: scf.if
+// INSERT-NEXT: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>, <EVENT_ID0>]
+// INSERT: scf.if
+// INSERT-NEXT: pto.wait_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID1>]
+// INSERT: scf.if
+// INSERT-NEXT: pto.wait_flag[<PIPE_MTE3>, <PIPE_MTE2>, <EVENT_ID0>]

--- a/test/lit/pto/multi_tile_prefetch_event_balance.pto
+++ b/test/lit/pto/multi_tile_prefetch_event_balance.pto
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas %s --enable-insert-sync --pto-arch=a3 --emit-pto-ir -o %t
+// RUN: %python %S/Inputs/check_multi_tile_prefetch_sync.py ptoas %s %t
+// REQUIRES: pto-python-bindings
+//
+// Issue #1519: preload slot 0, then prefetch the next slot before consuming
+// the current one. Check the emitted event protocol and cross-pipe ordering
+// for zero, odd, and even trip counts, including alternate slot expressions.
+module {
+  func.func @double_prefetch(%gm : !pto.partition_tensor_view<16x16xf16>, %n : index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+
+    %mb = pto.alloc_multi_tile : !pto.multi_tile_buf<vec, 16x16xf16, count=2>
+    %acc = pto.alloc_tile : !pto.tile_buf<vec, 16x16xf16>
+
+    // preload iter 0 -> slot0
+    %pre = pto.multi_tile_get %mb[%c0] : !pto.multi_tile_buf<vec, 16x16xf16, count=2> -> !pto.tile_buf<vec, 16x16xf16>
+    pto.tload ins(%gm : !pto.partition_tensor_view<16x16xf16>) outs(%pre : !pto.tile_buf<vec, 16x16xf16>)
+
+    scf.for %i = %c0 to %n step %c1 {
+      %next     = arith.addi  %i,    %c1 : index
+      %cur_idx  = arith.remui %i,    %c2 : index
+      %next_idx = arith.remui %next, %c2 : index
+
+      // prefetch into the other slot
+      %s_next = pto.multi_tile_get %mb[%next_idx] : !pto.multi_tile_buf<vec, 16x16xf16, count=2> -> !pto.tile_buf<vec, 16x16xf16>
+      pto.tload ins(%gm : !pto.partition_tensor_view<16x16xf16>) outs(%s_next : !pto.tile_buf<vec, 16x16xf16>)
+
+      %s_cur = pto.multi_tile_get %mb[%cur_idx] : !pto.multi_tile_buf<vec, 16x16xf16, count=2> -> !pto.tile_buf<vec, 16x16xf16>
+      pto.tadd ins(%s_cur, %s_cur : !pto.tile_buf<vec, 16x16xf16>, !pto.tile_buf<vec, 16x16xf16>) outs(%acc : !pto.tile_buf<vec, 16x16xf16>)
+    }
+    return
+  }
+}


### PR DESCRIPTION
A preload followed by a multi-tile prefetch loop initialized and drained every slot event, allowing reads or overwrites before their dependencies completed and leaving unmatched waits for odd trip counts. Compute entry and exit events from each slot's first set/wait order and the loop's final rotation position, including loops with zero iterations.

Keep boundary events scoped to their owning loop and avoid duplicate enclosing-loop events. Preserve static synchronization for unproven distinct slot expressions, and use the existing PIPE_ALL fallback when a proven rotation cannot obtain enough event IDs. Update the design documentation and strengthen the existing boundary checks.

Validation:

- Full lit suite: 1,871 passed, 1 unsupported (VFSIM cost model disabled). After the final change for event exhaustion, rebuilt and reran all 89 sync/multi_tile/event tests; all passed.
- New protocol regression: 30 level2/level3 configurations and 434 total executions, checking binary-event balance and tile RAW/WAR/WAW ordering. Covers odd/even/zero trips, alternate slot expressions, nested loops, epilogues, and N=2/3/4/8/16.
- WSL CANN 8.5 Ascend910B1 simulator: the old 7-trip kernel hangs until the 60-second timeout; fixed 1/7/8-trip kernels finish with zero mismatches and zero maximum error. The final compiler emits byte-identical C++ to the simulated kernels.
- The old 8-trip kernel also passes on this local model, so the reported even-trip device race was checked through the protocol regression rather than reproduced on hardware. CANN 9.0 hardware was not tested.
- All builds used one job. Code compliance checks and git diff --check passed.

Fixes #1519.
